### PR TITLE
feat(billing): push credit balance to navbar at every mutation, not just chat finish

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -19,7 +19,6 @@ import { requiresProSubscription } from '@/lib/subscription/rate-limit-middlewar
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
-import { emitCreditsUpdated } from '@/lib/subscription/credit-balance';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
@@ -1065,9 +1064,9 @@ export async function POST(request: Request) {
                 }
               });
 
-              // Push the user's new credit balance to their open tabs so the header
-              // widget updates live after the call settles. Best-effort; never blocks.
-              void emitCreditsUpdated(userId!, { conversationId, pageId: chatId });
+              // Credit balance is pushed live by consumeCredits itself (called from
+              // AIMonitoring.trackUsage above), which now broadcasts at every balance
+              // mutation — so the header widget updates without a route-level emit here.
 
               // Track tool usage separately for analytics
               if (extractedToolCalls.length > 0) {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -7,7 +7,6 @@ import { createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-mid
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
-import { emitCreditsUpdated } from '@/lib/subscription/credit-balance';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
@@ -1039,11 +1038,9 @@ MENTION PROCESSING:
 
             // NOTE: daily per-call counting/broadcast removed — prepaid credits are
             // the sole volume limiter. The credit hold placed by the gate is settled
-            // by the AIMonitoring.trackUsage call above (holdId threaded in).
-
-            // Push the user's new credit balance to their open tabs so the header
-            // widget updates live after the call settles. Best-effort; never blocks.
-            void emitCreditsUpdated(userId!, { conversationId });
+            // by the AIMonitoring.trackUsage call above (holdId threaded in), which
+            // now also broadcasts the user's fresh balance — so no route-level emit
+            // is needed for the header widget to update live.
           } catch (error) {
             loggers.api.error('Global Assistant Chat API: Failed to save AI response message', error as Error);
           }

--- a/apps/web/src/hooks/useCreditBalance.ts
+++ b/apps/web/src/hooks/useCreditBalance.ts
@@ -55,7 +55,12 @@ export function useCreditBalance() {
     connect();
   }, [connect]);
 
-  // Apply live balance pushes without a refetch.
+  // Apply live balance pushes. The payload is shown immediately for instant feedback,
+  // then we revalidate against `/api/credits` (the authoritative current balance) so an
+  // out-of-order or stale snapshot can't stick — e.g. a delayed turn-start "hold placed"
+  // push arriving AFTER its own settlement push would otherwise roll the navbar back to
+  // the reserved value. SWR dedupes concurrent revalidations, so bursty start+finish
+  // events coalesce into a single refetch.
   useEffect(() => {
     if (!socket) return;
 
@@ -68,7 +73,7 @@ export function useCreditBalance() {
           spendable: payload.spendable,
           reserved: payload.reserved,
         },
-        false,
+        { revalidate: true },
       );
     };
 

--- a/apps/web/src/lib/subscription/credit-balance.ts
+++ b/apps/web/src/lib/subscription/credit-balance.ts
@@ -1,190 +1,20 @@
 /**
- * credit-balance — read-only view of a user's prepaid AI-credit balance for the
- * dashboard widget and the `GET /api/credits` endpoint, plus the live-update emitter.
+ * Re-export shim. The prepaid credit-balance read model and the live `credits:updated`
+ * emitter now live in @pagespace/lib/billing so the billing primitives (credit-consume,
+ * credit-gate, credit-backfill) can recompute and broadcast a fresh balance at EVERY
+ * mutation — not just the few AI routes that used to call the emitter by hand.
  *
- * This is the DISPLAY layer; it never mutates. The authoritative spend decision and
- * the monthly reset live in `@pagespace/lib/billing/credit-gate` (the imperative
- * shell that owns the clock and the row lock). Here we only mirror the gate's
- * semantics for presentation:
- *   - free tier whose monthly window has lapsed is shown its full allowance (the gate
- *     will reset it on the next call) rather than a stale, pessimistic remainder;
- *   - paid tier whose window has lapsed is shown 0 monthly (use-it-or-lose-it — the
- *     gate excludes the expired allowance until the renewal invoice refills it);
- *   - spendable nets out the sum of the user's still-active holds (reservations on
- *     calls currently in flight), clamped at 0.
- *
- * Money is always whole cents of customer-facing credit value, matching credit-core.
+ * Kept here so existing imports (`GET /api/credits`, the Stripe webhook) keep resolving
+ * `@/lib/subscription/credit-balance`. New code should import from @pagespace/lib directly.
  */
 
-import { db } from '@pagespace/db/db';
-import { creditBalances, creditHolds } from '@pagespace/db/schema/credits';
-import { users } from '@pagespace/db/schema/auth';
-import { and, eq, gt, sql } from '@pagespace/db/operators';
-import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
-import { TIER_MONTHLY_ALLOWANCE_CENTS } from '@pagespace/lib/billing/credit-pricing';
-import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
-import { broadcastCreditsEvent } from '@/lib/websocket/socket-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config';
+export {
+  getCreditBalance,
+  resolveTier,
+  type CreditBalanceSummary,
+} from '@pagespace/lib/billing/credit-balance';
 
-export interface CreditBalanceSummary {
-  /** false on billing-disabled deployments (tenant/onprem); the widget then hides. */
-  billingEnabled: boolean;
-  monthly: {
-    remaining: number;
-    allowance: number;
-    /** ISO string of the current period end, or null if never stamped. */
-    periodEnd: string | null;
-  };
-  topup: {
-    remaining: number;
-  };
-  /** monthly + topup remaining, minus active holds, clamped to >= 0. */
-  spendable: number;
-  /** Sum of this user's non-expired holds (estimated spend on in-flight calls). */
-  reserved: number;
-}
-
-function allowanceFor(tier: SubscriptionTier): number {
-  return TIER_MONTHLY_ALLOWANCE_CENTS[tier] ?? TIER_MONTHLY_ALLOWANCE_CENTS.free;
-}
-
-/** The unlimited/hidden summary used when prepaid billing is disabled. */
-function disabledSummary(): CreditBalanceSummary {
-  return {
-    billingEnabled: false,
-    monthly: { remaining: 0, allowance: 0, periodEnd: null },
-    topup: { remaining: 0 },
-    spendable: 0,
-    reserved: 0,
-  };
-}
-
-/**
- * Read a user's current prepaid credit balance for display. Pure read: no lazy-init,
- * no reset — those are owned by the gate. A user with no balance row yet is shown the
- * tier's monthly allowance (what the gate will lazy-init on their first call).
- */
-export async function getCreditBalance(
-  userId: string,
-  tier: SubscriptionTier = 'free',
-): Promise<CreditBalanceSummary> {
-  if (!isBillingEnabled()) return disabledSummary();
-
-  const now = new Date();
-
-  const [rows, holdAgg] = await Promise.all([
-    db
-      .select({
-        monthlyRemainingCents: creditBalances.monthlyRemainingCents,
-        monthlyAllowanceCents: creditBalances.monthlyAllowanceCents,
-        topupRemainingCents: creditBalances.topupRemainingCents,
-        monthlyPeriodEnd: creditBalances.monthlyPeriodEnd,
-      })
-      .from(creditBalances)
-      .where(eq(creditBalances.userId, userId))
-      .limit(1),
-    db
-      .select({ reserved: sql<number>`coalesce(sum(${creditHolds.estCents}), 0)` })
-      .from(creditHolds)
-      .where(and(eq(creditHolds.userId, userId), gt(creditHolds.expiresAt, now))),
-  ]);
-
-  const reserved = Number(holdAgg[0]?.reserved ?? 0);
-  const row = rows[0] ?? null;
-
-  // No row yet: the gate will lazy-init from the tier allowance on the first call,
-  // so present that as the spendable monthly balance.
-  if (!row) {
-    const allowance = allowanceFor(tier);
-    const spendable = Math.max(0, allowance - reserved);
-    return {
-      billingEnabled: true,
-      monthly: { remaining: allowance, allowance, periodEnd: null },
-      topup: { remaining: 0 },
-      spendable,
-      reserved,
-    };
-  }
-
-  const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
-  const periodEnd = row.monthlyPeriodEnd;
-  const expired = periodEnd === null || periodEnd < now;
-
-  // Mirror the gate's window semantics for display (see file header).
-  let monthlyRemaining: number;
-  if (tier === 'free' && expired) {
-    monthlyRemaining = allowance; // gate resets free tiers on next call
-  } else if (tier !== 'free' && expired && periodEnd !== null) {
-    monthlyRemaining = 0; // paid use-it-or-lose-it: expired allowance is forfeit
-  } else {
-    monthlyRemaining = row.monthlyRemainingCents;
-  }
-
-  const topupRemaining = row.topupRemainingCents;
-  const spendable = Math.max(0, monthlyRemaining + topupRemaining - reserved);
-
-  return {
-    billingEnabled: true,
-    monthly: {
-      remaining: monthlyRemaining,
-      allowance,
-      periodEnd: periodEnd ? periodEnd.toISOString() : null,
-    },
-    topup: { remaining: topupRemaining },
-    spendable,
-    reserved,
-  };
-}
-
-/** The user's stored subscription tier, defaulting to free if unknown. */
-async function resolveTier(userId: string): Promise<SubscriptionTier> {
-  const rows = await db
-    .select({ subscriptionTier: users.subscriptionTier })
-    .from(users)
-    .where(eq(users.id, userId))
-    .limit(1);
-  return (rows[0]?.subscriptionTier as SubscriptionTier) ?? 'free';
-}
-
-export interface EmitCreditsOptions {
-  /** Pre-resolved tier to avoid an extra users lookup when the caller already has it. */
-  tier?: SubscriptionTier;
-  /** Optional scoping hints so the per-conversation usage monitor refreshes the right view. */
-  conversationId?: string;
-  pageId?: string;
-}
-
-/**
- * Recompute the user's balance and push it to their notifications channel as a
- * `credits:updated` event. Best-effort and never throws — called from AI-stream
- * onFinish handlers and the Stripe webhook, where a failed broadcast must not break
- * the request. A no-op when billing is disabled.
- */
-export async function emitCreditsUpdated(
-  userId: string,
-  opts: EmitCreditsOptions = {},
-): Promise<void> {
-  if (!isBillingEnabled()) return;
-  try {
-    const tier = opts.tier ?? (await resolveTier(userId));
-    const summary = await getCreditBalance(userId, tier);
-    await broadcastCreditsEvent({
-      userId,
-      operation: 'updated',
-      billingEnabled: summary.billingEnabled,
-      monthly: summary.monthly,
-      topup: summary.topup,
-      spendable: summary.spendable,
-      reserved: summary.reserved,
-      ...(opts.conversationId ? { conversationId: opts.conversationId } : {}),
-      ...(opts.pageId ? { pageId: opts.pageId } : {}),
-    });
-  } catch (error) {
-    // Best-effort: a failed balance read/broadcast must never turn into an unhandled
-    // rejection on the fire-and-forget call path. Log defensively so a partial logger
-    // (e.g. in a unit-test mock) can't escalate a swallowed error.
-    loggers?.api?.debug?.('emitCreditsUpdated failed', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
+export {
+  emitCreditsUpdated,
+  type EmitCreditsOptions,
+} from '@pagespace/lib/billing/credit-emit';

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -77,6 +77,16 @@
       "import": "./dist/billing/credit-consume.js",
       "require": "./dist/billing/credit-consume.js"
     },
+    "./billing/credit-balance": {
+      "types": "./dist/billing/credit-balance.d.ts",
+      "import": "./dist/billing/credit-balance.js",
+      "require": "./dist/billing/credit-balance.js"
+    },
+    "./billing/credit-emit": {
+      "types": "./dist/billing/credit-emit.d.ts",
+      "import": "./dist/billing/credit-emit.js",
+      "require": "./dist/billing/credit-emit.js"
+    },
     "./logging/siem-error-hook": {
       "types": "./dist/logging/siem-error-hook.d.ts",
       "import": "./dist/logging/siem-error-hook.js",
@@ -896,6 +906,12 @@
       ],
       "billing/credit-consume": [
         "./dist/billing/credit-consume.d.ts"
+      ],
+      "billing/credit-balance": [
+        "./dist/billing/credit-balance.d.ts"
+      ],
+      "billing/credit-emit": [
+        "./dist/billing/credit-emit.d.ts"
       ],
       "billing/credit-pricing": [
         "./dist/billing/credit-pricing.d.ts"

--- a/packages/lib/src/billing/__tests__/credit-backfill.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-backfill.test.ts
@@ -33,6 +33,8 @@ vi.mock('../credit-consume', () => ({
   consumeCredits: mockConsumeCredits,
   settlePendingLedgerRow: mockSettlePending,
 }));
+const mockEmitCreditsUpdated = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../credit-emit', () => ({ emitCreditsUpdated: mockEmitCreditsUpdated }));
 
 import { backfillCredits } from '../credit-backfill';
 
@@ -114,10 +116,15 @@ describe('backfillCredits', () => {
     expect(result).toEqual({ retried: 0, orphans: 0, expiredHolds: 0 });
   });
 
-  it('sweeps holds past their expiresAt and reports the count', async () => {
-    // Three stale holds (crashed/abandoned streams) reclaimed; no pending/orphan work.
+  it('sweeps holds past their expiresAt, reports the count, and pushes each affected user once', async () => {
+    // Three stale holds (crashed/abandoned streams) reclaimed; two belong to u1, one
+    // to u2 — reclaiming raises their spendable, so each distinct owner gets one push.
     mockDb.delete.mockReturnValue({
-      where: () => ({ returning: () => Promise.resolve([{ id: 'h1' }, { id: 'h2' }, { id: 'h3' }]) }),
+      where: () => ({ returning: () => Promise.resolve([
+        { id: 'h1', userId: 'u1' },
+        { id: 'h2', userId: 'u1' },
+        { id: 'h3', userId: 'u2' },
+      ]) }),
     });
     mockSelects([], []);
 
@@ -125,6 +132,10 @@ describe('backfillCredits', () => {
 
     expect(mockDb.delete).toHaveBeenCalledTimes(1);
     expect(result.expiredHolds).toBe(3);
+    // One push per distinct user (deduped), not one per hold.
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledTimes(2);
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u2');
   });
 
   it('drains a >BATCH backlog across multiple passes (does not stop at one batch)', async () => {

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -15,12 +15,7 @@ vi.mock('@pagespace/db/operators', () => ({
 }));
 
 const { mockIsBillingEnabled } = vi.hoisted(() => ({ mockIsBillingEnabled: vi.fn(() => true) }));
-vi.mock('@pagespace/lib/deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
-
-vi.mock('@/lib/websocket/socket-utils', () => ({ broadcastCreditsEvent: vi.fn() }));
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: { api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
-}));
+vi.mock('../../deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
 
 // Mutable fixtures the db mock reads.
 let balanceRows: Array<Record<string, unknown>> = [];
@@ -47,7 +42,7 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 
-import { getCreditBalance } from '../credit-balance';
+import { getCreditBalance, resolveTier } from '../credit-balance';
 
 const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 const past = new Date(Date.now() - 24 * 60 * 60 * 1000);
@@ -140,5 +135,17 @@ describe('getCreditBalance', () => {
     holdRows = [{ reserved: 50 }];
     const b = await getCreditBalance('u1', 'free');
     expect(b.spendable).toBe(0);
+  });
+});
+
+describe('resolveTier', () => {
+  it('returns the stored subscription tier', async () => {
+    userRows = [{ subscriptionTier: 'pro' }];
+    expect(await resolveTier('u1')).toBe('pro');
+  });
+
+  it('defaults to free when the user has no stored tier', async () => {
+    userRows = [{ subscriptionTier: null as unknown as string }];
+    expect(await resolveTier('u1')).toBe('free');
   });
 });

--- a/packages/lib/src/billing/__tests__/credit-consume.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-consume.test.ts
@@ -9,6 +9,7 @@ const mockDb = vi.hoisted(() => ({
   delete: vi.fn(),
 }));
 const mockAiLogger = vi.hoisted(() => ({ debug: vi.fn(), error: vi.fn() }));
+const mockEmitCreditsUpdated = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 vi.mock('@pagespace/db/db', () => ({ db: mockDb }));
 vi.mock('@pagespace/db/schema/credits', () => ({
@@ -22,6 +23,9 @@ vi.mock('@pagespace/db/operators', () => ({
 }));
 vi.mock('../../deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
 vi.mock('../../logging/logger-config', () => ({ loggers: { ai: mockAiLogger } }));
+// The live `credits:updated` broadcast is exercised by its own suite; here we only
+// assert that the billing primitives FIRE it at each balance/hold mutation.
+vi.mock('../credit-emit', () => ({ emitCreditsUpdated: mockEmitCreditsUpdated }));
 
 import { consumeCredits, settlePendingLedgerRow, releaseHold } from '../credit-consume';
 
@@ -71,6 +75,8 @@ describe('consumeCredits', () => {
     expect(captured.balanceSet).toEqual({ monthlyRemainingCents: 0, topupRemainingCents: 950, pendingMillicents: 0 });
     // appliedCents records what truly left the balance (signed -): 100 monthly + 50 topup.
     expect(captured.ledgerSet).toMatchObject({ consumeStatus: 'applied', appliedCents: -150 });
+    // The debit committed -> push the user's fresh balance for the live navbar.
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1', expect.anything());
   });
 
   it('floors the balance at 0 and records the uncovered remainder as a debt adjustment row', async () => {
@@ -318,27 +324,45 @@ describe('consumeCredits', () => {
     // Ledger settled 'skipped' AND the hold released, both outside a transaction.
     expect(mockDb.delete).toHaveBeenCalledTimes(1);
     expect(deleteWhere).toHaveBeenCalledTimes(1);
+    // Releasing the hold frees spendable -> push the user's fresh balance.
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1', expect.anything());
   });
 });
 
 describe('releaseHold', () => {
+  // delete().where().returning({ userId }) — returning() yields the freed hold's owner.
+  function deleteReturning(rows: Array<{ userId: string }>) {
+    const returning = vi.fn().mockResolvedValue(rows);
+    const where = vi.fn().mockReturnValue({ returning });
+    mockDb.delete.mockReturnValue({ where });
+    return { where, returning };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsBillingEnabled.mockReturnValue(true);
   });
 
-  it('deletes the hold row by id', async () => {
-    const deleteWhere = vi.fn().mockResolvedValue(undefined);
-    mockDb.delete.mockReturnValue({ where: deleteWhere });
+  it('deletes the hold row by id and pushes the freed balance to its owner', async () => {
+    const { where } = deleteReturning([{ userId: 'u1' }]);
     await releaseHold('hold_99');
     expect(mockDb.delete).toHaveBeenCalledTimes(1);
-    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
+  });
+
+  it('does not emit when no hold row was deleted (already swept/expired)', async () => {
+    deleteReturning([]);
+    await releaseHold('hold_gone');
+    expect(mockDb.delete).toHaveBeenCalledTimes(1);
+    expect(mockEmitCreditsUpdated).not.toHaveBeenCalled();
   });
 
   it('is a no-op when billing is disabled', async () => {
     mockIsBillingEnabled.mockReturnValue(false);
     await releaseHold('hold_99');
     expect(mockDb.delete).not.toHaveBeenCalled();
+    expect(mockEmitCreditsUpdated).not.toHaveBeenCalled();
   });
 
   it('never throws if the delete fails', async () => {
@@ -376,6 +400,8 @@ describe('settlePendingLedgerRow', () => {
     await settlePendingLedgerRow('led_1');
     expect(captured.balanceSet).toEqual({ monthlyRemainingCents: 50, topupRemainingCents: 0, pendingMillicents: 0 });
     expect(captured.ledgerSet).toMatchObject({ consumeStatus: 'applied', appliedCents: -150 });
+    // A cron retry that settles still pushes the user's fresh balance.
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
   });
 
   it('is a no-op when the row is already applied', async () => {
@@ -390,5 +416,7 @@ describe('settlePendingLedgerRow', () => {
     });
     await settlePendingLedgerRow('led_1');
     expect(update).not.toHaveBeenCalled();
+    // Nothing settled -> nothing to push.
+    expect(mockEmitCreditsUpdated).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/src/billing/__tests__/credit-emit.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-emit.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockIsBillingEnabled = vi.hoisted(() => vi.fn(() => true));
+const mockGetCreditBalance = vi.hoisted(() => vi.fn());
+const mockResolveTier = vi.hoisted(() => vi.fn());
+const mockAiLogger = vi.hoisted(() => ({ debug: vi.fn(), error: vi.fn() }));
+
+vi.mock('../../deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
+vi.mock('../../logging/logger-config', () => ({ loggers: { ai: mockAiLogger } }));
+vi.mock('../../auth/broadcast-auth', () => ({
+  // The HMAC signing itself is covered by broadcast-auth's own tests; here we only
+  // care that emit signs and posts. Return a deterministic header.
+  createSignedBroadcastHeaders: vi.fn(() => ({
+    'Content-Type': 'application/json',
+    'X-Broadcast-Signature': 't=1,v1=sig',
+  })),
+}));
+vi.mock('../credit-balance', () => ({
+  getCreditBalance: mockGetCreditBalance,
+  resolveTier: mockResolveTier,
+}));
+
+import { emitCreditsUpdated } from '../credit-emit';
+
+const SUMMARY = {
+  billingEnabled: true,
+  monthly: { remaining: 300, allowance: 500, periodEnd: '2026-07-01T00:00:00.000Z' },
+  topup: { remaining: 1200 },
+  spendable: 1500,
+  reserved: 25,
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsBillingEnabled.mockReturnValue(true);
+  mockResolveTier.mockResolvedValue('pro');
+  mockGetCreditBalance.mockResolvedValue(SUMMARY);
+  process.env.INTERNAL_REALTIME_URL = 'http://realtime.test';
+  fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.INTERNAL_REALTIME_URL;
+});
+
+function postedBody() {
+  const [, init] = fetchMock.mock.calls[0];
+  return JSON.parse((init as { body: string }).body);
+}
+
+describe('emitCreditsUpdated', () => {
+  it('is a no-op when billing is disabled (no balance read, no broadcast)', async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    await emitCreditsUpdated('u1');
+    expect(mockGetCreditBalance).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('recomputes the balance and POSTs a credits:updated event to the user channel', async () => {
+    await emitCreditsUpdated('u1');
+
+    expect(mockResolveTier).toHaveBeenCalledWith('u1');
+    expect(mockGetCreditBalance).toHaveBeenCalledWith('u1', 'pro');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://realtime.test/api/broadcast');
+    expect((init as { method: string }).method).toBe('POST');
+
+    const body = postedBody();
+    expect(body.channelId).toBe('notifications:u1');
+    expect(body.event).toBe('credits:updated');
+    expect(body.payload).toMatchObject({
+      userId: 'u1',
+      operation: 'updated',
+      billingEnabled: true,
+      spendable: 1500,
+      reserved: 25,
+      monthly: SUMMARY.monthly,
+      topup: SUMMARY.topup,
+    });
+    // Scopeless by default: no conversation/page hints leak when not provided.
+    expect(body.payload.conversationId).toBeUndefined();
+    expect(body.payload.pageId).toBeUndefined();
+  });
+
+  it('skips the tier lookup when a tier is supplied', async () => {
+    await emitCreditsUpdated('u1', { tier: 'free' });
+    expect(mockResolveTier).not.toHaveBeenCalled();
+    expect(mockGetCreditBalance).toHaveBeenCalledWith('u1', 'free');
+  });
+
+  it('carries conversation/page scope when provided (per-conversation usage monitor)', async () => {
+    await emitCreditsUpdated('u1', { conversationId: 'c1', pageId: 'p1' });
+    const body = postedBody();
+    expect(body.payload.conversationId).toBe('c1');
+    expect(body.payload.pageId).toBe('p1');
+  });
+
+  it('never throws when the broadcast fails (best-effort fire-and-forget)', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    await expect(emitCreditsUpdated('u1')).resolves.toBeUndefined();
+    expect(mockAiLogger.debug).toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/billing/__tests__/credit-emit.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-emit.test.ts
@@ -105,4 +105,12 @@ describe('emitCreditsUpdated', () => {
     await expect(emitCreditsUpdated('u1')).resolves.toBeUndefined();
     expect(mockAiLogger.debug).toHaveBeenCalled();
   });
+
+  it('records a dropped broadcast when the realtime server returns non-2xx', async () => {
+    // A 4xx/5xx must not look like success: it should hit the catch path and log,
+    // not silently pass (the only signal the navbar push was dropped).
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+    await expect(emitCreditsUpdated('u1')).resolves.toBeUndefined();
+    expect(mockAiLogger.debug).toHaveBeenCalled();
+  });
 });

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -25,6 +25,8 @@ vi.mock('@pagespace/db/operators', () => ({
   sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: true, strings, values })),
 }));
 vi.mock('../../deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
+const mockEmitCreditsUpdated = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../credit-emit', () => ({ emitCreditsUpdated: mockEmitCreditsUpdated }));
 
 import { canConsumeAI, addOneMonth } from '../credit-gate';
 
@@ -135,6 +137,9 @@ describe('canConsumeAI', () => {
     // The hold reserves this call's estimate and is scoped to the user.
     expect(sink.holdValues).toMatchObject({ userId: 'u1', estCents: EST });
     expect(sink.holdValues?.expiresAt).toBeInstanceOf(Date);
+    // Placing the hold shrank spendable -> push the fresh balance so the navbar
+    // drops the instant the call starts (not just when it settles).
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
   });
 
   it('denies with out_of_credits when both buckets are empty (no hold inserted)', async () => {
@@ -147,6 +152,8 @@ describe('canConsumeAI', () => {
     expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' });
     expect(r.holdId).toBeUndefined();
     expect(sink.insertCalled).toBeFalsy();
+    // No hold created -> nothing changed -> no push.
+    expect(mockEmitCreditsUpdated).not.toHaveBeenCalled();
   });
 
   it('denies a free user who has reached the in-flight cap (too_many_in_flight), even with credit', async () => {

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -353,6 +353,10 @@ vi.mock('@pagespace/db/schema/monitoring', () => ({ aiUsageLogs: H.schema.aiUsag
 vi.mock('@pagespace/db/operators', () => H.ops);
 vi.mock('../../deployment-mode', () => ({ isBillingEnabled: H.isBillingEnabled }));
 vi.mock('../../logging/logger-config', () => ({ loggers: { api: H.logger, ai: H.logger } }));
+// The live balance broadcast is fire-and-forget I/O (signed POST to the realtime
+// server); stub it so this end-to-end money-path test stays hermetic. Its own suite
+// (credit-emit.test.ts) covers the broadcast.
+vi.mock('../credit-emit', () => ({ emitCreditsUpdated: vi.fn().mockResolvedValue(undefined) }));
 
 import { applyStripeFunding } from '../credit-funding';
 import { canConsumeAI } from '../credit-gate';

--- a/packages/lib/src/billing/credit-backfill.ts
+++ b/packages/lib/src/billing/credit-backfill.ts
@@ -31,6 +31,24 @@ export interface BackfillResult {
   expiredHolds: number;
 }
 
+/** Max concurrent balance broadcasts when reclaiming swept holds (bounds the fan-out). */
+const EMIT_CONCURRENCY = 10;
+
+/**
+ * Push fresh balances to many users without blocking the caller. Runs in bounded
+ * batches so a large hold sweep doesn't open one socket per user simultaneously.
+ * `emitCreditsUpdated` swallows its own errors, so allSettled never rejects; this is
+ * launched fire-and-forget (the app server is long-running, so detached work runs to
+ * completion). Exported-free: internal to the backfill shell.
+ */
+async function emitBalancesBestEffort(userIds: string[]): Promise<void> {
+  for (let i = 0; i < userIds.length; i += EMIT_CONCURRENCY) {
+    await Promise.allSettled(
+      userIds.slice(i, i + EMIT_CONCURRENCY).map((uid) => emitCreditsUpdated(uid)),
+    );
+  }
+}
+
 export async function backfillCredits(): Promise<BackfillResult> {
   if (!isBillingEnabled()) return { retried: 0, orphans: 0, expiredHolds: 0 };
 
@@ -52,11 +70,12 @@ export async function backfillCredits(): Promise<BackfillResult> {
     // Reclaiming a stale hold raises that user's spendable back up — push the fresh
     // balance so the navbar recovers without a refresh. This is the backstop for a
     // call that was interrupted before settlement: its dangling reservation finally
-    // clears here. One emit per distinct user; best-effort, never blocks the cron.
+    // clears here. One emit per distinct user. Fire-and-forget (void) so a slow or
+    // unreachable realtime server (each emit self-times-out at 5s) never serializes
+    // its delay across users and stalls the pending/orphan reconciliation below;
+    // the fan-out is bounded so a large sweep doesn't open one socket per user at once.
     const affected = [...new Set(swept.map((h) => h.userId))];
-    for (const uid of affected) {
-      await emitCreditsUpdated(uid);
-    }
+    void emitBalancesBestEffort(affected);
   } catch (error) {
     loggers.ai.debug('credit hold expiry sweep failed', { error: (error as Error).message });
   }

--- a/packages/lib/src/billing/credit-backfill.ts
+++ b/packages/lib/src/billing/credit-backfill.ts
@@ -14,6 +14,7 @@ import { and, eq, lt, gt, isNull } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import { computeBackfillActions } from './credit-core';
 import { consumeCredits, settlePendingLedgerRow } from './credit-consume';
+import { emitCreditsUpdated } from './credit-emit';
 import { loggers } from '../logging/logger-config';
 
 const BATCH = 200;
@@ -46,8 +47,16 @@ export async function backfillCredits(): Promise<BackfillResult> {
     const swept = await db
       .delete(creditHolds)
       .where(lt(creditHolds.expiresAt, now))
-      .returning({ id: creditHolds.id });
+      .returning({ id: creditHolds.id, userId: creditHolds.userId });
     expiredHolds = swept.length;
+    // Reclaiming a stale hold raises that user's spendable back up — push the fresh
+    // balance so the navbar recovers without a refresh. This is the backstop for a
+    // call that was interrupted before settlement: its dangling reservation finally
+    // clears here. One emit per distinct user; best-effort, never blocks the cron.
+    const affected = [...new Set(swept.map((h) => h.userId))];
+    for (const uid of affected) {
+      await emitCreditsUpdated(uid);
+    }
   } catch (error) {
     loggers.ai.debug('credit hold expiry sweep failed', { error: (error as Error).message });
   }

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -1,0 +1,148 @@
+/**
+ * credit-balance — read-only view of a user's prepaid AI-credit balance for the
+ * dashboard widget and the `GET /api/credits` endpoint.
+ *
+ * This is the DISPLAY layer; it never mutates. The authoritative spend decision and
+ * the monthly reset live in `./credit-gate` (the imperative shell that owns the clock
+ * and the row lock). Here we only mirror the gate's semantics for presentation:
+ *   - free tier whose monthly window has lapsed is shown its full allowance (the gate
+ *     will reset it on the next call) rather than a stale, pessimistic remainder;
+ *   - paid tier whose window has lapsed is shown 0 monthly (use-it-or-lose-it — the
+ *     gate excludes the expired allowance until the renewal invoice refills it);
+ *   - spendable nets out the sum of the user's still-active holds (reservations on
+ *     calls currently in flight), clamped at 0.
+ *
+ * Money is always whole cents of customer-facing credit value, matching credit-core.
+ *
+ * Lives in @pagespace/lib so the billing primitives (credit-consume, credit-gate,
+ * credit-backfill) can recompute and broadcast a fresh balance at every mutation
+ * without reaching back into apps/web. See ./credit-emit.
+ */
+
+import { db } from '@pagespace/db/db';
+import { creditBalances, creditHolds } from '@pagespace/db/schema/credits';
+import { users } from '@pagespace/db/schema/auth';
+import { and, eq, gt, sql } from '@pagespace/db/operators';
+import { isBillingEnabled } from '../deployment-mode';
+import { TIER_MONTHLY_ALLOWANCE_CENTS } from './credit-pricing';
+import type { SubscriptionTier } from '../services/subscription-utils';
+
+export interface CreditBalanceSummary {
+  /** false on billing-disabled deployments (tenant/onprem); the widget then hides. */
+  billingEnabled: boolean;
+  monthly: {
+    remaining: number;
+    allowance: number;
+    /** ISO string of the current period end, or null if never stamped. */
+    periodEnd: string | null;
+  };
+  topup: {
+    remaining: number;
+  };
+  /** monthly + topup remaining, minus active holds, clamped to >= 0. */
+  spendable: number;
+  /** Sum of this user's non-expired holds (estimated spend on in-flight calls). */
+  reserved: number;
+}
+
+function allowanceFor(tier: SubscriptionTier): number {
+  return TIER_MONTHLY_ALLOWANCE_CENTS[tier] ?? TIER_MONTHLY_ALLOWANCE_CENTS.free;
+}
+
+/** The unlimited/hidden summary used when prepaid billing is disabled. */
+function disabledSummary(): CreditBalanceSummary {
+  return {
+    billingEnabled: false,
+    monthly: { remaining: 0, allowance: 0, periodEnd: null },
+    topup: { remaining: 0 },
+    spendable: 0,
+    reserved: 0,
+  };
+}
+
+/**
+ * Read a user's current prepaid credit balance for display. Pure read: no lazy-init,
+ * no reset — those are owned by the gate. A user with no balance row yet is shown the
+ * tier's monthly allowance (what the gate will lazy-init on their first call).
+ */
+export async function getCreditBalance(
+  userId: string,
+  tier: SubscriptionTier = 'free',
+): Promise<CreditBalanceSummary> {
+  if (!isBillingEnabled()) return disabledSummary();
+
+  const now = new Date();
+
+  const [rows, holdAgg] = await Promise.all([
+    db
+      .select({
+        monthlyRemainingCents: creditBalances.monthlyRemainingCents,
+        monthlyAllowanceCents: creditBalances.monthlyAllowanceCents,
+        topupRemainingCents: creditBalances.topupRemainingCents,
+        monthlyPeriodEnd: creditBalances.monthlyPeriodEnd,
+      })
+      .from(creditBalances)
+      .where(eq(creditBalances.userId, userId))
+      .limit(1),
+    db
+      .select({ reserved: sql<number>`coalesce(sum(${creditHolds.estCents}), 0)` })
+      .from(creditHolds)
+      .where(and(eq(creditHolds.userId, userId), gt(creditHolds.expiresAt, now))),
+  ]);
+
+  const reserved = Number(holdAgg[0]?.reserved ?? 0);
+  const row = rows[0] ?? null;
+
+  // No row yet: the gate will lazy-init from the tier allowance on the first call,
+  // so present that as the spendable monthly balance.
+  if (!row) {
+    const allowance = allowanceFor(tier);
+    const spendable = Math.max(0, allowance - reserved);
+    return {
+      billingEnabled: true,
+      monthly: { remaining: allowance, allowance, periodEnd: null },
+      topup: { remaining: 0 },
+      spendable,
+      reserved,
+    };
+  }
+
+  const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
+  const periodEnd = row.monthlyPeriodEnd;
+  const expired = periodEnd === null || periodEnd < now;
+
+  // Mirror the gate's window semantics for display (see file header).
+  let monthlyRemaining: number;
+  if (tier === 'free' && expired) {
+    monthlyRemaining = allowance; // gate resets free tiers on next call
+  } else if (tier !== 'free' && expired && periodEnd !== null) {
+    monthlyRemaining = 0; // paid use-it-or-lose-it: expired allowance is forfeit
+  } else {
+    monthlyRemaining = row.monthlyRemainingCents;
+  }
+
+  const topupRemaining = row.topupRemainingCents;
+  const spendable = Math.max(0, monthlyRemaining + topupRemaining - reserved);
+
+  return {
+    billingEnabled: true,
+    monthly: {
+      remaining: monthlyRemaining,
+      allowance,
+      periodEnd: periodEnd ? periodEnd.toISOString() : null,
+    },
+    topup: { remaining: topupRemaining },
+    spendable,
+    reserved,
+  };
+}
+
+/** The user's stored subscription tier, defaulting to free if unknown. */
+export async function resolveTier(userId: string): Promise<SubscriptionTier> {
+  const rows = await db
+    .select({ subscriptionTier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+  return (rows[0]?.subscriptionTier as SubscriptionTier) ?? 'free';
+}

--- a/packages/lib/src/billing/credit-consume.ts
+++ b/packages/lib/src/billing/credit-consume.ts
@@ -20,6 +20,7 @@ import { eq, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import { chargeMillicents, accruePending, allocateSpend } from './credit-core';
 import { MARKUP_BPS } from './credit-pricing';
+import { emitCreditsUpdated } from './credit-emit';
 import { loggers } from '../logging/logger-config';
 
 export interface ConsumeCreditsInput {
@@ -32,6 +33,14 @@ export interface ConsumeCreditsInput {
    * orphan/retry paths pass none (the hold, if any, is reclaimed by expiry).
    */
   holdId?: string;
+  /**
+   * Optional scope so the live `credits:updated` push can carry conversation/page
+   * hints (the per-conversation usage monitor filters on them). Live chat routes
+   * thread these through; background jobs and the reconcile cron leave them unset,
+   * so the navbar still updates while the per-conversation view is untouched.
+   */
+  conversationId?: string;
+  pageId?: string;
 }
 
 type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -223,6 +232,11 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
       // counting against the in-flight cap until it expires.
       if (input.holdId) {
         await db.delete(creditHolds).where(eq(creditHolds.id, input.holdId));
+        // Releasing the hold frees the user's spendable — push the fresh balance.
+        void emitCreditsUpdated(input.userId, {
+          conversationId: input.conversationId,
+          pageId: input.pageId,
+        });
       }
     } catch (error) {
       loggers.ai.debug('credit zero-charge settle failed', {
@@ -238,6 +252,12 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
     await db.transaction((tx) =>
       decrementAndSettle(tx, ledgerId, input.userId, chargeMc, input.aiUsageLogId, input.holdId ?? null),
     );
+    // The debit + hold release committed: push the user's fresh balance so the navbar
+    // reflects this call's spend live (no refresh). Best-effort, never blocks the call.
+    void emitCreditsUpdated(input.userId, {
+      conversationId: input.conversationId,
+      pageId: input.pageId,
+    });
   } catch (error) {
     // Leave the row 'pending' for the backfill cron to retry. Never throw.
     loggers.ai.debug('credit consume failed', {
@@ -257,7 +277,14 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
 export async function releaseHold(holdId: string): Promise<void> {
   if (!isBillingEnabled()) return;
   try {
-    await db.delete(creditHolds).where(eq(creditHolds.id, holdId));
+    // Return the hold's owner so we can push their freed balance. A missing/expired
+    // hold deletes zero rows and yields no userId — then there's nothing to emit.
+    const deleted = await db
+      .delete(creditHolds)
+      .where(eq(creditHolds.id, holdId))
+      .returning({ userId: creditHolds.userId });
+    const userId = deleted[0]?.userId;
+    if (userId) void emitCreditsUpdated(userId);
   } catch (error) {
     loggers.ai.debug('credit hold release failed', { error: (error as Error).message, holdId });
   }
@@ -269,6 +296,7 @@ export async function releaseHold(holdId: string): Promise<void> {
  * atomically. A no-op if the row is missing or already applied — safe to retry.
  */
 export async function settlePendingLedgerRow(ledgerId: string): Promise<void> {
+  let settledUserId: string | null = null;
   await db.transaction(async (tx) => {
     const rows = await tx
       .select()
@@ -290,5 +318,9 @@ export async function settlePendingLedgerRow(ledgerId: string): Promise<void> {
     // precision on those legacy rows only).
     const chargeMc = row.chargeMillicents ?? Math.abs(row.amountCents) * 1000;
     await decrementAndSettle(tx, ledgerId, row.userId, chargeMc, row.aiUsageLogId);
+    settledUserId = row.userId;
   });
+  // A pending row settled this run (cron retry): push the user's fresh balance so a
+  // call that never emitted at its own finish still reaches the navbar live.
+  if (settledUserId) void emitCreditsUpdated(settledUserId);
 }

--- a/packages/lib/src/billing/credit-emit.ts
+++ b/packages/lib/src/billing/credit-emit.ts
@@ -44,12 +44,18 @@ async function broadcastCreditsUpdated(
     payload: { userId, operation: 'updated', ...body },
   });
 
-  await fetch(`${realtimeUrl}/api/broadcast`, {
+  const response = await fetch(`${realtimeUrl}/api/broadcast`, {
     method: 'POST',
     headers: createSignedBroadcastHeaders(requestBody),
     body: requestBody,
     signal: AbortSignal.timeout(5000),
   });
+  // A 4xx/5xx means the broadcast was dropped (bad signature, realtime error). Throw
+  // so emitCreditsUpdated's catch records it — otherwise dropped pushes look silently
+  // successful and we lose the only signal that the navbar didn't get updated.
+  if (!response.ok) {
+    throw new Error(`realtime broadcast failed: ${response.status}`);
+  }
 }
 
 /**

--- a/packages/lib/src/billing/credit-emit.ts
+++ b/packages/lib/src/billing/credit-emit.ts
@@ -1,0 +1,85 @@
+/**
+ * credit-emit — recompute a user's prepaid balance and push it to their
+ * notifications channel as a `credits:updated` socket event.
+ *
+ * Centralized here, in @pagespace/lib, so EVERY balance/holds mutation broadcasts a
+ * fresh balance regardless of which caller triggered it — the billing primitives
+ * (credit-consume, credit-gate, credit-backfill) call this directly instead of each
+ * of the many AI routes / background jobs having to remember to emit. New billing
+ * callers inherit live navbar updates for free.
+ *
+ * Best-effort and never throws: a failed balance read or broadcast must not break the
+ * request or turn a fire-and-forget call into an unhandled rejection. A no-op when
+ * billing is disabled. Always invoke as `void emitCreditsUpdated(...)`.
+ *
+ * The broadcast mirrors the notifications broadcaster (notifications/notifications.ts):
+ * a signed POST to the realtime server's /api/broadcast, channel `notifications:{userId}`.
+ * The payload is structurally identical to the client's CreditsEventPayload
+ * (apps/web socket-utils), so the navbar widget and per-conversation usage monitor
+ * consume it unchanged.
+ */
+
+import { createSignedBroadcastHeaders } from '../auth/broadcast-auth';
+import { isBillingEnabled } from '../deployment-mode';
+import { loggers } from '../logging/logger-config';
+import type { SubscriptionTier } from '../services/subscription-utils';
+import { getCreditBalance, resolveTier } from './credit-balance';
+
+export interface EmitCreditsOptions {
+  /** Pre-resolved tier to avoid an extra users lookup when the caller already has it. */
+  tier?: SubscriptionTier;
+  /** Optional scoping hints so the per-conversation usage monitor refreshes the right view. */
+  conversationId?: string;
+  pageId?: string;
+}
+
+async function broadcastCreditsUpdated(
+  userId: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const realtimeUrl = process.env.INTERNAL_REALTIME_URL || 'http://localhost:3001';
+  const requestBody = JSON.stringify({
+    channelId: `notifications:${userId}`,
+    event: 'credits:updated',
+    payload: { userId, operation: 'updated', ...body },
+  });
+
+  await fetch(`${realtimeUrl}/api/broadcast`, {
+    method: 'POST',
+    headers: createSignedBroadcastHeaders(requestBody),
+    body: requestBody,
+    signal: AbortSignal.timeout(5000),
+  });
+}
+
+/**
+ * Recompute the user's balance and broadcast it. Called from the billing primitives
+ * after any mutation (hold create/release, debit, sweep) and from the Stripe webhook
+ * after funding.
+ */
+export async function emitCreditsUpdated(
+  userId: string,
+  opts: EmitCreditsOptions = {},
+): Promise<void> {
+  if (!isBillingEnabled()) return;
+  try {
+    const tier = opts.tier ?? (await resolveTier(userId));
+    const summary = await getCreditBalance(userId, tier);
+    await broadcastCreditsUpdated(userId, {
+      billingEnabled: summary.billingEnabled,
+      monthly: summary.monthly,
+      topup: summary.topup,
+      spendable: summary.spendable,
+      reserved: summary.reserved,
+      ...(opts.conversationId ? { conversationId: opts.conversationId } : {}),
+      ...(opts.pageId ? { pageId: opts.pageId } : {}),
+    });
+  } catch (error) {
+    // Best-effort: a failed balance read/broadcast must never escalate on the
+    // fire-and-forget call path. Log defensively so a partial logger (e.g. a unit-test
+    // mock) can't itself turn a swallowed error into a throw.
+    loggers?.ai?.debug?.('emitCreditsUpdated failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -33,6 +33,7 @@ import {
   MAX_FREE_INFLIGHT,
   isCreditsEnforcementEnabled,
 } from './credit-pricing';
+import { emitCreditsUpdated } from './credit-emit';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
 /**
@@ -206,6 +207,13 @@ export async function canConsumeAI(
 
     return { ...result, holdId: inserted[0]?.id };
   });
+
+  // A hold was placed: the reservation just shrank this user's spendable. Push the
+  // fresh balance now (scopeless — navbar only; no usage exists yet) so the widget
+  // drops the instant the call starts, not just when it settles. This is the
+  // always-fires update that keeps the navbar correct even if the stream is
+  // interrupted and onFinish/settlement never runs. Best-effort, never blocks.
+  if (result.holdId) void emitCreditsUpdated(userId);
 
   // Dark launch: the gate did all its bookkeeping above (lazy-init, reset, balance
   // read, and a hold on the allow path), but when enforcement is OFF we never hand

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -801,7 +801,16 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
       // zero-charge call still reaches consumeCredits, which settles it as
       // 'skipped' without churning a $0 ledger transaction.
       if (aiUsageLogId && (success || (totalTokens ?? 0) > 0)) {
-        await consumeCredits({ aiUsageLogId, userId: data.userId, costDollars: cost, holdId: data.holdId })
+        await consumeCredits({
+          aiUsageLogId,
+          userId: data.userId,
+          costDollars: cost,
+          holdId: data.holdId,
+          // Scope the live balance push so the per-conversation usage monitor
+          // refreshes the right view; the navbar widget updates regardless.
+          conversationId: data.conversationId,
+          pageId: data.pageId,
+        })
           .catch((error) => {
             loggers.ai.debug('credit consume failed', { error: (error as Error).message });
           });


### PR DESCRIPTION
## Problem

Credit usage only updated the navbar widget on **AI-chat `onFinish`**, and only on 2 of 5 chat routes. But a user's `spendable` (`= monthly + topup − reserved`) changes at many points that never emitted `credits:updated`:

- the **reservation hold** placed at turn start (spendable drops)
- **hold release** on error/abort (spendable restored)
- **8 background AI jobs** that bill via `trackAIUsage` (memory compaction/discovery/integration, workflow executor, Zoom ×2, pulse cron, `ask_agent` sub-agent tool)
- the **reconcile cron** (orphan-consume, pending-settle, expired-hold sweep)

The decisive case: `onFinish` is **not guaranteed**. The AI-SDK `abortSignal` only fires on an explicit `/api/ai/abort`; on a hard disconnect (tab close, navigation, network drop, function killed) settlement never runs, so the balance only corrects when the cron sweeps the dangling hold — and the cron emitted nothing. A manual refresh then "changed the number." That's the reported bug.

## Fix

Centralize the broadcast in the **billing primitives in `@pagespace/lib`** so *every* balance/holds mutation pushes a fresh balance automatically — regardless of which route or background job triggered it. New billing callers inherit live navbar updates for free.

- **`packages/lib/src/billing/credit-balance.ts`** (new) — `getCreditBalance` + `resolveTier` moved here from apps/web; apps/web re-exports them so `GET /api/credits` and the Stripe webhook are unchanged.
- **`packages/lib/src/billing/credit-emit.ts`** (new) — `emitCreditsUpdated()` recomputes the balance and signs+POSTs to the realtime server (same pattern as `notifications.ts`). No-op when billing is disabled; never throws; treats non-2xx realtime responses as dropped broadcasts (logged, not silently swallowed).
- **Emits wired at each chokepoint:**
  - `canConsumeAI` → on hold create (navbar drops at turn *start*, even if `onFinish` never runs)
  - `consumeCredits` + `settlePendingLedgerRow` → after every debit (all 5 routes + 8 background jobs + cron orphan/pending settle)
  - `releaseHold` → returns the freed hold's `userId` and emits (error/abort restore)
  - `backfillCredits` → emits per affected user on the expired-hold sweep (**interrupted-call backstop**), via a non-blocking bounded fan-out so a slow realtime server can't stall the cron
- Thread `conversationId`/`pageId` through `ConsumeCreditsInput` → `ai-monitoring` so the per-conversation usage monitor still scopes correctly.
- Remove the now-redundant manual finish emits in `ai/chat` and `ai/global` (the centralized debit emit replaces them; avoids double-fire).

### Client (`useCreditBalance`)
Each `credits:updated` event now applies the payload optimistically **and revalidates against `/api/credits`** (the authoritative current balance), so an out-of-order or stale snapshot (e.g. a delayed turn-start "hold placed" push arriving after its own settlement push) can't stick — the follow-up refetch corrects it. SWR dedupes concurrent revalidations, so bursty start+finish events coalesce into a single refetch. No payload-shape change; `CreditBalance`/`AiUsageMonitor` are untouched.

No DB schema change.

## Tests

- New `credit-emit.test.ts` (broadcast shape/scope/no-op/never-throws/**non-2xx logged**) and moved `credit-balance.test.ts` into lib.
- Added emit assertions across `credit-consume`, `credit-gate`, `credit-backfill` tests; integration test stubs the broadcast.
- `@pagespace/lib` + `web` typecheck ✅, lint ✅, full lib suite ✅, affected web tests (credits route, both AI routes, socket-utils, all Stripe) ✅.

## Review feedback addressed (Codex + CodeRabbit)
- Backfill no longer serializes best-effort emits (non-blocking bounded fan-out).
- `credit-emit` surfaces non-2xx realtime responses instead of treating them as success.
- Client revalidates on each event to defeat stale/out-of-order broadcast races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)