### PR TITLE
refactor(storage): review-hardening follow-ups to #1515

### DIFF
--- a/apps/web/src/lib/storage/__tests__/reap-orphaned-files.test.ts
+++ b/apps/web/src/lib/storage/__tests__/reap-orphaned-files.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const {
+  mockFindOrphans,
+  mockDeleteRecords,
+  mockCreateSystemFileDeleteToken,
+  mockUpdateStorageUsage,
+} = vi.hoisted(() => ({
+  mockFindOrphans: vi.fn(),
+  mockDeleteRecords: vi.fn(),
+  mockCreateSystemFileDeleteToken: vi.fn(),
+  mockUpdateStorageUsage: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/compliance/file-cleanup/orphan-detector', () => ({
+  findOrphanedFileRecords: mockFindOrphans,
+  deleteFileRecords: mockDeleteRecords,
+}));
+
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+  createSystemFileDeleteToken: mockCreateSystemFileDeleteToken,
+}));
+
+vi.mock('@pagespace/lib/services/storage-limits', () => ({
+  updateStorageUsage: mockUpdateStorageUsage,
+}));
+
+import { reapOrphanedFiles } from '../reap-orphaned-files';
+
+const db = {} as never;
+
+const orphan = (overrides: Partial<{ id: string; storagePath: string; driveId: string | null; sizeBytes: number; createdBy: string | null }> = {}) => ({
+  id: overrides.id ?? 'f1',
+  storagePath: overrides.storagePath ?? '/storage/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/original',
+  driveId: 'driveId' in overrides ? overrides.driveId ?? null : 'd1',
+  sizeBytes: overrides.sizeBytes ?? 1024,
+  createdBy: 'createdBy' in overrides ? overrides.createdBy ?? null : 'u1',
+});
+
+describe('reapOrphanedFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindOrphans.mockResolvedValue([]);
+    mockDeleteRecords.mockResolvedValue([]);
+    mockCreateSystemFileDeleteToken.mockResolvedValue({ token: 'sys-tok' });
+    mockUpdateStorageUsage.mockResolvedValue(undefined);
+  });
+
+  it('forwards an explicit fileIds list to findOrphanedFileRecords (scoped reap)', async () => {
+    await reapOrphanedFiles(db, { fileIds: ['a', 'b'] });
+    expect(mockFindOrphans).toHaveBeenCalledWith(db, ['a', 'b']);
+  });
+
+  it('passes undefined to findOrphanedFileRecords when no options (global sweep)', async () => {
+    await reapOrphanedFiles(db);
+    expect(mockFindOrphans).toHaveBeenCalledWith(db, undefined);
+  });
+
+  it('does no processor work and returns zeros when no orphans are found', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await reapOrphanedFiles(db, { fileIds: ['none'] });
+
+    expect(result).toEqual({ orphansFound: 0, physicalFilesDeleted: 0, dbRecordsDeleted: 0, failedPhysicalDeletes: [] });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockDeleteRecords).not.toHaveBeenCalled();
+    expect(mockUpdateStorageUsage).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('credits the uploader only for rows this call actually deleted (race-safe)', async () => {
+    mockFindOrphans.mockResolvedValue([orphan({ id: 'f1', sizeBytes: 2048, createdBy: 'u1' })]);
+    mockDeleteRecords.mockResolvedValue(['f1']);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+
+    const result = await reapOrphanedFiles(db, { fileIds: ['f1'] });
+
+    expect(mockUpdateStorageUsage).toHaveBeenCalledWith('u1', -2048, expect.objectContaining({ eventType: 'delete' }));
+    expect(result.physicalFilesDeleted).toBe(1);
+    expect(result.dbRecordsDeleted).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does NOT credit when the row was deleted by a racing reap (not in this call\'s deleted set)', async () => {
+    mockFindOrphans.mockResolvedValue([orphan({ id: 'f1' })]);
+    // Physical delete succeeded, but another reap already removed the DB row,
+    // so deleteFileRecords returns it as NOT deleted by this call.
+    mockDeleteRecords.mockResolvedValue([]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 200 })));
+
+    await reapOrphanedFiles(db, { fileIds: ['f1'] });
+
+    expect(mockUpdateStorageUsage).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does not credit when the physical delete fails (row left for retry)', async () => {
+    mockFindOrphans.mockResolvedValue([orphan({ id: 'f1' })]);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('boom', { status: 500 })));
+
+    const result = await reapOrphanedFiles(db);
+
+    expect(mockUpdateStorageUsage).not.toHaveBeenCalled();
+    expect(mockDeleteRecords).not.toHaveBeenCalled();
+    expect(result.failedPhysicalDeletes).toEqual(['f1']);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
@@ -1,4 +1,4 @@
-import { eq, sql, inArray } from 'drizzle-orm';
+import { sql, inArray } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { files } from '@pagespace/db/schema/storage';
 
@@ -42,7 +42,7 @@ export async function findOrphanedFileRecords(
   if (restrictToFileIds && restrictToFileIds.length === 0) return [];
 
   const idFilter = restrictToFileIds
-    ? sql` AND f.id = ANY(${restrictToFileIds})`
+    ? sql` AND f.id = ANY(${restrictToFileIds}::text[])`
     : sql``;
 
   const result = await database.execute(sql`

--- a/packages/lib/src/services/subscription-utils.ts
+++ b/packages/lib/src/services/subscription-utils.ts
@@ -82,10 +82,12 @@ export function getStorageTierFromSubscription(subscriptionTier: SubscriptionTie
 }
 
 /**
- * Get storage quota in bytes from subscription tier
+ * Get storage quota in bytes from subscription tier.
+ * Delegates to getStorageConfigFromSubscription so the on-prem/tenant override
+ * is honored consistently (otherwise these two could disagree for on-prem).
  */
 export function getStorageQuotaFromSubscription(subscriptionTier: SubscriptionTier): number {
-  return STORAGE_TIERS[getStorageTierFromSubscription(subscriptionTier)].quotaBytes;
+  return getStorageConfigFromSubscription(subscriptionTier).quotaBytes;
 }
 
 /**


### PR DESCRIPTION
Small follow-ups to #1515 (storage limit unification + permanent-delete reclaim), which merged at `f1e7f401e`. These are proactive self-review improvements that landed on the branch just after the squash-merge, so they didn't make it into master. No behavior change to the happy paths.

## Changes
- **orphan-detector**: drop the now-unused `eq` import; make the scoped filter's array param type explicit as `f.id = ANY(${ids}::text[])` instead of relying on Postgres inference (it's the only such `ANY(${jsArray})` usage in the repo).
- **subscription-utils**: `getStorageQuotaFromSubscription` now delegates to `getStorageConfigFromSubscription` so the on-prem/tenant business-tier override is honored consistently. The two previously disagreed for on-prem; the function currently has no live callers, so this closes a latent trap before anyone wires it up.
- **tests**: direct unit tests for `reapOrphanedFiles` (previously only exercised via the cron route) — covers `fileIds` forwarding (scoped vs global sweep), the no-orphans early return, and race-safe crediting (credit only rows this call deleted; none when a racing reap won or the physical delete failed).

## Validation
- `@pagespace/lib`: 118 storage/orphan/subscription/upload tests pass; typecheck + lint clean.
- `web`: reap-helper (6) + cron route (10) tests pass; typecheck clean.

## Context
Confirmed during review (not a bug, no change needed): `files.id === storagePath === contentHash` (upload/complete sets `id: contentHash`), so the processor's `eq(files.id, contentHash)` lookup + `isFileOrphaned(contentHash)` resolve correctly and physical reaping works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)