### PR TITLE
feat(billing): per-environment credits feature flag (dark-launch) + marketing transition

### DIFF
--- a/apps/marketing/src/app/faq/page.tsx
+++ b/apps/marketing/src/app/faq/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata } from "@/lib/metadata";
-import { MONTHLY_CREDITS, creditPacksPhrase } from "@/lib/credits";
+import { MONTHLY_CREDITS, creditPacksPhrase, CREDITS_IN_TRANSITION } from "@/lib/credits";
 import { FAQHashOpener } from "./hash-opener";
 
 export const metadata = pageMetadata.faq;
@@ -88,6 +88,18 @@ const faqs: FAQItem[] = [
     answer: `Everything else keeps working — your documents, tasks, channels, and collaboration are unaffected. AI features pause until you either buy more credits (top-up packs come in ${creditPacksPhrase()}) or your monthly allowance resets at the start of the next billing period.`,
     category: "Pricing and plans",
   },
+  // TRANSITION: remove when AI credits are live for all accounts
+  ...(CREDITS_IN_TRANSITION
+    ? [
+        {
+          id: "existing-user-credits-transition",
+          question: "I'm an existing user — when do AI credits start?",
+          answer:
+            "We're transitioning from daily AI limits to monthly AI credits. The allowances on this page are what each plan includes once credits are active for your account; until then, existing accounts continue on the previous daily limits. Either way, your documents, tasks, channels, and collaboration are unaffected.",
+          category: "Pricing and plans",
+        },
+      ]
+    : []),
 
   // Getting started
   {

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -3,8 +3,9 @@ import { Check, X, Building2, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
+import { CreditsTransitionNotice } from "@/components/CreditsTransitionNotice";
 import { pageMetadata, APP_URL } from "@/lib/metadata";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { MONTHLY_CREDITS, CREDITS_IN_TRANSITION } from "@/lib/credits";
 
 export const metadata = pageMetadata.pricing;
 
@@ -120,6 +121,17 @@ export default function PricingPage() {
           </div>
         </div>
       </section>
+
+      {/* TRANSITION: remove when AI credits are live for all accounts */}
+      {CREDITS_IN_TRANSITION && (
+        <section className="pb-4">
+          <div className="container mx-auto px-4 md:px-6">
+            <div className="mx-auto max-w-3xl">
+              <CreditsTransitionNotice />
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Pricing Cards */}
       <section className="pb-16 md:pb-24">

--- a/apps/marketing/src/app/terms/page.tsx
+++ b/apps/marketing/src/app/terms/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata, LEGAL_LAST_UPDATED } from "@/lib/metadata";
-import { MONTHLY_CREDITS } from "@/lib/credits";
+import { MONTHLY_CREDITS, CREDITS_IN_TRANSITION } from "@/lib/credits";
 
 export const metadata = pageMetadata.terms;
 
@@ -148,6 +148,12 @@ export default function TermsOfService() {
             <p className="mb-4">
               AI usage is metered against your plan&#39;s monthly AI-credit allowance. When your available credits are exhausted, AI features pause until you purchase additional credits or your monthly allowance resets at the start of the next billing period; all non-AI features (documents, tasks, channels, and collaboration) remain available. AI-credit prices and allowances may be adjusted with reasonable notice. Storage and file-size limits also apply per plan, and exceeding them may result in service throttling or temporary suspension until your next billing cycle.
             </p>
+            {/* TRANSITION: remove when AI credits are live for all accounts */}
+            {CREDITS_IN_TRANSITION && (
+              <p className="mb-4">
+                AI-credit pricing is currently being rolled out. During this transition, some existing accounts may continue to operate under the prior daily AI-usage limits until they are migrated to the AI-credit model described above.
+              </p>
+            )}
           </section>
 
           <section className="mb-8">

--- a/apps/marketing/src/components/CreditsTransitionNotice.tsx
+++ b/apps/marketing/src/components/CreditsTransitionNotice.tsx
@@ -1,0 +1,32 @@
+import { Info } from "lucide-react";
+import { CREDITS_IN_TRANSITION } from "@/lib/credits";
+
+/**
+ * TRANSITION: disclaimer shown while AI-credit pricing is rolling out. The marketing site
+ * advertises the new credit model, but some production accounts remain on the legacy
+ * daily-limit experience until they're switched over. Renders nothing once
+ * `CREDITS_IN_TRANSITION` is flipped off. Matches the amber "beta notice" style used on
+ * the downloads page. Remove when AI credits are live for all accounts.
+ */
+export function CreditsTransitionNotice() {
+  if (!CREDITS_IN_TRANSITION) return null;
+
+  return (
+    <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-6">
+      <div className="flex items-start gap-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-amber-500/10 flex-shrink-0">
+          <Info className="h-5 w-5 text-amber-600" />
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">AI credits pricing is rolling out</h3>
+          <p className="text-sm text-muted-foreground">
+            We&#39;re moving from daily AI limits to monthly AI credits. The allowances below
+            are what each plan includes once credits are active for your account — some
+            existing accounts remain on the previous daily limits until they&#39;re switched
+            over. Your documents, tasks, and collaboration are unaffected.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/marketing/src/lib/credits.ts
+++ b/apps/marketing/src/lib/credits.ts
@@ -17,6 +17,16 @@ import {
 } from "@pagespace/lib/billing/credit-pricing";
 import type { SubscriptionTier } from "@pagespace/lib/services/subscription-utils";
 
+/**
+ * TRANSITION: whether to show the "AI credits pricing is rolling out" disclaimer across
+ * the marketing site. The site advertises the new credit model, but production accounts
+ * may still be on the legacy daily-limit experience until the app's per-environment
+ * `CREDITS_ENFORCEMENT_ENABLED` flag is flipped on. Flip this to `false` (then delete the
+ * treatment) once AI credits are live for all accounts. Marketing is one global SSG site,
+ * so this is a deliberate constant — NOT the app's per-deploy flag.
+ */
+export const CREDITS_IN_TRANSITION = true;
+
 /** Format whole cents as a plain dollar string, dropping a trailing ".00". */
 function formatDollars(cents: number): string {
   const dollars = cents / 100;

--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { SessionAuthResult } from '@/lib/auth';
 
 // ============================================================================
@@ -171,6 +171,8 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({ hasVisionCapability: vi.fn(
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { getCurrentUsage } from '@/lib/subscription/usage-service';
+import { createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
 import { streamText } from 'ai';
 
 const mockUserId = 'user_123';
@@ -240,5 +242,45 @@ describe('POST /api/ai/chat - prepaid credit gate', () => {
     const response = await POST(createChatRequest());
 
     expect(response.status).not.toBe(402);
+  });
+
+  // Per-environment switch (CREDITS_ENFORCEMENT_ENABLED): OFF restores the legacy
+  // daily-limit path; ON skips it (prepaid credits are the sole limiter).
+  describe('legacy daily-limit path (credits mode OFF)', () => {
+    afterEach(() => {
+      delete process.env.CREDITS_ENFORCEMENT_ENABLED;
+      // clearAllMocks() keeps implementations, so restore the permissive defaults this
+      // block overrode — otherwise the exhausted-quota mock leaks into later suites.
+      vi.mocked(getCurrentUsage).mockResolvedValue({ success: true, remainingCalls: 100, currentCount: 0, limit: 100 });
+      vi.mocked(createRateLimitResponse).mockReset();
+    });
+
+    it('OFF: enforces the legacy daily quota (429) when calls are exhausted', async () => {
+      delete process.env.CREDITS_ENFORCEMENT_ENABLED; // OFF (default)
+      vi.mocked(canConsumeAI).mockResolvedValue({ allowed: true, reason: 'enforcement_disabled' });
+      vi.mocked(getCurrentUsage).mockResolvedValue({ success: true, remainingCalls: 0, currentCount: 50, limit: 50 });
+      vi.mocked(createRateLimitResponse).mockReturnValue(
+        new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429 }) as never,
+      );
+
+      const response = await POST(createChatRequest());
+
+      expect(getCurrentUsage).toHaveBeenCalled();
+      expect(createRateLimitResponse).toHaveBeenCalled();
+      expect(response.status).toBe(429);
+      expect(streamText).not.toHaveBeenCalled();
+    });
+
+    it('ON: skips the legacy daily quota entirely (credits are the sole limiter)', async () => {
+      process.env.CREDITS_ENFORCEMENT_ENABLED = 'true';
+      vi.mocked(canConsumeAI).mockResolvedValue({ allowed: true, reason: 'ok' });
+      vi.mocked(getCurrentUsage).mockResolvedValue({ success: true, remainingCalls: 0, currentCount: 50, limit: 50 });
+
+      const response = await POST(createChatRequest());
+
+      expect(getCurrentUsage).not.toHaveBeenCalled();
+      expect(createRateLimitResponse).not.toHaveBeenCalled();
+      expect(response.status).not.toBe(429);
+    });
   });
 });

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -11,11 +11,14 @@ import {
   type TextUIPart,
   type ToolSet,
 } from 'ai';
-import { ONPREM_ALLOWED_PROVIDERS, isAdminOnlyProvider } from '@/lib/ai/core/ai-providers-config';
+import { ONPREM_ALLOWED_PROVIDERS, isAdminOnlyProvider, getProviderTier } from '@/lib/ai/core/ai-providers-config';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
-import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
+import { requiresProSubscription, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
+// LEGACY: daily-quota path, active only when isCreditsModeEnabled() is OFF. Remove at final credits cutover.
+import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
+import { isCreditsModeEnabled } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
@@ -542,10 +545,27 @@ export async function POST(request: Request) {
     // Update user's current provider/model if changed
     await updateUserProviderSettings(userId, selectedProvider, selectedModel);
 
-    // NOTE: daily per-call rate limiting has been retired. Prepaid AI credits are
-    // now the sole volume limiter — enforced by the credit gate above (which also
-    // bounds concurrency via the in-flight hold cap). Model-tier gating
-    // (requiresProSubscription / admin-only providers) above is unchanged.
+    // LEGACY daily-quota path (credits mode OFF): prod's "old way". The credit gate
+    // above already metered (and, when enforcement is ON, blocked); here we layer the
+    // legacy per-tier daily limit so a dark-launch environment behaves exactly as before.
+    // getCurrentUsage returns unlimited when !isBillingEnabled(), so onprem/tenant bypass.
+    // Remove at final credits cutover.
+    if (!isCreditsModeEnabled()) {
+      const providerType = getProviderTier(currentProvider, currentModel);
+      const currentUsage = await getCurrentUsage(userId, providerType);
+      if (!currentUsage.success || currentUsage.remainingCalls <= 0) {
+        loggers.ai.warn('AI Chat API: Legacy daily rate limit exceeded', {
+          userId: maskIdentifier(userId),
+          providerType,
+          limit: currentUsage.limit,
+          remaining: currentUsage.remainingCalls,
+        });
+        // The gate placed a hold above (it runs even in OFF mode, for metering); this
+        // early return never streams, so release it now rather than wait for the sweep.
+        if (holdId && !holdHandedOff) void releaseHold(holdId).catch(() => {});
+        return createRateLimitResponse(providerType, currentUsage.limit);
+      }
+    }
 
     // Parse read-only mode (defaults to false for full access)
     const readOnlyMode = isReadOnly === true;
@@ -1025,9 +1045,22 @@ export async function POST(request: Request) {
               
               loggers.ai.debug('AI Chat API: AI response message saved to database with tools');
 
+              // LEGACY daily-quota counting (credits mode OFF): keep the old per-tier
+              // counter moving so the restored UsageCounter is accurate on prod during
+              // dark launch. Best-effort — never fail the chat. Remove at final cutover.
+              if (!isCreditsModeEnabled()) {
+                try {
+                  await incrementUsage(userId!, getProviderTier(currentProvider, currentModel));
+                } catch (usageError) {
+                  loggers.ai.error('AI Chat API: legacy usage increment failed', usageError as Error, {
+                    userId: maskIdentifier(userId!),
+                  });
+                }
+              }
+
               // Track enhanced AI usage with token counting and cost calculation.
-              // (Daily per-call counting/broadcast removed — prepaid credits are the
-              // sole volume limiter; the credit hold from the gate is settled below.)
+              // Prepaid credit metering ALWAYS runs (both modes) — it settles the gate's
+              // hold and feeds unit-economics observability.
               const duration = Date.now() - startTime;
 
               const usage = usagePromise ? await usagePromise : undefined;

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -8,7 +8,7 @@
  *   provider returns no usage metadata, so the orphan-sweep has a row to bill.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const {
   mockCreateStreamLifecycle,
@@ -230,6 +230,8 @@ import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import type { SessionAuthResult } from '@/lib/auth';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { getCurrentUsage } from '@/lib/subscription/usage-service';
+import { createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { streamText } from 'ai';
 
@@ -303,6 +305,46 @@ describe('POST /api/ai/global/[id]/messages — prepaid credit gate', () => {
 
     expect(canConsumeAI).toHaveBeenCalled();
     expect(response.status).not.toBe(402);
+  });
+
+  // Per-environment switch (CREDITS_ENFORCEMENT_ENABLED): OFF restores the legacy
+  // daily-limit path; ON skips it (prepaid credits are the sole limiter).
+  describe('legacy daily-limit path (credits mode OFF)', () => {
+    afterEach(() => {
+      delete process.env.CREDITS_ENFORCEMENT_ENABLED;
+      // clearAllMocks() keeps implementations, so restore the permissive defaults this
+      // block overrode — otherwise the exhausted-quota mock leaks into later suites.
+      vi.mocked(getCurrentUsage).mockResolvedValue({ success: true, remainingCalls: 100, currentCount: 0, limit: 100 });
+      vi.mocked(createRateLimitResponse).mockReset();
+    });
+
+    it('OFF: enforces the legacy daily quota (429) when calls are exhausted', async () => {
+      delete process.env.CREDITS_ENFORCEMENT_ENABLED; // OFF (default)
+      vi.mocked(canConsumeAI).mockResolvedValue({ allowed: true, reason: 'enforcement_disabled' });
+      vi.mocked(getCurrentUsage).mockResolvedValue({ success: true, remainingCalls: 0, currentCount: 50, limit: 50 });
+      vi.mocked(createRateLimitResponse).mockReturnValue(
+        new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429 }) as never,
+      );
+
+      const response = await POST(makeRequest(), makeContext());
+
+      expect(getCurrentUsage).toHaveBeenCalled();
+      expect(createRateLimitResponse).toHaveBeenCalled();
+      expect(response.status).toBe(429);
+      expect(streamText).not.toHaveBeenCalled();
+    });
+
+    it('ON: skips the legacy daily quota entirely (credits are the sole limiter)', async () => {
+      process.env.CREDITS_ENFORCEMENT_ENABLED = 'true';
+      vi.mocked(canConsumeAI).mockResolvedValue({ allowed: true, reason: 'ok' });
+      vi.mocked(getCurrentUsage).mockResolvedValue({ success: true, remainingCalls: 0, currentCount: 50, limit: 50 });
+
+      const response = await POST(makeRequest(), makeContext());
+
+      expect(getCurrentUsage).not.toHaveBeenCalled();
+      expect(createRateLimitResponse).not.toHaveBeenCalled();
+      expect(response.status).not.toBe(429);
+    });
   });
 });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
 import { streamText, convertToModelMessages, stepCountIs, hasToolCall, UIMessage, createUIMessageStream, createUIMessageStreamResponse, type LanguageModelUsage, type ToolSet } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
-import { isAdminOnlyProvider } from '@/lib/ai/core/ai-providers-config';
+import { isAdminOnlyProvider, getProviderTier } from '@/lib/ai/core/ai-providers-config';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
-import { createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
+import { createAdminRestrictedResponse, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
+// LEGACY: daily-quota path, active only when isCreditsModeEnabled() is OFF. Remove at final credits cutover.
+import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
+import { isCreditsModeEnabled } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
@@ -444,10 +447,27 @@ export async function POST(
     // Update user's current provider/model if changed
     await updateUserProviderSettings(userId, selectedProvider, selectedModel);
 
-    // NOTE: daily per-call rate limiting has been retired. Prepaid AI credits are
-    // now the sole volume limiter — enforced by the credit gate above (which also
-    // bounds concurrency via the in-flight hold cap). Model-tier gating
-    // (requiresProSubscription / admin-only providers) above is unchanged.
+    // LEGACY daily-quota path (credits mode OFF): prod's "old way". The credit gate
+    // above already metered (and blocked when enforcement is ON); here we layer the
+    // legacy per-tier daily limit so a dark-launch environment behaves exactly as before.
+    // getCurrentUsage returns unlimited when !isBillingEnabled(), so onprem/tenant bypass.
+    // Remove at final credits cutover.
+    if (!isCreditsModeEnabled()) {
+      const providerType = getProviderTier(currentProvider, currentModel);
+      const currentUsage = await getCurrentUsage(userId, providerType);
+      if (!currentUsage.success || currentUsage.remainingCalls <= 0) {
+        loggers.api.warn('Global Assistant Chat API: Legacy daily rate limit exceeded', {
+          userId: maskIdentifier(userId),
+          providerType,
+          limit: currentUsage.limit,
+          remaining: currentUsage.remainingCalls,
+        });
+        // The gate placed a hold above (it runs even in OFF mode, for metering); this
+        // early return never streams, so release it now rather than wait for the sweep.
+        if (holdId && !holdHandedOff) void releaseHold(holdId).catch(() => {});
+        return createRateLimitResponse(providerType, currentUsage.limit);
+      }
+    }
 
     loggers.api.debug('Global Assistant Chat API: Read-only mode', { isReadOnly: readOnlyMode });
 
@@ -991,6 +1011,19 @@ MENTION PROCESSING:
               .where(eq(conversations.id, conversationId));
 
             loggers.api.debug('Global Assistant Chat API: AI response message saved to database', {});
+
+            // LEGACY daily-quota counting (credits mode OFF): keep the old per-tier
+            // counter moving so the restored UsageCounter is accurate on prod during
+            // dark launch. Best-effort — never fail the chat. Remove at final cutover.
+            if (!isCreditsModeEnabled()) {
+              try {
+                await incrementUsage(userId!, getProviderTier(currentProvider, currentModel));
+              } catch (usageError) {
+                loggers.api.error('Global Assistant Chat API: legacy usage increment failed', usageError as Error, {
+                  userId: maskIdentifier(userId!),
+                });
+              }
+            }
 
             // Track detailed AI usage (tokens, cost, etc.).
             // ALWAYS log a row — even when the provider returns no usage metadata —

--- a/apps/web/src/app/api/credits/__tests__/route.test.ts
+++ b/apps/web/src/app/api/credits/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
@@ -43,11 +43,22 @@ beforeEach(() => {
   mockGetCreditBalance.mockResolvedValue(summary);
 });
 
+afterEach(() => {
+  delete process.env.CREDITS_ENFORCEMENT_ENABLED;
+});
+
 describe('GET /api/credits', () => {
-  it('returns the user balance summary', async () => {
+  it('returns the user balance summary plus the per-environment creditsMode flag', async () => {
     const res = await GET(createMockRequest('https://example.com/api/credits'));
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(summary);
+    // Default env (unset) → credits mode OFF; the client renders the legacy quota UI.
+    expect(await res.json()).toEqual({ ...summary, creditsMode: false });
+  });
+
+  it('reports creditsMode:true when CREDITS_ENFORCEMENT_ENABLED is set', async () => {
+    process.env.CREDITS_ENFORCEMENT_ENABLED = 'true';
+    const res = await GET(createMockRequest('https://example.com/api/credits'));
+    expect(await res.json()).toMatchObject({ creditsMode: true });
   });
 
   it("resolves the user's tier and passes it to getCreditBalance", async () => {

--- a/apps/web/src/app/api/credits/route.ts
+++ b/apps/web/src/app/api/credits/route.ts
@@ -6,6 +6,7 @@ import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { getCreditBalance } from '@/lib/subscription/credit-balance';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { isCreditsModeEnabled } from '@pagespace/lib/billing/credit-pricing';
 
 const isSubscriptionTier = (value: string): value is SubscriptionTier =>
   value === 'free' || value === 'pro' || value === 'founder' || value === 'business';
@@ -16,6 +17,10 @@ const isSubscriptionTier = (value: string): value is SubscriptionTier =>
  * Returns the monthly allowance bucket (resets each period), the never-expiring
  * top-up bucket, the spendable total (net of in-flight reservations), and the
  * reserved amount. Drives the credit-balance widget and the buy-credits surfaces.
+ *
+ * Also carries `creditsMode` (the per-environment switch, read at request time) so the
+ * client can render the new credits UI vs the legacy daily-quota UI from the same image
+ * — NEXT_PUBLIC_* can't differ per-env, so the mode must come from the server at runtime.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -41,7 +46,7 @@ export async function GET(request: NextRequest) {
       resourceId: 'self',
     });
 
-    return NextResponse.json(balance);
+    return NextResponse.json({ ...balance, creditsMode: isCreditsModeEnabled() });
   } catch (error) {
     console.error('Error fetching credit balance:', error);
     return NextResponse.json({ error: 'Failed to fetch credit balance' }, { status: 500 });

--- a/apps/web/src/app/api/subscriptions/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/subscriptions/usage/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// Mock usage service - use vi.hoisted to ensure mock is available before vi.mock
+const { mockGetUserUsageSummary } = vi.hoisted(() => ({
+  mockGetUserUsageSummary: vi.fn(),
+}));
+vi.mock('@/lib/subscription/usage-service', () => ({
+  getUserUsageSummary: mockGetUserUsageSummary,
+}));
+
+// Mock auth
+vi.mock('@/lib/auth/auth-helpers', () => ({
+  requireAuth: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    security: { warn: vi.fn() },
+  },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+// Import after mocks
+import { GET } from '../route';
+import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+// Helper to create mock SessionAuthResult
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  adminRoleVersion: 0,
+  role: 'user',
+});
+
+describe('GET /api/subscriptions/usage', () => {
+  const mockUserId = 'user_123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(requireAuth).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    mockGetUserUsageSummary.mockResolvedValue({
+      aiCredits: { used: 10, limit: 100 },
+      storage: { used: 1024, limit: 524288000 },
+    });
+  });
+
+  it('should return usage summary', async () => {
+    const request = new Request('https://example.com/api/subscriptions/usage', {
+      method: 'GET',
+    }) as unknown as import('next/server').NextRequest;
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockGetUserUsageSummary).toHaveBeenCalledWith(mockUserId);
+    expect(body.aiCredits).toBeDefined();
+  });
+
+  it('should return auth error when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(requireAuth).mockResolvedValue(
+      NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    );
+
+    const request = new Request('https://example.com/api/subscriptions/usage', {
+      method: 'GET',
+    }) as unknown as import('next/server').NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('should log audit event on GET usage', async () => {
+    const request = new Request('https://example.com/api/subscriptions/usage', {
+      method: 'GET',
+    }) as unknown as import('next/server').NextRequest;
+
+    await GET(request);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.read', userId: mockUserId, resourceType: 'subscription_usage', resourceId: 'self' })
+    );
+  });
+
+  it('should not include userId in audit details (GDPR: details field is in hash chain)', async () => {
+    const request = new Request('https://example.com/api/subscriptions/usage', {
+      method: 'GET',
+    }) as unknown as import('next/server').NextRequest;
+
+    await GET(request);
+
+    const eventArg = vi.mocked(auditRequest).mock.calls[0]?.[1];
+    expect(eventArg?.details).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/subscriptions/usage/route.ts
+++ b/apps/web/src/app/api/subscriptions/usage/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
+import { getUserUsageSummary } from '@/lib/subscription/usage-service';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+/**
+ * GET /api/subscriptions/usage — legacy per-call daily-quota summary.
+ *
+ * Drives the legacy `UsageCounter` navbar widget, shown only when the per-environment
+ * credits switch is OFF (`creditsMode === false`). Restored from pre-cutover so prod
+ * stays on the old quota experience during dark launch.
+ *
+ * LEGACY: remove at final credits cutover.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const authResult = await requireAuth(request);
+    if (isAuthError(authResult)) {
+      return authResult;
+    }
+
+    const { userId } = authResult;
+    const usageSummary = await getUserUsageSummary(userId);
+
+    auditRequest(request, { eventType: 'data.read', userId, resourceType: 'subscription_usage', resourceId: 'self' });
+
+    return NextResponse.json(usageSummary);
+
+  } catch (error) {
+    console.error('Error fetching usage:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch usage' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -26,6 +26,7 @@ import { UpcomingInvoice } from '@/components/billing/UpcomingInvoice';
 import { BillingAddressForm, type BillingAddress } from '@/components/billing/BillingAddressForm';
 import { BillingGuard } from '@/components/billing/BillingGuard';
 import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
+import { useCreditsMode } from '@/hooks/useCreditsMode';
 import { getPlan, getPlanFromPriceId, type SubscriptionTier } from '@/lib/subscription/plans';
 import { post } from '@/lib/auth/auth-fetch';
 
@@ -54,6 +55,8 @@ interface UpcomingInvoiceData {
 export default function BillingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  // Per-environment switch: credit surfaces show only when credits mode is ON.
+  const creditsMode = useCreditsMode();
 
   // State
   const [loading, setLoading] = useState(true);
@@ -259,8 +262,8 @@ export default function BillingPage() {
         </Alert>
       )}
 
-      {/* Credit top-up result alerts */}
-      {creditsParam === 'success' && (
+      {/* Credit top-up result alerts (credits mode only) */}
+      {creditsMode && creditsParam === 'success' && (
         <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20">
           <CheckCircle className="h-4 w-4 text-green-600" />
           <AlertDescription className="text-green-800 dark:text-green-200">
@@ -268,7 +271,7 @@ export default function BillingPage() {
           </AlertDescription>
         </Alert>
       )}
-      {creditsParam === 'canceled' && (
+      {creditsMode && creditsParam === 'canceled' && (
         <Alert>
           <AlertTriangle className="h-4 w-4" />
           <AlertDescription>
@@ -285,8 +288,8 @@ export default function BillingPage() {
         </Alert>
       )}
 
-      {/* AI Credits */}
-      <CreditBalanceCard />
+      {/* AI Credits (credits mode only; legacy daily-quota build hides this) */}
+      {creditsMode && <CreditBalanceCard />}
 
       {/* Current Subscription */}
       <Card>

--- a/apps/web/src/app/settings/plan/page.tsx
+++ b/apps/web/src/app/settings/plan/page.tsx
@@ -15,6 +15,7 @@ import { PlanCard } from '@/components/billing/PlanCard';
 import { BillingGuard } from '@/components/billing/BillingGuard';
 import { getAllPlans, getPlan, getTierFromPriceId, type SubscriptionTier, type PlanDefinition } from '@/lib/subscription/plans';
 import { formatCreditDollars } from '@/lib/subscription/credits';
+import { useCreditsMode } from '@/hooks/useCreditsMode';
 import type { AppliedPromo } from '@/components/billing/PromoCodeInput';
 
 interface SubscriptionData {
@@ -32,6 +33,8 @@ interface SubscriptionData {
 export default function PlanPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  // Per-environment switch: ON shows credit allowances, OFF shows legacy calls/day.
+  const creditsMode = useCreditsMode();
   const { resolvedTheme } = useTheme();
   const [subscriptionData, setSubscriptionData] = useState<SubscriptionData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -410,14 +413,39 @@ export default function PlanPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  <tr className="border-b">
-                    <td className="py-4 pr-6">Monthly AI credits</td>
-                    {plans.map((plan) => (
-                      <td key={plan.id} className="text-center py-4 px-4 font-semibold">
-                        {formatCreditDollars(plan.limits.monthlyCreditsCents)}/mo
-                      </td>
-                    ))}
-                  </tr>
+                  {creditsMode ? (
+                    <tr className="border-b">
+                      <td className="py-4 pr-6">Monthly AI credits</td>
+                      {plans.map((plan) => (
+                        <td key={plan.id} className="text-center py-4 px-4 font-semibold">
+                          {formatCreditDollars(plan.limits.monthlyCreditsCents)}/mo
+                        </td>
+                      ))}
+                    </tr>
+                  ) : (
+                    <>
+                      <tr className="border-b">
+                        <td className="py-4 pr-6">Standard AI calls</td>
+                        {plans.map((plan) => (
+                          <td key={plan.id} className="text-center py-4 px-4 font-semibold">
+                            {plan.limits.aiCalls}/day
+                          </td>
+                        ))}
+                      </tr>
+                      <tr className="border-b">
+                        <td className="py-4 pr-6">Pro AI calls</td>
+                        {plans.map((plan) => (
+                          <td key={plan.id} className="text-center py-4 px-4">
+                            {plan.limits.proCalls > 0 ? (
+                              <span className="font-semibold">{plan.limits.proCalls}/day</span>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </td>
+                        ))}
+                      </tr>
+                    </>
+                  )}
                   <tr className="border-b">
                     <td className="py-4 pr-6">AI models</td>
                     {plans.map((plan) => (
@@ -430,14 +458,16 @@ export default function PlanPage() {
                       </td>
                     ))}
                   </tr>
-                  <tr className="border-b">
-                    <td className="py-4 pr-6">Buy more credits</td>
-                    {plans.map((plan) => (
-                      <td key={plan.id} className="text-center py-4 px-4 text-muted-foreground">
-                        Anytime
-                      </td>
-                    ))}
-                  </tr>
+                  {creditsMode && (
+                    <tr className="border-b">
+                      <td className="py-4 pr-6">Buy more credits</td>
+                      {plans.map((plan) => (
+                        <td key={plan.id} className="text-center py-4 px-4 text-muted-foreground">
+                          Anytime
+                        </td>
+                      ))}
+                    </tr>
+                  )}
                   <tr className="border-b">
                     <td className="py-4 pr-6">Storage</td>
                     {plans.map((plan) => (

--- a/apps/web/src/components/billing/AiBalanceWidget.tsx
+++ b/apps/web/src/components/billing/AiBalanceWidget.tsx
@@ -10,13 +10,19 @@ import { UsageCounter } from './UsageCounter';
  * widget when ON, the legacy daily-quota `UsageCounter` when OFF. One `/api/credits`
  * fetch (SWR-deduped) decides the mode; each child owns its own data fetch.
  *
- * Renders nothing until the mode resolves so prod (dark-launch) never flashes a credits
- * UI it shouldn't show.
+ * Renders nothing only on the very first load (no cached balance yet) so prod
+ * (dark-launch) never flashes a credits UI it shouldn't show. If `/api/credits` then
+ * errors or never resolves the mode, we fall back to the legacy `UsageCounter` — OFF is
+ * the safe default, and that widget fetches `/api/subscriptions/usage` independently, so
+ * a credits-endpoint outage can't blank the navbar in a credits-mode-OFF environment.
  *
  * LEGACY: collapse back to a bare <CreditBalance /> at the final credits cutover.
  */
 export function AiBalanceWidget() {
   const { balance, isLoading } = useCreditBalance();
-  if (isLoading || !balance) return null;
-  return balance.creditsMode ? <CreditBalance /> : <UsageCounter />;
+  // Initial load with no data yet: render nothing briefly to avoid a wrong-widget flash.
+  if (isLoading && !balance) return null;
+  // OFF is the safe default: when the mode is unknown (error / not yet resolved),
+  // `balance?.creditsMode` is falsy and we show the legacy quota widget, not nothing.
+  return balance?.creditsMode ? <CreditBalance /> : <UsageCounter />;
 }

--- a/apps/web/src/components/billing/AiBalanceWidget.tsx
+++ b/apps/web/src/components/billing/AiBalanceWidget.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useCreditBalance } from '@/hooks/useCreditBalance';
+import { CreditBalance } from './CreditBalance';
+import { UsageCounter } from './UsageCounter';
+
+/**
+ * Navbar AI-usage widget. Picks the experience by the per-environment credits switch
+ * delivered at runtime via `/api/credits` (`creditsMode`): the new `CreditBalance`
+ * widget when ON, the legacy daily-quota `UsageCounter` when OFF. One `/api/credits`
+ * fetch (SWR-deduped) decides the mode; each child owns its own data fetch.
+ *
+ * Renders nothing until the mode resolves so prod (dark-launch) never flashes a credits
+ * UI it shouldn't show.
+ *
+ * LEGACY: collapse back to a bare <CreditBalance /> at the final credits cutover.
+ */
+export function AiBalanceWidget() {
+  const { balance, isLoading } = useCreditBalance();
+  if (isLoading || !balance) return null;
+  return balance.creditsMode ? <CreditBalance /> : <UsageCounter />;
+}

--- a/apps/web/src/components/billing/CreditBalance.tsx
+++ b/apps/web/src/components/billing/CreditBalance.tsx
@@ -80,15 +80,15 @@ export function CreditBalance() {
           </TooltipTrigger>
           <TooltipContent>
             <p className="font-medium">{formatCreditDollars(spendable)} AI credits left</p>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-primary-foreground/80">
               Monthly: {formatCreditDollars(monthly.remaining)} of{' '}
               {formatCreditDollars(monthly.allowance)}
             </p>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-primary-foreground/80">
               Top-up: {formatCreditDollars(topup.remaining)}
             </p>
             {resetDate && (
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-primary-foreground/80">
                 Monthly resets {resetDate.toLocaleDateString()}
               </p>
             )}

--- a/apps/web/src/components/billing/UsageCounter.tsx
+++ b/apps/web/src/components/billing/UsageCounter.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { AlertCircle } from 'lucide-react';
+import useSWR from 'swr';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useBillingVisibility } from '@/hooks/useBillingVisibility';
+
+/**
+ * LEGACY daily-quota navbar widget — shown when the per-environment credits switch is
+ * OFF (`creditsMode === false`). Restored from pre-cutover so prod keeps the old
+ * "N/limit calls" experience during dark launch. Refreshes via SWR focus/visibility
+ * revalidation only — the old `usage:updated` socket event was retired with the cutover
+ * and is intentionally NOT resurrected.
+ *
+ * LEGACY: remove at final credits cutover (along with /api/subscriptions/usage).
+ */
+
+interface UsageData {
+  subscriptionTier: 'free' | 'pro' | 'founder' | 'business';
+  standard: {
+    current: number;
+    limit: number;
+    remaining: number;
+  };
+  pro: {
+    current: number;
+    limit: number;
+    remaining: number;
+  };
+}
+
+const fetcher = async (url: string): Promise<UsageData> => {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch: ${response.status}`);
+  }
+  return response.json();
+};
+
+export function UsageCounter() {
+  const router = useRouter();
+  const { showBilling } = useBillingVisibility();
+
+  const { data: usage, error, mutate } = useSWR<UsageData>('/api/subscriptions/usage', fetcher, {
+    refreshInterval: 0,
+    revalidateOnFocus: true,
+  });
+
+  const isBusiness = usage?.subscriptionTier === 'business';
+  // All non-free tiers are paid and carry a Pro-call allowance (Pro, Founder, Business),
+  // so they get the "Billing" button + Pro quota display rather than the upgrade CTA.
+  const isPaid = usage?.subscriptionTier != null && usage.subscriptionTier !== 'free';
+
+  const isNearStandardLimit = usage && usage.standard.limit > 0 && usage.standard.remaining <= 10;
+  const isNearProLimit = usage && usage.pro.limit > 0 && usage.pro.remaining <= 10;
+
+  const handleBillingClick = () => {
+    router.push('/settings/billing');
+  };
+
+  // Refresh usage when the tab regains focus (covers AI calls completing in the background).
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        mutate();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [mutate]);
+
+  const showStandardQuota = usage && usage.standard.limit > 0;
+  const showProQuota = usage && isPaid && usage.pro.limit > 0;
+
+  const renderQuotaDisplay = () => {
+    if (error) {
+      return (
+        <div className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground">
+          <AlertCircle className="h-4 w-4" />
+          <span className="hidden md:inline">Usage unavailable</span>
+        </div>
+      );
+    }
+
+    if (!usage) {
+      return (
+        <div className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground">
+          <Skeleton className="h-4 w-4" />
+          <span className="hidden md:inline">Loading...</span>
+        </div>
+      );
+    }
+
+    if (showStandardQuota || showProQuota) {
+      return (
+        <div className="hidden sm:flex items-center gap-3 text-sm">
+          {showStandardQuota && (
+            <div className="flex items-center gap-1.5">
+              <span className="hidden lg:inline text-muted-foreground text-xs">Standard:</span>
+              <Badge
+                variant={isNearStandardLimit ? "destructive" : "secondary"}
+                className="text-xs font-medium"
+              >
+                {usage.standard.current}/{usage.standard.limit}
+              </Badge>
+            </div>
+          )}
+
+          {showProQuota && (
+            <div className="flex items-center gap-1.5">
+              <span className="hidden lg:inline text-muted-foreground text-xs">Pro:</span>
+              <Badge
+                variant={isNearProLimit ? "destructive" : "secondary"}
+                className="text-xs font-medium"
+              >
+                {usage.pro.current}/{usage.pro.limit}
+              </Badge>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {renderQuotaDisplay()}
+
+      {/* Hidden on iOS Capacitor apps (Apple App Store compliance). */}
+      {showBilling && (
+        <Button
+          variant={isPaid ? "ghost" : "default"}
+          size="sm"
+          onClick={handleBillingClick}
+          className={`text-xs h-8 ${!isPaid ? 'upgrade-gradient' : ''}`}
+        >
+          {isPaid ? (
+            <>
+              <span className="hidden md:inline">Billing</span>
+              <span className="md:hidden">{isBusiness ? 'Bus' : 'Pro'}</span>
+            </>
+          ) : (
+            <>
+              <span className="hidden md:inline">Upgrade</span>
+              <span className="md:hidden">+</span>
+            </>
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/main-header/index.tsx
+++ b/apps/web/src/components/layout/main-header/index.tsx
@@ -11,7 +11,7 @@ import InlineSearch from "@/components/search/InlineSearch";
 import GlobalSearch from "@/components/search/GlobalSearch";
 import UserDropdown from "@/components/shared/UserDropdown";
 import RecentsDropdown from "@/components/shared/RecentsDropdown";
-import { CreditBalance } from "@/components/billing/CreditBalance";
+import { AiBalanceWidget } from "@/components/billing/AiBalanceWidget";
 import NavButtons from "./NavButtons";
 
 interface TopBarProps {
@@ -75,7 +75,7 @@ export default function TopBar({ onToggleLeftPanel, onToggleRightPanel }: TopBar
         </div>
 
         <div className="flex flex-shrink-0 items-center gap-2">
-          <CreditBalance />
+          <AiBalanceWidget />
 
           <VerifyEmailButton />
 

--- a/apps/web/src/hooks/useCreditBalance.ts
+++ b/apps/web/src/hooks/useCreditBalance.ts
@@ -22,6 +22,12 @@ export interface CreditBalance {
   };
   spendable: number;
   reserved: number;
+  /**
+   * Per-environment switch: true → show the new credits UI; false → show the legacy
+   * daily-quota UI. Constant for the process, so it's preserved across `credits:updated`
+   * socket pushes (whose payload carries only the per-user balance, not the mode).
+   */
+  creditsMode: boolean;
 }
 
 const fetcher = async (url: string): Promise<CreditBalance> => {
@@ -66,13 +72,17 @@ export function useCreditBalance() {
 
     const handleCreditsUpdated = (payload: CreditsEventPayload) => {
       mutate(
-        {
+        (current) => ({
           billingEnabled: payload.billingEnabled,
           monthly: payload.monthly,
           topup: payload.topup,
           spendable: payload.spendable,
           reserved: payload.reserved,
-        },
+          // Mode is environment-level (not in the socket payload) — keep the value the
+          // initial fetch established; default OFF until it resolves. The revalidate
+          // below re-reads it authoritatively from /api/credits regardless.
+          creditsMode: current?.creditsMode ?? false,
+        }),
         { revalidate: true },
       );
     };

--- a/apps/web/src/hooks/useCreditsMode.ts
+++ b/apps/web/src/hooks/useCreditsMode.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useCreditBalance } from '@/hooks/useCreditBalance';
+
+/**
+ * The per-environment credits switch, delivered to the client at runtime via the
+ * `/api/credits` payload (`creditsMode`). When true the app shows the new credits UI +
+ * enforcement; when false it shows the legacy daily-quota UI. Reuses the SWR-deduped
+ * `useCreditBalance` fetch, so adding this hook costs no extra request.
+ *
+ * Defaults to **false (legacy)** until the fetch resolves so a slow/failed `/api/credits`
+ * never flashes a credits UI that prod (dark-launch) shouldn't show.
+ */
+export function useCreditsMode(): boolean {
+  const { balance } = useCreditBalance();
+  return balance?.creditsMode ?? false;
+}

--- a/apps/web/src/lib/ai/shared/__tests__/error-messages.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/error-messages.test.ts
@@ -25,6 +25,18 @@ describe('classifyAIError', () => {
     expect(classifyAIError('Too many AI requests in flight at once.')).toBe('too_many_in_flight');
   });
 
+  it('classifies the legacy daily-quota 429 (credits mode OFF) as daily_quota', () => {
+    // createRateLimitResponse's body message (the dark-launch / OFF path).
+    expect(
+      classifyAIError('Standard AI calls limited to 50 per day. Upgrade to Pro (200/day) or Business.'),
+    ).toBe('daily_quota');
+    expect(
+      classifyAIError('Pro AI calls limited to 50 per day. Upgrade to Pro or Business for more access.'),
+    ).toBe('daily_quota');
+    // Must win over the generic rate-limit patterns even when the body also says 429.
+    expect(classifyAIError('429: Standard AI calls limited to 50 per day.')).toBe('daily_quota');
+  });
+
   it('classifies provider rate limits / transient failures', () => {
     expect(classifyAIError('rate limit exceeded')).toBe('rate_limit');
     expect(classifyAIError('Provider returned error')).toBe('rate_limit');
@@ -43,6 +55,7 @@ describe('getAIErrorMessage', () => {
     expect(getAIErrorMessage('too_many_in_flight')).toMatch(/wait/i);
     expect(getAIErrorMessage('401')).toMatch(/authentication/i);
     expect(getAIErrorMessage('rate limit')).toMatch(/busy|try again/i);
+    expect(getAIErrorMessage('Standard AI calls limited to 50 per day.')).toMatch(/limit|upgrade|resets/i);
     expect(getAIErrorMessage(undefined)).toMatch(/something went wrong/i);
   });
 
@@ -71,6 +84,7 @@ describe('predicate helpers', () => {
     expect(isRateLimitError('rate limit')).toBe(true);
     expect(isRateLimitError('out_of_credits')).toBe(true);
     expect(isRateLimitError('too_many_in_flight')).toBe(true);
+    expect(isRateLimitError('Standard AI calls limited to 50 per day.')).toBe(true);
     expect(isRateLimitError('boom')).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/shared/error-messages.ts
+++ b/apps/web/src/lib/ai/shared/error-messages.ts
@@ -9,12 +9,18 @@
  *                                  in-flight call to finish, then retry.
  * The thrown client error carries the status code and the JSON error body, so we
  * branch on those tokens to show the right copy and the right call to action.
+ *
+ * When the per-environment credits switch is OFF, the AI routes instead return the
+ * LEGACY daily-quota 429 (`createRateLimitResponse` — "… AI calls limited to N per
+ * day. Upgrade …"). That's classified as `daily_quota` so it shows an upgrade prompt
+ * rather than the generic "service is busy" copy. Remove at the final credits cutover.
  */
 
 export type AIErrorKind =
   | 'auth'
   | 'out_of_credits'
   | 'too_many_in_flight'
+  | 'daily_quota'
   | 'rate_limit'
   | 'generic';
 
@@ -24,6 +30,10 @@ export type AIErrorKind =
 // alone would route any message merely mentioning credits to the buy-more CTA.
 const OUT_OF_CREDITS_PATTERNS = [/\bout_of_credits\b/, /\b402\b/, /\bout of ai credits\b/];
 const IN_FLIGHT_PATTERNS = [/\btoo_many_in_flight\b/, /\bin[-\s]flight\b/];
+// LEGACY daily-quota 429 (credits mode OFF) — createRateLimitResponse's phrasing.
+// Checked before the generic rate-limit patterns since that body also says "429"/"rate
+// limit". Remove at the final credits cutover.
+const DAILY_QUOTA_PATTERNS = [/\bai calls limited to\b/, /\bcalls? (?:per day|\/day)\b/];
 const RATE_LIMIT_PATTERNS = [
   /\brate limit\b/,
   /\btoo many requests\b/,
@@ -45,6 +55,10 @@ export function classifyAIError(errorMessage: string | undefined): AIErrorKind {
   // Free-tier in-flight concurrency cap (429, distinct error code).
   if (IN_FLIGHT_PATTERNS.some((p) => p.test(msg))) return 'too_many_in_flight';
 
+  // Legacy daily-quota cap (429) — checked before generic rate limits, which it'd
+  // otherwise match (its body also contains "429"/"rate limit").
+  if (DAILY_QUOTA_PATTERNS.some((p) => p.test(msg))) return 'daily_quota';
+
   // Provider/transport rate limits and transient failures.
   if (RATE_LIMIT_PATTERNS.some((p) => p.test(msg))) return 'rate_limit';
 
@@ -62,6 +76,8 @@ export function getAIErrorMessage(errorMessage: string | undefined): string {
       return "You've used up your AI credits. Buy more credits or wait for your monthly allowance to reset.";
     case 'too_many_in_flight':
       return 'Too many AI requests are running at once. Wait for one to finish, then try again.';
+    case 'daily_quota':
+      return "You've hit today's AI call limit. It resets tomorrow — or upgrade your plan for more.";
     case 'rate_limit':
       return 'The AI service is busy right now. Please try again in a few seconds.';
     default:
@@ -97,5 +113,10 @@ export function isInFlightCapError(errorMessage: string | undefined): boolean {
  */
 export function isRateLimitError(errorMessage: string | undefined): boolean {
   const kind = classifyAIError(errorMessage);
-  return kind === 'rate_limit' || kind === 'out_of_credits' || kind === 'too_many_in_flight';
+  return (
+    kind === 'rate_limit' ||
+    kind === 'out_of_credits' ||
+    kind === 'too_many_in_flight' ||
+    kind === 'daily_quota'
+  );
 }

--- a/apps/web/src/lib/subscription/plans.ts
+++ b/apps/web/src/lib/subscription/plans.ts
@@ -42,6 +42,13 @@ export interface PlanDefinition {
      * to standard models (model-tier gating is kept); paid tiers get standard + Pro.
      */
     proModels: boolean;
+    /**
+     * LEGACY per-day call limits, shown only when the credits switch is OFF
+     * (`creditsMode === false`) so prod keeps the old "N calls/day" plan copy during
+     * dark launch. Remove at the final credits cutover.
+     */
+    aiCalls: number;
+    proCalls: number;
     storage: {
       bytes: number;
       formatted: string;
@@ -79,6 +86,8 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
     limits: {
       monthlyCreditsCents: MONTHLY_CREDIT_CENTS.free,
       proModels: false,
+      aiCalls: 50,
+      proCalls: 0,
       storage: {
         bytes: 500 * 1024 * 1024, // 500MB
         formatted: '500MB',
@@ -125,6 +134,8 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
     limits: {
       monthlyCreditsCents: MONTHLY_CREDIT_CENTS.pro,
       proModels: true,
+      aiCalls: 200,
+      proCalls: 50,
       storage: {
         bytes: 2 * 1024 * 1024 * 1024, // 2GB
         formatted: '2GB',
@@ -168,6 +179,8 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
     limits: {
       monthlyCreditsCents: MONTHLY_CREDIT_CENTS.founder,
       proModels: true,
+      aiCalls: 500,
+      proCalls: 100,
       storage: {
         bytes: 10 * 1024 * 1024 * 1024, // 10GB
         formatted: '10GB',
@@ -206,6 +219,8 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
     limits: {
       monthlyCreditsCents: MONTHLY_CREDIT_CENTS.business,
       proModels: true,
+      aiCalls: 1000,
+      proCalls: 500,
       storage: {
         bytes: 50 * 1024 * 1024 * 1024, // 50GB
         formatted: '50GB',

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -42,6 +42,19 @@ export function isCreditsEnforcementEnabled(): boolean {
   return envBool('CREDITS_ENFORCEMENT_ENABLED', false);
 }
 
+/**
+ * The ONE per-environment switch that selects the whole AI-usage experience, aliasing
+ * the enforcement flag so the same image runs two ways by env alone:
+ *   ON  → credits UI + credits enforcement (the new prepaid model).
+ *   OFF → legacy daily-quota UI + the old per-call daily-limit path (prod stays "the old
+ *         way"); credit metering still runs in the background for observability.
+ * Drives: the AI-route limiter choice, the navbar widget, settings copy, and error copy.
+ * Same env flag as enforcement on purpose — one lever flips presentation AND behaviour.
+ */
+export function isCreditsModeEnabled(): boolean {
+  return isCreditsEnforcementEnabled();
+}
+
 /** Markup applied to real provider cost, in basis points. 15000 = 1.5×. */
 export const MARKUP_BPS = envInt('CREDIT_MARKUP_BPS', 15000);
 


### PR DESCRIPTION
## Why

Gets the **per-environment credits feature flag** onto `master` so we can deploy the credits UX dark and flip it on per environment (Fly ON to verify, VPS OFF to keep prod on the old quota UX). The gate kill-switch (`CREDITS_ENFORCEMENT_ENABLED`) already shipped via #1484; this adds the **presentation/behaviour switch** that was developed on `pu/credits-remediation` after #1484 merged (originally PR #1507).

This is **#1507 (`e8f64c95e`) cherry-picked onto the latest master** — not a re-merge of `pu/credits-remediation` (which #1484 already squash-merged; re-merging it would re-apply already-merged content). The cherry-pick conflicted on exactly one file (`useCreditBalance.ts`, resolved to keep #1508's `{ revalidate: true }` out-of-order fix **and** the new `creditsMode` field).

## What it does

One env flag selects the whole AI-usage experience from the same image:
- **OFF (prod default)** → legacy daily-quota UX: `UsageCounter` navbar widget, "calls/day" plan/settings copy, real daily-limit 429s. Credit metering still runs in the background.
- **ON (a Fly test deploy)** → credits UI + enforcement; daily limits off.

Surfaces (all gated on `isCreditsModeEnabled()`, the runtime alias of the env flag):
- `AiBalanceWidget` picks `CreditBalance` (ON) vs restored `UsageCounter` (OFF); restored `GET /api/subscriptions/usage`; `/api/credits` carries `creditsMode`; `useCreditsMode` hook (defaults OFF until loaded).
- AI routes (chat + global messages) re-add the legacy daily-limit path under `!isCreditsModeEnabled()`; credit gate/metering stay unconditional.
- `settings/plan` + `settings/billing` copy gated; `plans.ts` carries legacy `aiCalls`/`proCalls`; `error-messages` classifies the legacy daily 429 as `daily_quota`.
- **Marketing transition** (`CREDITS_IN_TRANSITION` constant): "AI credits pricing is rolling out" banner on `/pricing`, an FAQ entry, and a Terms §11.3 note — flip the constant off at full cutover.
- Fixes the unreadable credit-balance tooltip (muted text on the primary tooltip bg).

All legacy/transition sites are tagged (`// LEGACY:` / `// TRANSITION:`) for cleanup at the final cutover.

## Validation
- `@pagespace/db` + `@pagespace/lib` build; **lib + web + marketing typecheck** clean.
- **526** billing/monitoring tests + **461** web AI/credits/subscription tests pass (both credits-mode ON and OFF covered).
- No DB migration (the dark-launch UI uses `aiUsageLogs.metadata`; credits schema `0146` already on master via #1484).

## Deploy note
Default is **OFF** — merging + deploying does not change prod behaviour. Set `CREDITS_ENFORCEMENT_ENABLED=true` on an environment to turn the credits experience on there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)