### PR TITLE
fix(ai): stop system-message prompt-injection warning flood

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -133,7 +133,8 @@ import { db } from '@pagespace/db/db';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
-import { sanitizeMessagesForModel } from '@/lib/ai/core';
+import { sanitizeMessagesForModel, extractMessageContent } from '@/lib/ai/core';
+import type { UIMessage } from 'ai';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 
 const mcpAuth = {
@@ -422,6 +423,30 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'pass 3 messages to sanitizeMessagesForModel (2 history + 1 new)',
       actual: sanitizeCalls[0]?.[0]?.length,
       expected: 3,
+    });
+  });
+
+  test('openai mode: caller-supplied system message is hoisted into the system prompt', async () => {
+    // Extract real part text so the assertion can distinguish the caller's system content.
+    vi.mocked(extractMessageContent).mockImplementation((m: UIMessage) =>
+      (m.parts ?? [])
+        .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map(p => p.text)
+        .join('')
+    );
+    await POST(makeRequest({
+      model: 'ps-agent://page-123',
+      messages: [
+        { role: 'system', id: 'sys-1', content: 'Answer only JSON', parts: [{ type: 'text', text: 'Answer only JSON' }] },
+        { role: 'user', id: 'msg-1', content: 'Hi', parts: [{ type: 'text', text: 'Hi' }] },
+      ],
+    }));
+    const systemArg = vi.mocked(streamText).mock.calls[0]?.[0]?.system;
+    assert({
+      given: 'an OpenAI-style request carrying a caller system message',
+      should: 'hoist the caller system content into the system: option instead of silently dropping it',
+      actual: typeof systemArg === 'string' && systemArg.includes('Answer only JSON'),
+      expected: true,
     });
   });
 

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -190,6 +190,17 @@ export async function POST(request: Request): Promise<Response> {
   // 9. Run inference — no UI coupling (no WebSocket, no stream lifecycle, no session ID)
   const startTime = Date.now();
   const providerType = getProviderTier(page.aiProvider ?? DEFAULT_PROVIDER, page.aiModel ?? undefined);
+
+  // OpenAI-style callers may supply their own system message(s) in the request.
+  // sanitizeMessagesForModel strips system-role messages from the array (system content
+  // must ride in the `system:` option, not messages[], per AI SDK prompt-injection
+  // hardening), so hoist any caller system instructions into the system prompt first —
+  // dropping them silently would break standard OpenAI clients.
+  const callerSystemPrompt = inferenceMessages
+    .filter(m => m.role === 'system')
+    .map(extractMessageContent)
+    .filter(Boolean)
+    .join('\n\n');
   const sanitized = sanitizeMessagesForModel(inferenceMessages);
 
   // Standard OpenAI-style cancel: the consumer closing the HTTP connection stops generation.
@@ -263,7 +274,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const aiResult = streamText({
     model: providerResult.model,
-    system: systemPrompt + toolDiscoveryPrompt,
+    system: systemPrompt + (callerSystemPrompt ? `\n\n${callerSystemPrompt}` : '') + toolDiscoveryPrompt,
     messages: convertToModelMessages(sanitized),
     tools: filteredTools,
     stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)],

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
@@ -5,6 +5,7 @@ import {
   extractToolCalls,
   extractToolResults,
   convertDbMessageToUIMessage,
+  sanitizeMessagesForModel,
 } from '../message-utils';
 
 /** Helper to build a UIMessage with typed parts */
@@ -181,5 +182,43 @@ describe('convertDbMessageToUIMessage — output-error round-trip', () => {
         state: 'output-available',
       },
     ]);
+  });
+});
+
+describe('sanitizeMessagesForModel', () => {
+  it('drops system-role messages (system prompt belongs in the system: option)', () => {
+    const messages: UIMessage[] = [
+      { id: 's1', role: 'system', parts: [{ type: 'text' as const, text: 'You are a helpful assistant' }] },
+      makeMessage([{ type: 'text' as const, text: 'Hi' }], 'user'),
+      makeMessage([{ type: 'text' as const, text: 'Hello!' }], 'assistant'),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+
+    expect(result.map(m => m.role)).toEqual(['user', 'assistant']);
+    expect(result.some(m => m.role === 'system')).toBe(false);
+  });
+
+  it('preserves user/assistant messages while still filtering tool parts without results', () => {
+    const messages: UIMessage[] = [
+      makeMessage(
+        [
+          { type: 'text' as const, text: 'done' },
+          // tool part lacking output should be dropped
+          {
+            type: 'tool-list_pages',
+            toolCallId: 'tc1',
+            input: { driveId: 'd1' },
+            state: 'input-available',
+          },
+        ],
+        'assistant'
+      ),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].parts).toEqual([{ type: 'text', text: 'done' }]);
   });
 });

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -706,10 +706,14 @@ export function sanitizeContent(content: string): string {
 
 /**
  * Sanitize messages before passing to convertToModelMessages
- * Filters out tool parts without results to prevent "input-available" state errors
+ * - Drops system-role messages: the authoritative system prompt is always supplied via the
+ *   `system:` option at every call site, so a system-role message in the array is never needed
+ *   and trips the AI SDK's prompt-injection warning ("System messages in the prompt or messages
+ *   fields can be a security risk..."), which floods logs inside agent retry loops.
+ * - Filters out tool parts without results to prevent "input-available" state errors.
  */
 export function sanitizeMessagesForModel(msgs: UIMessage[]): UIMessage[] {
-  return msgs.map(message => ({
+  return msgs.filter(message => message.role !== 'system').map(message => ({
     ...message,
     parts: message.parts?.filter(part => {
       // Keep text parts


### PR DESCRIPTION
## Problem

The Vercel AI SDK logs this warning on **every** model call whose `messages[]` array contains a `role: 'system'` entry:

> AI SDK Warning: System messages in the prompt or messages fields can be a security risk because they may enable prompt injection attacks. Use the system option instead when possible.

It fires in the SDK's `standardizePrompt` for any system-role message. Those messages leak in from DB-loaded history (`convertDbMessageToUIMessage` preserves `role: 'system'` verbatim). Because the server-side agent retry loop re-runs `streamText` each iteration, the warning repeats endlessly and floods the logs. It's a legitimate prompt-injection hardening signal, not noise to suppress.

## Fix

Every model-call site already supplies its authoritative system prompt via the dedicated `system:` option, so a system-role message in the array is redundant. This drops system-role messages at the shared chokepoint `sanitizeMessagesForModel`, which gates 4 of the 5 model-call paths:

- `api/ai/chat/route.ts`
- `api/ai/global/[id]/messages/route.ts`
- `api/v1/chat/completions/route.ts`
- `lib/ai/tools/agent-communication-tools.ts`

The `page-agents/consult` route already filtered `m.role !== 'system'` inline, so it's unchanged. `lib/workflows/workflow-executor.ts` only ever builds a single `role:'user'` message, so it can't emit the warning. No `streamObject`/`generateObject` paths exist.

### OpenAI-compatible endpoint (caller system messages preserved)

The `/api/v1/chat/completions` endpoint accepts `role:'system'` from external clients, and in stateless mode passes the client array straight through. To avoid silently discarding a legitimate caller instruction, that route now **hoists** caller-supplied system messages into the `system:` option (appended after the agent page prompt, before the tool-discovery prompt) *before* `sanitizeMessagesForModel` strips them from the array. The caller's instruction is honored via the dedicated `system` option — no behavior loss, no array-borne system message, no warning. (Addresses Codex review P2.)

## Tests

- `message-utils.test.ts`: asserts `sanitizeMessagesForModel` drops `role:'system'` messages while preserving user/assistant messages and the existing tool-part filtering.
- `v1/chat/completions/route.test.ts`: asserts a caller-supplied system message is hoisted into the `system:` option.

## Validation

- Affected-caller test suites: green (message-utils + chat + global + agent-comm + v1, 158 tests)
- `bun run --filter 'web' typecheck`: clean
- `bun run --filter 'web' lint`: passes (only pre-existing warnings in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)