### PR TITLE
feat(ai): public model catalog endpoint + list_models tool + agent-config model validation

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -85,7 +85,8 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['notifications/[id]/read', 'Notification read receipt, low-risk'],
   ['notifications/read-all', 'Bulk notification read receipt, low-risk'],
 
-  // --- Local model discovery (no user data, no external calls) ---
+  // --- Model discovery (no user data, no external calls) ---
+  ['ai/models', 'Public model-catalog discovery, unauthenticated, no user data or resource access'],
   ['ai/ollama/models', 'Local Ollama model discovery, no user data'],
   ['ai/lmstudio/models', 'Local LMStudio model discovery, no user data'],
 

--- a/apps/web/src/app/api/ai/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/models/__tests__/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the server-only catalog builder's monitoring dep so no DB client loads.
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  MODEL_CONTEXT_WINDOWS: {
+    'openai/gpt-5.3-chat': 400000,
+  },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/ai/models', () => {
+  it('returns providers, defaultProvider and defaultModel with no auth', async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.providers)).toBe(true);
+    expect(body.defaultProvider).toBe('openai');
+    expect(body.defaultModel).toBe('openai/gpt-5.3-chat');
+  });
+
+  it('includes a known model and never includes pricing', async () => {
+    const res = await GET();
+    const body = await res.json();
+    const openai = body.providers.find((p: { provider: string }) => p.provider === 'openai');
+    const model = openai.models.find((m: { id: string }) => m.id === 'openai/gpt-5.3-chat');
+    expect(model.free).toBe(true);
+    expect(model.contextWindow).toBe(400000);
+    expect(model).not.toHaveProperty('pricing');
+  });
+
+  it('sets a public Cache-Control header', async () => {
+    const res = await GET();
+    expect(res.headers.get('Cache-Control')).toMatch(/public/);
+  });
+});

--- a/apps/web/src/app/api/ai/models/route.ts
+++ b/apps/web/src/app/api/ai/models/route.ts
@@ -1,0 +1,29 @@
+import { buildModelCatalog } from '@/lib/ai/core/model-catalog';
+import { DEFAULT_PROVIDER, DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
+
+/**
+ * GET /api/ai/models — PUBLIC model catalog.
+ *
+ * Returns the real AI providers and models (grouped by provider) so clients and
+ * agents configure agents against actual model ids instead of hallucinating them.
+ * No auth: the catalog already ships to the browser and is not secret. Pricing is
+ * intentionally NOT included.
+ *
+ * This is distinct from the OpenAI-compatible `/api/v1/models`, which lists
+ * PageSpace *agents* as models for SDK inference — leave that one untouched.
+ */
+export async function GET(): Promise<Response> {
+  return Response.json(
+    {
+      providers: buildModelCatalog(),
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    },
+  );
+}

--- a/apps/web/src/app/api/ai/models/route.ts
+++ b/apps/web/src/app/api/ai/models/route.ts
@@ -12,6 +12,12 @@ import { DEFAULT_PROVIDER, DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-conf
  * This is distinct from the OpenAI-compatible `/api/v1/models`, which lists
  * PageSpace *agents* as models for SDK inference — leave that one untouched.
  */
+
+// The payload depends on the runtime DEPLOYMENT_MODE (via getVisibleProviders), so
+// it must be computed per-request — never statically prerendered at build time with
+// a frozen mode. Downstream caching is still handled by the Cache-Control header.
+export const dynamic = 'force-dynamic';
+
 export async function GET(): Promise<Response> {
   return Response.json(
     {

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
@@ -533,13 +533,16 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
       );
     });
 
-    it('nullifies empty aiProvider after trim', async () => {
-      await PATCH(createPatchRequest({ aiProvider: '' }), mockParams);
+    it('nullifies empty aiProvider after trim (provider+model cleared together)', async () => {
+      // A model can't be stored without a provider, so clearing the provider clears
+      // the model too — the UI always sends both fields together.
+      await PATCH(createPatchRequest({ aiProvider: '', aiModel: '' }), mockParams);
 
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
         expect.objectContaining({
           updates: expect.objectContaining({
             aiProvider: null,
+            aiModel: null,
           }),
         })
       );
@@ -752,6 +755,18 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
 
       expect(response.status).toBe(400);
       expect(body.error).toMatch(/not a valid model/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a model set without a provider (no provider to validate against)', async () => {
+      const response = await PATCH(
+        createPatchRequest({ aiProvider: '', aiModel: 'openai/gpt-6-ultra' }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/provider/i);
       expect(mockApplyPageMutation).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
@@ -149,7 +149,7 @@ const mockPage = {
   systemPrompt: 'You are helpful',
   enabledTools: ['read_page'],
   aiProvider: 'anthropic',
-  aiModel: 'claude-3',
+  aiModel: 'anthropic/claude-haiku-4.5',
   includeDrivePrompt: true,
   agentDefinition: 'Agent definition text',
   visibleToGlobalAssistant: true,
@@ -273,7 +273,7 @@ describe('GET /api/pages/[pageId]/agent-config', () => {
       expect(body.systemPrompt).toBe('You are helpful');
       expect(body.enabledTools).toEqual(['read_page']);
       expect(body.aiProvider).toBe('anthropic');
-      expect(body.aiModel).toBe('claude-3');
+      expect(body.aiModel).toBe('anthropic/claude-haiku-4.5');
       expect(body.includeDrivePrompt).toBe(true);
       expect(body.drivePrompt).toBe('Drive system prompt');
       expect(body.agentDefinition).toBe('Agent definition text');
@@ -546,12 +546,12 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
     });
 
     it('updates aiModel (trims whitespace)', async () => {
-      await PATCH(createPatchRequest({ aiModel: '  claude-3  ' }), mockParams);
+      await PATCH(createPatchRequest({ aiModel: '  anthropic/claude-haiku-4.5  ' }), mockParams);
 
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
         expect.objectContaining({
           updates: expect.objectContaining({
-            aiModel: 'claude-3',
+            aiModel: 'anthropic/claude-haiku-4.5',
           }),
         })
       );
@@ -716,6 +716,43 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
           expectedRevision: undefined,
         })
       );
+    });
+  });
+
+  describe('model validation', () => {
+    it('returns 400 for a hallucinated model id', async () => {
+      const response = await PATCH(
+        createPatchRequest({ aiProvider: 'openai', aiModel: 'openai/gpt-6-ultra' }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/not a valid model/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('accepts a valid catalog model id', async () => {
+      const response = await PATCH(
+        createPatchRequest({ aiProvider: 'openai', aiModel: 'openai/gpt-5.3-chat' }),
+        mockParams
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockApplyPageMutation).toHaveBeenCalled();
+    });
+
+    it('returns 400 when only a bad aiModel is sent (validated against stored provider)', async () => {
+      // mockPage.aiProvider is "anthropic"; the bad model resolves against it.
+      const response = await PATCH(
+        createPatchRequest({ aiModel: 'anthropic/not-real' }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/not a valid model/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -5,6 +5,7 @@ import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core';
 import { pageSpaceTools } from '@/lib/ai/core';
+import { validateAgentModelSelection } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
@@ -155,6 +156,18 @@ export async function PATCH(
           { error: `Invalid tools: ${invalidTools.join(', ')}` },
           { status: 400 }
         );
+      }
+    }
+
+    // Validate the model selection against the real catalog (anti-hallucination).
+    // Fall back to the stored provider/model so a bad aiModel is caught even when
+    // only one of the two fields is sent.
+    if (aiProvider !== undefined || aiModel !== undefined) {
+      const nextProvider = aiProvider !== undefined ? String(aiProvider).trim() : page.aiProvider;
+      const nextModel = aiModel !== undefined ? String(aiModel).trim() : page.aiModel;
+      const reason = validateAgentModelSelection(nextProvider, nextModel);
+      if (reason) {
+        return NextResponse.json({ error: reason }, { status: 400 });
       }
     }
 

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ModelListRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ModelListRenderer.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { memo } from 'react';
+import { Boxes } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface ModelListModel {
+  id: string;
+  displayName: string;
+  provider: string;
+  free?: boolean;
+  contextWindow?: number;
+}
+
+export interface ModelListProvider {
+  provider: string;
+  name: string;
+  dynamic?: boolean;
+  models: ModelListModel[];
+}
+
+interface ModelListRendererProps {
+  providers: ModelListProvider[];
+  className?: string;
+}
+
+const formatContext = (tokens?: number): string | null => {
+  if (!tokens || tokens <= 0) return null;
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(tokens % 1_000_000 === 0 ? 0 : 1)}M ctx`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K ctx`;
+  return `${tokens} ctx`;
+};
+
+/**
+ * ModelListRenderer — compact card for the `list_models` tool result.
+ *
+ * Groups the catalog by provider, with a free-tier badge and context window per
+ * model. Dynamic providers (Ollama/LM Studio/Azure) whose models are discovered
+ * at runtime show a note instead of an (empty) model list.
+ */
+export const ModelListRenderer: React.FC<ModelListRendererProps> = memo(function ModelListRenderer({
+  providers,
+  className,
+}) {
+  const totalModels = providers.reduce((sum, p) => sum + p.models.length, 0);
+
+  return (
+    <div className={cn('rounded-md border border-border bg-muted/30 text-sm', className)}>
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2 font-medium">
+        <Boxes className="h-4 w-4 text-muted-foreground" />
+        <span>Available models</span>
+        <span className="text-muted-foreground">
+          · {providers.length} provider{providers.length === 1 ? '' : 's'} · {totalModels} model
+          {totalModels === 1 ? '' : 's'}
+        </span>
+      </div>
+      <div className="max-h-80 space-y-3 overflow-y-auto p-3">
+        {providers.map((provider) => (
+          <div key={provider.provider}>
+            <div className="mb-1 text-xs font-semibold text-muted-foreground">{provider.name}</div>
+            {provider.dynamic && provider.models.length === 0 ? (
+              <div className="text-xs text-muted-foreground/80">Models discovered at runtime.</div>
+            ) : (
+              <ul className="space-y-0.5">
+                {provider.models.map((model) => {
+                  const ctx = formatContext(model.contextWindow);
+                  return (
+                    <li key={model.id} className="flex items-center gap-2">
+                      <span className="truncate">{model.displayName}</span>
+                      <code className="truncate text-xs text-muted-foreground">{model.id}</code>
+                      {model.free && (
+                        <span className="rounded bg-emerald-500/15 px-1 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                          free
+                        </span>
+                      )}
+                      {ctx && <span className="ml-auto text-[10px] text-muted-foreground">{ctx}</span>}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -13,6 +13,7 @@ import { WebSearchRenderer, type WebSearchResult } from './WebSearchRenderer';
 import { MemberListRenderer, type MemberInfo } from './MemberListRenderer';
 import { SheetEditRenderer } from './SheetEditRenderer';
 import { AgentConfigRenderer, type AgentConfigData } from './AgentConfigRenderer';
+import { ModelListRenderer, type ModelListProvider } from './ModelListRenderer';
 import { WebFetchRenderer } from './WebFetchRenderer';
 import { TaskStatusRenderer } from './TaskStatusRenderer';
 import { CalendarEventRenderer, type CalendarEventData } from './calendar/CalendarEventRenderer';
@@ -551,6 +552,11 @@ export const toolRenderers: Record<string, ToolRenderer> = {
   multi_drive_list_agents: ({ parsedOutput }) => {
     if (!parsedOutput.agents) return null;
     return <AgentListRenderer agents={parsedOutput.agents as AgentInfo[]} isMultiDrive />;
+  },
+
+  list_models: ({ parsedOutput }) => {
+    if (!Array.isArray(parsedOutput.providers)) return null;
+    return <ModelListRenderer providers={parsedOutput.providers as ModelListProvider[]} />;
   },
 
   update_agent_config: ({ parsedOutput }) => {

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -11,6 +11,8 @@ import {
   getModelDisplayName,
   getUserFacingModelName,
   getVisibleProviders,
+  isDynamicModelProvider,
+  validateAgentModelSelection,
 } from '../ai-providers-config';
 
 describe('ai-providers-config', () => {
@@ -163,6 +165,63 @@ describe('ai-providers-config', () => {
     it('returns AI for a null/undefined model', () => {
       expect(getUserFacingModelName('openai', null)).toBe('AI');
       expect(getUserFacingModelName('openai', undefined)).toBe('AI');
+    });
+  });
+
+  describe('isDynamicModelProvider', () => {
+    it('is true for runtime-discovered providers', () => {
+      expect(isDynamicModelProvider('ollama')).toBe(true);
+      expect(isDynamicModelProvider('lmstudio')).toBe(true);
+      expect(isDynamicModelProvider('azure_openai')).toBe(true);
+    });
+
+    it('is false for static cloud providers', () => {
+      expect(isDynamicModelProvider('openai')).toBe(false);
+      expect(isDynamicModelProvider('anthropic')).toBe(false);
+    });
+  });
+
+  describe('validateAgentModelSelection', () => {
+    const origNextPublic = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE;
+    const origServer = process.env.DEPLOYMENT_MODE;
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = origNextPublic;
+      process.env.DEPLOYMENT_MODE = origServer;
+    });
+
+    it('accepts a valid (provider, model) pair', () => {
+      expect(validateAgentModelSelection('openai', 'openai/gpt-5.3-chat')).toBeNull();
+      expect(validateAgentModelSelection('anthropic', 'anthropic/claude-opus-4.8')).toBeNull();
+    });
+
+    it('rejects a hallucinated model for a real provider', () => {
+      const reason = validateAgentModelSelection('openai', 'openai/gpt-6-ultra');
+      expect(reason).toMatch(/not a valid model/i);
+    });
+
+    it('rejects an unknown provider', () => {
+      const reason = validateAgentModelSelection('acme', 'acme/whatever');
+      expect(reason).toMatch(/unknown or unavailable/i);
+    });
+
+    it('allows any model for dynamic/local providers (runtime-discovered)', () => {
+      expect(validateAgentModelSelection('ollama', 'llama3.1:70b-custom')).toBeNull();
+      expect(validateAgentModelSelection('lmstudio', 'some-local-model')).toBeNull();
+      expect(validateAgentModelSelection('azure_openai', 'my-deployment')).toBeNull();
+    });
+
+    it('treats clearing (both unset) as acceptable', () => {
+      expect(validateAgentModelSelection(null, null)).toBeNull();
+      expect(validateAgentModelSelection('', '')).toBeNull();
+      expect(validateAgentModelSelection(undefined, undefined)).toBeNull();
+    });
+
+    it('respects deployment-mode visibility (cloud provider rejected on-prem)', () => {
+      process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = 'onprem';
+      process.env.DEPLOYMENT_MODE = 'onprem';
+      const reason = validateAgentModelSelection('openai', 'openai/gpt-5.3-chat');
+      expect(reason).toMatch(/unknown or unavailable/i);
     });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -205,6 +205,17 @@ describe('ai-providers-config', () => {
       expect(reason).toMatch(/unknown or unavailable/i);
     });
 
+    it('rejects a model with no provider (null/empty) — closes the bypass', () => {
+      expect(validateAgentModelSelection(null, 'openai/gpt-6-ultra')).toMatch(/provider/i);
+      expect(validateAgentModelSelection('', 'openai/whatever')).toMatch(/provider/i);
+      expect(validateAgentModelSelection(undefined, 'anything')).toMatch(/provider/i);
+    });
+
+    it('allows a provider with no model (model can default later)', () => {
+      expect(validateAgentModelSelection('openai', null)).toBeNull();
+      expect(validateAgentModelSelection('openai', '')).toBeNull();
+    });
+
     it('allows any model for dynamic/local providers (runtime-discovered)', () => {
       expect(validateAgentModelSelection('ollama', 'llama3.1:70b-custom')).toBeNull();
       expect(validateAgentModelSelection('lmstudio', 'some-local-model')).toBeNull();

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -145,6 +145,7 @@ import { calendarReadTools } from '../../tools/calendar-read-tools';
 import { calendarWriteTools } from '../../tools/calendar-write-tools';
 import { channelTools } from '../../tools/channel-tools';
 import { workflowTools } from '../../tools/workflow-tools';
+import { modelTools } from '../../tools/model-tools';
 
 describe('ai-tools', () => {
   describe('pageSpaceTools aggregation', () => {
@@ -168,6 +169,7 @@ describe('ai-tools', () => {
         ...calendarWriteTools,
         ...channelTools,
         ...workflowTools,
+        ...modelTools,
       });
     });
 
@@ -187,6 +189,7 @@ describe('ai-tools', () => {
         Object.keys(calendarWriteTools),
         Object.keys(channelTools),
         Object.keys(workflowTools),
+        Object.keys(modelTools),
       ];
 
       const allKeys = moduleKeysets.flat();

--- a/apps/web/src/lib/ai/core/__tests__/model-catalog.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/model-catalog.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+// Mock the server-only monitoring module so the test never pulls in the DB client.
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  MODEL_CONTEXT_WINDOWS: {
+    'openai/gpt-5.3-chat': 400000,
+    'anthropic/claude-opus-4.8': 200000,
+  },
+}));
+
+import { buildModelCatalog } from '../model-catalog';
+
+describe('buildModelCatalog', () => {
+  const origNextPublic = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE;
+  const origServer = process.env.DEPLOYMENT_MODE;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = origNextPublic;
+    process.env.DEPLOYMENT_MODE = origServer;
+  });
+
+  it('returns providers each with provider/name/dynamic/models', () => {
+    const catalog = buildModelCatalog();
+    const openai = catalog.find((p) => p.provider === 'openai');
+    expect(openai).toBeDefined();
+    expect(openai!.name).toBe('OpenAI');
+    expect(openai!.dynamic).toBe(false);
+    expect(openai!.models.length).toBeGreaterThan(0);
+  });
+
+  it('populates a known model with id/displayName/free/contextWindow', () => {
+    const catalog = buildModelCatalog();
+    const openai = catalog.find((p) => p.provider === 'openai')!;
+    const model = openai.models.find((m) => m.id === 'openai/gpt-5.3-chat');
+    expect(model).toEqual({
+      id: 'openai/gpt-5.3-chat',
+      displayName: 'GPT-5.3 Chat',
+      provider: 'openai',
+      free: true,
+      contextWindow: 400000,
+    });
+  });
+
+  it('omits contextWindow when unknown for a model', () => {
+    const catalog = buildModelCatalog();
+    const openai = catalog.find((p) => p.provider === 'openai')!;
+    const noWindow = openai.models.find((m) => m.id === 'openai/gpt-4o');
+    expect(noWindow).toBeDefined();
+    expect(noWindow!.contextWindow).toBeUndefined();
+  });
+
+  it('marks frontier models as not free', () => {
+    const catalog = buildModelCatalog();
+    const anthropic = catalog.find((p) => p.provider === 'anthropic')!;
+    const opus = anthropic.models.find((m) => m.id === 'anthropic/claude-opus-4.8')!;
+    expect(opus.free).toBe(false);
+  });
+
+  it('marks local providers dynamic with empty models', () => {
+    const catalog = buildModelCatalog();
+    const ollama = catalog.find((p) => p.provider === 'ollama')!;
+    expect(ollama.dynamic).toBe(true);
+    expect(ollama.models).toEqual([]);
+  });
+
+  it('on-prem mode returns only local/Azure providers', () => {
+    process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = 'onprem';
+    process.env.DEPLOYMENT_MODE = 'onprem';
+    const providers = buildModelCatalog().map((p) => p.provider);
+    expect(providers).not.toContain('openai');
+    expect(providers).not.toContain('anthropic');
+    for (const p of providers) {
+      expect(['ollama', 'lmstudio', 'azure_openai']).toContain(p);
+    }
+  });
+});

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -416,6 +416,12 @@ export function validateAgentModelSelection(
   model: string | null | undefined,
 ): string | null {
   if (!provider && !model) return null; // clearing/unset is fine
+  // A model can't be stored without a provider — the pair is what gets validated
+  // and routed. Without a provider there's nothing to check the model against, so
+  // a hallucinated id would otherwise slip through.
+  if (model && !provider) {
+    return `Set an AI provider alongside model "${model}".`;
+  }
   const visible = getVisibleProviders();
   if (provider && !(provider in visible)) {
     return `Unknown or unavailable AI provider "${provider}".`;

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -383,3 +383,46 @@ export function getVisibleProviders(): Partial<typeof AI_PROVIDERS> {
     Object.entries(AI_PROVIDERS).filter(([key]) => ONPREM_ALLOWED_PROVIDERS.has(key))
   ) as Partial<typeof AI_PROVIDERS>;
 }
+
+/**
+ * Providers whose model catalog is empty in `AI_PROVIDERS` because their models
+ * are discovered at runtime (local Ollama/LM Studio instances, Azure deployment
+ * names). Model-id validation must short-circuit to "allow" for these — there is
+ * no static list to check a selection against. Supersets `DYNAMIC_MODEL_PROVIDERS`
+ * with `azure_openai` (also deployment-name driven).
+ */
+const DYNAMIC_CATALOG_PROVIDERS = new Set<string>([...DYNAMIC_MODEL_PROVIDERS, 'azure_openai']);
+
+/**
+ * Whether the provider's models are discovered at runtime (so the static catalog
+ * has no entries to validate against).
+ */
+export function isDynamicModelProvider(provider: string): boolean {
+  return DYNAMIC_CATALOG_PROVIDERS.has(provider);
+}
+
+/**
+ * Validate an agent's (provider, model) selection against the real catalog so a
+ * hallucinated model id can never be stored. Returns `null` when the selection is
+ * acceptable, otherwise a human-readable reason string.
+ *
+ * This is the anti-hallucination gate, NOT a tier gate — subscription-tier access
+ * is enforced where the call is made (`isModelAllowedForTier`). Clearing the config
+ * (both unset) is allowed, dynamic/local providers are allowed (runtime-discovered
+ * models), and deployment-mode visibility is respected via `getVisibleProviders`.
+ */
+export function validateAgentModelSelection(
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): string | null {
+  if (!provider && !model) return null; // clearing/unset is fine
+  const visible = getVisibleProviders();
+  if (provider && !(provider in visible)) {
+    return `Unknown or unavailable AI provider "${provider}".`;
+  }
+  if (isDynamicModelProvider(provider ?? '')) return null; // ollama/lmstudio/azure: runtime-discovered
+  if (model && provider && !isValidModel(provider, model)) {
+    return `Model "${model}" is not a valid model for provider "${provider}".`;
+  }
+  return null;
+}

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -14,6 +14,7 @@ import { calendarReadTools } from '../tools/calendar-read-tools';
 import { calendarWriteTools } from '../tools/calendar-write-tools';
 import { channelTools } from '../tools/channel-tools';
 import { workflowTools } from '../tools/workflow-tools';
+import { modelTools } from '../tools/model-tools';
 import { buildSandboxTools } from '../tools/sandbox-tools-runtime';
 import { CORE_TOOL_NAMES } from './stub-tools';
 
@@ -32,6 +33,7 @@ const baseTools = {
   ...calendarWriteTools,
   ...channelTools,
   ...workflowTools,
+  ...modelTools,
 };
 
 /**

--- a/apps/web/src/lib/ai/core/model-catalog.ts
+++ b/apps/web/src/lib/ai/core/model-catalog.ts
@@ -1,0 +1,56 @@
+/**
+ * Server-only model-catalog payload builder.
+ *
+ * Single source for the model list returned by the public `/api/ai/models`
+ * endpoint AND the `list_models` agent tool, so both stay in lockstep.
+ *
+ * SERVER-ONLY: imports `MODEL_CONTEXT_WINDOWS` from `@pagespace/lib/monitoring/ai-monitoring`,
+ * which transitively pulls in the DB client. Import this module only from server
+ * code (route handlers, tool `execute`). It is deliberately NOT re-exported from
+ * `core/index.ts` so it can never leak into the client bundle.
+ */
+import { MODEL_CONTEXT_WINDOWS } from '@pagespace/lib/monitoring/ai-monitoring';
+import { getVisibleProviders, FREE_TIER_MODELS, isDynamicModelProvider } from './ai-providers-config';
+
+export interface CatalogModel {
+  /** Full OpenRouter model id, e.g. "openai/gpt-5.3-chat". The value to store as an agent's aiModel. */
+  id: string;
+  /** Human-friendly display name from the catalog. */
+  displayName: string;
+  /** Provider key this model belongs to, e.g. "openai". */
+  provider: string;
+  /** True if the model is selectable on the free subscription tier. */
+  free: boolean;
+  /** Context window size in tokens, when known. */
+  contextWindow?: number;
+}
+
+export interface CatalogProvider {
+  /** Provider key, e.g. "openai", "anthropic", "ollama". */
+  provider: string;
+  /** Display name, e.g. "OpenAI". */
+  name: string;
+  /** True when models are discovered at runtime (local/Azure) — `models` is empty here. */
+  dynamic: boolean;
+  models: CatalogModel[];
+}
+
+/**
+ * Build the model catalog grouped by provider, filtered to the providers visible
+ * in the current deployment mode. No pricing is included by design.
+ */
+export function buildModelCatalog(): CatalogProvider[] {
+  const visible = getVisibleProviders();
+  return Object.entries(visible).map(([provider, cfg]) => ({
+    provider,
+    name: cfg!.name,
+    dynamic: isDynamicModelProvider(provider),
+    models: Object.entries(cfg!.models).map(([id, displayName]) => ({
+      id,
+      displayName: displayName as string,
+      provider,
+      free: FREE_TIER_MODELS.has(id),
+      contextWindow: MODEL_CONTEXT_WINDOWS[id as keyof typeof MODEL_CONTEXT_WINDOWS],
+    })),
+  }));
+}

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -161,6 +161,8 @@ export function getToolsSummary(isReadOnly: boolean, webSearchEnabled = true): {
     'web_fetch',
     // Agent communication
     'ask_agent',
+    // Model catalog (read-only)
+    'list_models',
     // Workflow read
     'list_workflows',
     // Write tools

--- a/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
@@ -414,6 +414,41 @@ describe('agent-tools', () => {
       expect(applyPageMutation).not.toHaveBeenCalled();
     });
 
+    it('rejects a model set with no provider on a fresh agent (no stored provider)', async () => {
+      const mockAgent = {
+        id: 'agent-1',
+        title: 'My Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: null,
+        enabledTools: null,
+        aiProvider: null,
+        aiModel: null,
+        agentDefinition: null,
+        visibleToGlobalAssistant: false,
+        includeDrivePrompt: false,
+        includePageTree: false,
+        pageTreeScope: null,
+        revision: 1,
+      };
+      mockAgentRepository.findById.mockResolvedValue(mockAgent);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1',
+        messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        agentTools.update_agent_config.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', aiModel: 'openai/gpt-6-ultra' },
+          context
+        )
+      ).rejects.toThrow(/provider/i);
+      expect(applyPageMutation).not.toHaveBeenCalled();
+    });
+
     it('allows an arbitrary model for a dynamic provider (ollama)', async () => {
       const mockAgent = {
         id: 'agent-1',

--- a/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
@@ -290,7 +290,7 @@ describe('agent-tools', () => {
       const updatedMockAgent = {
         ...mockAgent,
         aiProvider: 'google',
-        aiModel: 'gemini-pro',
+        aiModel: 'google/gemini-3.5-flash',
         revision: 4,
       };
       // First call returns original, second call (after mutation) returns updated
@@ -311,7 +311,7 @@ describe('agent-tools', () => {
           agentPath: '/drive/agent',
           agentId: 'agent-1',
           aiProvider: 'google',
-          aiModel: 'gemini-pro',
+          aiModel: 'google/gemini-3.5-flash',
         },
         context
       );
@@ -321,7 +321,7 @@ describe('agent-tools', () => {
         success: true,
         agentConfig: {
           aiProvider: 'google',
-          aiModel: 'gemini-pro',
+          aiModel: 'google/gemini-3.5-flash',
         },
       });
 
@@ -331,10 +331,135 @@ describe('agent-tools', () => {
           pageId: 'agent-1',
           updates: expect.objectContaining({
             aiProvider: 'google',
-            aiModel: 'gemini-pro',
+            aiModel: 'google/gemini-3.5-flash',
           }),
         })
       );
+    });
+
+    it('rejects a hallucinated model id and points to list_models', async () => {
+      const mockAgent = {
+        id: 'agent-1',
+        title: 'My Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: null,
+        enabledTools: null,
+        aiProvider: null,
+        aiModel: null,
+        agentDefinition: null,
+        visibleToGlobalAssistant: false,
+        includeDrivePrompt: false,
+        includePageTree: false,
+        pageTreeScope: null,
+        revision: 1,
+      };
+      mockAgentRepository.findById.mockResolvedValue(mockAgent);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1',
+        messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        agentTools.update_agent_config.execute!(
+          {
+            agentPath: '/drive/agent',
+            agentId: 'agent-1',
+            aiProvider: 'openai',
+            aiModel: 'openai/gpt-6-ultra',
+          },
+          context
+        )
+      ).rejects.toThrow(/list_models/);
+
+      // No write should occur on a rejected model id
+      expect(applyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('catches a bad model even when only aiModel is sent (uses stored provider)', async () => {
+      const mockAgent = {
+        id: 'agent-1',
+        title: 'My Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: null,
+        enabledTools: null,
+        aiProvider: 'openai',
+        aiModel: 'openai/gpt-5.3-chat',
+        agentDefinition: null,
+        visibleToGlobalAssistant: false,
+        includeDrivePrompt: false,
+        includePageTree: false,
+        pageTreeScope: null,
+        revision: 1,
+      };
+      mockAgentRepository.findById.mockResolvedValue(mockAgent);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1',
+        messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        agentTools.update_agent_config.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', aiModel: 'openai/not-real' },
+          context
+        )
+      ).rejects.toThrow(/not a valid model/);
+      expect(applyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('allows an arbitrary model for a dynamic provider (ollama)', async () => {
+      const mockAgent = {
+        id: 'agent-1',
+        title: 'My Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: null,
+        enabledTools: null,
+        aiProvider: null,
+        aiModel: null,
+        agentDefinition: null,
+        visibleToGlobalAssistant: false,
+        includeDrivePrompt: false,
+        includePageTree: false,
+        pageTreeScope: null,
+        revision: 1,
+      };
+      const updatedMockAgent = {
+        ...mockAgent,
+        aiProvider: 'ollama',
+        aiModel: 'llama3.1:70b-custom',
+        revision: 2,
+      };
+      mockAgentRepository.findById
+        .mockResolvedValueOnce(mockAgent)
+        .mockResolvedValueOnce(updatedMockAgent);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1',
+        messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await agentTools.update_agent_config.execute!(
+        {
+          agentPath: '/drive/agent',
+          agentId: 'agent-1',
+          aiProvider: 'ollama',
+          aiModel: 'llama3.1:70b-custom',
+        },
+        context
+      );
+
+      expect(result).toMatchObject({ success: true });
+      expect(applyPageMutation).toHaveBeenCalled();
     });
 
     it('updates visibility and context settings', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/model-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/model-tools.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  MODEL_CONTEXT_WINDOWS: {
+    'openai/gpt-5.3-chat': 400000,
+  },
+}));
+
+import { modelTools } from '../model-tools';
+import type { ToolExecutionContext } from '../../core';
+
+type ListModelsResult = {
+  providers: Array<{ provider: string; dynamic: boolean; models: Array<{ id: string; free: boolean }> }>;
+};
+
+const run = async (
+  args: { provider?: string; freeOnly?: boolean },
+  experimentalContext: Partial<ToolExecutionContext>,
+): Promise<ListModelsResult> => {
+  const result = await modelTools.list_models.execute!(args, {
+    toolCallId: '1',
+    messages: [],
+    experimental_context: experimentalContext as ToolExecutionContext,
+  });
+  return result as unknown as ListModelsResult;
+};
+
+const ctx: Partial<ToolExecutionContext> = { userId: 'user-1' };
+
+describe('list_models tool', () => {
+  it('returns the full provider catalog', async () => {
+    const result = await run({}, ctx);
+    expect(result.providers.some((p) => p.provider === 'openai')).toBe(true);
+    expect(result.providers.some((p) => p.provider === 'anthropic')).toBe(true);
+  });
+
+  it('filters to a single provider', async () => {
+    const result = await run({ provider: 'anthropic' }, ctx);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0].provider).toBe('anthropic');
+  });
+
+  it('freeOnly strips non-free models and empty static providers', async () => {
+    const result = await run({ freeOnly: true }, ctx);
+    for (const p of result.providers) {
+      if (!p.dynamic) {
+        expect(p.models.length).toBeGreaterThan(0);
+        expect(p.models.every((m) => m.free)).toBe(true);
+      }
+    }
+  });
+
+  it('throws without an authenticated user', async () => {
+    await expect(run({}, {})).rejects.toThrow(/authentication required/i);
+  });
+});

--- a/apps/web/src/lib/ai/tools/agent-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-tools.ts
@@ -7,6 +7,7 @@ import { agentRepository } from '@pagespace/lib/repositories/agent-repository';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { type ToolExecutionContext, pageSpaceTools } from '../core';
+import { validateAgentModelSelection } from '../core/ai-providers-config';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 
 const agentLogger = loggers.ai.child({ module: 'agent-tools' });
@@ -57,6 +58,19 @@ export const agentTools = {
           const invalidTools = enabledTools.filter(toolName => !availableToolNames.includes(toolName));
           if (invalidTools.length > 0) {
             throw new Error(`Invalid tools specified: ${invalidTools.join(', ')}. Available tools: ${availableToolNames.join(', ')}`);
+          }
+        }
+
+        // Validate the model selection against the real catalog so a hallucinated
+        // model id can't be stored. Fall back to the agent's stored provider/model
+        // so a bad aiModel is caught even when aiProvider isn't sent.
+        if (aiProvider !== undefined || aiModel !== undefined) {
+          const reason = validateAgentModelSelection(
+            aiProvider ?? agent.aiProvider,
+            aiModel ?? agent.aiModel,
+          );
+          if (reason) {
+            throw new Error(`${reason} Call list_models to see valid providers and models.`);
           }
         }
 

--- a/apps/web/src/lib/ai/tools/model-tools.ts
+++ b/apps/web/src/lib/ai/tools/model-tools.ts
@@ -1,0 +1,44 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { buildModelCatalog } from '../core/model-catalog';
+import { type ToolExecutionContext } from '../core';
+
+/**
+ * Read-only tool exposing the real AI model catalog so an agent uses a valid
+ * model id when configuring another agent (via `update_agent_config`) instead of
+ * inventing one. Not a write tool — must never appear in `WRITE_TOOLS`.
+ */
+export const modelTools = {
+  list_models: tool({
+    description:
+      'List the AI providers and models that can be assigned to an agent via update_agent_config. ALWAYS call this before setting aiProvider/aiModel so you use a real model id and never invent one. Returns model id, display name, provider, free-tier flag, and context window.',
+    inputSchema: z.object({
+      provider: z
+        .string()
+        .optional()
+        .describe('Filter to one provider key, e.g. "openai", "anthropic".'),
+      freeOnly: z
+        .boolean()
+        .optional()
+        .describe('If true, only return free-tier models.'),
+    }),
+    execute: async ({ provider, freeOnly }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      let providers = buildModelCatalog();
+      if (provider) {
+        providers = providers.filter((p) => p.provider === provider);
+      }
+      if (freeOnly) {
+        providers = providers
+          .map((p) => ({ ...p, models: p.models.filter((m) => m.free) }))
+          .filter((p) => p.models.length > 0 || p.dynamic);
+      }
+
+      return { providers };
+    },
+  }),
+};


### PR DESCRIPTION
## Context

Agents in PageSpace can configure *other* agents — the `update_agent_config` tool and the `PATCH /api/pages/[pageId]/agent-config` route behind it let them set an agent's `aiProvider`/`aiModel`. **Neither path validated the model.** An invalid id was silently swapped for the default at chat time (`createAIProvider`), so a hallucinated model name (e.g. `openai/gpt-6-ultra`) was stored and then quietly ignored — confusing and hard to debug. There was also no way for an agent (or any client) to *discover* the real model list before configuring.

This PR closes the loop: a public catalog endpoint, a read-only tool over the same data, and validation on both write paths so a model id that isn't in the catalog is rejected.

## What changed

**1. Public endpoint — `GET /api/ai/models`** (`apps/web/src/app/api/ai/models/route.ts`)
- No auth (catalog already ships to the browser; not secret), cacheable (`s-maxage=300`).
- Returns the real catalog grouped by provider — each model with `id`, `displayName`, `provider`, `free` flag, and `contextWindow`. **No pricing** (avoids publishing raw provider list-prices).
- Respects deployment-mode visibility (`getVisibleProviders`); local providers reported as `dynamic: true` with empty `models`. Marked `export const dynamic = 'force-dynamic'` so the runtime `DEPLOYMENT_MODE` is never frozen by static prerender.
- The existing OpenAI-compatible `/api/v1/models` (which lists *agents* as models for SDK inference) is intentionally **untouched** — that surface is agent-centric (`/v1/chat/completions` only accepts `ps-agent://<pageId>`), so the raw-model catalog lives on a separate path.

**2. `list_models` agent tool** (`apps/web/src/lib/ai/tools/model-tools.ts`, registered in `core/ai-tools.ts`)
- Read-only, over the same `buildModelCatalog()`, with optional `provider` / `freeOnly` filters.
- Description instructs the model to call it before setting `aiProvider`/`aiModel`.
- Not in `WRITE_TOOLS`, so it stays available in read-only mode.

**3. Model validation on both write paths** via shared `validateAgentModelSelection()` (`core/ai-providers-config.ts`)
- `update_agent_config` tool → throws with "Call list_models…" on a bad id.
- `PATCH .../agent-config` → 400 with reason.
- Resolves provider/model against the stored values so a bad `aiModel` is caught even when sent alone.
- **A model can't be stored without a provider** (no provider ⇒ nothing to validate against ⇒ would bypass the gate). The UI always sends both fields together (`PageAgentSettingsTab`), so clearing the provider clears the model too.
- Dynamic providers (ollama/lmstudio/azure) are allowed; deployment mode respected. **Tier gating stays at chat time** (`isModelAllowedForTier`) — this is the anti-hallucination gate, not a tier gate.

### Architecture note
`core/ai-providers-config.ts` is client-reachable, so it must not import the server-only `@pagespace/lib/monitoring/ai-monitoring` (which pulls the DB client). Therefore the context-window-aware **catalog builder lives in a server-only `core/model-catalog.ts`** (imported only by the route + tool, not re-exported from the `core` barrel), while the lightweight **validator stays in the client-safe config file**.

### Scope note
Other `aiModel`/`aiProvider` writers were swept: the create-agent route (`page-agents/create`) already validates via `isValidModel`; generic page-create/PATCH HTTP routes accept arbitrary values but are **not agent-tool-reachable**, so they're outside this PR's "agents hallucinating" goal (they still degrade safely via the provider-factory runtime fallback). The only agent-tool config-write path is `update_agent_config`, now gated.

## Validation
- `bun run --filter 'web' typecheck` — clean.
- `bun run --filter 'web' lint` — clean (no new warnings).
- Affected unit tests — **117 passing** across:
  - `ai-providers-config.test.ts` (validator incl. model-without-provider, dynamic providers, on-prem visibility)
  - `model-catalog.test.ts` (catalog shape, free flags, dynamic providers, on-prem filter)
  - `api/ai/models/route.test.ts` (shape, no-pricing, Cache-Control)
  - `model-tools.test.ts` (filters, auth)
  - `agent-tools.test.ts` + `agent-config/route.test.ts` (reject hallucinated id, reject model-without-provider, accept valid, stored-provider fallback)

### Manual smoke
```
curl -s localhost:3000/api/ai/models | jq '.providers[0].models[0], .defaultModel'
```