### PR TITLE
feat(billing): e2e metering coverage + close pulse-cron metering bypass

### DIFF
--- a/apps/e2e/README.metering.md
+++ b/apps/e2e/README.metering.md
@@ -1,0 +1,51 @@
+# Metering & billing e2e
+
+End-to-end coverage that **metering cannot be bypassed** and that **billing works** —
+exercised against the real Next.js app, real Postgres, and the real credit pipeline, with
+only the model provider and Stripe (webhook side) faked.
+
+## What it covers
+
+| Spec | Proves |
+|------|--------|
+| `09-metering-no-bypass.spec.ts` | With enforcement ON, an out-of-credits user is refused at **every** AI entry point (chat, global chat, page-agent consult, voice synthesize, pulse generate, MCP `/v1/chat/completions`, **pulse cron**) → 402 and **no usage/billing row**. For OpenRouter-backed routes it also asserts the mock model was **never hit**. |
+| `10-metering-billing.spec.ts` | A funded chat call hits the model once and debits **exactly `cost × 1.5`** (mock returns 2¢ → 3¢ charged); a usage ledger row is written and the in-flight hold settles. |
+| `11-metering-limits.spec.ts` | `402 out_of_credits` at the reserve floor; `429 too_many_in_flight` at the free-tier concurrency cap. |
+| `12-token-packs.spec.ts` | Credit-pack checkout validation (400s) and the funding webhook: a paid `checkout.session.completed` (`metadata.kind=credit_pack`) credits the never-expiring top-up bucket **exactly once** (idempotent on event id). |
+
+Meter-only mode (`CREDITS_ENFORCEMENT_ENABLED=false`) and the cost-extraction/settlement
+math are covered by unit tests in `packages/lib/src/billing/__tests__/` — they aren't
+re-run here because the flag is read in the app process and is fixed at app launch.
+
+## Running
+
+1. Start the **web app** with this env (the mock server is started for you by Playwright on :4998):
+
+   ```
+   DATABASE_URL=postgres://…@localhost:5432/…   # local DB only — seeders refuse non-local hosts
+   CREDITS_ENFORCEMENT_ENABLED=true             # enforcement is OFF by default — turn it ON for this run
+   OPENROUTER_DEFAULT_API_KEY=sk-e2e            # any non-empty value; enables the openrouter branch
+   OPENROUTER_BASE_URL=http://127.0.0.1:4998/api/v1
+   WEB_APP_URL=http://localhost:3000
+   CRON_SECRET=<shared>
+   STRIPE_WEBHOOK_SECRET=<shared>
+   CSRF_SECRET=<shared>
+   ```
+
+   `CRON_SECRET`, `STRIPE_WEBHOOK_SECRET`, and `CSRF_SECRET` must be the **same** values the
+   Playwright process sees (both load `.env`), so the test can forge valid signatures/tokens.
+
+2. Run the suite:
+
+   ```
+   bun run --filter '@pagespace/e2e' test:e2e -- tests/09-metering-no-bypass.spec.ts \
+     tests/10-metering-billing.spec.ts tests/11-metering-limits.spec.ts tests/12-token-packs.spec.ts
+   ```
+
+## How the model is faked
+
+`support/mock-openrouter.ts` is an OpenAI/OpenRouter-compatible `/chat/completions` stub
+that returns a deterministic completion carrying `usage.cost` (the value PageSpace bills
+on). Users are seeded with `currentAiProvider='openrouter'` so their calls route to it via
+the `OPENROUTER_BASE_URL` override added in `provider-factory.ts`. The stub records hits
+(`GET /__calls`, `POST /__reset`) so a test can prove a blocked request never reached it.

--- a/apps/e2e/README.metering.md
+++ b/apps/e2e/README.metering.md
@@ -21,7 +21,7 @@ re-run here because the flag is read in the app process and is fixed at app laun
 
 1. Start the **web app** with this env (the mock server is started for you by Playwright on :4998):
 
-   ```
+   ```bash
    DATABASE_URL=postgres://…@localhost:5432/…   # local DB only — seeders refuse non-local hosts
    CREDITS_ENFORCEMENT_ENABLED=true             # enforcement is OFF by default — turn it ON for this run
    OPENROUTER_DEFAULT_API_KEY=sk-e2e            # any non-empty value; enables the openrouter branch
@@ -37,7 +37,7 @@ re-run here because the flag is read in the app process and is fixed at app laun
 
 2. Run the suite:
 
-   ```
+   ```bash
    bun run --filter '@pagespace/e2e' test:e2e -- tests/09-metering-no-bypass.spec.ts \
      tests/10-metering-billing.spec.ts tests/11-metering-limits.spec.ts tests/12-token-packs.spec.ts
    ```

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const baseURL = process.env.E2E_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const mockPort = Number(process.env.E2E_MOCK_OPENROUTER_PORT ?? 4998);
 
 export default defineConfig({
   testDir: './tests',
@@ -12,6 +13,19 @@ export default defineConfig({
   use: {
     baseURL,
     trace: 'on-first-retry',
+  },
+  // The metering specs need the web app to be running with its AI provider pointed at
+  // the mock below. Start the app separately with (at least):
+  //   CREDITS_ENFORCEMENT_ENABLED=true (OFF by default — the enforcement specs need it ON)
+  //   OPENROUTER_DEFAULT_API_KEY=sk-e2e
+  //   OPENROUTER_BASE_URL=http://127.0.0.1:4998/api/v1
+  //   CRON_SECRET / STRIPE_WEBHOOK_SECRET / CSRF_SECRET shared with this process's env
+  // See apps/e2e/README.metering.md.
+  webServer: {
+    command: 'bun run support/mock-server-main.ts',
+    url: `http://127.0.0.1:${mockPort}/__health`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
   },
   globalSetup: './global-setup.ts',
   globalTeardown: './global-teardown.ts',

--- a/apps/e2e/support/db.ts
+++ b/apps/e2e/support/db.ts
@@ -1,0 +1,153 @@
+import { randomBytes } from 'crypto';
+import { factories } from '@pagespace/db/test/factories';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { creditBalances, creditLedger, creditHolds } from '@pagespace/db/schema/credits';
+import { mcpTokens } from '@pagespace/db/schema/auth';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { sessionService } from '../../../packages/lib/src/auth/session-service';
+import { generateCSRFToken } from '../../../packages/lib/src/auth/csrf-utils';
+import { hashToken } from '../../../packages/lib/src/auth/token-utils';
+
+export type Tier = 'free' | 'pro' | 'founder' | 'business';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface SeededUser {
+  userId: string;
+  driveId: string;
+  /** Raw opaque session token to put in the `session` cookie. */
+  sessionToken: string;
+  /** Valid X-CSRF-Token header value bound to the session. */
+  csrf: string;
+}
+
+export interface SeedOptions {
+  tier?: Tier;
+  /** AI provider for this user. Defaults to 'openrouter' so calls hit the mock stub. */
+  provider?: string;
+  model?: string;
+  monthlyRemainingCents?: number;
+  monthlyAllowanceCents?: number;
+  topupRemainingCents?: number;
+  /** How far in the future the monthly window ends. Default +30d (active window). */
+  monthlyWindowDays?: number;
+}
+
+/**
+ * Create a fully provisioned user: row + owned drive + credit balance + a live session
+ * (with matching CSRF token). Provider defaults to 'openrouter' so any AI call this user
+ * makes is served by the mock stub.
+ */
+export async function seedUser(opts: SeedOptions = {}): Promise<SeededUser> {
+  const tier = opts.tier ?? 'pro';
+  const user = await factories.createUser({
+    subscriptionTier: tier,
+    currentAiProvider: opts.provider ?? 'openrouter',
+    currentAiModel: opts.model ?? 'e2e/stub-model',
+  });
+  const drive = await factories.createDrive(user.id);
+
+  await setBalance(user.id, {
+    monthlyRemainingCents: opts.monthlyRemainingCents ?? 10_000,
+    monthlyAllowanceCents: opts.monthlyAllowanceCents ?? 10_000,
+    topupRemainingCents: opts.topupRemainingCents ?? 0,
+    monthlyWindowDays: opts.monthlyWindowDays ?? 30,
+  });
+
+  const sessionToken = await sessionService.createSession({
+    userId: user.id,
+    type: 'user',
+    scopes: [],
+    expiresInMs: 7 * DAY_MS,
+  });
+  const claims = await sessionService.validateSession(sessionToken);
+  if (!claims) throw new Error('seedUser: session did not validate');
+  const csrf = generateCSRFToken(claims.sessionId);
+
+  return { userId: user.id, driveId: drive.id, sessionToken, csrf };
+}
+
+export async function setBalance(
+  userId: string,
+  b: {
+    monthlyRemainingCents: number;
+    monthlyAllowanceCents: number;
+    topupRemainingCents: number;
+    monthlyWindowDays?: number;
+  },
+): Promise<void> {
+  const now = Date.now();
+  const windowMs = (b.monthlyWindowDays ?? 30) * DAY_MS;
+  const row = {
+    userId,
+    monthlyRemainingCents: b.monthlyRemainingCents,
+    monthlyAllowanceCents: b.monthlyAllowanceCents,
+    topupRemainingCents: b.topupRemainingCents,
+    pendingMillicents: 0,
+    monthlyPeriodStart: new Date(now - DAY_MS),
+    monthlyPeriodEnd: new Date(now + windowMs),
+    updatedAt: new Date(now),
+  };
+  await db
+    .insert(creditBalances)
+    .values(row)
+    .onConflictDoUpdate({ target: creditBalances.userId, set: row });
+}
+
+export async function getBalance(userId: string) {
+  const [row] = await db
+    .select()
+    .from(creditBalances)
+    .where(eq(creditBalances.userId, userId));
+  return row ?? null;
+}
+
+export async function getLedger(userId: string, entryType?: string) {
+  const rows = await db.select().from(creditLedger).where(eq(creditLedger.userId, userId));
+  return entryType ? rows.filter((r) => r.entryType === entryType) : rows;
+}
+
+export async function getHolds(userId: string) {
+  return db.select().from(creditHolds).where(eq(creditHolds.userId, userId));
+}
+
+/** Pre-seed N active (non-expired) holds to simulate concurrent in-flight calls. */
+export async function seedHolds(userId: string, count: number, estCents = 25): Promise<void> {
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+  for (let i = 0; i < count; i++) {
+    await db.insert(creditHolds).values({ userId, estCents, expiresAt });
+  }
+}
+
+/**
+ * Create an AI_CHAT page in the given drive and grant the user view+edit on it, so the
+ * route's permission check passes and we reach the credit gate (chatId/agentId/pageId).
+ */
+export async function createAgentPage(driveId: string, userId: string): Promise<string> {
+  const page = await factories.createPage(driveId, { type: 'AI_CHAT' });
+  await factories.createPagePermission(page.id, userId, { canView: true, canEdit: true });
+  return page.id;
+}
+
+/** Create a global conversation owned by the user (for /api/ai/global/[id]/messages). */
+export async function createGlobalConversation(userId: string): Promise<string> {
+  const [row] = await db
+    .insert(conversations)
+    .values({ userId, type: 'global', title: 'e2e' })
+    .returning();
+  return row.id;
+}
+
+/** Insert an MCP bearer token for the user; returns the raw `mcp_...` token. */
+export async function createMcpToken(userId: string): Promise<string> {
+  const raw = `mcp_${randomBytes(24).toString('hex')}`;
+  await db.insert(mcpTokens).values({
+    userId,
+    tokenHash: hashToken(raw),
+    tokenPrefix: raw.slice(0, 12),
+    name: 'e2e',
+    isScoped: false,
+  });
+  return raw;
+}

--- a/apps/e2e/support/http.ts
+++ b/apps/e2e/support/http.ts
@@ -1,0 +1,58 @@
+import type { APIRequestContext, APIResponse } from '@playwright/test';
+import type { SeededUser } from './db';
+
+const MOCK_BASE = process.env.E2E_MOCK_OPENROUTER_URL ?? 'http://127.0.0.1:4998';
+
+/**
+ * POST as a session-authenticated user: sends the opaque session cookie plus the
+ * matching X-CSRF-Token header. No Origin header — `validateOrigin` allows a missing
+ * Origin (same-origin / non-browser clients), so this satisfies the CSRF gate.
+ */
+export function sessionPost(
+  request: APIRequestContext,
+  path: string,
+  user: SeededUser,
+  body?: unknown,
+  extraHeaders: Record<string, string> = {},
+): Promise<APIResponse> {
+  return request.post(path, {
+    headers: {
+      cookie: `session=${user.sessionToken}`,
+      'x-csrf-token': user.csrf,
+      'content-type': 'application/json',
+      ...extraHeaders,
+    },
+    data: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+/**
+ * POST with an MCP bearer token. Bearer auth is exempt from CSRF/origin checks, so this
+ * is the clean way to drive routes that accept `allow: ['session', 'mcp']`.
+ */
+export function mcpPost(
+  request: APIRequestContext,
+  path: string,
+  mcpToken: string,
+  body?: unknown,
+): Promise<APIResponse> {
+  return request.post(path, {
+    headers: {
+      authorization: `Bearer ${mcpToken}`,
+      'content-type': 'application/json',
+    },
+    data: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+/** Reset the mock OpenRouter call recorder. */
+export async function resetMock(request: APIRequestContext): Promise<void> {
+  await request.post(`${MOCK_BASE}/__reset`);
+}
+
+/** How many chat-completions hits the mock has seen since the last reset. */
+export async function mockCallCount(request: APIRequestContext): Promise<number> {
+  const res = await request.get(`${MOCK_BASE}/__calls`);
+  const json = (await res.json()) as { count: number };
+  return json.count;
+}

--- a/apps/e2e/support/mock-openrouter.ts
+++ b/apps/e2e/support/mock-openrouter.ts
@@ -1,0 +1,146 @@
+import http from 'http';
+
+/**
+ * Mock OpenRouter / OpenAI-compatible chat-completions server for metering e2e.
+ *
+ * The web app, started with OPENROUTER_BASE_URL pointed here (and an
+ * OPENROUTER_DEFAULT_API_KEY set), routes its AI calls to this stub instead of the
+ * real OpenRouter. The stub returns a deterministic completion that carries
+ * `usage.cost` — the authoritative per-request cost PageSpace bills on
+ * (providerMetadata.openrouter.usage.cost). That makes the credit debit assertable
+ * end-to-end: a known cost in → a known charge out (cost × 1.5 markup).
+ *
+ * It also records every chat-completions hit so a test can prove the OPPOSITE: that a
+ * blocked (out-of-credits / over-cap) request NEVER reached the model. Introspection is
+ * exposed over HTTP (not in-process state) so the Playwright worker — a different
+ * process from this server — can read it:
+ *   GET  /__health  → { ok: true }
+ *   GET  /__calls   → { count, requests: [{ model, stream, messages }] }
+ *   POST /__reset   → zeroes the recorder
+ */
+
+/** Real provider cost in US dollars returned for every completion. 0.02 → 2¢ real → 3¢ charged at 1.5×. */
+export const MOCK_COST_DOLLARS = 0.02;
+export const MOCK_PROMPT_TOKENS = 12;
+export const MOCK_COMPLETION_TOKENS = 4;
+
+interface RecordedRequest {
+  model: string | undefined;
+  stream: boolean;
+  messageCount: number;
+}
+
+export function createMockOpenRouter() {
+  const requests: RecordedRequest[] = [];
+
+  const completionUsage = {
+    prompt_tokens: MOCK_PROMPT_TOKENS,
+    completion_tokens: MOCK_COMPLETION_TOKENS,
+    total_tokens: MOCK_PROMPT_TOKENS + MOCK_COMPLETION_TOKENS,
+    // OpenRouter's usage-accounting cost. The AI SDK surfaces this under
+    // providerMetadata.openrouter.usage.cost, which trackAIUsage bills on.
+    cost: MOCK_COST_DOLLARS,
+  };
+
+  function readBody(req: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve) => {
+      let data = '';
+      req.on('data', (c) => (data += c));
+      req.on('end', () => resolve(data));
+    });
+  }
+
+  function writeJson(res: http.ServerResponse, status: number, body: unknown): void {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(payload);
+  }
+
+  const server = http.createServer(async (req, res) => {
+    const url = req.url ?? '';
+    const method = req.method ?? 'GET';
+
+    if (method === 'GET' && url.startsWith('/__health')) {
+      return writeJson(res, 200, { ok: true });
+    }
+    if (method === 'GET' && url.startsWith('/__calls')) {
+      return writeJson(res, 200, { count: requests.length, requests });
+    }
+    if (method === 'POST' && url.startsWith('/__reset')) {
+      requests.length = 0;
+      return writeJson(res, 200, { ok: true });
+    }
+
+    if (method === 'POST' && url.includes('/chat/completions')) {
+      const raw = await readBody(req);
+      let body: { model?: string; stream?: boolean; messages?: unknown[] } = {};
+      try {
+        body = JSON.parse(raw) as typeof body;
+      } catch {
+        /* ignore — record as empty */
+      }
+      const stream = body.stream === true;
+      requests.push({
+        model: body.model,
+        stream,
+        messageCount: Array.isArray(body.messages) ? body.messages.length : 0,
+      });
+
+      const id = 'gen-e2e-stub';
+      const model = body.model ?? 'e2e/stub';
+
+      if (stream) {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        });
+        const contentChunk = {
+          id,
+          provider: 'e2e',
+          model,
+          object: 'chat.completion.chunk',
+          created: 0,
+          choices: [
+            { index: 0, delta: { role: 'assistant', content: 'pong' }, finish_reason: null },
+          ],
+        };
+        // Final chunk carries finish_reason + usage (with cost) — OpenRouter's shape
+        // when usage:{include:true} is set on the request.
+        const finalChunk = {
+          id,
+          provider: 'e2e',
+          model,
+          object: 'chat.completion.chunk',
+          created: 0,
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+          usage: completionUsage,
+        };
+        res.write(`data: ${JSON.stringify(contentChunk)}\n\n`);
+        res.write(`data: ${JSON.stringify(finalChunk)}\n\n`);
+        res.write('data: [DONE]\n\n');
+        return res.end();
+      }
+
+      return writeJson(res, 200, {
+        id,
+        provider: 'e2e',
+        model,
+        object: 'chat.completion',
+        created: 0,
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'pong' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: completionUsage,
+      });
+    }
+
+    writeJson(res, 404, { error: `mock-openrouter: unhandled ${method} ${url}` });
+  });
+
+  return server;
+}

--- a/apps/e2e/support/mock-server-main.ts
+++ b/apps/e2e/support/mock-server-main.ts
@@ -1,0 +1,20 @@
+import 'dotenv/config';
+import { createMockOpenRouter } from './mock-openrouter';
+
+/**
+ * Standalone entry point for the mock OpenRouter server, started by Playwright's
+ * `webServer` config so its lifecycle is managed for the whole run. The web app must
+ * be launched with OPENROUTER_BASE_URL=http://127.0.0.1:<port>/api/v1 so its AI calls
+ * land here. Port is fixed (default 4998) so the app can be configured before the
+ * Playwright run starts.
+ */
+const port = Number(process.env.E2E_MOCK_OPENROUTER_PORT ?? 4998);
+const server = createMockOpenRouter();
+server.listen(port, '127.0.0.1', () => {
+  // eslint-disable-next-line no-console
+  console.log(`[mock-openrouter] listening on http://127.0.0.1:${port}`);
+});
+
+for (const sig of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(sig, () => server.close(() => process.exit(0)));
+}

--- a/apps/e2e/support/sign.ts
+++ b/apps/e2e/support/sign.ts
@@ -1,0 +1,68 @@
+import { createHmac, randomUUID } from 'crypto';
+
+/**
+ * Forge the headers `validateSignedCronRequest` expects (apps/web/src/lib/auth/cron-auth.ts):
+ *   message   = `${timestamp}:${nonce}:${method}:${path}`
+ *   signature = HMAC-SHA256(CRON_SECRET, message) hex
+ * Timestamp is unix seconds and must be within the 300s skew window; nonce must be unique.
+ */
+export function cronHeaders(opts: { method?: string; path: string; secret?: string }): Record<string, string> {
+  const secret = opts.secret ?? process.env.CRON_SECRET;
+  if (!secret) throw new Error('CRON_SECRET is required to sign cron requests');
+  const method = opts.method ?? 'POST';
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const nonce = randomUUID();
+  const message = `${timestamp}:${nonce}:${method}:${opts.path}`;
+  const signature = createHmac('sha256', secret).update(message).digest('hex');
+  return {
+    'X-Cron-Timestamp': timestamp,
+    'X-Cron-Nonce': nonce,
+    'X-Cron-Signature': signature,
+  };
+}
+
+/**
+ * Build a Stripe-compatible `stripe-signature` header for a raw JSON payload, matching
+ * what `stripe.webhooks.constructEvent` verifies:
+ *   signed_payload = `${t}.${payload}`
+ *   v1             = HMAC-SHA256(STRIPE_WEBHOOK_SECRET, signed_payload) hex
+ *   header         = `t=${t},v1=${v1}`
+ */
+export function stripeSignature(payload: string, secret = process.env.STRIPE_WEBHOOK_SECRET): string {
+  if (!secret) throw new Error('STRIPE_WEBHOOK_SECRET is required to sign webhook events');
+  const t = Math.floor(Date.now() / 1000);
+  const v1 = createHmac('sha256', secret).update(`${t}.${payload}`).digest('hex');
+  return `t=${t},v1=${v1}`;
+}
+
+/** A minimal Stripe `checkout.session.completed` event for a credit-pack top-up. */
+export function creditPackEvent(opts: {
+  eventId: string;
+  userId: string;
+  packId: string;
+  packCents: number;
+  sessionId?: string;
+}): Record<string, unknown> {
+  return {
+    id: opts.eventId,
+    object: 'event',
+    type: 'checkout.session.completed',
+    api_version: '2024-06-20',
+    created: Math.floor(Date.now() / 1000),
+    data: {
+      object: {
+        id: opts.sessionId ?? `cs_test_${opts.eventId}`,
+        object: 'checkout.session',
+        mode: 'payment',
+        payment_status: 'paid',
+        status: 'complete',
+        metadata: {
+          kind: 'credit_pack',
+          packId: opts.packId,
+          packCents: String(opts.packCents),
+          userId: opts.userId,
+        },
+      },
+    },
+  };
+}

--- a/apps/e2e/tests/09-metering-no-bypass.spec.ts
+++ b/apps/e2e/tests/09-metering-no-bypass.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUser,
+  createAgentPage,
+  createGlobalConversation,
+  createMcpToken,
+  getLedger,
+  type SeededUser,
+} from '../support/db';
+import { sessionPost, mcpPost, resetMock, mockCallCount } from '../support/http';
+import { cronHeaders } from '../support/sign';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pulseSummaries } from '@pagespace/db/schema/dashboard';
+
+/**
+ * The core claim: with enforcement ON, EVERY AI entry point refuses an out-of-credits
+ * user BEFORE invoking the model. For each surface we assert (a) the request is blocked
+ * (402 out_of_credits) and (b) no `usage` ledger row was written — i.e. nothing was
+ * billed and, by extension, no model call settled. This is the "no bypass" proof.
+ */
+
+// These are pure API tests — drop the seeded browser session so only our explicit
+// per-user auth headers are in play.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function expectNoUsage(user: SeededUser) {
+  const usage = await getLedger(user.userId, 'usage');
+  expect(usage, 'an out-of-credits request must not produce a usage/billing row').toHaveLength(0);
+}
+
+const brokeOpts = { monthlyRemainingCents: 0, monthlyAllowanceCents: 0, topupRemainingCents: 0 } as const;
+
+test.describe('metering cannot be bypassed (enforcement ON, 0 credits)', () => {
+  test('POST /api/pulse/generate → 402, nothing billed', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+    const res = await sessionPost(request, '/api/pulse/generate', user, {});
+    expect(res.status()).toBe(402);
+    await expectNoUsage(user);
+  });
+
+  test('POST /api/voice/synthesize → 402, nothing billed', async ({ request }) => {
+    // Voice is paid-only; use a paid tier so we hit the credit gate, not the tier gate.
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+    const res = await sessionPost(request, '/api/voice/synthesize', user, {
+      text: 'hello world',
+      voice: 'nova',
+      model: 'tts-1',
+      speed: 1.0,
+    });
+    expect(res.status()).toBe(402);
+    await expectNoUsage(user);
+  });
+
+  test('POST /api/ai/chat → 402, model never called, nothing billed', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+    const chatId = await createAgentPage(user.driveId, user.userId);
+    const mcp = await createMcpToken(user.userId);
+    await resetMock(request);
+
+    const res = await mcpPost(request, '/api/ai/chat', mcp, {
+      messages: [{ role: 'user', content: 'hello' }],
+      chatId,
+    });
+
+    expect(res.status()).toBe(402);
+    expect(await mockCallCount(request), 'blocked chat must not reach the model').toBe(0);
+    await expectNoUsage(user);
+  });
+
+  test('POST /api/ai/page-agents/consult → 402, nothing billed', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+    const agentId = await createAgentPage(user.driveId, user.userId);
+    const mcp = await createMcpToken(user.userId);
+    await resetMock(request);
+
+    const res = await mcpPost(request, '/api/ai/page-agents/consult', mcp, {
+      agentId,
+      question: 'What is the status?',
+    });
+
+    expect(res.status()).toBe(402);
+    expect(await mockCallCount(request)).toBe(0);
+    await expectNoUsage(user);
+  });
+
+  test('POST /api/v1/chat/completions (MCP passthrough) → 402, nothing billed', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+    const pageId = await createAgentPage(user.driveId, user.userId);
+    const mcp = await createMcpToken(user.userId);
+    await resetMock(request);
+
+    const res = await mcpPost(request, '/api/v1/chat/completions', mcp, {
+      messages: [{ role: 'user', content: 'hello' }],
+      pageId,
+      model: 'e2e/stub-model',
+    });
+
+    expect(res.status()).toBe(402);
+    expect(await mockCallCount(request)).toBe(0);
+    await expectNoUsage(user);
+  });
+
+  test('POST /api/ai/global/[id]/messages → 402, nothing billed', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+    const conversationId = await createGlobalConversation(user.userId);
+
+    const res = await sessionPost(request, `/api/ai/global/${conversationId}/messages`, user, {
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(res.status()).toBe(402);
+    await expectNoUsage(user);
+  });
+
+  test('POST /api/pulse/cron skips an out-of-credits user (the closed bypass)', async ({ request }) => {
+    // A 0-credit user who is "active" (fresh session) and has no recent summary is a
+    // cron candidate. Pre-fix, cron generated + billed for them with no gate. Now the
+    // gate must skip them: no summary, no usage row.
+    const user = await seedUser({ tier: 'pro', ...brokeOpts });
+
+    const res = await request.post('/api/pulse/cron', {
+      headers: cronHeaders({ path: '/api/pulse/cron' }),
+    });
+    expect(res.status()).toBe(200);
+
+    const summaries = await db
+      .select()
+      .from(pulseSummaries)
+      .where(eq(pulseSummaries.userId, user.userId));
+    expect(summaries, 'cron must not generate a summary for an out-of-credits user').toHaveLength(0);
+    await expectNoUsage(user);
+  });
+});

--- a/apps/e2e/tests/10-metering-billing.spec.ts
+++ b/apps/e2e/tests/10-metering-billing.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, createAgentPage, createMcpToken, getBalance, getLedger, getHolds } from '../support/db';
+import { mcpPost, resetMock, mockCallCount } from '../support/http';
+import { MOCK_COST_DOLLARS } from '../support/mock-openrouter';
+
+/**
+ * Billing happy-path: a funded user makes a real (stubbed) chat call, and the exact
+ * cost the provider reported is metered against their balance. The mock returns
+ * usage.cost = $0.02 (2¢ real); at the 1.5× markup the charged amount is 3¢.
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const EXPECTED_REAL_CENTS = Math.round(MOCK_COST_DOLLARS * 100); // 2
+const EXPECTED_CHARGE_CENTS = Math.round(EXPECTED_REAL_CENTS * 1.5); // 3
+
+test('a funded chat call hits the model and debits exactly cost × markup', async ({ request }) => {
+  const START = 10_000;
+  const user = await seedUser({
+    tier: 'pro',
+    provider: 'openrouter',
+    monthlyRemainingCents: START,
+    monthlyAllowanceCents: START,
+  });
+  const chatId = await createAgentPage(user.driveId, user.userId);
+  const mcp = await createMcpToken(user.userId);
+  await resetMock(request);
+
+  const res = await mcpPost(request, '/api/ai/chat', mcp, {
+    messages: [{ role: 'user', content: 'ping' }],
+    chatId,
+  });
+  expect(res.status()).toBe(200);
+  await res.body(); // drain the stream so onFinish settlement runs
+
+  // The model was actually invoked exactly once via the mock.
+  expect(await mockCallCount(request)).toBe(1);
+
+  // Settlement may land just after the stream closes — poll until the debit appears.
+  await expect
+    .poll(async () => (await getBalance(user.userId))?.monthlyRemainingCents, { timeout: 10_000 })
+    .toBe(START - EXPECTED_CHARGE_CENTS);
+
+  // A single usage ledger row recorded the charge, and the in-flight hold was released.
+  const usage = await getLedger(user.userId, 'usage');
+  expect(usage).toHaveLength(1);
+  expect(Math.abs(usage[0].appliedCents ?? 0)).toBe(EXPECTED_CHARGE_CENTS);
+  expect(await getHolds(user.userId), 'hold must settle, not linger').toHaveLength(0);
+});

--- a/apps/e2e/tests/11-metering-limits.spec.ts
+++ b/apps/e2e/tests/11-metering-limits.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, createAgentPage, createMcpToken, seedHolds, getLedger } from '../support/db';
+import { mcpPost, resetMock, mockCallCount } from '../support/http';
+
+/**
+ * The two enforcement limits, exercised against real routes:
+ *   - out_of_credits → 402 once spendable would drop to/below the reserve floor (25¢)
+ *   - too_many_in_flight → 429 once a free user hits MAX_FREE_INFLIGHT (2) live holds
+ * In both cases the model must not be reached and nothing may be billed.
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('402 out_of_credits when spendable is at the reserve floor', async ({ request }) => {
+  // 20¢ spendable, 25¢ floor + a per-call hold estimate → denied before any call.
+  const user = await seedUser({
+    tier: 'pro',
+    monthlyRemainingCents: 20,
+    monthlyAllowanceCents: 1_500,
+    topupRemainingCents: 0,
+  });
+  const chatId = await createAgentPage(user.driveId, user.userId);
+  const mcp = await createMcpToken(user.userId);
+  await resetMock(request);
+
+  const res = await mcpPost(request, '/api/ai/chat', mcp, {
+    messages: [{ role: 'user', content: 'ping' }],
+    chatId,
+  });
+
+  expect(res.status()).toBe(402);
+  expect(await mockCallCount(request)).toBe(0);
+  expect(await getLedger(user.userId, 'usage')).toHaveLength(0);
+});
+
+test('429 too_many_in_flight when a free user is at the concurrency cap', async ({ request }) => {
+  // Plenty of credits, but already at MAX_FREE_INFLIGHT (2) live holds → the in-flight
+  // cap (checked before the balance) denies with 429.
+  const user = await seedUser({
+    tier: 'free',
+    monthlyRemainingCents: 5_000,
+    monthlyAllowanceCents: 5_000,
+  });
+  await seedHolds(user.userId, 2);
+  const chatId = await createAgentPage(user.driveId, user.userId);
+  const mcp = await createMcpToken(user.userId);
+  await resetMock(request);
+
+  const res = await mcpPost(request, '/api/ai/chat', mcp, {
+    messages: [{ role: 'user', content: 'ping' }],
+    chatId,
+  });
+
+  expect(res.status()).toBe(429);
+  expect(await mockCallCount(request)).toBe(0);
+  expect(await getLedger(user.userId, 'usage')).toHaveLength(0);
+});

--- a/apps/e2e/tests/12-token-packs.spec.ts
+++ b/apps/e2e/tests/12-token-packs.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { seedUser, getBalance, getLedger } from '../support/db';
+import { sessionPost } from '../support/http';
+import { stripeSignature, creditPackEvent } from '../support/sign';
+import { CREDIT_PACKS } from '../../../packages/lib/src/billing/credit-pricing';
+
+/**
+ * Buying a token (credit) pack, end-to-end on the funding side. There are no persistent
+ * Stripe Product/Price objects — checkout uses inline price_data from CREDIT_PACKS — so
+ * the contract under test is: a paid `checkout.session.completed` webhook with
+ * metadata.kind='credit_pack' credits the never-expiring top-up bucket exactly once.
+ */
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('credit-pack checkout creation (validation)', () => {
+  test('rejects an unknown pack with 400', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro' });
+    const res = await sessionPost(request, '/api/stripe/create-credit-topup', user, {
+      packId: 'pack_does_not_exist',
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('rejects a missing packId with 400', async ({ request }) => {
+    const user = await seedUser({ tier: 'pro' });
+    const res = await sessionPost(request, '/api/stripe/create-credit-topup', user, {});
+    expect(res.status()).toBe(400);
+  });
+});
+
+test.describe('credit-pack webhook funding', () => {
+  test('a paid credit_pack session credits the top-up bucket exactly once', async ({ request }) => {
+    const pack = CREDIT_PACKS.pack_10;
+    const user = await seedUser({ tier: 'pro', topupRemainingCents: 0 });
+
+    const before = (await getBalance(user.userId))?.topupRemainingCents ?? 0;
+    const eventId = `evt_${randomUUID().replace(/-/g, '')}`;
+    const payload = JSON.stringify(
+      creditPackEvent({ eventId, userId: user.userId, packId: pack.id, packCents: pack.cents }),
+    );
+
+    const post = () =>
+      request.post('/api/stripe/webhook', {
+        headers: { 'stripe-signature': stripeSignature(payload), 'content-type': 'application/json' },
+        data: payload,
+      });
+
+    const res1 = await post();
+    expect(res1.status()).toBe(200);
+
+    await expect
+      .poll(async () => (await getBalance(user.userId))?.topupRemainingCents, { timeout: 10_000 })
+      .toBe(before + pack.cents);
+
+    const purchases = await getLedger(user.userId, 'topup_purchase');
+    expect(purchases).toHaveLength(1);
+    expect(purchases[0].amountCents).toBe(pack.cents);
+
+    // Stripe redelivers events; the same event id must be idempotent — no double credit.
+    const res2 = await post();
+    expect(res2.status()).toBe(200);
+
+    // Give any (incorrect) second funding a chance to land, then assert it did not.
+    await new Promise((r) => setTimeout(r, 500));
+    expect((await getBalance(user.userId))?.topupRemainingCents).toBe(before + pack.cents);
+    expect(await getLedger(user.userId, 'topup_purchase')).toHaveLength(1);
+  });
+});

--- a/apps/e2e/tests/12-token-packs.spec.ts
+++ b/apps/e2e/tests/12-token-packs.spec.ts
@@ -62,9 +62,14 @@ test.describe('credit-pack webhook funding', () => {
     const res2 = await post();
     expect(res2.status()).toBe(200);
 
-    // Give any (incorrect) second funding a chance to land, then assert it did not.
-    await new Promise((r) => setTimeout(r, 500));
-    expect((await getBalance(user.userId))?.topupRemainingCents).toBe(before + pack.cents);
-    expect(await getLedger(user.userId, 'topup_purchase')).toHaveLength(1);
+    // A late duplicate could land any time during the redelivery-processing window, so
+    // assert the invariants HOLD for the whole window — fail the instant either changes,
+    // rather than sampling once after a fixed sleep.
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      expect((await getBalance(user.userId))?.topupRemainingCents).toBe(before + pack.cents);
+      expect(await getLedger(user.userId, 'topup_purchase')).toHaveLength(1);
+      await new Promise((r) => setTimeout(r, 100));
+    }
   });
 });

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -160,8 +160,36 @@ async function generatePulseForUser(userId: string, now: Date): Promise<boolean>
     });
     return false;
   }
-  const holdId = gate.holdId;
 
+  // The gate's reservation is owned here until trackUsage settles it (handoff). The
+  // finally releases it on ANY pre-settle exit — including a throw from the context
+  // gathering below — so a transient failure can't leave the hold sitting until TTL,
+  // mirroring the on-demand /api/pulse/generate route.
+  const holdId = gate.holdId;
+  let holdHandedOff = false;
+  try {
+    await buildAndPersistPulse(user, now, holdId, () => {
+      holdHandedOff = true;
+    });
+    return true;
+  } finally {
+    if (holdId && !holdHandedOff) void releaseHold(holdId).catch(() => {});
+  }
+}
+
+/**
+ * Build the workspace context, generate the summary, bill it, and persist it. The
+ * reservation `holdId` is handed to trackUsage on success (call `markHandedOff` so the
+ * caller's finally won't double-release); any throw before that leaves the caller to
+ * release the hold.
+ */
+async function buildAndPersistPulse(
+  user: typeof users.$inferSelect,
+  now: Date,
+  holdId: string | undefined,
+  markHandedOff: () => void,
+): Promise<void> {
+  const userId = user.id;
   const userName = user.name || user.email?.split('@')[0] || 'there';
   // Use stored timezone or default to UTC
   const userTimezone = normalizeTimezone(user.timezone);
@@ -795,27 +823,19 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
   });
 
   if (isProviderError(providerResult)) {
-    // Never reached a model call — free the reservation so it doesn't sit until expiry.
-    if (holdId) void releaseHold(holdId).catch(() => {});
+    // Throws before any model call — the caller's finally releases the reservation.
     throw new Error(providerResult.error);
   }
 
-  // Generate summary
-  let result;
-  try {
-    result = await generateText({
-      model: providerResult.model,
-      system: `${PULSE_SYSTEM_PROMPT}\n\n${buildTimestampSystemPrompt(userTimezone)}`,
-      messages: [{ role: 'user', content: userPrompt }],
-      temperature: 0.7,
-      maxRetries: 3,
-    });
-  } catch (err) {
-    // Generation failed before any billable usage — release the hold and rethrow so
-    // the per-user loop records the error.
-    if (holdId) void releaseHold(holdId).catch(() => {});
-    throw err;
-  }
+  // Generate summary. A throw here propagates to the caller, whose finally releases
+  // the still-unsettled hold.
+  const result = await generateText({
+    model: providerResult.model,
+    system: `${PULSE_SYSTEM_PROMPT}\n\n${buildTimestampSystemPrompt(userTimezone)}`,
+    messages: [{ role: 'user', content: userPrompt }],
+    temperature: 0.7,
+    maxRetries: 3,
+  });
 
   const summary = result.text.trim();
 
@@ -833,6 +853,8 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
     holdId,
     success: true,
   });
+  // The hold is now owned by trackUsage — keep the caller's finally from releasing it.
+  markHandedOff();
 
   // Extract greeting
   let greeting: string | null = null;
@@ -913,8 +935,6 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
     diffCount: contentDiffs.length,
     contextSize: JSON.stringify(contextData).length,
   });
-
-  return true;
 }
 
 // Also support GET for easy cron setup (some cron services only support GET)

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -97,13 +97,15 @@ export async function POST(req: Request) {
     loggers.api.info(`Pulse cron: Generating summaries for ${usersNeedingSummary.length} users`);
 
     let generated = 0;
+    let skipped = 0;
     const errors: string[] = [];
 
     // Generate summaries for each user (with rate limiting)
     for (const userId of usersNeedingSummary) {
       try {
-        await generatePulseForUser(userId, now);
-        generated++;
+        const didGenerate = await generatePulseForUser(userId, now);
+        if (didGenerate) generated++;
+        else skipped++;
 
         // Add a small delay between users to avoid overwhelming the AI provider
         if (usersNeedingSummary.length > 1) {
@@ -116,11 +118,14 @@ export async function POST(req: Request) {
       }
     }
 
-    loggers.api.info(`Pulse cron: Complete. Generated ${generated}/${usersNeedingSummary.length} summaries`);
+    loggers.api.info(
+      `Pulse cron: Complete. Generated ${generated}/${usersNeedingSummary.length} summaries (${skipped} skipped by credit gate)`,
+    );
 
     return NextResponse.json({
       message: 'Pulse generation complete',
       generated,
+      skipped,
       total: usersNeedingSummary.length,
       errors: errors.length > 0 ? errors : undefined,
     });
@@ -131,7 +136,12 @@ export async function POST(req: Request) {
   }
 }
 
-async function generatePulseForUser(userId: string, now: Date): Promise<void> {
+/**
+ * Generate and persist one user's pulse summary. Returns true if a summary was
+ * generated, false if the user was skipped by the credit gate (out of credits / over
+ * the in-flight cap). Throws on real failures so the caller records them.
+ */
+async function generatePulseForUser(userId: string, now: Date): Promise<boolean> {
   // Get user info
   const [user] = await db.select().from(users).where(eq(users.id, userId));
   if (!user) throw new Error('User not found');
@@ -148,7 +158,7 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
       userId,
       reason: gate.reason,
     });
-    return;
+    return false;
   }
   const holdId = gate.holdId;
 
@@ -903,6 +913,8 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
     diffCount: contentDiffs.length,
     contextSize: JSON.stringify(contextData).length,
   });
+
+  return true;
 }
 
 // Also support GET for easy cron setup (some cron services only support GET)

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -36,6 +36,9 @@ import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring, extractOpenRouterCostDollars } from '@pagespace/lib/monitoring/ai-monitoring';
+import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { releaseHold } from '@pagespace/lib/billing/credit-consume';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { PULSE_SYSTEM_PROMPT } from '../pulse-prompt';
 
@@ -132,6 +135,22 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
   // Get user info
   const [user] = await db.select().from(users).where(eq(users.id, userId));
   if (!user) throw new Error('User not found');
+
+  // Prepaid credit gate — the cron path bills through the SAME pipeline as the
+  // on-demand route, so background generation can't spend uncapped. Denied users
+  // (out of credits / over the in-flight cap) are simply skipped this run; the
+  // reservation is released on any pre-settle exit and settled by trackUsage on
+  // success. Gated up front so we don't do the heavy context-gathering for a user
+  // we won't bill.
+  const gate = await canConsumeAI(userId, (user.subscriptionTier ?? 'free') as SubscriptionTier);
+  if (!gate.allowed) {
+    loggers.api.info('Pulse cron: skipped user (credit gate denied)', {
+      userId,
+      reason: gate.reason,
+    });
+    return;
+  }
+  const holdId = gate.holdId;
 
   const userName = user.name || user.email?.split('@')[0] || 'there';
   // Use stored timezone or default to UTC
@@ -766,21 +785,32 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
   });
 
   if (isProviderError(providerResult)) {
+    // Never reached a model call — free the reservation so it doesn't sit until expiry.
+    if (holdId) void releaseHold(holdId).catch(() => {});
     throw new Error(providerResult.error);
   }
 
   // Generate summary
-  const result = await generateText({
-    model: providerResult.model,
-    system: `${PULSE_SYSTEM_PROMPT}\n\n${buildTimestampSystemPrompt(userTimezone)}`,
-    messages: [{ role: 'user', content: userPrompt }],
-    temperature: 0.7,
-    maxRetries: 3,
-  });
+  let result;
+  try {
+    result = await generateText({
+      model: providerResult.model,
+      system: `${PULSE_SYSTEM_PROMPT}\n\n${buildTimestampSystemPrompt(userTimezone)}`,
+      messages: [{ role: 'user', content: userPrompt }],
+      temperature: 0.7,
+      maxRetries: 3,
+    });
+  } catch (err) {
+    // Generation failed before any billable usage — release the hold and rethrow so
+    // the per-user loop records the error.
+    if (holdId) void releaseHold(holdId).catch(() => {});
+    throw err;
+  }
 
   const summary = result.text.trim();
 
-  // Track AI usage
+  // Track AI usage. Passing holdId hands the reservation to trackUsage, which settles
+  // it atomically with the debit (or releases it if there was nothing billable).
   const usage = result.usage;
   AIMonitoring.trackUsage({
     userId,
@@ -790,6 +820,7 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
     outputTokens: usage?.outputTokens,
     totalTokens: usage ? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)) : undefined,
     providerCostDollars: extractOpenRouterCostDollars(result.steps),
+    holdId,
     success: true,
   });
 

--- a/apps/web/src/lib/ai/core/provider-factory.ts
+++ b/apps/web/src/lib/ai/core/provider-factory.ts
@@ -114,6 +114,10 @@ export async function createAIProvider(
       // to the cache window so genuine repeats (regenerate/retry) can HIT.
       const openrouter = createOpenRouter({
         apiKey: managed.apiKey,
+        // OPENROUTER_BASE_URL lets a non-prod environment (e.g. e2e) redirect the
+        // OpenRouter API at a deterministic stub that returns known usage.cost, so
+        // billing can be asserted end-to-end. Unset in prod → real OpenRouter.
+        ...(process.env.OPENROUTER_BASE_URL ? { baseURL: process.env.OPENROUTER_BASE_URL } : {}),
         headers: { 'X-OpenRouter-Cache': 'true' },
       });
       // usage: { include: true } turns on OpenRouter usage accounting so the


### PR DESCRIPTION
## Summary

Adds an end-to-end **metering & billing** test suite and closes the one AI path that invoked the model without going through the credit pipeline. **Enforcement (`CREDITS_ENFORCEMENT_ENABLED`) stays OFF by default** — this PR is safe to ship during dark launch; the enforcement specs turn the flag on only for their own run.

## Metering bypass fix
- **`pulse/cron/route.ts`** now runs each user through `canConsumeAI()` (hold → settle/release), exactly like the on-demand `pulse/generate` route. Out-of-credit users are skipped; the hold is released on any pre-settle failure and handed to `trackUsage` on success. Previously cron called the model with **no gate** — it now meters like every other path (and will enforce automatically whenever the flag is flipped).

## Test hook
- **`provider-factory.ts`** gains an optional `OPENROUTER_BASE_URL` override (prod default unchanged) so e2e can point the model at a deterministic stub returning a known `usage.cost`, making the credit debit assertable end-to-end.

## E2E suite (`apps/e2e/`)
| Spec | Proves |
|------|--------|
| `09-metering-no-bypass` | Enforcement ON → out-of-credits user refused at **every** entry point (chat, global, consult, voice synthesize, pulse generate, MCP `/v1/chat/completions`, **pulse cron**): 402, no usage row, model never hit. |
| `10-metering-billing` | Funded chat call debits **exactly `cost × 1.5`**, writes one usage row, settles the hold. |
| `11-metering-limits` | `402 out_of_credits` at the reserve floor; `429 too_many_in_flight` at the free-tier concurrency cap. |
| `12-token-packs` | Credit-pack checkout validation + funding webhook credits the top-up bucket **exactly once** (idempotent on event id). |

Harness: mock OpenRouter server (managed via Playwright `webServer`), billing/db fixtures, signed-cron + Stripe-webhook helpers, and `README.metering.md` with the required app env.

## On token packs
There are **no persistent Stripe Product/Price objects** for credit packs — checkout uses inline `price_data` from `CREDIT_PACKS` (`pack_10/25/50`). That's intentional and kept as-is; the funding path is now covered e2e.

## Testing
- `@pagespace/lib` billing unit tests: **170 pass**. Changed source files typecheck + lint clean. e2e package typechecks clean.
- The e2e specs require a running app + local Postgres (CI/local per the README); they were authored against the real route contracts but not executed in this environment.
- Default-behavior unchanged: the enforcement flag default and all existing credit-gate unit tests are byte-identical to baseline.

## Note before flipping enforcement
Per prior guidance, validate per-tier allowances against real spend before setting `CREDITS_ENFORCEMENT_ENABLED=true` in production. This PR does **not** change that default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for metering and billing end-to-end test coverage

* **Tests**
  * Added extensive E2E test suite covering credit enforcement, billing settlement with cost markup, spending limits, and credit pack purchases with idempotency validation

* **Bug Fixes**
  * Improved credit balance validation in background tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->