### PR TITLE
fix(ai-chat): make stop authoritative + kill duplicate stream render

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -27,7 +27,8 @@ import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
 import { useSWRConfig } from 'swr';
 
 import { clearActiveStreamId } from '@/lib/ai/core/client';
-import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
+import { abortActiveStream, abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
+import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
@@ -50,7 +51,6 @@ import {
   useConversations,
   useChatTransport,
   useStreamingRegistration,
-  useChatStop,
   useSendHandoff,
   AgentConfig,
 } from '@/lib/ai/shared';
@@ -263,7 +263,6 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);
   const currentFindMsgId = findMatchIds[findIndex] ?? null;
   const { wrapSend } = useSendHandoff(currentConversationId, status);
-  const stop = useChatStop(streamTrackingId, chatStop);
 
   const streamingAssistantText = useMemo(() => {
     if (!isStreaming) return null;
@@ -401,14 +400,23 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     : null;
 
   const effectiveStop = useCallback(() => {
-    if (isStreaming) {
-      stop();
+    // Stop the local fetch immediately for instant UI feedback.
+    chatStop();
+    // Abort by the stable assistant messageId — reaches the server registry even
+    // when the conversation id shifted mid-stream, and tears down any multicast
+    // SSE join via the resulting chat:stream_complete broadcast.
+    const messageId = resolveActiveAssistantMessageId({
+      ownStreamMessageId,
+      isStreaming,
+      lastAssistantMessageId,
+    });
+    if (messageId) {
+      void abortActiveStreamByMessageId({ messageId });
       return;
     }
-    if (ownStreamMessageId) {
-      abortActiveStreamByMessageId({ messageId: ownStreamMessageId });
-    }
-  }, [isStreaming, stop, ownStreamMessageId]);
+    // No assistant id yet (submitted, before first chunk): fall back to the chatId map.
+    if (streamTrackingId) void abortActiveStream({ chatId: streamTrackingId });
+  }, [chatStop, ownStreamMessageId, isStreaming, lastAssistantMessageId, streamTrackingId]);
 
   usePageSocketRoom(page.id);
   useChannelStreamSocket(page.id, {
@@ -448,7 +456,13 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
 
       if (stream && stream.parts.length > 0 && stream.conversationId === currentConversationId) {
-        setMessages((prev) => [...prev, synthesizeAssistantMessage(messageId, stream.parts)]);
+        // Guard against a duplicate: useChat may already hold this message when the
+        // stream was consumed by both the POST stream and the multicast SSE join.
+        setMessages((prev) =>
+          prev.some((m) => m.id === messageId)
+            ? prev
+            : [...prev, synthesizeAssistantMessage(messageId, stream.parts)],
+        );
         return;
       }
 
@@ -469,7 +483,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             const persisted = data.conversations?.[0];
             if (!persisted || persisted.id !== streamConvId) return;
             setCurrentConversationId(persisted.id);
-            setMessages((prev) => [...prev, synthesizeAssistantMessage(messageId, parts)]);
+            setMessages((prev) =>
+              prev.some((m) => m.id === messageId)
+                ? prev
+                : [...prev, synthesizeAssistantMessage(messageId, parts)],
+            );
           })
           .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));
       }

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -91,6 +91,7 @@ vi.mock('@/hooks/useDisplayPreferences', () => ({
 
 vi.mock('@/lib/ai/core/client', () => ({ clearActiveStreamId: vi.fn() }));
 vi.mock('@/lib/ai/core/stream-abort-client', () => ({
+  abortActiveStream: vi.fn(),
   abortActiveStreamByMessageId: mockAbortByMessageId,
 }));
 vi.mock('@/lib/ai/core/vision-models', () => ({ hasVisionCapability: vi.fn(() => false) }));
@@ -1031,13 +1032,14 @@ describe('AiChatView stop button for reconnected own streams', () => {
     });
   });
 
-  test('given useChat is actively streaming, calling ChatLayout.onStop calls the local useChat stop and not the remote abort', async () => {
+  test('given useChat is actively streaming, calling ChatLayout.onStop stops the local fetch AND aborts the server stream by the stable messageId', async () => {
     setupHappyInit();
     setStoreSelectors({
       own: [{ messageId: 'msg-own-2', pageId: PAGE_ID, isOwn: true }],
     });
     const { useChat } = await import('@ai-sdk/react');
     const useChatMock = useChat as unknown as Mock;
+    const streamingStop = vi.fn();
     const idleReturn = {
       messages: [],
       sendMessage: vi.fn(),
@@ -1047,7 +1049,7 @@ describe('AiChatView stop button for reconnected own streams', () => {
       setMessages: mockSetMessages,
       stop: vi.fn(),
     };
-    useChatMock.mockReturnValue({ ...idleReturn, status: 'streaming' });
+    useChatMock.mockReturnValue({ ...idleReturn, status: 'streaming', stop: streamingStop });
 
     try {
       render(<AiChatView page={page} />);
@@ -1067,16 +1069,16 @@ describe('AiChatView stop button for reconnected own streams', () => {
 
       assert({
         given: 'isStreaming=true, onStop invoked',
-        should: 'call local stop exactly once',
-        actual: mockLocalStop.mock.calls.length,
+        should: 'call the local useChat stop exactly once',
+        actual: streamingStop.mock.calls.length,
         expected: 1,
       });
 
       assert({
-        given: 'isStreaming=true, onStop invoked',
-        should: 'NOT call abortActiveStreamByMessageId (avoid double-stop)',
-        actual: mockAbortByMessageId.mock.calls.length,
-        expected: 0,
+        given: 'isStreaming=true with a known assistant messageId, onStop invoked',
+        should: 'abort the server stream by the stable messageId (authoritative stop)',
+        actual: mockAbortByMessageId.mock.calls.map((args) => args[0]),
+        expected: [{ messageId: 'msg-own-2' }],
       });
     } finally {
       useChatMock.mockReturnValue(idleReturn);

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -348,6 +348,17 @@ const GlobalAssistantView: React.FC = () => {
   }, [globalLocalMessages]);
   const stop = useChatStop(currentConversationId, rawStop);
 
+  // The stable assistant messageId of the live stream (the rendered streaming
+  // bubble === serverAssistantMessageId). Used to abort authoritatively by
+  // messageId rather than the fragile chatId→streamId map.
+  const liveAssistantMessageId = useMemo(() => {
+    if (!isStreaming) return undefined;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'assistant') return messages[i].id;
+    }
+    return undefined;
+  }, [isStreaming, messages]);
+
   // After a refresh mid-stream, useChat starts at idle — but the
   // GlobalChatContext bootstrap may have detected an own in-flight stream
   // and registered a stop function. Surface either source so the UI shows
@@ -358,6 +369,7 @@ const GlobalAssistantView: React.FC = () => {
     selectedAgent,
     contextIsStreaming,
     contextStopStreaming,
+    activeMessageId: liveAssistantMessageId,
   });
 
   const remoteStreamingUser = !effectiveIsStreaming

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/useGlobalEffectiveStream.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/useGlobalEffectiveStream.test.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
+
+const { mockAbortByMessageId } = vi.hoisted(() => ({ mockAbortByMessageId: vi.fn() }));
+vi.mock('@/lib/ai/core/stream-abort-client', () => ({
+  abortActiveStreamByMessageId: mockAbortByMessageId,
+}));
 
 import { useGlobalEffectiveStream } from '../useGlobalEffectiveStream';
 
 describe('useGlobalEffectiveStream', () => {
+  beforeEach(() => {
+    mockAbortByMessageId.mockClear();
+  });
+
   // AC9
   it('given global mode with local idle and context isStreaming=true, should report effectiveIsStreaming=true', () => {
     const { result } = renderHook(() =>
@@ -132,5 +141,48 @@ describe('useGlobalEffectiveStream', () => {
     result.current.effectiveStop();
 
     expect(rawStop).not.toHaveBeenCalled();
+  });
+
+  it('given a live activeMessageId, should abort by messageId and stop the local fetch (not the context stop)', () => {
+    const rawStop = vi.fn();
+    const contextStopStreaming = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: true,
+        rawStop,
+        selectedAgent: null,
+        contextIsStreaming: true,
+        contextStopStreaming,
+        activeMessageId: 'msg-live-1',
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(mockAbortByMessageId).toHaveBeenCalledTimes(1);
+    expect(mockAbortByMessageId).toHaveBeenCalledWith({ messageId: 'msg-live-1' });
+    expect(rawStop).toHaveBeenCalledTimes(1);
+    expect(contextStopStreaming).not.toHaveBeenCalled();
+  });
+
+  it('given an activeMessageId in agent mode, should abort by messageId regardless of mode', () => {
+    const rawStop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: true,
+        rawStop,
+        selectedAgent: { id: 'agent-1' },
+        contextIsStreaming: false,
+        contextStopStreaming: null,
+        activeMessageId: 'msg-agent-live',
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(mockAbortByMessageId).toHaveBeenCalledWith({ messageId: 'msg-agent-live' });
+    expect(rawStop).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
 
 interface UseGlobalEffectiveStreamArgs {
   localIsStreaming: boolean;
@@ -6,6 +7,13 @@ interface UseGlobalEffectiveStreamArgs {
   selectedAgent: { id: string } | null;
   contextIsStreaming: boolean;
   contextStopStreaming: (() => void) | null;
+  /**
+   * The stable assistant messageId of the live stream, when known. Aborting by
+   * messageId reaches the server registry even if the conversation id shifted
+   * mid-stream, and tears down any multicast SSE join. The bootstrap (refresh)
+   * path is still served by `contextStopStreaming`.
+   */
+  activeMessageId?: string;
 }
 
 interface GlobalEffectiveStream {
@@ -28,6 +36,7 @@ export function useGlobalEffectiveStream({
   selectedAgent,
   contextIsStreaming,
   contextStopStreaming,
+  activeMessageId,
 }: UseGlobalEffectiveStreamArgs): GlobalEffectiveStream {
   const inGlobalMode = !selectedAgent;
   const effectiveIsStreaming = inGlobalMode
@@ -35,14 +44,20 @@ export function useGlobalEffectiveStream({
     : localIsStreaming;
 
   const effectiveStop = useCallback(() => {
-    if (localIsStreaming) {
-      rawStop();
+    // Stop the local fetch immediately (rawStop also best-effort aborts by chatId).
+    rawStop();
+    // Authoritative: abort by the stable assistant messageId when the live stream
+    // is known, regardless of mode.
+    if (activeMessageId) {
+      void abortActiveStreamByMessageId({ messageId: activeMessageId });
       return;
     }
+    // No live messageId (e.g. resumed via bootstrap after refresh): fall back to
+    // the context's messageId-based stop registered at bootstrap.
     if (inGlobalMode && contextStopStreaming) {
       contextStopStreaming();
     }
-  }, [localIsStreaming, rawStop, inGlobalMode, contextStopStreaming]);
+  }, [rawStop, activeMessageId, inGlobalMode, contextStopStreaming]);
 
   return { effectiveIsStreaming, effectiveStop };
 }

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts
@@ -44,20 +44,26 @@ export function useGlobalEffectiveStream({
     : localIsStreaming;
 
   const effectiveStop = useCallback(() => {
-    // Stop the local fetch immediately (rawStop also best-effort aborts by chatId).
-    rawStop();
     // Authoritative: abort by the stable assistant messageId when the live stream
-    // is known, regardless of mode.
+    // is known — reaches the server registry regardless of conversation-id drift
+    // and tears down any multicast SSE join. Also stop the local fetch.
     if (activeMessageId) {
+      rawStop();
       void abortActiveStreamByMessageId({ messageId: activeMessageId });
       return;
     }
-    // No live messageId (e.g. resumed via bootstrap after refresh): fall back to
-    // the context's messageId-based stop registered at bootstrap.
+    // Streaming but no messageId yet (submitted, before first chunk): stop the
+    // local fetch (rawStop also best-effort aborts by chatId).
+    if (localIsStreaming) {
+      rawStop();
+      return;
+    }
+    // Idle locally but resumed via bootstrap after refresh: use the context's
+    // messageId-based stop registered at bootstrap.
     if (inGlobalMode && contextStopStreaming) {
       contextStopStreaming();
     }
-  }, [rawStop, activeMessageId, inGlobalMode, contextStopStreaming]);
+  }, [activeMessageId, localIsStreaming, rawStop, inGlobalMode, contextStopStreaming]);
 
   return { effectiveIsStreaming, effectiveStop };
 }

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -32,7 +32,8 @@ import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { toast } from 'sonner';
 import { LocationContext } from '@/lib/ai/shared';
-import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
+import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId } from '@/lib/ai/core/client';
+import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
 import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery } from '@/lib/ai/shared';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
@@ -758,17 +759,34 @@ const SidebarChatTab: React.FC = () => {
       // Agent mode: use dashboard store stop function (already calls abort endpoint)
       dashboardStopStreaming();
     } else {
-      // Fallback: call abort endpoint directly + local useChat stop
-      // Use try/finally to guarantee client-side stop runs even if server abort fails
-      try {
-        if (currentConversationId) {
-          await abortActiveStream({ chatId: currentConversationId });
-        }
-      } finally {
-        stop();
+      // Fallback (live stream, no bootstrap-registered stop): stop the local fetch
+      // first, then abort authoritatively by the stable assistant messageId — this
+      // reaches the server registry even if the conversation id shifted mid-stream
+      // and tears down any multicast SSE join. Fall back to the chatId map only when
+      // no assistant id exists yet (submitted, before the first chunk).
+      stop();
+      const messageId = resolveActiveAssistantMessageId({
+        ownStreamMessageId: undefined,
+        isStreaming,
+        lastAssistantMessageId,
+      });
+      if (messageId) {
+        void abortActiveStreamByMessageId({ messageId });
+        return;
+      }
+      if (currentConversationId) {
+        await abortActiveStream({ chatId: currentConversationId });
       }
     }
-  }, [selectedAgent, contextStopStreaming, dashboardStopStreaming, currentConversationId, stop]);
+  }, [
+    selectedAgent,
+    contextStopStreaming,
+    dashboardStopStreaming,
+    currentConversationId,
+    stop,
+    isStreaming,
+    lastAssistantMessageId,
+  ]);
 
   const handleUndoFromHere = useCallback((messageId: string) => {
     setUndoDialogMessageId(messageId);

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -119,22 +119,11 @@ export function useChannelStreamSocket(
   onConversationRenamedRef.current = options?.onConversationRenamed;
   onConversationDeletedRef.current = options?.onConversationDeleted;
 
-  // Tracks the channel we've already bootstrapped for this mount. `useSocket()`
-  // can hand back a new socket ref on reconnect, which re-runs this effect; on
-  // such a re-run we must NOT re-consume our OWN in-flight stream (useChat is
-  // still rendering it — re-joining would create a second renderer). Resets when
-  // the channel changes or the component unmounts.
-  const bootstrappedChannelRef = useRef<string | null>(null);
-
   useEffect(() => {
     if (!socket || !channelId) return;
 
     let cancelled = false;
     const localBrowserSessionId = getBrowserSessionId();
-    // First bootstrap for this channel on this mount (e.g. a genuine refresh
-    // mid-stream) re-attaches own streams; a bare socket-reconnect re-run does not.
-    const isFirstBootstrapForChannel = bootstrappedChannelRef.current !== channelId;
-    bootstrappedChannelRef.current = channelId;
     const controllers = new Map<string, AbortController>();
     // Tracks which messageIds have had onStreamComplete called to prevent
     // double-firing when both the SSE done sentinel and chat:stream_complete
@@ -211,10 +200,6 @@ export function useChannelStreamSocket(
         for (const stream of data.streams ?? []) {
           if (shouldSkipBootstrappedStream(stream.messageId, processed, controllers)) continue;
           const isOwn = isOwnStream(stream.triggeredBy, localBrowserSessionId);
-          // On a socket-reconnect re-run (not the first mount for this channel),
-          // skip re-consuming our own in-flight stream — the live useChat instance
-          // is still driving it, so a second SSE join would double-render.
-          if (isOwn && !isFirstBootstrapForChannel) continue;
           addStream({
             messageId: stream.messageId,
             pageId: channelId,

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -119,11 +119,22 @@ export function useChannelStreamSocket(
   onConversationRenamedRef.current = options?.onConversationRenamed;
   onConversationDeletedRef.current = options?.onConversationDeleted;
 
+  // Tracks the channel we've already bootstrapped for this mount. `useSocket()`
+  // can hand back a new socket ref on reconnect, which re-runs this effect; on
+  // such a re-run we must NOT re-consume our OWN in-flight stream (useChat is
+  // still rendering it — re-joining would create a second renderer). Resets when
+  // the channel changes or the component unmounts.
+  const bootstrappedChannelRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!socket || !channelId) return;
 
     let cancelled = false;
     const localBrowserSessionId = getBrowserSessionId();
+    // First bootstrap for this channel on this mount (e.g. a genuine refresh
+    // mid-stream) re-attaches own streams; a bare socket-reconnect re-run does not.
+    const isFirstBootstrapForChannel = bootstrappedChannelRef.current !== channelId;
+    bootstrappedChannelRef.current = channelId;
     const controllers = new Map<string, AbortController>();
     // Tracks which messageIds have had onStreamComplete called to prevent
     // double-firing when both the SSE done sentinel and chat:stream_complete
@@ -200,6 +211,10 @@ export function useChannelStreamSocket(
         for (const stream of data.streams ?? []) {
           if (shouldSkipBootstrappedStream(stream.messageId, processed, controllers)) continue;
           const isOwn = isOwnStream(stream.triggeredBy, localBrowserSessionId);
+          // On a socket-reconnect re-run (not the first mount for this channel),
+          // skip re-consuming our own in-flight stream — the live useChat instance
+          // is still driving it, so a second SSE join would double-render.
+          if (isOwn && !isFirstBootstrapForChannel) continue;
           addStream({
             messageId: stream.messageId,
             pageId: channelId,

--- a/apps/web/src/lib/ai/streams/__tests__/resolveActiveAssistantMessageId.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/resolveActiveAssistantMessageId.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { resolveActiveAssistantMessageId } from '../resolveActiveAssistantMessageId';
+
+describe('resolveActiveAssistantMessageId', () => {
+  it('given an own/bootstrapped stream messageId, should return it (takes precedence)', () => {
+    expect(
+      resolveActiveAssistantMessageId({
+        ownStreamMessageId: 'own-msg',
+        isStreaming: true,
+        lastAssistantMessageId: 'last-msg',
+      }),
+    ).toBe('own-msg');
+  });
+
+  it('given own stream present but not streaming, should still return the own messageId', () => {
+    expect(
+      resolveActiveAssistantMessageId({
+        ownStreamMessageId: 'own-msg',
+        isStreaming: false,
+        lastAssistantMessageId: undefined,
+      }),
+    ).toBe('own-msg');
+  });
+
+  it('given a live stream and no own stream, should return the last assistant messageId', () => {
+    expect(
+      resolveActiveAssistantMessageId({
+        ownStreamMessageId: undefined,
+        isStreaming: true,
+        lastAssistantMessageId: 'last-msg',
+      }),
+    ).toBe('last-msg');
+  });
+
+  it('given submitted-before-first-chunk (streaming, no assistant id yet), should return undefined', () => {
+    expect(
+      resolveActiveAssistantMessageId({
+        ownStreamMessageId: undefined,
+        isStreaming: true,
+        lastAssistantMessageId: null,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('given idle (not streaming, no own stream), should return undefined', () => {
+    expect(
+      resolveActiveAssistantMessageId({
+        ownStreamMessageId: undefined,
+        isStreaming: false,
+        lastAssistantMessageId: 'last-msg',
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/streams/resolveActiveAssistantMessageId.ts
+++ b/apps/web/src/lib/ai/streams/resolveActiveAssistantMessageId.ts
@@ -1,0 +1,31 @@
+/**
+ * Resolves the stable assistant messageId to abort when the user clicks stop.
+ *
+ * The server registers its AbortController under the assistant `messageId`
+ * (`serverAssistantMessageId`), and the client's rendered assistant message
+ * shares that id (`generateId: () => serverAssistantMessageId`). So aborting by
+ * messageId reliably reaches the server registry — unlike the chatId→streamId
+ * map, which can be orphaned when the conversation id shifts mid-stream.
+ *
+ * Precedence:
+ *   1. `ownStreamMessageId` — an own stream tracked via the multicast/bootstrap
+ *      path (e.g. after a refresh mid-stream); always the authoritative target.
+ *   2. The last assistant message id, but only while `useChat` is actively
+ *      streaming it (the rendered streaming bubble === serverAssistantMessageId).
+ *
+ * Returns `undefined` only in the brief `submitted`-before-first-chunk window
+ * where no assistant id exists yet; callers fall back to the chatId abort.
+ */
+export const resolveActiveAssistantMessageId = ({
+  ownStreamMessageId,
+  isStreaming,
+  lastAssistantMessageId,
+}: {
+  ownStreamMessageId: string | undefined;
+  isStreaming: boolean;
+  lastAssistantMessageId: string | null | undefined;
+}): string | undefined => {
+  if (ownStreamMessageId) return ownStreamMessageId;
+  if (isStreaming && lastAssistantMessageId) return lastAssistantMessageId;
+  return undefined;
+};


### PR DESCRIPTION
## Problem

In AI chat interfaces, there were intermittent times where the **stop button did nothing** — the AI kept streaming and couldn't be halted — and in that same state the response **rendered twice** (two loading spinners, tool calls + text duplicated, "two chats smashed into one window").

## Root cause

Each in-app chat surface has **two independent client renderers** for the same assistant message:

1. The Vercel AI SDK `useChat` hook rendering the POST `/api/ai/chat` (or global messages) stream.
2. A multicast path — `useChannelStreamSocket` bootstraps in-flight streams from `/api/ai/chat/active-streams` and listens for `chat:stream_start`, then opens an SSE stream-join that writes parts into `usePendingStreamsStore`.

Server streams are **decoupled from client disconnect** by design (`streamText` is not bound to `request.signal`; only `/api/ai/abort` stops them — intentional for multiplayer + reconnect). So if abort never reaches the server with a valid key, generation continues regardless of what the client does.

Two concrete gaps produced the reported symptoms:

- **Duplicate in the messages array.** When the own stream was consumed by *both* the `useChat` POST stream and the multicast SSE join, `onStreamComplete` appended `synthesizeAssistantMessage(messageId, …)` into the `useChat` messages array without checking that the id was already present. Render-level dedup (`dedupRemoteStreams` / `ChatMessagesArea`) only dedups remoteStreams-vs-messages, **not** messages-internal duplicates — so this produced a permanent double bubble.
- **Stop was chatId-fragile and mutually exclusive.** The stop handler aborted via the `chatId→streamId` map, which is orphaned when `streamTrackingId` shifts `null → conversationId` mid-stream, and the streaming branch never aborted by the stable `messageId` — so when both renderers were live it couldn't fully halt.

## Fix (in-app surfaces only)

- **Kill the persistent double render** — `AiChatView.onStreamComplete` guards both append sites with `prev.some(m => m.id === messageId)`. (The dashboard surface uses a refresh signal, not an append, so it had no such bug.) Combined with the existing render-level dedup, the response now renders exactly once in every window.
- **Authoritative stop** — new pure helper `resolveActiveAssistantMessageId` (`ownStreamMessageId ?? (isStreaming ? lastAssistantMessageId : undefined)`). `AiChatView`, `useGlobalEffectiveStream`/`GlobalAssistantView`, and the `SidebarChatTab` fallback now stop the local fetch immediately, then abort by the **stable messageId** — which reaches the server registry regardless of conversation-id drift and tears down the multicast SSE join via the resulting `chat:stream_complete` broadcast. The `chatId` map is kept only as the no-id fallback (the brief submitted-before-first-chunk window).

### Why no `useChannelStreamSocket` change

An earlier revision guarded against re-bootstrapping the own stream on a socket-reconnect effect re-run. It was **dropped**: on a reconnect without remount it would skip re-attaching the user's own in-flight stream, and `AiChatView` (unlike the other two surfaces) has no `useStreamRecovery`, so a network blip that killed the POST fetch would lose the tail of the response with no recovery. The visible double-render is already fully covered by the append guard + existing dedup, so the guard only traded a now-invisible double-*consumption* (pre-existing behavior) for a real re-attach regression.

Out of scope (not changed): the `/api/v1/chat/completions` MCP/OpenAI-compatible route, which separately has no abort wiring.

## Files

- `apps/web/src/lib/ai/streams/resolveActiveAssistantMessageId.ts` (new) + test
- `apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx`
- `apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts` + `GlobalAssistantView.tsx`
- `apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx`

## Testing

- `bun run --filter 'web' typecheck` — clean
- 501 existing streaming/abort tests + 5 new `resolveActiveAssistantMessageId` tests pass
- Lint clean on changed files

**Manual repro (recommended before merge):** open an AI Chat page, send a long agentic prompt, force a socket reconnect mid-stream (devtools offline→online) → before: doubled response / Stop does nothing; after: single response / Stop halts. Repeat sending the **first** message of a brand-new conversation (so `streamTrackingId` flips null→real). Also verify two users streaming in one channel still render both bubbles (dedup is messageId-keyed and never collapses distinct streams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)