### PR TITLE
fix(chat): show friendly credit-gate errors with buy-credits CTA

### DIFF
--- a/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
+++ b/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { UIMessage } from 'ai';
 import { InputPositioner, type InputPosition } from '@/components/ui/floating-input/InputPositioner';
 import { InputCard } from '@/components/ui/floating-input/InputCard';
+import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 import { ChatMessagesArea, ChatMessagesAreaRef } from '@/components/ai/shared/chat/ChatMessagesArea';
 import { WelcomeContent } from './WelcomeContent';
 import { useEnterToSend } from '@/hooks/useEnterToSend';
@@ -296,8 +297,9 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
         {/* Floating input */}
         <InputPositioner position={inputPosition}>
           <InputCard
-            error={showError && error ? error.message : null}
-            onClearError={onClearError}
+            errorSlot={
+              <ChatErrorBanner error={error} show={showError} onClearError={onClearError} />
+            }
           >
             {inputContent}
           </InputCard>

--- a/apps/web/src/components/ai/shared/chat/ChatErrorBanner.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatErrorBanner.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import React from 'react';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { cn } from '@/lib/utils';
+import { getAIErrorMessage, isOutOfCreditsError } from '@/lib/ai/shared/error-messages';
+import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
+
+export interface ChatErrorBannerProps {
+  /** The AI SDK chat error, if any. */
+  error?: Error | null;
+  /** Whether the banner should be shown (parent dismiss state). Defaults to true. */
+  show?: boolean;
+  /** Callback to dismiss the error. When omitted, no dismiss button is rendered. */
+  onClearError?: () => void;
+  /** Optional container class override. */
+  className?: string;
+}
+
+/**
+ * ChatErrorBanner - the single error banner shared by every AI-chat surface
+ * (AI Chat page, Global Assistant, sidebar assistant, and the agent input area).
+ *
+ * It translates the raw chat error — which for credit-gate denials is the raw JSON
+ * body, e.g. `{"error":"out_of_credits",...}` — into friendly copy via
+ * `getAIErrorMessage()`, and surfaces a "Buy credits" call to action when the user is
+ * out of prepaid credits. Never render `error.message` directly anywhere else.
+ */
+export function ChatErrorBanner({
+  error,
+  show = true,
+  onClearError,
+  className,
+}: ChatErrorBannerProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  const visible = Boolean(error) && show;
+
+  return (
+    <AnimatePresence>
+      {visible && error && (
+        <motion.div
+          initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+          transition={{ duration: 0.2 }}
+          className={cn(
+            'mb-3 p-3 rounded-xl bg-destructive/10 border border-destructive/20 flex flex-col gap-2',
+            className
+          )}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm text-destructive flex-1">{getAIErrorMessage(error.message)}</p>
+            {onClearError && (
+              <button
+                type="button"
+                onClick={onClearError}
+                className="text-sm text-destructive/70 hover:text-destructive underline underline-offset-2 ml-3 shrink-0"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+          {isOutOfCreditsError(error.message) && (
+            <BuyCreditsButton variant="default" size="sm" className="self-start" />
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default ChatErrorBanner;

--- a/apps/web/src/components/ai/shared/chat/ChatInputArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatInputArea.tsx
@@ -8,8 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Send, StopCircle } from 'lucide-react';
 import AiInput from './AiInput';
 import { ChatInputRef } from '@/components/messages/ChatInput';
-import { getAIErrorMessage, isOutOfCreditsError } from '@/lib/ai/shared/error-messages';
-import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
+import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 
 interface ChatInputAreaProps {
@@ -115,26 +114,7 @@ export const ChatInputArea = forwardRef<ChatInputAreaRef, ChatInputAreaProps>(
       <div className="border-t border-[var(--separator)] p-4">
         <div className="max-w-4xl mx-auto w-full">
           {/* Error display */}
-          {error && showError && (
-            <div className="mb-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex flex-col gap-2">
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-sm text-red-700 dark:text-red-300">
-                  {getAIErrorMessage(error.message)}
-                </p>
-                {onClearError && (
-                  <button
-                    onClick={onClearError}
-                    className="shrink-0 text-sm text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 underline"
-                  >
-                    Clear
-                  </button>
-                )}
-              </div>
-              {isOutOfCreditsError(error.message) && (
-                <BuyCreditsButton variant="default" size="sm" className="self-start" />
-              )}
-            </div>
-          )}
+          <ChatErrorBanner error={error} show={showError} onClearError={onClearError} />
 
           {/* Input and buttons */}
           <div className="flex space-x-2">

--- a/apps/web/src/components/ai/shared/chat/__tests__/ChatErrorBanner.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/ChatErrorBanner.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * ChatErrorBanner tests
+ *
+ * The banner is the single error surface for every AI-chat view. Its job is to turn
+ * the raw chat error — which for credit-gate denials is the raw JSON body, e.g.
+ * `{"error":"out_of_credits", ...}` — into friendly copy and, when out of credits,
+ * surface a "Buy credits" call to action. These tests pin that contract.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { ChatErrorBanner } from '../ChatErrorBanner';
+
+// Stub the billing CTA so the test stays isolated from billing visibility / Stripe.
+vi.mock('@/components/billing/BuyCreditsButton', () => ({
+  BuyCreditsButton: () => <button data-testid="buy-credits">Buy credits</button>,
+}));
+
+// The exact JSON body the credit gate returns before streaming starts.
+const OUT_OF_CREDITS_BODY =
+  '{"error":"out_of_credits","message":"You have run out of AI credits. Add credits or wait for your monthly allowance to reset."}';
+const IN_FLIGHT_BODY =
+  '{"error":"too_many_in_flight","message":"Too many AI requests in flight at once. Wait for one to finish, then try again."}';
+
+describe('ChatErrorBanner', () => {
+  it('renders nothing when there is no error', () => {
+    const { container } = render(<ChatErrorBanner error={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when show is false, even with an error', () => {
+    const { container } = render(
+      <ChatErrorBanner error={new Error(OUT_OF_CREDITS_BODY)} show={false} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows friendly copy and the buy-credits CTA for an out-of-credits error', () => {
+    const { getByTestId, getByText, queryByText } = render(
+      <ChatErrorBanner error={new Error(OUT_OF_CREDITS_BODY)} />
+    );
+    // Friendly copy, not the raw JSON body.
+    getByText(/used up your AI credits/i);
+    expect(queryByText(/out_of_credits/)).toBeNull();
+    expect(queryByText(/"error"/)).toBeNull();
+    // CTA present.
+    getByTestId('buy-credits');
+  });
+
+  it('shows in-flight copy with NO buy-credits CTA for a too-many-in-flight error', () => {
+    const { getByText, queryByTestId, queryByText } = render(
+      <ChatErrorBanner error={new Error(IN_FLIGHT_BODY)} />
+    );
+    getByText(/too many ai requests are running at once/i);
+    expect(queryByText(/too_many_in_flight/)).toBeNull();
+    expect(queryByTestId('buy-credits')).toBeNull();
+  });
+
+  it('shows generic copy with no CTA for an unrecognized error', () => {
+    const { getByText, queryByTestId } = render(
+      <ChatErrorBanner error={new Error('kaboom')} />
+    );
+    getByText(/something went wrong/i);
+    expect(queryByTestId('buy-credits')).toBeNull();
+  });
+
+  it('renders a Dismiss button that invokes onClearError', () => {
+    const onClearError = vi.fn();
+    const { getByText } = render(
+      <ChatErrorBanner error={new Error('kaboom')} onClearError={onClearError} />
+    );
+    fireEvent.click(getByText('Dismiss'));
+    expect(onClearError).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the Dismiss button when no onClearError is provided', () => {
+    const { queryByText } = render(<ChatErrorBanner error={new Error('kaboom')} />);
+    expect(queryByText('Dismiss')).toBeNull();
+  });
+});

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -40,8 +40,7 @@ import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import { isEditingActive } from '@/stores/useEditingStore';
-import { getAIErrorMessage, isOutOfCreditsError } from '@/lib/ai/shared/error-messages';
-import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
+import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
 
@@ -902,24 +901,11 @@ const SidebarChatTab: React.FC = () => {
           paddingBottom: isKeyboardOpen ? `calc(0.75rem + ${keyboardHeight}px)` : undefined,
         }}
       >
-        {error && showError && (
-          <div className="p-2 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-xs flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-2">
-              <p className="text-red-700 dark:text-red-300">
-                {getAIErrorMessage(error.message)}
-              </p>
-              <button
-                onClick={() => setShowError(false)}
-                className="shrink-0 text-xs text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-200 underline"
-              >
-                Clear
-              </button>
-            </div>
-            {isOutOfCreditsError(error.message) && (
-              <BuyCreditsButton variant="default" size="sm" className="self-start" />
-            )}
-          </div>
-        )}
+        <ChatErrorBanner
+          error={error}
+          show={showError}
+          onClearError={() => setShowError(false)}
+        />
 
         <div className="px-1">
           <ProviderModelSelector

--- a/apps/web/src/components/ui/floating-input/InputCard.tsx
+++ b/apps/web/src/components/ui/floating-input/InputCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { cn } from '@/lib/utils';
 
 export interface InputCardProps {
@@ -9,10 +8,8 @@ export interface InputCardProps {
   children: React.ReactNode;
   /** Additional class names */
   className?: string;
-  /** Error message to display above the input */
-  error?: string | null;
-  /** Callback when error is dismissed */
-  onClearError?: () => void;
+  /** Optional slot rendered above the card (e.g. an error banner). */
+  errorSlot?: React.ReactNode;
 }
 
 /**
@@ -24,36 +21,12 @@ export interface InputCardProps {
 export function InputCard({
   children,
   className,
-  error,
-  onClearError,
+  errorSlot,
 }: InputCardProps) {
-  const shouldReduceMotion = useReducedMotion();
-
   return (
     <div className="relative">
-      {/* Error banner */}
-      <AnimatePresence>
-        {error && (
-          <motion.div
-            initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: -8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-            transition={{ duration: 0.2 }}
-            className="mb-3 p-3 rounded-xl bg-destructive/10 border border-destructive/20 flex items-center justify-between"
-          >
-            <p className="text-sm text-destructive flex-1">{error}</p>
-            {onClearError && (
-              <button
-                type="button"
-                onClick={onClearError}
-                className="text-sm text-destructive/70 hover:text-destructive underline underline-offset-2 ml-3 shrink-0"
-              >
-                Dismiss
-              </button>
-            )}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* Slot above the card — used for the chat error banner. */}
+      {errorSlot}
 
       {/* Main card */}
       <div


### PR DESCRIPTION
## Problem

When an AI chat request is denied by the credit gate, the chat UI showed the **raw JSON error body** verbatim:

```
{"error":"out_of_credits","message":"You have run out of AI credits. Add credits or wait for your monthly allowance to reset."}
```

The gate denies *before* streaming starts with a non-stream response (`402 out_of_credits` / `429 too_many_in_flight`, from `creditGateErrorResponse`). The AI SDK's `useChat` surfaces that as an `Error` whose `.message` is the JSON body, and the **AI Chat page** + **Global Assistant** rendered it raw (`ChatLayout` → `InputCard`) — no friendly copy, no CTA.

The correct friendly-copy + buy-credits pattern already existed (`getAIErrorMessage()`, `isOutOfCreditsError()`, `BuyCreditsButton`) and was wired into two *other* surfaces, but duplicated across them and missing entirely on the `ChatLayout` path.

## Fix

Consolidate the per-surface error banners into one shared `ChatErrorBanner` and route all four AI-chat surfaces through it.

- **New** `apps/web/src/components/ai/shared/chat/ChatErrorBanner.tsx` — translates the error via `getAIErrorMessage()`, renders a Dismiss button, and shows `BuyCreditsButton` when `isOutOfCreditsError()`. Uses design-system `destructive` tokens with the glass banner's enter/exit animation.
- `InputCard.tsx` — dropped its billing-aware `error`/`onClearError` props for a generic `errorSlot` node, keeping it design-system-agnostic (it lives in `components/ui/`). The only consumer that passed those props was `ChatLayout`.
- `ChatLayout.tsx` — renders `<ChatErrorBanner>` into `errorSlot`; public props unchanged. **This is the actual bug fix.**
- `ChatInputArea.tsx` + `SidebarChatTab.tsx` — dropped their duplicated inline banners (and now-unused imports).

This also unifies the previous `red-50` banner styling onto the destructive token across all surfaces.

## Tests

- **New** `ChatErrorBanner.test.tsx` (7 tests) pins the contract: the raw credit-gate JSON never reaches the DOM, friendly copy is shown per error kind, the buy-credits CTA appears only for `out_of_credits` (not `too_many_in_flight`/generic), and Dismiss wires to `onClearError`.
- Existing `error-messages.test.ts` (12) covers the classifier; `ChatLayout.remoteStreams.test.tsx` (4) and `SidebarChatTab.test.tsx` (24) still pass.

## Verification

- `web typecheck` → clean
- `eslint` on all touched files → clean
- All touched-area tests green (47 total)

**Manual check still recommended:** force a gate denial (zero credits / `CREDITS_ENFORCEMENT_ENABLED`) and confirm each surface shows the friendly message + working Buy-credits button, and that a `429` shows the in-flight copy with no CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)