### PR TITLE
fix(chat): make DM/channel image viewer fill the window

### DIFF
--- a/apps/web/src/components/shared/MessageAttachment.tsx
+++ b/apps/web/src/components/shared/MessageAttachment.tsx
@@ -152,12 +152,11 @@ function ZoomableImage({ src, alt }: { src: string; alt: string }) {
   const isZoomed = view.zoom > 1;
 
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div className="flex h-full flex-col items-center gap-2">
       <div
         ref={containerRef}
-        className="overflow-hidden flex items-center justify-center w-full"
+        className="overflow-hidden flex items-center justify-center w-full flex-1 min-h-0"
         style={{
-          maxHeight: '78vh',
           cursor: isZoomed ? (dragging ? 'grabbing' : 'grab') : 'zoom-in',
         }}
         onWheel={handleWheel}
@@ -180,7 +179,7 @@ function ZoomableImage({ src, alt }: { src: string; alt: string }) {
             transformOrigin: 'center',
             transition: dragging ? 'none' : 'transform 0.1s ease-out',
             maxWidth: '100%',
-            maxHeight: '78vh',
+            maxHeight: '100%',
             objectFit: 'contain',
             userSelect: 'none',
             pointerEvents: 'none',
@@ -235,7 +234,7 @@ export function MessageAttachment({ message }: MessageAttachmentProps) {
         </button>
 
         <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-          <DialogContent className="max-w-[92vw] max-h-[92vh] p-4 flex flex-col gap-0">
+          <DialogContent className="w-[92vw] max-w-[92vw] sm:max-w-[92vw] h-[90vh] max-h-[90vh] p-4 flex flex-col gap-0">
             <DialogTitle className="sr-only">Image preview</DialogTitle>
             <ZoomableImage src={`/api/files/${fileId}/view`} alt={name} />
           </DialogContent>

--- a/apps/web/src/components/shared/MessageAttachment.tsx
+++ b/apps/web/src/components/shared/MessageAttachment.tsx
@@ -234,7 +234,9 @@ export function MessageAttachment({ message }: MessageAttachmentProps) {
         </button>
 
         <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-          <DialogContent className="w-[92vw] max-w-[92vw] sm:max-w-[92vw] h-[90vh] max-h-[90vh] p-4 flex flex-col gap-0">
+          {/* sm:max-w-[92vw] overrides shadcn DialogContent's default sm:max-w-lg (~512px),
+              which would otherwise clamp the viewer to a tiny window on desktop. */}
+          <DialogContent className="w-[92vw] sm:max-w-[92vw] h-[90vh] p-4 flex flex-col gap-0">
             <DialogTitle className="sr-only">Image preview</DialogTitle>
             <ZoomableImage src={`/api/files/${fileId}/view`} alt={name} />
           </DialogContent>


### PR DESCRIPTION
## Problem

Opening an image attachment in a channel/DM pops it into a preview modal with a `− 100% +` zoom stepper, but the **window itself was tiny** (~512px wide on any desktop) — so zooming the image inside had nowhere to go.

## Root cause

shadcn's default `DialogContent` class string ends with `sm:max-w-lg` (≈512px). `MessageAttachment` overrode it with a *base* utility `max-w-[92vw]`. Because base and `sm:` are different breakpoint variants, `tailwind-merge` keeps **both**, and on any screen ≥640px the `sm:` rule wins — clamping the viewer to ~512px regardless of the intended 92vw. Height was also content-driven (image capped at `78vh`, dialog shrink-wrapped it), so non-tall images yielded a small box.

## Fix

`apps/web/src/components/shared/MessageAttachment.tsx`:

- **`DialogContent`** → `w-[92vw] sm:max-w-[92vw] h-[90vh] p-4 flex flex-col gap-0`. The load-bearing override is `sm:max-w-[92vw]`, which defeats the inherited `sm:max-w-lg` clamp; `w-[92vw]` + `h-[90vh]` make it a large fixed window instead of shrink-wrapping the image. (Commented inline so the intent survives future edits.)
- **`ZoomableImage`** fills the dialog height (`h-full` + image container `flex-1 min-h-0`); image bounded by its container (`maxHeight: 100%`) instead of `78vh`, so it's centered and as large as possible.

## Not changed
- Zoom math, pan/drag, pinch, and wheel handlers — preserved; the problem was the window frame, not the zoom logic.
- The shared `components/ui/dialog.tsx` primitive — fix is local to the one consumer to avoid regressions in every other dialog.
- Inline thumbnail, video/file attachment branches.

## Validation
- `bun run --filter 'web' typecheck` → exit 0.
- `bun run --filter 'web' lint` → no new errors/warnings on the touched file (pre-existing video-branch `media-has-caption` warning is on `master`, out of scope).
- Manual: open an image attachment in a channel/DM — viewer now fills ~92vw × 90vh; small images centered in the large window; `+/−`, double-click reset, wheel-zoom, drag-to-pan still work. Re-checked at ≥640px width (where the old clamp triggered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)