### PR TITLE
feat(marketing): use-case landing page prototypes

### DIFF
--- a/prototypes/pagespace-book-writing/index.html
+++ b/prototypes/pagespace-book-writing/index.html
@@ -1,0 +1,588 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PageSpace for Book Writing — research, draft, and revise your manuscript in one workspace</title>
+<meta name="description" content="A writing workspace where AI agents do the work alongside you: research the world, build your story bible, draft chapters in a real editor, and catch continuity slips across 90,000 words — using 33+ real tools, not chatbot copy-paste.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..900;1,9..144,400..700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --bg:#f4ece0;        /* warm parchment */
+    --paper:#fbf6ee;     /* page white */
+    --s1:#fffdf9;
+    --s2:#f0e6d6;
+    --s3:#e8dcc8;
+    --border:#ddcdb4;
+    --border2:#cdb893;
+    --ink:#221c17;       /* warm near-black */
+    --ink2:#4a3f34;
+    --mid:#7a6c5b;
+    --dim:#a4937c;
+    --wine:#8a2f3b;      /* burgundy accent */
+    --wine2:#b4434f;
+    --gold:#b07d24;      /* aged gold */
+    --gold2:#d49a36;
+    --sage:#5f7a4f;      /* "done" green */
+    --teal:#2f6f6a;
+    --serif:"Fraunces",Georgia,serif;
+    --sans:"Inter",system-ui,sans-serif;
+    --mono:"JetBrains Mono",monospace;
+    --maxw:1140px;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--bg);
+    color:var(--ink);
+    font-family:var(--sans);
+    line-height:1.6;
+    -webkit-font-smoothing:antialiased;
+    overflow-x:hidden;
+  }
+  ::selection{background:var(--wine);color:#fff}
+  a{color:inherit;text-decoration:none}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px}
+
+  /* subtle paper grain via layered gradients */
+  body::before{
+    content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;
+    background:
+      radial-gradient(900px 500px at 78% -8%, rgba(176,125,36,.10), transparent 60%),
+      radial-gradient(700px 500px at -5% 12%, rgba(138,47,59,.07), transparent 55%);
+  }
+
+  /* NAV */
+  nav{position:sticky;top:0;z-index:50;background:rgba(244,236,224,.82);
+    backdrop-filter:blur(14px);border-bottom:1px solid var(--border)}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;height:66px}
+  .logo{display:flex;align-items:center;gap:11px;font-family:var(--serif);
+    font-weight:600;font-size:21px;letter-spacing:-.01em}
+  .mark{width:30px;height:30px;border-radius:8px;display:grid;place-items:center;
+    background:linear-gradient(135deg,var(--wine),var(--gold));color:#fff;
+    font-weight:700;font-size:16px;font-family:var(--serif);box-shadow:0 4px 12px rgba(138,47,59,.3)}
+  .nav-links{display:flex;align-items:center;gap:30px;font-size:15px;font-weight:500;color:var(--ink2)}
+  .nav-links a:not(.btn):hover{color:var(--wine)}
+  .btn{display:inline-flex;align-items:center;gap:8px;border-radius:10px;font-weight:600;
+    font-family:var(--sans);cursor:pointer;transition:.18s;border:1px solid transparent;font-size:15px}
+  .btn-primary{background:var(--ink);color:var(--paper);padding:10px 18px}
+  .btn-primary:hover{background:var(--wine);transform:translateY(-1px);box-shadow:0 8px 22px rgba(138,47,59,.28)}
+  .btn-ghost{background:transparent;color:var(--ink);border-color:var(--border2);padding:10px 18px}
+  .btn-ghost:hover{background:var(--s2);border-color:var(--ink2)}
+  .btn-lg{padding:15px 28px;font-size:16.5px;border-radius:12px}
+
+  /* HERO */
+  .hero{padding:84px 0 40px;text-align:center}
+  .eyebrow{display:inline-flex;align-items:center;gap:9px;background:var(--s1);
+    border:1px solid var(--border);color:var(--ink2);padding:7px 15px;border-radius:100px;
+    font-size:13.5px;font-weight:600;letter-spacing:.01em;margin-bottom:30px}
+  .eyebrow .dot{width:7px;height:7px;border-radius:50%;background:var(--gold);
+    box-shadow:0 0 0 4px rgba(176,125,36,.18)}
+  h1{font-family:var(--serif);font-weight:600;font-size:clamp(38px,6.2vw,70px);
+    line-height:1.04;letter-spacing:-.02em;margin-bottom:24px;color:var(--ink)}
+  h1 .grad{font-style:italic;background:linear-gradient(115deg,var(--wine),var(--gold));
+    -webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+  .sub{max-width:680px;margin:0 auto 34px;font-size:clamp(17px,2vw,20px);color:var(--ink2);line-height:1.62}
+  .hero-cta{display:flex;gap:14px;justify-content:center;flex-wrap:wrap}
+  .micro{margin-top:24px;font-size:14px;color:var(--mid);font-weight:500}
+  .micro strong{color:var(--ink)}
+
+  /* MOCK */
+  .mock{max-width:1020px;margin:58px auto 0;background:var(--s1);
+    border:1px solid var(--border);border-radius:16px;overflow:hidden;
+    box-shadow:0 40px 90px -30px rgba(58,42,28,.4),0 8px 26px -12px rgba(58,42,28,.22)}
+  .mock-bar{display:flex;align-items:center;gap:8px;padding:13px 16px;
+    background:var(--s2);border-bottom:1px solid var(--border)}
+  .mock-bar .d{width:11px;height:11px;border-radius:50%;background:var(--border2)}
+  .mock-bar .tab{margin-left:14px;font-family:var(--mono);font-size:12px;color:var(--mid);
+    background:var(--s1);padding:5px 13px;border-radius:7px;border:1px solid var(--border);
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:74%}
+  .mock-body{display:grid;grid-template-columns:198px 1fr 268px;min-height:412px;text-align:left}
+  .mock-side{background:var(--s2);border-right:1px solid var(--border);padding:14px 10px;font-size:13px}
+  .grp{font-size:10.5px;text-transform:uppercase;letter-spacing:.09em;color:var(--dim);
+    font-weight:700;margin:13px 8px 7px}
+  .grp:first-child{margin-top:2px}
+  .tree-item{display:flex;align-items:center;gap:9px;padding:6px 9px;border-radius:7px;
+    color:var(--ink2);cursor:default;font-weight:500}
+  .tree-item .ic{font-size:14px}
+  .tree-item.active{background:var(--s1);color:var(--ink);font-weight:600;
+    box-shadow:inset 2px 0 0 var(--wine)}
+  .tree-item.sub{margin-left:13px;font-size:12.5px;color:var(--mid)}
+
+  .mock-main{padding:22px 24px;background:var(--paper);overflow:hidden}
+  .doc-h{font-family:var(--serif);font-size:23px;font-weight:600;letter-spacing:-.01em;margin-bottom:4px}
+  .doc-meta{font-family:var(--mono);font-size:11px;color:var(--dim);margin-bottom:18px}
+  .doc-p{font-family:var(--serif);font-size:14.5px;line-height:1.75;color:var(--ink2);margin-bottom:11px}
+  .doc-p .drop{float:left;font-size:46px;line-height:.82;padding:4px 8px 0 0;
+    font-weight:600;color:var(--wine);font-family:var(--serif)}
+  .flag{margin-top:6px;background:var(--s1);border:1px solid var(--border);
+    border-left:3px solid var(--gold);border-radius:9px;padding:12px 14px}
+  .flag .lbl{font-family:var(--mono);font-size:10.5px;font-weight:600;color:var(--gold);
+    text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px}
+  .flag p{font-size:13px;color:var(--ink2);line-height:1.55}
+  .flag .hl{background:rgba(138,47,59,.13);color:var(--wine);border-radius:4px;padding:0 4px;font-weight:600}
+
+  .mock-ai{background:var(--s1);border-left:1px solid var(--border);padding:15px 15px;display:flex;flex-direction:column}
+  .ai-h{display:flex;align-items:center;gap:9px;font-size:12.5px;font-weight:700;color:var(--ink);margin-bottom:4px}
+  .ai-av{width:24px;height:24px;border-radius:7px;background:linear-gradient(135deg,var(--wine),var(--gold));
+    display:grid;place-items:center;color:#fff;font-size:13px}
+  .ai-sub{font-size:11px;color:var(--dim);margin-bottom:14px;font-family:var(--mono)}
+  .tool{font-family:var(--mono);font-size:11px;background:var(--paper);border:1px solid var(--border);
+    border-radius:7px;padding:8px 10px;margin-bottom:8px;color:var(--ink2)}
+  .tool .tn{color:var(--wine);font-weight:600}
+  .tool .ok{color:var(--sage);float:right;font-weight:600}
+  .tool .args{color:var(--mid);display:block;margin-top:3px;font-size:10.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .ai-msg{margin-top:auto;font-size:12.5px;color:var(--ink2);background:var(--paper);
+    border:1px solid var(--border);border-radius:10px;padding:11px 12px;line-height:1.5}
+  .ai-msg b{color:var(--ink)}
+  .typing{display:inline-flex;gap:3px;margin-left:3px}
+  .typing span{width:4px;height:4px;border-radius:50%;background:var(--gold);animation:bl 1.2s infinite}
+  .typing span:nth-child(2){animation-delay:.2s}.typing span:nth-child(3){animation-delay:.4s}
+  @keyframes bl{0%,60%,100%{opacity:.25}30%{opacity:1}}
+
+  /* SECTION shell */
+  section{padding:88px 0}
+  .sec-head{text-align:center;max-width:680px;margin:0 auto 54px}
+  .kicker{font-family:var(--mono);font-size:12.5px;font-weight:600;letter-spacing:.12em;
+    text-transform:uppercase;color:var(--wine);margin-bottom:14px}
+  h2{font-family:var(--serif);font-weight:600;font-size:clamp(29px,3.8vw,44px);
+    line-height:1.1;letter-spacing:-.015em;margin-bottom:16px}
+  h2 .it{font-style:italic;color:var(--wine)}
+  .sec-head p{font-size:17.5px;color:var(--ink2)}
+
+  /* PROBLEM */
+  .prob-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
+  .prob{background:var(--s1);border:1px solid var(--border);border-radius:14px;padding:24px 22px}
+  .prob .pe{font-size:26px;margin-bottom:13px;display:block}
+  .prob h3{font-family:var(--serif);font-size:18px;font-weight:600;margin-bottom:8px}
+  .prob p{font-size:14.5px;color:var(--mid);line-height:1.55}
+
+  /* HOW */
+  .steps{display:flex;flex-direction:column;gap:18px;max-width:920px;margin:0 auto}
+  .step{display:grid;grid-template-columns:62px 1fr;gap:24px;background:var(--s1);
+    border:1px solid var(--border);border-radius:16px;padding:26px 28px;align-items:start}
+  .step-n{font-family:var(--serif);font-size:30px;font-weight:600;color:#fff;
+    width:52px;height:52px;border-radius:13px;display:grid;place-items:center;
+    background:linear-gradient(140deg,var(--wine),var(--gold));box-shadow:0 8px 20px -6px rgba(138,47,59,.4)}
+  .step h3{font-family:var(--serif);font-size:21px;font-weight:600;margin-bottom:7px}
+  .step p{color:var(--ink2);font-size:15.5px;margin-bottom:14px;max-width:640px}
+  .tags{display:flex;flex-wrap:wrap;gap:8px}
+  .tag{font-family:var(--mono);font-size:12px;font-weight:500;background:var(--s2);
+    border:1px solid var(--border);color:var(--ink2);padding:5px 11px;border-radius:7px}
+  .tag b{color:var(--wine);font-weight:600}
+
+  /* FEATURES */
+  .feat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+  .feat{background:var(--s1);border:1px solid var(--border);border-radius:14px;padding:26px 24px;transition:.2s}
+  .feat:hover{transform:translateY(-3px);border-color:var(--border2);box-shadow:0 18px 40px -22px rgba(58,42,28,.45)}
+  .feat .fi{width:42px;height:42px;border-radius:11px;display:grid;place-items:center;
+    font-size:20px;background:var(--s2);border:1px solid var(--border);margin-bottom:15px}
+  .feat h3{font-family:var(--serif);font-size:19px;font-weight:600;margin-bottom:9px}
+  .feat p{font-size:14.5px;color:var(--mid);line-height:1.58}
+  .feat p code{font-family:var(--mono);font-size:12.5px;color:var(--wine);background:var(--s2);
+    padding:1px 5px;border-radius:5px}
+
+  /* SPLIT / artifact */
+  .split{display:grid;grid-template-columns:1fr 1fr;gap:54px;align-items:center}
+  .split h2{text-align:left}
+  .check{list-style:none;margin-top:26px;display:flex;flex-direction:column;gap:15px}
+  .check li{display:flex;gap:13px;font-size:15.5px;color:var(--ink2)}
+  .check .ck{flex:none;width:23px;height:23px;border-radius:7px;background:var(--sage);
+    color:#fff;display:grid;place-items:center;font-size:13px;margin-top:1px}
+  .check b{color:var(--ink)}
+
+  /* sheet artifact */
+  .sheet{background:var(--s1);border:1px solid var(--border);border-radius:14px;overflow:hidden;
+    box-shadow:0 28px 60px -28px rgba(58,42,28,.4)}
+  .sheet-h{display:flex;align-items:center;gap:9px;padding:13px 16px;background:var(--s2);
+    border-bottom:1px solid var(--border);font-size:13.5px;font-weight:600}
+  .sheet-h .ic{font-size:15px}
+  .sheet-h .by{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--dim)}
+  table{width:100%;border-collapse:collapse;font-size:12.5px}
+  th{background:var(--s2);text-align:left;padding:9px 13px;font-weight:600;color:var(--mid);
+    font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;border-bottom:1px solid var(--border)}
+  td{padding:10px 13px;border-bottom:1px solid var(--border);color:var(--ink2)}
+  td b{color:var(--ink);font-weight:600}
+  tr:last-child td{border-bottom:none}
+  .pill{font-family:var(--mono);font-size:10.5px;font-weight:600;padding:2px 8px;border-radius:20px}
+  .pill.s{background:rgba(95,122,79,.16);color:var(--sage)}
+  .pill.w{background:rgba(176,125,36,.16);color:var(--gold)}
+  .pill.r{background:rgba(138,47,59,.13);color:var(--wine)}
+  .sheet-foot{padding:9px 14px;font-family:var(--mono);font-size:10.5px;color:var(--dim);
+    background:var(--s2);border-top:1px solid var(--border)}
+
+  /* STATS */
+  .stats{background:var(--ink);border-radius:22px;padding:54px 40px;color:var(--paper)}
+  .stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:30px;text-align:center}
+  .stat .num{font-family:var(--serif);font-size:clamp(38px,5vw,56px);font-weight:600;line-height:1;
+    background:linear-gradient(120deg,var(--gold2),var(--wine2));-webkit-background-clip:text;
+    background-clip:text;-webkit-text-fill-color:transparent}
+  .stat .lbl{margin-top:11px;font-size:14px;color:#d9cdba;font-weight:500}
+
+  /* USE CASES */
+  .uc-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:18px}
+  .uc{background:var(--s1);border:1px solid var(--border);border-radius:14px;padding:25px 26px;
+    display:flex;gap:18px;align-items:flex-start}
+  .uc .ue{font-size:27px;flex:none}
+  .uc h3{font-family:var(--serif);font-size:19px;font-weight:600;margin-bottom:7px}
+  .uc p{font-size:14.5px;color:var(--mid);line-height:1.55}
+
+  /* QUOTE */
+  .quote{max-width:840px;margin:0 auto;text-align:center}
+  .quote blockquote{font-family:var(--serif);font-size:clamp(22px,3.2vw,32px);
+    font-weight:500;line-height:1.36;letter-spacing:-.01em;color:var(--ink)}
+  .quote blockquote .mk{color:var(--wine);font-style:italic}
+  .qby{margin-top:26px;display:flex;align-items:center;gap:13px;justify-content:center}
+  .qav{width:46px;height:46px;border-radius:50%;background:linear-gradient(135deg,var(--wine),var(--gold));
+    display:grid;place-items:center;color:#fff;font-family:var(--serif);font-weight:600;font-size:18px}
+  .qby .qn{text-align:left;font-size:14px}
+  .qby .qn b{display:block;color:var(--ink)}
+  .qby .qn span{color:var(--mid);font-size:13px}
+
+  /* CTA */
+  .cta-panel{background:linear-gradient(140deg,var(--wine),#6d2530 55%,var(--gold));
+    border-radius:24px;padding:64px 40px;text-align:center;color:#fff;position:relative;overflow:hidden}
+  .cta-panel::after{content:"";position:absolute;inset:0;opacity:.5;
+    background:radial-gradient(600px 300px at 80% -20%,rgba(255,255,255,.18),transparent 60%)}
+  .cta-panel>*{position:relative;z-index:1}
+  .cta-panel h2{color:#fff}
+  .cta-panel h2 .it{color:#f6d99a}
+  .cta-panel p{font-size:18px;color:rgba(255,255,255,.9);max-width:560px;margin:14px auto 30px}
+  .cta-panel .btn-primary{background:#fff;color:var(--ink)}
+  .cta-panel .btn-primary:hover{background:#f6ecdb;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+  .cta-panel .btn-ghost{color:#fff;border-color:rgba(255,255,255,.5)}
+  .cta-panel .btn-ghost:hover{background:rgba(255,255,255,.12)}
+  .cta-micro{margin-top:22px;font-size:13.5px;color:rgba(255,255,255,.8)}
+
+  /* FOOTER */
+  footer{border-top:1px solid var(--border);padding:54px 0 40px;margin-top:30px}
+  .foot-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:36px}
+  .foot-brand .logo{margin-bottom:14px}
+  .foot-brand p{font-size:14px;color:var(--mid);max-width:300px;line-height:1.6}
+  .foot-col h4{font-size:12.5px;text-transform:uppercase;letter-spacing:.08em;color:var(--dim);
+    font-weight:700;margin-bottom:14px}
+  .foot-col a{display:block;font-size:14.5px;color:var(--ink2);margin-bottom:10px}
+  .foot-col a:hover{color:var(--wine)}
+  .foot-bot{margin-top:42px;padding-top:22px;border-top:1px solid var(--border);
+    display:flex;justify-content:space-between;flex-wrap:wrap;gap:12px;
+    font-size:13px;color:var(--mid)}
+  .proto{font-family:var(--mono);font-size:12px;color:var(--dim);
+    background:var(--s2);border:1px solid var(--border);padding:4px 11px;border-radius:7px}
+
+  /* reveal */
+  .fade{opacity:0;transform:translateY(26px);transition:.7s cubic-bezier(.2,.7,.2,1)}
+  .fade.in{opacity:1;transform:none}
+
+  @media(max-width:880px){
+    .nav-links a:not(.btn){display:none}
+    .hero{padding:54px 0 20px}
+    section{padding:62px 0}
+    .mock-body{grid-template-columns:1fr}
+    .mock-side{display:none}
+    .mock-ai{border-left:none;border-top:1px solid var(--border)}
+    .prob-grid,.feat-grid,.stats-grid,.uc-grid{grid-template-columns:1fr}
+    .stats-grid{gap:34px}
+    .split{grid-template-columns:1fr;gap:34px}
+    .split h2{text-align:center}
+    .step{grid-template-columns:1fr;gap:14px}
+    .foot-grid{grid-template-columns:1fr 1fr}
+    .foot-brand{grid-column:1/-1}
+  }
+  @media(max-width:520px){
+    .foot-grid{grid-template-columns:1fr}
+    .stats{padding:40px 24px}
+  }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#bible">Story bible</a>
+      <a href="#usecases">Who it's for</a>
+      <a href="#cta" class="btn btn-primary">Start your book free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI-native writing workspace</div>
+    <h1>From blank page to<br>finished manuscript —<br><span class="grad">without losing the thread.</span></h1>
+    <p class="sub">Drop your premise into a drive. PageSpace agents research the world, build your story bible, draft chapters in a real editor beside you, and catch the continuity slip on page 240 — all in one workspace where the AI does the work with you, not in a chat window you copy out of.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Start your book free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">No credit card · <strong>33+ real AI tools</strong> · 100+ models · Self-host or cloud</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / the-salt-road / Ch. 14 — The Tide Turns</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">Manuscript</div>
+          <div class="tree-item"><span class="ic">📖</span> Ch. 12 — Low Water</div>
+          <div class="tree-item"><span class="ic">📖</span> Ch. 13 — The Wreck</div>
+          <div class="tree-item active"><span class="ic">📖</span> Ch. 14 — The Tide Turns</div>
+          <div class="grp">Story bible</div>
+          <div class="tree-item"><span class="ic">👤</span> Characters</div>
+          <div class="tree-item"><span class="ic">🗺️</span> Worldbuilding</div>
+          <div class="tree-item"><span class="ic">🕰️</span> Timeline</div>
+          <div class="grp">Process</div>
+          <div class="tree-item"><span class="ic">🔎</span> Research</div>
+          <div class="tree-item"><span class="ic">✅</span> Revision board</div>
+          <div class="tree-item"><span class="ic">💬</span> Dev editor</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">Ch. 14 — The Tide Turns</div>
+          <div class="doc-meta">document · 2,140 words · last edited 3m ago</div>
+          <p class="doc-p"><span class="drop">M</span>ara had not gone down to the harbour since the morning they pulled her brother's boat in empty. But the bell was ringing now, the cracked one in the chapel tower, and a ringing bell meant a ship on the rocks or a body on the sand.</p>
+          <p class="doc-p">She took the cliff path anyway, the salt wind tearing at the grey shawl her mother had —</p>
+          <div class="flag">
+            <div class="lbl">⚑ continuity · flagged by Dev editor</div>
+            <p>In Ch. 3, Mara's shawl is described as <span class="hl">"the colour of dried heather."</span> Here it's <span class="hl">grey</span>. Same garment? I can fix this line or update the character sheet — your call.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-h"><span class="ai-av">✦</span> Dev editor</div>
+          <div class="ai-sub">AI Chat · briefed agent</div>
+          <div class="tool"><span class="tn">regex_search</span><span class="ok">12 hits</span><span class="args">"shawl|heather" · across Manuscript</span></div>
+          <div class="tool"><span class="tn">read_page</span><span class="ok">✓</span><span class="args">Ch. 3 — The Salt Cellar</span></div>
+          <div class="tool"><span class="tn">edit_sheet_cells</span><span class="ok">✓</span><span class="args">Characters › Mara › "shawl"</span></div>
+          <div class="ai-msg"><b>Logged the discrepancy</b> and pinned the canonical detail in the story bible. Drafting Ch. 14's next beat from the timeline<span class="typing"><span></span><span></span><span></span></span></div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- PROBLEM -->
+<section id="problem">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="kicker">The mid-book wall</div>
+      <h2>A novel is too big to hold in <span class="it">one head.</span></h2>
+      <p>Somewhere around 40,000 words, the project stops fitting in your memory — and the tools fight you.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob fade"><span class="pe">🗂️</span><h3>Twelve scattered places</h3><p>Manuscript in one app, research in tabs, character notes in a notebook, outline on a whiteboard. Nothing knows about anything else.</p></div>
+      <div class="prob fade"><span class="pe">🔁</span><h3>Continuity rot</h3><p>Her eyes were green in chapter two. The journey took three days, then somehow four. You only catch it when a reader does.</p></div>
+      <div class="prob fade"><span class="pe">📋</span><h3>Copy-paste AI</h3><p>The chatbot drafts in its own window. You paste it in, lose the formatting, lose the thread, and it never saw chapter nine.</p></div>
+      <div class="prob fade"><span class="pe">🌫️</span><h3>The sagging middle</h3><p>You know what happens in act one and the ending. The 30,000 words between them are fog — and no outline survives them.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW -->
+<section id="how" style="background:var(--s1);border-block:1px solid var(--border)">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="kicker">How it works</div>
+      <h2>One workspace, the <span class="it">whole arc.</span></h2>
+      <p>Research, bible, draft, revise — every step uses real tools the AI actually runs in your pages.</p>
+    </div>
+    <div class="steps">
+      <div class="step fade">
+        <div class="step-n">1</div>
+        <div>
+          <h3>Research the world before you build it</h3>
+          <p>Ask for the texture you need — 1890s Cornish pilchard fishing, period diction, the inheritance laws that drive your plot. The agent searches the live web, reads the strong sources, and writes a clean research Document you can cite from while drafting.</p>
+          <div class="tags"><span class="tag"><b>web_search</b></span><span class="tag"><b>web_fetch</b></span><span class="tag"><b>create_page</b> · Document</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-n">2</div>
+        <div>
+          <h3>Build a story bible that stays canon</h3>
+          <p>Characters, timeline, and worldbuilding live in Sheets the AI fills and maintains. As you draft, it writes new facts back into the bible — so the source of truth is one place, not your memory.</p>
+          <div class="tags"><span class="tag"><b>edit_sheet_cells</b> · Sheet</span><span class="tag"><b>create_page</b></span><span class="tag"><b>update_drive_context</b></span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-n">3</div>
+        <div>
+          <h3>Draft chapters in a real editor, beside you</h3>
+          <p>Each chapter is a Document in the rich-text editor — not a chat bubble. The agent drafts a scene, you rewrite a line, it makes a precise edit to the paragraph you point at. Real-time, in the actual manuscript.</p>
+          <div class="tags"><span class="tag"><b>create_page</b> · Document</span><span class="tag"><b>replace_lines</b></span><span class="tag"><b>read_page</b></span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-n">4</div>
+        <div>
+          <h3>Revise with an editor agent and a real board</h3>
+          <p>Brief an AI Chat agent as your developmental editor — its own persona, your style notes. It sweeps the manuscript for continuity slips, consults on a sagging scene, and turns its notes into a Task List you can actually work through.</p>
+          <div class="tags"><span class="tag"><b>ask_agent</b></span><span class="tag"><b>regex_search</b></span><span class="tag"><b>create_task</b> · Task List</span><span class="tag"><b>update_agent_config</b></span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="kicker">What's in the workspace</div>
+      <h2>Built from real <span class="it">primitives</span>, not promises.</h2>
+      <p>Nine page types and 33+ tools, mapped onto the work of finishing a book.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade"><div class="fi">📖</div><h3>Chapters as Documents</h3><p>Every chapter is a rich-text Document in the TipTap editor. The AI drafts and edits in place with <code>replace_lines</code> — no copy-paste round trips.</p></div>
+      <div class="feat fade"><div class="fi">👤</div><h3>Character & timeline Sheets</h3><p>Your bible is a set of Sheets the agent maintains with <code>edit_sheet_cells</code>. Eye colour, allegiances, who knows what when — one canonical row each.</p></div>
+      <div class="feat fade"><div class="fi">✦</div><h3>Briefed editor agents</h3><p>An AI Chat page is a configurable agent. Give it a persona and your style with <code>update_agent_config</code>, then consult it with <code>ask_agent</code> — a dev editor that remembers the book.</p></div>
+      <div class="feat fade"><div class="fi">🔎</div><h3>Continuity sweeps</h3><p>Find every mention of a character, place, or motif across the whole manuscript with <code>regex_search</code> and <code>multi_drive_search</code> — catch the slip before a reader does.</p></div>
+      <div class="feat fade"><div class="fi">✅</div><h3>A revision board</h3><p>Turn editorial notes into a Task List with <code>create_task</code> and custom statuses. Track every scene from <em>rough</em> to <em>polished</em> without a separate app.</p></div>
+      <div class="feat fade"><div class="fi">🌐</div><h3>Research that lands in the book</h3><p><code>web_search</code> and <code>web_fetch</code> bring period detail, facts, and comp-title research straight into a Document you draft from — sources and all.</p></div>
+      <div class="feat fade"><div class="fi">💬</div><h3>Co-authors & beta readers</h3><p>Channels and real-time collaboration mean a co-writer or editor works in the same drive — comments and messages, not a thread of emailed .docx files.</p></div>
+      <div class="feat fade"><div class="fi">🧠</div><h3>100+ models, your pick</h3><p>Draft prose on one model, plan structure on another, run a local model for privacy. 100+ models across 6 providers, including Ollama on your own machine.</p></div>
+      <div class="feat fade"><div class="fi">🔒</div><h3>Your manuscript, your infrastructure</h3><p>Cloud, self-hosted, desktop, or mobile. Keep an unpublished novel on your own server in on-prem mode — passwordless auth, no third party in the middle.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- SPLIT / story bible -->
+<section id="bible" style="background:var(--s1);border-block:1px solid var(--border)">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">The artifact</div>
+      <h2>A story bible the AI <span class="it">keeps for you.</span></h2>
+      <p style="color:var(--ink2);font-size:17px;margin-top:6px">It's a Sheet — the AI builds it, fills it, and writes new canon back into it every time you draft a scene. Ask "what colour is Mara's shawl?" and it reads the row, not its imagination.</p>
+      <ul class="check">
+        <li><span class="ck">✓</span><span>One canonical row per character, place, and object — updated with <b>edit_sheet_cells</b> as the story grows.</span></li>
+        <li><span class="ck">✓</span><span>Flags contradictions between a chapter and the bible, then offers to fix the line or the record.</span></li>
+        <li><span class="ck">✓</span><span>The whole drive's context feeds the agents, so every chapter draft stays consistent with canon.</span></li>
+        <li><span class="ck">✓</span><span>Export-ready: it's a real page in your workspace, not a hidden model memory you can't inspect.</span></li>
+      </ul>
+    </div>
+    <div class="fade">
+      <div class="sheet">
+        <div class="sheet-h"><span class="ic">👤</span> Characters — The Salt Road <span class="by">edit_sheet_cells · agent</span></div>
+        <table>
+          <thead><tr><th>Name</th><th>Detail</th><th>Last seen</th><th>Status</th></tr></thead>
+          <tbody>
+            <tr><td><b>Mara Trevenna</b></td><td>Heather-grey shawl; brother lost at sea</td><td>Ch. 14</td><td><span class="pill r">conflict</span></td></tr>
+            <tr><td><b>Old Pengelly</b></td><td>Harbour master; limp, left leg</td><td>Ch. 13</td><td><span class="pill s">canon</span></td></tr>
+            <tr><td><b>The Curate</b></td><td>Name not yet given — pin before Ch. 16</td><td>Ch. 9</td><td><span class="pill w">open</span></td></tr>
+            <tr><td><b>Esther</b></td><td>Knows about the wreck; mother doesn't</td><td>Ch. 11</td><td><span class="pill s">canon</span></td></tr>
+          </tbody>
+        </table>
+        <div class="sheet-foot">4 tracked · 1 conflict flagged · synced from manuscript 3m ago</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats fade">
+      <div class="stats-grid">
+        <div class="stat"><div class="num">9</div><div class="lbl">page types — Document, Sheet, Task List, Channel, AI Chat & more</div></div>
+        <div class="stat"><div class="num">33+</div><div class="lbl">real tools the AI runs inside your pages</div></div>
+        <div class="stat"><div class="num">100+</div><div class="lbl">models across 6 providers, incl. local Ollama</div></div>
+        <div class="stat"><div class="num">∞</div><div class="lbl">cloud, self-host, desktop or mobile — your call</div></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background:var(--s1);border-block:1px solid var(--border)">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="kicker">Who it's for</div>
+      <h2>Long-form, any <span class="it">genre.</span></h2>
+      <p>If it has chapters, characters, or a structure to hold together, the same workspace fits.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><span class="ue">🗡️</span><div><h3>Fantasy & sci-fi worldbuilders</h3><p>Magic systems, maps, and lineages in Sheets the AI keeps consistent across a trilogy. Continuity sweeps catch the rule you broke in book two.</p></div></div>
+      <div class="uc fade"><span class="ue">📚</span><div><h3>Nonfiction & memoir authors</h3><p>Research with <code style="font-family:var(--mono);font-size:12px;color:var(--wine)">web_search</code>, outline in a Document, draft chapters with citations landing straight in the page.</p></div></div>
+      <div class="uc fade"><span class="ue">✍️</span><div><h3>Indie & serial authors</h3><p>A revision Task List across a backlist, a briefed editor agent per series, and self-hosting so the unpublished work stays yours.</p></div></div>
+      <div class="uc fade"><span class="ue">🎬</span><div><h3>Screen & game writers</h3><p>Beat sheets in Sheets, scene status on a board, a writers'-room Channel for the team — structure and collaboration in one drive.</p></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote fade">
+    <blockquote>"It's the first time the research, the outline, and the actual chapters lived in <span class="mk">one place that talks to itself.</span> The editor agent caught a timeline error I'd have shipped."</blockquote>
+    <div class="qby">
+      <div class="qav">R</div>
+      <div class="qn"><b>Rowan Ellis</b><span>novelist · illustrative persona</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta-panel fade">
+      <h2>Your book is waiting in <span class="it">chapter one.</span></h2>
+      <p>Open a drive, drop in your premise, and let the agents start building the world with you. Finish the draft you keep starting.</p>
+      <div class="hero-cta">
+        <a href="#" class="btn btn-primary btn-lg">Start your book free</a>
+        <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+      </div>
+      <p class="cta-micro">Passwordless sign-in · 33+ real tools · self-host or cloud — your manuscript, your infrastructure</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native workspace where humans and AI agents write, research, and revise together — using real tools, in real pages.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Workspace</h4>
+        <a href="#how">How it works</a>
+        <a href="#features">Features</a>
+        <a href="#bible">Story bible</a>
+      </div>
+      <div class="foot-col">
+        <h4>For writers</h4>
+        <a href="#usecases">Fiction</a>
+        <a href="#usecases">Nonfiction</a>
+        <a href="#usecases">Screen & games</a>
+      </div>
+      <div class="foot-col">
+        <h4>Deploy</h4>
+        <a href="#">Cloud</a>
+        <a href="#">Self-hosted</a>
+        <a href="#">Desktop & mobile</a>
+      </div>
+    </div>
+    <div class="foot-bot">
+      <span>© PageSpace — AI-native knowledge & collaboration.</span>
+      <span class="proto">Prototype · book-writing landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io=new IntersectionObserver((es)=>{
+    es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target);}});
+  },{threshold:.12,rootMargin:'0px 0px -40px 0px'});
+  document.querySelectorAll('.fade').forEach((el,i)=>{
+    el.style.transitionDelay=(Math.min(i%4,3)*0.06)+'s';
+    io.observe(el);
+  });
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-churches/index.html
+++ b/prototypes/pagespace-churches/index.html
@@ -1,0 +1,655 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — The AI-Native Workspace for Churches</title>
+<meta name="description" content="Run your whole week of ministry in one place. PageSpace agents research the passage and draft your sermon, build the order of service, fill the volunteer roster, schedule the calendar, and keep your team connected — so you can spend Saturday with your people, not your tabs." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #faf5ec;
+    --s1: #ffffff;
+    --s2: #fbf6ed;
+    --s3: #f3e9d6;
+    --border: #ebdfca;
+    --border2: #ddccac;
+    --gold: #bf8a2c;
+    --clay: #c1683d;
+    --sage: #5b8a6e;
+    --teal: #2c7a6f;
+    --plum: #7c5076;
+    --text: #2c241b;
+    --mid: #6e6253;
+    --dim: #9b8c78;
+    --serif: "Fraunces", Georgia, serif;
+    --sans: "Inter", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(191,138,44,0.24); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(14px);
+    background: rgba(250,245,236,0.82);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 66px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-weight: 600; font-size: 17px; letter-spacing: -0.3px; font-family: var(--serif); }
+  .logo .mark {
+    width: 28px; height: 28px; border-radius: 9px;
+    background: linear-gradient(140deg, var(--gold), var(--clay));
+    display: grid; place-items: center; font-size: 15px; font-weight: 700; color: #fff;
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.4), 0 4px 14px rgba(193,104,61,0.35);
+  }
+  .nav-links { display: flex; align-items: center; gap: 30px; }
+  .nav-links a { font-size: 13.5px; color: var(--mid); transition: color .15s; font-weight: 500; }
+  .nav-links a:hover { color: var(--text); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 13.5px;
+    padding: 10px 18px; border-radius: 10px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--gold), var(--clay));
+    color: #fff; box-shadow: 0 6px 20px rgba(193,104,61,0.32);
+  }
+  .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 28px rgba(193,104,61,0.45); }
+  .btn-ghost { background: var(--s1); color: var(--text); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s2); border-color: var(--gold); }
+  .btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 12px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 104px 0 70px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(680px 400px at 50% -10%, rgba(191,138,44,0.18), transparent 70%),
+      radial-gradient(560px 380px at 84% 12%, rgba(193,104,61,0.14), transparent 70%),
+      radial-gradient(520px 360px at 12% 28%, rgba(91,138,110,0.12), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.4px;
+    color: var(--clay); background: rgba(193,104,61,0.09);
+    border: 1px solid rgba(193,104,61,0.28); padding: 6px 14px; border-radius: 999px;
+    margin-bottom: 28px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--sage); box-shadow: 0 0 8px var(--sage); }
+  h1 {
+    font-family: var(--serif);
+    font-size: clamp(38px, 6.1vw, 66px); font-weight: 600;
+    letter-spacing: -1.4px; line-height: 1.05; margin-bottom: 24px;
+  }
+  h1 .grad {
+    background: linear-gradient(110deg, var(--gold) 8%, var(--clay) 60%, var(--plum) 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 668px; margin: 0 auto 38px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 22px; }
+  .micro { font-size: 12.5px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 64px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 110px -34px rgba(120,80,40,0.42), 0 0 0 1px rgba(255,255,255,0.5);
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--s2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#e8896f; } .mock-bar .d:nth-child(2){ background:#e9bd5c; } .mock-bar .d:nth-child(3){ background:#7fb98c; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 196px 1fr 234px; min-height: 432px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: var(--s2); }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; font-weight: 600; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 7px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(191,138,44,0.14); color: var(--text); font-weight: 500; }
+  .tree-item .ic { font-size: 13px; }
+  .mock-main { padding: 24px 26px; border-right: 1px solid var(--border); background: var(--s1); }
+  .doc-h { font-family: var(--serif); font-size: 21px; font-weight: 600; letter-spacing: -0.4px; margin-bottom: 4px; }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-bottom: 18px; }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 82%; } .doc-line.w3 { width: 90%; } .doc-line.w4 { width: 68%; }
+  .doc-cite {
+    font-size: 11.5px; font-family: var(--mono); color: var(--teal);
+    background: rgba(44,122,111,0.08); border: 1px solid rgba(44,122,111,0.22);
+    border-radius: 6px; padding: 4px 8px; display: inline-block; margin: 6px 6px 0 0;
+  }
+  .doc-block {
+    margin-top: 18px; border-left: 2px solid var(--plum); padding: 10px 14px;
+    background: rgba(124,80,118,0.07); border-radius: 0 8px 8px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--plum); font-weight: 600; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); }
+  .mock-ai { padding: 16px 16px; background: var(--s2); display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--text); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--sage); box-shadow: 0 0 8px var(--sage); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 10px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s1); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--text); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--teal);
+    background: rgba(44,122,111,0.08); border: 1px solid rgba(44,122,111,0.22);
+    border-radius: 7px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--sage); animation: pulse 1s infinite; flex-shrink: 0; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- STRIP ---------- */
+  .strip { padding: 44px 0 10px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 22px; font-weight: 600; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 38px; opacity: .85; }
+  .strip-row span { font-size: 15px; font-weight: 500; color: var(--mid); letter-spacing: -0.2px; font-family: var(--serif); }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 90px 0; }
+  .sec-head { text-align: center; max-width: 690px; margin: 0 auto 56px; }
+  .kicker { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--clay); margin-bottom: 16px; }
+  h2 { font-family: var(--serif); font-size: clamp(28px, 4vw, 42px); font-weight: 600; letter-spacing: -0.8px; line-height: 1.14; margin-bottom: 18px; }
+  h2 .hl { background: linear-gradient(110deg, var(--gold), var(--clay)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; box-shadow: 0 1px 2px rgba(120,80,40,0.04); }
+  .prob-card .x { color: var(--clay); font-size: 22px; margin-bottom: 14px; }
+  .prob-card h3 { font-size: 16px; font-weight: 600; margin-bottom: 8px; font-family: var(--serif); }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 15px; display: grid; place-items: center;
+    font-weight: 700; font-size: 20px; color: #fff; font-family: var(--serif);
+    background: linear-gradient(140deg, var(--gold), var(--clay));
+    box-shadow: 0 8px 22px rgba(193,104,61,0.3); z-index: 1;
+  }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-size: 19px; font-weight: 600; margin-bottom: 8px; letter-spacing: -0.3px; font-family: var(--serif); }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 624px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--teal);
+    background: rgba(44,122,111,0.08); border: 1px solid rgba(44,122,111,0.22);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px;
+    transition: transform .15s, border-color .2s, box-shadow .2s;
+    box-shadow: 0 1px 2px rgba(120,80,40,0.04);
+  }
+  .feat:hover { transform: translateY(-3px); border-color: var(--border2); box-shadow: 0 14px 30px -16px rgba(120,80,40,0.28); }
+  .feat .ic {
+    width: 46px; height: 46px; border-radius: 12px; display: grid; place-items: center;
+    font-size: 22px; margin-bottom: 16px; background: var(--s3); border: 1px solid var(--border2);
+  }
+  .feat h3 { font-size: 16.5px; font-weight: 600; margin-bottom: 8px; font-family: var(--serif); }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.86em; color: var(--teal); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / ROSTER ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(91,138,110,0.14); border: 1px solid rgba(91,138,110,0.4); color: var(--sage); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .sheet-card {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    box-shadow: 0 30px 70px -34px rgba(120,80,40,0.4);
+  }
+  .sheet-card .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--s2); display: flex; align-items: center; justify-content: space-between; }
+  .sheet-card .bh .t { font-weight: 600; font-size: 14px; font-family: var(--serif); }
+  .sheet-card .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .grid-tbl { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .grid-tbl th { text-align: left; font-size: 9.5px; letter-spacing: 1px; text-transform: uppercase; color: var(--dim); font-weight: 600; padding: 11px 14px; border-bottom: 1px solid var(--border); background: var(--s2); }
+  .grid-tbl td { padding: 11px 14px; border-bottom: 1px solid var(--border); color: var(--mid); }
+  .grid-tbl td b { color: var(--text); font-weight: 600; }
+  .grid-tbl tr:last-child td { border-bottom: none; }
+  .pill { display: inline-block; font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 999px; }
+  .pill.ok { color: var(--sage); background: rgba(91,138,110,0.14); }
+  .pill.gap { color: var(--clay); background: rgba(193,104,61,0.12); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 30px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 14px; box-shadow: 0 1px 2px rgba(120,80,40,0.04); }
+  .stat .n { font-family: var(--serif); font-size: 40px; font-weight: 600; letter-spacing: -1.5px; background: linear-gradient(120deg, var(--gold), var(--clay)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; line-height: 1.4; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; box-shadow: 0 1px 2px rgba(120,80,40,0.04); }
+  .uc .ic { font-size: 24px; margin-bottom: 14px; }
+  .uc h3 { font-size: 16.5px; font-weight: 600; margin-bottom: 8px; font-family: var(--serif); }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 800px; margin: 0 auto; }
+  .quote-wrap .q { font-family: var(--serif); font-size: clamp(22px, 3.2vw, 31px); font-weight: 500; line-height: 1.4; letter-spacing: -0.5px; margin-bottom: 24px; }
+  .quote-wrap .q .hl { color: var(--clay); }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--text); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 24px; overflow: hidden;
+    padding: 76px 32px; border: 1px solid var(--border2); background: var(--s1);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(620px 320px at 50% -20%, rgba(191,138,44,0.22), transparent 70%),
+                radial-gradient(520px 320px at 82% 120%, rgba(193,104,61,0.18), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 560px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; background: var(--s2); }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 290px; }
+  .foot-brand p { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--mid); margin-bottom: 14px; font-weight: 700; }
+  .foot-col a { display: block; font-size: 13px; color: var(--dim); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--text); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#roster">Sunday plan</a>
+      <a href="#usecases">For your church</a>
+      <a href="#cta" class="btn btn-primary">Start free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI-native workspace for churches</div>
+    <h1>Get Sunday off your shoulders<br>and back into <span class="grad">your ministry.</span></h1>
+    <p class="sub">PageSpace agents research the passage and draft your sermon outline, build the order of service, fill the volunteer roster, put events on the calendar, and keep your team in the loop — all in one shared workspace your staff and volunteers actually work inside.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Plan this Sunday free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">No credit card · <strong>33+ real AI tools</strong> · 100+ models · Self-host or cloud</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / grace-community / "Sunday · The Father Who Runs (Luke 15)"</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">This Sunday</div>
+          <div class="tree-item active"><span class="ic">📖</span> Sermon — Luke 15</div>
+          <div class="tree-item"><span class="ic">🎵</span> Order of service</div>
+          <div class="tree-item"><span class="ic">🙋</span> Volunteer roster</div>
+          <div class="tree-item"><span class="ic">📰</span> Bulletin</div>
+          <div class="grp">The church</div>
+          <div class="tree-item"><span class="ic">📅</span> Calendar &amp; events</div>
+          <div class="tree-item"><span class="ic">✅</span> Staff tasks</div>
+          <div class="tree-item"><span class="ic">💬</span> Team channel</div>
+          <div class="tree-item"><span class="ic">🕊️</span> Care &amp; follow-up</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">The Father Who Runs — Luke 15:11–32</div>
+          <div class="doc-meta">sermon outline · drafted from 6 sources · edited 4m ago</div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <span class="doc-cite">Luke 15:20</span>
+          <span class="doc-cite">[1] Keller, Prodigal God</span>
+          <span class="doc-cite">[2] 1st-c. context</span>
+          <div class="doc-block">
+            <div class="lbl">✦ Illustration · point 2</div>
+            <p>The father runs — scandalous for a dignified elder in that culture. Land the grace here, not just the wandering. Tie to the welcome-home meal as a picture of the table this week.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Ministry Assistant</div>
+          <div class="ai-tool"><span class="sp"></span> web_search · "Luke 15 1st-century context"</div>
+          <div class="ai-tool"><span class="sp"></span> web_fetch · commentary source</div>
+          <div class="ai-tool"><span class="sp"></span> create_page · Order of service</div>
+          <div class="ai-tool"><span class="sp"></span> edit_sheet_cells · Volunteer roster</div>
+          <div class="ai-msg bot">Drafted a <b>3-point outline</b> with historical context and an illustration into your sermon doc, built the <b>order of service</b>, and filled the roster — <b>2 spots still open</b> (nursery, sound). Want me to message the team channel to fill them?</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>Built for the people who run the church</p>
+  <div class="strip-row">
+    <span>Lead pastors</span>
+    <span>Worship leaders</span>
+    <span>Church admins</span>
+    <span>Kids &amp; students</span>
+    <span>Small groups</span>
+    <span>Volunteer teams</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The Saturday-night scramble</div>
+      <h2>The whole week lives in <span class="hl">ten places and three group texts.</span></h2>
+      <p>The sermon's in a doc. The roster's in a spreadsheet someone forgot to share. The calendar's in your head. Announcements go out by text. And it all has to come together before the doors open at nine.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Prep eats your week</h3>
+        <p>Hours of commentary-reading, formatting, and chasing down an illustration — time you'd rather spend with people, not with tabs.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Volunteers fall through</h3>
+        <p>The nursery spot is empty, two greeters double-booked, and nobody noticed until Sunday because the roster lived in one person's inbox.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Nothing is connected</h3>
+        <p>Sermon, service plan, calendar, care notes, and the team chat don't talk to each other — so the same thing gets re-typed five times.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: var(--s2); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>From a passage to a <span class="hl">Sunday that's ready</span></h2>
+      <p>PageSpace isn't a chatbot you copy answers out of. It's a workspace where AI agents do the research, drafting, and logistics <em>inside</em> your pages — using real tools. You stay the shepherd; it handles the legwork.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Bring the church into one drive</h3>
+          <p>Sermons, service plans, rosters, the calendar, and care notes all live in a single drive your team shares. Ask your agent anything and it reads what's already there for context — last week's series, who served when, what's coming up.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">read_page</span><span class="tag">multi_drive_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Draft the sermon and service</h3>
+          <p>Point the agent at the passage. It researches historical context and illustrations on the live web, drafts a structured outline straight into a Document page with references inline, then builds the order of service. You edit live — refresh protection means it never overwrites the line you're working on.</p>
+          <div class="tags"><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">replace_lines</span><span class="tag">create_page</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Staff the Sunday and set the calendar</h3>
+          <p>The agent fills the volunteer roster in a Sheet, flags the open spots, turns loose ends into assigned tasks, and puts events and meetings on the church calendar with invites — rehearsal, the elders' meeting, the baptism.</p>
+          <div class="tags"><span class="tag">edit_sheet_cells</span><span class="tag">create_task</span><span class="tag">create_calendar_event</span><span class="tag">invite_calendar_attendees</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Keep the team connected</h3>
+          <p>Announcements and reminders post to a team channel; your staff and volunteers co-edit in real time. Brief a dedicated Care assistant — its own AI Chat agent with the right context — and consult it with <span style="font-family:var(--mono);font-size:0.85em;color:var(--teal)">ask_agent</span> for this week's follow-ups.</p>
+          <div class="tags"><span class="tag">send_channel_message</span><span class="tag">update_agent_config</span><span class="tag">ask_agent</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Everything in one place</div>
+      <h2>The whole week of ministry, <span class="hl">in one workspace</span></h2>
+      <p>Nine page types, 33+ AI tools, and 100+ models — composed for how a church staff and its volunteers actually work.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">📖</div>
+        <h3>Sermon &amp; study prep</h3>
+        <p>Agents research context and illustrations with <span class="ttag">web_search</span> and <span class="ttag">web_fetch</span>, draft into a Document, and make precise edits with <span class="ttag">replace_lines</span>. You shape the message; it does the digging.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🎵</div>
+        <h3>Service planning</h3>
+        <p>Build the order of service in a Document or Sheet — songs, scripture, transitions, who's doing what — and keep every week's plan together and searchable.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🙋</div>
+        <h3>Volunteer rosters</h3>
+        <p>Sheet pages the AI reads and writes via <span class="ttag">edit_sheet_cells</span> — greeters, nursery, sound, worship — with open spots flagged before Sunday.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📅</div>
+        <h3>Church calendar</h3>
+        <p>Schedule services, rehearsals, and events with <span class="ttag">create_calendar_event</span>, check who's free with <span class="ttag">check_calendar_availability</span>, and send invites with <span class="ttag">invite_calendar_attendees</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">✅</div>
+        <h3>Tasks &amp; follow-through</h3>
+        <p>Turn loose ends into a Task List — <span class="ttag">create_task</span> and <span class="ttag">get_assigned_tasks</span> so the bulletin, the supplies run, and the hospital visit don't slip.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🕊️</div>
+        <h3>Ministry assistants</h3>
+        <p>Every AI Chat page is a configurable agent. Brief one for worship, kids, or pastoral care with <span class="ttag">update_agent_config</span> and consult it with <span class="ttag">ask_agent</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">👥</div>
+        <h3>Team &amp; volunteers, together</h3>
+        <p>Staff and volunteers work in the same drive in real time, with channels for the back-and-forth — no more re-typing the plan into five places.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Your flock's data, protected</h3>
+        <p>Care notes and member info are sensitive. Self-host on-prem so the data stays under your roof — passwordless passkey sign-in keeps it simple for volunteers.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔌</div>
+        <h3>Models &amp; integrations</h3>
+        <p>Route across 100+ models from six providers — including a local Ollama model on a budget — and connect Google Calendar, Drive, and any MCP tool.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ROSTER SPLIT -->
+<section id="roster" style="background: var(--s2); border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Sunday plan</div>
+      <h2>Every seat filled, <span class="hl">before the doors open.</span></h2>
+      <p class="lead">The agent builds the volunteer roster as a Sheet, checks it against last week so nobody's serving four Sundays in a row, and flags the gaps. The open spots become assigned tasks and a message to the team channel — so the nursery is never empty at 8:55.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>A living roster, not a stale doc</h4><p>The AI fills and updates a Sheet with <span class="ttag">edit_sheet_cells</span> — everyone sees the same version in real time.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Gaps turn into action</h4><p>Open spots become tasks with <span class="ttag">create_task</span> and a nudge to the team with <span class="ttag">send_channel_message</span>.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Rehearsal on the calendar</h4><p>The agent books the run-through and invites the team with <span class="ttag">create_calendar_event</span> and <span class="ttag">invite_calendar_attendees</span>.</p></div></div>
+      </div>
+    </div>
+    <div class="sheet-card fade">
+      <div class="bh">
+        <span class="t">Volunteer Roster · Sun May 31</span>
+        <span class="m">Sheet page · 8 positions</span>
+      </div>
+      <table class="grid-tbl">
+        <thead><tr><th>Position</th><th>Serving</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr><td><b>Worship lead</b></td><td>Dana Whitfield</td><td><span class="pill ok">Confirmed</span></td></tr>
+          <tr><td><b>Greeters (2)</b></td><td>Marcus &amp; Priya</td><td><span class="pill ok">Confirmed</span></td></tr>
+          <tr><td><b>Nursery</b></td><td>—</td><td><span class="pill gap">Open</span></td></tr>
+          <tr><td><b>Sound / tech</b></td><td>—</td><td><span class="pill gap">Open</span></td></tr>
+          <tr><td><b>Kids teacher</b></td><td>Ruth Alvarez</td><td><span class="pill ok">Confirmed</span></td></tr>
+          <tr><td><b>Communion prep</b></td><td>The Hales</td><td><span class="pill ok">Confirmed</span></td></tr>
+          <tr><td><b>Coffee team</b></td><td>Sam Okoro</td><td><span class="pill ok">Confirmed</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — docs, sheets, calendar, chat &amp; more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models across 6 providers</div></div>
+      <div class="stat fade"><div class="n">4</div><div class="l">Ways to run it — cloud, self-host, desktop, mobile</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: var(--s2); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">For your church</div>
+      <h2>One workspace, <span class="hl">every kind of ministry</span></h2>
+      <p>Whether you're a solo pastor or a multi-site team, the week runs in the same place.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">⛪</div><h3>Solo &amp; bivocational pastors</h3><p>Get the research, the service plan, and the logistics off your plate in an evening — so the hours you have go to people, not paperwork.</p></div>
+      <div class="uc fade"><div class="ic">🎶</div><h3>Worship &amp; creative teams</h3><p>Plan sets, build the run sheet, roster the band and tech, and schedule rehearsals — everyone editing the same plan in real time.</p></div>
+      <div class="uc fade"><div class="ic">🧒</div><h3>Kids &amp; student ministry</h3><p>Brief a kids-ministry assistant with your curriculum, draft lesson outlines, and keep the volunteer roster and check-in plan in order.</p></div>
+      <div class="uc fade"><div class="ic">🏛️</div><h3>Multi-site &amp; church plants</h3><p>Give each location its own drive, search across all of them, and keep agents and members scoped to the right campus.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"Saturday night used to be commentaries and a spreadsheet until midnight. Now the legwork's done by dinner — and I spend the evening <span class="hl">praying over the message, not formatting it.</span>"</div>
+    <div class="by"><b>Pastor Daniel R.</b> · Lead pastor, 220-member church <span style="color:var(--dim)">· illustrative</span></div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Plan this Sunday tonight.</h2>
+      <p>Drop in the passage and watch PageSpace research it, draft the outline, build the service, and fill the roster — free, no card required.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Start free</a>
+        <a href="#" class="btn btn-ghost btn-lg">Book a walkthrough</a>
+      </div>
+      <p class="micro">Cloud · self-hosted · desktop · mobile — your church's data, under your roof.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native knowledge workspace where your team and AI agents plan, write, and run the week — together.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#roster">Sunday plan</a>
+          <a href="#usecases">For your church</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">Documents &amp; sheets</a>
+          <a href="#">Calendar &amp; tasks</a>
+          <a href="#">AI agents</a>
+          <a href="#">MCP integrations</a>
+        </div>
+        <div class="foot-col">
+          <h5>Deploy</h5>
+          <a href="#">Cloud</a>
+          <a href="#">Self-hosted</a>
+          <a href="#">Desktop</a>
+          <a href="#">Mobile</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span>Prototype · churches landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-college-students/index.html
+++ b/prototypes/pagespace-college-students/index.html
@@ -1,0 +1,689 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — The AI Study Workspace for College Students</title>
+<meta name="description" content="Your whole semester in one workspace. PageSpace turns your notes, readings, and syllabus into study guides, flashcards, and a deadline plan — with an AI study buddy that researches, drafts, and quizzes you. Free, on your laptop or your phone." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #fbf8f1;          /* warm paper */
+    --bg2: #f4efe4;         /* notebook margin */
+    --s1: #ffffff;          /* cards */
+    --s2: #fcfaf4;          /* subtle surface */
+    --s3: #f1ece0;          /* wells */
+    --border: #e7dfce;
+    --border2: #d8ceb8;
+    --ink: #211f2e;         /* near-black ink */
+    --mid: #6a6478;         /* muted ink */
+    --dim: #9a93a6;         /* faint ink */
+
+    --grape: #7c5cff;       /* primary */
+    --grape-d: #6240e6;
+    --tangerine: #ff7a3d;   /* energy */
+    --berry: #ff4f86;       /* pink highlighter */
+    --leaf: #21b884;        /* fresh green */
+    --sky: #2bb8d6;         /* cyan-ish for tool tags */
+    --sun: #ffd64d;         /* highlighter yellow */
+
+    --sans: "Inter", system-ui, sans-serif;
+    --disp: "Poppins", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(124,92,255,0.22); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* highlighter swipe behind key phrases */
+  .mark {
+    position: relative; white-space: nowrap; z-index: 0;
+  }
+  .mark::after {
+    content: ""; position: absolute; left: -2px; right: -2px; bottom: 0.08em; height: 0.46em;
+    background: var(--sun); z-index: -1; border-radius: 3px;
+    transform: rotate(-1deg);
+  }
+  .mark.pink::after { background: var(--berry); opacity: .55; }
+  .mark.green::after { background: var(--leaf); opacity: .42; }
+  .mark.grape::after { background: var(--grape); opacity: .30; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(12px);
+    background: rgba(251,248,241,0.82);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 66px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-family: var(--disp); font-weight: 700; font-size: 17px; letter-spacing: -0.4px; }
+  .logo .lm {
+    width: 28px; height: 28px; border-radius: 9px;
+    background: linear-gradient(140deg, var(--grape), var(--berry));
+    display: grid; place-items: center; font-size: 14px; font-weight: 800; color: #fff;
+    box-shadow: 0 4px 14px rgba(124,92,255,0.4);
+  }
+  .nav-links { display: flex; align-items: center; gap: 28px; }
+  .nav-links a { font-size: 14px; font-weight: 500; color: var(--mid); transition: color .15s; }
+  .nav-links a:hover { color: var(--ink); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 14px;
+    padding: 10px 18px; border-radius: 11px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--grape), var(--grape-d));
+    color: #fff; box-shadow: 0 6px 20px rgba(124,92,255,0.34);
+  }
+  .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 10px 28px rgba(124,92,255,0.5); }
+  .btn-ghost { background: var(--s1); color: var(--ink); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s2); border-color: var(--grape); }
+  .btn-lg { padding: 15px 28px; font-size: 15.5px; border-radius: 13px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 92px 0 64px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(620px 380px at 50% -6%, rgba(124,92,255,0.16), transparent 70%),
+      radial-gradient(520px 340px at 84% 12%, rgba(255,122,61,0.14), transparent 70%),
+      radial-gradient(520px 360px at 12% 26%, rgba(33,184,132,0.12), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12.5px; font-weight: 600; letter-spacing: 0.3px;
+    color: var(--grape-d); background: rgba(124,92,255,0.10);
+    border: 1px solid rgba(124,92,255,0.28); padding: 7px 15px; border-radius: 999px;
+    margin-bottom: 26px;
+  }
+  .eyebrow .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--leaf); box-shadow: 0 0 8px var(--leaf); }
+  h1 {
+    font-family: var(--disp);
+    font-size: clamp(38px, 6vw, 66px); font-weight: 800;
+    letter-spacing: -1.6px; line-height: 1.06; margin-bottom: 24px; color: var(--ink);
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 640px; margin: 0 auto 36px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 20px; }
+  .micro { font-size: 13px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 60px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 18px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 90px -34px rgba(60,40,120,0.34), 0 2px 0 rgba(255,255,255,0.6) inset;
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--bg2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#ff6b5e; } .mock-bar .d:nth-child(2){ background:#ffc043; } .mock-bar .d:nth-child(3){ background:#34c759; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 196px 1fr 236px; min-height: 432px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: var(--s2); }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.4px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; font-weight: 600; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 8px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(124,92,255,0.12); color: var(--ink); font-weight: 600; }
+  .tree-item .ic { font-size: 13px; }
+  .mock-main { padding: 24px 26px; border-right: 1px solid var(--border); }
+  .doc-h { font-family: var(--disp); font-size: 19px; font-weight: 700; letter-spacing: -0.3px; margin-bottom: 4px; }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-bottom: 18px; }
+  .doc-sub { font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: var(--grape-d); margin: 4px 0 10px; }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 80%; } .doc-line.w3 { width: 90%; }
+  .doc-cite {
+    font-size: 11.5px; font-family: var(--mono); color: var(--sky);
+    background: rgba(43,184,214,0.10); border: 1px solid rgba(43,184,214,0.28);
+    border-radius: 6px; padding: 4px 8px; display: inline-block; margin: 4px 6px 0 0;
+  }
+  .doc-block {
+    margin-top: 18px; border-left: 3px solid var(--tangerine); padding: 10px 14px;
+    background: rgba(255,122,61,0.07); border-radius: 0 9px 9px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.4px; text-transform: uppercase; color: var(--tangerine); font-weight: 700; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); }
+  .doc-block p b { color: var(--ink); }
+  .mock-ai { padding: 16px; background: var(--s2); display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12.5px; font-weight: 700; color: var(--ink); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--leaf); box-shadow: 0 0 8px var(--leaf); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 11px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s1); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--ink); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--grape-d);
+    background: rgba(124,92,255,0.07); border: 1px solid rgba(124,92,255,0.22);
+    border-radius: 8px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--grape); animation: pulse 1s infinite; flex: none; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- STRIP ---------- */
+  .strip { padding: 44px 0 6px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 20px; font-weight: 600; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 12px 18px; }
+  .strip-row span { font-family: var(--disp); font-size: 14px; font-weight: 600; color: var(--mid); background: var(--s1); border: 1px solid var(--border); border-radius: 999px; padding: 7px 16px; }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 88px 0; }
+  .sec-head { text-align: center; max-width: 680px; margin: 0 auto 54px; }
+  .kicker { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--grape-d); margin-bottom: 16px; }
+  h2 { font-family: var(--disp); font-size: clamp(28px, 4vw, 42px); font-weight: 800; letter-spacing: -0.9px; line-height: 1.12; margin-bottom: 18px; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 16px; padding: 26px; box-shadow: 0 1px 0 rgba(255,255,255,0.6) inset; }
+  .prob-card .x { font-size: 26px; margin-bottom: 12px; }
+  .prob-card h3 { font-family: var(--disp); font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 16px; display: grid; place-items: center;
+    font-family: var(--disp); font-weight: 800; font-size: 21px; color: #fff;
+    background: linear-gradient(140deg, var(--grape), var(--berry));
+    box-shadow: 0 8px 22px rgba(124,92,255,0.32); z-index: 1;
+  }
+  .step:nth-child(2) .step-num { background: linear-gradient(140deg, var(--tangerine), var(--berry)); box-shadow: 0 8px 22px rgba(255,122,61,0.3); }
+  .step:nth-child(3) .step-num { background: linear-gradient(140deg, var(--leaf), var(--sky)); box-shadow: 0 8px 22px rgba(33,184,132,0.3); }
+  .step:nth-child(4) .step-num { background: linear-gradient(140deg, var(--grape), var(--sky)); box-shadow: 0 8px 22px rgba(124,92,255,0.3); }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-family: var(--disp); font-size: 19px; font-weight: 700; margin-bottom: 8px; letter-spacing: -0.3px; }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 620px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--grape-d);
+    background: rgba(124,92,255,0.07); border: 1px solid rgba(124,92,255,0.22);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 16px; padding: 26px;
+    transition: transform .15s, border-color .2s, box-shadow .2s;
+  }
+  .feat:hover { transform: translateY(-4px); border-color: var(--border2); box-shadow: 0 18px 40px -22px rgba(80,50,140,0.3); }
+  .feat .ic {
+    width: 46px; height: 46px; border-radius: 13px; display: grid; place-items: center;
+    font-size: 22px; margin-bottom: 16px; background: var(--s3); border: 1px solid var(--border);
+  }
+  .feat h3 { font-family: var(--disp); font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.86em; color: var(--grape-d); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / FLASHCARDS ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(33,184,132,0.14); border: 1px solid rgba(33,184,132,0.4); color: var(--leaf); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 700; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .card-art {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 18px; overflow: hidden;
+    box-shadow: 0 30px 70px -32px rgba(80,50,140,0.4);
+  }
+  .card-art .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--bg2); display: flex; align-items: center; justify-content: space-between; }
+  .card-art .bh .t { font-family: var(--disp); font-weight: 700; font-size: 14.5px; }
+  .card-art .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .card-art .bb { padding: 18px 20px; }
+  .fc-row { display: grid; grid-template-columns: 1fr 1.3fr 78px; gap: 10px; align-items: center; padding: 11px 0; border-bottom: 1px solid var(--border); }
+  .fc-row:last-child { border-bottom: none; }
+  .fc-head { font-size: 10px; letter-spacing: 1.2px; text-transform: uppercase; color: var(--dim); font-weight: 700; padding-bottom: 4px; }
+  .fc-term { font-size: 12.5px; font-weight: 700; color: var(--ink); }
+  .fc-def { font-size: 12px; color: var(--mid); line-height: 1.45; }
+  .chip { font-size: 10.5px; font-weight: 700; padding: 4px 9px; border-radius: 999px; text-align: center; }
+  .chip.got { background: rgba(33,184,132,0.14); color: #1a9e72; border: 1px solid rgba(33,184,132,0.35); }
+  .chip.soso { background: rgba(255,214,77,0.22); color: #a07b00; border: 1px solid rgba(255,214,77,0.5); }
+  .chip.no { background: rgba(255,79,134,0.12); color: var(--berry); border: 1px solid rgba(255,79,134,0.32); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 30px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 16px; }
+  .stat .n { font-family: var(--disp); font-size: 40px; font-weight: 800; letter-spacing: -1.5px; background: linear-gradient(120deg, var(--grape), var(--berry)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 16px; padding: 26px; }
+  .uc .ic { font-size: 26px; margin-bottom: 14px; }
+  .uc h3 { font-family: var(--disp); font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 800px; margin: 0 auto; }
+  .quote-wrap .q { font-family: var(--disp); font-size: clamp(22px, 3.2vw, 31px); font-weight: 600; line-height: 1.38; letter-spacing: -0.5px; margin-bottom: 24px; }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--ink); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 26px; overflow: hidden;
+    padding: 74px 32px; border: 1px solid var(--border2);
+    background: linear-gradient(160deg, #fffdf7, #f6f0e4);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(560px 300px at 50% -20%, rgba(124,92,255,0.20), transparent 70%),
+                radial-gradient(480px 300px at 82% 120%, rgba(255,122,61,0.18), transparent 70%),
+                radial-gradient(420px 280px at 14% 110%, rgba(33,184,132,0.16), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 540px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; background: var(--bg2); }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 290px; }
+  .foot-brand p { font-size: 13px; color: var(--mid); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--ink); margin-bottom: 14px; font-weight: 700; }
+  .foot-col a { display: block; font-size: 13px; color: var(--mid); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--ink); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="lm">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#study">Study tools</a>
+      <a href="#usecases">For students</a>
+      <a href="#cta" class="btn btn-primary">Start free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI study workspace for students</div>
+    <h1>Your whole semester,<br>finally in <span class="mark">one place.</span></h1>
+    <p class="sub">Drop in your notes, readings, and syllabus. PageSpace researches the hard parts, drafts your study guide, builds flashcards, and tracks every deadline — with an AI study buddy that quizzes you until it clicks.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Start free — no card</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">Free to start · <strong>33+ real AI tools</strong> · 100+ models · works on your laptop &amp; phone</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / fall-semester / BIO&nbsp;201 — Midterm 2 study guide</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">Fall semester</div>
+          <div class="tree-item"><span class="ic">📓</span> Lecture notes</div>
+          <div class="tree-item"><span class="ic">📚</span> Readings &amp; PDFs</div>
+          <div class="tree-item active"><span class="ic">📝</span> Midterm 2 study guide</div>
+          <div class="tree-item"><span class="ic">🗂️</span> Flashcards</div>
+          <div class="grp">Stay on track</div>
+          <div class="tree-item"><span class="ic">✅</span> Deadlines</div>
+          <div class="tree-item"><span class="ic">👥</span> Lab group project</div>
+          <div class="tree-item"><span class="ic">🤖</span> Study buddy</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">Midterm 2 — Cellular Respiration</div>
+          <div class="doc-meta">built from your notes + 9 sources · edited 3m ago</div>
+          <div class="doc-sub">Key concept · The electron transport chain</div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <span class="doc-cite">📓 Lecture 14</span>
+          <span class="doc-cite">[2] Khan Academy</span>
+          <span class="doc-cite">[5] OpenStax Bio</span>
+          <div class="doc-block">
+            <div class="lbl">★ Likely on the exam</div>
+            <p><b>Compare</b> substrate-level vs. oxidative phosphorylation — Prof flagged this twice in Lecture 14. ATP yield: glycolysis 2, Krebs 2, ETC ~34. Drafted a practice question for it.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Study buddy</div>
+          <div class="ai-tool"><span class="sp"></span> read_page · Lecture 14 notes</div>
+          <div class="ai-tool"><span class="sp"></span> web_search · "ATP yield cellular respiration"</div>
+          <div class="ai-tool"><span class="sp"></span> edit_sheet_cells · Flashcards</div>
+          <div class="ai-tool"><span class="sp"></span> create_task · Review session Thu</div>
+          <div class="ai-msg bot">Turned your Lecture 14 notes into a <b>study guide</b>, pulled <b>9 sources</b> to fill the gaps, and built <b>24 flashcards</b>. Want me to quiz you on the 6 terms you marked shaky?</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>One workspace for every kind of coursework</p>
+  <div class="strip-row">
+    <span>Essays &amp; papers</span>
+    <span>Exam prep</span>
+    <span>Lab reports</span>
+    <span>Problem sets</span>
+    <span>Group projects</span>
+    <span>Thesis research</span>
+    <span>Reading loads</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Sound familiar?</div>
+      <h2>Five classes, fifty tabs, and the test is <span class="mark pink">tomorrow.</span></h2>
+      <p>Notes in one app. PDFs in another. The group chat somewhere else. Deadlines on a sticky note you lost. Studying turns into finding your stuff before you can even start.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">🗂️</div>
+        <h3>Everything's scattered</h3>
+        <p>Lecture notes, slides, readings, and that one Google Doc — spread across six apps, none of which talk to each other.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">😵</div>
+        <h3>Cramming doesn't stick</h3>
+        <p>You re-read the chapter at 1am and remember none of it by morning. Re-reading isn't studying — but making real study material takes hours you don't have.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">⏰</div>
+        <h3>Deadlines ambush you</h3>
+        <p>The essay, the problem set, and the group slide deck were all due the same week — and you found out two days before.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: var(--bg2); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>From a pile of notes to a <span class="mark green">plan you can actually follow</span></h2>
+      <p>PageSpace isn't a chatbot you copy answers out of. It's a workspace where an AI agent does the research, drafting, and organizing <em>inside</em> your pages — using real tools.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Drop your notes &amp; syllabus into a drive</h3>
+          <p>Paste lecture notes, upload readings, add the syllabus. Each class is a page in your semester drive. Your study buddy reads everything that's already there for context — so it knows what <em>your</em> professor actually covered.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">read_page</span><span class="tag">multi_drive_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>It researches and builds your study guide</h3>
+          <p>Stuck on a concept your notes gloss over? The agent runs live web searches, fetches the clearest explanations as clean text, and writes a structured study guide straight into a Document — every fact linked back to where it came from.</p>
+          <div class="tags"><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">create_page</span><span class="tag">replace_lines</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Quiz yourself with a study-buddy agent</h3>
+          <p>Every AI Chat page is a configurable agent. Brief one as a tutor for the course, and it builds flashcards into a Sheet and quizzes you on the terms you keep missing — consult it any time with <span style="font-family:var(--mono);font-size:0.85em;color:var(--grape-d)">ask_agent</span>.</p>
+          <div class="tags"><span class="tag">update_agent_config</span><span class="tag">ask_agent</span><span class="tag">edit_sheet_cells</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Stay ahead of every deadline</h3>
+          <p>The agent turns your syllabus into a Task List and drops exams and due dates onto your calendar — so essays, problem sets, and that group deck never sneak up again. Ask it what's due this week and it just tells you.</p>
+          <div class="tags"><span class="tag">create_task</span><span class="tag">get_assigned_tasks</span><span class="tag">create_calendar_event</span><span class="tag">check_calendar_availability</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">What you get</div>
+      <h2>Everything a semester needs, <span class="mark grape">in one workspace</span></h2>
+      <p>Nine page types, 33+ AI tools, and 100+ models — put to work for the way students actually study, write, and group up.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">🔎</div>
+        <h3>Research without 40 tabs</h3>
+        <p>Your agent runs live <span class="ttag">web_search</span> and pulls full source text with <span class="ttag">web_fetch</span>, then searches across all your own notes with glob, regex, and multi-drive search.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📝</div>
+        <h3>Essays &amp; papers in the editor</h3>
+        <p>Outline, draft, and revise in a Document page with sources linked inline. The agent makes precise line-level edits with <span class="ttag">replace_lines</span> — you stay the author the whole way.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🗂️</div>
+        <h3>Flashcards that build themselves</h3>
+        <p>Sheet pages the AI reads and writes via <span class="ttag">edit_sheet_cells</span> — term, definition, and how shaky you still feel on each one, ready to quiz from.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🤖</div>
+        <h3>A study buddy per class</h3>
+        <p>Every AI Chat page is a configurable agent. Brief one as your Orgo tutor and another for History — consult either with <span class="ttag">ask_agent</span> whenever you're stuck.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">✅</div>
+        <h3>Deadlines &amp; calendar</h3>
+        <p>Task List pages plus calendar tools — <span class="ttag">create_task</span>, <span class="ttag">create_calendar_event</span> — so every due date, exam, and study block lives in one place.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">👥</div>
+        <h3>Group projects that don't implode</h3>
+        <p>Share a drive, work in real time, assign tasks, and keep the back-and-forth in a Channel with <span class="ttag">send_channel_message</span> — no more lost group chats.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧠</div>
+        <h3>100+ models, your pick</h3>
+        <p>Route to Anthropic, OpenAI, Google, xAI, or OpenRouter — or run a free local Ollama model on your own laptop when you're watching the budget.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📱</div>
+        <h3>Laptop, desktop, or phone</h3>
+        <p>PageSpace runs in the browser, as a desktop app, and on iOS and Android — review flashcards on the bus, write the paper at your desk.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Yours, and private</h3>
+        <p>Passwordless passkey sign-in, no password to leak. Self-host the whole thing if your program needs to keep data in-house.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STUDY SPLIT -->
+<section id="study" style="background: var(--bg2); border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Study tools</div>
+      <h2>Stop re-reading. <span class="mark pink">Start recalling.</span></h2>
+      <p class="lead">Active recall beats highlighting every time — but making flashcards by hand eats your whole evening. Your study buddy builds them from your own notes, tracks which ones you keep missing, and drills you on exactly those.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>Built from your notes</h4><p>The agent reads your lecture pages with <span class="ttag">read_page</span> and fills a flashcard Sheet — no copy-pasting.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Knows what you don't</h4><p>Mark a card shaky and it focuses your next session there. Confidence lives in a column it reads and updates.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Quizzes you out loud</h4><p>Consult your study buddy with <span class="ttag">ask_agent</span> and it runs you through the deck, conversationally.</p></div></div>
+      </div>
+    </div>
+    <div class="card-art fade">
+      <div class="bh">
+        <span class="t">🗂️ BIO 201 — Flashcards</span>
+        <span class="m">Sheet page · 24 cards</span>
+      </div>
+      <div class="bb">
+        <div class="fc-row">
+          <div class="fc-head">Term</div><div class="fc-head">Definition</div><div class="fc-head" style="text-align:center;">Got it?</div>
+        </div>
+        <div class="fc-row">
+          <div class="fc-term">Glycolysis</div>
+          <div class="fc-def">Glucose → 2 pyruvate in the cytoplasm; net 2 ATP.</div>
+          <span class="chip got">Got it</span>
+        </div>
+        <div class="fc-row">
+          <div class="fc-term">Krebs cycle</div>
+          <div class="fc-def">Oxidizes acetyl-CoA; yields NADH, FADH₂, 2 ATP.</div>
+          <span class="chip soso">So-so</span>
+        </div>
+        <div class="fc-row">
+          <div class="fc-term">Electron transport chain</div>
+          <div class="fc-def">Proton gradient across the inner membrane drives ATP synthase.</div>
+          <span class="chip no">Shaky</span>
+        </div>
+        <div class="fc-row">
+          <div class="fc-term">Chemiosmosis</div>
+          <div class="fc-def">ATP made as H⁺ flows back down its gradient.</div>
+          <span class="chip no">Shaky</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — docs, sheets, chat &amp; more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models across 6 providers</div></div>
+      <div class="stat fade"><div class="n">1</div><div class="l">Drive that holds your whole semester</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: var(--bg2); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Built for how you study</div>
+      <h2>Whatever you're <span class="mark">up against this week</span></h2>
+      <p>Midterms, a 12-page paper, or a group project with four flaky teammates — same workspace.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">📚</div><h3>Exam crunch</h3><p>Turn a semester of notes into study guides and flashcards, then drill the terms you keep missing — in an evening, not a week.</p></div>
+      <div class="uc fade"><div class="ic">✍️</div><h3>Essays &amp; research papers</h3><p>Gather sources, keep every claim traceable to a link, and draft the whole thing in the same place you researched it.</p></div>
+      <div class="uc fade"><div class="ic">🧪</div><h3>STEM &amp; lab reports</h3><p>Work problem sets in a Document, keep data in a Sheet, and ask your agent to walk a tough derivation step by step.</p></div>
+      <div class="uc fade"><div class="ic">👥</div><h3>Group projects</h3><p>Share one drive, split the work into assigned tasks, and keep the whole team — and the AI — on the same page in real time.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"I dumped a whole semester of messy notes into one drive and had a study guide and flashcards before dinner. I finally <span class="mark green">quizzed myself instead of re-reading.</span>"</div>
+    <div class="by"><b>Priya N.</b> · Sophomore, Biology &amp; illustrative student persona</div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Get your semester sorted tonight.</h2>
+      <p>Drop in your notes and watch PageSpace research, study-guide, flashcard, and plan it with you — free, no card required.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Start free</a>
+        <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+      </div>
+      <p class="micro">Browser · desktop · iOS &amp; Android — your notes, your study buddy, everywhere.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="lm">P</span> PageSpace</div>
+        <p>The AI-native workspace where you and an AI study buddy research, write, and remember — together, in one place.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#study">Study tools</a>
+          <a href="#usecases">For students</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">Documents &amp; sheets</a>
+          <a href="#">Flashcards</a>
+          <a href="#">Study-buddy agents</a>
+          <a href="#">Tasks &amp; calendar</a>
+        </div>
+        <div class="foot-col">
+          <h5>Run it on</h5>
+          <a href="#">Browser</a>
+          <a href="#">Desktop</a>
+          <a href="#">iOS &amp; Android</a>
+          <a href="#">Self-hosted</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span>Prototype · college-students landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-course-creators/index.html
+++ b/prototypes/pagespace-course-creators/index.html
@@ -1,0 +1,677 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace for Course Creators — Research, write & launch in one workspace</title>
+<meta name="description" content="The AI-native workspace where course creators go from blank page to launched course. Research with web_search, draft lessons with the AI, build a curriculum map in a Sheet, and run production from a Task List — all in one place." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#fffaf3;
+    --surface:#ffffff;
+    --surface-2:#fff4e8;
+    --surface-3:#fdeede;
+    --border:#f1e4d2;
+    --border-2:#ebd9c2;
+    --ink:#2c2118;
+    --ink-soft:#4a3c2e;
+    --muted:#857562;
+    --muted-2:#a3937e;
+    --accent:#ff5a3c;       /* coral */
+    --accent-2:#ff9f1c;     /* amber */
+    --accent-3:#0fa18a;     /* teal */
+    --violet:#7b5cff;
+    --grad:linear-gradient(115deg,#ff5a3c 0%,#ff9f1c 100%);
+    --grad-soft:linear-gradient(115deg,rgba(255,90,60,.14),rgba(255,159,28,.14));
+    --shadow-sm:0 1px 2px rgba(60,40,20,.05),0 2px 8px rgba(60,40,20,.04);
+    --shadow:0 10px 34px rgba(90,55,20,.10),0 2px 8px rgba(90,55,20,.06);
+    --shadow-lg:0 30px 70px rgba(90,55,20,.16),0 6px 18px rgba(90,55,20,.08);
+    --radius:18px;
+    --radius-sm:12px;
+    --max:1140px;
+    --mono:'JetBrains Mono',ui-monospace,SFMono-Regular,Menlo,monospace;
+    --serif:'Fraunces',Georgia,serif;
+    --sans:'Inter',system-ui,-apple-system,sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:var(--bg);
+    color:var(--ink);
+    font-family:var(--sans);
+    line-height:1.6;
+    -webkit-font-smoothing:antialiased;
+    overflow-x:hidden;
+  }
+  ::selection{background:rgba(255,90,60,.22);color:var(--ink)}
+  a{color:inherit;text-decoration:none}
+  h1,h2,h3{font-family:var(--serif);font-weight:600;line-height:1.07;letter-spacing:-.018em}
+
+  /* warm dotted backdrop */
+  body::before{
+    content:"";position:fixed;inset:0;z-index:-2;
+    background:
+      radial-gradient(1100px 620px at 78% -8%, rgba(255,159,28,.16), transparent 60%),
+      radial-gradient(900px 560px at 5% 8%, rgba(255,90,60,.10), transparent 55%),
+      var(--bg);
+  }
+  body::after{
+    content:"";position:fixed;inset:0;z-index:-1;opacity:.45;
+    background-image:radial-gradient(rgba(180,140,90,.16) 1px, transparent 1px);
+    background-size:26px 26px;
+    -webkit-mask-image:linear-gradient(180deg,#000,transparent 70%);
+    mask-image:linear-gradient(180deg,#000,transparent 70%);
+  }
+
+  .wrap{max-width:var(--max);margin:0 auto;padding:0 24px}
+
+  /* ---------- nav ---------- */
+  nav{
+    position:sticky;top:0;z-index:50;
+    backdrop-filter:saturate(160%) blur(14px);
+    background:rgba(255,250,243,.78);
+    border-bottom:1px solid var(--border);
+  }
+  .nav-in{display:flex;align-items:center;justify-content:space-between;height:66px}
+  .brand{display:flex;align-items:center;gap:11px;font-weight:700;font-size:1.06rem;letter-spacing:-.01em}
+  .mark{
+    width:32px;height:32px;border-radius:9px;background:var(--grad);
+    display:grid;place-items:center;color:#fff;font-family:var(--serif);font-weight:700;
+    box-shadow:0 6px 16px rgba(255,90,60,.34);position:relative;flex:none;
+  }
+  .mark::after{content:"";position:absolute;inset:0;border-radius:9px;border:1px solid rgba(255,255,255,.4)}
+  .nav-links{display:flex;align-items:center;gap:30px}
+  .nav-links a{color:var(--ink-soft);font-size:.93rem;font-weight:500;transition:color .18s}
+  .nav-links a:hover{color:var(--accent)}
+  .nav-cta{
+    background:var(--ink);color:#fff;padding:9px 18px;border-radius:10px;
+    font-size:.9rem;font-weight:600;transition:transform .18s, box-shadow .18s;
+  }
+  .nav-cta:hover{transform:translateY(-1px);box-shadow:0 8px 20px rgba(44,33,24,.28)}
+  .nav-toggle{display:none}
+
+  /* ---------- buttons ---------- */
+  .btn{
+    display:inline-flex;align-items:center;gap:9px;border-radius:12px;
+    font-weight:600;font-size:1rem;padding:14px 24px;cursor:pointer;border:1px solid transparent;
+    transition:transform .18s, box-shadow .18s, background .18s;
+  }
+  .btn-primary{background:var(--grad);color:#fff;box-shadow:0 12px 30px rgba(255,90,60,.32)}
+  .btn-primary:hover{transform:translateY(-2px);box-shadow:0 18px 42px rgba(255,90,60,.42)}
+  .btn-ghost{background:var(--surface);color:var(--ink);border-color:var(--border-2);box-shadow:var(--shadow-sm)}
+  .btn-ghost:hover{transform:translateY(-2px);border-color:var(--accent);color:var(--accent)}
+
+  /* ---------- hero ---------- */
+  .hero{padding:84px 0 36px;text-align:center}
+  .eyebrow{
+    display:inline-flex;align-items:center;gap:9px;padding:7px 15px;border-radius:999px;
+    background:var(--surface);border:1px solid var(--border-2);box-shadow:var(--shadow-sm);
+    font-size:.82rem;font-weight:600;color:var(--ink-soft);letter-spacing:.01em;margin-bottom:26px;
+  }
+  .eyebrow .dot{width:7px;height:7px;border-radius:50%;background:var(--accent);box-shadow:0 0 0 4px rgba(255,90,60,.16)}
+  .hero h1{font-size:clamp(2.5rem,6.2vw,4.4rem);max-width:14ch;margin:0 auto 22px}
+  .grad-text{background:var(--grad);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .hero p.sub{font-size:clamp(1.05rem,2.1vw,1.27rem);color:var(--ink-soft);max-width:660px;margin:0 auto 32px}
+  .hero-cta{display:flex;gap:14px;justify-content:center;flex-wrap:wrap;margin-bottom:26px}
+  .microtrust{
+    display:flex;gap:10px 22px;justify-content:center;flex-wrap:wrap;
+    font-size:.86rem;color:var(--muted);font-weight:500;
+  }
+  .microtrust span{display:inline-flex;align-items:center;gap:8px}
+  .microtrust b{color:var(--ink);font-weight:700}
+  .microtrust .sep{width:5px;height:5px;border-radius:50%;background:var(--accent-2)}
+
+  /* ---------- product mock ---------- */
+  .mockwrap{padding:46px 0 30px}
+  .browser{
+    background:var(--surface);border:1px solid var(--border-2);border-radius:16px;
+    box-shadow:var(--shadow-lg);overflow:hidden;max-width:1060px;margin:0 auto;
+  }
+  .chrome{
+    display:flex;align-items:center;gap:8px;padding:13px 16px;
+    background:var(--surface-2);border-bottom:1px solid var(--border);
+  }
+  .dots{display:flex;gap:7px}
+  .dots i{width:12px;height:12px;border-radius:50%;display:block}
+  .dots i:nth-child(1){background:#ff6058}.dots i:nth-child(2){background:#ffbd2e}.dots i:nth-child(3){background:#28c840}
+  .urlbar{
+    flex:1;margin-left:10px;background:var(--bg);border:1px solid var(--border);border-radius:8px;
+    padding:6px 14px;font-size:.78rem;color:var(--muted);font-family:var(--mono);
+    overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+  }
+  .panes{display:grid;grid-template-columns:212px 1fr 296px;min-height:430px}
+  .pane{padding:16px}
+  .pane.tree{border-right:1px solid var(--border);background:var(--surface-2)}
+  .pane.center{background:var(--surface);overflow:hidden}
+  .pane.agent{border-left:1px solid var(--border);background:linear-gradient(180deg,var(--surface-3),var(--surface))}
+  .pane-label{font-size:.68rem;text-transform:uppercase;letter-spacing:.13em;color:var(--muted-2);font-weight:700;margin-bottom:13px}
+  .tree-item{
+    display:flex;align-items:center;gap:8px;padding:6px 9px;border-radius:8px;
+    font-size:.84rem;color:var(--ink-soft);font-weight:500;margin-bottom:2px;
+  }
+  .tree-item .ic{font-size:.92rem;width:18px;text-align:center}
+  .tree-item.active{background:var(--surface);color:var(--ink);font-weight:600;box-shadow:var(--shadow-sm)}
+  .tree-item.child{margin-left:16px;font-size:.8rem;color:var(--muted)}
+
+  /* center editor */
+  .doc-title{font-family:var(--serif);font-size:1.28rem;font-weight:600;margin-bottom:4px}
+  .doc-meta{font-size:.74rem;color:var(--muted-2);margin-bottom:16px;font-family:var(--mono)}
+  .doc-h{font-family:var(--serif);font-size:.98rem;font-weight:600;margin:14px 0 7px;color:var(--ink)}
+  .doc-p{font-size:.83rem;color:var(--ink-soft);margin-bottom:8px}
+  .doc-li{font-size:.82rem;color:var(--ink-soft);padding-left:18px;position:relative;margin-bottom:5px}
+  .doc-li::before{content:"";position:absolute;left:3px;top:8px;width:6px;height:6px;border-radius:2px;background:var(--accent-2)}
+  .typing{display:inline-block;width:9px;height:15px;background:var(--accent);vertical-align:-2px;border-radius:1px;animation:blink 1.1s steps(2) infinite;margin-left:2px}
+  @keyframes blink{0%,50%{opacity:1}51%,100%{opacity:0}}
+
+  /* agent panel */
+  .agent-head{display:flex;align-items:center;gap:10px;margin-bottom:14px}
+  .agent-av{width:34px;height:34px;border-radius:9px;background:var(--grad);display:grid;place-items:center;color:#fff;font-size:1rem;flex:none;box-shadow:0 5px 14px rgba(255,90,60,.32)}
+  .agent-name{font-size:.86rem;font-weight:700;line-height:1.2}
+  .agent-status{font-size:.7rem;color:var(--accent-3);font-weight:600;display:flex;align-items:center;gap:5px}
+  .agent-status .live{width:6px;height:6px;border-radius:50%;background:var(--accent-3);box-shadow:0 0 0 3px rgba(15,161,138,.2);animation:pulse 1.6s infinite}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
+  .bubble{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:11px 13px;font-size:.8rem;color:var(--ink-soft);margin-bottom:10px;box-shadow:var(--shadow-sm)}
+  .toolcall{
+    font-family:var(--mono);font-size:.72rem;background:#2c2118;color:#ffd9a8;
+    border-radius:9px;padding:9px 11px;margin-bottom:9px;display:flex;align-items:center;gap:8px;
+  }
+  .toolcall .tk{color:#ff9f6e;font-weight:600}
+  .toolcall .ck{color:#7fe6c9;margin-left:auto}
+  .toolchip{display:inline-block;font-family:var(--mono);font-size:.72rem;color:var(--accent);background:var(--surface-3);border:1px solid var(--border-2);border-radius:7px;padding:3px 9px;margin:2px 4px 2px 0;font-weight:500}
+
+  /* ---------- sections ---------- */
+  section{padding:78px 0}
+  .sec-head{text-align:center;max-width:680px;margin:0 auto 50px}
+  .sec-tag{font-family:var(--mono);font-size:.78rem;font-weight:600;color:var(--accent);text-transform:uppercase;letter-spacing:.1em;margin-bottom:14px}
+  .sec-head h2{font-size:clamp(1.9rem,4vw,2.85rem);margin-bottom:16px}
+  .sec-head p{font-size:1.06rem;color:var(--ink-soft)}
+
+  /* problem cards */
+  .prob-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+  .prob{
+    background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+    padding:26px;box-shadow:var(--shadow-sm);transition:transform .22s, box-shadow .22s;
+  }
+  .prob:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
+  .prob .pic{font-size:1.6rem;margin-bottom:14px;display:block}
+  .prob h3{font-size:1.16rem;margin-bottom:8px}
+  .prob p{font-size:.92rem;color:var(--muted)}
+
+  /* steps */
+  .steps{display:grid;grid-template-columns:repeat(2,1fr);gap:22px}
+  .step{
+    background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+    padding:28px;box-shadow:var(--shadow-sm);position:relative;overflow:hidden;
+    transition:transform .22s, box-shadow .22s, border-color .22s;
+  }
+  .step:hover{transform:translateY(-4px);box-shadow:var(--shadow);border-color:var(--border-2)}
+  .step .num{
+    font-family:var(--serif);font-size:1.05rem;font-weight:700;color:#fff;width:38px;height:38px;
+    border-radius:11px;background:var(--grad);display:grid;place-items:center;margin-bottom:16px;
+    box-shadow:0 8px 18px rgba(255,90,60,.3);
+  }
+  .step h3{font-size:1.24rem;margin-bottom:9px}
+  .step p{font-size:.95rem;color:var(--ink-soft);margin-bottom:15px}
+  .step .tools{display:flex;flex-wrap:wrap}
+
+  /* features */
+  .feat-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}
+  .feat{
+    background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);
+    padding:24px;box-shadow:var(--shadow-sm);transition:transform .22s, box-shadow .22s;
+  }
+  .feat:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
+  .feat .fic{
+    width:42px;height:42px;border-radius:11px;background:var(--grad-soft);
+    display:grid;place-items:center;font-size:1.25rem;margin-bottom:14px;
+    border:1px solid var(--border-2);
+  }
+  .feat h3{font-size:1.1rem;margin-bottom:7px}
+  .feat p{font-size:.9rem;color:var(--muted)}
+
+  /* split artifact */
+  .split{display:grid;grid-template-columns:1fr 1.05fr;gap:48px;align-items:center}
+  .split h2{font-size:clamp(1.8rem,3.6vw,2.5rem);margin-bottom:18px}
+  .split .lead{font-size:1.05rem;color:var(--ink-soft);margin-bottom:24px}
+  .checklist{list-style:none;display:flex;flex-direction:column;gap:13px}
+  .checklist li{display:flex;gap:12px;align-items:flex-start;font-size:.97rem;color:var(--ink-soft)}
+  .checklist .ck{
+    flex:none;width:24px;height:24px;border-radius:7px;background:var(--grad);color:#fff;
+    display:grid;place-items:center;font-size:.78rem;font-weight:700;box-shadow:0 5px 12px rgba(255,90,60,.3)
+  }
+  .checklist b{color:var(--ink);font-weight:600}
+
+  /* sheet mock */
+  .sheet{
+    background:var(--surface);border:1px solid var(--border-2);border-radius:14px;
+    box-shadow:var(--shadow-lg);overflow:hidden;
+  }
+  .sheet-bar{display:flex;align-items:center;gap:8px;padding:12px 15px;background:var(--surface-2);border-bottom:1px solid var(--border);font-size:.82rem;font-weight:600}
+  .sheet-bar .ic{font-size:1rem}
+  .sheet-bar .pill{margin-left:auto;font-family:var(--mono);font-size:.68rem;color:var(--accent-3);background:rgba(15,161,138,.1);border:1px solid rgba(15,161,138,.25);border-radius:6px;padding:3px 8px;font-weight:600}
+  table{width:100%;border-collapse:collapse;font-size:.8rem}
+  th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--border)}
+  th{background:var(--surface-3);font-size:.68rem;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);font-weight:700}
+  td{color:var(--ink-soft)}
+  td.mod{font-weight:600;color:var(--ink)}
+  .badge{display:inline-block;font-size:.68rem;font-weight:700;padding:3px 9px;border-radius:999px}
+  .b-done{background:rgba(15,161,138,.13);color:#0a7d6b}
+  .b-prog{background:rgba(255,159,28,.16);color:#b3690a}
+  .b-todo{background:rgba(123,92,255,.13);color:#5a3fd6}
+  tr:last-child td{border-bottom:none}
+
+  /* stats */
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:20px}
+  .stat{
+    text-align:center;background:var(--surface);border:1px solid var(--border);
+    border-radius:var(--radius);padding:30px 18px;box-shadow:var(--shadow-sm);
+  }
+  .stat .n{font-family:var(--serif);font-size:clamp(2.1rem,4.4vw,3rem);font-weight:700;line-height:1;background:var(--grad);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .stat .l{font-size:.86rem;color:var(--muted);margin-top:10px;font-weight:500}
+
+  /* use cases */
+  .uc-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:18px}
+  .uc{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:24px;box-shadow:var(--shadow-sm);transition:transform .22s,box-shadow .22s}
+  .uc:hover{transform:translateY(-4px);box-shadow:var(--shadow)}
+  .uc .uic{font-size:1.5rem;margin-bottom:12px;display:block}
+  .uc h3{font-size:1.04rem;margin-bottom:7px}
+  .uc p{font-size:.86rem;color:var(--muted)}
+
+  /* quote */
+  .quote{
+    max-width:820px;margin:0 auto;text-align:center;background:var(--surface);
+    border:1px solid var(--border-2);border-radius:24px;padding:54px 44px;box-shadow:var(--shadow);
+    position:relative;overflow:hidden;
+  }
+  .quote::before{content:"\201C";position:absolute;top:-12px;left:30px;font-family:var(--serif);font-size:8rem;color:rgba(255,90,60,.12);line-height:1}
+  .quote blockquote{font-family:var(--serif);font-size:clamp(1.3rem,2.8vw,1.85rem);font-weight:500;line-height:1.35;color:var(--ink);margin-bottom:24px;position:relative}
+  .quote .who{display:flex;align-items:center;gap:13px;justify-content:center}
+  .quote .av{width:46px;height:46px;border-radius:50%;background:var(--grad);display:grid;place-items:center;color:#fff;font-weight:700;font-family:var(--serif)}
+  .quote .meta{text-align:left}
+  .quote .meta b{display:block;font-size:.95rem}
+  .quote .meta span{font-size:.83rem;color:var(--muted)}
+
+  /* final cta */
+  .cta-panel{
+    background:var(--grad);border-radius:28px;padding:70px 40px;text-align:center;color:#fff;
+    box-shadow:0 30px 70px rgba(255,90,60,.34);position:relative;overflow:hidden;
+  }
+  .cta-panel::after{content:"";position:absolute;inset:0;background-image:radial-gradient(rgba(255,255,255,.16) 1px,transparent 1px);background-size:24px 24px;opacity:.5;-webkit-mask-image:linear-gradient(180deg,#000,transparent);mask-image:linear-gradient(180deg,#000,transparent)}
+  .cta-panel h2{font-size:clamp(2rem,4.5vw,3rem);margin-bottom:16px;color:#fff;position:relative}
+  .cta-panel p{font-size:1.12rem;max-width:560px;margin:0 auto 30px;opacity:.95;position:relative}
+  .cta-panel .hero-cta{position:relative}
+  .cta-panel .btn-primary{background:#fff;color:var(--accent);box-shadow:0 12px 30px rgba(0,0,0,.2)}
+  .cta-panel .btn-ghost{background:rgba(255,255,255,.14);color:#fff;border-color:rgba(255,255,255,.4);box-shadow:none;backdrop-filter:blur(4px)}
+  .cta-panel .btn-ghost:hover{color:#fff;border-color:#fff;background:rgba(255,255,255,.22)}
+  .cta-micro{margin-top:22px;font-size:.88rem;opacity:.9;position:relative}
+
+  /* footer */
+  footer{border-top:1px solid var(--border);padding:54px 0 36px;margin-top:30px}
+  .foot-grid{display:grid;grid-template-columns:1.6fr 1fr 1fr 1fr;gap:36px;margin-bottom:40px}
+  .foot-brand p{font-size:.9rem;color:var(--muted);margin-top:14px;max-width:30ch}
+  .foot-col h4{font-size:.78rem;text-transform:uppercase;letter-spacing:.1em;color:var(--muted-2);margin-bottom:14px;font-family:var(--sans);font-weight:700}
+  .foot-col a{display:block;font-size:.9rem;color:var(--ink-soft);margin-bottom:10px;transition:color .18s}
+  .foot-col a:hover{color:var(--accent)}
+  .foot-bottom{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:12px;padding-top:24px;border-top:1px solid var(--border);font-size:.82rem;color:var(--muted)}
+  .proto-tag{font-family:var(--mono);font-size:.74rem;color:var(--accent);background:var(--surface-3);border:1px solid var(--border-2);border-radius:7px;padding:4px 10px}
+
+  /* reveal */
+  .fade{opacity:0;transform:translateY(26px);transition:opacity .7s cubic-bezier(.2,.7,.2,1),transform .7s cubic-bezier(.2,.7,.2,1)}
+  .fade.in{opacity:1;transform:none}
+  .fade.d1{transition-delay:.08s}.fade.d2{transition-delay:.16s}.fade.d3{transition-delay:.24s}.fade.d4{transition-delay:.32s}
+
+  /* responsive */
+  @media (max-width:980px){
+    .panes{grid-template-columns:1fr}
+    .pane.tree{display:none}
+    .pane.agent{border-left:none;border-top:1px solid var(--border)}
+    .split{grid-template-columns:1fr;gap:34px}
+    .uc-grid{grid-template-columns:repeat(2,1fr)}
+  }
+  @media (max-width:880px){
+    .nav-links{
+      position:absolute;top:66px;left:0;right:0;background:rgba(255,250,243,.98);
+      flex-direction:column;gap:0;padding:8px 24px 18px;border-bottom:1px solid var(--border);
+      display:none;
+    }
+    .nav-links.open{display:flex}
+    .nav-links a{padding:12px 0;width:100%;border-bottom:1px solid var(--border)}
+    .nav-links .nav-cta{margin-top:12px;text-align:center;border-bottom:none}
+    .nav-toggle{display:grid;place-items:center;width:40px;height:40px;border:1px solid var(--border-2);border-radius:10px;background:var(--surface);cursor:pointer}
+    .nav-toggle span{width:18px;height:2px;background:var(--ink);position:relative;display:block}
+    .nav-toggle span::before,.nav-toggle span::after{content:"";position:absolute;left:0;width:18px;height:2px;background:var(--ink)}
+    .nav-toggle span::before{top:-6px}.nav-toggle span::after{top:6px}
+    .prob-grid,.feat-grid,.stats{grid-template-columns:1fr 1fr}
+    .steps{grid-template-columns:1fr}
+    section{padding:60px 0}
+  }
+  @media (max-width:560px){
+    .prob-grid,.feat-grid,.stats,.uc-grid{grid-template-columns:1fr}
+    .hero{padding:56px 0 24px}
+    .quote{padding:40px 24px}
+    .cta-panel{padding:50px 24px}
+    .foot-grid{grid-template-columns:1fr 1fr}
+  }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-in">
+    <a href="#" class="brand"><span class="mark">P</span> PageSpace</a>
+    <div class="nav-links" id="navlinks">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#artifact">Curriculum map</a>
+      <a href="#stats">Why PageSpace</a>
+      <a href="#start" class="nav-cta">Start building free</a>
+    </div>
+    <button class="nav-toggle" id="navtoggle" aria-label="Toggle menu"><span></span></button>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow fade"><span class="dot"></span> The AI-native workspace for course creators</div>
+    <h1 class="fade d1">From blank page to <span class="grad-text">a launched course</span> — in one workspace.</h1>
+    <p class="sub fade d2">Research your topic, draft every lesson, map the curriculum in a Sheet, and run production from a Task List — with an AI that does the work alongside you using 33+ real tools, not just answers questions.</p>
+    <div class="hero-cta fade d3">
+      <a href="#start" class="btn btn-primary">Start building free →</a>
+      <a href="#how" class="btn btn-ghost">See how it works</a>
+    </div>
+    <div class="microtrust fade d4">
+      <span><b>33+</b> real AI tools</span><span class="sep"></span>
+      <span><b>9</b> page types</span><span class="sep"></span>
+      <span><b>100+</b> models</span><span class="sep"></span>
+      <span>self-host or cloud</span>
+    </div>
+  </div>
+</header>
+
+<!-- PRODUCT MOCK -->
+<div class="mockwrap">
+  <div class="wrap">
+    <div class="browser fade">
+      <div class="chrome">
+        <div class="dots"><i></i><i></i><i></i></div>
+        <div class="urlbar">pagespace.ai / watercolor-botanicals / module-1 — materials &amp; mindset</div>
+      </div>
+      <div class="panes">
+        <!-- tree -->
+        <div class="pane tree">
+          <div class="pane-label">Watercolor Botanicals</div>
+          <div class="tree-item"><span class="ic">📄</span> Course Brief</div>
+          <div class="tree-item"><span class="ic">📊</span> Curriculum Map</div>
+          <div class="tree-item"><span class="ic">📁</span> Module 1 · Materials</div>
+          <div class="tree-item active child"><span class="ic">📄</span> Lesson 1.1 Script</div>
+          <div class="tree-item child"><span class="ic">📄</span> Lesson 1.2 Script</div>
+          <div class="tree-item"><span class="ic">📁</span> Module 2 · First Strokes</div>
+          <div class="tree-item"><span class="ic">✅</span> Production Pipeline</div>
+          <div class="tree-item"><span class="ic">💬</span> Studio Team</div>
+          <div class="tree-item"><span class="ic">🤖</span> Sasha · Beginner Student</div>
+        </div>
+        <!-- center editor -->
+        <div class="pane center">
+          <div class="pane-label">Document · Lesson 1.1 Script</div>
+          <div class="doc-title">Lesson 1.1 — Your Three Brushes &amp; Why They're Enough</div>
+          <div class="doc-meta">draft · edited by ✨ AI 4s ago</div>
+          <div class="doc-h">Hook (0:00–0:25)</div>
+          <div class="doc-p">"You do not need 40 brushes. You need three — and by the end of this lesson you'll know exactly what each one is for."</div>
+          <div class="doc-h">Teach (0:25–3:10)</div>
+          <div class="doc-li">Round #8 — washes &amp; petals (the workhorse)</div>
+          <div class="doc-li">Round #2 — stems, veins, fine detail</div>
+          <div class="doc-li">Flat ¾" — backgrounds &amp; lifting<span class="typing"></span></div>
+          <div class="doc-h">Do (3:10–5:00)</div>
+          <div class="doc-p">On-screen exercise: three swatches, one brush each. Downloadable worksheet attached.</div>
+        </div>
+        <!-- agent -->
+        <div class="pane agent">
+          <div class="agent-head">
+            <div class="agent-av">✨</div>
+            <div>
+              <div class="agent-name">Course Builder</div>
+              <div class="agent-status"><span class="live"></span> building Module 1</div>
+            </div>
+          </div>
+          <div class="bubble">Pulling what beginners actually ask before lesson 1, then drafting the script.</div>
+          <div class="toolcall"><span class="tk">web_search</span> "beginner watercolor mistakes" <span class="ck">28 ✓</span></div>
+          <div class="toolcall"><span class="tk">web_fetch</span> top 3 forum threads <span class="ck">✓</span></div>
+          <div class="toolcall"><span class="tk">create_page</span> "Lesson 1.1 Script" <span class="ck">✓</span></div>
+          <div class="toolcall"><span class="tk">ask_agent</span> Sasha: "is the hook clear?" <span class="ck">✓</span></div>
+          <div class="bubble">Sasha (your beginner-student agent) flagged the term "wash" — I added a one-line definition on first use.</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section id="problem">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="sec-tag">The status quo</div>
+      <h2>Your course lives in 30 tabs and a panic</h2>
+      <p>Great teaching, scattered everywhere. The course is in your head — getting it out is the hard part.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob fade d1"><span class="pic">🗂️</span><h3>Tool sprawl</h3><p>Outline in Google Docs, scripts in Notion, lesson tracker in a spreadsheet, research in 22 open tabs. Nothing talks to each other.</p></div>
+      <div class="prob fade d2"><span class="pic">😶‍🌫️</span><h3>Blank-page paralysis</h3><p>You know the material cold, but staring at an empty module outline for the fourth night running kills the momentum.</p></div>
+      <div class="prob fade d3"><span class="pic">🎬</span><h3>Production chaos</h3><p>Which lessons are scripted? Recorded? Edited? Published? You're the writer, editor, and project manager — with no single board.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="sec-tag">How it works</div>
+      <h2>One workspace, four moves to a finished course</h2>
+      <p>The AI works <em>inside</em> your pages — researching, drafting, and organizing with the same real tools you can see it use.</p>
+    </div>
+    <div class="steps">
+      <div class="step fade d1">
+        <div class="num">1</div>
+        <h3>Research the topic &amp; your students</h3>
+        <p>Ask the AI what beginners struggle with, what competing courses skip, and which questions keep coming up. It searches the live web and reads the strong sources into your Document.</p>
+        <div class="tools"><span class="toolchip">web_search</span><span class="toolchip">web_fetch</span><span class="toolchip">create_page</span></div>
+      </div>
+      <div class="step fade d2">
+        <div class="num">2</div>
+        <h3>Draft the curriculum &amp; lesson scripts</h3>
+        <p>Turn your brain-dump into a module-by-module outline, then full video scripts in a Document. Refine any line with precise edits — no full rewrites, no copy-paste shuffle.</p>
+        <div class="tools"><span class="toolchip">create_page</span><span class="toolchip">replace_lines</span></div>
+      </div>
+      <div class="step fade d3">
+        <div class="num">3</div>
+        <h3>Map &amp; track it all</h3>
+        <p>The AI builds a curriculum map in a Sheet and a production pipeline as a Task List — script, record, edit, publish — and keeps every status current as you work.</p>
+        <div class="tools"><span class="toolchip">edit_sheet_cells</span><span class="toolchip">create_task</span><span class="toolchip">update_task</span></div>
+      </div>
+      <div class="step fade d4">
+        <div class="num">4</div>
+        <h3>Pressure-test with a student agent</h3>
+        <p>Spin up an AI Chat agent, brief it as your ideal beginner, and have your Course Builder consult it on every lesson: "Is this clear? Where would a newcomer get lost?"</p>
+        <div class="tools"><span class="toolchip">update_agent_config</span><span class="toolchip">ask_agent</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="sec-tag">Built on real capabilities</div>
+      <h2>Everything a course needs, in one place</h2>
+      <p>Nine page types and 33+ tools mean every part of your course — research, scripts, slides outline, tracker, team — lives together.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade d1"><div class="fic">🔎</div><h3>Live topic research</h3><p>The AI runs <code>web_search</code> and <code>web_fetch</code> to mine forums, reviews, and competitor curricula — then writes findings straight into your brief.</p></div>
+      <div class="feat fade d2"><div class="fic">📄</div><h3>Lesson scripts as Documents</h3><p>Write and edit scripts in a rich TipTap editor. Precise <code>replace_lines</code> edits tweak a single beat without disturbing the rest.</p></div>
+      <div class="feat fade d3"><div class="fic">📊</div><h3>Curriculum map in a Sheet</h3><p>Module, lesson, length, status, worksheet — the AI fills and updates the grid with <code>edit_sheet_cells</code> as the course evolves.</p></div>
+      <div class="feat fade d1"><div class="fic">✅</div><h3>Production pipeline</h3><p>A Task List for script → record → edit → publish, with custom statuses. The AI creates and moves cards so nothing slips.</p></div>
+      <div class="feat fade d2"><div class="fic">🤖</div><h3>Briefed student agents</h3><p>AI Chat pages <em>are</em> configurable agents. Brief one as a "total beginner" and have your builder <code>ask_agent</code> to catch confusing jargon.</p></div>
+      <div class="feat fade d3"><div class="fic">💬</div><h3>Bring your team in</h3><p>Loop your editor or VA into a Channel with real-time collaboration. The AI can post updates with <code>send_channel_message</code>.</p></div>
+      <div class="feat fade d1"><div class="fic">🗓️</div><h3>Launch calendar</h3><p>Plan drip dates, live Q&amp;As, and launch milestones. The AI can schedule with <code>create_calendar_event</code> and check availability.</p></div>
+      <div class="feat fade d2"><div class="fic">🧩</div><h3>100+ models, your pick</h3><p>Run Anthropic, OpenAI, Google, xAI, OpenRouter, or local Ollama — choose the model that fits the task and budget.</p></div>
+      <div class="feat fade d3"><div class="fic">🔌</div><h3>Connect your stack via MCP</h3><p>Model Context Protocol integration links external tools and servers, so your existing workflow plugs in.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- SPLIT / ARTIFACT -->
+<section id="artifact">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="sec-tag">The artifact</div>
+      <h2>A curriculum map the AI builds and keeps current</h2>
+      <p class="lead">Ask once. The AI lays out every module and lesson in a Sheet, then updates the status column each time you finish recording or editing — so you always see the whole course at a glance.</p>
+      <ul class="checklist">
+        <li><span class="ck">✓</span><span><b>Real page type.</b> It's a Sheet, edited with <code>edit_sheet_cells</code> — not a screenshot, not a mockup feature.</span></li>
+        <li><span class="ck">✓</span><span><b>Always in sync.</b> Mark a lesson recorded and the AI moves its status and the matching Task List card.</span></li>
+        <li><span class="ck">✓</span><span><b>Searchable.</b> <code>glob_search</code> and <code>regex_search</code> find any lesson, term, or note across the whole drive.</span></li>
+        <li><span class="ck">✓</span><span><b>Yours to keep.</b> Cloud, self-hosted, desktop, or mobile — your course, your infrastructure.</span></li>
+      </ul>
+    </div>
+    <div class="fade d2">
+      <div class="sheet">
+        <div class="sheet-bar"><span class="ic">📊</span> Curriculum Map <span class="pill">edit_sheet_cells</span></div>
+        <table>
+          <thead><tr><th>Module / Lesson</th><th>Len</th><th>Worksheet</th><th>Status</th></tr></thead>
+          <tbody>
+            <tr><td class="mod">1.1 Three Brushes</td><td>5:00</td><td>✓</td><td><span class="badge b-done">Published</span></td></tr>
+            <tr><td class="mod">1.2 Paper &amp; Paint</td><td>6:20</td><td>✓</td><td><span class="badge b-done">Published</span></td></tr>
+            <tr><td class="mod">2.1 Flat Wash</td><td>7:10</td><td>✓</td><td><span class="badge b-prog">Editing</span></td></tr>
+            <tr><td class="mod">2.2 Wet-on-Wet</td><td>8:00</td><td>✓</td><td><span class="badge b-prog">Recorded</span></td></tr>
+            <tr><td class="mod">3.1 First Leaf</td><td>9:30</td><td>—</td><td><span class="badge b-todo">Scripted</span></td></tr>
+            <tr><td class="mod">3.2 First Bloom</td><td>11:00</td><td>—</td><td><span class="badge b-todo">Outlined</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section id="stats">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="sec-tag">Why PageSpace</div>
+      <h2>Real product, real tools</h2>
+      <p>No fabricated outcome metrics — just what the platform actually gives you.</p>
+    </div>
+    <div class="stats">
+      <div class="stat fade d1"><div class="n">9</div><div class="l">page types — Document, Sheet, Task List, Channel, AI Chat &amp; more</div></div>
+      <div class="stat fade d2"><div class="n">33+</div><div class="l">real AI tools the agent can call directly</div></div>
+      <div class="stat fade d3"><div class="n">100+</div><div class="l">models across 6 providers, incl. local Ollama</div></div>
+      <div class="stat fade d4"><div class="n">4</div><div class="l">ways to run it — cloud, self-host, desktop, mobile</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases">
+  <div class="wrap">
+    <div class="sec-head fade">
+      <div class="sec-tag">Also great for</div>
+      <h2>However you teach online</h2>
+      <p>The same research → draft → map → ship motion fits every flavor of course creator.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade d1"><span class="uic">🎥</span><h3>YouTube educators</h3><p>Script series, track episodes in a Task List, and research topics without leaving the editor.</p></div>
+      <div class="uc fade d2"><span class="uic">👥</span><h3>Cohort-based courses</h3><p>Plan live sessions on the calendar, run a student Channel, and keep the curriculum map in sync.</p></div>
+      <div class="uc fade d3"><span class="uic">🏢</span><h3>Corporate training</h3><p>Self-host on-prem with local models — sensitive material never leaves your infrastructure.</p></div>
+      <div class="uc fade d4"><span class="uic">📝</span><h3>Workshop &amp; bootcamp leads</h3><p>Build worksheets, slide outlines, and exercise sheets, then reuse them across every cohort.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap">
+    <div class="quote fade">
+      <blockquote>I used to keep my whole course in seven apps and my head. Now the research, the scripts, and the production board live in one place — and the AI actually moves the work forward instead of handing me more to copy-paste.</blockquote>
+      <div class="who">
+        <div class="av">MR</div>
+        <div class="meta">
+          <b>Mara Reyes</b>
+          <span>illustration course creator · illustrative persona</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FINAL CTA -->
+<section id="start">
+  <div class="wrap">
+    <div class="cta-panel fade">
+      <h2>Build your next course where the work happens</h2>
+      <p>Open a workspace, point the AI at your topic, and watch the brief, scripts, and curriculum map take shape — with you in the driver's seat.</p>
+      <div class="hero-cta">
+        <a href="#" class="btn btn-primary">Start building free →</a>
+        <a href="#how" class="btn btn-ghost">See how it works</a>
+      </div>
+      <div class="cta-micro">Passwordless sign-in with passkeys or a magic link · cloud or self-hosted</div>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-grid">
+      <div class="foot-brand">
+        <a href="#" class="brand"><span class="mark">P</span> PageSpace</a>
+        <p>The AI-native workspace where humans and AI agents build, organize, and ship together.</p>
+      </div>
+      <div class="foot-col">
+        <h4>Product</h4>
+        <a href="#how">How it works</a>
+        <a href="#features">Features</a>
+        <a href="#artifact">Curriculum map</a>
+        <a href="#stats">Why PageSpace</a>
+      </div>
+      <div class="foot-col">
+        <h4>For creators</h4>
+        <a href="#usecases">YouTube educators</a>
+        <a href="#usecases">Cohort courses</a>
+        <a href="#usecases">Corporate training</a>
+        <a href="#usecases">Workshops</a>
+      </div>
+      <div class="foot-col">
+        <h4>Deploy</h4>
+        <a href="#">Cloud (pagespace.ai)</a>
+        <a href="#">Self-hosted</a>
+        <a href="#">Desktop</a>
+        <a href="#">Mobile</a>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© PageSpace — AI-native knowledge &amp; collaboration.</span>
+      <span class="proto-tag">Prototype · course-creators landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // scroll reveal
+  const io = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{ if(e.isIntersecting){ e.target.classList.add('in'); io.unobserve(e.target);} });
+  },{threshold:.14, rootMargin:'0px 0px -40px 0px'});
+  document.querySelectorAll('.fade').forEach(el=>io.observe(el));
+
+  // mobile nav
+  const toggle = document.getElementById('navtoggle');
+  const links = document.getElementById('navlinks');
+  toggle.addEventListener('click', ()=> links.classList.toggle('open'));
+  links.querySelectorAll('a').forEach(a=> a.addEventListener('click', ()=> links.classList.remove('open')));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-debate-prep/index.html
+++ b/prototypes/pagespace-debate-prep/index.html
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — The Debate Prep & Research Workspace</title>
+<meta name="description" content="Research, brief, and rehearse in one AI-native workspace. PageSpace auto-researches the motion, drafts your case file, builds rebuttals, and stress-tests your arguments before you ever take the floor." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #07070c;
+    --s1: #0e0e16;
+    --s2: #14141f;
+    --s3: #1c1c2b;
+    --border: #26263a;
+    --border2: #34344c;
+    --blue: #4d8eff;
+    --green: #3dd68c;
+    --red: #ff4d6a;
+    --amber: #ffb84d;
+    --violet: #a78bfa;
+    --cyan: #22d3ee;
+    --text: #e6e6f2;
+    --mid: #9494ab;
+    --dim: #5f5f78;
+    --sans: "Plus Jakarta Sans", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(77,142,255,0.28); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(14px);
+    background: rgba(7,7,12,0.72);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 16px; letter-spacing: -0.3px; }
+  .logo .mark {
+    width: 26px; height: 26px; border-radius: 7px;
+    background: linear-gradient(140deg, var(--blue), var(--violet));
+    display: grid; place-items: center; font-size: 13px; font-weight: 800; color: #fff;
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 4px 16px rgba(77,142,255,0.35);
+  }
+  .nav-links { display: flex; align-items: center; gap: 30px; }
+  .nav-links a { font-size: 13.5px; color: var(--mid); transition: color .15s; }
+  .nav-links a:hover { color: var(--text); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 13.5px;
+    padding: 10px 18px; border-radius: 9px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--blue), #6d6dff);
+    color: #fff; box-shadow: 0 6px 22px rgba(77,142,255,0.35);
+  }
+  .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 30px rgba(77,142,255,0.5); }
+  .btn-ghost { background: var(--s2); color: var(--text); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s3); border-color: var(--blue); }
+  .btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 11px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 100px 0 70px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(640px 380px at 50% -8%, rgba(77,142,255,0.20), transparent 70%),
+      radial-gradient(540px 360px at 82% 14%, rgba(167,139,250,0.16), transparent 70%),
+      radial-gradient(520px 340px at 14% 26%, rgba(34,211,238,0.10), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.4px;
+    color: var(--blue); background: rgba(77,142,255,0.10);
+    border: 1px solid rgba(77,142,255,0.30); padding: 6px 14px; border-radius: 999px;
+    margin-bottom: 28px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); }
+  h1 {
+    font-size: clamp(38px, 6.2vw, 68px); font-weight: 800;
+    letter-spacing: -1.8px; line-height: 1.04; margin-bottom: 24px;
+  }
+  h1 .grad {
+    background: linear-gradient(110deg, var(--blue) 10%, var(--violet) 55%, var(--cyan) 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 660px; margin: 0 auto 38px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 22px; }
+  .micro { font-size: 12.5px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 64px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 120px -30px rgba(0,0,0,0.85), 0 0 0 1px rgba(255,255,255,0.03);
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--s2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#ff5f57; } .mock-bar .d:nth-child(2){ background:#febc2e; } .mock-bar .d:nth-child(3){ background:#28c840; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 188px 1fr 230px; min-height: 420px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: var(--s1); }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 7px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(77,142,255,0.12); color: var(--text); }
+  .tree-item .ic { font-size: 13px; }
+  .mock-main { padding: 24px 26px; border-right: 1px solid var(--border); }
+  .doc-h { font-size: 19px; font-weight: 700; letter-spacing: -0.4px; margin-bottom: 4px; }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-bottom: 18px; }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 82%; } .doc-line.w3 { width: 90%; } .doc-line.w4 { width: 68%; }
+  .doc-cite {
+    font-size: 11.5px; font-family: var(--mono); color: var(--cyan);
+    background: rgba(34,211,238,0.08); border: 1px solid rgba(34,211,238,0.2);
+    border-radius: 6px; padding: 4px 8px; display: inline-block; margin: 6px 6px 0 0;
+  }
+  .doc-block {
+    margin-top: 18px; border-left: 2px solid var(--violet); padding: 10px 14px;
+    background: rgba(167,139,250,0.06); border-radius: 0 8px 8px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--violet); font-weight: 600; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); }
+  .mock-ai { padding: 16px 16px; background: var(--s1); display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--text); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 10px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s2); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--text); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--green);
+    background: rgba(61,214,140,0.07); border: 1px solid rgba(61,214,140,0.22);
+    border-radius: 7px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--green); animation: pulse 1s infinite; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- LOGO STRIP ---------- */
+  .strip { padding: 40px 0 10px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 22px; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 40px; opacity: .7; }
+  .strip-row span { font-size: 15px; font-weight: 700; color: var(--mid); letter-spacing: -0.3px; }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 90px 0; }
+  .sec-head { text-align: center; max-width: 680px; margin: 0 auto 56px; }
+  .kicker { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--blue); margin-bottom: 16px; }
+  h2 { font-size: clamp(28px, 4vw, 42px); font-weight: 800; letter-spacing: -1px; line-height: 1.12; margin-bottom: 18px; }
+  h2 .hl { background: linear-gradient(110deg, var(--blue), var(--violet)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .prob-card .x { color: var(--red); font-size: 22px; margin-bottom: 14px; }
+  .prob-card h3 { font-size: 16px; font-weight: 700; margin-bottom: 8px; }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 14px; display: grid; place-items: center;
+    font-weight: 800; font-size: 20px; color: #fff;
+    background: linear-gradient(140deg, var(--blue), var(--violet));
+    box-shadow: 0 8px 24px rgba(77,142,255,0.3); z-index: 1;
+  }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-size: 19px; font-weight: 700; margin-bottom: 8px; letter-spacing: -0.3px; }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 620px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--cyan);
+    background: rgba(34,211,238,0.07); border: 1px solid rgba(34,211,238,0.2);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px;
+    transition: transform .15s, border-color .2s, background .2s;
+  }
+  .feat:hover { transform: translateY(-3px); border-color: var(--border2); background: var(--s2); }
+  .feat .ic {
+    width: 44px; height: 44px; border-radius: 11px; display: grid; place-items: center;
+    font-size: 21px; margin-bottom: 16px; background: var(--s3); border: 1px solid var(--border2);
+  }
+  .feat h3 { font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.86em; color: var(--cyan); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / BRIEF ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(61,214,140,0.12); border: 1px solid rgba(61,214,140,0.35); color: var(--green); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .brief-card {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    box-shadow: 0 30px 80px -30px rgba(0,0,0,0.8);
+  }
+  .brief-card .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--s2); display: flex; align-items: center; justify-content: space-between; }
+  .brief-card .bh .t { font-weight: 700; font-size: 14px; }
+  .brief-card .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .brief-card .bb { padding: 20px; }
+  .arg-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .arg-col h5 { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; margin-bottom: 10px; }
+  .arg-col.pro h5 { color: var(--green); } .arg-col.con h5 { color: var(--red); }
+  .arg-item { font-size: 12px; color: var(--mid); line-height: 1.5; padding: 10px 12px; border-radius: 9px; background: var(--s2); border: 1px solid var(--border); margin-bottom: 10px; }
+  .arg-item b { color: var(--text); font-weight: 600; }
+  .arg-item .src { display: block; margin-top: 5px; font-family: var(--mono); font-size: 10px; color: var(--cyan); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 28px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 14px; }
+  .stat .n { font-size: 38px; font-weight: 800; letter-spacing: -1.5px; background: linear-gradient(120deg, var(--blue), var(--violet)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .uc .ic { font-size: 24px; margin-bottom: 14px; }
+  .uc h3 { font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 780px; margin: 0 auto; }
+  .quote-wrap .q { font-size: clamp(22px, 3.2vw, 30px); font-weight: 600; line-height: 1.4; letter-spacing: -0.6px; margin-bottom: 24px; }
+  .quote-wrap .q .hl { color: var(--violet); }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--text); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 24px; overflow: hidden;
+    padding: 72px 32px; border: 1px solid var(--border2); background: var(--s1);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(600px 300px at 50% -20%, rgba(77,142,255,0.28), transparent 70%),
+                radial-gradient(500px 300px at 80% 120%, rgba(167,139,250,0.22), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 540px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 280px; }
+  .foot-brand p { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--mid); margin-bottom: 14px; }
+  .foot-col a { display: block; font-size: 13px; color: var(--dim); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--text); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#brief">Case files</a>
+      <a href="#usecases">Use cases</a>
+      <a href="#cta" class="btn btn-primary">Start prepping free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI-native debate workspace</div>
+    <h1>Win the round before<br>you walk into it.<br><span class="grad">PageSpace preps the whole case.</span></h1>
+    <p class="sub">Drop the motion into a drive. PageSpace agents research the web, draft a sourced case file in the editor, build your evidence and rebuttal sheets, and spar against an opposition agent — all in one workspace you and your team actually work inside.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Prep your first motion free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">No credit card · <strong>33+ real AI tools</strong> · 100+ models · Self-host or cloud</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / debate-prep / "This house would ban facial recognition"</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">Case file</div>
+          <div class="tree-item active"><span class="ic">📄</span> Motion brief</div>
+          <div class="tree-item"><span class="ic">⚖️</span> Gov / Opp arguments</div>
+          <div class="tree-item"><span class="ic">🛡️</span> Rebuttal matrix</div>
+          <div class="tree-item"><span class="ic">📊</span> Evidence sheet</div>
+          <div class="grp">Research</div>
+          <div class="tree-item"><span class="ic">🔎</span> Sources (42)</div>
+          <div class="tree-item"><span class="ic">🗂️</span> Definitions</div>
+          <div class="tree-item"><span class="ic">💬</span> Sparring log</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">Government Case — Opening</div>
+          <div class="doc-meta">auto-drafted · 42 sources · last edited 2m ago</div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <span class="doc-cite">[1] EFF 2024</span>
+          <span class="doc-cite">[2] MIT Media Lab</span>
+          <span class="doc-cite">[3] GDPR Art. 9</span>
+          <div class="doc-block">
+            <div class="lbl">⚠ Anticipated rebuttal</div>
+            <p>Opp will argue public safety gains. Counter with false-positive rates from Gender Shades study (34.7% for darker-skinned women) → reframe as discriminatory tooling, not safety.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Research Agent</div>
+          <div class="ai-tool"><span class="sp"></span> web_search · "facial recognition bans 2024"</div>
+          <div class="ai-tool"><span class="sp"></span> web_fetch · eff.org/deeplinks</div>
+          <div class="ai-tool"><span class="sp"></span> edit_sheet_cells · Evidence sheet</div>
+          <div class="ai-msg bot">Pulled <b>42 sources</b> with summaries and publish dates into your evidence sheet, drafted the gov case with source links, and flagged <b>3 weak links</b> the opp will attack. Want me to set up an opposition agent to spar?</div>
+          <div class="ai-msg bot">I'll build the <b>rebuttal matrix</b> as a sheet — every opp argument mapped to your best response + source.</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>Built for debaters, researchers, analysts & policy teams</p>
+  <div class="strip-row">
+    <span>Competitive debate</span>
+    <span>Mock trial</span>
+    <span>Policy research</span>
+    <span>Litigation prep</span>
+    <span>Consulting</span>
+    <span>Journalism</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The old way is broken</div>
+      <h2>Prep shouldn't mean <span class="hl">30 tabs and a panic the night before.</span></h2>
+      <p>Research lives in your browser. Notes live in a doc. The case file lives in someone's head. Nothing talks to each other — and the round starts in twelve hours.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Research is scattered</h3>
+        <p>Forty open tabs, half-copied quotes, and sources you can't relocate when the judge asks where the stat came from.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Writing the brief is slow</h3>
+        <p>You spend the prep window formatting and citing instead of thinking about strategy and the actual clash points.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>You never see the counter</h3>
+        <p>You walk in having only argued your own side. The opponent's best line lands cold — and you've got nothing rehearsed.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>From a one-line motion to a <span class="hl">round-ready case file</span></h2>
+      <p>PageSpace isn't a chatbot you copy answers out of. It's a workspace where AI agents do the research and drafting <em>inside</em> your documents, using real tools.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Drop the motion into a drive</h3>
+          <p>Paste the resolution, the brief, or the research question into a page. Ask your agent to define the terms, scope the clash, and outline what you need to win both sides — it reads everything already in the drive for context.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">read_page</span><span class="tag">multi_drive_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>The agent researches the web</h3>
+          <p>It runs live web searches, fetches the full text of the strongest sources as clean markdown, and writes them into a structured evidence sheet — titles, summaries, and publish dates, every claim traceable to a link.</p>
+          <div class="tags"><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">edit_sheet_cells</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Your brief drafts in the editor — then you sharpen it</h3>
+          <p>The case file writes straight into a Document page: opening, contentions, evidence, and anticipated rebuttals, with source links inline. You edit live; refresh protection means the AI never clobbers the line you're working on.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">replace_lines</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Spar against an opposition agent</h3>
+          <p>Spin up a second AI_CHAT agent, brief it to argue the other side, and consult it with <span style="font-family:var(--mono);font-size:0.85em;color:var(--cyan)">ask_agent</span>. It attacks your weakest links; you map every counter into a rebuttal matrix sheet before the round.</p>
+          <div class="tags"><span class="tag">update_agent_config</span><span class="tag">ask_agent</span><span class="tag">edit_sheet_cells</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The toolkit</div>
+      <h2>Everything prep needs, <span class="hl">in one workspace</span></h2>
+      <p>Nine page types, 33+ AI tools, and 100+ models — composed for the way researchers and debaters actually work.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">🔎</div>
+        <h3>Web research, built in</h3>
+        <p>Agents run live <span class="ttag">web_search</span> and pull full source text with <span class="ttag">web_fetch</span> — then search across your own drives with glob, regex, and multi-drive search.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📝</div>
+        <h3>Brief writing in the editor</h3>
+        <p>Agents draft cases and memos straight into Document pages with source links inline, and make precise line-level edits with <span class="ttag">replace_lines</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🥊</div>
+        <h3>Opposition agents</h3>
+        <p>Every AI Chat page is a configurable agent. Brief one to argue the other side and consult it with <span class="ttag">ask_agent</span> — your case sparred before the round.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🗂️</div>
+        <h3>One drive, the whole case</h3>
+        <p>Documents, sheets, code, task lists, channels, and files live together in a drive — your case stays connected, searchable, and shared.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📊</div>
+        <h3>Evidence & rebuttal sheets</h3>
+        <p>Sheet pages the AI reads and writes via <span class="ttag">edit_sheet_cells</span> — quotes, stats, sources, and your counter to every opposition line, query-ready.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">👥</div>
+        <h3>Team in real time</h3>
+        <p>Your partner, coach, or research team works alongside the agents in the same drive — real-time collaboration plus channels for the back-and-forth.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧠</div>
+        <h3>100+ models</h3>
+        <p>Route to Anthropic, OpenAI, Google, xAI, OpenRouter, or a local Ollama model per task — the right brain for research, drafting, or sparring.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔌</div>
+        <h3>MCP & integrations</h3>
+        <p>PageSpace speaks the Model Context Protocol, and connects calendar and drive integrations so prep slots into the rest of your workflow.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Yours to keep</h3>
+        <p>Cloud, self-hosted on-prem, desktop, or mobile. Passwordless passkey auth and on-prem mode keep sensitive research under your control.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- BRIEF SPLIT -->
+<section id="brief" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Case files</div>
+      <h2>Both sides of the motion, <span class="hl">argued for you.</span></h2>
+      <p class="lead">PageSpace never builds a one-sided brief. It researches the government and opposition cases in parallel, maps every clash, and hands you a matrix of attacks and the best response to each — so you're ready no matter which side you draw.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>Sourced from the live web</h4><p>Claims come from <span class="ttag">web_search</span> + <span class="ttag">web_fetch</span> with links back to the original, so you can verify and cite on the floor.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Rebuttals in a sheet</h4><p>The AI fills a Sheet page pairing each opposition argument with your strongest counter and the evidence behind it.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>You stay the author</h4><p>Edit anything live — refresh protection means the AI never overwrites the line you're working on.</p></div></div>
+      </div>
+    </div>
+    <div class="brief-card fade">
+      <div class="bh">
+        <span class="t">Rebuttal Matrix</span>
+        <span class="m">Sheet page · 16 clashes</span>
+      </div>
+      <div class="bb">
+        <div class="arg-row">
+          <div class="arg-col pro">
+            <h5>Our line</h5>
+            <div class="arg-item"><b>Bans protect civil liberties</b> from mass surveillance creep.<span class="src">[1] EFF 2024</span></div>
+            <div class="arg-item"><b>Tech is provably biased</b> — high false-positive rates on minorities.<span class="src">[7] Gender Shades</span></div>
+            <div class="arg-item"><b>No consent framework</b> exists for public biometric capture.<span class="src">[3] GDPR Art. 9</span></div>
+          </div>
+          <div class="arg-col con">
+            <h5>Their attack → our counter</h5>
+            <div class="arg-item"><b>"It stops crime"</b> → reframe: accuracy too low to be just; harms outweigh.<span class="src">[12] NIST FRVT</span></div>
+            <div class="arg-item"><b>"Opt-in is enough"</b> → public space = no meaningful opt-out.<span class="src">[3] GDPR Art. 9</span></div>
+            <div class="arg-item"><b>"Regulate, don't ban"</b> → regulation hasn't curbed deployment to date.<span class="src">[9] AINow 2023</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — docs, sheets, chat & more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models across 6 providers</div></div>
+      <div class="stat fade"><div class="n">1</div><div class="l">Drive that holds the whole case</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Who it's for</div>
+      <h2>One workspace, <span class="hl">many kinds of clash</span></h2>
+      <p>If your work is winning an argument with evidence, PageSpace was built for you.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">🏆</div><h3>Competitive debaters</h3><p>Prep both sides of any motion in an evening — definitions, contentions, evidence, and a rebuttal matrix ready for the round.</p></div>
+      <div class="uc fade"><div class="ic">⚖️</div><h3>Mock trial & litigation</h3><p>Build case theory, marshal exhibits, and rehearse cross-examination against an AI that argues the other side.</p></div>
+      <div class="uc fade"><div class="ic">📑</div><h3>Policy & think tanks</h3><p>Auto-research a question, draft a cited brief, and pressure-test the recommendation before it reaches a decision-maker.</p></div>
+      <div class="uc fade"><div class="ic">📰</div><h3>Researchers & journalists</h3><p>Chase a story across dozens of sources, keep every claim traceable, and write the piece in the same place you gathered it.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"I used to spend the night before a round drowning in tabs. Now I spend it <span class="hl">sparring against the case</span> — because PageSpace already built it."</div>
+    <div class="by"><b>Maya R.</b> · National circuit debater</div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Prep your first motion tonight.</h2>
+      <p>Drop in a resolution and watch PageSpace research it, brief it, and spar with you — free, no card required.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Start prepping free</a>
+        <a href="#" class="btn btn-ghost btn-lg">Book a walkthrough</a>
+      </div>
+      <p class="micro">Cloud · self-hosted · desktop · mobile — your research, your infrastructure.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native knowledge workspace where humans and agents research, write, and argue — together.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#brief">Case files</a>
+          <a href="#usecases">Use cases</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">Documents</a>
+          <a href="#">Sheets & canvas</a>
+          <a href="#">AI agents</a>
+          <a href="#">MCP integrations</a>
+        </div>
+        <div class="foot-col">
+          <h5>Deploy</h5>
+          <a href="#">Cloud</a>
+          <a href="#">Self-hosted</a>
+          <a href="#">Desktop</a>
+          <a href="#">Mobile</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span>Prototype · debate-prep landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // scroll reveal
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-local-ai-teams/index.html
+++ b/prototypes/pagespace-local-ai-teams/index.html
@@ -1,0 +1,674 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — Take Your Local AI Agent to the Whole Team</title>
+<meta name="description" content="Coming from OpenClaw or Hermes? You proved agents can do the work. PageSpace is the cloud workspace that makes them multiplayer — your team and AI agents on shared documents, sheets, and tasks, with full parity from web to mobile and nothing to host." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #0b0a08;
+    --s1: #131210;
+    --s2: #1a1814;
+    --s3: #23201a;
+    --border: #2c2820;
+    --border2: #3c3526;
+    --ember: #ff7a45;
+    --amber: #f6b352;
+    --teal: #2dd4bf;
+    --green: #4ade80;
+    --red: #fb7185;
+    --text: #f2ede2;
+    --mid: #a8a08f;
+    --dim: #6b6557;
+    --sans: "Inter", system-ui, sans-serif;
+    --display: "Space Grotesk", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(255,122,69,0.28); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(14px);
+    background: rgba(11,10,8,0.74);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-family: var(--display); font-weight: 700; font-size: 16px; letter-spacing: -0.3px; }
+  .logo .mark {
+    width: 26px; height: 26px; border-radius: 7px;
+    background: linear-gradient(140deg, var(--ember), var(--amber));
+    display: grid; place-items: center; font-size: 13px; font-weight: 700; color: #1a1008;
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 4px 16px rgba(255,122,69,0.35);
+  }
+  .nav-links { display: flex; align-items: center; gap: 30px; }
+  .nav-links a { font-size: 13.5px; color: var(--mid); transition: color .15s; }
+  .nav-links a:hover { color: var(--text); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 13.5px;
+    padding: 10px 18px; border-radius: 9px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s, border-color .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--ember), #ff944f);
+    color: #1a1008; box-shadow: 0 6px 22px rgba(255,122,69,0.32);
+  }
+  .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 30px rgba(255,122,69,0.48); }
+  .btn-ghost { background: var(--s2); color: var(--text); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s3); border-color: var(--ember); }
+  .btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 11px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 100px 0 70px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(640px 380px at 50% -8%, rgba(255,122,69,0.20), transparent 70%),
+      radial-gradient(540px 360px at 82% 14%, rgba(246,179,82,0.14), transparent 70%),
+      radial-gradient(520px 340px at 14% 26%, rgba(45,212,191,0.10), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.4px;
+    color: var(--ember); background: rgba(255,122,69,0.10);
+    border: 1px solid rgba(255,122,69,0.30); padding: 6px 14px; border-radius: 999px;
+    margin-bottom: 28px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); }
+  h1 {
+    font-family: var(--display);
+    font-size: clamp(38px, 6.2vw, 66px); font-weight: 700;
+    letter-spacing: -1.8px; line-height: 1.05; margin-bottom: 24px;
+  }
+  h1 .grad {
+    background: linear-gradient(110deg, var(--ember) 8%, var(--amber) 52%, var(--teal) 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 680px; margin: 0 auto 38px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 22px; }
+  .micro { font-size: 12.5px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 64px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 120px -30px rgba(0,0,0,0.85), 0 0 0 1px rgba(255,255,255,0.03);
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--s2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#ff5f57; } .mock-bar .d:nth-child(2){ background:#febc2e; } .mock-bar .d:nth-child(3){ background:#28c840; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 196px 1fr 236px; min-height: 432px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: var(--s1); }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; }
+  .mock-side .grp:first-child { margin-top: 0; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 7px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(255,122,69,0.12); color: var(--text); }
+  .tree-item .ic { font-size: 13px; }
+  .tree-item .on { margin-left: auto; width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+  .mock-main { padding: 22px 26px; border-right: 1px solid var(--border); }
+  .doc-top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+  .doc-h { font-family: var(--display); font-size: 19px; font-weight: 600; letter-spacing: -0.4px; }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-top: 4px; }
+  .avatars { display: flex; }
+  .avatars .av { width: 24px; height: 24px; border-radius: 50%; display: grid; place-items: center; font-size: 10px; font-weight: 700; color: #1a1008; border: 2px solid var(--s1); margin-left: -7px; }
+  .avatars .av:first-child { margin-left: 0; }
+  .av.a1 { background: var(--ember); } .av.a2 { background: var(--teal); } .av.a3 { background: var(--amber); }
+  .av.bot { background: var(--s3); color: var(--teal); border-color: var(--border2); }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 82%; } .doc-line.w3 { width: 90%; } .doc-line.w4 { width: 68%; }
+  .doc-tag {
+    font-size: 11.5px; font-family: var(--mono); color: var(--teal);
+    background: rgba(45,212,191,0.08); border: 1px solid rgba(45,212,191,0.2);
+    border-radius: 6px; padding: 4px 8px; display: inline-block; margin: 6px 6px 0 0;
+  }
+  .doc-block {
+    margin-top: 18px; border-left: 2px solid var(--amber); padding: 10px 14px;
+    background: rgba(246,179,82,0.06); border-radius: 0 8px 8px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--amber); font-weight: 600; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); }
+  .doc-block p b { color: var(--text); }
+  .mock-ai { padding: 16px; background: var(--s1); display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--text); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--green); box-shadow: 0 0 8px var(--green); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 10px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s2); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--text); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--teal);
+    background: rgba(45,212,191,0.07); border: 1px solid rgba(45,212,191,0.22);
+    border-radius: 7px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--teal); animation: pulse 1s infinite; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- STRIP ---------- */
+  .strip { padding: 40px 0 10px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 22px; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 36px; opacity: .75; }
+  .strip-row span { font-size: 14.5px; font-weight: 600; color: var(--mid); letter-spacing: -0.2px; }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 90px 0; }
+  .sec-head { text-align: center; max-width: 700px; margin: 0 auto 56px; }
+  .kicker { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--ember); margin-bottom: 16px; }
+  h2 { font-family: var(--display); font-size: clamp(28px, 4vw, 42px); font-weight: 700; letter-spacing: -1px; line-height: 1.12; margin-bottom: 18px; }
+  h2 .hl { background: linear-gradient(110deg, var(--ember), var(--amber)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .prob-card .x { color: var(--red); font-size: 22px; margin-bottom: 14px; }
+  .prob-card h3 { font-family: var(--display); font-size: 16px; font-weight: 600; margin-bottom: 8px; }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 14px; display: grid; place-items: center;
+    font-family: var(--display); font-weight: 700; font-size: 20px; color: #1a1008;
+    background: linear-gradient(140deg, var(--ember), var(--amber));
+    box-shadow: 0 8px 24px rgba(255,122,69,0.3); z-index: 1;
+  }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-family: var(--display); font-size: 19px; font-weight: 600; margin-bottom: 8px; letter-spacing: -0.3px; }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 640px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--teal);
+    background: rgba(45,212,191,0.07); border: 1px solid rgba(45,212,191,0.2);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px;
+    transition: transform .15s, border-color .2s, background .2s;
+  }
+  .feat:hover { transform: translateY(-3px); border-color: var(--border2); background: var(--s2); }
+  .feat .ic {
+    width: 44px; height: 44px; border-radius: 11px; display: grid; place-items: center;
+    font-size: 21px; margin-bottom: 16px; background: var(--s3); border: 1px solid var(--border2);
+  }
+  .feat h3 { font-family: var(--display); font-size: 16.5px; font-weight: 600; margin-bottom: 8px; }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.86em; color: var(--teal); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / ARTIFACT ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(74,222,128,0.12); border: 1px solid rgba(74,222,128,0.35); color: var(--green); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .board-card {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    box-shadow: 0 30px 80px -30px rgba(0,0,0,0.8);
+  }
+  .board-card .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--s2); display: flex; align-items: center; justify-content: space-between; }
+  .board-card .bh .t { font-family: var(--display); font-weight: 600; font-size: 14px; }
+  .board-card .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .board-card .bb { padding: 16px 20px 20px; }
+  .col-h { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 0 10px; }
+  .col-h:first-child { margin-top: 0; }
+  .task {
+    display: flex; align-items: center; gap: 10px; padding: 11px 12px; border-radius: 9px;
+    background: var(--s2); border: 1px solid var(--border); margin-bottom: 9px; font-size: 12.5px; color: var(--text);
+  }
+  .task .st { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+  .st.done { background: var(--green); } .st.prog { background: var(--amber); } .st.todo { background: var(--dim); }
+  .task .who { margin-left: auto; font-family: var(--mono); font-size: 10px; padding: 3px 7px; border-radius: 6px; background: var(--s3); color: var(--mid); }
+  .task .who.agent { color: var(--teal); background: rgba(45,212,191,0.1); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 28px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 14px; }
+  .stat .n { font-family: var(--display); font-size: 38px; font-weight: 700; letter-spacing: -1.5px; background: linear-gradient(120deg, var(--ember), var(--amber)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .uc .ic { font-size: 24px; margin-bottom: 14px; }
+  .uc h3 { font-family: var(--display); font-size: 16.5px; font-weight: 600; margin-bottom: 8px; }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 800px; margin: 0 auto; }
+  .quote-wrap .q { font-family: var(--display); font-size: clamp(22px, 3.2vw, 30px); font-weight: 500; line-height: 1.42; letter-spacing: -0.6px; margin-bottom: 24px; }
+  .quote-wrap .q .hl { color: var(--ember); }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--text); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 24px; overflow: hidden;
+    padding: 72px 32px; border: 1px solid var(--border2); background: var(--s1);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(600px 300px at 50% -20%, rgba(255,122,69,0.28), transparent 70%),
+                radial-gradient(500px 300px at 80% 120%, rgba(45,212,191,0.20), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 560px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 300px; }
+  .foot-brand p { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--mid); margin-bottom: 14px; }
+  .foot-col a { display: block; font-size: 13px; color: var(--dim); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--text); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#board">Shared work</a>
+      <a href="#usecases">Use cases</a>
+      <a href="#cta" class="btn btn-primary">Bring your team free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The cloud AI workspace for teams</div>
+    <h1>Your local AI agent<br>was just the prototype.<br><span class="grad">Give the whole team one.</span></h1>
+    <p class="sub">OpenClaw and Hermes proved an agent can actually <em>do the work</em>, not just chat. PageSpace takes that power multiplayer — a cloud workspace where your team and AI agents work side by side on real documents, sheets, and tasks. Nothing to host, no box to babysit, full parity from web to mobile.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Spin up a team drive free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">Free to start · <strong>33+ real AI tools</strong> · 100+ models · Web, desktop &amp; full-parity mobile</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / northwind-platform / Deploy runbook — v4 rollout</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">Team drive</div>
+          <div class="tree-item active"><span class="ic">📓</span> Deploy runbook <span class="on"></span></div>
+          <div class="tree-item"><span class="ic">🚨</span> Incident log</div>
+          <div class="tree-item"><span class="ic">🧩</span> Service catalog</div>
+          <div class="tree-item"><span class="ic">✅</span> On-call tasks</div>
+          <div class="grp">Agents</div>
+          <div class="tree-item"><span class="ic">🤖</span> Ops Agent <span class="on"></span></div>
+          <div class="tree-item"><span class="ic">🔬</span> Research Agent</div>
+          <div class="tree-item"><span class="ic">🛡️</span> Security Agent</div>
+          <div class="grp">Channels</div>
+          <div class="tree-item"><span class="ic">💬</span> #incidents</div>
+          <div class="tree-item"><span class="ic">💬</span> #standup</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-top">
+            <div>
+              <div class="doc-h">Deploy Runbook — v4 rollout</div>
+              <div class="doc-meta">shared drive · 3 editing now · updated 30s ago</div>
+            </div>
+            <div class="avatars">
+              <span class="av a1">DA</span><span class="av a2">PR</span><span class="av a3">JL</span><span class="av bot">AI</span>
+            </div>
+          </div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <span class="doc-tag">step 3 · drain node pool</span>
+          <span class="doc-tag">CVE-2026-1185</span>
+          <span class="doc-tag">rollback ↩</span>
+          <div class="doc-block">
+            <div class="lbl">⚠ Flagged for the team</div>
+            <p><b>Security Agent</b> confirmed CVE-2026-1185 is high severity on the auth service. Patch lands before rollout — opened a task for <b>@priya</b> and posted the rollback steps to <b>#incidents</b>.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Ops Agent · shared</div>
+          <div class="ai-tool"><span class="sp"></span> ask_agent · Security Agent</div>
+          <div class="ai-tool"><span class="sp"></span> create_task · "@priya: patch CVE"</div>
+          <div class="ai-tool"><span class="sp"></span> send_channel_message · #incidents</div>
+          <div class="ai-msg bot">Read the whole drive for context, asked <b>Security Agent</b> to confirm the CVE, and opened a task for <b>Priya</b>. The runbook's updated — <b>Dana's editing it live</b> right now.</div>
+          <div class="ai-msg bot">Same agent, same context for everyone — and Priya can pick it up from her phone on the way in.</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>For teams graduating from solo, local agents</p>
+  <div class="strip-row">
+    <span>OpenClaw</span>
+    <span>Hermes Agent</span>
+    <span>Indie teams</span>
+    <span>Startups</span>
+    <span>On-call teams</span>
+    <span>Remote crews</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The wall every solo agent hits</div>
+      <h2>A great agent on one laptop is <span class="hl">still a silo of one.</span></h2>
+      <p>You love that it acts on its own. But the moment a second person needs in — or you get tired of being the one keeping the box alive at 2am — the magic stops, because all of it lives on your machine.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>The brain lives on one machine</h3>
+        <p>Memory, skills, and everything the agent learned about your stack are trapped on your box. A teammate gets a blank bot and starts from zero.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Handoff means copy-paste</h3>
+        <p>The agent does great work, then you paste it into a chat thread. The thread becomes the deliverable — nobody can edit it, search it, or build on it.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>You're the one keeping it alive</h3>
+        <p>Someone has to babysit the process, watch the spend, and patch it. The agent is only as available as your laptop — and only you can fix it when it falls over.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>Keep the agent. <span class="hl">Lose the single point of failure.</span></h2>
+      <p>PageSpace isn't a chatbot you copy answers out of. It's a shared cloud workspace where agents do the work <em>inside</em> the team's documents, sheets, and tasks — using real tools, with everyone watching it happen and nothing to run.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Spin up a shared drive and write the context once</h3>
+          <p>Create a team drive and set its standing context — your stack, conventions, and runbooks — with <span style="font-family:var(--mono);font-size:0.85em;color:var(--teal)">update_drive_context</span>. Every agent and every teammate reads from the same source instead of re-explaining the world to a fresh bot.</p>
+          <div class="tags"><span class="tag">create_drive</span><span class="tag">update_drive_context</span><span class="tag">create_page</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>Brief agents as roles — once, for everyone</h3>
+          <p>Every AI Chat page <em>is</em> a configurable agent. Brief an Ops, Research, or Security agent with <span style="font-family:var(--mono);font-size:0.85em;color:var(--teal)">update_agent_config</span>, and the whole team consults the same expert. No more one bot per person, each with its own half-remembered context.</p>
+          <div class="tags"><span class="tag">update_agent_config</span><span class="tag">list_agents</span><span class="tag">multi_drive_list_agents</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Agents do the work across the workspace</h3>
+          <p>They run live web research, edit pages with precise line-level changes, fill structured sheets, and open tasks — the same do-real-things power you came for, now landing in shared artifacts the whole team can see, search, and edit.</p>
+          <div class="tags"><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">replace_lines</span><span class="tag">edit_sheet_cells</span><span class="tag">create_task</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Everyone works in the same place, live</h3>
+          <p>Real-time collaboration means humans and agents are in the drive together — on the web or on a phone. Agents consult each other with <span style="font-family:var(--mono);font-size:0.85em;color:var(--teal)">ask_agent</span>, post to channels, and assign work, and refresh protection means an agent never clobbers the line a teammate is typing.</p>
+          <div class="tags"><span class="tag">ask_agent</span><span class="tag">send_channel_message</span><span class="tag">get_assigned_tasks</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">What you keep, what you gain</div>
+      <h2>The part you loved — <span class="hl">now built for a team</span></h2>
+      <p>Nine page types, 33+ real AI tools, and 100+ models — composed so a solo agent stops being a one-laptop trick and becomes how the whole team works.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">⚙️</div>
+        <h3>Agents that act, not chat</h3>
+        <p>33+ real tools — agents run <span class="ttag">web_search</span>, write pages with <span class="ttag">replace_lines</span>, fill sheets, and open tasks. The do-things power you came for, now in shared space.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧠</div>
+        <h3>One agent, shared context</h3>
+        <p>Every AI Chat page is a configurable agent. Brief it once with <span class="ttag">update_agent_config</span> — the whole team consults the same expert, and agents consult each other with <span class="ttag">ask_agent</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🗂️</div>
+        <h3>One drive holds everything</h3>
+        <p>Documents, sheets, code, task lists, channels, and files live together in a shared drive — nine page types, one connected, searchable source of truth.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">👥</div>
+        <h3>Real-time multiplayer</h3>
+        <p>Humans and agents work in the same drive at once. Refresh protection means an agent never overwrites the line a teammate is editing live.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧩</div>
+        <h3>100+ models, managed</h3>
+        <p>Route the right model to each task across leading providers — research, drafting, reasoning. No keys to wire up and no endpoints to maintain.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📱</div>
+        <h3>Full parity on every screen</h3>
+        <p>The same shared workspace on web, desktop, and mobile — a teammate picks up the agent's work from their phone in full, not a stripped-down view.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔌</div>
+        <h3>MCP &amp; integrations</h3>
+        <p>PageSpace speaks the Model Context Protocol, and connects GitHub, Google Calendar, and Drive — wire in the external tools your team already runs.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">✅</div>
+        <h3>Tasks &amp; channels</h3>
+        <p>Agents open and update work with <span class="ttag">create_task</span> and <span class="ttag">get_assigned_tasks</span>, and post the back-and-forth to channels with <span class="ttag">send_channel_message</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Secure by default</h3>
+        <p>Passwordless passkey and magic-link sign-in, granular permissions, and a private workspace per team — no passwords to leak, nothing to run or maintain.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- BOARD SPLIT -->
+<section id="board" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Shared work, not a DM thread</div>
+      <h2>The agent's output becomes <span class="hl">the team's, not yours alone.</span></h2>
+      <p class="lead">When a solo agent finishes, the work is stuck in your terminal. In PageSpace the agent builds a real Task List, assigns it across people <em>and</em> agents, and keeps it live — so the next teammate picks up exactly where it left off, from any device, not from a pasted summary.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>Agents assign work, to humans and agents</h4><p>It opens and updates tasks with <span class="ttag">create_task</span> and <span class="ttag">update_task</span>, then routes them to whoever — or whatever — should own each one.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Everyone sees the same board</h4><p>No more "what did the bot say in your DMs?" — the task list, the runbook, and the incident log are shared pages the whole team reads and edits.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>You stay in control, with nothing to run</h4><p>Granular permissions and passwordless passkey auth keep the workspace private — and it's a managed cloud, so there's no box to patch or babysit.</p></div></div>
+      </div>
+    </div>
+    <div class="board-card fade">
+      <div class="bh">
+        <span class="t">On-call tasks</span>
+        <span class="m">Task List page · v4 rollout</span>
+      </div>
+      <div class="bb">
+        <div class="col-h">In progress</div>
+        <div class="task"><span class="st prog"></span> Patch CVE-2026-1185 on auth service <span class="who">@priya</span></div>
+        <div class="task"><span class="st prog"></span> Draft rollback playbook section <span class="who agent">Ops Agent</span></div>
+        <div class="col-h">To do</div>
+        <div class="task"><span class="st todo"></span> Verify staging health checks <span class="who">@dana</span></div>
+        <div class="task"><span class="st todo"></span> Pull recent CVE advisories <span class="who agent">Research Agent</span></div>
+        <div class="col-h">Done</div>
+        <div class="task"><span class="st done"></span> Confirm CVE severity <span class="who agent">Security Agent</span></div>
+        <div class="task"><span class="st done"></span> Post rollback steps to #incidents <span class="who agent">Ops Agent</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — docs, sheets, tasks, chat &amp; more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models, routed per task</div></div>
+      <div class="stat fade"><div class="n">0</div><div class="l">Servers, keys, or infra to manage</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Who makes the jump</div>
+      <h2>From a personal agent to <span class="hl">a team that runs on agents</span></h2>
+      <p>If you fell in love with an agent that actually does things, here's where it goes once more than one person needs it.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">🛠️</div><h3>Engineering &amp; on-call teams</h3><p>A shared Ops agent that knows the stack, drafts runbooks, opens tasks, and posts to incident channels — instead of one bot per engineer.</p></div>
+      <div class="uc fade"><div class="ic">🚀</div><h3>Indie hackers &amp; small startups</h3><p>You ran the agent solo to ship faster. Now your cofounders and first hires share the same agent-powered workspace, on day one.</p></div>
+      <div class="uc fade"><div class="ic">🔬</div><h3>Research labs &amp; collectives</h3><p>Bring the whole collective into one cloud drive — research logs, sheets, and shared agents — with nothing to provision or maintain.</p></div>
+      <div class="uc fade"><div class="ic">☁️</div><h3>Off the laptop, into the cloud</h3><p>You proved it solo on your own hardware. Hand off the maintenance and give the whole crew the same agent power — instantly, on every device.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"We each ran our own agent on our own boxes. Great — until we had to work together, and until I got tired of being the one who fixed it at midnight. PageSpace gave the whole team <span class="hl">one agent-powered workspace</span>, with nothing for us to run."</div>
+    <div class="by"><b>Sam K.</b> · Platform lead, 9-person team <span style="color:var(--dim)">· illustrative</span></div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Take your agent multiplayer.</h2>
+      <p>Spin up a shared drive, invite your team, and brief your first agent in minutes — free, with nothing to install or host.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Spin up a team drive free</a>
+        <a href="#" class="btn btn-ghost btn-lg">Book a walkthrough</a>
+      </div>
+      <p class="micro">Cloud workspace · web, desktop &amp; full-parity mobile · your team online in minutes.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native workspace where humans and AI agents research, write, and ship — together. Cloud-hosted, full parity from web to mobile, nothing for you to run.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#board">Shared work</a>
+          <a href="#usecases">Use cases</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">AI agents</a>
+          <a href="#">Documents &amp; sheets</a>
+          <a href="#">Tasks &amp; channels</a>
+          <a href="#">MCP integrations</a>
+        </div>
+        <div class="foot-col">
+          <h5>Get it</h5>
+          <a href="#">Web app</a>
+          <a href="#">Desktop app</a>
+          <a href="#">iOS &amp; Android</a>
+          <a href="#">Integrations</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span>Prototype · local-ai-teams landing · OpenClaw and Hermes are independent projects, referenced for audience context only.</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-mentors-consulting/index.html
+++ b/prototypes/pagespace-mentors-consulting/index.html
@@ -1,0 +1,679 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — The Consulting & Mentoring Workspace</title>
+<meta name="description" content="Run every client engagement from one AI-native workspace. PageSpace gives each client a drive, preps your session briefs from live research and past notes, drafts deliverables in the editor, and tracks action items and next sessions — so you show up sharp and follow through every time." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #faf7f1;
+    --s1: #ffffff;
+    --s2: #f4efe6;
+    --s3: #ece4d6;
+    --border: #e7ddcb;
+    --border2: #d8ccb4;
+    --ink: #20251f;
+    --teal: #0f6b5f;
+    --teal2: #14897a;
+    --gold: #b07d20;
+    --gold2: #c79534;
+    --plum: #8a3b4c;
+    --sky: #2f6f8f;
+    --text: #20251f;
+    --mid: #5e6259;
+    --dim: #8c8c80;
+    --serif: "Fraunces", Georgia, serif;
+    --sans: "Inter", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(15,107,95,0.18); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(14px);
+    background: rgba(250,247,241,0.78);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 66px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 17px; letter-spacing: -0.3px; font-family: var(--serif); }
+  .logo .mark {
+    width: 27px; height: 27px; border-radius: 8px;
+    background: linear-gradient(140deg, var(--teal), var(--teal2));
+    display: grid; place-items: center; font-size: 14px; font-weight: 700; color: #fff;
+    box-shadow: 0 0 0 1px rgba(0,0,0,0.04), 0 4px 14px rgba(15,107,95,0.28); font-family: var(--serif);
+  }
+  .nav-links { display: flex; align-items: center; gap: 30px; }
+  .nav-links a { font-size: 13.5px; color: var(--mid); transition: color .15s; font-weight: 500; }
+  .nav-links a:hover { color: var(--ink); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 13.5px;
+    padding: 10px 18px; border-radius: 9px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--teal), var(--teal2));
+    color: #fff; box-shadow: 0 6px 18px rgba(15,107,95,0.28);
+  }
+  .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 26px rgba(15,107,95,0.4); }
+  .btn-ghost { background: var(--s1); color: var(--ink); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s2); border-color: var(--teal); }
+  .btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 11px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 96px 0 64px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(640px 380px at 50% -8%, rgba(15,107,95,0.10), transparent 70%),
+      radial-gradient(540px 360px at 82% 10%, rgba(176,125,32,0.10), transparent 70%),
+      radial-gradient(520px 340px at 14% 24%, rgba(47,111,143,0.07), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.4px;
+    color: var(--teal); background: rgba(15,107,95,0.08);
+    border: 1px solid rgba(15,107,95,0.22); padding: 6px 14px; border-radius: 999px;
+    margin-bottom: 28px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--gold2); box-shadow: 0 0 8px var(--gold2); }
+  h1 {
+    font-family: var(--serif); font-size: clamp(38px, 6.1vw, 66px); font-weight: 600;
+    letter-spacing: -1.4px; line-height: 1.05; margin-bottom: 24px; color: var(--ink);
+  }
+  h1 .grad {
+    background: linear-gradient(110deg, var(--teal) 8%, var(--teal2) 48%, var(--gold) 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 670px; margin: 0 auto 38px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 22px; }
+  .micro { font-size: 12.5px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 60px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 90px -34px rgba(50,40,20,0.35), 0 0 0 1px rgba(255,255,255,0.5);
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--s2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#e6816f; } .mock-bar .d:nth-child(2){ background:#dab14a; } .mock-bar .d:nth-child(3){ background:#5fae7a; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 196px 1fr 234px; min-height: 432px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: #fcfaf6; }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; font-weight: 600; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 7px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(15,107,95,0.10); color: var(--ink); font-weight: 600; }
+  .tree-item .ic { font-size: 13px; }
+  .mock-main { padding: 24px 26px; border-right: 1px solid var(--border); }
+  .doc-h { font-family: var(--serif); font-size: 20px; font-weight: 600; letter-spacing: -0.4px; margin-bottom: 4px; color: var(--ink); }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-bottom: 18px; }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 82%; } .doc-line.w3 { width: 90%; } .doc-line.w4 { width: 68%; }
+  .doc-cite {
+    font-size: 11.5px; font-family: var(--mono); color: var(--sky);
+    background: rgba(47,111,143,0.08); border: 1px solid rgba(47,111,143,0.2);
+    border-radius: 6px; padding: 4px 8px; display: inline-block; margin: 6px 6px 0 0;
+  }
+  .doc-block {
+    margin-top: 18px; border-left: 2px solid var(--gold); padding: 10px 14px;
+    background: rgba(176,125,32,0.07); border-radius: 0 8px 8px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--gold); font-weight: 700; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); }
+  .mock-ai { padding: 16px 16px; background: #fcfaf6; display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--ink); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--teal2); box-shadow: 0 0 8px var(--teal2); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 10px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s2); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--ink); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--teal);
+    background: rgba(15,107,95,0.06); border: 1px solid rgba(15,107,95,0.2);
+    border-radius: 7px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--teal2); animation: pulse 1s infinite; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- LOGO STRIP ---------- */
+  .strip { padding: 44px 0 10px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 22px; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 40px; opacity: .82; }
+  .strip-row span { font-size: 15px; font-weight: 600; color: var(--mid); letter-spacing: -0.2px; font-family: var(--serif); }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 90px 0; }
+  .sec-head { text-align: center; max-width: 690px; margin: 0 auto 56px; }
+  .kicker { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--teal); margin-bottom: 16px; }
+  h2 { font-family: var(--serif); font-size: clamp(28px, 4vw, 42px); font-weight: 600; letter-spacing: -0.8px; line-height: 1.12; margin-bottom: 18px; color: var(--ink); }
+  h2 .hl { background: linear-gradient(110deg, var(--teal), var(--gold)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; box-shadow: 0 1px 0 rgba(0,0,0,0.02); }
+  .prob-card .x { color: var(--plum); font-size: 22px; margin-bottom: 14px; }
+  .prob-card h3 { font-size: 16px; font-weight: 700; margin-bottom: 8px; }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 14px; display: grid; place-items: center;
+    font-weight: 600; font-size: 20px; color: #fff; font-family: var(--serif);
+    background: linear-gradient(140deg, var(--teal), var(--teal2));
+    box-shadow: 0 8px 20px rgba(15,107,95,0.28); z-index: 1;
+  }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-family: var(--serif); font-size: 20px; font-weight: 600; margin-bottom: 8px; letter-spacing: -0.3px; color: var(--ink); }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 620px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--teal);
+    background: rgba(15,107,95,0.06); border: 1px solid rgba(15,107,95,0.2);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px;
+    transition: transform .15s, border-color .2s, box-shadow .2s; box-shadow: 0 1px 0 rgba(0,0,0,0.02);
+  }
+  .feat:hover { transform: translateY(-3px); border-color: var(--border2); box-shadow: 0 16px 40px -20px rgba(50,40,20,0.22); }
+  .feat .ic {
+    width: 44px; height: 44px; border-radius: 11px; display: grid; place-items: center;
+    font-size: 21px; margin-bottom: 16px; background: var(--s2); border: 1px solid var(--border2);
+  }
+  .feat h3 { font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.86em; color: var(--teal); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / BRIEF ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(15,107,95,0.10); border: 1px solid rgba(15,107,95,0.32); color: var(--teal); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .brief-card {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    box-shadow: 0 30px 70px -30px rgba(50,40,20,0.3);
+  }
+  .brief-card .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--s2); display: flex; align-items: center; justify-content: space-between; }
+  .brief-card .bh .t { font-weight: 700; font-size: 14px; font-family: var(--serif); }
+  .brief-card .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .brief-card .bb { padding: 20px; }
+  .task-row { display: flex; align-items: flex-start; gap: 12px; padding: 12px; border-radius: 10px; background: var(--s2); border: 1px solid var(--border); margin-bottom: 10px; }
+  .task-row .chk { width: 18px; height: 18px; border-radius: 6px; flex-shrink: 0; margin-top: 1px; display: grid; place-items: center; font-size: 11px; font-weight: 700; }
+  .task-row.done .chk { background: rgba(15,107,95,0.14); border: 1px solid rgba(15,107,95,0.4); color: var(--teal); }
+  .task-row.open .chk { background: var(--s1); border: 1px solid var(--border2); color: transparent; }
+  .task-row .body { flex: 1; }
+  .task-row .ti { font-size: 12.5px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+  .task-row.done .ti { color: var(--dim); text-decoration: line-through; }
+  .task-row .tm { display: flex; gap: 8px; margin-top: 6px; flex-wrap: wrap; }
+  .pill { font-family: var(--mono); font-size: 9.5px; padding: 2px 7px; border-radius: 999px; }
+  .pill.owner { background: rgba(47,111,143,0.1); color: var(--sky); border: 1px solid rgba(47,111,143,0.22); }
+  .pill.due { background: rgba(176,125,32,0.1); color: var(--gold); border: 1px solid rgba(176,125,32,0.25); }
+  .pill.src { background: rgba(15,107,95,0.07); color: var(--teal); border: 1px solid rgba(15,107,95,0.2); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 28px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 14px; }
+  .stat .n { font-family: var(--serif); font-size: 40px; font-weight: 600; letter-spacing: -1.5px; background: linear-gradient(120deg, var(--teal), var(--gold)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .uc .ic { font-size: 24px; margin-bottom: 14px; }
+  .uc h3 { font-size: 16.5px; font-weight: 700; margin-bottom: 8px; }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 800px; margin: 0 auto; }
+  .quote-wrap .q { font-family: var(--serif); font-size: clamp(22px, 3.2vw, 31px); font-weight: 500; line-height: 1.4; letter-spacing: -0.5px; margin-bottom: 24px; color: var(--ink); }
+  .quote-wrap .q .hl { color: var(--gold); }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--ink); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 24px; overflow: hidden;
+    padding: 72px 32px; border: 1px solid var(--border2); background: var(--s1);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(600px 300px at 50% -20%, rgba(15,107,95,0.14), transparent 70%),
+                radial-gradient(500px 300px at 80% 120%, rgba(176,125,32,0.13), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 560px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; background: #fcfaf6; }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 290px; }
+  .foot-brand p { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--mid); margin-bottom: 14px; }
+  .foot-col a { display: block; font-size: 13px; color: var(--dim); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--ink); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#followthrough">Follow-through</a>
+      <a href="#usecases">Who it's for</a>
+      <a href="#cta" class="btn btn-primary">Start free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI-native workspace for advisors &amp; mentors</div>
+    <h1>Show up sharp for every client.<br><span class="grad">Follow through on every one.</span></h1>
+    <p class="sub">Give each client their own drive. PageSpace agents research their market before the call, draft your session brief from past notes, write the deliverable in the editor, and turn every decision into tracked action items with the next session already booked.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Set up your practice free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">No credit card · <strong>33+ real AI tools</strong> · 100+ models · Self-host or cloud</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / clients / atlas-fintech / "Q3 GTM review — session brief"</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">Clients</div>
+          <div class="tree-item active"><span class="ic">🏦</span> Atlas Fintech</div>
+          <div class="tree-item"><span class="ic">🛍️</span> Northwind Retail</div>
+          <div class="tree-item"><span class="ic">⚙️</span> Lumen Robotics</div>
+          <div class="grp">Atlas Fintech</div>
+          <div class="tree-item"><span class="ic">📋</span> Session brief</div>
+          <div class="tree-item"><span class="ic">🗒️</span> Session notes log</div>
+          <div class="tree-item"><span class="ic">📈</span> Metrics model</div>
+          <div class="tree-item"><span class="ic">✅</span> Action items</div>
+          <div class="tree-item"><span class="ic">💬</span> Client channel</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">Atlas Fintech — Q3 GTM Review</div>
+          <div class="doc-meta">session brief · drafted from 6 past sessions · in 2h</div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <span class="doc-cite">[1] a16z fintech ’25</span>
+          <span class="doc-cite">[2] Q2 notes</span>
+          <span class="doc-cite">[3] CAC model</span>
+          <div class="doc-block">
+            <div class="lbl">◆ Open from last session</div>
+            <p>You advised narrowing ICP to mid-market lenders. Pipeline data shows CAC down 22% there vs. SMB — lead with that win, then push on the self-serve onboarding they keep deferring.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Advisory Agent</div>
+          <div class="ai-tool"><span class="sp"></span> read_page · Q2 session notes</div>
+          <div class="ai-tool"><span class="sp"></span> web_search · "fintech CAC benchmarks 2025"</div>
+          <div class="ai-tool"><span class="sp"></span> edit_sheet_cells · Metrics model</div>
+          <div class="ai-msg bot">Pulled your <b>last 6 sessions</b>, refreshed their market with live research, and drafted the brief: 3 wins to open with, 2 open commitments, and 1 hard question on retention. Their numbers are in the metrics model.</div>
+          <div class="ai-msg bot">Booked the readout for <b>Thu 3pm</b> and turned last week's decisions into <b>4 tracked action items</b>.</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>Built for the people clients pay to think clearly</p>
+  <div class="strip-row">
+    <span>Independent consultants</span>
+    <span>Fractional execs</span>
+    <span>Business coaches</span>
+    <span>Startup mentors</span>
+    <span>Advisory firms</span>
+    <span>Accelerators</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The advisor's tax</div>
+      <h2>You sell judgment. You spend your week on <span class="hl">admin and context-switching.</span></h2>
+      <p>Every client lives in a different folder, inbox thread, and half-remembered call. You re-build context before each session and chase your own follow-ups after — time that should have been billable thinking.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Context is scattered</h3>
+        <p>Notes in one doc, their metrics in a spreadsheet, the last decision buried in a thread. You rebuild the picture from scratch before every call.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Prep eats the margin</h3>
+        <p>An hour of reading old notes and Googling their market for a one-hour session. Multiply by a full roster and your real rate quietly halves.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Follow-through slips</h3>
+        <p>Great advice, no system behind it. Action items live in your head, the next session never gets booked, and clients feel the drift.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: #fcfaf6; border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>From a roster of clients to a <span class="hl">prepped, tracked practice</span></h2>
+      <p>PageSpace isn't a chatbot you copy answers out of. It's a workspace where AI agents do the prep, drafting, and tracking <em>inside</em> each client's drive, using real tools.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Give each client a drive</h3>
+          <p>Spin up a drive per client — notes, metrics, deliverables, and a private channel in one place. Set the engagement context once, and every agent in that drive reads it for free. Search across all of them when a pattern repeats.</p>
+          <div class="tags"><span class="tag">create_drive</span><span class="tag">update_drive_context</span><span class="tag">multi_drive_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>The agent preps your session brief</h3>
+          <p>Before the call, your advisory agent reads the last sessions, runs live web research on the client's market, and drafts a brief into a Document page — wins to open with, open commitments, and the hard questions to ask, every point traceable to a source.</p>
+          <div class="tags"><span class="tag">read_page</span><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">create_page</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Deliverables draft in the editor — you stay the expert</h3>
+          <p>The strategy memo writes straight into a Document; their numbers go into a Sheet the agent reads and updates. You sharpen the judgment live — refresh protection means the AI never clobbers the line you're editing.</p>
+          <div class="tags"><span class="tag">replace_lines</span><span class="tag">edit_sheet_cells</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Every decision becomes follow-through</h3>
+          <p>Turn the call's outcomes into tracked tasks with owners and due dates, post the recap to the client channel, and book the next session on the calendar — so nothing said in the room quietly evaporates.</p>
+          <div class="tags"><span class="tag">create_task</span><span class="tag">send_channel_message</span><span class="tag">create_calendar_event</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The toolkit</div>
+      <h2>Your whole practice, <span class="hl">in one workspace</span></h2>
+      <p>Nine page types, 33+ AI tools, and 100+ models — composed for the way advisors and mentors actually run a book of clients.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">🗂️</div>
+        <h3>A drive per client</h3>
+        <p>Notes, metrics, deliverables, files, and a private channel live together. Set the engagement context with <span class="ttag">update_drive_context</span> and every agent reads it.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔎</div>
+        <h3>Market research, built in</h3>
+        <p>Agents run live <span class="ttag">web_search</span> and pull full articles with <span class="ttag">web_fetch</span> — so your brief reflects the client's market this week, not last quarter.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧠</div>
+        <h3>A briefed advisory agent</h3>
+        <p>Every AI Chat page is a configurable agent. Brief one as your GTM, finance, or ops specialist with <span class="ttag">update_agent_config</span> and consult it across clients via <span class="ttag">ask_agent</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📝</div>
+        <h3>Deliverables in the editor</h3>
+        <p>Memos and decks-as-docs draft into Document pages with sources inline; precise edits land with <span class="ttag">replace_lines</span> — and you stay the author.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📈</div>
+        <h3>Live metrics models</h3>
+        <p>Client KPIs, CAC, and runway live in Sheet pages the AI reads and updates with <span class="ttag">edit_sheet_cells</span> — the model speaks in the brief, not a stale tab.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">✅</div>
+        <h3>Action items that stick</h3>
+        <p>Decisions become Task List items with owners and due dates via <span class="ttag">create_task</span>; pull what's open across the roster with <span class="ttag">get_assigned_tasks</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📅</div>
+        <h3>Sessions booked for you</h3>
+        <p>The agent checks availability and books the next session — <span class="ttag">check_calendar_availability</span>, <span class="ttag">create_calendar_event</span> — so cadence never depends on you remembering.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">💬</div>
+        <h3>Client channels &amp; recaps</h3>
+        <p>Post the session recap straight to a shared Channel with <span class="ttag">send_channel_message</span>, in real time — clients stay in the loop without another email thread.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Confidential by design</h3>
+        <p>Cloud, self-hosted on-prem, desktop, or mobile. Passwordless passkey auth and an on-prem mode keep privileged client work under your control.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FOLLOW-THROUGH SPLIT -->
+<section id="followthrough" style="background: #fcfaf6; border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Follow-through</div>
+      <h2>The value isn't the advice. It's that <span class="hl">it actually happens.</span></h2>
+      <p class="lead">PageSpace closes the loop between sessions. Every commitment from the call becomes a tracked task with an owner and a date, the recap lands in the client's channel, and the next session is already on the calendar — so the engagement keeps moving when you're not in the room.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>Owners and due dates, not vibes</h4><p>The agent turns outcomes into Task List items with <span class="ttag">create_task</span> — and surfaces what's overdue across every client with <span class="ttag">get_assigned_tasks</span>.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>The recap writes itself</h4><p>A clean summary posts to the client's Channel via <span class="ttag">send_channel_message</span> the moment the call ends.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Cadence on autopilot</h4><p>The next session books straight to the calendar, so momentum never depends on a follow-up email you forgot to send.</p></div></div>
+      </div>
+    </div>
+    <div class="brief-card fade">
+      <div class="bh">
+        <span class="t">Action Items — Atlas Fintech</span>
+        <span class="m">Task List · 4 open · 2 done</span>
+      </div>
+      <div class="bb">
+        <div class="task-row done">
+          <span class="chk">✓</span>
+          <div class="body">
+            <div class="ti">Narrow ICP to mid-market lenders in Q3 plan</div>
+            <div class="tm"><span class="pill owner">@founder</span><span class="pill src">from: Q2 session</span></div>
+          </div>
+        </div>
+        <div class="task-row open">
+          <span class="chk">✓</span>
+          <div class="body">
+            <div class="ti">Ship self-serve onboarding flow to beta cohort</div>
+            <div class="tm"><span class="pill owner">@product</span><span class="pill due">due Jun 14</span></div>
+          </div>
+        </div>
+        <div class="task-row open">
+          <span class="chk">✓</span>
+          <div class="body">
+            <div class="ti">Pull 90-day retention by segment for next readout</div>
+            <div class="tm"><span class="pill owner">@founder</span><span class="pill due">due Jun 9</span></div>
+          </div>
+        </div>
+        <div class="task-row open">
+          <span class="chk">✓</span>
+          <div class="body">
+            <div class="ti">Advisor: draft pricing-tier memo before Thu session</div>
+            <div class="tm"><span class="pill owner">@me</span><span class="pill due">due Jun 12</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — docs, sheets, tasks &amp; more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models across 6 providers</div></div>
+      <div class="stat fade"><div class="n">1</div><div class="l">Drive per client, fully connected</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: #fcfaf6; border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Who it's for</div>
+      <h2>One workspace, <span class="hl">every kind of advisor</span></h2>
+      <p>If you're paid to think clearly for other people's businesses, PageSpace runs the practice around you.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">🧭</div><h3>Independent consultants</h3><p>Run a roster of engagements from one place — prepped briefs, sourced deliverables, and tracked action items per client, without the admin tax.</p></div>
+      <div class="uc fade"><div class="ic">⏱️</div><h3>Fractional execs</h3><p>Hold deep context on three companies at once. Each drive remembers the decisions, the metrics, and what's still open between your days on.</p></div>
+      <div class="uc fade"><div class="ic">🌱</div><h3>Coaches &amp; mentors</h3><p>Keep every mentee's goals, commitments, and history in their own drive — so each session builds on the last instead of starting over.</p></div>
+      <div class="uc fade"><div class="ic">🚀</div><h3>Accelerators &amp; advisory firms</h3><p>Give a whole cohort drives, brief specialist agents once, and let your mentors and founders collaborate in real time in the same workspace.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"I carry six clients now without dropping a thread. PageSpace walks into every session already knowing the story — so I spend the hour <span class="hl">advising, not remembering.</span>"</div>
+    <div class="by"><b>Dana K.</b> · Fractional CMO &amp; startup advisor</div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Run your practice like your best client thinks you do.</h2>
+      <p>Set up your first client drive and watch PageSpace prep the session, draft the deliverable, and track the follow-through — free, no card required.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Set up your practice free</a>
+        <a href="#" class="btn btn-ghost btn-lg">Book a walkthrough</a>
+      </div>
+      <p class="micro">Cloud · self-hosted · desktop · mobile — your clients' data, your infrastructure.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native knowledge workspace where advisors and the people they help research, decide, and follow through — together.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#followthrough">Follow-through</a>
+          <a href="#usecases">Who it's for</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">Documents &amp; sheets</a>
+          <a href="#">Task lists</a>
+          <a href="#">AI agents</a>
+          <a href="#">MCP integrations</a>
+        </div>
+        <div class="foot-col">
+          <h5>Deploy</h5>
+          <a href="#">Cloud</a>
+          <a href="#">Self-hosted</a>
+          <a href="#">Desktop</a>
+          <a href="#">Mobile</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span>Prototype · mentors-consulting landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  // scroll reveal
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-pastors/index.html
+++ b/prototypes/pagespace-pastors/index.html
@@ -1,0 +1,672 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — The AI-Native Workspace for Pastors & Ministry</title>
+<meta name="description" content="Study the passage, draft the sermon, and keep every prayer request and visit from slipping — in one workspace where AI does the legwork in your documents while you stay the shepherd. Sermon prep, pastoral care, calendar, and team, together." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Spectral:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #f6f1e7;          /* warm parchment */
+    --s1: #fffdf9;          /* card surface */
+    --s2: #f0e8d9;          /* subtle surface */
+    --s3: #e8ddc9;          /* deeper surface */
+    --border: #e4dac6;
+    --border2: #d3c4a6;
+    --navy: #33476f;        /* deep slate-blue, primary */
+    --navy2: #455d8d;
+    --gold: #b9842c;        /* amber gold accent */
+    --plum: #7a4f86;        /* tool / accent */
+    --sage: #5d8a6a;        /* care / live */
+    --clay: #b5573f;        /* problem accent */
+    --ink: #2a2820;         /* warm near-black text */
+    --mid: #6c6350;         /* muted text */
+    --dim: #9a917b;         /* dim text */
+    --serif: "Spectral", Georgia, serif;
+    --sans: "Inter", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(51,71,111,0.18); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(14px);
+    background: rgba(246,241,231,0.82);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 16px; letter-spacing: -0.3px; font-family: var(--serif); }
+  .logo .mark {
+    width: 27px; height: 27px; border-radius: 8px;
+    background: linear-gradient(140deg, var(--navy), var(--plum));
+    display: grid; place-items: center; font-size: 14px; font-weight: 800; color: #fff;
+    box-shadow: 0 0 0 1px rgba(0,0,0,0.04), 0 4px 14px rgba(51,71,111,0.32);
+  }
+  .nav-links { display: flex; align-items: center; gap: 30px; }
+  .nav-links a { font-size: 13.5px; color: var(--mid); transition: color .15s; font-weight: 500; }
+  .nav-links a:hover { color: var(--ink); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 13.5px;
+    padding: 10px 18px; border-radius: 9px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--navy), var(--plum));
+    color: #fff; box-shadow: 0 6px 20px rgba(51,71,111,0.30);
+  }
+  .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 28px rgba(51,71,111,0.42); }
+  .btn-ghost { background: var(--s1); color: var(--ink); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s2); border-color: var(--navy); }
+  .btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 11px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 96px 0 64px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(620px 380px at 50% -8%, rgba(51,71,111,0.14), transparent 70%),
+      radial-gradient(540px 360px at 84% 12%, rgba(185,132,44,0.16), transparent 70%),
+      radial-gradient(520px 340px at 12% 24%, rgba(122,79,134,0.10), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.4px;
+    color: var(--navy); background: rgba(51,71,111,0.08);
+    border: 1px solid rgba(51,71,111,0.22); padding: 6px 14px; border-radius: 999px;
+    margin-bottom: 28px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--sage); box-shadow: 0 0 8px var(--sage); }
+  h1 {
+    font-family: var(--serif); font-size: clamp(38px, 6.2vw, 66px); font-weight: 800;
+    letter-spacing: -1.2px; line-height: 1.06; margin-bottom: 24px; color: var(--ink);
+  }
+  h1 .grad {
+    background: linear-gradient(110deg, var(--navy) 8%, var(--plum) 60%, var(--gold) 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 666px; margin: 0 auto 38px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 22px; }
+  .micro { font-size: 12.5px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 60px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 100px -34px rgba(51,55,40,0.40), 0 0 0 1px rgba(255,255,255,0.5);
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--s2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#e0795f; } .mock-bar .d:nth-child(2){ background:#dcae4e; } .mock-bar .d:nth-child(3){ background:#7aa67e; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 200px 1fr 236px; min-height: 432px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: var(--s1); }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; font-weight: 600; }
+  .mock-side .grp:first-child { margin-top: 0; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 7px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(51,71,111,0.10); color: var(--ink); font-weight: 500; }
+  .tree-item .ic { font-size: 13px; }
+  .mock-main { padding: 24px 26px; border-right: 1px solid var(--border); }
+  .doc-h { font-family: var(--serif); font-size: 21px; font-weight: 700; letter-spacing: -0.3px; margin-bottom: 4px; color: var(--ink); }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-bottom: 18px; }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 82%; } .doc-line.w3 { width: 90%; } .doc-line.w4 { width: 68%; }
+  .doc-cite {
+    font-size: 11.5px; font-family: var(--mono); color: var(--gold);
+    background: rgba(185,132,44,0.10); border: 1px solid rgba(185,132,44,0.28);
+    border-radius: 6px; padding: 4px 8px; display: inline-block; margin: 6px 6px 0 0;
+  }
+  .doc-block {
+    margin-top: 18px; border-left: 2px solid var(--plum); padding: 10px 14px;
+    background: rgba(122,79,134,0.06); border-radius: 0 8px 8px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--plum); font-weight: 600; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); font-family: var(--serif); font-style: italic; }
+  .mock-ai { padding: 16px; background: linear-gradient(180deg, rgba(51,71,111,0.04), rgba(122,79,134,0.03)); display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--ink); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--sage); box-shadow: 0 0 8px var(--sage); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 10px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s1); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--ink); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--sage);
+    background: rgba(93,138,106,0.08); border: 1px solid rgba(93,138,106,0.26);
+    border-radius: 7px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--sage); animation: pulse 1s infinite; flex-shrink: 0; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- STRIP ---------- */
+  .strip { padding: 38px 0 8px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 22px; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 38px; opacity: .8; }
+  .strip-row span { font-size: 15px; font-weight: 600; color: var(--mid); letter-spacing: -0.2px; font-family: var(--serif); }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 88px 0; }
+  .sec-head { text-align: center; max-width: 690px; margin: 0 auto 56px; }
+  .kicker { font-size: 12px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--gold); margin-bottom: 16px; }
+  h2 { font-family: var(--serif); font-size: clamp(28px, 4vw, 42px); font-weight: 800; letter-spacing: -0.6px; line-height: 1.14; margin-bottom: 18px; color: var(--ink); }
+  h2 .hl { background: linear-gradient(110deg, var(--navy), var(--plum)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; box-shadow: 0 1px 2px rgba(0,0,0,0.02); }
+  .prob-card .x { color: var(--clay); font-size: 22px; margin-bottom: 14px; }
+  .prob-card h3 { font-family: var(--serif); font-size: 17px; font-weight: 700; margin-bottom: 8px; }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 14px; display: grid; place-items: center;
+    font-weight: 800; font-size: 20px; color: #fff; font-family: var(--serif);
+    background: linear-gradient(140deg, var(--navy), var(--plum));
+    box-shadow: 0 8px 22px rgba(51,71,111,0.28); z-index: 1;
+  }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-family: var(--serif); font-size: 20px; font-weight: 700; margin-bottom: 8px; letter-spacing: -0.2px; }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 624px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--plum);
+    background: rgba(122,79,134,0.08); border: 1px solid rgba(122,79,134,0.22);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px;
+    transition: transform .15s, border-color .2s, box-shadow .2s; box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+  }
+  .feat:hover { transform: translateY(-3px); border-color: var(--border2); box-shadow: 0 16px 36px -22px rgba(51,55,40,0.35); }
+  .feat .ic {
+    width: 44px; height: 44px; border-radius: 11px; display: grid; place-items: center;
+    font-size: 21px; margin-bottom: 16px; background: var(--s2); border: 1px solid var(--border2);
+  }
+  .feat h3 { font-family: var(--serif); font-size: 17.5px; font-weight: 700; margin-bottom: 8px; }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.85em; color: var(--plum); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / CARE ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(93,138,106,0.14); border: 1px solid rgba(93,138,106,0.4); color: var(--sage); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .care-card {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    box-shadow: 0 30px 70px -30px rgba(51,55,40,0.4);
+  }
+  .care-card .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--s2); display: flex; align-items: center; justify-content: space-between; }
+  .care-card .bh .t { font-family: var(--serif); font-weight: 700; font-size: 15px; }
+  .care-card .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .care-card .bb { padding: 14px; display: flex; flex-direction: column; gap: 10px; }
+  .task {
+    display: grid; grid-template-columns: 24px 1fr auto; gap: 11px; align-items: center;
+    padding: 11px 13px; border-radius: 11px; background: var(--s2); border: 1px solid var(--border);
+  }
+  .task .box { width: 19px; height: 19px; border-radius: 6px; border: 1.5px solid var(--border2); display: grid; place-items: center; font-size: 11px; }
+  .task.done .box { background: var(--sage); border-color: var(--sage); color: #fff; }
+  .task .ttl { font-size: 12.5px; color: var(--ink); line-height: 1.4; }
+  .task .ttl .sm { display: block; font-size: 11px; color: var(--dim); margin-top: 2px; }
+  .task.done .ttl { color: var(--mid); }
+  .pill { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.3px; padding: 3px 9px; border-radius: 999px; white-space: nowrap; }
+  .pill.visit { color: var(--clay); background: rgba(181,87,63,0.10); border: 1px solid rgba(181,87,63,0.28); }
+  .pill.pray { color: var(--plum); background: rgba(122,79,134,0.10); border: 1px solid rgba(122,79,134,0.28); }
+  .pill.prog { color: var(--gold); background: rgba(185,132,44,0.12); border: 1px solid rgba(185,132,44,0.30); }
+  .pill.done { color: var(--sage); background: rgba(93,138,106,0.12); border: 1px solid rgba(93,138,106,0.32); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 28px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 14px; }
+  .stat .n { font-family: var(--serif); font-size: 40px; font-weight: 800; letter-spacing: -1px; background: linear-gradient(120deg, var(--navy), var(--plum)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; line-height: 1.45; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .uc .ic { font-size: 24px; margin-bottom: 14px; }
+  .uc h3 { font-family: var(--serif); font-size: 17.5px; font-weight: 700; margin-bottom: 8px; }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 800px; margin: 0 auto; }
+  .quote-wrap .q { font-family: var(--serif); font-size: clamp(22px, 3.2vw, 31px); font-weight: 600; line-height: 1.42; letter-spacing: -0.4px; margin-bottom: 24px; color: var(--ink); }
+  .quote-wrap .q .hl { color: var(--plum); }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--ink); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 24px; overflow: hidden;
+    padding: 72px 32px; border: 1px solid var(--border2); background: var(--s1);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(600px 300px at 50% -20%, rgba(51,71,111,0.16), transparent 70%),
+                radial-gradient(500px 300px at 82% 120%, rgba(185,132,44,0.16), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 560px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; background: var(--s2); }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 290px; }
+  .foot-brand p { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--mid); margin-bottom: 14px; }
+  .foot-col a { display: block; font-size: 13px; color: var(--dim); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--ink); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#care">Pastoral care</a>
+      <a href="#usecases">Use cases</a>
+      <a href="#cta" class="btn btn-primary">Start free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI-native workspace for ministry</div>
+    <h1>Sunday comes every week.<br><span class="grad">Carry the whole load in one place.</span></h1>
+    <p class="sub">Study the passage, draft the sermon, and keep every prayer request and visit from slipping — in one workspace where AI does the legwork inside your documents while you stay the shepherd.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Prepare this week free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">No credit card · <strong>33+ real AI tools</strong> · 100+ models · Self-host or cloud</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / grace-church / "Sermon — Matthew 5: Blessed Are the Poor in Spirit"</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">This week</div>
+          <div class="tree-item active"><span class="ic">📖</span> Sermon manuscript</div>
+          <div class="tree-item"><span class="ic">🔖</span> Passage study</div>
+          <div class="tree-item"><span class="ic">💡</span> Illustrations</div>
+          <div class="grp">Ministry</div>
+          <div class="tree-item"><span class="ic">🙏</span> Prayer &amp; care list</div>
+          <div class="tree-item"><span class="ic">📅</span> Calendar</div>
+          <div class="tree-item"><span class="ic">🗓️</span> Sermon series</div>
+          <div class="tree-item"><span class="ic">🎵</span> Worship team</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">Blessed Are the Poor in Spirit</div>
+          <div class="doc-meta">Matthew 5:1–12 · drafting · last edited 3m ago</div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <span class="doc-cite">Isaiah 57:15</span>
+          <span class="doc-cite">Psalm 51:17</span>
+          <span class="doc-cite">Luke 6:20</span>
+          <div class="doc-block">
+            <div class="lbl">💡 Illustration slot</div>
+            <p>The empty hands of the tax collector in Luke 18 — he had nothing to bring, and went home justified. Tie back to "poor in spirit" as the posture, not the bank balance.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Study Agent</div>
+          <div class="ai-tool"><span class="sp"></span> web_search · Beatitudes 1st-century context</div>
+          <div class="ai-tool"><span class="sp"></span> web_fetch · commentary on Matthew 5</div>
+          <div class="ai-tool"><span class="sp"></span> create_page · Passage study</div>
+          <div class="ai-tool"><span class="sp"></span> replace_lines · Sermon manuscript</div>
+          <div class="ai-msg bot">Gathered <b>6 cross-references</b> and <b>3 commentary excerpts</b> into your passage-study page, and drafted an outline with an illustration slot. You stay the author — edit any line and I won't overwrite it.</div>
+          <div class="ai-msg bot">Added <b>2 hospital visits</b> from the prayer list to your care list, and put Sunday's order of service on the calendar.</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>Built for pastors, chaplains, worship leaders & ministry teams</p>
+  <div class="strip-row">
+    <span>Sermon prep</span>
+    <span>Pastoral care</span>
+    <span>Bible study</span>
+    <span>Service planning</span>
+    <span>Small groups</span>
+    <span>Missions</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The weight you carry</div>
+      <h2>The message matters. <span class="hl">The grind shouldn't cost you the week.</span></h2>
+      <p>Study lives in a stack of tabs and commentaries. The prayer list is on a sticky note. The calendar is somewhere else. And Saturday night, the sermon still isn't done.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Sermon prep eats the week</h3>
+        <p>Hours lost to hunting cross-references, chasing context, and reformatting notes — time that belonged to the message and your people.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Care falls through the cracks</h3>
+        <p>The family in the hospital, the prayer request from Sunday, the follow-up you meant to make — held in your head until one slips.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">✕</div>
+        <h3>Ministry is scattered</h3>
+        <p>Sermon in a doc, notes in a notebook, schedule in a spreadsheet, team in a group text. Nothing talks to anything else.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>From a passage to a <span class="hl">Sunday-ready week</span></h2>
+      <p>PageSpace isn't a chatbot you copy answers out of. It's a workspace where AI agents do the research, drafting, and follow-up <em>inside</em> your documents, using real tools — while you stay the shepherd.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Gather the week into one drive</h3>
+          <p>Put the passage, your notes, and last year's series into pages in a single drive. Ask your agent to scope the text and pull what's relevant — it reads everything already in the drive for context, including your own study notes.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">read_page</span><span class="tag">multi_drive_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>The study agent does the legwork</h3>
+          <p>It runs live web searches for historical and cultural background, fetches the strongest commentaries and articles as clean text, and organizes cross-references, word studies, and illustration ideas into a passage-study sheet — every claim traceable to its source.</p>
+          <div class="tags"><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">edit_sheet_cells</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>The sermon drafts in the editor — you shepherd it</h3>
+          <p>An outline and manuscript scaffold write straight into a Document page: big idea, movements, cross-references, and illustration slots. You write the message; the AI makes precise line edits where you ask. Refresh protection means it never clobbers the line you're working on.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">replace_lines</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Nothing slips — care, calendar, and team</h3>
+          <p>Turn prayer requests and visits into tasks with due dates, put services and counseling on the calendar, and keep your staff and worship team in sync in a channel. The week is held in one place, not in your head.</p>
+          <div class="tags"><span class="tag">create_task</span><span class="tag">create_calendar_event</span><span class="tag">send_channel_message</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The toolkit</div>
+      <h2>Everything ministry needs, <span class="hl">in one workspace</span></h2>
+      <p>Nine page types, 33+ AI tools, and 100+ models — composed for the way pastors and ministry teams actually work.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">📖</div>
+        <h3>Study, gathered</h3>
+        <p>Agents run live <span class="ttag">web_search</span> for context and pull full articles with <span class="ttag">web_fetch</span> — then search your own notes across drives with glob, regex, and multi-drive search.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">✍️</div>
+        <h3>Draft in the editor</h3>
+        <p>Outlines and manuscripts write into Document pages, with precise line-level edits via <span class="ttag">replace_lines</span> — and refresh protection so the AI never overwrites the line you're writing.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🙏</div>
+        <h3>No soul slips through</h3>
+        <p>Pastoral care lives as a Task List — visits and prayer requests become tasks with due dates via <span class="ttag">create_task</span>, with custom statuses via <span class="ttag">create_task_status</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📅</div>
+        <h3>The week, on the calendar</h3>
+        <p>Services, counseling, weddings, and funerals scheduled with <span class="ttag">create_calendar_event</span>; the agent checks availability and pulls up what's ahead with <span class="ttag">list_calendar_events</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🗓️</div>
+        <h3>Plan the series</h3>
+        <p>Map passages, themes, and dates across a whole preaching series in a Sheet page the AI reads and fills with <span class="ttag">edit_sheet_cells</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">👥</div>
+        <h3>Your team, together</h3>
+        <p>Staff, elders, and worship leaders work in the same drive in real time, with Channels for the back-and-forth via <span class="ttag">send_channel_message</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧑‍🏫</div>
+        <h3>Brief your own agents</h3>
+        <p>Every AI Chat page is a configurable agent. Brief one for word studies or background and consult it with <span class="ttag">ask_agent</span>, tuned to your tradition with <span class="ttag">update_agent_config</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Private and yours</h3>
+        <p>Cloud, self-hosted on-prem, desktop, or mobile. Passwordless passkey auth and on-prem mode keep counseling notes and member care under your own roof.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧠</div>
+        <h3>100+ models</h3>
+        <p>Route to Anthropic, OpenAI, Google, xAI, OpenRouter, or a local Ollama model per task — the right help for study, drafting, or planning.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CARE SPLIT -->
+<section id="care" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Pastoral care</div>
+      <h2>The list that <span class="hl">remembers your people.</span></h2>
+      <p class="lead">Every prayer request, hospital visit, and follow-up becomes a task the agent keeps current — with due dates, custom statuses, and assignments — so the family that's hurting this week isn't the one that gets forgotten next week.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>Requests become tasks</h4><p>Mention a need in your notes or a channel; the agent adds it to the care list with a due date via <span class="ttag">create_task</span>.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Your team sees their part</h4><p>Assign visits and meals across staff and volunteers; each person pulls their own list with <span class="ttag">get_assigned_tasks</span>.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Status that fits ministry</h4><p>Define your own stages — To visit, Praying, Followed up — with <span class="ttag">create_task_status</span>, not someone else's project board.</p></div></div>
+      </div>
+    </div>
+    <div class="care-card fade">
+      <div class="bh">
+        <span class="t">🙏 Prayer &amp; Care</span>
+        <span class="m">Task List · 4 of 12 shown</span>
+      </div>
+      <div class="bb">
+        <div class="task">
+          <span class="box"></span>
+          <span class="ttl">Visit Tom H. — cardiac unit<span class="sm">Mercy General · Due today</span></span>
+          <span class="pill visit">To visit</span>
+        </div>
+        <div class="task">
+          <span class="box"></span>
+          <span class="ttl">Follow up with the Alvarez family<span class="sm">Bereavement · Due Thu</span></span>
+          <span class="pill pray">Praying</span>
+        </div>
+        <div class="task">
+          <span class="box"></span>
+          <span class="ttl">Call Denise — prayer request<span class="sm">Job loss · Due Wed</span></span>
+          <span class="pill prog">In progress</span>
+        </div>
+        <div class="task done">
+          <span class="box">✓</span>
+          <span class="ttl">Meal train for the Okafors<span class="sm">New baby · assigned to deacons</span></span>
+          <span class="pill done">Followed up</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — docs, sheets, tasks &amp; more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models across 6 providers</div></div>
+      <div class="stat fade"><div class="n">1</div><div class="l">Drive that holds the whole ministry</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Who it's for</div>
+      <h2>One workspace, <span class="hl">every season of ministry</span></h2>
+      <p>If your week is study, care, and keeping a community moving, PageSpace was built to carry it with you.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">⛪</div><h3>Solo &amp; bivocational pastors</h3><p>Carry sermon prep, pastoral care, and admin without a staff — let the agents handle the legwork so the hours go to people and the Word.</p></div>
+      <div class="uc fade"><div class="ic">🏛️</div><h3>Multi-staff churches</h3><p>Share one drive across pastors, elders, and volunteers; everyone works alongside the agents with care and tasks assigned to the right person.</p></div>
+      <div class="uc fade"><div class="ic">🎵</div><h3>Worship &amp; ministry leaders</h3><p>Plan the series, set lists, and rehearsals in a sheet and a channel — connected to the sermon it serves.</p></div>
+      <div class="uc fade"><div class="ic">✝️</div><h3>Chaplains &amp; missions</h3><p>Keep visits, notes, and follow-ups together and self-hosted when privacy matters — on desktop or mobile, online or off the main grid.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"Sunday always comes. PageSpace gave me back the hours I was losing to tabs and to-do lists — so I can spend them <span class="hl">with my people, and on the message.</span>"</div>
+    <div class="by"><b>Pastor Daniel K.</b> · lead pastor, a 200-member church <span style="color:var(--dim)">(illustrative)</span></div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Start this week's sermon today.</h2>
+      <p>Drop in the passage and watch PageSpace study it, draft with you, and keep your week's care and calendar in one place — free, no card required.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Start free</a>
+        <a href="#" class="btn btn-ghost btn-lg">Book a walkthrough</a>
+      </div>
+      <p class="micro">Cloud · self-hosted · desktop · mobile — your ministry, your infrastructure.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native knowledge workspace where people and agents study, write, and care for a community — together.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#care">Pastoral care</a>
+          <a href="#usecases">Use cases</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">Documents</a>
+          <a href="#">Sheets &amp; tasks</a>
+          <a href="#">AI agents</a>
+          <a href="#">MCP integrations</a>
+        </div>
+        <div class="foot-col">
+          <h5>Deploy</h5>
+          <a href="#">Cloud</a>
+          <a href="#">Self-hosted</a>
+          <a href="#">Desktop</a>
+          <a href="#">Mobile</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span>Prototype · pastors landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>

--- a/prototypes/pagespace-software-teams/index.html
+++ b/prototypes/pagespace-software-teams/index.html
@@ -1,0 +1,671 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>PageSpace — The AI-Native Workspace for Software Teams</title>
+<meta name="description" content="Specs, code, sprint boards, and runbooks in one AI-native workspace. PageSpace agents research with live web search, draft RFCs in the editor, break work into a sprint board, and review against a second agent — using 33+ real tools, not just chat." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+  :root {
+    --bg: #060a0a;
+    --s1: #0b1212;
+    --s2: #101a1a;
+    --s3: #162424;
+    --border: #1d2e2c;
+    --border2: #294240;
+    --emerald: #34e0a1;
+    --cyan: #2dd4d4;
+    --lime: #9be15d;
+    --coral: #ff6b5e;
+    --amber: #ffc24b;
+    --sky: #5cc7ff;
+    --text: #e4f0ec;
+    --mid: #8ca59d;
+    --dim: #56716a;
+    --sans: "Inter", system-ui, sans-serif;
+    --disp: "Space Grotesk", system-ui, sans-serif;
+    --mono: "JetBrains Mono", monospace;
+    --maxw: 1140px;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  ::selection { background: rgba(52,224,161,0.26); }
+  a { color: inherit; text-decoration: none; }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 28px; }
+
+  /* ---------- NAV ---------- */
+  nav {
+    position: sticky; top: 0; z-index: 50;
+    backdrop-filter: blur(14px);
+    background: rgba(6,10,10,0.74);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+  .logo { display: flex; align-items: center; gap: 10px; font-family: var(--disp); font-weight: 700; font-size: 16px; letter-spacing: -0.3px; }
+  .logo .mark {
+    width: 26px; height: 26px; border-radius: 7px;
+    background: linear-gradient(140deg, var(--emerald), var(--cyan));
+    display: grid; place-items: center; font-size: 13px; font-weight: 700; color: #042018;
+    box-shadow: 0 0 0 1px rgba(255,255,255,0.08), 0 4px 16px rgba(52,224,161,0.32);
+  }
+  .nav-links { display: flex; align-items: center; gap: 30px; }
+  .nav-links a { font-size: 13.5px; color: var(--mid); transition: color .15s; }
+  .nav-links a:hover { color: var(--text); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--sans); font-weight: 600; font-size: 13.5px;
+    padding: 10px 18px; border-radius: 9px; cursor: pointer; border: none;
+    transition: transform .12s, box-shadow .2s, background .2s;
+  }
+  .btn-primary {
+    background: linear-gradient(140deg, var(--emerald), var(--cyan));
+    color: #042018; box-shadow: 0 6px 22px rgba(52,224,161,0.30);
+  }
+  .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 30px rgba(52,224,161,0.45); }
+  .btn-ghost { background: var(--s2); color: var(--text); border: 1px solid var(--border2); }
+  .btn-ghost:hover { background: var(--s3); border-color: var(--emerald); }
+  .btn-lg { padding: 14px 26px; font-size: 15px; border-radius: 11px; }
+  @media (max-width: 760px) { .nav-links a:not(.btn) { display: none; } }
+
+  /* ---------- HERO ---------- */
+  .hero { position: relative; padding: 100px 0 70px; text-align: center; }
+  .hero::before {
+    content: ""; position: absolute; inset: 0; z-index: -1;
+    background:
+      radial-gradient(640px 380px at 50% -8%, rgba(52,224,161,0.18), transparent 70%),
+      radial-gradient(540px 360px at 82% 14%, rgba(45,212,212,0.14), transparent 70%),
+      radial-gradient(520px 340px at 14% 26%, rgba(155,225,93,0.08), transparent 70%);
+  }
+  .eyebrow {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--mono);
+    font-size: 12px; font-weight: 500; letter-spacing: 0.2px;
+    color: var(--emerald); background: rgba(52,224,161,0.09);
+    border: 1px solid rgba(52,224,161,0.28); padding: 6px 14px; border-radius: 999px;
+    margin-bottom: 28px;
+  }
+  .eyebrow .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--emerald); box-shadow: 0 0 8px var(--emerald); }
+  h1 {
+    font-family: var(--disp);
+    font-size: clamp(38px, 6.2vw, 67px); font-weight: 700;
+    letter-spacing: -1.8px; line-height: 1.05; margin-bottom: 24px;
+  }
+  h1 .grad {
+    background: linear-gradient(110deg, var(--emerald) 10%, var(--cyan) 55%, var(--sky) 100%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+  .sub {
+    font-size: clamp(16px, 2vw, 19px); color: var(--mid); line-height: 1.65;
+    max-width: 668px; margin: 0 auto 38px;
+  }
+  .hero-cta { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-bottom: 22px; }
+  .micro { font-size: 12.5px; color: var(--dim); }
+  .micro strong { color: var(--mid); font-weight: 600; }
+
+  /* ---------- HERO MOCK ---------- */
+  .mock {
+    max-width: 1000px; margin: 64px auto 0; text-align: left;
+    border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    background: var(--s1);
+    box-shadow: 0 40px 120px -30px rgba(0,0,0,0.85), 0 0 0 1px rgba(255,255,255,0.03);
+  }
+  .mock-bar {
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px; border-bottom: 1px solid var(--border);
+    background: var(--s2);
+  }
+  .mock-bar .d { width: 11px; height: 11px; border-radius: 50%; }
+  .mock-bar .d:nth-child(1){ background:#ff5f57; } .mock-bar .d:nth-child(2){ background:#febc2e; } .mock-bar .d:nth-child(3){ background:#28c840; }
+  .mock-bar .tab { margin-left: 14px; font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+  .mock-body { display: grid; grid-template-columns: 196px 1fr 234px; min-height: 432px; }
+  .mock-side { border-right: 1px solid var(--border); padding: 16px 12px; background: var(--s1); }
+  .mock-side .grp { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin: 14px 8px 8px; }
+  .tree-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 7px; font-size: 12.5px; color: var(--mid); }
+  .tree-item.active { background: rgba(52,224,161,0.12); color: var(--text); }
+  .tree-item .ic { font-size: 13px; }
+  .mock-main { padding: 22px 24px; border-right: 1px solid var(--border); }
+  .doc-h { font-family: var(--disp); font-size: 19px; font-weight: 600; letter-spacing: -0.4px; margin-bottom: 4px; }
+  .doc-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); margin-bottom: 18px; }
+  .doc-line { height: 9px; border-radius: 5px; background: var(--s3); margin-bottom: 11px; }
+  .doc-line.w1 { width: 96%; } .doc-line.w2 { width: 82%; } .doc-line.w3 { width: 90%; } .doc-line.w4 { width: 68%; }
+  .code-blk {
+    margin: 16px 0 10px; border: 1px solid var(--border); border-radius: 9px;
+    background: #07100f; padding: 12px 14px; font-family: var(--mono); font-size: 11px; line-height: 1.7;
+    overflow-x: auto;
+  }
+  .code-blk .ln { color: var(--dim); }
+  .code-blk .kw { color: var(--sky); } .code-blk .fn { color: var(--emerald); } .code-blk .st { color: var(--amber); } .code-blk .cm { color: var(--dim); }
+  .doc-block {
+    margin-top: 16px; border-left: 2px solid var(--cyan); padding: 10px 14px;
+    background: rgba(45,212,212,0.06); border-radius: 0 8px 8px 0;
+  }
+  .doc-block .lbl { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--cyan); font-weight: 600; margin-bottom: 6px; }
+  .doc-block p { font-size: 12.5px; line-height: 1.6; color: var(--mid); }
+  .mock-ai { padding: 16px 16px; background: var(--s1); display: flex; flex-direction: column; gap: 12px; }
+  .ai-head { display: flex; align-items: center; gap: 8px; font-size: 12px; font-weight: 600; color: var(--text); }
+  .ai-head .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--emerald); box-shadow: 0 0 8px var(--emerald); animation: pulse 1.6s infinite; }
+  @keyframes pulse { 0%,100%{ opacity: 1; } 50%{ opacity: .35; } }
+  .ai-msg { font-size: 12px; line-height: 1.55; border-radius: 10px; padding: 10px 12px; }
+  .ai-msg.bot { background: var(--s2); color: var(--mid); border: 1px solid var(--border); }
+  .ai-msg.bot b { color: var(--text); }
+  .ai-tool {
+    font-family: var(--mono); font-size: 10.5px; color: var(--emerald);
+    background: rgba(52,224,161,0.07); border: 1px solid rgba(52,224,161,0.22);
+    border-radius: 7px; padding: 7px 10px; display: flex; align-items: center; gap: 7px;
+  }
+  .ai-tool .sp { width: 6px; height: 6px; border-radius: 50%; background: var(--emerald); animation: pulse 1s infinite; }
+  @media (max-width: 880px){ .mock-body { grid-template-columns: 1fr; } .mock-side, .mock-ai { display: none; } .mock-main { border-right: none; } }
+
+  /* ---------- LOGO STRIP ---------- */
+  .strip { padding: 40px 0 10px; text-align: center; }
+  .strip p { font-size: 11.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); margin-bottom: 22px; }
+  .strip-row { display: flex; flex-wrap: wrap; justify-content: center; gap: 14px 40px; opacity: .75; }
+  .strip-row span { font-family: var(--mono); font-size: 13.5px; font-weight: 500; color: var(--mid); letter-spacing: -0.2px; }
+
+  /* ---------- SECTION SHELL ---------- */
+  section { padding: 90px 0; }
+  .sec-head { text-align: center; max-width: 690px; margin: 0 auto 56px; }
+  .kicker { font-family: var(--mono); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--emerald); margin-bottom: 16px; }
+  h2 { font-family: var(--disp); font-size: clamp(28px, 4vw, 42px); font-weight: 700; letter-spacing: -1px; line-height: 1.12; margin-bottom: 18px; }
+  h2 .hl { background: linear-gradient(110deg, var(--emerald), var(--cyan)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .sec-head p { font-size: 16.5px; color: var(--mid); line-height: 1.65; }
+
+  /* ---------- PROBLEM ---------- */
+  .prob-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .prob-card { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .prob-card .x { color: var(--coral); font-size: 20px; margin-bottom: 14px; font-family: var(--mono); }
+  .prob-card h3 { font-family: var(--disp); font-size: 16px; font-weight: 600; margin-bottom: 8px; }
+  .prob-card p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .prob-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- WORKFLOW ---------- */
+  .flow { display: flex; flex-direction: column; gap: 0; max-width: 920px; margin: 0 auto; }
+  .step { display: grid; grid-template-columns: 56px 1fr; gap: 24px; position: relative; padding-bottom: 44px; }
+  .step:last-child { padding-bottom: 0; }
+  .step::before { content: ""; position: absolute; left: 27px; top: 56px; bottom: 0; width: 2px; background: linear-gradient(var(--border2), transparent); }
+  .step:last-child::before { display: none; }
+  .step-num {
+    width: 56px; height: 56px; border-radius: 14px; display: grid; place-items: center;
+    font-family: var(--mono); font-weight: 600; font-size: 18px; color: #042018;
+    background: linear-gradient(140deg, var(--emerald), var(--cyan));
+    box-shadow: 0 8px 24px rgba(52,224,161,0.28); z-index: 1;
+  }
+  .step-body { padding-top: 4px; }
+  .step-body h3 { font-family: var(--disp); font-size: 19px; font-weight: 600; margin-bottom: 8px; letter-spacing: -0.3px; }
+  .step-body p { font-size: 14.5px; color: var(--mid); line-height: 1.65; max-width: 620px; }
+  .step-body .tags { margin-top: 12px; display: flex; flex-wrap: wrap; gap: 8px; }
+  .tag {
+    font-family: var(--mono); font-size: 11px; color: var(--cyan);
+    background: rgba(45,212,212,0.07); border: 1px solid rgba(45,212,212,0.2);
+    border-radius: 999px; padding: 4px 11px;
+  }
+
+  /* ---------- FEATURES ---------- */
+  .feat-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .feat {
+    background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px;
+    transition: transform .15s, border-color .2s, background .2s;
+  }
+  .feat:hover { transform: translateY(-3px); border-color: var(--border2); background: var(--s2); }
+  .feat .ic {
+    width: 44px; height: 44px; border-radius: 11px; display: grid; place-items: center;
+    font-size: 21px; margin-bottom: 16px; background: var(--s3); border: 1px solid var(--border2);
+  }
+  .feat h3 { font-family: var(--disp); font-size: 16.5px; font-weight: 600; margin-bottom: 8px; }
+  .feat p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  .ttag { font-family: var(--mono); font-size: 0.86em; color: var(--emerald); }
+  @media (max-width: 880px){ .feat-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- SPLIT / SPRINT ---------- */
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 56px; align-items: center; }
+  .split h2 { text-align: left; }
+  .split .lead { font-size: 16px; color: var(--mid); line-height: 1.7; margin-bottom: 24px; }
+  .check-list { display: flex; flex-direction: column; gap: 16px; }
+  .check { display: grid; grid-template-columns: 26px 1fr; gap: 12px; }
+  .check .c { width: 22px; height: 22px; border-radius: 7px; background: rgba(52,224,161,0.12); border: 1px solid rgba(52,224,161,0.35); color: var(--emerald); display: grid; place-items: center; font-size: 12px; font-weight: 700; }
+  .check h4 { font-size: 14.5px; font-weight: 600; margin-bottom: 3px; }
+  .check p { font-size: 13px; color: var(--mid); line-height: 1.55; }
+  .brief-card {
+    background: var(--s1); border: 1px solid var(--border2); border-radius: 16px; overflow: hidden;
+    box-shadow: 0 30px 80px -30px rgba(0,0,0,0.8);
+  }
+  .brief-card .bh { padding: 16px 20px; border-bottom: 1px solid var(--border); background: var(--s2); display: flex; align-items: center; justify-content: space-between; }
+  .brief-card .bh .t { font-family: var(--disp); font-weight: 600; font-size: 14px; }
+  .brief-card .bh .m { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .brief-card .bb { padding: 16px; }
+  .board { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
+  .board-col h5 { font-family: var(--mono); font-size: 10px; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 10px; display: flex; align-items: center; gap: 6px; }
+  .board-col h5 .cnt { color: var(--dim); }
+  .board-col.todo h5 { color: var(--mid); } .board-col.prog h5 { color: var(--amber); } .board-col.done h5 { color: var(--emerald); }
+  .card-t { font-size: 11.5px; color: var(--text); line-height: 1.4; padding: 9px 10px; border-radius: 8px; background: var(--s2); border: 1px solid var(--border); margin-bottom: 9px; }
+  .card-t .tk { display: block; margin-top: 6px; font-family: var(--mono); font-size: 9.5px; color: var(--dim); }
+  .card-t.d { opacity: .62; text-decoration: line-through; text-decoration-color: var(--dim); }
+  @media (max-width: 880px){ .split { grid-template-columns: 1fr; gap: 36px; } .board { grid-template-columns: 1fr; } }
+
+  /* ---------- STATS ---------- */
+  .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+  .stat { text-align: center; padding: 28px 18px; background: var(--s1); border: 1px solid var(--border); border-radius: 14px; }
+  .stat .n { font-family: var(--disp); font-size: 38px; font-weight: 700; letter-spacing: -1.5px; background: linear-gradient(120deg, var(--emerald), var(--cyan)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .stat .l { font-size: 13px; color: var(--mid); margin-top: 6px; }
+  @media (max-width: 820px){ .stats { grid-template-columns: 1fr 1fr; } }
+
+  /* ---------- USE CASES ---------- */
+  .uc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+  .uc { background: var(--s1); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+  .uc .ic { font-size: 24px; margin-bottom: 14px; }
+  .uc h3 { font-family: var(--disp); font-size: 16.5px; font-weight: 600; margin-bottom: 8px; }
+  .uc p { font-size: 13.5px; color: var(--mid); line-height: 1.6; }
+  @media (max-width: 820px){ .uc-grid { grid-template-columns: 1fr; } }
+
+  /* ---------- QUOTE ---------- */
+  .quote-wrap { text-align: center; max-width: 800px; margin: 0 auto; }
+  .quote-wrap .q { font-family: var(--disp); font-size: clamp(22px, 3.2vw, 30px); font-weight: 500; line-height: 1.4; letter-spacing: -0.6px; margin-bottom: 24px; }
+  .quote-wrap .q .hl { color: var(--cyan); }
+  .quote-wrap .by { font-size: 14px; color: var(--mid); }
+  .quote-wrap .by b { color: var(--text); }
+
+  /* ---------- CTA ---------- */
+  .cta {
+    position: relative; text-align: center; border-radius: 24px; overflow: hidden;
+    padding: 72px 32px; border: 1px solid var(--border2); background: var(--s1);
+  }
+  .cta::before {
+    content: ""; position: absolute; inset: 0; z-index: 0;
+    background: radial-gradient(600px 300px at 50% -20%, rgba(52,224,161,0.26), transparent 70%),
+                radial-gradient(500px 300px at 80% 120%, rgba(45,212,212,0.20), transparent 70%);
+  }
+  .cta > * { position: relative; z-index: 1; }
+  .cta h2 { font-size: clamp(28px, 4vw, 44px); }
+  .cta p { font-size: 17px; color: var(--mid); max-width: 560px; margin: 0 auto 32px; line-height: 1.6; }
+
+  /* ---------- FOOTER ---------- */
+  footer { border-top: 1px solid var(--border); padding: 48px 0 40px; }
+  .foot-inner { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 32px; }
+  .foot-brand { max-width: 290px; }
+  .foot-brand p { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; }
+  .foot-cols { display: flex; gap: 56px; flex-wrap: wrap; }
+  .foot-col h5 { font-family: var(--mono); font-size: 11px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--mid); margin-bottom: 14px; }
+  .foot-col a { display: block; font-size: 13px; color: var(--dim); margin-bottom: 10px; transition: color .15s; }
+  .foot-col a:hover { color: var(--text); }
+  .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; color: var(--dim); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 10px; }
+  .foot-bottom .mono { font-family: var(--mono); }
+
+  .fade { opacity: 0; transform: translateY(24px); transition: opacity .7s ease, transform .7s ease; }
+  .fade.in { opacity: 1; transform: none; }
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <div class="wrap nav-inner">
+    <div class="logo"><span class="mark">P</span> PageSpace</div>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#features">Features</a>
+      <a href="#sprint">Sprint board</a>
+      <a href="#usecases">Use cases</a>
+      <a href="#cta" class="btn btn-primary">Start building free</a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow"><span class="dot"></span> The AI-native workspace for software teams</div>
+    <h1>Spec it, build it, ship it —<br><span class="grad">with agents that do the work.</span></h1>
+    <p class="sub">PageSpace is one drive for your specs, code, sprint board, and runbooks — where AI agents research with live web search, draft RFCs in the editor, break work into a task board, and review against a second agent. Real tools doing real work, not a chatbot you copy-paste out of.</p>
+    <div class="hero-cta">
+      <a href="#cta" class="btn btn-primary btn-lg">Start building free</a>
+      <a href="#how" class="btn btn-ghost btn-lg">See how it works</a>
+    </div>
+    <p class="micro">No credit card · <strong>33+ real AI tools</strong> · 100+ models · Self-host or cloud</p>
+
+    <!-- HERO MOCK -->
+    <div class="mock fade">
+      <div class="mock-bar">
+        <span class="d"></span><span class="d"></span><span class="d"></span>
+        <span class="tab">pagespace.ai / drives / payments-service / RFC: idempotent refunds</span>
+      </div>
+      <div class="mock-body">
+        <aside class="mock-side">
+          <div class="grp">payments-service</div>
+          <div class="tree-item active"><span class="ic">📄</span> RFC: idempotent refunds</div>
+          <div class="tree-item"><span class="ic">💻</span> refund_handler.ts</div>
+          <div class="tree-item"><span class="ic">✅</span> Sprint 24 board</div>
+          <div class="tree-item"><span class="ic">💬</span> #eng-payments</div>
+          <div class="grp">Agents</div>
+          <div class="tree-item"><span class="ic">🤖</span> Reviewer agent</div>
+          <div class="tree-item"><span class="ic">🚨</span> On-call agent</div>
+          <div class="grp">Knowledge</div>
+          <div class="tree-item"><span class="ic">📚</span> Architecture docs</div>
+          <div class="tree-item"><span class="ic">🗂️</span> Runbooks</div>
+        </aside>
+        <main class="mock-main">
+          <div class="doc-h">RFC: Idempotent Refunds</div>
+          <div class="doc-meta">Document · drafted by agent · 9 sources · edited 3m ago</div>
+          <div class="doc-line w1"></div>
+          <div class="doc-line w3"></div>
+          <div class="doc-line w2"></div>
+          <div class="code-blk">
+<span class="cm">// dedupe on provider idempotency key</span>
+<span class="kw">async function</span> <span class="fn">refund</span>(req) {
+  <span class="kw">const</span> key = req.headers[<span class="st">"idempotency-key"</span>];
+  <span class="kw">if</span> (<span class="kw">await</span> <span class="fn">seen</span>(key)) <span class="kw">return</span> <span class="fn">cached</span>(key);
+  ...
+}
+          </div>
+          <div class="doc-block">
+            <div class="lbl">⚠ Reviewer agent flagged</div>
+            <p>Race on concurrent retries: two requests with the same key can both pass <code>seen()</code> before either writes. Wrap in a unique constraint on <code>(key)</code> and catch the conflict — covered in source [4], Stripe idempotency docs.</p>
+          </div>
+        </main>
+        <aside class="mock-ai">
+          <div class="ai-head"><span class="pulse"></span> Build Agent</div>
+          <div class="ai-tool"><span class="sp"></span> web_search · "idempotency key retries"</div>
+          <div class="ai-tool"><span class="sp"></span> web_fetch · stripe.com/docs/idempotency</div>
+          <div class="ai-tool"><span class="sp"></span> regex_search · "refund(" in drive</div>
+          <div class="ai-tool"><span class="sp"></span> create_task · Sprint 24 board</div>
+          <div class="ai-msg bot">Drafted the RFC with <b>9 sources</b>, scaffolded <code>refund_handler.ts</code> as a Code page, and broke it into <b>5 tasks</b> on the Sprint 24 board. Want me to <b>ask the Reviewer agent</b> to red-team the retry path?</div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- STRIP -->
+<div class="strip wrap">
+  <p>Built for the way engineering teams actually work</p>
+  <div class="strip-row">
+    <span>Backend</span>
+    <span>Frontend</span>
+    <span>Platform</span>
+    <span>DevOps / SRE</span>
+    <span>Open source</span>
+    <span>Startups</span>
+  </div>
+</div>
+
+<!-- PROBLEM -->
+<section>
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The old way is fragmented</div>
+      <h2>The spec, the code, and the board <span class="hl">never live in the same place.</span></h2>
+      <p>The RFC is in one doc tool. The ticket is in another. The runbook is a wiki page nobody updated. And your AI assistant can't touch any of it — it just answers questions in a side panel.</p>
+    </div>
+    <div class="prob-grid">
+      <div class="prob-card fade">
+        <div class="x">// context lost</div>
+        <h3>Context is scattered</h3>
+        <p>The design doc, the tickets, the code samples, and the incident notes live in four tools that don't know each other exist. Onboarding means a tab tour.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">// copy → paste</div>
+        <h3>Your AI just chats</h3>
+        <p>It writes you a snippet you paste somewhere else by hand. It can't create the page, fill the board, or search your own docs — so you're still the integration layer.</p>
+      </div>
+      <div class="prob-card fade">
+        <div class="x">// who owns this?</div>
+        <h3>Specs rot, boards drift</h3>
+        <p>The RFC says one thing, the board says another, and the runbook is six months stale. Nothing keeps planning and execution in sync.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">How it works</div>
+      <h2>From a one-line ticket to a <span class="hl">spec, a scaffold, and a sprint</span></h2>
+      <p>PageSpace isn't a chatbot in a side panel. It's a workspace where AI agents do the research, drafting, and planning <em>inside</em> your pages, using real tools.</p>
+    </div>
+    <div class="flow">
+      <div class="step fade">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>Drop the ticket into a drive</h3>
+          <p>Paste the feature request, the bug, or the design question into a page. The agent reads the architecture docs and existing code pages already in the drive for context, then drafts an RFC straight into a Document.</p>
+          <div class="tags"><span class="tag">create_page</span><span class="tag">read_page</span><span class="tag">multi_drive_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>The agent researches the unknowns</h3>
+          <p>It runs live web searches for the library, the API, or the failure mode, fetches the docs as clean markdown, and searches your own drives by glob or regex to find every call site — then writes the findings into the RFC with links.</p>
+          <div class="tags"><span class="tag">web_search</span><span class="tag">web_fetch</span><span class="tag">glob_search</span><span class="tag">regex_search</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Scaffold and break down the work</h3>
+          <p>The agent writes a starter implementation into a Code page (Monaco editor), makes precise line-level edits with <span style="font-family:var(--mono);font-size:0.85em;color:var(--cyan)">replace_lines</span>, and breaks the RFC into ordered tasks on a Task List board — with your team's own statuses.</p>
+          <div class="tags"><span class="tag">replace_lines</span><span class="tag">create_task</span><span class="tag">create_task_status</span><span class="tag">reorder_task</span></div>
+        </div>
+      </div>
+      <div class="step fade">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>Review against a second agent</h3>
+          <p>Spin up an AI Chat agent, brief it as your reviewer, and consult it with <span style="font-family:var(--mono);font-size:0.85em;color:var(--cyan)">ask_agent</span>. It red-teams the design and the code; the team hashes it out in a Channel — all in the same drive.</p>
+          <div class="tags"><span class="tag">update_agent_config</span><span class="tag">ask_agent</span><span class="tag">send_channel_message</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FEATURES -->
+<section id="features">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">The toolkit</div>
+      <h2>Everything a team needs, <span class="hl">in one drive</span></h2>
+      <p>Nine page types, 33+ real AI tools, and 100+ models — composed for how engineers plan, build, and ship.</p>
+    </div>
+    <div class="feat-grid">
+      <div class="feat fade">
+        <div class="ic">💻</div>
+        <h3>Code pages, real editor</h3>
+        <p>A full Code page type on the Monaco editor. Agents scaffold implementations and make precise edits with <span class="ttag">replace_lines</span> — your snippets and configs live in the drive, not a gist.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">📄</div>
+        <h3>RFCs in the editor</h3>
+        <p>Agents draft design docs and runbooks straight into Document pages on the TipTap editor, with source links inline and clean line-level edits as the plan changes.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">✅</div>
+        <h3>Task boards agents fill</h3>
+        <p>Task List pages with custom statuses. Agents create, reorder, and update tasks via <span class="ttag">create_task</span> and <span class="ttag">reorder_task</span>, so the board reflects the spec.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔎</div>
+        <h3>Search across everything</h3>
+        <p>Find any call site or doc with <span class="ttag">glob_search</span>, <span class="ttag">regex_search</span>, and <span class="ttag">multi_drive_search</span> — plus live web research with <span class="ttag">web_search</span> and <span class="ttag">web_fetch</span>.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🤖</div>
+        <h3>Reviewer agents</h3>
+        <p>Every AI Chat page is a configurable agent. Brief one as a reviewer or an on-call responder, then consult it with <span class="ttag">ask_agent</span> — a second opinion that lives in the drive.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">💬</div>
+        <h3>Channels + real-time</h3>
+        <p>Channel pages for team back-and-forth, with agents posting via <span class="ttag">send_channel_message</span> — and real-time collaboration so people and agents work the same page at once.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔌</div>
+        <h3>MCP & integrations</h3>
+        <p>PageSpace speaks the Model Context Protocol to connect your own tools and servers, and integrates GitHub, Google Calendar, and Drive into the workspace.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🧠</div>
+        <h3>100+ models, your pick</h3>
+        <p>Route to Anthropic, OpenAI, Google, xAI, OpenRouter, or a local Ollama model per task — a frontier model to design, a local one to keep code in-house.</p>
+      </div>
+      <div class="feat fade">
+        <div class="ic">🔒</div>
+        <h3>Self-host your source</h3>
+        <p>Run on-prem with password auth and local AI, or in the cloud with passwordless passkeys. Desktop and mobile too — your code stays on your infrastructure.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- SPRINT SPLIT -->
+<section id="sprint" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap split">
+    <div class="fade">
+      <div class="kicker">Plan ↔ execution</div>
+      <h2>The spec and the board <span class="hl">stay in sync.</span></h2>
+      <p class="lead">When the agent drafts an RFC, it breaks the work into tasks on the same drive's board — with the statuses your team actually uses. Change the plan and the agent updates the board. No more spec that says one thing while the tickets say another.</p>
+      <div class="check-list">
+        <div class="check"><span class="c">✓</span><div><h4>Tasks created from the spec</h4><p>The agent turns each RFC section into an ordered task with <span class="ttag">create_task</span> and <span class="ttag">reorder_task</span> — traceable back to the doc.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>Your statuses, not ours</h4><p>Define <span class="ttag">create_task_status</span> columns that match your flow — Backlog, In review, Blocked, Done.</p></div></div>
+        <div class="check"><span class="c">✓</span><div><h4>You stay in control</h4><p>Edit any task or doc live — refresh protection means the agent never clobbers the line you're working on.</p></div></div>
+      </div>
+    </div>
+    <div class="brief-card fade">
+      <div class="bh">
+        <span class="t">Sprint 24 board</span>
+        <span class="m">Task List · 5 tasks · idempotent refunds</span>
+      </div>
+      <div class="bb">
+        <div class="board">
+          <div class="board-col todo">
+            <h5>Backlog <span class="cnt">2</span></h5>
+            <div class="card-t">Add unique constraint on idempotency key<span class="tk">PAY-412 · from RFC §3</span></div>
+            <div class="card-t">Backfill keys for in-flight refunds<span class="tk">PAY-415 · from RFC §5</span></div>
+          </div>
+          <div class="board-col prog">
+            <h5>In review <span class="cnt">1</span></h5>
+            <div class="card-t">Dedupe handler + conflict catch<span class="tk">PAY-410 · reviewer flagged race</span></div>
+          </div>
+          <div class="board-col done">
+            <h5>Done <span class="cnt">2</span></h5>
+            <div class="card-t d">Scaffold refund_handler.ts<span class="tk">PAY-408</span></div>
+            <div class="card-t d">Research provider idempotency<span class="tk">PAY-409</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- STATS -->
+<section>
+  <div class="wrap">
+    <div class="stats">
+      <div class="stat fade"><div class="n">9</div><div class="l">Page types — code, docs, tasks &amp; more</div></div>
+      <div class="stat fade"><div class="n">33+</div><div class="l">Real AI tools, not just chat</div></div>
+      <div class="stat fade"><div class="n">100+</div><div class="l">Models across 6 providers</div></div>
+      <div class="stat fade"><div class="n">1</div><div class="l">Drive from spec to ship</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- USE CASES -->
+<section id="usecases" style="background: var(--s1); border-block: 1px solid var(--border);">
+  <div class="wrap">
+    <div class="sec-head">
+      <div class="kicker">Who it's for</div>
+      <h2>One workspace, <span class="hl">every kind of team</span></h2>
+      <p>If your work is turning an idea into shipped, maintained software, PageSpace was built for you.</p>
+    </div>
+    <div class="uc-grid">
+      <div class="uc fade"><div class="ic">⚙️</div><h3>Backend &amp; platform</h3><p>Draft RFCs, scaffold services in Code pages, search every call site by regex, and keep the design doc and the board in one drive.</p></div>
+      <div class="uc fade"><div class="ic">🚨</div><h3>DevOps &amp; SRE</h3><p>Keep runbooks live in Document pages, brief an on-call agent on the system, and let it pull incident research from the web mid-page.</p></div>
+      <div class="uc fade"><div class="ic">🧩</div><h3>Open-source maintainers</h3><p>Triage issues into a Task List, draft contributor docs, and connect your own tooling over MCP — self-hosted, your data.</p></div>
+      <div class="uc fade"><div class="ic">🚀</div><h3>Startup engineering</h3><p>A small team and a lot of context — keep specs, code, sprint board, and the team channel in one searchable drive the AI works inside.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- QUOTE -->
+<section>
+  <div class="wrap quote-wrap fade">
+    <div class="q">"Our RFC, the scaffold, and the sprint tickets used to live in three tools. Now they live in one drive — and the agent <span class="hl">keeps them in sync</span> while it red-teams my design."</div>
+    <div class="by"><b>Devon K.</b> · Staff engineer, payments <span style="color:var(--dim)">· illustrative</span></div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section id="cta">
+  <div class="wrap">
+    <div class="cta fade">
+      <h2>Ship your next feature here.</h2>
+      <p>Drop in a ticket and watch PageSpace research it, draft the RFC, scaffold the code, and fill the board — free, no card required.</p>
+      <div class="hero-cta" style="margin-bottom: 14px;">
+        <a href="#" class="btn btn-primary btn-lg">Start building free</a>
+        <a href="#" class="btn btn-ghost btn-lg">Book a walkthrough</a>
+      </div>
+      <p class="micro">Cloud · self-hosted · desktop · mobile — your code, your infrastructure.</p>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <div class="foot-brand">
+        <div class="logo"><span class="mark">P</span> PageSpace</div>
+        <p>The AI-native knowledge workspace where humans and agents plan, build, and ship software — together, in one drive.</p>
+      </div>
+      <div class="foot-cols">
+        <div class="foot-col">
+          <h5>Product</h5>
+          <a href="#how">How it works</a>
+          <a href="#features">Features</a>
+          <a href="#sprint">Sprint board</a>
+          <a href="#usecases">Use cases</a>
+        </div>
+        <div class="foot-col">
+          <h5>Workspace</h5>
+          <a href="#">Code &amp; documents</a>
+          <a href="#">Task boards</a>
+          <a href="#">AI agents</a>
+          <a href="#">MCP integrations</a>
+        </div>
+        <div class="foot-col">
+          <h5>Deploy</h5>
+          <a href="#">Cloud</a>
+          <a href="#">Self-hosted</a>
+          <a href="#">Desktop</a>
+          <a href="#">Mobile</a>
+        </div>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>© 2026 PageSpace · pagespace.ai</span>
+      <span class="mono">Prototype · software-teams landing</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); } });
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.fade').forEach((el) => io.observe(el));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds nine self-contained, audience-tailored landing page prototypes under `prototypes/`. Each is a single static `index.html` (inline styles, no build step) grounded in PageSpace's actual feature set — generated via the `/landing` skill.

## Prototypes

| Use case | Path |
|----------|------|
| Book writing | `prototypes/pagespace-book-writing/` |
| Churches | `prototypes/pagespace-churches/` |
| College students | `prototypes/pagespace-college-students/` |
| Course creators | `prototypes/pagespace-course-creators/` |
| Debate prep | `prototypes/pagespace-debate-prep/` |
| Local AI teams | `prototypes/pagespace-local-ai-teams/` |
| Mentors / consulting | `prototypes/pagespace-mentors-consulting/` |
| Pastors | `prototypes/pagespace-pastors/` |
| Software teams | `prototypes/pagespace-software-teams/` |

## Notes

- Prototypes only — no changes to `apps/` or shipping code.
- Open any `index.html` directly in a browser to preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)