### PR TITLE
feat(voice): meter & bill voice mode through the prepaid credit pipeline

### DIFF
--- a/apps/web/src/app/admin/ai-billing/page.tsx
+++ b/apps/web/src/app/admin/ai-billing/page.tsx
@@ -21,7 +21,7 @@ import { fetchWithAuth } from "@/lib/auth/auth-fetch";
 
 type Range = "24h" | "7d" | "30d" | "all";
 type Granularity = "day" | "month";
-type Coverage = "real" | "estimate";
+type Coverage = "real" | "estimate" | "list_price";
 type Tier = "free" | "pro" | "founder" | "business";
 
 interface TokenTotals {
@@ -349,7 +349,9 @@ export default function AdminAiBillingPage() {
           <CardDescription>
             What we pay providers per model, split by billing basis. <Badge variant="outline">real</Badge> =
             OpenRouter&apos;s returned cost; <Badge variant="secondary">estimate</Badge> = static fallback
-            (direct providers, or an OpenRouter call whose cost metadata was missing).
+            (direct providers, or an OpenRouter call whose cost metadata was missing);{" "}
+            <Badge variant="default">list_price</Badge> = voice (STT/TTS) billed at exact
+            quantity × OpenAI&apos;s published rate.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -377,7 +379,15 @@ export default function AdminAiBillingPage() {
                     <TableCell>{row.provider}</TableCell>
                     <TableCell className="font-mono text-xs">{row.model}</TableCell>
                     <TableCell>
-                      <Badge variant={row.coverage === "real" ? "outline" : "secondary"}>
+                      <Badge
+                        variant={
+                          row.coverage === "real"
+                            ? "outline"
+                            : row.coverage === "list_price"
+                              ? "default"
+                              : "secondary"
+                        }
+                      >
                         {row.coverage}
                       </Badge>
                     </TableCell>

--- a/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
@@ -97,8 +97,8 @@ describe('POST /api/voice/synthesize — metering', () => {
 
     expect(res.status).toBe(200);
     // Gated with the exact per-call reservation: 1000 chars × $15/1M × 1.5 = $0.0225
-    // → ceil to 3¢ (not a flat estimate).
-    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 3 });
+    // → ceil to 3¢ (not a flat estimate), plus the voice concurrency cap.
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 3, maxInFlight: 4 });
     // Billed real cost: 1000 chars × $15/1M = $0.015, tagged as voice/list_price.
     expect(mockTrackUsage).toHaveBeenCalledTimes(1);
     const usage = mockTrackUsage.mock.calls[0][0];

--- a/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const {
+  mockAuth,
+  mockIsAuthError,
+  mockGetManagedKey,
+  mockIsBillingEnabled,
+  mockGetUserSettings,
+  mockCanConsumeAI,
+  mockReleaseHold,
+  mockTrackUsage,
+  mockEmitCreditsUpdated,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+  mockGetManagedKey: vi.fn(),
+  mockIsBillingEnabled: vi.fn(),
+  mockGetUserSettings: vi.fn(),
+  mockCanConsumeAI: vi.fn(),
+  mockReleaseHold: vi.fn(),
+  mockTrackUsage: vi.fn(),
+  mockEmitCreditsUpdated: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: mockAuth,
+  isAuthError: mockIsAuthError,
+}));
+vi.mock('@/lib/ai/core/ai-utils', () => ({ getManagedProviderKey: mockGetManagedKey }));
+vi.mock('@pagespace/lib/deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
+vi.mock('@/lib/repositories/ai-settings-repository', () => ({
+  aiSettingsRepository: { getUserSettings: mockGetUserSettings },
+}));
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  PAID_TIERS: new Set(['pro', 'founder', 'business']),
+}));
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({ canConsumeAI: mockCanConsumeAI }));
+vi.mock('@pagespace/lib/billing/credit-consume', () => ({ releaseHold: mockReleaseHold }));
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: mockTrackUsage },
+}));
+vi.mock('@/lib/subscription/credit-balance', () => ({ emitCreditsUpdated: mockEmitCreditsUpdated }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+}));
+
+import { POST } from '../route';
+
+function ttsRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/voice/synthesize', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function okAudioFetch() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(16)),
+  });
+}
+
+describe('POST /api/voice/synthesize — metering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: 'u1' });
+    mockIsAuthError.mockReturnValue(false);
+    mockGetManagedKey.mockReturnValue({ apiKey: 'sk-test' });
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'pro' });
+    mockCanConsumeAI.mockResolvedValue({ allowed: true, reason: 'ok', holdId: 'hold_1' });
+    mockTrackUsage.mockResolvedValue(undefined);
+    mockReleaseHold.mockResolvedValue(undefined);
+    mockEmitCreditsUpdated.mockResolvedValue(undefined);
+  });
+
+  it('blocks free users with 403 before gating or calling the provider', async () => {
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'free' });
+    const fetchSpy = okAudioFetch();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(ttsRequest({ text: 'hello world' }));
+
+    expect(res.status).toBe(403);
+    expect(mockCanConsumeAI).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('meters a successful call: gates with the small voice hold, bills real char cost, releases nothing', async () => {
+    const fetchSpy = okAudioFetch();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(ttsRequest({ text: 'a'.repeat(1000), model: 'tts-1', voice: 'nova' }));
+
+    expect(res.status).toBe(200);
+    // Gated with the voice-sized reservation (VOICE_HOLD_ESTIMATE_CENTS = 2).
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 2 });
+    // Billed real cost: 1000 chars × $15/1M = $0.015, tagged as voice/list_price.
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    const usage = mockTrackUsage.mock.calls[0][0];
+    expect(usage).toMatchObject({
+      userId: 'u1',
+      provider: 'openai_voice',
+      model: 'tts-1',
+      holdId: 'hold_1',
+      success: true,
+      costSource: 'list_price',
+    });
+    expect(usage.providerCostDollars).toBeCloseTo(0.015, 6);
+    expect(usage.metadata).toMatchObject({ type: 'voice_tts', chars: 1000 });
+    // trackUsage owns the hold release; the route must not double-release.
+    expect(mockReleaseHold).not.toHaveBeenCalled();
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
+  });
+
+  it('returns the gate denial (402/429) and never calls the provider or bills', async () => {
+    mockCanConsumeAI.mockResolvedValue({ allowed: false, reason: 'out_of_credits' });
+    const fetchSpy = okAudioFetch();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(ttsRequest({ text: 'hello' }));
+
+    expect(res.status).toBe(402);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+    // No hold was issued on a denial, so nothing to release.
+    expect(mockReleaseHold).not.toHaveBeenCalled();
+  });
+
+  it('releases the hold (and does not bill) when the provider call fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: { message: 'boom' } }),
+    }));
+
+    const res = await POST(ttsRequest({ text: 'hello' }));
+
+    expect(res.status).toBe(500);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold_1');
+  });
+});

--- a/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
@@ -48,6 +48,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 import { POST } from '../route';
 
+/** Build a synthesize POST request with the given JSON body. */
 function ttsRequest(body: Record<string, unknown>) {
   return new Request('http://localhost/api/voice/synthesize', {
     method: 'POST',
@@ -56,6 +57,7 @@ function ttsRequest(body: Record<string, unknown>) {
   });
 }
 
+/** Mock `fetch` returning a successful OpenAI TTS audio response. */
 function okAudioFetch() {
   return vi.fn().mockResolvedValue({
     ok: true,

--- a/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
@@ -96,8 +96,9 @@ describe('POST /api/voice/synthesize — metering', () => {
     const res = await POST(ttsRequest({ text: 'a'.repeat(1000), model: 'tts-1', voice: 'nova' }));
 
     expect(res.status).toBe(200);
-    // Gated with the voice-sized reservation (VOICE_HOLD_ESTIMATE_CENTS = 2).
-    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 2 });
+    // Gated with the exact per-call reservation: 1000 chars × $15/1M × 1.5 = $0.0225
+    // → ceil to 3¢ (not a flat estimate).
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 3 });
     // Billed real cost: 1000 chars × $15/1M = $0.015, tagged as voice/list_price.
     expect(mockTrackUsage).toHaveBeenCalledTimes(1);
     const usage = mockTrackUsage.mock.calls[0][0];

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -19,9 +19,8 @@ import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
-import { VOICE_HOLD_ESTIMATE_CENTS } from '@pagespace/lib/billing/credit-pricing';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
-import { calculateVoiceCostDollars } from '@pagespace/lib/monitoring/voice-pricing';
+import { calculateVoiceCostDollars, estimateVoiceHoldCents } from '@pagespace/lib/monitoring/voice-pricing';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import { emitCreditsUpdated } from '@/lib/subscription/credit-balance';
@@ -45,6 +44,7 @@ export async function POST(request: Request) {
   // failed TTS call never strands a hold against the user's spendable balance.
   let holdId: string | undefined;
   let holdHandedOff = false;
+  const startTime = Date.now();
 
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
@@ -144,11 +144,15 @@ export async function POST(request: Request) {
     const clampedSpeed = Math.min(4.0, Math.max(0.25, speedNumber));
 
     // Reserve credits before billing the provider. Gated AFTER input validation so a
-    // malformed request never opens a hold. TTS fires once per streamed sentence
-    // chunk, so the small VOICE_HOLD_ESTIMATE_CENTS reservation avoids locking the
-    // chat-sized estimate behind each sub-cent chunk. Blocks out-of-credit paid users
-    // only once CREDITS_ENFORCEMENT_ENABLED is on; otherwise still records spend.
-    const gate = await canConsumeAI(userId, tier, { estCostCents: VOICE_HOLD_ESTIMATE_CENTS });
+    // malformed request never opens a hold. The reservation is computed from the
+    // exact character count (cost × markup) so it accurately reflects this call —
+    // tiny for a sentence chunk, up to ~18¢ for a max-length tts-1-hd request —
+    // rather than a flat estimate a long request would blow past. Blocks
+    // out-of-credit paid users only once CREDITS_ENFORCEMENT_ENABLED is on; otherwise
+    // still records spend.
+    const gate = await canConsumeAI(userId, tier, {
+      estCostCents: estimateVoiceHoldCents(model, { chars: text.length }),
+    });
     if (!gate.allowed) {
       return creditGateErrorResponse(gate.reason);
     }
@@ -205,6 +209,9 @@ export async function POST(request: Request) {
       provider: 'openai_voice',
       model,
       providerCostDollars: costDollars,
+      // Request latency (ms), matching the chat route. The billing quantity (chars)
+      // lives in metadata.
+      duration: Date.now() - startTime,
       success: true,
       holdId,
       // Deterministic list-price cost (chars × published rate), not a live

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -19,6 +19,7 @@ import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
+import { VOICE_MAX_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { calculateVoiceCostDollars, estimateVoiceHoldCents } from '@pagespace/lib/monitoring/voice-pricing';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -152,6 +153,7 @@ export async function POST(request: Request) {
     // still records spend.
     const gate = await canConsumeAI(userId, tier, {
       estCostCents: estimateVoiceHoldCents(model, { chars: text.length }),
+      maxInFlight: VOICE_MAX_INFLIGHT,
     });
     if (!gate.allowed) {
       return creditGateErrorResponse(gate.reason);

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -17,6 +17,14 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
+import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { releaseHold } from '@pagespace/lib/billing/credit-consume';
+import { VOICE_HOLD_ESTIMATE_CENTS } from '@pagespace/lib/billing/credit-pricing';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { calculateVoiceCostDollars } from '@pagespace/lib/monitoring/voice-pricing';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
+import { emitCreditsUpdated } from '@/lib/subscription/credit-balance';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -32,14 +40,23 @@ type TTSModel = (typeof VALID_MODELS)[number];
 const MAX_TEXT_LENGTH = 4096;
 
 export async function POST(request: Request) {
+  // Reservation placed by the credit gate; released here on any path that doesn't
+  // hand it off to trackUsage (validation error, provider failure, or throw), so a
+  // failed TTS call never strands a hold against the user's spendable balance.
+  let holdId: string | undefined;
+  let holdHandedOff = false;
+
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
+    // Free users can't use voice at all; paid users meter against their own credits.
+    let tier: SubscriptionTier = 'free';
     if (isBillingEnabled()) {
       const user = await aiSettingsRepository.getUserSettings(userId);
-      if (!PAID_TIERS.has(user?.subscriptionTier ?? 'free')) {
+      tier = (user?.subscriptionTier ?? 'free') as SubscriptionTier;
+      if (!PAID_TIERS.has(tier)) {
         return NextResponse.json(
           {
             error: 'Pro plan required',
@@ -126,6 +143,17 @@ export async function POST(request: Request) {
     }
     const clampedSpeed = Math.min(4.0, Math.max(0.25, speedNumber));
 
+    // Reserve credits before billing the provider. Gated AFTER input validation so a
+    // malformed request never opens a hold. TTS fires once per streamed sentence
+    // chunk, so the small VOICE_HOLD_ESTIMATE_CENTS reservation avoids locking the
+    // chat-sized estimate behind each sub-cent chunk. Blocks out-of-credit paid users
+    // only once CREDITS_ENFORCEMENT_ENABLED is on; otherwise still records spend.
+    const gate = await canConsumeAI(userId, tier, { estCostCents: VOICE_HOLD_ESTIMATE_CENTS });
+    if (!gate.allowed) {
+      return creditGateErrorResponse(gate.reason);
+    }
+    holdId = gate.holdId;
+
     // Call OpenAI TTS API
     const response = await fetch('https://api.openai.com/v1/audio/speech', {
       method: 'POST',
@@ -167,6 +195,25 @@ export async function POST(request: Request) {
     // Stream the audio response
     const audioData = await response.arrayBuffer();
 
+    // Bill the real provider cost (input characters × published TTS rate) against the
+    // user's prepaid credits, with the standard markup applied downstream. This
+    // settles the hold and releases it; trackUsage now owns the reservation.
+    const costDollars = calculateVoiceCostDollars(model, { chars: text.length });
+    holdHandedOff = true;
+    await AIMonitoring.trackUsage({
+      userId,
+      provider: 'openai_voice',
+      model,
+      providerCostDollars: costDollars,
+      success: true,
+      holdId,
+      // Deterministic list-price cost (chars × published rate), not a live
+      // provider-returned figure — labels the admin-panel coverage honestly.
+      costSource: 'list_price',
+      metadata: { type: 'voice_tts', voice, chars: text.length },
+    });
+    void emitCreditsUpdated(userId);
+
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'voice', resourceId: 'self', details: { operation: 'synthesize', voice, model, textLength: text.length } });
 
     return new Response(audioData, {
@@ -183,5 +230,7 @@ export async function POST(request: Request) {
       { error: 'Failed to synthesize speech' },
       { status: 500 }
     );
+  } finally {
+    if (holdId && !holdHandedOff) void releaseHold(holdId).catch(() => {});
   }
 }

--- a/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
@@ -48,9 +48,11 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 import { POST } from '../route';
 
-// A real Request's multipart body parse can hang in the test runtime, and the
-// route only ever calls `request.formData()` (auth/audit are mocked), so hand it a
-// minimal stub whose formData() resolves directly.
+/**
+ * Build a transcribe request. A real Request's multipart body parse can hang in the
+ * test runtime, and the route only ever calls `request.formData()` (auth/audit are
+ * mocked), so hand it a minimal stub whose formData() resolves directly.
+ */
 function audioRequest() {
   const form = new FormData();
   const file = new File([new Uint8Array(2048)], 'clip.webm', { type: 'audio/webm' });
@@ -58,8 +60,10 @@ function audioRequest() {
   return { formData: () => Promise.resolve(form) } as unknown as Request;
 }
 
-// Whisper verbose_json returns the exact audio `duration` in seconds plus `text`.
-// Pass `undefined` to simulate a (degenerate) response with no duration.
+/**
+ * Mock `fetch` for Whisper's verbose_json response (exact audio `duration` + `text`).
+ * Pass `undefined` to simulate a degenerate response with no duration.
+ */
 function okWhisperFetch(duration: number | undefined) {
   return vi.fn().mockResolvedValue({
     ok: true,

--- a/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
@@ -59,10 +59,11 @@ function audioRequest() {
 }
 
 // Whisper verbose_json returns the exact audio `duration` in seconds plus `text`.
-function okWhisperFetch(duration: number) {
+// Pass `undefined` to simulate a (degenerate) response with no duration.
+function okWhisperFetch(duration: number | undefined) {
   return vi.fn().mockResolvedValue({
     ok: true,
-    json: () => Promise.resolve({ text: 'hello there', duration }),
+    json: () => Promise.resolve({ text: 'hello there', ...(duration !== undefined ? { duration } : {}) }),
   });
 }
 
@@ -118,6 +119,22 @@ describe('POST /api/voice/transcribe — metering', () => {
     expect(usage.metadata).toMatchObject({ type: 'voice_stt' });
     expect(mockReleaseHold).not.toHaveBeenCalled();
     expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
+  });
+
+  it('still bills $0 and hands off (not releases) the hold when Whisper returns no duration', async () => {
+    const fetchSpy = okWhisperFetch(undefined);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(audioRequest());
+
+    expect(res.status).toBe(200);
+    // A degenerate no-duration response must still settle the hold via trackUsage
+    // (billing $0), NOT leak/release it — the row is flagged for observability.
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    const usage = mockTrackUsage.mock.calls[0][0];
+    expect(usage.providerCostDollars).toBe(0);
+    expect(usage.metadata).toMatchObject({ type: 'voice_stt', missingDuration: true });
+    expect(mockReleaseHold).not.toHaveBeenCalled();
   });
 
   it('returns the gate denial (402) and never calls the provider or bills', async () => {

--- a/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
@@ -104,7 +104,7 @@ describe('POST /api/voice/transcribe — metering', () => {
     const sentForm = fetchSpy.mock.calls[0][1].body as FormData;
     expect(sentForm.get('response_format')).toBe('verbose_json');
 
-    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 2 });
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 2, maxInFlight: 4 });
     expect(mockTrackUsage).toHaveBeenCalledTimes(1);
     const usage = mockTrackUsage.mock.calls[0][0];
     expect(usage).toMatchObject({

--- a/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/transcribe/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+const {
+  mockAuth,
+  mockIsAuthError,
+  mockGetManagedKey,
+  mockIsBillingEnabled,
+  mockGetUserSettings,
+  mockCanConsumeAI,
+  mockReleaseHold,
+  mockTrackUsage,
+  mockEmitCreditsUpdated,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockIsAuthError: vi.fn(),
+  mockGetManagedKey: vi.fn(),
+  mockIsBillingEnabled: vi.fn(),
+  mockGetUserSettings: vi.fn(),
+  mockCanConsumeAI: vi.fn(),
+  mockReleaseHold: vi.fn(),
+  mockTrackUsage: vi.fn(),
+  mockEmitCreditsUpdated: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: mockAuth,
+  isAuthError: mockIsAuthError,
+}));
+vi.mock('@/lib/ai/core/ai-utils', () => ({ getManagedProviderKey: mockGetManagedKey }));
+vi.mock('@pagespace/lib/deployment-mode', () => ({ isBillingEnabled: mockIsBillingEnabled }));
+vi.mock('@/lib/repositories/ai-settings-repository', () => ({
+  aiSettingsRepository: { getUserSettings: mockGetUserSettings },
+}));
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  PAID_TIERS: new Set(['pro', 'founder', 'business']),
+}));
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({ canConsumeAI: mockCanConsumeAI }));
+vi.mock('@pagespace/lib/billing/credit-consume', () => ({ releaseHold: mockReleaseHold }));
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: mockTrackUsage },
+}));
+vi.mock('@/lib/subscription/credit-balance', () => ({ emitCreditsUpdated: mockEmitCreditsUpdated }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+}));
+
+import { POST } from '../route';
+
+// A real Request's multipart body parse can hang in the test runtime, and the
+// route only ever calls `request.formData()` (auth/audit are mocked), so hand it a
+// minimal stub whose formData() resolves directly.
+function audioRequest() {
+  const form = new FormData();
+  const file = new File([new Uint8Array(2048)], 'clip.webm', { type: 'audio/webm' });
+  form.append('audio', file);
+  return { formData: () => Promise.resolve(form) } as unknown as Request;
+}
+
+// Whisper verbose_json returns the exact audio `duration` in seconds plus `text`.
+function okWhisperFetch(duration: number) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ text: 'hello there', duration }),
+  });
+}
+
+describe('POST /api/voice/transcribe — metering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: 'u1' });
+    mockIsAuthError.mockReturnValue(false);
+    mockGetManagedKey.mockReturnValue({ apiKey: 'sk-test' });
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'pro' });
+    mockCanConsumeAI.mockResolvedValue({ allowed: true, reason: 'ok', holdId: 'hold_1' });
+    mockTrackUsage.mockResolvedValue(undefined);
+    mockReleaseHold.mockResolvedValue(undefined);
+    mockEmitCreditsUpdated.mockResolvedValue(undefined);
+  });
+
+  it('blocks free users with 403 before gating or calling the provider', async () => {
+    mockGetUserSettings.mockResolvedValue({ subscriptionTier: 'free' });
+    const fetchSpy = okWhisperFetch(60);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(audioRequest());
+
+    expect(res.status).toBe(403);
+    expect(mockCanConsumeAI).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('requests verbose_json and bills real duration cost, releasing nothing on success', async () => {
+    const fetchSpy = okWhisperFetch(60); // 60s = 1 min = $0.006
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(audioRequest());
+
+    expect(res.status).toBe(200);
+    // Provider asked for verbose_json so a real duration comes back to bill on.
+    const sentForm = fetchSpy.mock.calls[0][1].body as FormData;
+    expect(sentForm.get('response_format')).toBe('verbose_json');
+
+    expect(mockCanConsumeAI).toHaveBeenCalledWith('u1', 'pro', { estCostCents: 2 });
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    const usage = mockTrackUsage.mock.calls[0][0];
+    expect(usage).toMatchObject({
+      userId: 'u1',
+      provider: 'openai_voice',
+      model: 'whisper-1',
+      holdId: 'hold_1',
+      success: true,
+      costSource: 'list_price',
+    });
+    expect(usage.providerCostDollars).toBeCloseTo(0.006, 6);
+    expect(usage.metadata).toMatchObject({ type: 'voice_stt' });
+    expect(mockReleaseHold).not.toHaveBeenCalled();
+    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
+  });
+
+  it('returns the gate denial (402) and never calls the provider or bills', async () => {
+    mockCanConsumeAI.mockResolvedValue({ allowed: false, reason: 'out_of_credits' });
+    const fetchSpy = okWhisperFetch(60);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const res = await POST(audioRequest());
+
+    expect(res.status).toBe(402);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+    expect(mockReleaseHold).not.toHaveBeenCalled();
+  });
+
+  it('releases the hold (and does not bill) when the provider call fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: { message: 'boom' } }),
+    }));
+
+    const res = await POST(audioRequest());
+
+    expect(res.status).toBe(500);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold_1');
+  });
+});

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -15,6 +15,14 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
+import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { releaseHold } from '@pagespace/lib/billing/credit-consume';
+import { VOICE_HOLD_ESTIMATE_CENTS } from '@pagespace/lib/billing/credit-pricing';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { calculateVoiceCostDollars } from '@pagespace/lib/monitoring/voice-pricing';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
+import { emitCreditsUpdated } from '@/lib/subscription/credit-balance';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -33,14 +41,23 @@ const SUPPORTED_FORMATS = [
 ];
 
 export async function POST(request: Request) {
+  // Reservation placed by the credit gate; released here on any path that doesn't
+  // hand it off to trackUsage (validation error, provider failure, or throw), so a
+  // failed STT call never strands a hold against the user's spendable balance.
+  let holdId: string | undefined;
+  let holdHandedOff = false;
+
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
+    // Free users can't use voice at all; paid users meter against their own credits.
+    let tier: SubscriptionTier = 'free';
     if (isBillingEnabled()) {
       const user = await aiSettingsRepository.getUserSettings(userId);
-      if (!PAID_TIERS.has(user?.subscriptionTier ?? 'free')) {
+      tier = (user?.subscriptionTier ?? 'free') as SubscriptionTier;
+      if (!PAID_TIERS.has(tier)) {
         return NextResponse.json(
           {
             error: 'Pro plan required',
@@ -99,11 +116,24 @@ export async function POST(request: Request) {
       );
     }
 
+    // Reserve credits before billing the provider. Gated AFTER input validation so a
+    // malformed request never opens a hold. Voice uses a small per-call reservation
+    // (VOICE_HOLD_ESTIMATE_CENTS) since STT/TTS cost a fraction of a cent. Blocks
+    // out-of-credit paid users only once CREDITS_ENFORCEMENT_ENABLED is on; otherwise
+    // it still books the hold and records spend (dark launch, same as chat).
+    const gate = await canConsumeAI(userId, tier, { estCostCents: VOICE_HOLD_ESTIMATE_CENTS });
+    if (!gate.allowed) {
+      return creditGateErrorResponse(gate.reason);
+    }
+    holdId = gate.holdId;
+
     // Create form data for OpenAI API
     const openAIFormData = new FormData();
     openAIFormData.append('file', audioFile);
     openAIFormData.append('model', 'whisper-1');
-    openAIFormData.append('response_format', 'json');
+    // verbose_json returns the exact audio `duration` (seconds) OpenAI bills on, so
+    // we charge real cost (duration × rate), not an approximation. Still has `.text`.
+    openAIFormData.append('response_format', 'verbose_json');
 
     // Optionally set language for better accuracy
     if (language) {
@@ -143,6 +173,27 @@ export async function POST(request: Request) {
 
     const result = await response.json();
 
+    // Bill the real provider cost (audio seconds × published Whisper rate) against
+    // the user's prepaid credits, with the standard markup applied downstream. This
+    // settles the hold and releases it; trackUsage now owns the reservation.
+    const seconds = typeof result.duration === 'number' ? result.duration : undefined;
+    const costDollars = calculateVoiceCostDollars('whisper-1', { seconds });
+    holdHandedOff = true;
+    await AIMonitoring.trackUsage({
+      userId,
+      provider: 'openai_voice',
+      model: 'whisper-1',
+      providerCostDollars: costDollars,
+      duration: seconds !== undefined ? Math.round(seconds * 1000) : undefined,
+      success: true,
+      holdId,
+      // Deterministic list-price cost (audio seconds × published rate), not a live
+      // provider-returned figure — labels the admin-panel coverage honestly.
+      costSource: 'list_price',
+      metadata: { type: 'voice_stt', audioBytes: audioFile.size },
+    });
+    void emitCreditsUpdated(userId);
+
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'voice', resourceId: 'self', details: { operation: 'transcribe', audioSize: audioFile.size } });
 
     return NextResponse.json({
@@ -155,5 +206,7 @@ export async function POST(request: Request) {
       { error: 'Failed to transcribe audio' },
       { status: 500 }
     );
+  } finally {
+    if (holdId && !holdHandedOff) void releaseHold(holdId).catch(() => {});
   }
 }

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -46,6 +46,7 @@ export async function POST(request: Request) {
   // failed STT call never strands a hold against the user's spendable balance.
   let holdId: string | undefined;
   let holdHandedOff = false;
+  const startTime = Date.now();
 
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
@@ -177,6 +178,15 @@ export async function POST(request: Request) {
     // the user's prepaid credits, with the standard markup applied downstream. This
     // settles the hold and releases it; trackUsage now owns the reservation.
     const seconds = typeof result.duration === 'number' ? result.duration : undefined;
+    // verbose_json should always carry a duration; if it ever doesn't we'd bill $0
+    // (free transcription). Surface it so the gap is observable instead of silent —
+    // the usage row is also flagged (metadata.missingDuration) for the admin panel.
+    if (seconds === undefined) {
+      loggers.ai.warn('Whisper transcription returned no duration; billing $0 for this call', {
+        userId,
+        audioBytes: audioFile.size,
+      });
+    }
     const costDollars = calculateVoiceCostDollars('whisper-1', { seconds });
     holdHandedOff = true;
     await AIMonitoring.trackUsage({
@@ -184,13 +194,21 @@ export async function POST(request: Request) {
       provider: 'openai_voice',
       model: 'whisper-1',
       providerCostDollars: costDollars,
-      duration: seconds !== undefined ? Math.round(seconds * 1000) : undefined,
+      // Request latency (ms), matching the chat route — NOT the audio length, which
+      // would pollute response-time analytics. Audio seconds (the billing quantity)
+      // live in metadata.
+      duration: Date.now() - startTime,
       success: true,
       holdId,
       // Deterministic list-price cost (audio seconds × published rate), not a live
       // provider-returned figure — labels the admin-panel coverage honestly.
       costSource: 'list_price',
-      metadata: { type: 'voice_stt', audioBytes: audioFile.size },
+      metadata: {
+        type: 'voice_stt',
+        audioBytes: audioFile.size,
+        audioSeconds: seconds,
+        ...(seconds === undefined ? { missingDuration: true } : {}),
+      },
     });
     void emitCreditsUpdated(userId);
 

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -17,7 +17,7 @@ import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
-import { VOICE_HOLD_ESTIMATE_CENTS } from '@pagespace/lib/billing/credit-pricing';
+import { VOICE_HOLD_ESTIMATE_CENTS, VOICE_MAX_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { calculateVoiceCostDollars } from '@pagespace/lib/monitoring/voice-pricing';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -123,7 +123,10 @@ export async function POST(request: Request) {
     // VOICE_HOLD_ESTIMATE_CENTS; the real cost settles exactly afterwards. Blocks
     // out-of-credit paid users only once CREDITS_ENFORCEMENT_ENABLED is on; otherwise
     // it still books the hold and records spend (dark launch, same as chat).
-    const gate = await canConsumeAI(userId, tier, { estCostCents: VOICE_HOLD_ESTIMATE_CENTS });
+    const gate = await canConsumeAI(userId, tier, {
+      estCostCents: VOICE_HOLD_ESTIMATE_CENTS,
+      maxInFlight: VOICE_MAX_INFLIGHT,
+    });
     if (!gate.allowed) {
       return creditGateErrorResponse(gate.reason);
     }

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -118,8 +118,9 @@ export async function POST(request: Request) {
     }
 
     // Reserve credits before billing the provider. Gated AFTER input validation so a
-    // malformed request never opens a hold. Voice uses a small per-call reservation
-    // (VOICE_HOLD_ESTIMATE_CENTS) since STT/TTS cost a fraction of a cent. Blocks
+    // malformed request never opens a hold. STT can't know the audio duration (and
+    // thus the real cost) until Whisper responds, so it reserves the small flat
+    // VOICE_HOLD_ESTIMATE_CENTS; the real cost settles exactly afterwards. Blocks
     // out-of-credit paid users only once CREDITS_ENFORCEMENT_ENABLED is on; otherwise
     // it still books the hold and records spend (dark launch, same as chat).
     const gate = await canConsumeAI(userId, tier, { estCostCents: VOICE_HOLD_ESTIMATE_CENTS });

--- a/apps/web/src/lib/monitoring/__tests__/ai-billing-queries.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/ai-billing-queries.test.ts
@@ -214,6 +214,16 @@ describe('getProviderCostRollup', () => {
     expect(rows[1].coverage).toBe('estimate');
   });
 
+  it('labels voice rows list_price (deterministic quantity × published rate), distinct from real and estimate', async () => {
+    resetQueue([
+      { provider: 'openai_voice', model: 'whisper-1', costSource: 'list_price', realCostCents: 6, chargedCents: 9, requestCount: 5 },
+      { provider: 'openai_voice', model: 'tts-1', costSource: 'list_price', realCostCents: 15, chargedCents: 23, requestCount: 8 },
+    ]);
+    const rows = await getProviderCostRollup();
+    expect(rows[0]).toMatchObject({ provider: 'openai_voice', model: 'whisper-1', coverage: 'list_price' });
+    expect(rows[1]).toMatchObject({ provider: 'openai_voice', model: 'tts-1', coverage: 'list_price' });
+  });
+
   it('falls back to the provider-name heuristic when metadata (costSource) was purged', async () => {
     resetQueue([
       { provider: 'openrouter_free', model: 'm:free', costSource: null, realCostCents: 0, chargedCents: 0, requestCount: 1 },

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -805,7 +805,7 @@ export interface TokenUsageByUserRow extends TokenUsageTotals {
   userEmail: string | null;
 }
 
-export type CostCoverage = 'real' | 'estimate';
+export type CostCoverage = 'real' | 'estimate' | 'list_price';
 
 export interface ProviderCostRow {
   provider: string;
@@ -1002,6 +1002,9 @@ export async function getProviderCostRollup(
     let coverage: CostCoverage;
     if (r.costSource === 'openrouter') coverage = 'real';
     else if (r.costSource === 'estimate') coverage = 'estimate';
+    // Voice (STT/TTS): cost is deterministic exact-quantity × published OpenAI rate,
+    // not a live provider-returned figure (real) nor a token-guess fallback (estimate).
+    else if (r.costSource === 'list_price') coverage = 'list_price';
     // metadata purged: fall back to the provider-name heuristic.
     else coverage = provider === 'openrouter' || provider === 'openrouter_free' ? 'real' : 'estimate';
     return {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -97,6 +97,11 @@
       "import": "./dist/monitoring/ai-monitoring.js",
       "require": "./dist/monitoring/ai-monitoring.js"
     },
+    "./monitoring/voice-pricing": {
+      "types": "./dist/monitoring/voice-pricing.d.ts",
+      "import": "./dist/monitoring/voice-pricing.js",
+      "require": "./dist/monitoring/voice-pricing.js"
+    },
     "./monitoring/ai-context-calculator": {
       "types": "./dist/monitoring/ai-context-calculator.d.ts",
       "import": "./dist/monitoring/ai-context-calculator.js",

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -137,6 +137,19 @@ describe('canConsumeAI', () => {
     expect(sink.holdValues?.expiresAt).toBeInstanceOf(Date);
   });
 
+  it('reserves the estCostCents override (voice) instead of the chat default', async () => {
+    // Voice routes pass a small per-call estimate so a sub-cent STT/TTS call doesn't
+    // reserve the full 25¢ chat hold. The hold must reflect the override.
+    mockDb.select.mockReturnValue(selectReturning([{ monthlyRemainingCents: 100, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { holdValues?: Record<string, unknown> } = {};
+    mockTransaction({ monthlyRemainingCents: 100, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 }, sink);
+
+    const r = await canConsumeAI('u1', 'pro', { estCostCents: 2 });
+
+    expect(r.allowed).toBe(true);
+    expect(sink.holdValues).toMatchObject({ userId: 'u1', estCents: 2 });
+  });
+
   it('denies with out_of_credits when both buckets are empty (no hold inserted)', async () => {
     mockDb.select.mockReturnValue(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { insertCalled?: boolean } = {};

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -137,6 +137,19 @@ describe('canConsumeAI', () => {
     expect(sink.holdValues?.expiresAt).toBeInstanceOf(Date);
   });
 
+  it('caps a PAID user via opts.maxInFlight (voice concurrency bound) even with ample credit', async () => {
+    // Paid tiers are normally uncapped on concurrency; the voice routes pass a cap to
+    // bound concurrent paid voice spend. 4 holds already in flight == the cap → deny.
+    mockDb.select.mockReturnValue(selectReturning([{ monthlyRemainingCents: 100000, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { insertCalled?: boolean } = {};
+    mockTransaction({ monthlyRemainingCents: 100000, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 8, inFlight: 4 }, sink);
+
+    const r = await canConsumeAI('u1', 'pro', { estCostCents: 2, maxInFlight: 4 });
+
+    expect(r).toMatchObject({ allowed: false, reason: 'too_many_in_flight' });
+    expect(sink.insertCalled).toBeFalsy();
+  });
+
   it('reserves the estCostCents override (voice) instead of the chat default', async () => {
     // Voice routes pass a small per-call estimate so a sub-cent STT/TTS call doesn't
     // reserve the full 25¢ chat hold. The hold must reflect the override.

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -59,9 +59,21 @@ interface BalanceRow {
   monthlyPeriodEnd: Date | null;
 }
 
+export interface GateOptions {
+  /**
+   * Override the per-call reservation (in whole cents) for this gate check. The
+   * chat path omits it and uses the CREDIT_HOLD_ESTIMATE_CENTS default; voice
+   * routes pass the much smaller VOICE_HOLD_ESTIMATE_CENTS so a sub-cent STT/TTS
+   * call doesn't reserve the full chat estimate. Only bounds the in-flight hold —
+   * the real cost still settles exactly via consumeCredits.
+   */
+  estCostCents?: number;
+}
+
 export async function canConsumeAI(
   userId: string,
   tier: SubscriptionTier = 'free',
+  opts: GateOptions = {},
 ): Promise<GateResult> {
   if (!isBillingEnabled()) return { allowed: true, reason: 'unlimited' };
 
@@ -134,7 +146,7 @@ export async function canConsumeAI(
       .onConflictDoNothing({ target: creditBalances.userId });
   }
 
-  const estCost = reservationCents(CREDIT_HOLD_ESTIMATE_CENTS);
+  const estCost = reservationCents(opts.estCostCents ?? CREDIT_HOLD_ESTIMATE_CENTS);
   // Free users are capped on concurrent in-flight calls; paid tiers are bounded by
   // credits alone (no cap).
   const maxInFlight = tier === 'free' ? MAX_FREE_INFLIGHT : null;

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -63,11 +63,18 @@ export interface GateOptions {
   /**
    * Override the per-call reservation (in whole cents) for this gate check. The
    * chat path omits it and uses the CREDIT_HOLD_ESTIMATE_CENTS default; voice
-   * routes pass the much smaller VOICE_HOLD_ESTIMATE_CENTS so a sub-cent STT/TTS
-   * call doesn't reserve the full chat estimate. Only bounds the in-flight hold —
-   * the real cost still settles exactly via consumeCredits.
+   * routes pass a per-call estimate so a sub-cent STT/TTS call doesn't reserve the
+   * full chat estimate. Only bounds the in-flight hold — the real cost still settles
+   * exactly via consumeCredits.
    */
   estCostCents?: number;
+  /**
+   * Cap on this user's concurrent in-flight calls, applied to ALL tiers (combined
+   * with the free-tier cap via min). Voice routes pass VOICE_MAX_INFLIGHT to bound
+   * concurrent paid voice spend, which the per-call hold alone can't (the real cost
+   * only lands at settle). Omitted by chat, which leaves paid tiers uncapped.
+   */
+  maxInFlight?: number;
 }
 
 export async function canConsumeAI(
@@ -148,8 +155,13 @@ export async function canConsumeAI(
 
   const estCost = reservationCents(opts.estCostCents ?? CREDIT_HOLD_ESTIMATE_CENTS);
   // Free users are capped on concurrent in-flight calls; paid tiers are bounded by
-  // credits alone (no cap).
-  const maxInFlight = tier === 'free' ? MAX_FREE_INFLIGHT : null;
+  // credits alone UNLESS the caller supplies its own cap (voice passes one to bound
+  // concurrent paid voice spend). When both apply, the tighter (min) cap wins.
+  const caps = [
+    tier === 'free' ? MAX_FREE_INFLIGHT : null,
+    opts.maxInFlight ?? null,
+  ].filter((c): c is number => c !== null);
+  const maxInFlight = caps.length > 0 ? Math.min(...caps) : null;
   const expiresAt = new Date(holdExpiresAt(now.getTime(), CREDIT_HOLD_TTL_SECONDS * 1000));
 
   // Authoritative decision + reservation, atomic under a balance row lock. The lock

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -84,6 +84,19 @@ export const RESERVE_FLOOR_CENTS = envInt('CREDIT_RESERVE_FLOOR_CENTS', 25);
 export const CREDIT_HOLD_ESTIMATE_CENTS = envInt('CREDIT_HOLD_ESTIMATE_CENTS', RESERVE_FLOOR_CENTS);
 
 /**
+ * Per-call hold estimate for VOICE (STT/TTS), far below the chat default. Voice
+ * calls cost a fraction of a cent (a Whisper clip or a TTS sentence), and TTS in
+ * particular fires once PER streamed sentence chunk — so a single spoken reply can
+ * open many gate→settle cycles in a row. Reserving the 25¢ chat default on each
+ * would transiently lock dollars behind sub-cent work and could trip a paid user's
+ * spendable floor mid-sentence. A ~2¢ reservation comfortably covers any single
+ * voice call at the 1.5× markup while keeping the transient hold realistic. The
+ * real cost still settles exactly via consumeCredits; this only bounds the
+ * in-flight reservation. Tune via env per real usage data.
+ */
+export const VOICE_HOLD_ESTIMATE_CENTS = envInt('VOICE_HOLD_ESTIMATE_CENTS', 2);
+
+/**
  * How long a hold lives before the reconcile cron may sweep it. Must exceed the
  * longest possible stream plus its settle window (AI routes cap streams at 300s),
  * so a still-running call's reservation is never reclaimed out from under it.

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -91,10 +91,27 @@ export const CREDIT_HOLD_ESTIMATE_CENTS = envInt('CREDIT_HOLD_ESTIMATE_CENTS', R
  * the spendable-floor check meaningful without over-reserving. It is an ESTIMATE, not
  * a guaranteed cap (a very long upload could exceed it); the real cost always settles
  * exactly via consumeCredits and the 1.5× markup — not this hold — is the solvency
- * guarantee. TTS does NOT use this: its character count is known up front, so it
- * reserves the exact charged amount via estimateVoiceHoldCents(). Tune via env.
+ * guarantee. Because a single STT call can settle above this estimate, concurrent
+ * paid-voice overdraw is bounded by VOICE_MAX_INFLIGHT (a per-user concurrency cap),
+ * not by this reservation. TTS does NOT use this: its character count is known up
+ * front, so it reserves the exact charged amount via estimateVoiceHoldCents(). Tune
+ * via env.
  */
 export const VOICE_HOLD_ESTIMATE_CENTS = envInt('VOICE_HOLD_ESTIMATE_CENTS', 2);
+
+/**
+ * Max concurrent in-flight VOICE calls per user, applied to ALL tiers (paid voice
+ * is otherwise uncapped). Bounds worst-case concurrent overdraw: a hold reserves an
+ * ESTIMATE, but the real cost only lands at settle, so without a cap a paid user
+ * could open many simultaneous calls that each reserve little yet collectively
+ * settle past their balance. STT especially can't reserve exactly (audio duration
+ * is unknown until Whisper responds, and file size isn't a usable cost bound), so
+ * this concurrency cap — not the per-call hold — is what bounds that exposure to
+ * `VOICE_MAX_INFLIGHT × worst-case single call`. TTS already reserves its exact
+ * charged amount. Voice mode plays chunks sequentially (≤2 in flight), so 4 is
+ * comfortable for legitimate use. Default 4.
+ */
+export const VOICE_MAX_INFLIGHT = envInt('VOICE_MAX_INFLIGHT', 4);
 
 /**
  * How long a hold lives before the reconcile cron may sweep it. Must exceed the

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -84,15 +84,15 @@ export const RESERVE_FLOOR_CENTS = envInt('CREDIT_RESERVE_FLOOR_CENTS', 25);
 export const CREDIT_HOLD_ESTIMATE_CENTS = envInt('CREDIT_HOLD_ESTIMATE_CENTS', RESERVE_FLOOR_CENTS);
 
 /**
- * Per-call hold estimate for VOICE (STT/TTS), far below the chat default. Voice
- * calls cost a fraction of a cent (a Whisper clip or a TTS sentence), and TTS in
- * particular fires once PER streamed sentence chunk — so a single spoken reply can
- * open many gate→settle cycles in a row. Reserving the 25¢ chat default on each
- * would transiently lock dollars behind sub-cent work and could trip a paid user's
- * spendable floor mid-sentence. A ~2¢ reservation comfortably covers any single
- * voice call at the 1.5× markup while keeping the transient hold realistic. The
- * real cost still settles exactly via consumeCredits; this only bounds the
- * in-flight reservation. Tune via env per real usage data.
+ * Flat per-call hold estimate for voice STT (Whisper), where the audio duration —
+ * and therefore the real cost — isn't known until the provider responds, so the gate
+ * has nothing exact to reserve against. A short voice-mode clip costs a fraction of a
+ * cent ($0.006/min × 1.5), so 2¢ is a reasonable approximate reservation that keeps
+ * the spendable-floor check meaningful without over-reserving. It is an ESTIMATE, not
+ * a guaranteed cap (a very long upload could exceed it); the real cost always settles
+ * exactly via consumeCredits and the 1.5× markup — not this hold — is the solvency
+ * guarantee. TTS does NOT use this: its character count is known up front, so it
+ * reserves the exact charged amount via estimateVoiceHoldCents(). Tune via env.
  */
 export const VOICE_HOLD_ESTIMATE_CENTS = envInt('VOICE_HOLD_ESTIMATE_CENTS', 2);
 

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -375,6 +375,26 @@ describe('trackAIUsage', () => {
     expect(mockWriteAiUsage).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 
+  it('honors an explicit costSource override (voice list_price) instead of the computed openrouter/estimate', async () => {
+    // A finite providerCostDollars would normally stamp costSource='openrouter'
+    // (mislabeling voice as a live provider-returned cost). The explicit override
+    // must win so the admin panel classifies voice coverage as 'list_price'.
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'openai_voice',
+      model: 'whisper-1',
+      providerCostDollars: 0.006,
+      costSource: 'list_price',
+      metadata: { type: 'voice_stt' },
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockWriteAiUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ type: 'voice_stt', costSource: 'list_price' }),
+      }),
+    );
+  });
+
   it('should set success=false when explicitly set', async () => {
     await trackAIUsage({ userId: 'user-1', provider: 'openai', model: 'gpt-4o', success: false, error: 'fail' });
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateVoiceCostDollars, VOICE_RATES } from '../voice-pricing';
+import { calculateVoiceCostDollars, estimateVoiceHoldCents, VOICE_RATES } from '../voice-pricing';
 
 describe('calculateVoiceCostDollars — Whisper STT', () => {
   it('bills 60s of audio at the published $0.006/min rate', () => {
@@ -43,6 +43,24 @@ describe('calculateVoiceCostDollars — TTS', () => {
 describe('calculateVoiceCostDollars — unknown model', () => {
   it('bills nothing (never corrupts the ledger) for an unrecognized model', () => {
     expect(calculateVoiceCostDollars('gpt-4o', { seconds: 100, chars: 100 })).toBe(0);
+  });
+});
+
+describe('estimateVoiceHoldCents — reserves the exact charged amount for TTS', () => {
+  // Default markup is 1.5× (MARKUP_BPS=15000).
+  it('reserves the full worst-case max-length tts-1-hd call (~18¢), not a flat 2¢', () => {
+    // 4096 chars × $30/1M = $0.12288 raw × 1.5 = $0.18432 → ceil to 19¢.
+    expect(estimateVoiceHoldCents('tts-1-hd', { chars: 4096 })).toBe(19);
+  });
+
+  it('reserves a realistic ~1¢ for a typical sentence chunk', () => {
+    // 200 chars × $15/1M = $0.003 raw × 1.5 = $0.0045 → ceil to 1¢.
+    expect(estimateVoiceHoldCents('tts-1', { chars: 200 })).toBe(1);
+  });
+
+  it('never reserves below 1¢ (zero/unknown quantity still counts as one in-flight call)', () => {
+    expect(estimateVoiceHoldCents('tts-1', { chars: 0 })).toBe(1);
+    expect(estimateVoiceHoldCents('whisper-1', {})).toBe(1);
   });
 });
 

--- a/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/voice-pricing.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { calculateVoiceCostDollars, VOICE_RATES } from '../voice-pricing';
+
+describe('calculateVoiceCostDollars — Whisper STT', () => {
+  it('bills 60s of audio at the published $0.006/min rate', () => {
+    // 60 seconds = 1 minute = $0.006, exactly what OpenAI charges.
+    expect(calculateVoiceCostDollars('whisper-1', { seconds: 60 })).toBeCloseTo(0.006, 6);
+  });
+
+  it('prorates partial seconds (30s → half a minute)', () => {
+    expect(calculateVoiceCostDollars('whisper-1', { seconds: 30 })).toBeCloseTo(0.003, 6);
+  });
+
+  it('returns 0 for missing/invalid/zero duration rather than a NaN or negative charge', () => {
+    expect(calculateVoiceCostDollars('whisper-1', {})).toBe(0);
+    expect(calculateVoiceCostDollars('whisper-1', { seconds: 0 })).toBe(0);
+    expect(calculateVoiceCostDollars('whisper-1', { seconds: -5 })).toBe(0);
+    expect(calculateVoiceCostDollars('whisper-1', { seconds: Number.NaN })).toBe(0);
+  });
+
+  it('ignores a chars quantity for an STT model', () => {
+    expect(calculateVoiceCostDollars('whisper-1', { chars: 1000 })).toBe(0);
+  });
+});
+
+describe('calculateVoiceCostDollars — TTS', () => {
+  it('bills tts-1 at $15 / 1M chars', () => {
+    // 1000 chars × $15/1M = $0.015.
+    expect(calculateVoiceCostDollars('tts-1', { chars: 1000 })).toBeCloseTo(0.015, 6);
+  });
+
+  it('bills tts-1-hd at $30 / 1M chars (double tts-1)', () => {
+    expect(calculateVoiceCostDollars('tts-1-hd', { chars: 1000 })).toBeCloseTo(0.03, 6);
+  });
+
+  it('returns 0 for missing/invalid char counts', () => {
+    expect(calculateVoiceCostDollars('tts-1', {})).toBe(0);
+    expect(calculateVoiceCostDollars('tts-1', { chars: 0 })).toBe(0);
+    expect(calculateVoiceCostDollars('tts-1-hd', { chars: -1 })).toBe(0);
+  });
+});
+
+describe('calculateVoiceCostDollars — unknown model', () => {
+  it('bills nothing (never corrupts the ledger) for an unrecognized model', () => {
+    expect(calculateVoiceCostDollars('gpt-4o', { seconds: 100, chars: 100 })).toBe(0);
+  });
+});
+
+describe('VOICE_RATES defaults pinned to OpenAI published audio pricing', () => {
+  it('whisper-1 = $0.006/min', () => {
+    expect(VOICE_RATES['whisper-1'].usdPerSecond).toBeCloseTo(0.006 / 60, 12);
+  });
+  it('tts-1 = $15/1M chars, tts-1-hd = $30/1M chars', () => {
+    expect(VOICE_RATES['tts-1'].usdPerChar).toBeCloseTo(15 / 1_000_000, 12);
+    expect(VOICE_RATES['tts-1-hd'].usdPerChar).toBeCloseTo(30 / 1_000_000, 12);
+  });
+});

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -704,6 +704,13 @@ export interface AIUsageData {
   // route → here → consumeCredits. Absent for un-gated calls (e.g. cron paths).
   holdId?: string;
 
+  // Override the cost provenance stamped into metadata.costSource (which the admin
+  // panel reads to classify coverage). Defaults to 'openrouter' when a finite
+  // providerCostDollars is given, else 'estimate'. Voice routes pass 'list_price'
+  // because their cost is deterministic (exact quantity × published OpenAI rate),
+  // neither a live provider-returned figure nor a token-guess fallback.
+  costSource?: string;
+
   // Context tracking - track actual conversation context vs billing tokens
   contextMessages?: string[]; // Array of message IDs included in this call's context
   contextSize?: number; // Actual tokens in context (input + system prompt + tools)
@@ -792,8 +799,11 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
           streamingDuration: data.streamingDuration,
           // Provenance of the billed `cost`: 'openrouter' = real returned cost,
           // 'estimate' = static AI_PRICING fallback. Lets the admin panel be
-          // honest about real vs estimated coverage.
-          costSource,
+          // honest about real vs estimated coverage. Callers that compute their own
+          // authoritative cost (voice: 'list_price' = exact quantity × published
+          // rate) override this, since they pass a finite providerCostDollars that
+          // would otherwise be mislabeled 'openrouter'.
+          costSource: data.costSource ?? costSource,
         },
       });
       // Bill when real tokens were consumed, regardless of success. A token-less

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -708,8 +708,10 @@ export interface AIUsageData {
   // panel reads to classify coverage). Defaults to 'openrouter' when a finite
   // providerCostDollars is given, else 'estimate'. Voice routes pass 'list_price'
   // because their cost is deterministic (exact quantity × published OpenAI rate),
-  // neither a live provider-returned figure nor a token-guess fallback.
-  costSource?: string;
+  // neither a live provider-returned figure nor a token-guess fallback. Typed as the
+  // closed set the rollup recognizes so a typo can't silently fall through to the
+  // provider-name heuristic.
+  costSource?: 'openrouter' | 'estimate' | 'list_price';
 
   // Context tracking - track actual conversation context vs billing tokens
   contextMessages?: string[]; // Array of message IDs included in this call's context

--- a/packages/lib/src/monitoring/voice-pricing.ts
+++ b/packages/lib/src/monitoring/voice-pricing.ts
@@ -23,6 +23,8 @@
  * a deploy. Defaults pinned to OpenAI's published audio pricing (see the unit test).
  */
 
+import { MARKUP_BPS } from '../billing/credit-pricing';
+
 /** Parse a non-negative float env override; fall back to `fallback` on absence/garbage. */
 function envFloat(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
@@ -71,4 +73,19 @@ export function calculateVoiceCostDollars(model: string, quantity: VoiceUsageQua
   }
 
   return 0;
+}
+
+/**
+ * Charged-credit reservation (whole cents, minimum 1) for a voice call whose
+ * billable quantity is already known — i.e. TTS, where the input character count is
+ * in hand before the provider call. Reserves exactly what the call will be charged
+ * (real cost × markup), so the gate's spendable-floor check is accurate per call
+ * instead of relying on a flat estimate that a long TTS request would blow past.
+ * STT can't use this (audio duration is unknown until the provider responds) and
+ * falls back to the flat VOICE_HOLD_ESTIMATE_CENTS.
+ */
+export function estimateVoiceHoldCents(model: string, quantity: VoiceUsageQuantity): number {
+  const charged = calculateVoiceCostDollars(model, quantity) * (MARKUP_BPS / 10_000) * 100;
+  if (!Number.isFinite(charged) || charged <= 0) return 1;
+  return Math.max(1, Math.ceil(charged));
 }

--- a/packages/lib/src/monitoring/voice-pricing.ts
+++ b/packages/lib/src/monitoring/voice-pricing.ts
@@ -1,0 +1,74 @@
+/**
+ * voice-pricing — real provider cost for voice (STT/TTS) calls.
+ *
+ * Voice does NOT go through OpenRouter, and OpenAI's audio endpoints return no
+ * per-call cost or token figure (Whisper `verbose_json` gives the exact audio
+ * `duration`; TTS returns only audio bytes). So there is no live provider-returned
+ * cost to read back the way chat does via `extractOpenRouterCostDollars`.
+ *
+ * Instead the billable cost is computed DETERMINISTICALLY as
+ *   exact billed quantity × OpenAI's published unit rate
+ * — Whisper: audio seconds × per-minute rate (prorated to the second); TTS: input
+ * characters × per-char rate. Both quantities are exact and both rates are fixed,
+ * so `quantity × rate` equals what OpenAI bills us. This is real cost, not a
+ * probabilistic estimate.
+ *
+ * The returned value is PRE-markup. Callers hand it to `AIMonitoring.trackUsage`
+ * as `providerCostDollars`, and the credit pipeline applies the same 1.5× markup
+ * (`MARKUP_BPS`) as every other AI call — that markup is also the buffer that
+ * keeps us solvent if OpenAI's real rate ever drifts above this table (we'd only
+ * front cost on a >50% price hike). Keeping a rate current is a one-line change.
+ *
+ * Rates are env-overridable so the founder can track an OpenAI price change without
+ * a deploy. Defaults pinned to OpenAI's published audio pricing (see the unit test).
+ */
+
+/** Parse a non-negative float env override; fall back to `fallback` on absence/garbage. */
+function envFloat(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+export type VoiceModel = 'whisper-1' | 'tts-1' | 'tts-1-hd';
+
+/**
+ * Published OpenAI audio rates, in USD per base unit:
+ *   - STT (whisper-1): USD per audio SECOND (= $0.006 / minute ÷ 60).
+ *   - TTS (tts-1 / tts-1-hd): USD per input CHARACTER ($15 / $30 per 1M chars).
+ */
+export const VOICE_RATES = {
+  'whisper-1': { usdPerSecond: envFloat('VOICE_WHISPER_USD_PER_SECOND', 0.006 / 60) },
+  'tts-1': { usdPerChar: envFloat('VOICE_TTS1_USD_PER_CHAR', 15 / 1_000_000) },
+  'tts-1-hd': { usdPerChar: envFloat('VOICE_TTS1_HD_USD_PER_CHAR', 30 / 1_000_000) },
+} as const;
+
+export interface VoiceUsageQuantity {
+  /** Audio duration in seconds (STT / whisper-1). */
+  seconds?: number;
+  /** Input character count (TTS / tts-1, tts-1-hd). */
+  chars?: number;
+}
+
+/**
+ * Real provider cost (USD, pre-markup) for one voice call. Returns 0 for an
+ * unknown model or a missing/invalid quantity — never a negative or NaN charge,
+ * so a malformed call is billed nothing rather than corrupting the ledger. The
+ * routes only pass validated models, so 0 here means "nothing to bill".
+ */
+export function calculateVoiceCostDollars(model: string, quantity: VoiceUsageQuantity): number {
+  if (model === 'whisper-1') {
+    const seconds = quantity.seconds;
+    if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) return 0;
+    return Number((seconds * VOICE_RATES['whisper-1'].usdPerSecond).toFixed(6));
+  }
+
+  if (model === 'tts-1' || model === 'tts-1-hd') {
+    const chars = quantity.chars;
+    if (typeof chars !== 'number' || !Number.isFinite(chars) || chars <= 0) return 0;
+    return Number((chars * VOICE_RATES[model].usdPerChar).toFixed(6));
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Why

Voice mode (hands-free Whisper STT + OpenAI TTS) called the deployment's managed OpenAI key and debited **nothing** — so for every paid user PageSpace fronted **100% of the voice cost**, exactly what the prepaid-credits system exists to prevent. This wires voice into the **same gate → track → settle credit pipeline as text chat**, so every voice call spends from the user's own balance.

Free users were already blocked (both routes 403 non-paid tiers); this adds the missing **tracking / metering / billing**.

## What

Each `/api/voice/{transcribe,synthesize}` route now:
1. `canConsumeAI(userId, tier, { estCostCents: VOICE_HOLD_ESTIMATE_CENTS })` → reserves a small hold, returns 402/429 when enforcement is on and the user is out of credits.
2. Calls OpenAI, then `AIMonitoring.trackUsage({ provider: 'openai_voice', model, providerCostDollars, holdId, costSource: 'list_price' })` → settles the real cost (× 1.5 markup) against credits and releases the hold.
3. `emitCreditsUpdated()` pushes the live balance; the hold is released in `finally` on any early exit (validation error, provider failure).

### Cost is deterministic, not estimated
Voice has **no OpenRouter live-cost passthrough** and OpenAI's audio endpoints return no per-call cost. Cost = **exact billed quantity × OpenAI's published rate**:
- Whisper: `verbose_json` `duration` (sec) × $0.006/min — route switched to `verbose_json` for the authoritative duration.
- TTS: `text.length` × $15 (tts-1) / $30 (tts-1-hd) per 1M chars.

This equals what OpenAI bills us. The **1.5× markup is the solvency buffer** — we only front cost on a >50% OpenAI price hike — so no reconciliation cron is needed; rate drift only affects margin *reporting*.

## Key decisions
- **Enforcement rides the global flag.** Voice meters/records now; blocks out-of-credit paid users only once `CREDITS_ENFORCEMENT_ENABLED` flips on (same as chat).
- **Distinct admin line.** New `costSource: 'list_price'` → new `CostCoverage` value + badge in `/admin/ai-billing`, so voice shows as its own honestly-labeled row (not mislabeled `real`). Required adding an explicit `costSource?` override to `AIUsageData`, because `trackAIUsage` otherwise stamps `'openrouter'` for any finite `providerCostDollars`.
- **Small voice hold (2¢).** TTS fires once per streamed sentence chunk, so reserving the 25¢ chat hold per sub-cent call would lock dollars needlessly. Added an optional `estCostCents` override to `canConsumeAI`.

## Files
- **new** `packages/lib/src/monitoring/voice-pricing.ts` — rates + `calculateVoiceCostDollars()`
- `packages/lib/src/billing/credit-pricing.ts` — `VOICE_HOLD_ESTIMATE_CENTS`
- `packages/lib/src/billing/credit-gate.ts` — optional `estCostCents` override
- `packages/lib/src/monitoring/ai-monitoring.ts` — explicit `costSource` override on `AIUsageData`
- `apps/web/src/app/api/voice/{transcribe,synthesize}/route.ts` — gate + verbose_json + track + release
- `apps/web/src/lib/monitoring/monitoring-queries.ts` + `apps/web/src/app/admin/ai-billing/page.tsx` — `list_price` coverage

## Tests
All green (`typecheck` + `lint` clean on both packages):
- `voice-pricing` rate math (Whisper/TTS, unknown-model = $0, env-default pins)
- gate `estCostCents` override reserves the voice amount
- `list_price` coverage mapping in the admin rollup
- `costSource` override survives `trackAIUsage` (not overwritten to `openrouter`)
- both route handlers: free → 403 (before gate/provider), metered success (gate + real cost + no leftover hold), gate denial → 402 (no provider call), provider failure → hold released, no bill

## Not flipping enforcement
Consistent with #1505, `CREDITS_ENFORCEMENT_ENABLED` stays **off** — watch voice margins in `/admin/ai-billing` before enabling blocking.

## Review hardening (post-open commits)

Self-review + the Codex review bot surfaced several issues, all addressed:

- **Accurate TTS hold** (`f9365fcb6`): TTS reserves its exact charged amount (`estimateVoiceHoldCents` = chars × rate × markup), so a max-length `tts-1-hd` request holds ~19¢, not a flat 2¢. The flat `VOICE_HOLD_ESTIMATE_CENTS` is now STT-only (audio duration is unknown pre-call).
- **Bounded concurrent paid voice spend** (`5e5da23be`, resolves Codex P1): new `VOICE_MAX_INFLIGHT` (env, default 4) applied to all tiers via `GateOptions.maxInFlight` on `canConsumeAI`. Worst-case concurrent overdraw is now bounded by `VOICE_MAX_INFLIGHT × single-call cost` instead of unbounded.
- **Observable $0 transcription**: a missing Whisper `duration` now warns + flags the usage row (`metadata.missingDuration`) instead of silently billing $0.
- **Correct telemetry**: `trackUsage.duration` records real request latency (ms), not audio length; `AIUsageData.costSource` narrowed to the closed union the rollup recognizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Voice service billing now supports a third cost coverage type based on exact OpenAI published rates for transcription and synthesis
  * Enhanced credit reservation and settlement workflow for voice service requests

* **Tests**
  * Added comprehensive test coverage for voice billing metering and credit hold handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
