### PR TITLE
fix(billing): stabilize the displayed AI-credit balance

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -18,8 +18,9 @@ import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { requiresProSubscription, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
 // LEGACY: daily-quota path, active only when isCreditsModeEnabled() is OFF. Remove at final credits cutover.
 import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
-import { isCreditsModeEnabled } from '@pagespace/lib/billing/credit-pricing';
+import { isCreditsModeEnabled, MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -352,7 +353,10 @@ export async function POST(request: Request) {
     // unlimited) and lazy-inits balances. On an allowed request it places a hold
     // (reservation + in-flight marker) whose id is threaded to billing and released
     // at settle; out_of_credits -> 402, the free-tier in-flight cap -> 429.
-    const creditGate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier);
+    const creditGate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier, {
+      estCostCents: estimateChatHoldCentsForModel(selectedModel),
+      maxInFlight: MAX_CHAT_INFLIGHT,
+    });
     if (!creditGate.allowed) {
       loggers.ai.warn('AI Chat API: AI credit gate denied', { userId, reason: creditGate.reason });
       return creditGateErrorResponse(creditGate.reason);

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -6,8 +6,9 @@ import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { createAdminRestrictedResponse, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
 // LEGACY: daily-quota path, active only when isCreditsModeEnabled() is OFF. Remove at final credits cutover.
 import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
-import { isCreditsModeEnabled } from '@pagespace/lib/billing/credit-pricing';
+import { isCreditsModeEnabled, MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -335,7 +336,10 @@ export async function POST(
         .select({ subscriptionTier: users.subscriptionTier })
         .from(users)
         .where(eq(users.id, userId));
-      const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier);
+      const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
+        estCostCents: estimateChatHoldCentsForModel(selectedModel),
+        maxInFlight: MAX_CHAT_INFLIGHT,
+      });
       if (!creditGate.allowed) {
         loggers.api.warn('Global Assistant Chat API: AI credit gate denied', {
           userId: maskIdentifier(userId),

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -23,6 +23,8 @@ import { users } from '@pagespace/db/schema/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
+import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -219,7 +221,10 @@ export async function POST(request: Request) {
       .select({ subscriptionTier: users.subscriptionTier })
       .from(users)
       .where(eq(users.id, userId));
-    const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier);
+    const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
+      estCostCents: estimateChatHoldCentsForModel(agent.aiModel ?? undefined),
+      maxInFlight: MAX_CHAT_INFLIGHT,
+    });
     if (!creditGate.allowed) {
       loggers.api.warn('Agent consultation: AI credit gate denied', { userId, agentId, reason: creditGate.reason });
       return creditGateErrorResponse(creditGate.reason);

--- a/apps/web/src/app/api/pulse/generate/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/pulse/generate/__tests__/credit-gate.test.ts
@@ -73,6 +73,7 @@ vi.mock('ai', () => ({
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { createAIProvider } from '@/lib/ai/core';
 import { generateText } from 'ai';
 
@@ -127,11 +128,14 @@ describe('POST /api/pulse/generate — prepaid credit gate', () => {
     expect(generateText).not.toHaveBeenCalled();
   });
 
-  it("consults the gate with the user's resolved subscription tier", async () => {
+  it("consults the gate with the user's resolved subscription tier and the chat concurrency cap", async () => {
     vi.mocked(canConsumeAI).mockResolvedValue({ allowed: false, reason: 'out_of_credits' });
 
     await POST(makeRequest());
 
-    expect(canConsumeAI).toHaveBeenCalledWith('user-1', 'pro');
+    // The model isn't resolved at the gate, so Pulse passes no per-call estimate (the
+    // hold uses the default) but does apply the chat in-flight cap to bound concurrent
+    // overdraw.
+    expect(canConsumeAI).toHaveBeenCalledWith('user-1', 'pro', { maxInFlight: MAX_CHAT_INFLIGHT });
   });
 });

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -40,6 +40,7 @@ import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-id
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring, extractOpenRouterCostDollars } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -93,7 +94,11 @@ export async function POST(req: Request) {
     // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
     // This is the on-demand (user-triggered) Pulse path; the cron path is intentionally
     // NOT gated so a failed bill can't 500 the batch.
-    const creditGate = await canConsumeAI(userId, (user.subscriptionTier ?? 'free') as SubscriptionTier);
+    // Model isn't resolved until the generation step below, so we let the hold use the
+    // default flat estimate (estCostCents omitted) and just apply the chat concurrency cap.
+    const creditGate = await canConsumeAI(userId, (user.subscriptionTier ?? 'free') as SubscriptionTier, {
+      maxInFlight: MAX_CHAT_INFLIGHT,
+    });
     if (!creditGate.allowed) {
       loggers.api.warn('Pulse generate: AI credit gate denied', { userId, reason: creditGate.reason });
       return creditGateErrorResponse(creditGate.reason);

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -37,6 +37,8 @@ import { getProviderTier } from '@/lib/ai/core/ai-providers-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
+import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -114,7 +116,10 @@ export async function POST(request: Request): Promise<Response> {
     .select({ subscriptionTier: users.subscriptionTier })
     .from(users)
     .where(eq(users.id, authResult.userId));
-  const creditGate = await canConsumeAI(authResult.userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier);
+  const creditGate = await canConsumeAI(authResult.userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
+    estCostCents: estimateChatHoldCentsForModel(page.aiModel ?? undefined),
+    maxInFlight: MAX_CHAT_INFLIGHT,
+  });
   if (!creditGate.allowed) {
     auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: creditGate.reason }, riskScore: 0 });
     return creditGateErrorResponse(creditGate.reason);

--- a/apps/web/src/components/billing/CreditBalance.tsx
+++ b/apps/web/src/components/billing/CreditBalance.tsx
@@ -52,9 +52,13 @@ export function CreditBalance() {
     return null;
   }
 
-  const { spendable, monthly, topup } = balance;
+  const { spendable, monthly, topup, reserved } = balance;
   const isLow = spendable <= Math.max(LOW_BALANCE_FLOOR_CENTS, Math.round(monthly.allowance * 0.15));
   const resetDate = monthly.periodEnd ? new Date(monthly.periodEnd) : null;
+  // Surface in-flight reservations as a quiet signal, not in the headline number — the
+  // displayed balance is gross of holds (see getCreditBalance) so it doesn't dip-then-pop
+  // across a call; this dot just tells the user a call is currently consuming credits.
+  const hasInFlight = reserved > 0;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -67,9 +71,17 @@ export function CreditBalance() {
               className="hidden sm:flex items-center gap-1.5"
               aria-label="View AI credit balance"
             >
-              <Coins
-                className={`h-4 w-4 ${isLow ? 'text-amber-500' : 'text-muted-foreground'}`}
-              />
+              <span className="relative inline-flex">
+                <Coins
+                  className={`h-4 w-4 ${isLow ? 'text-amber-500' : 'text-muted-foreground'}`}
+                />
+                {hasInFlight && (
+                  <span
+                    className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 animate-pulse rounded-full bg-sky-500"
+                    aria-hidden="true"
+                  />
+                )}
+              </span>
               <Badge
                 variant={isLow ? 'destructive' : 'secondary'}
                 className="text-xs font-medium tabular-nums"
@@ -87,6 +99,11 @@ export function CreditBalance() {
             <p className="text-xs text-primary-foreground/80">
               Top-up: {formatCreditDollars(topup.remaining)}
             </p>
+            {hasInFlight && (
+              <p className="text-xs text-primary-foreground/80">
+                ~{formatCreditDollars(reserved)} reserved on in-flight calls
+              </p>
+            )}
             {resetDate && (
               <p className="text-xs text-primary-foreground/80">
                 Monthly resets {resetDate.toLocaleDateString()}

--- a/apps/web/src/hooks/__tests__/useCreditBalance.test.ts
+++ b/apps/web/src/hooks/__tests__/useCreditBalance.test.ts
@@ -1,0 +1,56 @@
+/**
+ * useCreditBalance — pure-logic tests.
+ *
+ * The hook itself wires SWR + a Socket.IO listener and can't be rendered in the .pu
+ * worktree (dual-React). We instead test the two pure pieces the socket handler is
+ * built from: how an authoritative `credits:updated` payload maps into the cached
+ * balance, and the mutate options used to apply it (must NOT revalidate — a refetch
+ * would race the already-authoritative payload and reintroduce the balance flicker).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Keep the module import side-effect-free: stub the heavy client deps.
+vi.mock('swr', () => ({ default: vi.fn(() => ({ data: undefined, error: undefined, isLoading: true, mutate: vi.fn() })) }));
+vi.mock('@/stores/useSocketStore', () => ({ useSocketStore: vi.fn(() => undefined) }));
+vi.mock('@/lib/auth/auth-fetch', () => ({ fetchWithAuth: vi.fn() }));
+
+import { applyCreditsPayload, CREDITS_PUSH_MUTATE_OPTIONS, type CreditBalance } from '../useCreditBalance';
+import type { CreditsEventPayload } from '@/lib/websocket';
+
+const payload = {
+  userId: 'u1',
+  operation: 'updated',
+  billingEnabled: true,
+  monthly: { remaining: 300, allowance: 500, periodEnd: null },
+  topup: { remaining: 100 },
+  spendable: 400,
+  reserved: 25,
+} as CreditsEventPayload;
+
+describe('applyCreditsPayload', () => {
+  it('maps the authoritative socket payload into the cached balance', () => {
+    const next = applyCreditsPayload(payload, undefined);
+    expect(next).toMatchObject({
+      billingEnabled: true,
+      spendable: 400,
+      reserved: 25,
+      monthly: payload.monthly,
+      topup: payload.topup,
+    });
+  });
+
+  it('preserves the process-level creditsMode from the current cache (payload omits it)', () => {
+    const current = { creditsMode: true } as CreditBalance;
+    expect(applyCreditsPayload(payload, current).creditsMode).toBe(true);
+  });
+
+  it('defaults creditsMode to false when there is no current cache', () => {
+    expect(applyCreditsPayload(payload, undefined).creditsMode).toBe(false);
+  });
+});
+
+describe('CREDITS_PUSH_MUTATE_OPTIONS', () => {
+  it('does NOT revalidate — the payload is authoritative; a refetch would race it', () => {
+    expect(CREDITS_PUSH_MUTATE_OPTIONS.revalidate).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useCreditBalance.ts
+++ b/apps/web/src/hooks/useCreditBalance.ts
@@ -39,6 +39,35 @@ const fetcher = async (url: string): Promise<CreditBalance> => {
 };
 
 /**
+ * Pure: fold an authoritative `credits:updated` payload into the cached balance. The
+ * payload carries the full server-computed balance, so we replace the per-user fields
+ * wholesale. `creditsMode` is a process-level flag absent from the payload, so we keep
+ * whatever the initial fetch established (default OFF until it resolves).
+ */
+export function applyCreditsPayload(
+  payload: CreditsEventPayload,
+  current: CreditBalance | undefined,
+): CreditBalance {
+  return {
+    billingEnabled: payload.billingEnabled,
+    monthly: payload.monthly,
+    topup: payload.topup,
+    spendable: payload.spendable,
+    reserved: payload.reserved,
+    creditsMode: current?.creditsMode ?? false,
+  };
+}
+
+/**
+ * Mutate options for applying a socket push. We do NOT revalidate: the payload is the
+ * authoritative server balance, so a follow-up GET /api/credits only races it — an
+ * in-flight hold created/expired between the emit and the refetch would yield a third,
+ * different number and reintroduce the "more → less → more" flicker. The initial fetch
+ * and the visibility-change refetch remain the authoritative reads.
+ */
+export const CREDITS_PUSH_MUTATE_OPTIONS = { revalidate: false } as const;
+
+/**
  * Live prepaid AI-credit balance. Reads `/api/credits` once and then updates from
  * `credits:updated` socket events (emitted after a call settles, a refill lands, or
  * a top-up is purchased) rather than polling.
@@ -61,30 +90,15 @@ export function useCreditBalance() {
     connect();
   }, [connect]);
 
-  // Apply live balance pushes. The payload is shown immediately for instant feedback,
-  // then we revalidate against `/api/credits` (the authoritative current balance) so an
-  // out-of-order or stale snapshot can't stick — e.g. a delayed turn-start "hold placed"
-  // push arriving AFTER its own settlement push would otherwise roll the navbar back to
-  // the reserved value. SWR dedupes concurrent revalidations, so bursty start+finish
-  // events coalesce into a single refetch.
+  // Apply live balance pushes. The payload is the authoritative server-computed balance
+  // (one push per settle/funding event — the gate no longer pushes when a hold is just
+  // placed), so we apply it without revalidating. Revalidating here used to race the
+  // payload and produce a third number; see CREDITS_PUSH_MUTATE_OPTIONS.
   useEffect(() => {
     if (!socket) return;
 
     const handleCreditsUpdated = (payload: CreditsEventPayload) => {
-      mutate(
-        (current) => ({
-          billingEnabled: payload.billingEnabled,
-          monthly: payload.monthly,
-          topup: payload.topup,
-          spendable: payload.spendable,
-          reserved: payload.reserved,
-          // Mode is environment-level (not in the socket payload) — keep the value the
-          // initial fetch established; default OFF until it resolves. The revalidate
-          // below re-reads it authoritatively from /api/credits regardless.
-          creditsMode: current?.creditsMode ?? false,
-        }),
-        { revalidate: true },
-      );
+      mutate((current) => applyCreditsPayload(payload, current), CREDITS_PUSH_MUTATE_OPTIONS);
     };
 
     socket.on('credits:updated', handleCreditsUpdated);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -122,6 +122,11 @@
       "import": "./dist/monitoring/voice-pricing.js",
       "require": "./dist/monitoring/voice-pricing.js"
     },
+    "./monitoring/chat-pricing": {
+      "types": "./dist/monitoring/chat-pricing.d.ts",
+      "import": "./dist/monitoring/chat-pricing.js",
+      "require": "./dist/monitoring/chat-pricing.js"
+    },
     "./monitoring/ai-context-calculator": {
       "types": "./dist/monitoring/ai-context-calculator.d.ts",
       "import": "./dist/monitoring/ai-context-calculator.js",

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -72,12 +72,14 @@ describe('getCreditBalance', () => {
     expect(b.spendable).toBe(b.monthly.allowance);
   });
 
-  it('subtracts active holds from spendable when no row exists', async () => {
+  it('reports active holds as reserved but does NOT subtract them from spendable when no row exists', async () => {
     balanceRows = [];
     holdRows = [{ reserved: 25 }];
     const b = await getCreditBalance('u1', 'free');
+    // Display is gross of in-flight holds: reserved is surfaced separately, but the
+    // headline spendable stays the funded balance so it doesn't dip when a call starts.
     expect(b.reserved).toBe(25);
-    expect(b.spendable).toBe(b.monthly.allowance - 25);
+    expect(b.spendable).toBe(b.monthly.allowance);
   });
 
   it('uses stored remaining for a free tier within its period', async () => {
@@ -123,7 +125,7 @@ describe('getCreditBalance', () => {
     expect(b.spendable).toBe(250); // only top-up survives
   });
 
-  it('clamps spendable at zero when holds exceed the balance', async () => {
+  it('does not let in-flight holds reduce the displayed spendable', async () => {
     balanceRows = [
       {
         monthlyRemainingCents: 10,
@@ -134,7 +136,10 @@ describe('getCreditBalance', () => {
     ];
     holdRows = [{ reserved: 50 }];
     const b = await getCreditBalance('u1', 'free');
-    expect(b.spendable).toBe(0);
+    // Holds larger than the balance must NOT drive the headline to 0 mid-call; the
+    // gate enforces overspend independently. Spendable stays the funded balance.
+    expect(b.reserved).toBe(50);
+    expect(b.spendable).toBe(10);
   });
 });
 

--- a/packages/lib/src/billing/__tests__/credit-core.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-core.test.ts
@@ -9,6 +9,7 @@ import {
   allocateSpend,
   evaluateGate,
   reservationCents,
+  estimateChatHoldCents,
   holdExpiresAt,
   computeMonthlyRefill,
   applyTopup,
@@ -250,6 +251,34 @@ describe('reservationCents', () => {
     expect(reservationCents(0)).toBe(0);
     expect(reservationCents(-5)).toBe(0);
     expect(reservationCents(Number.NaN)).toBe(0);
+  });
+});
+
+describe('estimateChatHoldCents', () => {
+  // markupBps 15000 = 1.5×. floor 2¢, ceiling 25¢ throughout.
+  it('applies the markup to the real-cost estimate and rounds to whole cents', () => {
+    // $0.10 real × 1.5 = $0.15 = 15¢, within [2, 25].
+    expect(estimateChatHoldCents(0.10, 15000, 2, 25)).toBe(15);
+  });
+
+  it('clamps up to the floor when the marked-up estimate is below it', () => {
+    // A sub-cent call ($0.0005 × 1.5 ≈ 0.075¢ → rounds to 0) must still reserve the floor.
+    expect(estimateChatHoldCents(0.0005, 15000, 2, 25)).toBe(2);
+    expect(estimateChatHoldCents(0, 15000, 2, 25)).toBe(2);
+  });
+
+  it('clamps down to the ceiling when the marked-up estimate exceeds it', () => {
+    // $0.50 real × 1.5 = 75¢ → capped at the legacy 25¢ ceiling.
+    expect(estimateChatHoldCents(0.50, 15000, 2, 25)).toBe(25);
+  });
+
+  it('treats a non-finite or negative estimate as zero cost (floor applies)', () => {
+    expect(estimateChatHoldCents(Number.NaN, 15000, 2, 25)).toBe(2);
+    expect(estimateChatHoldCents(-1, 15000, 2, 25)).toBe(2);
+  });
+
+  it('keeps floor <= ceiling even if misconfigured (ceiling below floor coerces up)', () => {
+    expect(estimateChatHoldCents(1, 15000, 10, 5)).toBe(10);
   });
 });
 

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -137,9 +137,10 @@ describe('canConsumeAI', () => {
     // The hold reserves this call's estimate and is scoped to the user.
     expect(sink.holdValues).toMatchObject({ userId: 'u1', estCents: EST });
     expect(sink.holdValues?.expiresAt).toBeInstanceOf(Date);
-    // Placing the hold shrank spendable -> push the fresh balance so the navbar
-    // drops the instant the call starts (not just when it settles).
-    expect(mockEmitCreditsUpdated).toHaveBeenCalledWith('u1');
+    // Placing the hold must NOT push a balance update: holds are hidden from the
+    // displayed balance, and the navbar updates only when the call settles (real
+    // cost) via consumeCredits. Emitting here would make the headline dip-then-pop.
+    expect(mockEmitCreditsUpdated).not.toHaveBeenCalled();
   });
 
   it('caps a PAID user via opts.maxInFlight (voice concurrency bound) even with ample credit', async () => {

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -9,8 +9,13 @@
  *     will reset it on the next call) rather than a stale, pessimistic remainder;
  *   - paid tier whose window has lapsed is shown 0 monthly (use-it-or-lose-it — the
  *     gate excludes the expired allowance until the renewal invoice refills it);
- *   - spendable nets out the sum of the user's still-active holds (reservations on
- *     calls currently in flight), clamped at 0.
+ *   - spendable is the FUNDED balance (monthly + top-up remaining), clamped at 0, and
+ *     is deliberately GROSS of in-flight holds. We surface the sum of still-active
+ *     holds separately as `reserved` (for an optional "call running" indicator) but do
+ *     NOT subtract it from the headline: a per-call reservation that places, then
+ *     settles to a fraction of its estimate, would otherwise make the displayed number
+ *     dip-then-pop on every call. Overspend is bounded by the gate's own locked check
+ *     (see ./credit-gate), not by this display; hiding holds here cannot over-grant.
  *
  * Money is always whole cents of customer-facing credit value, matching credit-core.
  *
@@ -39,9 +44,16 @@ export interface CreditBalanceSummary {
   topup: {
     remaining: number;
   };
-  /** monthly + topup remaining, minus active holds, clamped to >= 0. */
+  /**
+   * Funded balance for display: monthly + topup remaining, clamped to >= 0. GROSS of
+   * in-flight holds (see file header) — `reserved` is reported separately, not netted
+   * out here, so the headline doesn't dip-then-pop across a call's reserve/settle cycle.
+   */
   spendable: number;
-  /** Sum of this user's non-expired holds (estimated spend on in-flight calls). */
+  /**
+   * Sum of this user's non-expired holds (estimated spend on in-flight calls). Surfaced
+   * for an optional in-flight indicator; NOT subtracted from `spendable`.
+   */
   reserved: number;
 }
 
@@ -97,7 +109,7 @@ export async function getCreditBalance(
   // so present that as the spendable monthly balance.
   if (!row) {
     const allowance = allowanceFor(tier);
-    const spendable = Math.max(0, allowance - reserved);
+    const spendable = Math.max(0, allowance);
     return {
       billingEnabled: true,
       monthly: { remaining: allowance, allowance, periodEnd: null },
@@ -122,7 +134,7 @@ export async function getCreditBalance(
   }
 
   const topupRemaining = row.topupRemainingCents;
-  const spendable = Math.max(0, monthlyRemaining + topupRemaining - reserved);
+  const spendable = Math.max(0, monthlyRemaining + topupRemaining);
 
   return {
     billingEnabled: true,

--- a/packages/lib/src/billing/credit-core.ts
+++ b/packages/lib/src/billing/credit-core.ts
@@ -187,6 +187,30 @@ export function reservationCents(estimateCents: number): number {
 }
 
 /**
+ * Per-call chat hold estimate, in whole cents, clamped to [floorCents, ceilingCents].
+ *
+ * Takes a PRE-markup real-cost estimate for the call (dollars — the shell derives it
+ * from the model catalog and a token estimate), applies the markup, and clamps. The
+ * model-awareness lives in the dollar estimate the shell passes; this stays pure (no
+ * catalog, env, or clock). The floor keeps a sub-cent call from reserving nothing; the
+ * ceiling caps the reservation at the legacy flat hold so a pricey model can't lock up
+ * an unbounded slice of spendable. A misconfigured ceiling below the floor coerces up
+ * to the floor so the range is never inverted. Sits alongside {@link reservationCents}
+ * (the flat-estimate path); this is the cost-derived path.
+ */
+export function estimateChatHoldCents(
+  estimatedRealCostDollars: number,
+  markupBps: number,
+  floorCents: number,
+  ceilingCents: number,
+): number {
+  const floor = Math.max(0, Math.round(floorCents));
+  const ceiling = Math.max(floor, Math.round(ceilingCents));
+  const charged = markupCents(estimatedRealCostDollars, markupBps);
+  return Math.min(ceiling, Math.max(floor, charged));
+}
+
+/**
  * The instant a hold placed at `nowMs` should expire, in epoch ms. Pure (operates
  * on numbers only — the shell converts to/from Date). A hold lives long enough to
  * cover the longest stream plus its post-call settle; after that the reconcile

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -33,7 +33,6 @@ import {
   MAX_FREE_INFLIGHT,
   isCreditsEnforcementEnabled,
 } from './credit-pricing';
-import { emitCreditsUpdated } from './credit-emit';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
 /**
@@ -232,12 +231,13 @@ export async function canConsumeAI(
     return { ...result, holdId: inserted[0]?.id };
   });
 
-  // A hold was placed: the reservation just shrank this user's spendable. Push the
-  // fresh balance now (scopeless — navbar only; no usage exists yet) so the widget
-  // drops the instant the call starts, not just when it settles. This is the
-  // always-fires update that keeps the navbar correct even if the stream is
-  // interrupted and onFinish/settlement never runs. Best-effort, never blocks.
-  if (result.holdId) void emitCreditsUpdated(userId);
+  // NOTE: we deliberately do NOT emit a balance update when the hold is placed. Holds
+  // are hidden from the displayed balance (see getCreditBalance), and the navbar should
+  // step down only when the call SETTLES to its real cost (consumeCredits emits then).
+  // Emitting here pushed the reservation into the headline, making it dip on call start
+  // and pop back up at settle — the "more → less → more" flicker. An abandoned/crashed
+  // call leaves a dangling hold for the reconcile sweep (credit-backfill) to expire; it
+  // no longer affects the displayed balance, so no gate-time push is needed.
 
   // Dark launch: the gate did all its bookkeeping above (lazy-init, reset, balance
   // read, and a hold on the allow path), but when enforcement is OFF we never hand

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -149,8 +149,11 @@ export const MAX_FREE_INFLIGHT = envInt('MAX_FREE_INFLIGHT', 2);
  * each reserve little yet collectively settle past their balance. This matters now
  * that the chat hold is a (smaller) model-aware estimate clamped to [floor, ceiling]
  * rather than the old flat 25¢ reserve floor — the cap bounds worst-case concurrent
- * overdraw to `MAX_CHAT_INFLIGHT × worst-case single chat call`. Generous enough for
- * legitimate multi-tab / multi-agent use. Default 8.
+ * overdraw to `MAX_CHAT_INFLIGHT × the real settled cost of a single chat call` (the
+ * hold only bounds the up-front reservation, not the final settle, so the cap — not the
+ * hold — is what limits how far simultaneous calls can collectively run past the
+ * balance before any settles). Generous enough for legitimate multi-tab / multi-agent
+ * use. Default 8.
  */
 export const MAX_CHAT_INFLIGHT = envInt('MAX_CHAT_INFLIGHT', 8);
 

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -142,6 +142,35 @@ export const CREDIT_HOLD_TTL_SECONDS = envInt('CREDIT_HOLD_TTL_SECONDS', 900);
  */
 export const MAX_FREE_INFLIGHT = envInt('MAX_FREE_INFLIGHT', 2);
 
+/**
+ * Max concurrent in-flight CHAT calls per user, applied to ALL tiers. Mirrors
+ * {@link VOICE_MAX_INFLIGHT}: a hold reserves only an ESTIMATE, but the real cost
+ * lands at settle, so without a cap a user could open many simultaneous chats that
+ * each reserve little yet collectively settle past their balance. This matters now
+ * that the chat hold is a (smaller) model-aware estimate clamped to [floor, ceiling]
+ * rather than the old flat 25¢ reserve floor — the cap bounds worst-case concurrent
+ * overdraw to `MAX_CHAT_INFLIGHT × worst-case single chat call`. Generous enough for
+ * legitimate multi-tab / multi-agent use. Default 8.
+ */
+export const MAX_CHAT_INFLIGHT = envInt('MAX_CHAT_INFLIGHT', 8);
+
+/**
+ * Lower bound (whole cents) for a model-aware chat hold, so a sub-cent call still
+ * reserves something and the in-flight cap stays meaningful. Default 2¢.
+ */
+export const CHAT_HOLD_FLOOR_CENTS = envInt('CHAT_HOLD_FLOOR_CENTS', 2);
+
+/**
+ * Assumed per-call token budget used to size the model-aware chat hold BEFORE the call
+ * runs (the real token counts aren't known until the stream finishes; the real cost
+ * always settles exactly via consumeCredits regardless). Multiplied by the model's
+ * catalog rate to get a pre-markup dollar estimate, then marked up and clamped to
+ * [CHAT_HOLD_FLOOR_CENTS, RESERVE_FLOOR_CENTS]. Coarse on purpose — the clamp range,
+ * not this budget, is the safety bound. Defaults ~4k in / 1k out (a typical chat turn).
+ */
+export const CHAT_HOLD_ASSUMED_INPUT_TOKENS = envInt('CHAT_HOLD_ASSUMED_INPUT_TOKENS', 4000);
+export const CHAT_HOLD_ASSUMED_OUTPUT_TOKENS = envInt('CHAT_HOLD_ASSUMED_OUTPUT_TOKENS', 1000);
+
 export interface CreditPack {
   /** Stable SKU id, also stored in Stripe price metadata. */
   id: string;

--- a/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub the catalog so the test controls the per-call dollar estimate and the known-model
+// set, without pulling the heavy ai-monitoring module (and its db deps) or pinning to
+// live prices. AI_PRICING membership decides known-vs-unknown model handling.
+const { mockCalculateCost } = vi.hoisted(() => ({ mockCalculateCost: vi.fn() }));
+vi.mock('../ai-monitoring', () => ({
+  calculateCost: mockCalculateCost,
+  AI_PRICING: {
+    'anthropic/claude-opus-4.8': { input: 5, output: 25 },
+    'openai/gpt-5': { input: 1.25, output: 10 },
+    'openai/gpt-5-nano': { input: 0.05, output: 0.4 },
+    'openai/gpt-5.5-pro': { input: 30, output: 180 },
+    default: { input: 0, output: 0 },
+  },
+}));
+
+import { estimateChatHoldCentsForModel } from '../chat-pricing';
+import {
+  CHAT_HOLD_ASSUMED_INPUT_TOKENS,
+  CHAT_HOLD_ASSUMED_OUTPUT_TOKENS,
+  CHAT_HOLD_FLOOR_CENTS,
+  CREDIT_HOLD_ESTIMATE_CENTS,
+} from '../../billing/credit-pricing';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('estimateChatHoldCentsForModel', () => {
+  it('marks up the catalog cost estimate and returns whole cents within the clamp range', () => {
+    mockCalculateCost.mockReturnValue(0.10); // $0.10 real × 1.5 = 15¢
+    expect(estimateChatHoldCentsForModel('anthropic/claude-opus-4.8')).toBe(15);
+  });
+
+  it('prices the model using the assumed token budget by default', () => {
+    mockCalculateCost.mockReturnValue(0.05);
+    estimateChatHoldCentsForModel('openai/gpt-5');
+    expect(mockCalculateCost).toHaveBeenCalledWith(
+      'openai/gpt-5',
+      CHAT_HOLD_ASSUMED_INPUT_TOKENS,
+      CHAT_HOLD_ASSUMED_OUTPUT_TOKENS,
+    );
+  });
+
+  it('uses a caller-supplied input-token estimate when provided', () => {
+    mockCalculateCost.mockReturnValue(0.05);
+    estimateChatHoldCentsForModel('openai/gpt-5', { inputTokens: 12000 });
+    expect(mockCalculateCost).toHaveBeenCalledWith(
+      'openai/gpt-5',
+      12000,
+      CHAT_HOLD_ASSUMED_OUTPUT_TOKENS,
+    );
+  });
+
+  it('clamps a cheap (but known) model up to the floor', () => {
+    mockCalculateCost.mockReturnValue(0.0001);
+    expect(estimateChatHoldCentsForModel('openai/gpt-5-nano')).toBe(CHAT_HOLD_FLOOR_CENTS);
+  });
+
+  it('clamps an expensive model down to the legacy chat-hold ceiling', () => {
+    mockCalculateCost.mockReturnValue(1.0); // $1 × 1.5 = 150¢ → capped
+    expect(estimateChatHoldCentsForModel('openai/gpt-5.5-pro')).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
+  });
+
+  it('falls back to the legacy flat hold for an UNKNOWN model (never the 2¢ floor)', () => {
+    // An unrecognized model would price to $0 in the catalog and clamp to the floor —
+    // unsafe. Reserve the legacy flat estimate instead, and don't even price it.
+    expect(estimateChatHoldCentsForModel('some/unlisted-model')).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
+    expect(mockCalculateCost).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy flat hold when no model is supplied', () => {
+    expect(estimateChatHoldCentsForModel(undefined)).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
+    expect(mockCalculateCost).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
@@ -72,4 +72,12 @@ describe('estimateChatHoldCentsForModel', () => {
     expect(estimateChatHoldCentsForModel(undefined)).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
     expect(mockCalculateCost).not.toHaveBeenCalled();
   });
+
+  it('treats inherited Object keys (e.g. "toString", "constructor") as unknown models', () => {
+    // Guards against `model in AI_PRICING` matching prototype members and pricing a
+    // bogus model off Object.prototype. Own-property check only.
+    expect(estimateChatHoldCentsForModel('toString')).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
+    expect(estimateChatHoldCentsForModel('constructor')).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
+    expect(mockCalculateCost).not.toHaveBeenCalled();
+  });
 });

--- a/packages/lib/src/monitoring/chat-pricing.ts
+++ b/packages/lib/src/monitoring/chat-pricing.ts
@@ -40,7 +40,7 @@ export function estimateChatHoldCentsForModel(
   model: string | undefined,
   opts: { inputTokens?: number } = {},
 ): number {
-  if (!model || !(model in AI_PRICING)) {
+  if (!model || !Object.prototype.hasOwnProperty.call(AI_PRICING, model)) {
     return CREDIT_HOLD_ESTIMATE_CENTS;
   }
   const inputTokens =

--- a/packages/lib/src/monitoring/chat-pricing.ts
+++ b/packages/lib/src/monitoring/chat-pricing.ts
@@ -1,0 +1,57 @@
+/**
+ * chat-pricing — the per-call HOLD estimate for chat/text AI calls.
+ *
+ * The credit gate reserves a hold before a call runs, but the real token counts (and
+ * therefore the real cost) aren't known until the stream finishes — the real cost
+ * always settles exactly via consumeCredits on the OpenRouter-reported figure. So the
+ * hold is only a pre-settle BOUND. We make it model-aware (a pricey model reserves
+ * more than a cheap one) by pricing an assumed per-call token budget against the model
+ * catalog, marking it up, and clamping to [CHAT_HOLD_FLOOR_CENTS, RESERVE_FLOOR_CENTS].
+ *
+ * This is the impure shell (catalog lookup + config); the markup+clamp math is the pure
+ * {@link estimateChatHoldCents} in credit-core. Mirrors voice-pricing's
+ * estimateVoiceHoldCents. Holds are hidden from the displayed balance (see
+ * getCreditBalance), so this only affects gate enforcement, not the navbar number.
+ */
+
+import { calculateCost, AI_PRICING } from './ai-monitoring';
+import { estimateChatHoldCents } from '../billing/credit-core';
+import {
+  MARKUP_BPS,
+  CHAT_HOLD_FLOOR_CENTS,
+  CHAT_HOLD_ASSUMED_INPUT_TOKENS,
+  CHAT_HOLD_ASSUMED_OUTPUT_TOKENS,
+  CREDIT_HOLD_ESTIMATE_CENTS,
+} from '../billing/credit-pricing';
+
+/**
+ * Whole-cent hold reservation for one chat call against `model`. Prices the assumed
+ * per-call token budget (or a caller-supplied `inputTokens` estimate, when cheaply
+ * available) at the catalog rate, applies the markup, and clamps to
+ * [CHAT_HOLD_FLOOR_CENTS, CREDIT_HOLD_ESTIMATE_CENTS] — never below a sane minimum nor
+ * above the legacy flat chat hold.
+ *
+ * An UNKNOWN or absent model (not in the catalog) falls back to the legacy flat hold
+ * rather than being priced: the catalog default rate is $0, which would otherwise clamp
+ * a real call down to the floor and weaken the gate. A KNOWN free model (input/output
+ * both $0, e.g. gpt-oss) legitimately prices to the floor — that's fine.
+ */
+export function estimateChatHoldCentsForModel(
+  model: string | undefined,
+  opts: { inputTokens?: number } = {},
+): number {
+  if (!model || !(model in AI_PRICING)) {
+    return CREDIT_HOLD_ESTIMATE_CENTS;
+  }
+  const inputTokens =
+    typeof opts.inputTokens === 'number' && opts.inputTokens > 0
+      ? opts.inputTokens
+      : CHAT_HOLD_ASSUMED_INPUT_TOKENS;
+  const estDollars = calculateCost(model, inputTokens, CHAT_HOLD_ASSUMED_OUTPUT_TOKENS);
+  return estimateChatHoldCents(
+    estDollars,
+    MARKUP_BPS,
+    CHAT_HOLD_FLOOR_CENTS,
+    CREDIT_HOLD_ESTIMATE_CENTS,
+  );
+}


### PR DESCRIPTION
## Why

Users perceived their AI-credit balance as **unstable** — it appeared to go *"more → less → more again"* on every AI call. This is **not a money bug**; accounting was always correct. It's a **display** problem from how the hold/reserve lifecycle leaked into the headline number, plus a redundant client refetch racing the authoritative socket payload.

Root causes:
1. **Oversized reservation in the headline.** Displayed `spendable = max(0, monthly + topup − reserved)`. Each call reserved the flat `CREDIT_HOLD_ESTIMATE_CENTS` (~25¢) *before* the call, then settled to real cost (~1–5¢) *after* — so the headline dove ~25¢ on start and popped back at settle. Multi-step tool turns repeated this.
2. **Two emits per call** — `credits:updated` fired at hold placement (down) and at settle (up).
3. **Redundant revalidate** — the client applied the authoritative payload then fired a second `GET /api/credits` (`{ revalidate: true }`), which re-read active holds at `NOW()` and produced a third number.

## What changed

### Part A — kills the flicker
- **`credit-balance.ts`**: displayed `spendable` is now **gross of holds** (`max(0, monthly + topup)`). `reserved` is still returned and surfaced **separately** as a quiet in-flight indicator. The gate's locked overspend math (`credit-gate.ts`) is **untouched** — the display intentionally diverges from the gate and cannot over-grant.
- **`credit-gate.ts`**: removed the hold-placement emit. The navbar steps **down only at settle** (real cost). Abandoned holds are swept by the reconcile cron and never affect the displayed balance.
- **`useCreditBalance.ts`**: extracted pure `applyCreditsPayload` + `CREDITS_PUSH_MUTATE_OPTIONS = { revalidate: false }` — trust the authoritative socket payload, drop the racing refetch. `visibilitychange` refetch retained as the missed-event backstop.

### Part B — subtle in-flight indicator
- **`CreditBalance.tsx`**: a faint pulsing dot on the coins icon + a tooltip line `~$X reserved on in-flight calls` when `reserved > 0`. Headline number no longer moves on reserve. (`CreditBalanceCard.tsx` already showed `reserved` separately — consistent.)

### Part C — model-aware holds + concurrency cap (overdraw safety)
- **Pure** `estimateChatHoldCents(estDollars, markupBps, floor, ceiling)` in `credit-core.ts` (markup + clamp; passes the purity invariant).
- **Impure** `estimateChatHoldCentsForModel(model, { inputTokens? })` in new **`monitoring/chat-pricing.ts`** (mirrors `voice-pricing.ts`): prices an assumed token budget via the catalog, clamps to `[CHAT_HOLD_FLOOR_CENTS=2¢, CREDIT_HOLD_ESTIMATE_CENTS=25¢]`. **Unknown/absent model → legacy flat 25¢** (catalog default is \$0, which would otherwise wrongly clamp to the floor).
- New **`MAX_CHAT_INFLIGHT=8`** wired into all 5 chat gate callers (`ai/chat`, `ai/global/[id]/messages`, `page-agents/consult`, `v1/chat/completions`, `pulse/generate`) — bounds concurrent overdraw now that the per-call hold can be smaller than the old flat reserve.

> The reservation is the only pre-settle bound on overdraw; shrinking it without a paid-chat concurrency cap would reopen that hole, hence Part C ships together. The 1.5× `MARKUP_BPS` buffer remains the solvency guarantee.

## Engineering discipline
- **Functional core / imperative shell** preserved: all new decision logic is a pure function in `credit-core.ts`; the catalog lookup / env reads stay in the shell (`monitoring/chat-pricing.ts`).
- **Strict TDD** — every change was RED→GREEN (failing spec written and run before implementation).

## Tests
- `credit-balance.test.ts` — spendable now gross of holds; `reserved` still reported.
- `credit-gate.test.ts` — asserts **no** hold-placement emit.
- `credit-core.test.ts` — pure `estimateChatHoldCents` (floor/ceiling/markup/clamp).
- `chat-pricing.test.ts` (new) — model-aware estimate, unknown-model fallback, clamps.
- `useCreditBalance.test.ts` (new) — pure payload mapping + no-revalidate option (avoids the worktree dual-React render limitation).
- `pulse/generate` gate test updated for the concurrency cap.

**lib billing+monitoring: 585 passed. Affected web route suites: green. Web typecheck clean** (only pre-existing stale `.next` validator noise remains).

## Risk / flag
Display + hold-sizing only. Gate enforcement still rides `CREDITS_ENFORCEMENT_ENABLED` (default OFF) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Behavioral note for enabling enforcement** (`CREDITS_ENFORCEMENT_ENABLED`): chat holds now use a model-aware estimate clamped to `[2¢, 25¢]` instead of a flat 25¢. A marginal user can therefore pass the gate on a *cheap* model where the old flat hold would have blocked. This is intentional and bounded by `MAX_CHAT_INFLIGHT=8` (composed via `min` with the free-tier cap); the 1.5× `MARKUP_BPS` buffer remains the solvency guarantee. The gate's overspend math is otherwise unchanged.
