### PR TITLE
fix(ai): always settle credit holds + gate tools on resolved model id

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -912,7 +912,10 @@ export async function POST(request: Request) {
         generateId: () => serverAssistantMessageId!,
         execute: async ({ writer }) => {
           // Resolve once outside the per-attempt factory (the factory is synchronous).
-          const modelCapabilitiesForTools = await getModelCapabilities(currentModel, currentProvider);
+          // Gate tools on the CONCRETE backend model id (resolvedModelName), not the
+          // PageSpace alias in currentModel — vision/tool detection pattern-matches the
+          // model string, so an alias yields wrong capability flags.
+          const modelCapabilitiesForTools = await getModelCapabilities(resolvedModelName, currentProvider);
           // Server-side, in-request retry: if an attempt drops mid-loop (OpenRouter
           // disconnect) or ends mid-tool without the finish tool, transparently
           // re-drive the loop under one message envelope. The loop lives inside
@@ -1012,20 +1015,23 @@ export async function POST(request: Request) {
             }
           });
           
-          // Save the AI's response message with tool calls and results (database-first approach)
+          // Use the server-generated ID that was sent to the client at stream start.
+          const messageId = serverAssistantMessageId!;
+
+          // Extract tool calls/results with safe defaults — responseMessage is absent on
+          // exhausted/no-content runs, but usage settlement below still has to run.
+          const extractedToolCalls = responseMessage ? extractToolCalls(responseMessage) : [];
+          const extractedToolResults = responseMessage ? extractToolResults(responseMessage) : [];
+
+          // Save the AI's response message with tool calls and results (database-first
+          // approach). Best-effort: persistence errors must NOT skip usage/credit
+          // settlement below — that would leak the gate's hold.
           if (chatId && responseMessage) {
             try {
-              // Use the server-generated ID that was sent to the client at stream start
-              // This ensures the saved message ID matches what the client has
-              const messageId = serverAssistantMessageId!;
               const messageContent = extractMessageContent(responseMessage);
-              
-              // Extract tool calls and results from the response
-              const extractedToolCalls = extractToolCalls(responseMessage);
-              const extractedToolResults = extractToolResults(responseMessage);
-              
-              loggers.ai.debug('AI Chat API: Saving AI response message', { 
-                id: messageId, 
+
+              loggers.ai.debug('AI Chat API: Saving AI response message', {
+                id: messageId,
                 contentLength: messageContent.length,
                 contentPreview: messageContent.substring(0, 100),
                 toolCallsCount: extractedToolCalls.length,
@@ -1033,12 +1039,12 @@ export async function POST(request: Request) {
                 hasContent: messageContent.length > 0,
                 hasTools: extractedToolCalls.length > 0 || extractedToolResults.length > 0
               });
-              
-              loggers.ai.trace('AI Chat API: Tool tracking', { 
+
+              loggers.ai.trace('AI Chat API: Tool tracking', {
                 toolCalls: extractedToolCalls.length,
-                toolResults: extractedToolResults.length 
+                toolResults: extractedToolResults.length
               });
-              
+
               // Use the new helper function to save the message with complete UIMessage for chronological ordering
               await saveMessageToDatabase({
                 messageId,
@@ -1051,100 +1057,110 @@ export async function POST(request: Request) {
                 toolResults: extractedToolResults.length > 0 ? extractedToolResults : undefined,
                 uiMessage: responseMessage, // Pass complete UIMessage to preserve part ordering
               });
-              
+
               loggers.ai.debug('AI Chat API: AI response message saved to database with tools');
-
-              // LEGACY daily-quota counting (credits mode OFF): keep the old per-tier
-              // counter moving so the restored UsageCounter is accurate on prod during
-              // dark launch. Best-effort — never fail the chat. Remove at final cutover.
-              if (!isCreditsModeEnabled()) {
-                try {
-                  await incrementUsage(userId!, getProviderTier(currentProvider, currentModel));
-                } catch (usageError) {
-                  loggers.ai.error('AI Chat API: legacy usage increment failed', usageError as Error, {
-                    userId: maskIdentifier(userId!),
-                  });
-                }
-              }
-
-              // Track enhanced AI usage with token counting and cost calculation.
-              // Prepaid credit metering ALWAYS runs (both modes) — it settles the gate's
-              // hold and feeds unit-economics observability.
-              const duration = Date.now() - startTime;
-
-              const usage = agentRun?.accumulatedUsage;
-              const steps = agentRun?.accumulatedSteps;
-              const inputTokens = usage?.inputTokens ?? undefined;
-              const outputTokens = usage?.outputTokens ?? undefined;
-              const totalTokens =
-                usage?.totalTokens ??
-                ((usage?.inputTokens || 0) + (usage?.outputTokens || 0) || undefined);
-
-              // Use enhanced AI monitoring with token usage from SDK
-              await AIMonitoring.trackUsage({
-                userId: userId!,
-                provider: currentProvider,
-                model: resolvedModelName,
-                source: 'chat',
-                inputTokens,
-                outputTokens,
-                totalTokens,
-                providerCostDollars: extractOpenRouterCostDollars(steps),
-                duration,
-                conversationId, // Use actual conversation ID instead of pageId
-                messageId,
-                pageId: chatId,
-                driveId: pageContext?.driveId,
-                // 'exhausted' = retry shell gave up (failure); clean/terminal = a real
-                // completion. Cost still settles regardless (the provider charged us).
-                success: agentRun?.finalOutcome !== 'exhausted',
-                holdId,
-                metadata: {
-                  pageName: page.title,
-                  toolCallsCount: extractedToolCalls.length,
-                  toolResultsCount: extractedToolResults.length,
-                  hasTools: extractedToolCalls.length > 0 || extractedToolResults.length > 0,
-                  reasoningTokens: usage?.reasoningTokens,
-                  cachedInputTokens: usage?.cachedInputTokens,
-                  retryAttempts: agentRun?.attempts,
-                  retryOutcome: agentRun?.finalOutcome,
-                  retryTerminalReason: agentRun?.terminalReason,
-                }
-              });
-
-              // Credit balance is pushed live by consumeCredits itself (called from
-              // AIMonitoring.trackUsage above), which now broadcasts at every balance
-              // mutation — so the header widget updates without a route-level emit here.
-
-              // Track tool usage separately for analytics
-              if (extractedToolCalls.length > 0) {
-                for (const toolCall of extractedToolCalls) {
-                  await AIMonitoring.trackToolUsage({
-                    userId: userId!,
-                    provider: currentProvider,
-                    model: resolvedModelName,
-                    toolName: toolCall.toolName,
-                    toolId: toolCall.toolCallId,
-                    args: undefined,
-                    conversationId, // Use actual conversation ID instead of pageId
-                    pageId: chatId,
-                    success: true
-                  });
-                }
-                
-                // Also track feature usage
-                trackFeature(userId!, 'ai_tools_used', {
-                  toolCount: extractedToolCalls.length,
-                  provider: currentProvider,
-                  model: currentModel
-                });
-              }
             } catch (error) {
               loggers.ai.error('AI Chat API: Failed to save AI response message', error as Error);
               // Don't fail the response - persistence errors shouldn't break the chat
             }
           } else {
             loggers.ai.warn('AI Chat API: No chatId or response message provided, skipping persistence');
+          }
+
+          // Usage + credit settlement ALWAYS runs after runAgentWithRetry completes —
+          // regardless of whether a responseMessage was produced or persistence above
+          // succeeded. trackUsage settles the gate's hold (holdId) and feeds unit-economics
+          // observability; skipping it on exhausted/no-content runs or save failures would
+          // leak the hold (the route already set holdHandedOff = true).
+          try {
+            // LEGACY daily-quota counting (credits mode OFF): keep the old per-tier
+            // counter moving so the restored UsageCounter is accurate on prod during
+            // dark launch. Best-effort — never fail the chat. Remove at final cutover.
+            if (!isCreditsModeEnabled()) {
+              try {
+                await incrementUsage(userId!, getProviderTier(currentProvider, currentModel));
+              } catch (usageError) {
+                loggers.ai.error('AI Chat API: legacy usage increment failed', usageError as Error, {
+                  userId: maskIdentifier(userId!),
+                });
+              }
+            }
+
+            // Track enhanced AI usage with token counting and cost calculation.
+            // Prepaid credit metering ALWAYS runs (both modes) — it settles the gate's
+            // hold and feeds unit-economics observability.
+            const duration = Date.now() - startTime;
+
+            const usage = agentRun?.accumulatedUsage;
+            const steps = agentRun?.accumulatedSteps;
+            const inputTokens = usage?.inputTokens ?? undefined;
+            const outputTokens = usage?.outputTokens ?? undefined;
+            const totalTokens =
+              usage?.totalTokens ??
+              ((usage?.inputTokens || 0) + (usage?.outputTokens || 0) || undefined);
+
+            // Use enhanced AI monitoring with token usage from SDK
+            await AIMonitoring.trackUsage({
+              userId: userId!,
+              provider: currentProvider,
+              model: resolvedModelName,
+              source: 'chat',
+              inputTokens,
+              outputTokens,
+              totalTokens,
+              providerCostDollars: extractOpenRouterCostDollars(steps),
+              duration,
+              conversationId, // Use actual conversation ID instead of pageId
+              messageId,
+              pageId: chatId,
+              driveId: pageContext?.driveId,
+              // 'exhausted' = retry shell gave up (failure); clean/terminal = a real
+              // completion. Cost still settles regardless (the provider charged us).
+              success: agentRun?.finalOutcome !== 'exhausted',
+              holdId,
+              metadata: {
+                pageName: page.title,
+                toolCallsCount: extractedToolCalls.length,
+                toolResultsCount: extractedToolResults.length,
+                hasTools: extractedToolCalls.length > 0 || extractedToolResults.length > 0,
+                reasoningTokens: usage?.reasoningTokens,
+                cachedInputTokens: usage?.cachedInputTokens,
+                retryAttempts: agentRun?.attempts,
+                retryOutcome: agentRun?.finalOutcome,
+                retryTerminalReason: agentRun?.terminalReason,
+              }
+            });
+
+            // Credit balance is pushed live by consumeCredits itself (called from
+            // AIMonitoring.trackUsage above), which now broadcasts at every balance
+            // mutation — so the header widget updates without a route-level emit here.
+
+            // Track tool usage separately for analytics
+            if (extractedToolCalls.length > 0) {
+              for (const toolCall of extractedToolCalls) {
+                await AIMonitoring.trackToolUsage({
+                  userId: userId!,
+                  provider: currentProvider,
+                  model: resolvedModelName,
+                  toolName: toolCall.toolName,
+                  toolId: toolCall.toolCallId,
+                  args: undefined,
+                  conversationId, // Use actual conversation ID instead of pageId
+                  pageId: chatId,
+                  success: true
+                });
+              }
+
+              // Also track feature usage
+              trackFeature(userId!, 'ai_tools_used', {
+                toolCount: extractedToolCalls.length,
+                provider: currentProvider,
+                model: currentModel
+              });
+            }
+          } catch (error) {
+            loggers.ai.error('AI Chat API: Failed to settle AI usage/credits', error as Error);
+            // Don't fail the response - but the hold may remain for the reconcile sweep.
           }
 
           // Reflect a user stop, including one that landed during inter-attempt backoff or

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -413,4 +413,41 @@ describe('POST /api/ai/global/[id]/messages — usage logging durability (R4)', 
     expect(settled).toBe(true);
     expect(AIMonitoring.trackUsage).toHaveBeenCalledTimes(1);
   });
+
+  it('settles the hold (trackUsage) even when no responseMessage is produced', async () => {
+    // Exhausted/no-content run: the retry shell gave up without a message. Settlement
+    // must still run — it's the only thing that releases the gate's hold. Skipping it
+    // here (the old `if (responseMessage)` gate) silently leaked the hold.
+    // (saveGlobalAssistantMessageToDatabase also persists the user message during POST,
+    // so we assert the *assistant* save is skipped by comparing counts across onFinish.)
+    captured.totalUsage = { inputTokens: 3, outputTokens: 0, totalTokens: 3 };
+
+    await POST(makeRequest(), makeContext());
+    await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+    const savesBeforeFinish = mockSaveGlobalAssistantMessageToDatabase.mock.calls.length;
+    await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: undefined });
+
+    // No assistant-message save (nothing to persist), but the hold is still settled.
+    expect(mockSaveGlobalAssistantMessageToDatabase.mock.calls.length).toBe(savesBeforeFinish);
+    expect(AIMonitoring.trackUsage).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(AIMonitoring.trackUsage).mock.calls[0][0];
+    expect(call.model).toBe('glm-4.5-air');
+  });
+
+  it('settles the hold (trackUsage) even when persisting the assistant message throws', async () => {
+    // A save failure must not skip settlement — otherwise a transient DB error leaks the
+    // hold. Settlement lives outside the save try/catch, so it runs regardless.
+    // Arm the rejection AFTER the user-message save in POST so only the assistant save
+    // (in onFinish) throws.
+    captured.totalUsage = { inputTokens: 4, outputTokens: 6, totalTokens: 10 };
+
+    await POST(makeRequest(), makeContext());
+    await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+    mockSaveGlobalAssistantMessageToDatabase.mockRejectedValueOnce(new Error('db down'));
+    await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+    expect(AIMonitoring.trackUsage).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(AIMonitoring.trackUsage).mock.calls[0][0];
+    expect(call.totalTokens).toBe(10);
+  });
 });

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -985,12 +985,18 @@ MENTION PROCESSING:
 
         loggers.api.debug('Global Assistant Chat API: onFinish callback triggered for AI response', {});
 
+        const messageId = serverAssistantMessageId;
+
+        // Extract tool calls/results with safe defaults — responseMessage is absent on
+        // exhausted/no-content runs, but usage settlement below still has to run.
+        const extractedToolCalls = responseMessage ? extractToolCalls(responseMessage) : [];
+        const extractedToolResults = responseMessage ? extractToolResults(responseMessage) : [];
+
+        // Save the assistant message. Best-effort: persistence errors must NOT skip
+        // usage/credit settlement below — that would leak the gate's hold.
         if (responseMessage) {
           try {
-            const messageId = serverAssistantMessageId;
             const messageContent = extractMessageContent(responseMessage);
-            const extractedToolCalls = extractToolCalls(responseMessage);
-            const extractedToolResults = extractToolResults(responseMessage);
 
             loggers.api.debug('Global Assistant Chat API: Saving AI response message', {
               id: messageId,
@@ -1020,79 +1026,85 @@ MENTION PROCESSING:
               .where(eq(conversations.id, conversationId));
 
             loggers.api.debug('Global Assistant Chat API: AI response message saved to database', {});
-
-            // LEGACY daily-quota counting (credits mode OFF): keep the old per-tier
-            // counter moving so the restored UsageCounter is accurate on prod during
-            // dark launch. Best-effort — never fail the chat. Remove at final cutover.
-            if (!isCreditsModeEnabled()) {
-              try {
-                await incrementUsage(userId!, getProviderTier(currentProvider, currentModel));
-              } catch (usageError) {
-                loggers.api.error('Global Assistant Chat API: legacy usage increment failed', usageError as Error, {
-                  userId: maskIdentifier(userId!),
-                });
-              }
-            }
-
-            // Track detailed AI usage (tokens, cost, etc.).
-            // ALWAYS log a row — even when the provider returns no usage metadata —
-            // so the orphan-sweep can recover/bill it. Missing tokens mean a $0 cost
-            // row, not a skipped one (which would silently front the spend).
-            try {
-              const usage = agentRun?.accumulatedUsage;
-              const steps = agentRun?.accumulatedSteps;
-              const duration = Date.now() - startTime;
-
-              await AIMonitoring.trackUsage({
-                userId: userId!,
-                provider: currentProvider,
-                model: currentModel,
-                source: 'chat',
-                inputTokens: usage?.inputTokens,
-                outputTokens: usage?.outputTokens,
-                totalTokens: usage?.totalTokens,
-                providerCostDollars: extractOpenRouterCostDollars(steps),
-                duration,
-                conversationId,
-                messageId,
-                // 'exhausted' = retry shell gave up (failure); clean/terminal = a real
-                // completion. Cost still settles regardless (the provider charged us).
-                success: agentRun?.finalOutcome !== 'exhausted',
-                holdId,
-                contextMessages: contextCalculation.messageIds,
-                contextSize: contextCalculation.totalTokens,
-                systemPromptTokens: contextCalculation.systemPromptTokens,
-                toolDefinitionTokens: contextCalculation.toolDefinitionTokens,
-                conversationTokens: contextCalculation.conversationTokens,
-                messageCount: contextCalculation.messageCount,
-                wasTruncated: contextCalculation.wasTruncated,
-                truncationStrategy: contextCalculation.truncationStrategy,
-                metadata: {
-                  toolCallsCount: extractedToolCalls.length,
-                  toolResultsCount: extractedToolResults.length,
-                  isReadOnly: readOnlyMode,
-                  retryAttempts: agentRun?.attempts,
-                  retryOutcome: agentRun?.finalOutcome,
-                  retryTerminalReason: agentRun?.terminalReason,
-                }
-              });
-            } catch (trackingError) {
-              loggers.api.debug('Global Assistant: Could not track AI usage (stream aborted or failed)', {
-                conversationId: maskIdentifier(conversationId),
-                messageId: maskIdentifier(messageId),
-                error: trackingError instanceof Error ? trackingError.message : 'Unknown error',
-              });
-            }
-
-            // NOTE: daily per-call counting/broadcast removed — prepaid credits are
-            // the sole volume limiter. The credit hold placed by the gate is settled
-            // by the AIMonitoring.trackUsage call above (holdId threaded in), which
-            // now also broadcasts the user's fresh balance — so no route-level emit
-            // is needed for the header widget to update live.
           } catch (error) {
             loggers.api.error('Global Assistant Chat API: Failed to save AI response message', error as Error);
           }
         }
+
+        // Usage + credit settlement ALWAYS runs after runAgentWithRetry completes —
+        // regardless of whether a responseMessage was produced or persistence above
+        // succeeded. trackUsage settles the gate's hold (holdId); skipping it on
+        // exhausted/no-content runs or save failures would leak the hold (the route
+        // already set holdHandedOff = true).
+        //
+        // LEGACY daily-quota counting (credits mode OFF): keep the old per-tier
+        // counter moving so the restored UsageCounter is accurate on prod during
+        // dark launch. Best-effort — never fail the chat. Remove at final cutover.
+        if (!isCreditsModeEnabled()) {
+          try {
+            await incrementUsage(userId!, getProviderTier(currentProvider, currentModel));
+          } catch (usageError) {
+            loggers.api.error('Global Assistant Chat API: legacy usage increment failed', usageError as Error, {
+              userId: maskIdentifier(userId!),
+            });
+          }
+        }
+
+        // Track detailed AI usage (tokens, cost, etc.).
+        // ALWAYS log a row — even when the provider returns no usage metadata —
+        // so the orphan-sweep can recover/bill it. Missing tokens mean a $0 cost
+        // row, not a skipped one (which would silently front the spend).
+        try {
+          const usage = agentRun?.accumulatedUsage;
+          const steps = agentRun?.accumulatedSteps;
+          const duration = Date.now() - startTime;
+
+          await AIMonitoring.trackUsage({
+            userId: userId!,
+            provider: currentProvider,
+            model: currentModel,
+            source: 'chat',
+            inputTokens: usage?.inputTokens,
+            outputTokens: usage?.outputTokens,
+            totalTokens: usage?.totalTokens,
+            providerCostDollars: extractOpenRouterCostDollars(steps),
+            duration,
+            conversationId,
+            messageId,
+            // 'exhausted' = retry shell gave up (failure); clean/terminal = a real
+            // completion. Cost still settles regardless (the provider charged us).
+            success: agentRun?.finalOutcome !== 'exhausted',
+            holdId,
+            contextMessages: contextCalculation.messageIds,
+            contextSize: contextCalculation.totalTokens,
+            systemPromptTokens: contextCalculation.systemPromptTokens,
+            toolDefinitionTokens: contextCalculation.toolDefinitionTokens,
+            conversationTokens: contextCalculation.conversationTokens,
+            messageCount: contextCalculation.messageCount,
+            wasTruncated: contextCalculation.wasTruncated,
+            truncationStrategy: contextCalculation.truncationStrategy,
+            metadata: {
+              toolCallsCount: extractedToolCalls.length,
+              toolResultsCount: extractedToolResults.length,
+              isReadOnly: readOnlyMode,
+              retryAttempts: agentRun?.attempts,
+              retryOutcome: agentRun?.finalOutcome,
+              retryTerminalReason: agentRun?.terminalReason,
+            }
+          });
+        } catch (trackingError) {
+          loggers.api.debug('Global Assistant: Could not track AI usage (stream aborted or failed)', {
+            conversationId: maskIdentifier(conversationId),
+            messageId: maskIdentifier(messageId),
+            error: trackingError instanceof Error ? trackingError.message : 'Unknown error',
+          });
+        }
+
+        // NOTE: daily per-call counting/broadcast removed — prepaid credits are
+        // the sole volume limiter. The credit hold placed by the gate is settled
+        // by the AIMonitoring.trackUsage call above (holdId threaded in), which
+        // now also broadcasts the user's fresh balance — so no route-level emit
+        // is needed for the header widget to update live.
 
         // Reflect a user stop, including one that landed during inter-attempt backoff or
         // raced in after the loop broke (onAbort only fires while a streamText is live).


### PR DESCRIPTION
## Summary

Two correctness fixes in the agent chat routes (`api/ai/chat` and `api/ai/global/[id]/messages`), surfaced as review follow-ups to the server-side agent-retry work (#1526). Both verified against current code before fixing.

### 1. Tool capabilities gated on the wrong model id
`getModelCapabilities()` in the Page-AI route was called with `currentModel` — which may be a **PageSpace alias** — instead of the concrete backend id. `hasVisionCapability`/`hasToolCapability` pattern-match the model *string*, so an alias produces wrong vision/tool flags that then flow into `experimental_context.modelCapabilities` and drive tool gating in `runAgentWithRetry`/`streamText`. Switched to `resolvedModelName` (`providerResult.modelName`), the same resolved id already used for billing.

### 2. Credit hold settlement skipped on no-content runs / save failures
`AIMonitoring.trackUsage` (which settles the gate's `holdId`) lived **inside** the `if (... responseMessage)` save block, *after* `saveMessageToDatabase`. So:
- a null `responseMessage` (exhausted / no-content run), or
- a `saveMessageToDatabase` throw

…skipped settlement entirely — **leaking the hold**, since the route already set `holdHandedOff = true` (handing hold ownership to `onFinish`). Confirmed `trackUsage(holdId)` always settles: `consumeCredits` when tokens were consumed, `releaseHold` for token-less failures.

Moved usage/credit settlement (legacy `incrementUsage` + `trackUsage` + tool analytics) into an **always-run block** after `runAgentWithRetry` completes, with safe-default (`[]`) tool-call/result extraction so analytics don't crash when `responseMessage` is absent. The message save stays best-effort in its own try/catch. Applied to both routes.

## Scope check
- The third AI route with a hold (`api/ai/page-agents/consult`) uses synchronous `generateText` with a `finally` + `holdHandedOff` release — it does **not** have this streaming-`onFinish` leak and is already correct. No change needed.

## Tests
- Added two R4 regression tests to the global route's `credit-gate.test.ts` driving `onFinish` directly: settlement (`trackUsage`) still runs (a) when no `responseMessage` is produced, and (b) when persisting the assistant message throws. Both previously leaked the hold.
- The Page-AI chat route applies the identical control-flow fix and has no existing test harness; it relies on the global-route coverage (same pattern).

## Caveat
If `trackUsage` itself throws, the hold still isn't settled in-request — but it now *reaches* the call on every run (no longer gated by persistence), leaving the reconcile sweep as the only backstop. `consumeCredits`/`releaseHold` errors are already swallowed inside `trackUsage`, so this is effectively a defensive net.

## Validation
- `bun run --filter 'web' typecheck` → pass
- `eslint` on changed files → clean
- `vitest` global-route `credit-gate.test.ts` → 10 passed (8 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)