### PR TITLE
feat(ai): stop OpenAI-compatible completions on client disconnect

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -125,6 +125,7 @@ vi.mock('ai', async (importOriginal) => {
 
 // --- imports after mocks ---
 import { NextResponse } from 'next/server';
+import { streamText } from 'ai';
 import { POST } from '../route';
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
@@ -440,6 +441,71 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'not call getMessagesForPage',
       actual: vi.mocked(chatMessageRepository.getMessagesForPage).mock.calls.length,
       expected: 0,
+    });
+  });
+
+  test('successful finish settles billing exactly once with success=true', async () => {
+    const response = await POST(makeRequest(validBody));
+    await response.text();
+    const calls = vi.mocked(AIMonitoring.trackUsage).mock.calls;
+    assert({
+      given: 'a stream that finishes normally',
+      should: 'call AIMonitoring.trackUsage exactly once with success=true and no aborted flag',
+      actual: {
+        count: calls.length,
+        success: calls[0]?.[0]?.success,
+        aborted: (calls[0]?.[0]?.metadata as Record<string, unknown> | undefined)?.aborted,
+      },
+      expected: { count: 1, success: true, aborted: undefined },
+    });
+  });
+
+  test('consumer disconnect settles billing once as aborted and releases the hold', async () => {
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-xyz' });
+
+    const ac = new AbortController();
+    vi.mocked(streamText).mockImplementationOnce(((options: {
+      abortSignal?: AbortSignal;
+      onAbort?: () => void;
+    }) => ({
+      totalUsage: Promise.resolve({ inputTokens: 7, outputTokens: 3 }),
+      steps: Promise.resolve([]),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        yield { type: 'text-delta', id: 't1', delta: 'Partial' };
+        // Simulate the consumer dropping the connection mid-stream: this trips the route's
+        // abortController via request.signal, then streamText fires onAbort and tears down.
+        ac.abort();
+        options.onAbort?.();
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+        throw err;
+      },
+    })) as unknown as typeof streamText);
+
+    const req = new Request('http://localhost/api/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer mcp_test123' },
+      body: JSON.stringify(validBody),
+      signal: ac.signal,
+    });
+    const response = await POST(req);
+    await response.text();
+    // onAbort settles via a fire-and-forget IIFE; let its microtasks flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const calls = vi.mocked(AIMonitoring.trackUsage).mock.calls;
+    assert({
+      given: 'a consumer that disconnects mid-stream',
+      should: 'settle billing once with holdId, success=false, and metadata.aborted=true',
+      actual: {
+        count: calls.length,
+        holdId: calls[0]?.[0]?.holdId,
+        success: calls[0]?.[0]?.success,
+        aborted: (calls[0]?.[0]?.metadata as Record<string, unknown> | undefined)?.aborted,
+        status: response.status,
+      },
+      expected: { count: 1, holdId: 'hold-xyz', success: false, aborted: true, status: 200 },
     });
   });
 });

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -501,4 +501,37 @@ describe('POST /api/v1/chat/completions', () => {
       expected: { count: 1, holdId: 'hold-xyz', success: false, aborted: true, status: 200 },
     });
   });
+
+  test('request already aborted before streaming trips the model abort signal', async () => {
+    let capturedSignalAborted: boolean | undefined;
+    vi.mocked(streamText).mockImplementationOnce(((options: { abortSignal?: AbortSignal }) => {
+      // Captured at call time: the route must hand streamText an already-aborted signal
+      // when the consumer disconnected during the pre-stream setup.
+      capturedSignalAborted = options.abortSignal?.aborted;
+      return {
+        totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0 }),
+        steps: Promise.resolve([]),
+        toUIMessageStream: async function* () {
+          yield { type: 'start' };
+        },
+      };
+    }) as unknown as typeof streamText);
+
+    const preAborted = AbortSignal.abort();
+    const req = new Request('http://localhost/api/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer mcp_test123' },
+      body: JSON.stringify(validBody),
+      signal: preAborted,
+    });
+    const response = await POST(req);
+    await response.text().catch(() => undefined);
+
+    assert({
+      given: 'a request whose signal is already aborted before generation starts',
+      should: 'pass an already-aborted abortSignal to streamText so no tokens are burned',
+      actual: capturedSignalAborted,
+      expected: true,
+    });
+  });
 });

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -110,14 +110,15 @@ vi.mock('ai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('ai')>();
   return {
     ...actual,
-    streamText: vi.fn().mockImplementation((options: { onFinish?: (data: { text: string; totalUsage: { inputTokens: number; outputTokens: number } }) => Promise<void> }) => ({
+    // The route settles billing after the stream drains, reading aiResult.totalUsage and
+    // aiResult.steps, so the mock exposes those promises alongside the chunk stream.
+    streamText: vi.fn().mockImplementation(() => ({
+      totalUsage: Promise.resolve({ inputTokens: 10, outputTokens: 5 }),
+      steps: Promise.resolve([]),
       toUIMessageStream: async function* () {
         yield { type: 'start' };
         yield { type: 'text-delta', id: 'text-1', delta: 'Hello' };
         yield { type: 'finish' };
-        if (options?.onFinish) {
-          await options.onFinish({ text: 'Hello', totalUsage: { inputTokens: 10, outputTokens: 5 } });
-        }
       },
     })),
   };
@@ -464,22 +465,16 @@ describe('POST /api/v1/chat/completions', () => {
     vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-xyz' });
 
     const ac = new AbortController();
-    vi.mocked(streamText).mockImplementationOnce(((options: {
-      abortSignal?: AbortSignal;
-      onAbort?: () => void;
-    }) => ({
+    vi.mocked(streamText).mockImplementationOnce((() => ({
       totalUsage: Promise.resolve({ inputTokens: 7, outputTokens: 3 }),
       steps: Promise.resolve([]),
       toUIMessageStream: async function* () {
         yield { type: 'start' };
         yield { type: 'text-delta', id: 't1', delta: 'Partial' };
         // Simulate the consumer dropping the connection mid-stream: this trips the route's
-        // abortController via request.signal, then streamText fires onAbort and tears down.
+        // abortController via request.signal. The SDK then ends the stream gracefully (no
+        // throw), and the route settles using the abort signal state.
         ac.abort();
-        options.onAbort?.();
-        const err = new Error('The operation was aborted');
-        err.name = 'AbortError';
-        throw err;
       },
     })) as unknown as typeof streamText);
 
@@ -491,8 +486,6 @@ describe('POST /api/v1/chat/completions', () => {
     });
     const response = await POST(req);
     await response.text();
-    // onAbort settles via a fire-and-forget IIFE; let its microtasks flush.
-    await new Promise((r) => setTimeout(r, 0));
 
     const calls = vi.mocked(AIMonitoring.trackUsage).mock.calls;
     assert({

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -273,20 +273,6 @@ export async function POST(request: Request): Promise<Response> {
       mcpAllowedDriveIds: getAllowedDriveIds(authResult),
     },
     maxRetries: 20,
-    onFinish: async ({ text, totalUsage, steps }) => {
-      await settle({ aborted: false, text, totalUsage, steps });
-    },
-    onAbort: () => {
-      // Settle partial usage off the SDK's resolved promises (they resolve even on abort,
-      // matching chat/route.ts's usagePromise/stepsPromise approach). Fire-and-forget so the
-      // abort callback stays light; the `settled` guard keeps it single-shot.
-      void (async () => {
-        const totalUsage = await aiResult.totalUsage.catch(() => undefined);
-        const steps = await aiResult.steps.catch(() => undefined);
-        loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
-        await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
-      })();
-    },
   });
 
   // 10. Stream response as OpenAI SSE
@@ -304,18 +290,34 @@ export async function POST(request: Request): Promise<Response> {
             controller.enqueue(encoder.encode(line + '\n\n'));
           }
         }
+        // A consumer abort ends the stream gracefully (the SDK emits an abort part) rather
+        // than throwing, so settlement happens here for both normal finish and abort. Doing
+        // it inside the stream lifecycle — and awaiting it before closing — ensures billing
+        // and hold release complete before the response ends, instead of racing a detached
+        // callback that a serverless runtime may freeze after the connection drops.
+        const aborted = abortController.signal.aborted;
+        if (aborted) {
+          loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
+        }
+        const totalUsage = await aiResult.totalUsage.catch(() => undefined);
+        const steps = await aiResult.steps.catch(() => undefined);
+        await settle({ aborted, text: assistantText || undefined, totalUsage, steps });
         controller.close();
       } catch (err) {
-        // A consumer abort surfaces here as an AbortError once the SDK tears the stream
-        // down. onAbort already settled billing/hold, so just close cleanly.
+        // Some providers surface an abort as a thrown AbortError instead. Treat it as a
+        // clean stop and settle the partial usage the same way.
         if (abortController.signal.aborted) {
+          loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
+          const totalUsage = await aiResult.totalUsage.catch(() => undefined);
+          const steps = await aiResult.steps.catch(() => undefined);
+          await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
           controller.close();
           return;
         }
         loggers.ai.error('OpenAI API: stream failed', err as Error);
-        // The stream errored before onFinish could settle the charge, so the gate's
-        // reservation would otherwise linger until TTL/reconcile — leaving the user
-        // artificially short on credits. Release it now (idempotent if already settled).
+        // The stream errored before settlement, so the gate's reservation would otherwise
+        // linger until TTL/reconcile — leaving the user artificially short on credits.
+        // Release it now (idempotent if already settled).
         if (!settled && holdId) await releaseHold(holdId).catch(() => {});
         controller.error(err);
       }

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -191,7 +191,14 @@ export async function POST(request: Request): Promise<Response> {
   // Next.js fires request.signal on disconnect; the ReadableStream's cancel() (below) is a
   // belt-and-suspenders path for disconnects detected at the response-stream layer.
   const abortController = new AbortController();
-  request.signal.addEventListener('abort', () => abortController.abort(), { once: true });
+  if (request.signal.aborted) {
+    // The consumer already dropped the connection during the pre-stream setup above.
+    // addEventListener won't replay a past abort, so trip the controller now — otherwise
+    // streamText would receive a non-aborted signal and burn tokens for a gone client.
+    abortController.abort();
+  } else {
+    request.signal.addEventListener('abort', () => abortController.abort(), { once: true });
+  }
 
   // Settle billing exactly once. streamText.onFinish does NOT fire on abort (onAbort does),
   // so both callbacks funnel through here. Tokens burned before an abort are real provider

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -186,12 +186,76 @@ export async function POST(request: Request): Promise<Response> {
   const startTime = Date.now();
   const providerType = getProviderTier(page.aiProvider ?? 'pagespace', page.aiModel ?? undefined);
   const sanitized = sanitizeMessagesForModel(inferenceMessages);
+
+  // Standard OpenAI-style cancel: the consumer closing the HTTP connection stops generation.
+  // Next.js fires request.signal on disconnect; the ReadableStream's cancel() (below) is a
+  // belt-and-suspenders path for disconnects detected at the response-stream layer.
+  const abortController = new AbortController();
+  request.signal.addEventListener('abort', () => abortController.abort(), { once: true });
+
+  // Settle billing exactly once. streamText.onFinish does NOT fire on abort (onAbort does),
+  // so both callbacks funnel through here. Tokens burned before an abort are real provider
+  // spend, so we bill them and release the gate's hold in the same path.
+  let settled = false;
+  let assistantText = '';
+  const settle = async ({ aborted, text, totalUsage, steps }: {
+    aborted: boolean;
+    text?: string;
+    totalUsage?: { inputTokens?: number; outputTokens?: number };
+    steps?: unknown[];
+  }) => {
+    if (settled) return;
+    settled = true;
+
+    const assistantId = createId();
+    if (text) {
+      await saveMessageToDatabase({
+        messageId: assistantId,
+        pageId,
+        conversationId,
+        userId: null,
+        role: 'assistant',
+        content: text,
+      }).catch((err: unknown) => {
+        loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
+      });
+    }
+
+    if (authResult.userId) {
+      await incrementUsage(authResult.userId, providerType).catch((err: unknown) => {
+        loggers.ai.error('OpenAI API: failed to increment usage', err as Error);
+      });
+    }
+
+    // trackUsage -> consumeCredits decrements the balance and deletes the hold in one
+    // transaction (idempotent if the hold is already gone).
+    await AIMonitoring.trackUsage({
+      userId: authResult.userId,
+      provider: providerResult.provider,
+      model: providerResult.modelName,
+      inputTokens: totalUsage?.inputTokens,
+      outputTokens: totalUsage?.outputTokens,
+      providerCostDollars: extractOpenRouterCostDollars(steps as Parameters<typeof extractOpenRouterCostDollars>[0]),
+      duration: Date.now() - startTime,
+      conversationId,
+      messageId: assistantId,
+      pageId,
+      success: !aborted,
+      holdId,
+      metadata: { via: 'openai_api_v1', ...(aborted ? { aborted: true } : {}) },
+    }).catch((err: unknown) => {
+      loggers.ai.error('OpenAI API: failed to track usage', err as Error);
+    });
+  };
+
   const aiResult = streamText({
     model: providerResult.model,
     system: systemPrompt + toolDiscoveryPrompt,
     messages: convertToModelMessages(sanitized),
     tools: filteredTools,
     stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)],
+    // Aborts when the consumer closes the connection (see abortController above).
+    abortSignal: abortController.signal,
     experimental_context: {
       userId: authResult.userId,
       conversationId,
@@ -210,41 +274,18 @@ export async function POST(request: Request): Promise<Response> {
     },
     maxRetries: 20,
     onFinish: async ({ text, totalUsage, steps }) => {
-      const assistantId = createId();
-      await saveMessageToDatabase({
-        messageId: assistantId,
-        pageId,
-        conversationId,
-        userId: null,
-        role: 'assistant',
-        content: text,
-      }).catch((err: unknown) => {
-        loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
-      });
-
-      if (authResult.userId) {
-        await incrementUsage(authResult.userId, providerType).catch((err: unknown) => {
-          loggers.ai.error('OpenAI API: failed to increment usage', err as Error);
-        });
-      }
-
-      await AIMonitoring.trackUsage({
-        userId: authResult.userId,
-        provider: providerResult.provider,
-        model: providerResult.modelName,
-        inputTokens: totalUsage.inputTokens,
-        outputTokens: totalUsage.outputTokens,
-        providerCostDollars: extractOpenRouterCostDollars(steps),
-        duration: Date.now() - startTime,
-        conversationId,
-        messageId: assistantId,
-        pageId,
-        success: true,
-        holdId,
-        metadata: { via: 'openai_api_v1' },
-      }).catch((err: unknown) => {
-        loggers.ai.error('OpenAI API: failed to track usage', err as Error);
-      });
+      await settle({ aborted: false, text, totalUsage, steps });
+    },
+    onAbort: () => {
+      // Settle partial usage off the SDK's resolved promises (they resolve even on abort,
+      // matching chat/route.ts's usagePromise/stepsPromise approach). Fire-and-forget so the
+      // abort callback stays light; the `settled` guard keeps it single-shot.
+      void (async () => {
+        const totalUsage = await aiResult.totalUsage.catch(() => undefined);
+        const steps = await aiResult.steps.catch(() => undefined);
+        loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
+        await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
+      })();
     },
   });
 
@@ -257,6 +298,7 @@ export async function POST(request: Request): Promise<Response> {
     async start(controller) {
       try {
         for await (const chunk of aiResult.toUIMessageStream()) {
+          if (chunk.type === 'text-delta') assistantText += chunk.delta;
           const line = adaptToOpenAIChunk(chunk, { id: completionId, model: modelName, created });
           if (line) {
             controller.enqueue(encoder.encode(line + '\n\n'));
@@ -264,13 +306,23 @@ export async function POST(request: Request): Promise<Response> {
         }
         controller.close();
       } catch (err) {
+        // A consumer abort surfaces here as an AbortError once the SDK tears the stream
+        // down. onAbort already settled billing/hold, so just close cleanly.
+        if (abortController.signal.aborted) {
+          controller.close();
+          return;
+        }
         loggers.ai.error('OpenAI API: stream failed', err as Error);
         // The stream errored before onFinish could settle the charge, so the gate's
         // reservation would otherwise linger until TTL/reconcile — leaving the user
         // artificially short on credits. Release it now (idempotent if already settled).
-        if (holdId) await releaseHold(holdId).catch(() => {});
+        if (!settled && holdId) await releaseHold(holdId).catch(() => {});
         controller.error(err);
       }
+    },
+    cancel() {
+      // Consumer closed the connection mid-stream: stop the model.
+      abortController.abort();
     },
   });
 


### PR DESCRIPTION
## What

Gives consumers of the OpenAI-compatible completion endpoint (`/api/v1/chat/completions`) a way to **stop** a generation. Today the endpoint streams via `streamText()` but passes **no `abortSignal`** and never reacts to the consumer closing the HTTP connection — so once a generation starts it can't be stopped and keeps burning billed tokens server-side (up to `stepCountIs(100)` steps / `maxDuration: 300`s).

## Why

The in-app chat surfaces (`/api/ai/chat`, `/api/ai/global`) already have a working Stop button backed by an explicit stream-abort-registry + `/api/ai/abort`. Those deliberately ignore client disconnect (closing a browser tab shouldn't kill a backgrounded stream). The OpenAI-compatible endpoint is different: the **standard** cancel mechanism for an OpenAI streaming call is the client aborting the HTTP request. So the fix is to honor client disconnect — no new endpoint, no stream-id header, matching the contract OpenAI SDK consumers already expect.

## How

All changes are in `apps/web/src/app/api/v1/chat/completions/route.ts`:

- **Client disconnect → stop generation.** Wire `request.signal` into an `AbortController` passed to `streamText` as `abortSignal`, plus a `ReadableStream` `cancel()` handler so disconnects detected at the response-stream layer also abort the model.
- **Settle billing exactly once, inside the stream lifecycle.** After the stream drains, a single idempotent `settle()` runs (awaited before the controller closes) using `aiResult.totalUsage` / `aiResult.steps`, with `aborted` derived from the abort signal. A consumer abort ends the SDK stream gracefully (abort part) rather than throwing, so settling here — instead of in a detached `onAbort` callback a serverless runtime could freeze after the connection drops — guarantees billing and hold release complete. A thrown `AbortError` is handled identically in `catch`; genuine errors still release the hold. Tokens burned before an abort are real provider spend, so they're billed and the credit hold is released in the same path (`trackUsage → consumeCredits`, idempotent).

## Scope

- **In:** `/api/v1/chat/completions` only.
- **Out:** in-app chat surfaces (already have stop) and the non-streaming `generateText` endpoints (`/api/ai/page-agents/consult`, `/api/pulse/generate`).

## Tests / validation

- Added 2 tests to `__tests__/route.test.ts`: consumer disconnect settles billing once with `holdId` + `metadata.aborted: true` and returns 200; normal finish settles once with `success: true` (no double-settle).
- `bun run --filter 'web' test -- src/app/api/v1/chat/completions` → **21 passed**
- `bun run --filter 'web' typecheck` → clean
- `bun run --filter 'web' lint` → clean (only pre-existing warnings in unrelated files)

Manual: `curl -N --max-time 2 .../v1/chat/completions ...` on a long prompt logs `OpenAI API: stream aborted by consumer`, a single `aborted: true` settlement, and leaves no lingering `credit_holds` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)