### PR TITLE
feat(billing): real OpenRouter cost capture + AI-billing admin panel

### DIFF
--- a/apps/web/src/app/admin/AdminLayoutClient.tsx
+++ b/apps/web/src/app/admin/AdminLayoutClient.tsx
@@ -16,7 +16,8 @@ export default function AdminLayoutClient({
   const router = useRouter();
   const currentTab = pathname === '/admin' ? 'overview' :
                      pathname.includes('/global-prompt') ? 'global-prompt' :
-                     pathname.includes('/unit-economics') ? 'unit-economics' : 'overview';
+                     pathname.includes('/unit-economics') ? 'unit-economics' :
+                     pathname.includes('/ai-billing') ? 'ai-billing' : 'overview';
 
   return (
     <div className="min-h-screen bg-background px-4 py-6 sm:px-6 lg:px-10">
@@ -49,6 +50,9 @@ export default function AdminLayoutClient({
             </TabsTrigger>
             <TabsTrigger value="unit-economics" asChild>
               <Link href="/admin/unit-economics">Unit Economics</Link>
+            </TabsTrigger>
+            <TabsTrigger value="ai-billing" asChild>
+              <Link href="/admin/ai-billing">AI Billing</Link>
             </TabsTrigger>
           </TabsList>
 

--- a/apps/web/src/app/admin/ai-billing/page.tsx
+++ b/apps/web/src/app/admin/ai-billing/page.tsx
@@ -1,0 +1,561 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AlertCircle, Download, Receipt, ShieldAlert, ShieldCheck } from "lucide-react";
+import { fetchWithAuth } from "@/lib/auth/auth-fetch";
+
+type Range = "24h" | "7d" | "30d" | "all";
+type Granularity = "day" | "month";
+type Coverage = "real" | "estimate";
+type Tier = "free" | "pro" | "founder" | "business";
+
+interface TokenTotals {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  requestCount: number;
+}
+
+interface TokenModelRow extends TokenTotals {
+  provider: string;
+  model: string;
+}
+
+interface TokenPeriodRow extends TokenTotals {
+  period: string;
+}
+
+interface TokenUserRow extends TokenTotals {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+}
+
+interface ProviderCostRow {
+  provider: string;
+  model: string;
+  coverage: Coverage;
+  realCostCents: number;
+  chargedCents: number;
+  marginCents: number;
+  marginPct: number | null;
+  requestCount: number;
+}
+
+interface SubscriptionTierRow {
+  tier: Tier;
+  count: number;
+}
+
+interface Enforcement {
+  enabled: boolean;
+  markupBps: number;
+  tierAllowanceCents: Record<Tier, number>;
+}
+
+interface AiBillingResponse {
+  range: Range;
+  granularity: Granularity;
+  enforcement: Enforcement;
+  tokens: {
+    summary: TokenTotals;
+    byModel: TokenModelRow[];
+    byPeriod: TokenPeriodRow[];
+    byUser: TokenUserRow[];
+  };
+  providerCost: ProviderCostRow[];
+  revenue: {
+    topupCents: number;
+    topupCount: number;
+    monthlyGrantCents: number;
+    monthlyGrantCount: number;
+    totalCents: number;
+    subscriptionsByTier: SubscriptionTierRow[];
+  };
+  liability: {
+    monthlyRemainingCents: number;
+    topupRemainingCents: number;
+    totalLiabilityCents: number;
+    userCount: number;
+  };
+  holds: {
+    holdCount: number;
+    heldCents: number;
+  };
+}
+
+const TIERS: Tier[] = ["free", "pro", "founder", "business"];
+
+function usd(cents: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+}
+
+function num(value: number): string {
+  return value.toLocaleString();
+}
+
+/**
+ * Label a period bucket from the server's DATE_TRUNC timestamp string directly.
+ * Never reparse through `new Date(...)`: that shifts plain YYYY-MM-DD buckets for
+ * clients west of UTC and turns a monthly bucket into an arbitrary day.
+ */
+function formatPeriodLabel(period: string, granularity: Granularity): string {
+  const datePart = String(period).slice(0, 10);
+  return granularity === "month" ? datePart.slice(0, 7) : datePart;
+}
+
+function pct(value: number | null): string {
+  return value === null ? "—" : `${value.toFixed(1)}%`;
+}
+
+function marginClass(value: number | null): string {
+  if (value === null) return "text-muted-foreground";
+  if (value < 0) return "text-red-600 dark:text-red-400";
+  return "text-green-600 dark:text-green-400";
+}
+
+function userLabel(row: { userName: string | null; userEmail: string | null; userId: string }): string {
+  return row.userEmail ?? row.userName ?? row.userId;
+}
+
+export default function AdminAiBillingPage() {
+  const [data, setData] = useState<AiBillingResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [range, setRange] = useState<Range>("30d");
+  const [granularity, setGranularity] = useState<Granularity>("day");
+
+  const fetchData = useCallback(async (r: Range, g: Granularity) => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams({ range: r, granularity: g });
+      const response = await fetchWithAuth(`/api/admin/ai-billing?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch AI billing data");
+      }
+      const json = (await response.json()) as AiBillingResponse;
+      setData(json);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(range, granularity);
+  }, [fetchData, range, granularity]);
+
+  const downloadCsv = useCallback(async () => {
+    const params = new URLSearchParams({ range, granularity, format: "csv" });
+    const response = await fetchWithAuth(`/api/admin/ai-billing?${params.toString()}`);
+    if (!response.ok) return;
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `ai-billing-${range}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, [range, granularity]);
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96" />
+          </CardHeader>
+        </Card>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-8 w-32" />
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>Error loading AI billing: {error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>No data received</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const { enforcement, tokens, revenue, liability, holds } = data;
+  const markupMultiplier = (enforcement.markupBps / 10000).toFixed(2);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Receipt className="h-5 w-5" />
+            AI Billing
+          </CardTitle>
+          <CardDescription>
+            Token volume, provider cost (real vs estimated), Stripe credit revenue, and
+            outstanding liability. Watch real numbers here before enabling enforcement.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">Range</Label>
+              <Select value={range} onValueChange={(v) => setRange(v as Range)}>
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="24h">Last 24 hours</SelectItem>
+                  <SelectItem value="7d">Last 7 days</SelectItem>
+                  <SelectItem value="30d">Last 30 days</SelectItem>
+                  <SelectItem value="all">All time</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">Granularity</Label>
+              <Select value={granularity} onValueChange={(v) => setGranularity(v as Granularity)}>
+                <SelectTrigger className="w-[120px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="day">Daily</SelectItem>
+                  <SelectItem value="month">Monthly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button variant="outline" size="sm" onClick={downloadCsv} className="gap-2">
+              <Download className="h-4 w-4" />
+              Export CSV
+            </Button>
+            {loading && <span className="text-sm text-muted-foreground">Loading…</span>}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Enforcement status banner */}
+      <Alert variant={enforcement.enabled ? "destructive" : "default"}>
+        {enforcement.enabled ? <ShieldCheck className="h-4 w-4" /> : <ShieldAlert className="h-4 w-4" />}
+        <AlertDescription>
+          <span className="font-semibold">
+            Credit enforcement is {enforcement.enabled ? "ON" : "OFF (dark-launch)"}.
+          </span>{" "}
+          {enforcement.enabled
+            ? "Out-of-credits and over-in-flight-cap requests are being denied (402/429)."
+            : "Usage is metered and billed, but no request is denied. Markup "}
+          {!enforcement.enabled && <span className="font-mono">{markupMultiplier}×</span>}
+          {!enforcement.enabled && (
+            <>
+              . Monthly allowance:{" "}
+              {TIERS.map((t, i) => (
+                <span key={t}>
+                  {i > 0 ? ", " : ""}
+                  {t} {usd(enforcement.tierAllowanceCents[t])}
+                </span>
+              ))}
+              .
+            </>
+          )}
+        </AlertDescription>
+      </Alert>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Total tokens</CardDescription>
+            <CardTitle className="text-2xl">{num(tokens.summary.totalTokens)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Requests</CardDescription>
+            <CardTitle className="text-2xl">{num(tokens.summary.requestCount)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Credit revenue</CardDescription>
+            <CardTitle className="text-2xl">{usd(revenue.totalCents)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Outstanding liability</CardDescription>
+            <CardTitle className="text-2xl">{usd(liability.totalLiabilityCents)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Live holds</CardDescription>
+            <CardTitle className="text-2xl">
+              {usd(holds.heldCents)}
+              <span className="ml-2 text-base text-muted-foreground">({num(holds.holdCount)})</span>
+            </CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      {/* Provider cost rollup */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Provider cost</CardTitle>
+          <CardDescription>
+            What we pay providers per model. <Badge variant="outline">real</Badge> = OpenRouter&apos;s
+            returned cost; <Badge variant="secondary">estimate</Badge> = static fallback for direct providers.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.providerCost.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No billed AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Provider</TableHead>
+                  <TableHead>Model</TableHead>
+                  <TableHead>Basis</TableHead>
+                  <TableHead className="text-right">Real cost</TableHead>
+                  <TableHead className="text-right">Charged</TableHead>
+                  <TableHead className="text-right">Margin</TableHead>
+                  <TableHead className="text-right">Margin %</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.providerCost.map((row) => (
+                  <TableRow key={`${row.provider}/${row.model}`}>
+                    <TableCell>{row.provider}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.model}</TableCell>
+                    <TableCell>
+                      <Badge variant={row.coverage === "real" ? "outline" : "secondary"}>
+                        {row.coverage}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">{usd(row.realCostCents)}</TableCell>
+                    <TableCell className="text-right">{usd(row.chargedCents)}</TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {usd(row.marginCents)}
+                    </TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {pct(row.marginPct)}
+                    </TableCell>
+                    <TableCell className="text-right">{num(row.requestCount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Stripe revenue */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Credit revenue</CardTitle>
+            <CardDescription>Stripe-sourced credit funding in this range.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Source</TableHead>
+                  <TableHead className="text-right">Count</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell>Top-up purchases</TableCell>
+                  <TableCell className="text-right">{num(revenue.topupCount)}</TableCell>
+                  <TableCell className="text-right">{usd(revenue.topupCents)}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Monthly grants</TableCell>
+                  <TableCell className="text-right">{num(revenue.monthlyGrantCount)}</TableCell>
+                  <TableCell className="text-right">{usd(revenue.monthlyGrantCents)}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Active subscriptions</CardTitle>
+            <CardDescription>Live subscriptions by tier (point-in-time).</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Tier</TableHead>
+                  <TableHead className="text-right">Subscribers</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {revenue.subscriptionsByTier.map((row) => (
+                  <TableRow key={row.tier}>
+                    <TableCell className="capitalize">{row.tier}</TableCell>
+                    <TableCell className="text-right">{num(row.count)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Token usage by model */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Token usage by model</CardTitle>
+          <CardDescription>Input/output/total tokens per provider and model.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {tokens.byModel.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Provider</TableHead>
+                  <TableHead>Model</TableHead>
+                  <TableHead className="text-right">Input</TableHead>
+                  <TableHead className="text-right">Output</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.byModel.map((row) => (
+                  <TableRow key={`${row.provider}/${row.model}`}>
+                    <TableCell>{row.provider}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.model}</TableCell>
+                    <TableCell className="text-right">{num(row.inputTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.outputTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.totalTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.requestCount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Token usage by user */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Token usage by user</CardTitle>
+          <CardDescription>Heaviest users by total tokens.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {tokens.byUser.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead className="text-right">Input</TableHead>
+                  <TableHead className="text-right">Output</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.byUser.map((row) => (
+                  <TableRow key={row.userId}>
+                    <TableCell className="max-w-[260px] truncate">{userLabel(row)}</TableCell>
+                    <TableCell className="text-right">{num(row.inputTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.outputTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.totalTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.requestCount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Token usage over time */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Token usage over time</CardTitle>
+          <CardDescription>Tokens per {granularity === "month" ? "month" : "day"}.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {tokens.byPeriod.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Period</TableHead>
+                  <TableHead className="text-right">Input</TableHead>
+                  <TableHead className="text-right">Output</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tokens.byPeriod.map((row) => (
+                  <TableRow key={row.period}>
+                    <TableCell className="font-mono text-xs">
+                      {formatPeriodLabel(row.period, data.granularity)}
+                    </TableCell>
+                    <TableCell className="text-right">{num(row.inputTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.outputTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.totalTokens)}</TableCell>
+                    <TableCell className="text-right">{num(row.requestCount)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/ai-billing/page.tsx
+++ b/apps/web/src/app/admin/ai-billing/page.tsx
@@ -339,8 +339,9 @@ export default function AdminAiBillingPage() {
         <CardHeader>
           <CardTitle>Provider cost</CardTitle>
           <CardDescription>
-            What we pay providers per model. <Badge variant="outline">real</Badge> = OpenRouter&apos;s
-            returned cost; <Badge variant="secondary">estimate</Badge> = static fallback for direct providers.
+            What we pay providers per model, split by billing basis. <Badge variant="outline">real</Badge> =
+            OpenRouter&apos;s returned cost; <Badge variant="secondary">estimate</Badge> = static fallback
+            (direct providers, or an OpenRouter call whose cost metadata was missing).
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web/src/app/admin/ai-billing/page.tsx
+++ b/apps/web/src/app/admin/ai-billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -139,8 +139,14 @@ export default function AdminAiBillingPage() {
   const [error, setError] = useState<string | null>(null);
   const [range, setRange] = useState<Range>("30d");
   const [granularity, setGranularity] = useState<Granularity>("day");
+  // Monotonic request token: when the user flips range/granularity quickly, an
+  // older in-flight fetch can resolve after a newer one. We only commit a
+  // response if it's still the latest request, so stale data can't clobber the
+  // current selection.
+  const latestRequest = useRef(0);
 
   const fetchData = useCallback(async (r: Range, g: Granularity) => {
+    const reqId = ++latestRequest.current;
     try {
       setLoading(true);
       const params = new URLSearchParams({ range: r, granularity: g });
@@ -149,12 +155,14 @@ export default function AdminAiBillingPage() {
         throw new Error("Failed to fetch AI billing data");
       }
       const json = (await response.json()) as AiBillingResponse;
+      if (reqId !== latestRequest.current) return; // superseded by a newer request
       setData(json);
       setError(null);
     } catch (err) {
+      if (reqId !== latestRequest.current) return;
       setError(err instanceof Error ? err.message : "An error occurred");
     } finally {
-      setLoading(false);
+      if (reqId === latestRequest.current) setLoading(false);
     }
   }, []);
 
@@ -363,7 +371,9 @@ export default function AdminAiBillingPage() {
               </TableHeader>
               <TableBody>
                 {data.providerCost.map((row) => (
-                  <TableRow key={`${row.provider}/${row.model}`}>
+                  // coverage is part of the key: a provider/model can now appear
+                  // as both a 'real' and an 'estimate' row.
+                  <TableRow key={`${row.provider}/${row.model}/${row.coverage}`}>
                     <TableCell>{row.provider}</TableCell>
                     <TableCell className="font-mono text-xs">{row.model}</TableCell>
                     <TableCell>

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { MessageSquare, ExternalLink, TrendingUp } from "lucide-react";
+import { MessageSquare, ExternalLink, TrendingUp, Receipt } from "lucide-react";
 
 const ADMIN_APP_URL = process.env.NEXT_PUBLIC_ADMIN_APP_URL ?? 'http://localhost:3005';
 
@@ -28,6 +28,17 @@ export default function AdminPage() {
               Unit Economics
             </CardTitle>
             <CardDescription>AI real cost vs charged credits, margin, and outstanding debt</CardDescription>
+          </CardHeader>
+        </Card>
+      </Link>
+      <Link href="/admin/ai-billing">
+        <Card className="transition-colors hover:bg-accent h-full">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Receipt className="h-5 w-5" />
+              AI Billing
+            </CardTitle>
+            <CardDescription>Token volume, provider cost, credit revenue, liability, and enforcement status</CardDescription>
           </CardHeader>
         </Card>
       </Link>

--- a/apps/web/src/app/api/admin/ai-billing/route.ts
+++ b/apps/web/src/app/api/admin/ai-billing/route.ts
@@ -1,0 +1,191 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth';
+import {
+  getDateRange,
+  getTokenUsageSummary,
+  getTokenUsageByModel,
+  getTokenUsageByPeriod,
+  getTokenUsageByUser,
+  getProviderCostRollup,
+  getCreditRevenue,
+  getActiveSubscriptionsByTier,
+  getCreditLiability,
+  getLiveHolds,
+  type Granularity,
+} from '@/lib/monitoring';
+import {
+  isCreditsEnforcementEnabled,
+  MARKUP_BPS,
+  TIER_MONTHLY_ALLOWANCE_CENTS,
+} from '@pagespace/lib/billing/credit-pricing';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+type Range = '24h' | '7d' | '30d' | 'all';
+
+function parseRange(value: string | null): Range {
+  return value === '24h' || value === '7d' || value === '30d' || value === 'all' ? value : '30d';
+}
+
+function parseGranularity(value: string | null): Granularity {
+  return value === 'month' ? 'month' : 'day';
+}
+
+function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/**
+ * Neutralize spreadsheet formula injection: a cell starting with =, +, -, or @
+ * is evaluated as a formula by Excel/Sheets. Prefix attacker-controlled text
+ * (names/emails/model ids) with a single quote so it renders literally — but
+ * EXEMPT plain numbers so legitimate negative exports stay numeric.
+ */
+function sanitizeSpreadsheetCell(value: string): string {
+  if (/^-?\d+(\.\d+)?$/.test(value)) return value; // plain (possibly negative) number — safe
+  return /^[=+\-@]/.test(value) ? `'${value}` : value;
+}
+
+/** Escape a CSV field per RFC 4180 (quote if it contains comma, quote, or newline). */
+function csvField(value: string | number | null): string {
+  const s = sanitizeSpreadsheetCell(value === null ? '' : String(value));
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function toCsv(rows: (string | number | null)[][]): string {
+  return rows.map((row) => row.map(csvField).join(',')).join('\r\n');
+}
+
+/**
+ * GET /api/admin/ai-billing
+ * Comprehensive AI-billing snapshot: token volume, provider cost (real vs
+ * estimated), Stripe credit revenue, outstanding liability + live holds, and the
+ * enforcement-status banner. ADMIN ONLY — exposes revenue/cost internals.
+ *
+ * Query params:
+ *   - range:       24h | 7d | 30d (default) | all  — windows token/cost/revenue
+ *   - granularity: day (default) | month            — token time-series bucketing
+ *   - format:      json (default) | csv             — flat multi-section export
+ */
+export const GET = withAdminAuth(async (_adminUser, request) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const range = parseRange(searchParams.get('range'));
+    const granularity = parseGranularity(searchParams.get('granularity'));
+    const format = searchParams.get('format') === 'csv' ? 'csv' : 'json';
+
+    const { startDate, endDate } = getDateRange(range);
+
+    const [
+      tokenSummary,
+      tokensByModel,
+      tokensByPeriod,
+      tokensByUser,
+      providerCost,
+      revenue,
+      subscriptionsByTier,
+      liability,
+      holds,
+    ] = await Promise.all([
+      getTokenUsageSummary(startDate, endDate),
+      getTokenUsageByModel(startDate, endDate, 50),
+      getTokenUsageByPeriod(startDate, endDate, granularity),
+      getTokenUsageByUser(startDate, endDate, 10),
+      getProviderCostRollup(startDate, endDate),
+      getCreditRevenue(startDate, endDate),
+      getActiveSubscriptionsByTier(),
+      getCreditLiability(),
+      getLiveHolds(),
+    ]);
+
+    const enforcement = {
+      enabled: isCreditsEnforcementEnabled(),
+      markupBps: MARKUP_BPS,
+      tierAllowanceCents: TIER_MONTHLY_ALLOWANCE_CENTS,
+    };
+
+    if (format === 'csv') {
+      const rows: (string | number | null)[][] = [
+        ['section', 'key', 'detail', 'inputTokens', 'outputTokens', 'totalTokens', 'requests', 'realCostUSD', 'chargedUSD', 'amountUSD'],
+      ];
+
+      rows.push(['enforcement', 'enabled', String(enforcement.enabled), '', '', '', '', '', '', '']);
+      rows.push(['enforcement', 'markupBps', String(enforcement.markupBps), '', '', '', '', '', '', '']);
+
+      rows.push([
+        'tokens_summary', range, '',
+        tokenSummary.inputTokens, tokenSummary.outputTokens, tokenSummary.totalTokens,
+        tokenSummary.requestCount, '', '', '',
+      ]);
+
+      for (const r of tokensByModel) {
+        rows.push([
+          'tokens_model', r.provider, r.model,
+          r.inputTokens, r.outputTokens, r.totalTokens, r.requestCount, '', '', '',
+        ]);
+      }
+
+      for (const r of tokensByPeriod) {
+        rows.push([
+          'tokens_period', typeof r.period === 'string' ? r.period : String(r.period), '',
+          r.inputTokens, r.outputTokens, r.totalTokens, r.requestCount, '', '', '',
+        ]);
+      }
+
+      for (const r of tokensByUser) {
+        rows.push([
+          'tokens_user', r.userEmail ?? r.userName ?? r.userId, '',
+          r.inputTokens, r.outputTokens, r.totalTokens, r.requestCount, '', '', '',
+        ]);
+      }
+
+      for (const r of providerCost) {
+        rows.push([
+          'provider_cost', `${r.provider}/${r.model}`, r.coverage,
+          '', '', '', r.requestCount,
+          centsToDollars(r.realCostCents), centsToDollars(r.chargedCents), '',
+        ]);
+      }
+
+      rows.push(['revenue', 'topup_purchase', String(revenue.topupCount), '', '', '', '', '', '', centsToDollars(revenue.topupCents)]);
+      rows.push(['revenue', 'monthly_grant', String(revenue.monthlyGrantCount), '', '', '', '', '', '', centsToDollars(revenue.monthlyGrantCents)]);
+      for (const r of subscriptionsByTier) {
+        rows.push(['subscriptions', r.tier, String(r.count), '', '', '', '', '', '', '']);
+      }
+
+      rows.push(['liability', 'total', String(liability.userCount), '', '', '', '', '', '', centsToDollars(liability.totalLiabilityCents)]);
+      rows.push(['holds', 'live', String(holds.holdCount), '', '', '', '', '', '', centsToDollars(holds.heldCents)]);
+
+      return new NextResponse(toCsv(rows), {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="ai-billing-${range}.csv"`,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      range,
+      granularity,
+      startDate,
+      endDate,
+      enforcement,
+      tokens: {
+        summary: tokenSummary,
+        byModel: tokensByModel,
+        byPeriod: tokensByPeriod,
+        byUser: tokensByUser,
+      },
+      providerCost,
+      revenue: { ...revenue, subscriptionsByTier },
+      liability,
+      holds,
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching ai-billing data:', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to fetch ai-billing data' },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -150,6 +150,7 @@ vi.mock('@/lib/logging/mask', () => ({ maskIdentifier: vi.fn((id: string) => `**
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({ trackFeature: vi.fn() }));
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
 }));
 vi.mock('@/lib/mcp', () => ({ getMCPBridge: vi.fn() }));
 vi.mock('@/services/api/page-mutation-service', () => ({

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -171,6 +171,7 @@ vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
     trackUsage: vi.fn(),
     trackToolUsage: vi.fn(),
   },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
 }));
 
 vi.mock('@/lib/mcp', () => ({

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -170,6 +170,7 @@ vi.mock('ai', () => ({
     return {
       toUIMessageStream: () => (async function* () {})(),
       totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+      steps: Promise.resolve([]),
     };
   }),
   convertToModelMessages: vi.fn().mockReturnValue([]),
@@ -203,6 +204,7 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({ trackFeature: vi.
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
 }));
 
 vi.mock('@/lib/mcp', () => ({ getMCPBridge: vi.fn() }));

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -72,7 +72,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { trackFeature } from '@pagespace/lib/monitoring/activity-tracker';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, extractOpenRouterCostDollars, type ProviderMetadataCarrier } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { MCPTool } from '@/types/mcp';
 import { getMCPBridge } from '@/lib/mcp';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
@@ -101,6 +101,7 @@ export async function POST(request: Request) {
   let selectedProvider: string | undefined;
   let selectedModel: string | undefined;
   let usagePromise: Promise<LanguageModelUsage | undefined> | undefined;
+  let stepsPromise: Promise<ProviderMetadataCarrier[] | undefined> | undefined;
   let lifecycle: StreamLifecycleHandle | undefined;
   let activeStreamId: string | undefined;
   let serverAssistantMessageId: string | undefined;
@@ -948,6 +949,12 @@ export async function POST(request: Request) {
               return undefined;
             });
 
+          // Steps carry OpenRouter's per-request cost metadata (one request per
+          // tool-loop step); summed in trackUsage to bill on real cost.
+          stepsPromise = aiResult.steps
+            .then((steps) => steps as ProviderMetadataCarrier[])
+            .catch(() => undefined);
+
           await pipeUIMessageStreamStrippingStart(aiResult, writer);
         },
         onFinish: async ({ responseMessage }) => {
@@ -1025,6 +1032,7 @@ export async function POST(request: Request) {
               const duration = Date.now() - startTime;
 
               const usage = usagePromise ? await usagePromise : undefined;
+              const steps = stepsPromise ? await stepsPromise : undefined;
               const inputTokens = usage?.inputTokens ?? undefined;
               const outputTokens = usage?.outputTokens ?? undefined;
               const totalTokens =
@@ -1039,6 +1047,7 @@ export async function POST(request: Request) {
                 inputTokens,
                 outputTokens,
                 totalTokens,
+                providerCostDollars: extractOpenRouterCostDollars(steps),
                 duration,
                 conversationId, // Use actual conversation ID instead of pageId
                 messageId,
@@ -1132,6 +1141,7 @@ export async function POST(request: Request) {
     });
 
     const usage = usagePromise ? await usagePromise : undefined;
+    const steps = stepsPromise ? await stepsPromise : undefined;
 
     // Track AI usage even for errors using enhanced monitoring
     // Note: conversationId might not be available in error path, use chatId as fallback
@@ -1144,6 +1154,7 @@ export async function POST(request: Request) {
       totalTokens:
         usage?.totalTokens ??
         ((usage?.inputTokens || 0) + (usage?.outputTokens || 0) || undefined),
+      providerCostDollars: extractOpenRouterCostDollars(steps),
       duration: Date.now() - startTime,
       conversationId: conversationId || chatId, // Use conversationId if available, fallback to chatId
       pageId: chatId,

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -36,6 +36,7 @@ const captured = vi.hoisted(() => ({
   createUIMessageStreamOptions: {} as MockUIStreamOptions,
   streamTextOptions: {} as MockStreamTextOptions,
   totalUsage: undefined as unknown,
+  steps: [] as unknown,
 }));
 
 vi.mock('@/lib/ai/core/stream-lifecycle', () => ({
@@ -170,6 +171,7 @@ vi.mock('ai', () => ({
     return {
       toUIMessageStream: () => (async function* () {})(),
       get totalUsage() { return Promise.resolve(captured.totalUsage); },
+      get steps() { return Promise.resolve(captured.steps); },
     };
   }),
   convertToModelMessages: vi.fn().mockReturnValue([]),
@@ -187,6 +189,7 @@ vi.mock('@paralleldrive/cuid2', () => ({ createId: vi.fn().mockReturnValue('test
 vi.mock('@/lib/logging/mask', () => ({ maskIdentifier: vi.fn((id: string) => `***${id.slice(-3)}`) }));
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
 }));
 vi.mock('@pagespace/lib/monitoring/ai-context-calculator', () => ({
   calculateTotalContextSize: vi.fn().mockReturnValue({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -200,6 +200,7 @@ vi.mock('ai', () => ({
     return {
       toUIMessageStream: () => (async function* () {})(),
       totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+      steps: Promise.resolve([]),
     };
   }),
   convertToModelMessages: vi.fn().mockReturnValue([]),
@@ -223,6 +224,7 @@ vi.mock('@/lib/logging/mask', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
 }));
 
 vi.mock('@pagespace/lib/monitoring/ai-context-calculator', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -60,7 +60,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import type { MCPTool } from '@/types/mcp';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, extractOpenRouterCostDollars, type ProviderMetadataCarrier } from '@pagespace/lib/monitoring/ai-monitoring';
 import { calculateTotalContextSize } from '@pagespace/lib/monitoring/ai-context-calculator';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
@@ -894,6 +894,7 @@ MENTION PROCESSING:
     });
 
     let usagePromise: Promise<LanguageModelUsage | undefined> | undefined;
+    let stepsPromise: Promise<ProviderMetadataCarrier[] | undefined> | undefined;
 
     const stream = createUIMessageStream({
       originalMessages: processedMessages,
@@ -941,6 +942,12 @@ MENTION PROCESSING:
             });
             return undefined;
           });
+
+        // Steps carry OpenRouter's per-request cost metadata (one request per
+        // tool-loop step); summed in trackUsage to bill on real cost.
+        stepsPromise = aiResult.steps
+          .then((steps) => steps as ProviderMetadataCarrier[])
+          .catch(() => undefined);
 
         await pipeUIMessageStreamStrippingStart(aiResult, writer);
       },
@@ -992,6 +999,7 @@ MENTION PROCESSING:
             // row, not a skipped one (which would silently front the spend).
             try {
               const usage = usagePromise ? await usagePromise : undefined;
+              const steps = stepsPromise ? await stepsPromise : undefined;
               const duration = Date.now() - startTime;
 
               await AIMonitoring.trackUsage({
@@ -1001,6 +1009,7 @@ MENTION PROCESSING:
                 inputTokens: usage?.inputTokens,
                 outputTokens: usage?.outputTokens,
                 totalTokens: usage?.totalTokens,
+                providerCostDollars: extractOpenRouterCostDollars(steps),
                 duration,
                 conversationId,
                 messageId,

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -35,7 +35,7 @@ import {
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, extractOpenRouterCostDollars } from '@pagespace/lib/monitoring/ai-monitoring';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { PULSE_SYSTEM_PROMPT } from '../pulse-prompt';
 
@@ -789,6 +789,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
     inputTokens: usage?.inputTokens,
     outputTokens: usage?.outputTokens,
     totalTokens: usage ? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)) : undefined,
+    providerCostDollars: extractOpenRouterCostDollars(result.steps),
     success: true,
   });
 

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -36,7 +36,7 @@ import {
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, extractOpenRouterCostDollars } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
@@ -675,6 +675,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
       inputTokens: usage?.inputTokens,
       outputTokens: usage?.outputTokens,
       totalTokens: usage ? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)) : undefined,
+      providerCostDollars: extractOpenRouterCostDollars(result.steps),
       success: true,
       holdId,
     });

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -99,6 +99,7 @@ vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: {
     trackUsage: vi.fn().mockResolvedValue(undefined),
   },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
 }));
 
 vi.mock('@pagespace/lib/billing/credit-gate', () => ({

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -35,7 +35,7 @@ import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference
 import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
 import { getProviderTier } from '@/lib/ai/core/ai-providers-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { AIMonitoring, extractOpenRouterCostDollars } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
@@ -209,7 +209,7 @@ export async function POST(request: Request): Promise<Response> {
       mcpAllowedDriveIds: getAllowedDriveIds(authResult),
     },
     maxRetries: 20,
-    onFinish: async ({ text, totalUsage }) => {
+    onFinish: async ({ text, totalUsage, steps }) => {
       const assistantId = createId();
       await saveMessageToDatabase({
         messageId: assistantId,
@@ -234,6 +234,7 @@ export async function POST(request: Request): Promise<Response> {
         model: providerResult.modelName,
         inputTokens: totalUsage.inputTokens,
         outputTokens: totalUsage.outputTokens,
+        providerCostDollars: extractOpenRouterCostDollars(steps),
         duration: Date.now() - startTime,
         conversationId,
         messageId: assistantId,

--- a/apps/web/src/lib/ai/core/provider-factory.ts
+++ b/apps/web/src/lib/ai/core/provider-factory.ts
@@ -116,7 +116,11 @@ export async function createAIProvider(
         apiKey: managed.apiKey,
         headers: { 'X-OpenRouter-Cache': 'true' },
       });
-      model = openrouter.chat(currentModel);
+      // usage: { include: true } turns on OpenRouter usage accounting so the
+      // response carries the authoritative per-request cost under
+      // providerMetadata.openrouter.usage.cost — the basis we bill on (see
+      // extractOpenRouterCostDollars / trackAIUsage). Without it, cost is undefined.
+      model = openrouter.chat(currentModel, { usage: { include: true } });
     } else if (currentProvider === 'google') {
       const managed = getManagedProviderKey('google');
       if (!managed?.apiKey) return notConfigured('Google AI');

--- a/apps/web/src/lib/monitoring/__tests__/ai-billing-queries.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/ai-billing-queries.test.ts
@@ -190,9 +190,9 @@ describe('getTokenUsageByUser', () => {
 });
 
 describe('getProviderCostRollup', () => {
-  it('labels OpenRouter rows as real coverage and computes margin', async () => {
+  it('labels a row real when its costSource is openrouter and computes margin', async () => {
     resetQueue([
-      { provider: 'openrouter', model: 'anthropic/claude', realCostCents: 100, chargedCents: 150, requestCount: 4 },
+      { provider: 'openrouter', model: 'anthropic/claude', costSource: 'openrouter', realCostCents: 100, chargedCents: 150, requestCount: 4 },
     ]);
     const rows = await getProviderCostRollup();
     expect(rows[0]).toMatchObject({
@@ -203,15 +203,26 @@ describe('getProviderCostRollup', () => {
     });
   });
 
-  it('labels openrouter_free as real and direct providers as estimate', async () => {
+  it('labels coverage from the per-row costSource, NOT the provider name (an OpenRouter call that fell back to the estimate reports estimate)', async () => {
     resetQueue([
-      { provider: 'openrouter_free', model: 'm:free', realCostCents: 0, chargedCents: 0, requestCount: 1 },
-      { provider: 'anthropic', model: 'claude', realCostCents: 100, chargedCents: 150, requestCount: 2 },
-      { provider: null, model: null, realCostCents: 10, chargedCents: 10, requestCount: 1 },
+      { provider: 'openrouter', model: 'anthropic/claude', costSource: 'openrouter', realCostCents: 100, chargedCents: 150, requestCount: 2 },
+      { provider: 'openrouter', model: 'anthropic/claude', costSource: 'estimate', realCostCents: 50, chargedCents: 60, requestCount: 1 },
     ]);
     const rows = await getProviderCostRollup();
     expect(rows[0].coverage).toBe('real');
+    // Same provider/model, but this group billed on the static fallback — honest 'estimate'.
     expect(rows[1].coverage).toBe('estimate');
+  });
+
+  it('falls back to the provider-name heuristic when metadata (costSource) was purged', async () => {
+    resetQueue([
+      { provider: 'openrouter_free', model: 'm:free', costSource: null, realCostCents: 0, chargedCents: 0, requestCount: 1 },
+      { provider: 'anthropic', model: 'claude', costSource: null, realCostCents: 100, chargedCents: 150, requestCount: 2 },
+      { provider: null, model: null, costSource: null, realCostCents: 10, chargedCents: 10, requestCount: 1 },
+    ]);
+    const rows = await getProviderCostRollup();
+    expect(rows[0].coverage).toBe('real'); // openrouter_free → real
+    expect(rows[1].coverage).toBe('estimate'); // direct provider → estimate
     expect(rows[2]).toMatchObject({ provider: 'unknown', coverage: 'estimate' });
   });
 

--- a/apps/web/src/lib/monitoring/__tests__/ai-billing-queries.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/ai-billing-queries.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────────
+// FIFO queue of result sets; each db.select() dequeues the next set in query order.
+const resultQueue = vi.hoisted(() => [] as unknown[][]);
+
+const mockEq = vi.hoisted(() => vi.fn((col: unknown, val: unknown) => ({ type: 'eq', col, val })));
+const mockGte = vi.hoisted(() => vi.fn((col: unknown, val: unknown) => ({ type: 'gte', col, val })));
+const mockLte = vi.hoisted(() => vi.fn((col: unknown, val: unknown) => ({ type: 'lte', col, val })));
+const mockAnd = vi.hoisted(() => vi.fn((...args: unknown[]) => ({ type: 'and', args })));
+const mockDesc = vi.hoisted(() => vi.fn((col: unknown) => col));
+const mockCount = vi.hoisted(() => vi.fn(() => 'COUNT'));
+const mockInArray = vi.hoisted(() => vi.fn((col: unknown, vals: unknown) => ({ type: 'inArray', col, vals })));
+const mockSql = vi.hoisted(() => {
+  const tag = vi.fn(() => 'SQL') as unknown as { (..._a: unknown[]): string; raw: (s: string) => string };
+  tag.raw = vi.fn((s: string) => s) as unknown as (s: string) => string;
+  return tag;
+});
+const mockGetTierFromPrice = vi.hoisted(() => vi.fn());
+
+// Chainable db mock whose terminal resolves to the next queued result set.
+const makeChain = vi.hoisted(() => () => {
+  const rows = resultQueue.length ? resultQueue.shift()! : [];
+  const promise = Promise.resolve(rows);
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.leftJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.groupBy = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => promise);
+  chain.then = (resolve: (v: unknown[]) => void, reject?: (e: unknown) => void) =>
+    promise.then(resolve, reject);
+  return chain;
+});
+
+const mockSelect = vi.hoisted(() => vi.fn(() => makeChain()));
+
+vi.mock('@pagespace/db/db', () => ({ db: { select: mockSelect } }));
+
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  aiUsageLogs: {
+    id: 'AI_USAGE_ID',
+    timestamp: 'AI_USAGE_TIMESTAMP',
+    provider: 'AI_USAGE_PROVIDER',
+    model: 'AI_USAGE_MODEL',
+    cost: 'AI_USAGE_COST',
+    inputTokens: 'AI_USAGE_INPUT_TOKENS',
+    outputTokens: 'AI_USAGE_OUTPUT_TOKENS',
+    totalTokens: 'AI_USAGE_TOTAL_TOKENS',
+    userId: 'AI_USAGE_USER_ID',
+  },
+  systemLogs: {},
+  errorLogs: {},
+  apiMetrics: {},
+  userActivities: {},
+}));
+
+vi.mock('@pagespace/db/schema/credits', () => ({
+  creditLedger: {
+    entryType: 'CREDIT_LEDGER_ENTRY_TYPE',
+    amountCents: 'CREDIT_LEDGER_AMOUNT_CENTS',
+    chargeMillicents: 'CREDIT_LEDGER_CHARGE_MILLICENTS',
+    realCostCents: 'CREDIT_LEDGER_REAL_COST_CENTS',
+    aiUsageLogId: 'CREDIT_LEDGER_AI_USAGE_LOG_ID',
+    createdAt: 'CREDIT_LEDGER_CREATED_AT',
+    userId: 'CREDIT_LEDGER_USER_ID',
+  },
+  creditBalances: {
+    monthlyRemainingCents: 'CB_MONTHLY_REMAINING',
+    topupRemainingCents: 'CB_TOPUP_REMAINING',
+  },
+  creditHolds: {
+    estCents: 'CH_EST_CENTS',
+    expiresAt: 'CH_EXPIRES_AT',
+  },
+}));
+
+vi.mock('@pagespace/db/schema/subscriptions', () => ({
+  subscriptions: {
+    status: 'SUB_STATUS',
+    stripePriceId: 'SUB_PRICE_ID',
+  },
+}));
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'USERS_ID', name: 'USERS_NAME', email: 'USERS_EMAIL' },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: mockSql,
+  eq: mockEq,
+  gte: mockGte,
+  lte: mockLte,
+  and: mockAnd,
+  or: vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+  desc: mockDesc,
+  count: mockCount,
+  inArray: mockInArray,
+}));
+
+vi.mock('@/lib/stripe/price-config', () => ({
+  getTierFromPrice: mockGetTierFromPrice,
+}));
+
+import {
+  getTokenUsageSummary,
+  getTokenUsageByModel,
+  getTokenUsageByPeriod,
+  getTokenUsageByUser,
+  getProviderCostRollup,
+  getCreditRevenue,
+  getActiveSubscriptionsByTier,
+  getCreditLiability,
+  getLiveHolds,
+} from '../monitoring-queries';
+
+function resetQueue(...sets: unknown[][]) {
+  resultQueue.length = 0;
+  resultQueue.push(...sets);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resultQueue.length = 0;
+  mockSelect.mockImplementation(() => makeChain());
+});
+
+describe('getTokenUsageSummary', () => {
+  it('returns the SUM aggregates and request count', async () => {
+    resetQueue([{ inputTokens: 1200, outputTokens: 800, totalTokens: 2000, requestCount: 7 }]);
+    const result = await getTokenUsageSummary();
+    expect(result).toEqual({ inputTokens: 1200, outputTokens: 800, totalTokens: 2000, requestCount: 7 });
+  });
+
+  it('defaults to zeroes on an empty result', async () => {
+    resetQueue([]);
+    const result = await getTokenUsageSummary();
+    expect(result).toEqual({ inputTokens: 0, outputTokens: 0, totalTokens: 0, requestCount: 0 });
+  });
+
+  it('anchors the window on the usage-log timestamp (token usage is a usage-log view)', async () => {
+    resetQueue([]);
+    const start = new Date('2026-01-01');
+    const end = new Date('2026-02-01');
+    await getTokenUsageSummary(start, end);
+    const gteCols = mockGte.mock.calls.map((c) => c[0]);
+    const lteCols = mockLte.mock.calls.map((c) => c[0]);
+    expect(gteCols).toContain('AI_USAGE_TIMESTAMP');
+    expect(lteCols).toContain('AI_USAGE_TIMESTAMP');
+  });
+});
+
+describe('getTokenUsageByModel', () => {
+  it('returns rows and backfills unknown provider/model', async () => {
+    resetQueue([
+      { provider: 'openrouter', model: 'anthropic/claude', inputTokens: 10, outputTokens: 5, totalTokens: 15, requestCount: 1 },
+      { provider: null, model: null, inputTokens: 2, outputTokens: 1, totalTokens: 3, requestCount: 1 },
+    ]);
+    const rows = await getTokenUsageByModel();
+    expect(rows[0]).toMatchObject({ provider: 'openrouter', model: 'anthropic/claude', totalTokens: 15 });
+    expect(rows[1]).toMatchObject({ provider: 'unknown', model: 'unknown' });
+  });
+});
+
+describe('getTokenUsageByPeriod', () => {
+  it('returns period rows', async () => {
+    resetQueue([{ period: '2026-01-02', inputTokens: 4, outputTokens: 6, totalTokens: 10, requestCount: 2 }]);
+    const rows = await getTokenUsageByPeriod(undefined, undefined, 'day');
+    expect(rows[0]).toMatchObject({ period: '2026-01-02', totalTokens: 10 });
+  });
+
+  it('rejects an invalid granularity to prevent SQL injection', async () => {
+    await expect(
+      // @ts-expect-error intentional invalid granularity
+      getTokenUsageByPeriod(undefined, undefined, 'day; DROP TABLE'),
+    ).rejects.toThrow();
+  });
+});
+
+describe('getTokenUsageByUser', () => {
+  it('returns per-user token rows', async () => {
+    resetQueue([
+      { userId: 'u1', userName: 'Alice', userEmail: 'a@x.com', inputTokens: 100, outputTokens: 50, totalTokens: 150, requestCount: 3 },
+    ]);
+    const rows = await getTokenUsageByUser();
+    expect(rows[0]).toMatchObject({ userId: 'u1', totalTokens: 150 });
+  });
+});
+
+describe('getProviderCostRollup', () => {
+  it('labels OpenRouter rows as real coverage and computes margin', async () => {
+    resetQueue([
+      { provider: 'openrouter', model: 'anthropic/claude', realCostCents: 100, chargedCents: 150, requestCount: 4 },
+    ]);
+    const rows = await getProviderCostRollup();
+    expect(rows[0]).toMatchObject({
+      provider: 'openrouter',
+      coverage: 'real',
+      marginCents: 50,
+      marginPct: 50,
+    });
+  });
+
+  it('labels openrouter_free as real and direct providers as estimate', async () => {
+    resetQueue([
+      { provider: 'openrouter_free', model: 'm:free', realCostCents: 0, chargedCents: 0, requestCount: 1 },
+      { provider: 'anthropic', model: 'claude', realCostCents: 100, chargedCents: 150, requestCount: 2 },
+      { provider: null, model: null, realCostCents: 10, chargedCents: 10, requestCount: 1 },
+    ]);
+    const rows = await getProviderCostRollup();
+    expect(rows[0].coverage).toBe('real');
+    expect(rows[1].coverage).toBe('estimate');
+    expect(rows[2]).toMatchObject({ provider: 'unknown', coverage: 'estimate' });
+  });
+
+  it('anchors the window on the ledger createdAt, not the purgeable usage-log timestamp', async () => {
+    resetQueue([]);
+    await getProviderCostRollup(new Date('2026-01-01'), new Date('2026-02-01'));
+    const gteCols = mockGte.mock.calls.map((c) => c[0]);
+    expect(gteCols).toContain('CREDIT_LEDGER_CREATED_AT');
+    expect(gteCols).not.toContain('AI_USAGE_TIMESTAMP');
+  });
+});
+
+describe('getCreditRevenue', () => {
+  it('splits top-up and monthly-grant revenue and totals them', async () => {
+    resetQueue([
+      { entryType: 'topup_purchase', cents: 5000, count: 3 },
+      { entryType: 'monthly_grant', cents: 2000, count: 10 },
+    ]);
+    const result = await getCreditRevenue();
+    expect(result).toEqual({
+      topupCents: 5000,
+      topupCount: 3,
+      monthlyGrantCents: 2000,
+      monthlyGrantCount: 10,
+      totalCents: 7000,
+    });
+  });
+
+  it('filters to the two funding entry types via inArray', async () => {
+    resetQueue([]);
+    await getCreditRevenue();
+    expect(mockInArray).toHaveBeenCalledWith('CREDIT_LEDGER_ENTRY_TYPE', ['topup_purchase', 'monthly_grant']);
+  });
+
+  it('defaults to zero when no funding rows exist', async () => {
+    resetQueue([]);
+    const result = await getCreditRevenue();
+    expect(result).toEqual({ topupCents: 0, topupCount: 0, monthlyGrantCents: 0, monthlyGrantCount: 0, totalCents: 0 });
+  });
+});
+
+describe('getActiveSubscriptionsByTier', () => {
+  it('maps each active subscription price to a tier and counts per tier', async () => {
+    resetQueue([
+      { stripePriceId: 'price_pro' },
+      { stripePriceId: 'price_pro' },
+      { stripePriceId: 'price_business' },
+    ]);
+    mockGetTierFromPrice.mockImplementation((priceId: string) =>
+      priceId === 'price_business' ? 'business' : 'pro',
+    );
+    const rows = await getActiveSubscriptionsByTier();
+    const byTier = Object.fromEntries(rows.map((r) => [r.tier, r.count]));
+    expect(byTier).toEqual({ free: 0, pro: 2, founder: 0, business: 1 });
+    expect(mockEq).toHaveBeenCalledWith('SUB_STATUS', 'active');
+  });
+});
+
+describe('getCreditLiability', () => {
+  it('sums monthly + top-up remaining into total liability', async () => {
+    resetQueue([{ monthlyRemainingCents: 400, topupRemainingCents: 600, userCount: 12 }]);
+    const result = await getCreditLiability();
+    expect(result).toEqual({
+      monthlyRemainingCents: 400,
+      topupRemainingCents: 600,
+      totalLiabilityCents: 1000,
+      userCount: 12,
+    });
+  });
+
+  it('defaults to zero on an empty balances table', async () => {
+    resetQueue([]);
+    const result = await getCreditLiability();
+    expect(result).toEqual({ monthlyRemainingCents: 0, topupRemainingCents: 0, totalLiabilityCents: 0, userCount: 0 });
+  });
+});
+
+describe('getLiveHolds', () => {
+  it('returns the count and summed estimate of non-expired holds', async () => {
+    resetQueue([{ holdCount: 5, heldCents: 250 }]);
+    const result = await getLiveHolds();
+    expect(result).toEqual({ holdCount: 5, heldCents: 250 });
+  });
+
+  it('defaults to zero when no live holds exist', async () => {
+    resetQueue([]);
+    const result = await getLiveHolds();
+    expect(result).toEqual({ holdCount: 0, heldCents: 0 });
+  });
+});

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -953,20 +953,27 @@ export async function getTokenUsageByUser(
 }
 
 /**
- * What we pay providers, grouped by provider/model, from the real cost now
- * flowing into the ledger. `coverage` is honest about the basis: OpenRouter rows
- * bill on the provider's returned cost ('real'); direct providers fall back to
- * the static estimate ('estimate'). Anchored on the ledger's createdAt; the
- * usage-log join only enriches provider/model.
+ * What we pay providers, grouped by provider/model AND billing basis, from the
+ * real cost now flowing into the ledger. `coverage` is the EXACT per-row basis,
+ * read from `aiUsageLogs.metadata.costSource` that trackAIUsage stamps:
+ * 'openrouter' (real returned cost) → 'real', 'estimate' (static fallback) →
+ * 'estimate'. This is honest even when an OpenRouter call fell back to the
+ * estimate (missing cost metadata) — that row reports 'estimate', not 'real'.
+ * For rows whose usage log was purged (metadata gone) we best-effort fall back
+ * to the provider name. Anchored on the ledger's createdAt; the usage-log join
+ * only enriches provider/model/costSource.
  */
 export async function getProviderCostRollup(
   startDate?: Date,
   endDate?: Date,
 ): Promise<ProviderCostRow[]> {
+  const costSourceExpr = sql<string | null>`${aiUsageLogs.metadata} ->> 'costSource'`;
+
   const rows = await db
     .select({
       provider: aiUsageLogs.provider,
       model: aiUsageLogs.model,
+      costSource: costSourceExpr,
       realCostCents: realCostSum,
       chargedCents: chargedSum,
       requestCount: count(),
@@ -974,14 +981,17 @@ export async function getProviderCostRollup(
     .from(creditLedger)
     .leftJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
     .where(and(...usageConditions(startDate, endDate)))
-    .groupBy(aiUsageLogs.provider, aiUsageLogs.model)
+    .groupBy(aiUsageLogs.provider, aiUsageLogs.model, costSourceExpr)
     .orderBy(desc(realCostSum))
     .limit(50);
 
   return rows.map((r) => {
     const provider = r.provider ?? 'unknown';
-    const coverage: CostCoverage =
-      provider === 'openrouter' || provider === 'openrouter_free' ? 'real' : 'estimate';
+    let coverage: CostCoverage;
+    if (r.costSource === 'openrouter') coverage = 'real';
+    else if (r.costSource === 'estimate') coverage = 'estimate';
+    // metadata purged: fall back to the provider-name heuristic.
+    else coverage = provider === 'openrouter' || provider === 'openrouter_free' ? 'real' : 'estimate';
     return {
       provider,
       model: r.model ?? 'unknown',

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -3,11 +3,14 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { sql, eq, and, or, gte, lte, desc, count } from '@pagespace/db/operators'
+import { sql, eq, and, or, gte, lte, desc, count, inArray } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { apiMetrics, userActivities, aiUsageLogs, systemLogs, errorLogs } from '@pagespace/db/schema/monitoring';
-import { creditLedger } from '@pagespace/db/schema/credits';
+import { creditLedger, creditBalances, creditHolds } from '@pagespace/db/schema/credits';
+import { subscriptions } from '@pagespace/db/schema/subscriptions';
 import type { SQL } from '@pagespace/db/operators';
+import { getTierFromPrice } from '@/lib/stripe/price-config';
+import type { SubscriptionTier } from '@/lib/subscription/plans';
 
 /**
  * Get system health overview
@@ -755,6 +758,347 @@ export function getDateRange(range: '24h' | '7d' | '30d' | 'all') {
     default:
       startDate = undefined;
   }
-  
+
   return { startDate, endDate: now };
+}
+
+// ---------------------------------------------------------------------------
+// AI-billing admin panel queries
+//
+// A dedicated operational view (separate from unit-economics' margin focus):
+// raw token volume, provider cost coverage (real vs estimated), Stripe revenue,
+// and point-in-time credit liability + live holds. Reuses the same precise
+// sub-cent summing and createdAt anchoring as the margin queries above.
+// ---------------------------------------------------------------------------
+
+export interface TokenUsageTotals {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  requestCount: number;
+}
+
+export interface TokenUsageByModelRow extends TokenUsageTotals {
+  provider: string;
+  model: string;
+}
+
+export interface TokenUsageByPeriodRow extends TokenUsageTotals {
+  period: string;
+}
+
+export interface TokenUsageByUserRow extends TokenUsageTotals {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+}
+
+export type CostCoverage = 'real' | 'estimate';
+
+export interface ProviderCostRow {
+  provider: string;
+  model: string;
+  coverage: CostCoverage;
+  realCostCents: number;
+  chargedCents: number;
+  marginCents: number;
+  marginPct: number | null;
+  requestCount: number;
+}
+
+export interface CreditRevenue {
+  topupCents: number;
+  topupCount: number;
+  monthlyGrantCents: number;
+  monthlyGrantCount: number;
+  totalCents: number;
+}
+
+export interface SubscriptionsByTierRow {
+  tier: SubscriptionTier;
+  count: number;
+}
+
+export interface CreditLiability {
+  monthlyRemainingCents: number;
+  topupRemainingCents: number;
+  totalLiabilityCents: number;
+  userCount: number;
+}
+
+export interface LiveHolds {
+  holdCount: number;
+  heldCents: number;
+}
+
+// Token sums use double precision (not ::int) so high-volume windows can't
+// overflow int4 (~2.1B); tokens are display-only so float8's 53-bit mantissa is
+// ample. Token usage is inherently a usage-LOG view, so these anchor on
+// aiUsageLogs.timestamp (unlike the ledger-anchored margin queries).
+const inputTokenSum = sql<number>`COALESCE(SUM(${aiUsageLogs.inputTokens}), 0)::double precision`;
+const outputTokenSum = sql<number>`COALESCE(SUM(${aiUsageLogs.outputTokens}), 0)::double precision`;
+const totalTokenSum = sql<number>`COALESCE(SUM(${aiUsageLogs.totalTokens}), 0)::double precision`;
+
+function tokenConditions(startDate?: Date, endDate?: Date): SQL[] {
+  const conditions: SQL[] = [];
+  if (startDate) conditions.push(gte(aiUsageLogs.timestamp, startDate));
+  if (endDate) conditions.push(lte(aiUsageLogs.timestamp, endDate));
+  return conditions;
+}
+
+function tokenWhere(startDate?: Date, endDate?: Date): SQL | undefined {
+  const conditions = tokenConditions(startDate, endDate);
+  return conditions.length > 0 ? and(...conditions) : undefined;
+}
+
+/** SUM of input/output/total tokens and request count across the window. */
+export async function getTokenUsageSummary(
+  startDate?: Date,
+  endDate?: Date,
+): Promise<TokenUsageTotals> {
+  const rows = await db
+    .select({
+      inputTokens: inputTokenSum,
+      outputTokens: outputTokenSum,
+      totalTokens: totalTokenSum,
+      requestCount: count(),
+    })
+    .from(aiUsageLogs)
+    .where(tokenWhere(startDate, endDate));
+
+  return {
+    inputTokens: rows[0]?.inputTokens ?? 0,
+    outputTokens: rows[0]?.outputTokens ?? 0,
+    totalTokens: rows[0]?.totalTokens ?? 0,
+    requestCount: rows[0]?.requestCount ?? 0,
+  };
+}
+
+/** Token volume grouped by provider/model, busiest first. */
+export async function getTokenUsageByModel(
+  startDate?: Date,
+  endDate?: Date,
+  limit = 50,
+): Promise<TokenUsageByModelRow[]> {
+  const rows = await db
+    .select({
+      provider: aiUsageLogs.provider,
+      model: aiUsageLogs.model,
+      inputTokens: inputTokenSum,
+      outputTokens: outputTokenSum,
+      totalTokens: totalTokenSum,
+      requestCount: count(),
+    })
+    .from(aiUsageLogs)
+    .where(tokenWhere(startDate, endDate))
+    .groupBy(aiUsageLogs.provider, aiUsageLogs.model)
+    .orderBy(desc(totalTokenSum))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    ...r,
+    provider: r.provider ?? 'unknown',
+    model: r.model ?? 'unknown',
+  }));
+}
+
+/** Token volume per day/month over the window. */
+export async function getTokenUsageByPeriod(
+  startDate?: Date,
+  endDate?: Date,
+  granularity: Granularity = 'day',
+): Promise<TokenUsageByPeriodRow[]> {
+  if (granularity !== 'day' && granularity !== 'month') {
+    throw new Error(`Invalid granularity: ${granularity}`);
+  }
+  const periodExpr = sql<string>`DATE_TRUNC(${granularity}, ${aiUsageLogs.timestamp})`;
+
+  return db
+    .select({
+      period: periodExpr,
+      inputTokens: inputTokenSum,
+      outputTokens: outputTokenSum,
+      totalTokens: totalTokenSum,
+      requestCount: count(),
+    })
+    .from(aiUsageLogs)
+    .where(tokenWhere(startDate, endDate))
+    .groupBy(periodExpr)
+    .orderBy(desc(periodExpr))
+    .limit(366);
+}
+
+/** Token volume per user, heaviest first. */
+export async function getTokenUsageByUser(
+  startDate?: Date,
+  endDate?: Date,
+  limit = 10,
+): Promise<TokenUsageByUserRow[]> {
+  return db
+    .select({
+      userId: aiUsageLogs.userId,
+      userName: users.name,
+      userEmail: users.email,
+      inputTokens: inputTokenSum,
+      outputTokens: outputTokenSum,
+      totalTokens: totalTokenSum,
+      requestCount: count(),
+    })
+    .from(aiUsageLogs)
+    .innerJoin(users, eq(aiUsageLogs.userId, users.id))
+    .where(tokenWhere(startDate, endDate))
+    .groupBy(aiUsageLogs.userId, users.name, users.email)
+    .orderBy(desc(totalTokenSum))
+    .limit(limit);
+}
+
+/**
+ * What we pay providers, grouped by provider/model, from the real cost now
+ * flowing into the ledger. `coverage` is honest about the basis: OpenRouter rows
+ * bill on the provider's returned cost ('real'); direct providers fall back to
+ * the static estimate ('estimate'). Anchored on the ledger's createdAt; the
+ * usage-log join only enriches provider/model.
+ */
+export async function getProviderCostRollup(
+  startDate?: Date,
+  endDate?: Date,
+): Promise<ProviderCostRow[]> {
+  const rows = await db
+    .select({
+      provider: aiUsageLogs.provider,
+      model: aiUsageLogs.model,
+      realCostCents: realCostSum,
+      chargedCents: chargedSum,
+      requestCount: count(),
+    })
+    .from(creditLedger)
+    .leftJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
+    .where(and(...usageConditions(startDate, endDate)))
+    .groupBy(aiUsageLogs.provider, aiUsageLogs.model)
+    .orderBy(desc(realCostSum))
+    .limit(50);
+
+  return rows.map((r) => {
+    const provider = r.provider ?? 'unknown';
+    const coverage: CostCoverage =
+      provider === 'openrouter' || provider === 'openrouter_free' ? 'real' : 'estimate';
+    return {
+      provider,
+      model: r.model ?? 'unknown',
+      coverage,
+      realCostCents: r.realCostCents,
+      chargedCents: r.chargedCents,
+      marginCents: r.chargedCents - r.realCostCents,
+      marginPct: computeMarginPct(r.realCostCents, r.chargedCents),
+      requestCount: r.requestCount,
+    };
+  });
+}
+
+/**
+ * Stripe-sourced credit revenue over the window: top-up purchases and monthly
+ * grants. Both carry the positive credit value in `amountCents`; summed from the
+ * ledger anchored on createdAt.
+ */
+export async function getCreditRevenue(
+  startDate?: Date,
+  endDate?: Date,
+): Promise<CreditRevenue> {
+  const conditions: SQL[] = [inArray(creditLedger.entryType, ['topup_purchase', 'monthly_grant'])];
+  if (startDate) conditions.push(gte(creditLedger.createdAt, startDate));
+  if (endDate) conditions.push(lte(creditLedger.createdAt, endDate));
+
+  const rows = await db
+    .select({
+      entryType: creditLedger.entryType,
+      cents: sql<number>`COALESCE(SUM(${creditLedger.amountCents}), 0)::double precision`,
+      count: count(),
+    })
+    .from(creditLedger)
+    .where(and(...conditions))
+    .groupBy(creditLedger.entryType);
+
+  let topupCents = 0;
+  let topupCount = 0;
+  let monthlyGrantCents = 0;
+  let monthlyGrantCount = 0;
+  for (const r of rows) {
+    if (r.entryType === 'topup_purchase') {
+      topupCents = r.cents;
+      topupCount = r.count;
+    } else if (r.entryType === 'monthly_grant') {
+      monthlyGrantCents = r.cents;
+      monthlyGrantCount = r.count;
+    }
+  }
+
+  return {
+    topupCents,
+    topupCount,
+    monthlyGrantCents,
+    monthlyGrantCount,
+    totalCents: topupCents + monthlyGrantCents,
+  };
+}
+
+/**
+ * Active subscriptions counted by tier. Tier is derived from the Stripe price id
+ * via the authoritative price→tier map (the subscriptions table stores only the
+ * price id), aggregated in JS.
+ */
+export async function getActiveSubscriptionsByTier(): Promise<SubscriptionsByTierRow[]> {
+  const rows = await db
+    .select({ stripePriceId: subscriptions.stripePriceId })
+    .from(subscriptions)
+    .where(eq(subscriptions.status, 'active'));
+
+  const counts: Record<SubscriptionTier, number> = { free: 0, pro: 0, founder: 0, business: 0 };
+  for (const r of rows) {
+    counts[getTierFromPrice(r.stripePriceId)] += 1;
+  }
+
+  return (Object.keys(counts) as SubscriptionTier[]).map((tier) => ({ tier, count: counts[tier] }));
+}
+
+/**
+ * Outstanding prepaid liability: the sum of every user's spendable balance
+ * (monthly + top-up remaining) — credit value we owe service against.
+ * Point-in-time, not windowed.
+ */
+export async function getCreditLiability(): Promise<CreditLiability> {
+  const rows = await db
+    .select({
+      monthlyRemainingCents: sql<number>`COALESCE(SUM(${creditBalances.monthlyRemainingCents}), 0)::double precision`,
+      topupRemainingCents: sql<number>`COALESCE(SUM(${creditBalances.topupRemainingCents}), 0)::double precision`,
+      userCount: count(),
+    })
+    .from(creditBalances);
+
+  const monthlyRemainingCents = rows[0]?.monthlyRemainingCents ?? 0;
+  const topupRemainingCents = rows[0]?.topupRemainingCents ?? 0;
+  return {
+    monthlyRemainingCents,
+    topupRemainingCents,
+    totalLiabilityCents: monthlyRemainingCents + topupRemainingCents,
+    userCount: rows[0]?.userCount ?? 0,
+  };
+}
+
+/**
+ * Live in-flight credit holds (reservations placed by the gate not yet settled
+ * or expired). NOW()-relative so it matches what the gate actually subtracts.
+ */
+export async function getLiveHolds(): Promise<LiveHolds> {
+  const rows = await db
+    .select({
+      holdCount: count(),
+      heldCents: sql<number>`COALESCE(SUM(${creditHolds.estCents}), 0)::double precision`,
+    })
+    .from(creditHolds)
+    .where(sql`${creditHolds.expiresAt} > NOW()`);
+
+  return {
+    holdCount: rows[0]?.holdCount ?? 0,
+    heldCents: rows[0]?.heldCents ?? 0,
+  };
 }

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -528,7 +528,19 @@ export function computeMarginPct(realCostCents: number, chargedCents: number): n
 // $0 and report a bogus margin — so we SUM the precise fields and round ONCE at
 // the end. `appliedCents` is exempt: it is the whole-cent amount actually debited
 // (the sub-cent remainder is banked in pendingMillicents), so its sum is exact.
-const realCostSum = sql<number>`ROUND(COALESCE(SUM(${aiUsageLogs.cost}::numeric), 0) * 100)::int`;
+//
+// PURGE FALLBACK: `aiUsageLogs` is reaped on retention while its ledger row
+// survives. For those rows `aiUsageLogs.cost` is NULL, so we fall back per-row to
+// the ledger's preserved `realCostCents` audit value (already whole-cent). Without
+// this, an `?range=all` window would silently count purged traffic as $0 real cost
+// and overstate margin. `SUM(cost)*100 === SUM(cost*100)`, so live rows are
+// unchanged; only purged rows newly contribute their retained cost.
+const realCostSum = sql<number>`ROUND(COALESCE(SUM(
+  CASE
+    WHEN ${aiUsageLogs.cost} IS NOT NULL THEN ${aiUsageLogs.cost}::numeric * 100
+    ELSE ${creditLedger.realCostCents}
+  END
+), 0))::int`;
 const chargedSum = sql<number>`ROUND(COALESCE(SUM(COALESCE(${creditLedger.chargeMillicents}, ABS(${creditLedger.amountCents}) * 1000)), 0) / 1000.0)::int`;
 const appliedSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.appliedCents})), 0)::int`;
 // Debt comes from 'adjustment' rows, which carry only the whole-cent shortfall in

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -75,6 +75,7 @@ import {
   AI_PRICING,
   MODEL_CONTEXT_WINDOWS,
   AIMonitoring,
+  extractOpenRouterCostDollars,
 } from '../ai-monitoring';
 
 // ---------------------------------------------------------------------------
@@ -417,6 +418,169 @@ describe('trackAIUsage', () => {
     // Token counts must still be present
     expect(callArg.inputTokens).toBe(1000);
     expect(callArg.outputTokens).toBe(500);
+  });
+
+  // ── Real provider cost (OpenRouter) vs static estimate ──────────────────────
+
+  it('bills the real provider cost when providerCostDollars is present (preferred over the static estimate)', async () => {
+    mockWriteAiUsage.mockResolvedValueOnce('aul_real');
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openrouter',
+      model: 'anthropic/claude-3.5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 500,
+      providerCostDollars: 0.0123,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Both the usage log and the charge bill on the real cost, not calculateCost().
+    expect(mockWriteAiUsage).toHaveBeenCalledWith(expect.objectContaining({ cost: 0.0123 }));
+    const arg = mockConsumeCredits.mock.calls[0][0] as { costDollars: number };
+    expect(arg.costDollars).toBe(0.0123);
+  });
+
+  it('stamps costSource=openrouter on the usage log when real cost is used', async () => {
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openrouter',
+      model: 'anthropic/claude-3.5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 500,
+      providerCostDollars: 0.02,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockWriteAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: expect.objectContaining({ costSource: 'openrouter' }) }),
+    );
+  });
+
+  it('falls back to the static estimate and stamps costSource=estimate when providerCostDollars is absent', async () => {
+    mockWriteAiUsage.mockResolvedValueOnce('aul_est');
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const expected = calculateCost('claude-3-5-sonnet-20241022', 1_000_000, 0);
+    expect(mockWriteAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ cost: expected, metadata: expect.objectContaining({ costSource: 'estimate' }) }),
+    );
+    const arg = mockConsumeCredits.mock.calls[0][0] as { costDollars: number };
+    expect(arg.costDollars).toBe(expected);
+  });
+
+  it('accepts a real cost of exactly 0 (cached/free OpenRouter call) instead of falling back', async () => {
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openrouter',
+      model: 'anthropic/claude-3.5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 500,
+      providerCostDollars: 0,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockWriteAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ cost: 0, metadata: expect.objectContaining({ costSource: 'openrouter' }) }),
+    );
+  });
+
+  it('ignores a non-finite or negative providerCostDollars and falls back to the estimate', async () => {
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openrouter',
+      model: 'anthropic/claude-3.5-sonnet',
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      providerCostDollars: -5,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const expected = calculateCost('anthropic/claude-3.5-sonnet', 1_000_000, 0);
+    expect(mockWriteAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ cost: expected, metadata: expect.objectContaining({ costSource: 'estimate' }) }),
+    );
+  });
+
+  it('logs a coverage-gap debug when an OpenRouter call is missing cost metadata', async () => {
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openrouter_free',
+      model: 'some/model:free',
+      inputTokens: 10,
+      outputTokens: 10,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockAiLogger.debug).toHaveBeenCalledWith(
+      'openrouter cost metadata missing; falling back to estimate',
+      expect.objectContaining({ provider: 'openrouter_free' }),
+    );
+  });
+
+  it('does NOT log a coverage gap for a direct provider (estimate is expected there)', async () => {
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 10,
+      outputTokens: 10,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockAiLogger.debug).not.toHaveBeenCalledWith(
+      'openrouter cost metadata missing; falling back to estimate',
+      expect.anything(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractOpenRouterCostDollars
+// ---------------------------------------------------------------------------
+describe('extractOpenRouterCostDollars', () => {
+  function step(cost?: number, upstreamInferenceCost?: number) {
+    const usage: Record<string, unknown> = {};
+    if (cost !== undefined) usage.cost = cost;
+    if (upstreamInferenceCost !== undefined) usage.costDetails = { upstreamInferenceCost };
+    return { providerMetadata: { openrouter: { usage } } };
+  }
+
+  it('returns the single-step OpenRouter cost', () => {
+    expect(extractOpenRouterCostDollars([step(0.0042)])).toBe(0.0042);
+  });
+
+  it('sums cost across multiple tool-loop steps', () => {
+    expect(extractOpenRouterCostDollars([step(0.001), step(0.002), step(0.003)])).toBeCloseTo(0.006, 10);
+  });
+
+  it('adds BYOK upstream inference cost to the OpenRouter fee', () => {
+    expect(extractOpenRouterCostDollars([step(0.0001, 0.005)])).toBeCloseTo(0.0051, 10);
+  });
+
+  it('treats a zeroed (cached) cost as a real 0, not a missing value', () => {
+    expect(extractOpenRouterCostDollars([step(0)])).toBe(0);
+  });
+
+  it('returns undefined when no step carries OpenRouter metadata (caller falls back)', () => {
+    expect(extractOpenRouterCostDollars([{ providerMetadata: { anthropic: {} } }])).toBeUndefined();
+    expect(extractOpenRouterCostDollars([{ providerMetadata: undefined }])).toBeUndefined();
+    expect(extractOpenRouterCostDollars([{}])).toBeUndefined();
+  });
+
+  it('returns undefined for an empty or undefined steps array', () => {
+    expect(extractOpenRouterCostDollars([])).toBeUndefined();
+    expect(extractOpenRouterCostDollars(undefined)).toBeUndefined();
+  });
+
+  it('ignores malformed (non-numeric / NaN) cost fields', () => {
+    const bad = { providerMetadata: { openrouter: { usage: { cost: 'free' } } } } as unknown as { providerMetadata?: Record<string, unknown> };
+    expect(extractOpenRouterCostDollars([bad])).toBeUndefined();
+    const nan = { providerMetadata: { openrouter: { usage: { cost: Number.NaN } } } };
+    expect(extractOpenRouterCostDollars([nan])).toBeUndefined();
+  });
+
+  it('counts only the steps that carry cost when some are missing', () => {
+    expect(extractOpenRouterCostDollars([step(0.01), { providerMetadata: undefined }, step(0.02)])).toBeCloseTo(0.03, 10);
   });
 });
 

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -603,6 +603,67 @@ export function calculateCost(
 }
 
 /**
+ * A minimal view of an AI-SDK step carrying provider metadata. `streamText`'s
+ * onFinish event and `generateText` results both expose a `steps` array whose
+ * entries match this shape; we only read `providerMetadata`.
+ */
+export interface ProviderMetadataCarrier {
+  providerMetadata?: Record<string, unknown> | undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Extract OpenRouter's authoritative request cost (USD) from AI-SDK steps.
+ *
+ * OpenRouter returns the real per-request cost under
+ * `providerMetadata.openrouter.usage.cost` once usage accounting is enabled
+ * (see provider-factory `openrouter.chat(model, { usage: { include: true } })`).
+ * For BYOK passthrough the upstream provider's charge is reported separately in
+ * `usage.costDetails.upstreamInferenceCost`, so we add both to get total real cost.
+ *
+ * Tool loops (`stepCountIs(n)`) issue one OpenRouter request PER step, each with
+ * its own cost, so we sum across every step — mirroring how routes sum tokens via
+ * `totalUsage`. The AI-SDK types `providerMetadata` as opaque JSON, so every field
+ * is read defensively.
+ *
+ * Returns `undefined` when no step carries OpenRouter cost metadata, signalling the
+ * caller to fall back to the static `calculateCost()` estimate.
+ */
+export function extractOpenRouterCostDollars(
+  steps: ReadonlyArray<ProviderMetadataCarrier> | undefined,
+): number | undefined {
+  if (!steps || steps.length === 0) return undefined;
+
+  let total = 0;
+  let found = false;
+
+  for (const step of steps) {
+    const openrouter = asRecord(asRecord(step?.providerMetadata)?.openrouter);
+    const usage = asRecord(openrouter?.usage);
+    if (!usage) continue;
+
+    const cost = asFiniteNumber(usage.cost);
+    const upstream = asFiniteNumber(asRecord(usage.costDetails)?.upstreamInferenceCost);
+
+    if (cost === undefined && upstream === undefined) continue;
+
+    found = true;
+    total += (cost ?? 0) + (upstream ?? 0);
+  }
+
+  return found ? total : undefined;
+}
+
+/**
  * Estimate tokens from text (rough approximation)
  * Generally 1 token ≈ 4 characters for English text
  */
@@ -630,6 +691,13 @@ export interface AIUsageData {
   success?: boolean;
   error?: string;
   metadata?: Record<string, unknown>;
+
+  // Authoritative provider cost (USD) for this call, captured from OpenRouter's
+  // returned usage accounting (providerMetadata.openrouter.usage.cost, summed
+  // across tool-loop steps). When finite & >= 0 this is billed instead of the
+  // static AI_PRICING estimate. Absent for direct providers (google/anthropic/
+  // openai/ollama) that don't return a cost — those fall back to calculateCost().
+  providerCostDollars?: number;
 
   // The reservation placed by the credit gate (canConsumeAI) at the top of the
   // request, released when this call's real cost is billed. Threaded from the
@@ -659,8 +727,25 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
       totalTokens = (inputTokens || 0) + (outputTokens || 0);
     }
     
-    // Calculate cost
-    const cost = calculateCost(data.model, inputTokens, outputTokens);
+    // Bill on OpenRouter's authoritative returned cost when present; otherwise
+    // fall back to the static AI_PRICING estimate (direct providers, or an
+    // OpenRouter call whose metadata went missing). Never drop the charge.
+    const fallbackCost = calculateCost(data.model, inputTokens, outputTokens);
+    const hasRealCost =
+      typeof data.providerCostDollars === 'number' &&
+      Number.isFinite(data.providerCostDollars) &&
+      data.providerCostDollars >= 0;
+    const cost = hasRealCost ? (data.providerCostDollars as number) : fallbackCost;
+    const costSource = hasRealCost ? 'openrouter' : 'estimate';
+    const isOpenRouter = data.provider === 'openrouter' || data.provider === 'openrouter_free';
+    if (!hasRealCost && isOpenRouter) {
+      // An OpenRouter call that should have carried cost metadata didn't — log
+      // and fall back so we still bill (durability), but flag the coverage gap.
+      loggers.ai.debug('openrouter cost metadata missing; falling back to estimate', {
+        model: data.model,
+        provider: data.provider,
+      });
+    }
     const success = data.success !== false;
 
     // Persist the usage log, then debit the user's prepaid credit balance
@@ -705,6 +790,10 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
         metadata: {
           ...data.metadata,
           streamingDuration: data.streamingDuration,
+          // Provenance of the billed `cost`: 'openrouter' = real returned cost,
+          // 'estimate' = static AI_PRICING fallback. Lets the admin panel be
+          // honest about real vs estimated coverage.
+          costSource,
         },
       });
       // Bill when real tokens were consumed, regardless of success. A token-less


### PR DESCRIPTION
## Why

Follow-up to the prepaid AI-credits system (#1484, in `master`). We evaluated replacing it with Stripe metered/token billing and **decided against it** — Stripe credits apply at *invoice finalization* (post-paid), so to "never front AI cost" we must keep our real-time balance + holds + pre-call gate, which is exactly what's built. **The architecture is validated; the one real defect is the cost basis.**

`trackAIUsage()` billed on a *static* `AI_PRICING` table (`calculateCost`) instead of OpenRouter's authoritative returned cost, so every `realCostCents` ledger row and margin number drifted from our actual invoice. This PR fixes the cost basis and adds an admin panel to watch real numbers before flipping `CREDITS_ENFORCEMENT_ENABLED` on. **Non-blocking — enforcement stays OFF (dark-launch).**

## Deliverable 1 — Real OpenRouter cost capture

- **Enable usage accounting** on the OpenRouter provider (`provider-factory.ts`: `openrouter.chat(model, { usage: { include: true } })`) so `providerMetadata.openrouter.usage.cost` (USD) is actually returned. *(Verified against installed `ai@5.0.190` + `@openrouter/ai-sdk-provider@1.5.4`: `cost` is only populated when accounting is on.)*
- **`extractOpenRouterCostDollars(steps)`** — sums per-step `cost` (one OpenRouter request per `stepCountIs` tool-loop step) plus BYOK `costDetails.upstreamInferenceCost`. Reads the opaque `providerMetadata` defensively (no `any`).
- **`AIUsageData.providerCostDollars`** — `trackAIUsage()` prefers it when finite & ≥ 0 for **both** the usage log (`aiUsageLogs.cost`, the source for existing margin queries) and `consumeCredits`; falls back to `calculateCost()` for direct providers. Stamps `metadata.costSource` (`openrouter` | `estimate`); logs a coverage gap when an OpenRouter call is missing metadata. **Never drops the charge** (preserves the errored-but-real-spend durability guarantee).
- Threaded through all five entry points: `v1/chat/completions`, `ai/chat`, `ai/global/[id]/messages`, `pulse/cron`, `pulse/generate`.

## Deliverable 2 — `/admin/ai-billing` panel

Mirrors the existing `/admin/unit-economics` pattern exactly (sub-cent summing, `createdAt` anchoring, CSV-injection sanitization, `withAdminAuth`).

- **Queries** (`monitoring-queries.ts`): token usage by model/period/user; provider cost rollup (labeled **real vs estimate**); credit revenue (top-ups + monthly grants) and active subscriptions by tier; credit liability; live holds.
- **Route** `api/admin/ai-billing` with `?range`/`?format=csv`; **page** with an enforcement-status banner (reads `CREDITS_ENFORCEMENT_ENABLED` + tier allowances/markup); nav wired in `AdminLayoutClient` + admin index.

## Tests

`extractOpenRouterCostDollars`, real-vs-estimate billing + `costSource`, and all new queries (mocked DB). Updated affected route-test mocks for the new export + `aiResult.steps`.

## Verification

- `bun run --filter web typecheck` + `--filter @pagespace/lib typecheck`: clean.
- `bun run --filter web lint` + `--filter @pagespace/lib lint`: clean.
- `bun run test:unit`: green for all touched areas. (3 unrelated files — `admin-role-version`, message `grouping` cross-midnight, `activity-tools` — fail **identically on the clean base**; pre-existing/environmental, not introduced here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Note for reviewers — `aiUsageLogs.cost` now holds real cost

`trackAIUsage()` writes the billed cost (real OpenRouter cost when available, else the static estimate) to **both** `consumeCredits` **and** `aiUsageLogs.cost`. That column is the source for the existing cost dashboards (`/admin/unit-economics`, `/api/monitoring/ai-usage`, the user-facing `useAiUsage` hook). So going forward those surfaces get **more accurate** numbers; historical rows keep their old estimate (we can't retroactively fetch a provider cost that was never returned), so cost/margin trends shift at the deploy boundary by design. No backfill is possible or attempted. The new `metadata.costSource` (`openrouter` | `estimate`) marks each row's basis, and the AI-billing panel's provider-cost rollup reports it per row.

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive AI Billing admin dashboard displaying token usage metrics, provider costs, credit revenue, subscription tier data, and enforcement status
  * Integrated real provider cost tracking for accurate billing with fallback estimation
  * Added AI Billing navigation link to admin overview panel

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
