### PR TITLE
fix(canvas): remove UA body-margin border on published canvas pages

### DIFF
--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderCanvasDocument, escapeHtml, BASELINE_CSP } from '../render-document';
+import { renderCanvasDocument, escapeHtml, BASELINE_CSP, BASELINE_RESET } from '../render-document';
 
 describe('renderCanvasDocument', () => {
   it('given any input, should return a full HTML document', () => {
@@ -42,6 +42,20 @@ describe('renderCanvasDocument', () => {
     expect(out).toContain("default-src 'none'");
     expect(out).toContain("script-src 'unsafe-inline'");
     expect(BASELINE_CSP).not.toContain('sandbox');
+  });
+
+  it('should emit a baseline reset that zeroes the body margin (no UA border/frame)', () => {
+    const out = renderCanvasDocument({ html: '<div>x</div>' });
+    expect(out).toContain('html,body{margin:0;padding:0;}');
+    expect(BASELINE_RESET).toContain('box-sizing:border-box');
+  });
+
+  it('should emit the baseline reset BEFORE the author CSS so author rules win', () => {
+    const out = renderCanvasDocument({ html: '<style>body { margin: 40px; }</style><div>x</div>' });
+    const resetIdx = out.indexOf('html,body{margin:0;padding:0;}');
+    const authorIdx = out.indexOf('margin: 40px');
+    expect(resetIdx).toBeGreaterThanOrEqual(0);
+    expect(authorIdx).toBeGreaterThan(resetIdx);
   });
 
   it('should embed NO cookie, session, token, or API URL strings', () => {

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -47,7 +47,13 @@ describe('renderCanvasDocument', () => {
   it('should emit a baseline reset that zeroes the body margin (no UA border/frame)', () => {
     const out = renderCanvasDocument({ html: '<div>x</div>' });
     expect(out).toContain('html,body{margin:0;padding:0;}');
-    expect(BASELINE_RESET).toContain('box-sizing:border-box');
+  });
+
+  it('baseline reset is scoped to html/body — no universal box-sizing or font override', () => {
+    // A wider reset would silently reflow/restyle arbitrary author content on republish.
+    expect(BASELINE_RESET).toBe('html,body{margin:0;padding:0;}');
+    expect(BASELINE_RESET).not.toContain('box-sizing');
+    expect(BASELINE_RESET).not.toContain('font-family');
   });
 
   it('should emit the baseline reset BEFORE the author CSS so author rules win', () => {

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -46,6 +46,21 @@ export const BASELINE_CSP =
   "default-src 'none'; img-src data: https:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; object-src 'none'; base-uri 'none'; form-action 'none'";
 
 /**
+ * Baseline document reset, emitted BEFORE the author CSS.
+ *
+ * The author body is rendered into a real `<body>`, which carries the user-agent
+ * default `body { margin: 8px }`. For full-bleed content (e.g. a `min-height:100vh`
+ * background) that 8px gap shows the page background around the content and reads
+ * as an unwanted border/frame. Zeroing html/body margin removes it; the box-sizing
+ * reset and default font give predictable, app-consistent rendering. Author rules
+ * targeting html/body/* still win because the author CSS is concatenated after.
+ */
+export const BASELINE_RESET =
+  '*,*::before,*::after{box-sizing:border-box;}' +
+  'html,body{margin:0;padding:0;}' +
+  "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;line-height:1.6;}";
+
+/**
  * Escape a string for safe interpolation into HTML text / the <title> element.
  */
 export function escapeHtml(value: string): string {
@@ -99,7 +114,7 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
     baseTag +
     `<title>${safeTitle}</title>` +
     `<meta http-equiv="Content-Security-Policy" content="${BASELINE_CSP}">` +
-    `<style>${css}</style>` +
+    `<style>${BASELINE_RESET}${css}</style>` +
     '</head><body>' +
     body +
     '</body></html>'

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -51,14 +51,16 @@ export const BASELINE_CSP =
  * The author body is rendered into a real `<body>`, which carries the user-agent
  * default `body { margin: 8px }`. For full-bleed content (e.g. a `min-height:100vh`
  * background) that 8px gap shows the page background around the content and reads
- * as an unwanted border/frame. Zeroing html/body margin removes it; the box-sizing
- * reset and default font give predictable, app-consistent rendering. Author rules
- * targeting html/body/* still win because the author CSS is concatenated after.
+ * as an unwanted border/frame.
+ *
+ * DELIBERATELY scoped to html/body only — it just clears the UA margin/padding.
+ * A universal `box-sizing: border-box` or a default `font-family` would silently
+ * alter arbitrary author HTML/CSS that relies on the browser defaults (content-box
+ * sizing, the UA serif font), reflowing or restyling already-published canvases on
+ * republish. Authors who want a wider reset can add their own. Author rules
+ * targeting html/body still win because the author CSS is concatenated after.
  */
-export const BASELINE_RESET =
-  '*,*::before,*::after{box-sizing:border-box;}' +
-  'html,body{margin:0;padding:0;}' +
-  "body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;line-height:1.6;}";
+export const BASELINE_RESET = 'html,body{margin:0;padding:0;}';
 
 /**
  * Escape a string for safe interpolation into HTML text / the <title> element.


### PR DESCRIPTION
## Problem

Published canvas pages (e.g. https://getting-started.pagespace.site/my-dashboard) show a visible **border/frame** around the content that isn't present in the in-app editor preview.

**Root cause:** the renderer emits the author body into a real `<body>` with no margin reset. The browser user-agent default `body { margin: 8px }` leaves an 8px band of the page background around full-bleed content (`min-height:100vh`, gradient backgrounds, etc.), which reads as a border.

## Fix

Emit a **narrowly scoped** baseline reset in the shared `renderCanvasDocument` (`packages/lib/src/canvas/render-document.ts`), before the author CSS:

```css
html,body{margin:0;padding:0;}
```

- Lives in `<head>`, so body markup is unchanged.
- Author CSS is concatenated **after**, so any author `html`/`body` rule still overrides the reset.
- Applies to both the published artifact and the in-app sandboxed iframe (they share this renderer).

### Why scoped to html/body only

An earlier revision also added `*{box-sizing:border-box}` and a default `font-family`. Those silently alter arbitrary author content rendered through this shared path — content-box→border-box flips author elements that size with width/height + padding/border (shrinking/reflowing them), and unstyled text switches away from the UA font — which would change **already-published** canvases on republish. The reported frame only requires clearing the UA body margin, so the reset is kept minimal. Authors who want a wider reset can add their own.

## Notes

- This is the **border** half of the reported issue. The separate "links don't work" symptom was a stale edge CSP (`sandbox allow-scripts`) on `pagespace-proxy`; that fix is already committed in the deploy repo and only needs the proxy redeployed — no code change here.
- **Re-publish required:** existing published artifacts are static HTML generated at publish time. After this merges, re-publish affected canvas pages to regenerate them with the reset.

## Tests

`packages/lib/src/canvas/__tests__/render-document.test.ts` — added cases: the reset zeroes body margin, precedes author CSS so author rules win, and is scoped to html/body (no `box-sizing`/`font-family`). All 16 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)