### PR TITLE
test(credits): real-Postgres + e2e hardening for metering safety properties

### DIFF
--- a/apps/e2e/README.metering.md
+++ b/apps/e2e/README.metering.md
@@ -12,6 +12,8 @@ only the model provider and Stripe (webhook side) faked.
 | `10-metering-billing.spec.ts` | A funded chat call hits the model once and debits **exactly `cost × 1.5`** (mock returns 2¢ → 3¢ charged); a usage ledger row is written and the in-flight hold settles. |
 | `11-metering-limits.spec.ts` | `402 out_of_credits` at the reserve floor; `429 too_many_in_flight` at the free-tier concurrency cap. |
 | `12-token-packs.spec.ts` | Credit-pack checkout validation (400s) and the funding webhook: a paid `checkout.session.completed` (`metadata.kind=credit_pack`) credits the never-expiring top-up bucket **exactly once** (idempotent on event id). |
+| `13-metering-reconcile.spec.ts` | The cost-reconcile cron (`GET /api/cron/reconcile-ai-cost`): a billed-inline call whose authoritative `/generation` cost differs gets a correcting **adjustment** ledger row + balance delta; the correction is **idempotent** across a duplicate generation set and a re-run. The mock now also serves `GET /generation?id=` (overridable per-id via `POST /__set-generation-cost`). |
+| `14-metering-daily-cap.spec.ts` | The per-user/day exposure cap: with enforcement ON and a small `DAILY_CAP_BUSINESS_CENTS`, driving calls past the ceiling returns **429 `daily_cap_exceeded`** — the model isn't called on the over-cap request and nothing is billed beyond the cap. |
 
 Meter-only mode (`CREDITS_ENFORCEMENT_ENABLED=false`) and the cost-extraction/settlement
 math are covered by unit tests in `packages/lib/src/billing/__tests__/` — they aren't
@@ -24,13 +26,19 @@ re-run here because the flag is read in the app process and is fixed at app laun
    ```bash
    DATABASE_URL=postgres://…@localhost:5432/…   # local DB only — seeders refuse non-local hosts
    CREDITS_ENFORCEMENT_ENABLED=true             # enforcement is OFF by default — turn it ON for this run
-   OPENROUTER_DEFAULT_API_KEY=sk-e2e            # any non-empty value; enables the openrouter branch
+   DAILY_CAP_BUSINESS_CENTS=25                  # 14-metering-daily-cap only; read at call time in the app process
+   OPENROUTER_DEFAULT_API_KEY=sk-e2e            # any non-empty value; enables the openrouter branch + reconcile fetcher
    OPENROUTER_BASE_URL=http://127.0.0.1:4998/api/v1
    WEB_APP_URL=http://localhost:3000
    CRON_SECRET=<shared>
    STRIPE_WEBHOOK_SECRET=<shared>
    CSRF_SECRET=<shared>
    ```
+
+   `DAILY_CAP_BUSINESS_CENTS` is scoped to the `business` tier so it only affects the
+   daily-cap spec (every other metering spec uses `pro`/`free`). Like
+   `CREDITS_ENFORCEMENT_ENABLED`, it's read at call time in the app process, so it must be
+   set when the app launches — it cannot be set from inside a spec.
 
    `CRON_SECRET`, `STRIPE_WEBHOOK_SECRET`, and `CSRF_SECRET` must be the **same** values the
    Playwright process sees (both load `.env`), so the test can forge valid signatures/tokens.
@@ -39,7 +47,8 @@ re-run here because the flag is read in the app process and is fixed at app laun
 
    ```bash
    bun run --filter '@pagespace/e2e' test:e2e -- tests/09-metering-no-bypass.spec.ts \
-     tests/10-metering-billing.spec.ts tests/11-metering-limits.spec.ts tests/12-token-packs.spec.ts
+     tests/10-metering-billing.spec.ts tests/11-metering-limits.spec.ts tests/12-token-packs.spec.ts \
+     tests/13-metering-reconcile.spec.ts tests/14-metering-daily-cap.spec.ts
    ```
 
 ## How the model is faked

--- a/apps/e2e/support/db.ts
+++ b/apps/e2e/support/db.ts
@@ -3,6 +3,7 @@ import { factories } from '@pagespace/db/test/factories';
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { creditBalances, creditLedger, creditHolds } from '@pagespace/db/schema/credits';
+import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
 import { mcpTokens } from '@pagespace/db/schema/auth';
 import { conversations } from '@pagespace/db/schema/conversations';
 import { sessionService } from '../../../packages/lib/src/auth/session-service';
@@ -137,6 +138,54 @@ export async function createGlobalConversation(userId: string): Promise<string> 
     .values({ userId, type: 'global', title: 'e2e' })
     .returning();
   return row.id;
+}
+
+/**
+ * Seed a billed OpenRouter chat call that is still awaiting cost reconcile: an
+ * `ai_usage_logs` row (provider=openrouter, reconcileStatus='pending', carrying the
+ * generation id in metadata.generationIds, timestamped past the reconcile grace window)
+ * plus its base `usage` credit_ledger row (reconcile only CORRECTS an already-billed
+ * call). `billedCostDollars` is what we charged inline; the cron will fetch the
+ * authoritative `/generation` cost and correct any drift. Returns the row ids.
+ */
+export async function seedPendingReconcileCall(
+  userId: string,
+  opts: { generationId: string; billedCostDollars: number; chargedCents: number },
+): Promise<{ aiUsageLogId: string; generationId: string }> {
+  // Older than cost-reconcile's 2-minute grace window so it's eligible immediately.
+  const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
+  const [log] = await db
+    .insert(aiUsageLogs)
+    .values({
+      userId,
+      provider: 'openrouter',
+      model: 'e2e/stub-model',
+      cost: opts.billedCostDollars,
+      timestamp: tenMinAgo,
+      reconcileStatus: 'pending',
+      reconcileAttempts: 0,
+      metadata: { generationIds: [opts.generationId] },
+    })
+    .returning({ id: aiUsageLogs.id });
+
+  await db.insert(creditLedger).values({
+    userId,
+    entryType: 'usage',
+    bucket: 'monthly',
+    amountCents: -opts.chargedCents,
+    appliedCents: -opts.chargedCents,
+    chargeMillicents: opts.chargedCents * 1000,
+    realCostCents: Math.round(opts.billedCostDollars * 100),
+    aiUsageLogId: log.id,
+  });
+
+  return { aiUsageLogId: log.id, generationId: opts.generationId };
+}
+
+/** Read the ai_usage_logs row for a given id (to assert reconcileStatus transitions). */
+export async function getAiUsageLog(id: string) {
+  const [row] = await db.select().from(aiUsageLogs).where(eq(aiUsageLogs.id, id));
+  return row ?? null;
 }
 
 /** Insert an MCP bearer token for the user; returns the raw `mcp_...` token. */

--- a/apps/e2e/support/http.ts
+++ b/apps/e2e/support/http.ts
@@ -56,3 +56,19 @@ export async function mockCallCount(request: APIRequestContext): Promise<number>
   const json = (await res.json()) as { count: number };
   return json.count;
 }
+
+/**
+ * Override the authoritative `/generation` cost the reconcile cron will read. With `id`
+ * set, only that generation's cost changes; without it, the default for all unknown ids.
+ * `totalCost` is in US dollars (OpenRouter's `data.total_cost` shape).
+ */
+export async function setGenerationCost(
+  request: APIRequestContext,
+  totalCost: number,
+  id?: string,
+): Promise<void> {
+  await request.post(`${MOCK_BASE}/__set-generation-cost`, {
+    headers: { 'content-type': 'application/json' },
+    data: JSON.stringify({ totalCost, id }),
+  });
+}

--- a/apps/e2e/support/mock-openrouter.ts
+++ b/apps/e2e/support/mock-openrouter.ts
@@ -17,10 +17,21 @@ import http from 'http';
  *   GET  /__health  → { ok: true }
  *   GET  /__calls   → { count, requests: [{ model, stream, messages }] }
  *   POST /__reset   → zeroes the recorder
+ *
+ * It also serves OpenRouter's authoritative cost-reconcile endpoint:
+ *   GET  /generation?id=<id> → { data: { total_cost: <number> } }
+ * so the reconcile cron (cost-reconcile.ts) can fetch a FINAL cost that differs from the
+ * inline completion cost and induce a billing drift. The reported cost defaults to
+ * MOCK_GENERATION_COST_DOLLARS and is overridable per-id (and globally) via POST /__set-generation-cost.
  */
 
 /** Real provider cost in US dollars returned for every completion. 0.02 → 2¢ real → 3¢ charged at 1.5×. */
 export const MOCK_COST_DOLLARS = 0.02;
+/**
+ * Default authoritative `/generation` total_cost (dollars) returned to the reconcile cron.
+ * Higher than MOCK_COST_DOLLARS so, left at the default, the cron sees an undercharge drift.
+ */
+export const MOCK_GENERATION_COST_DOLLARS = 0.05;
 export const MOCK_PROMPT_TOKENS = 12;
 export const MOCK_COMPLETION_TOKENS = 4;
 
@@ -32,6 +43,11 @@ interface RecordedRequest {
 
 export function createMockOpenRouter() {
   const requests: RecordedRequest[] = [];
+  // Authoritative /generation cost (dollars) the reconcile cron reads, keyed by generation
+  // id. A test sets these via POST /__set-generation-cost; unknown ids fall back to the
+  // default so a plain reconcile run still produces a deterministic drift.
+  const generationCosts = new Map<string, number>();
+  let defaultGenerationCost = MOCK_GENERATION_COST_DOLLARS;
 
   const completionUsage = {
     prompt_tokens: MOCK_PROMPT_TOKENS,
@@ -68,7 +84,32 @@ export function createMockOpenRouter() {
     }
     if (method === 'POST' && url.startsWith('/__reset')) {
       requests.length = 0;
+      generationCosts.clear();
+      defaultGenerationCost = MOCK_GENERATION_COST_DOLLARS;
       return writeJson(res, 200, { ok: true });
+    }
+    // Override the authoritative /generation cost. Body: { id?, totalCost } — with `id`
+    // sets that generation's cost, without it sets the default for all unknown ids.
+    if (method === 'POST' && url.startsWith('/__set-generation-cost')) {
+      const raw = await readBody(req);
+      let body: { id?: string; totalCost?: number } = {};
+      try {
+        body = JSON.parse(raw) as typeof body;
+      } catch {
+        /* ignore */
+      }
+      if (typeof body.totalCost === 'number') {
+        if (typeof body.id === 'string' && body.id.length > 0) generationCosts.set(body.id, body.totalCost);
+        else defaultGenerationCost = body.totalCost;
+      }
+      return writeJson(res, 200, { ok: true });
+    }
+    // OpenRouter's authoritative cost endpoint, polled by the reconcile cron. Matched by
+    // `includes` because the cron hits it under the /api/v1 base path.
+    if (method === 'GET' && url.includes('/generation')) {
+      const id = new URL(url, 'http://127.0.0.1').searchParams.get('id') ?? '';
+      const totalCost = generationCosts.has(id) ? generationCosts.get(id)! : defaultGenerationCost;
+      return writeJson(res, 200, { data: { total_cost: totalCost } });
     }
 
     if (method === 'POST' && url.includes('/chat/completions')) {

--- a/apps/e2e/tests/13-metering-reconcile.spec.ts
+++ b/apps/e2e/tests/13-metering-reconcile.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test';
+import {
+  seedUser,
+  seedPendingReconcileCall,
+  getBalance,
+  getLedger,
+  getAiUsageLog,
+} from '../support/db';
+import { resetMock, setGenerationCost } from '../support/http';
+import { cronHeaders } from '../support/sign';
+
+/**
+ * End-to-end cost reconcile: we bill an OpenRouter call inline on the cost the stream
+ * returns, but OpenRouter's authoritative `/generation` cost can settle differently. The
+ * reconcile cron fetches that final cost and writes a correcting adjustment + balance
+ * delta. Here a billed-at-2¢ call's generation resolves to 10¢; the cron must debit the
+ * 8¢ drift (×1.5 markup = 12¢) and the correction must be idempotent across runs.
+ *
+ * The reconcile cron uses its DEFAULT fetcher, which hits OPENROUTER_BASE_URL/generation
+ * (pointed at the mock) with OPENROUTER_DEFAULT_API_KEY — both set when the app launches
+ * for the metering run (see README.metering.md).
+ */
+
+const RECONCILE_PATH = '/api/cron/reconcile-ai-cost';
+
+// Pure API tests — drop the seeded browser session.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+function reconcileHeaders(): Record<string, string> {
+  return cronHeaders({ method: 'GET', path: RECONCILE_PATH });
+}
+
+test('reconcile cron corrects a billed call against the authoritative /generation cost', async ({ request }) => {
+  await resetMock(request);
+  const START = 10_000;
+  const user = await seedUser({
+    tier: 'pro',
+    provider: 'openrouter',
+    monthlyRemainingCents: START,
+    monthlyAllowanceCents: START,
+  });
+
+  // Billed inline at 2¢ real; the authoritative generation cost is 10¢ → +8¢ drift.
+  const genId = `gen-recon-${user.userId}`;
+  await seedPendingReconcileCall(user.userId, { generationId: genId, billedCostDollars: 0.02, chargedCents: 3 });
+  await setGenerationCost(request, 0.1, genId);
+
+  const res = await request.get(RECONCILE_PATH, { headers: reconcileHeaders() });
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as { corrected: number };
+  expect(body.corrected).toBe(1);
+
+  // An adjustment ledger row was written, keyed to the generation set.
+  const adjustments = await getLedger(user.userId, 'adjustment');
+  expect(adjustments).toHaveLength(1);
+  expect(adjustments[0].reconcileGenerationKey).toBe(genId);
+
+  // The balance moved by the drift charge: 8¢ real × 1.5 = 12¢ debited monthly-first.
+  expect((await getBalance(user.userId))?.monthlyRemainingCents).toBe(START - 12);
+
+  // The usage row is now reconciled.
+  const log = await getAiUsageLog(
+    (await getLedger(user.userId, 'usage'))[0].aiUsageLogId as string,
+  );
+  expect(log?.reconcileStatus).toBe('reconciled');
+});
+
+test('reconcile is idempotent: a duplicate generation set and a re-run never double-correct', async ({ request }) => {
+  await resetMock(request);
+  const START = 10_000;
+  const user = await seedUser({
+    tier: 'pro',
+    provider: 'openrouter',
+    monthlyRemainingCents: START,
+    monthlyAllowanceCents: START,
+  });
+
+  // TWO pending calls share the SAME generation id — the second correction must hit the
+  // reconcileGenerationKey unique conflict (onConflictDoNothing) and apply nothing.
+  const genId = `gen-dup-${user.userId}`;
+  await seedPendingReconcileCall(user.userId, { generationId: genId, billedCostDollars: 0.02, chargedCents: 3 });
+  await seedPendingReconcileCall(user.userId, { generationId: genId, billedCostDollars: 0.02, chargedCents: 3 });
+  await setGenerationCost(request, 0.1, genId);
+
+  const first = await request.get(RECONCILE_PATH, { headers: reconcileHeaders() });
+  expect(first.status()).toBe(200);
+
+  // Exactly one adjustment despite two pending rows sharing the key; balance moved once.
+  expect(await getLedger(user.userId, 'adjustment')).toHaveLength(1);
+  expect((await getBalance(user.userId))?.monthlyRemainingCents).toBe(START - 12);
+
+  // Re-running the cron inserts no second adjustment and moves nothing further.
+  const second = await request.get(RECONCILE_PATH, { headers: reconcileHeaders() });
+  expect(second.status()).toBe(200);
+  expect(await getLedger(user.userId, 'adjustment')).toHaveLength(1);
+  expect((await getBalance(user.userId))?.monthlyRemainingCents).toBe(START - 12);
+});

--- a/apps/e2e/tests/14-metering-daily-cap.spec.ts
+++ b/apps/e2e/tests/14-metering-daily-cap.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { seedUser, createAgentPage, createMcpToken, getLedger } from '../support/db';
+import { mcpPost, resetMock, mockCallCount } from '../support/http';
+
+/**
+ * The per-user/day exposure cap, exercised against the real chat route. A runaway loop can
+ * stay within the in-flight concurrency cap yet accrue real spend all day; the daily cap is
+ * the backstop. With enforcement ON and a small DAILY_CAP_BUSINESS_CENTS, once a user's
+ * holds + charged spend would cross the ceiling the route must return 429 `daily_cap_exceeded`
+ * — without calling the model and without billing past the cap.
+ *
+ * GOTCHA: dailyExposureCapForTier reads DAILY_CAP_<TIER>_CENTS at CALL time, in the WEB
+ * SERVER's process, so it must be in the app's launch env (like CREDITS_ENFORCEMENT_ENABLED),
+ * NOT set from inside this spec. This spec uses the `business` tier so the cap it relies on
+ * (DAILY_CAP_BUSINESS_CENTS) doesn't perturb the other metering specs (which use pro/free).
+ * Launch the app for this run with (in addition to README.metering.md):
+ *   CREDITS_ENFORCEMENT_ENABLED=true
+ *   DAILY_CAP_BUSINESS_CENTS=25
+ * With the 25¢ stub-model hold estimate, the first call fits the 25¢ cap and the next is denied.
+ */
+
+const CAP_CENTS = 25;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('429 daily_cap_exceeded once the daily ceiling is reached; model not called, nothing billed past the cap', async ({ request }) => {
+  const user = await seedUser({
+    tier: 'business',
+    provider: 'openrouter',
+    monthlyRemainingCents: 100_000, // abundant credits → the daily cap, not the balance, is the limiter
+    monthlyAllowanceCents: 100_000,
+  });
+  const chatId = await createAgentPage(user.driveId, user.userId);
+  const mcp = await createMcpToken(user.userId);
+  await resetMock(request);
+
+  const statuses: number[] = [];
+  let capDenialSeen = false;
+  let modelCountBeforeDenial = -1;
+
+  // Drive calls until the cap denies one (bounded so a misconfigured env fails fast rather
+  // than looping forever).
+  for (let i = 0; i < 5 && !capDenialSeen; i++) {
+    const before = await mockCallCount(request);
+    const res = await mcpPost(request, '/api/ai/chat', mcp, {
+      messages: [{ role: 'user', content: 'ping' }],
+      chatId,
+    });
+    statuses.push(res.status());
+
+    if (res.status() === 429) {
+      const body = (await res.json()) as { error?: string };
+      expect(body.error, 'the daily cap denial is distinct from the in-flight cap').toBe('daily_cap_exceeded');
+      capDenialSeen = true;
+      modelCountBeforeDenial = before;
+      // The denied (over-cap) call must NOT reach the model.
+      expect(await mockCallCount(request)).toBe(before);
+    } else {
+      expect(res.status(), 'a within-cap call is served normally').toBe(200);
+      await res.body(); // drain so settlement runs
+    }
+  }
+
+  // The cap actually fired (requires DAILY_CAP_BUSINESS_CENTS in the app env — see header).
+  expect(capDenialSeen, 'expected a daily_cap_exceeded denial within the burst').toBe(true);
+  // At least one call got through before the cap — proves we were "driven past" a real ceiling,
+  // not denied from the first request.
+  expect(statuses.filter((s) => s === 200).length).toBeGreaterThanOrEqual(1);
+  // The model was invoked only for the allowed calls, never for the denied one.
+  expect(await mockCallCount(request)).toBe(modelCountBeforeDenial);
+
+  // Nothing was billed beyond the cap: total charged usage stays within the ceiling.
+  const usage = await getLedger(user.userId, 'usage');
+  const chargedCents = usage.reduce((sum, r) => sum + Math.abs(r.chargeMillicents ?? 0) / 1000, 0);
+  expect(chargedCents).toBeLessThanOrEqual(CAP_CENTS);
+});

--- a/apps/e2e/tests/14-metering-daily-cap.spec.ts
+++ b/apps/e2e/tests/14-metering-daily-cap.spec.ts
@@ -70,7 +70,8 @@ test('429 daily_cap_exceeded once the daily ceiling is reached; model not called
   expect(await mockCallCount(request)).toBe(modelCountBeforeDenial);
 
   // Nothing was billed beyond the cap: total charged usage stays within the ceiling.
+  // Summed in integer millicents (exact) and compared to the cap, avoiding float division.
   const usage = await getLedger(user.userId, 'usage');
-  const chargedCents = usage.reduce((sum, r) => sum + Math.abs(r.chargeMillicents ?? 0) / 1000, 0);
-  expect(chargedCents).toBeLessThanOrEqual(CAP_CENTS);
+  const chargedMillicents = usage.reduce((sum, r) => sum + Math.abs(r.chargeMillicents ?? 0), 0);
+  expect(chargedMillicents).toBeLessThanOrEqual(CAP_CENTS * 1000);
 });

--- a/apps/web/src/lib/monitoring/__tests__/account-alerts-queries.integration.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/account-alerts-queries.integration.test.ts
@@ -10,27 +10,49 @@
  * exercised, then asserts the flagged accounts + numbers, and that the SQL HAVING and the
  * JS isNegativeMargin re-check agree on real data.
  *
+ * SAFETY: these queries aggregate across ALL users (no user filter), but this test must
+ * never delete rows it did not create — a developer/CI job with a real or staging
+ * DATABASE_URL would otherwise have its billing tables silently wiped. So cleanup is
+ * scoped to the users this file creates, and every assertion filters the (global) query
+ * result down to those users, which also makes the test robust to pre-existing rows
+ * (a large `limit` keeps the seeded users in the result regardless of other data).
+ *
  * Requires DATABASE_URL → a running Postgres with migrations applied
  * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable.
  */
 
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
 import { creditLedger, creditBalances, creditHolds } from '@pagespace/db/schema/credits';
 import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
 import { factories } from '@pagespace/db/test/factories';
 import { isNegativeMargin } from '@pagespace/lib/billing/credit-core';
 import { getBalanceDriftAlerts, getNegativeMarginAccounts } from '../monitoring-queries';
 
-let dbAvailable = false;
+// Large enough that the seeded users always survive the queries' ORDER BY ... LIMIT even
+// if the target DB already holds unrelated billing rows.
+const BIG_LIMIT = 100_000;
 
-async function clearAll(): Promise<void> {
-  // No FK between these and each other; only to users (which we leave in place — stray
-  // users without ledger/balance rows can't appear in either query's joins).
-  await db.delete(creditHolds);
-  await db.delete(creditLedger);
-  await db.delete(creditBalances);
-  await db.delete(aiUsageLogs);
+let dbAvailable = false;
+// Every user this file creates — the ONLY rows cleanup is allowed to delete.
+const createdUserIds: string[] = [];
+
+async function mkUser(overrides?: Parameters<typeof factories.createUser>[0]) {
+  const user = await factories.createUser(overrides);
+  createdUserIds.push(user.id);
+  return user;
+}
+
+/** Delete only the rows belonging to users this file created (FK-safe order). */
+async function cleanupCreated(): Promise<void> {
+  for (const id of createdUserIds) {
+    await db.delete(creditHolds).where(eq(creditHolds.userId, id));
+    await db.delete(creditLedger).where(eq(creditLedger.userId, id));
+    await db.delete(creditBalances).where(eq(creditBalances.userId, id));
+    await db.delete(aiUsageLogs).where(eq(aiUsageLogs.userId, id));
+  }
+  createdUserIds.length = 0;
 }
 
 type LedgerRow = typeof creditLedger.$inferInsert;
@@ -49,18 +71,18 @@ describe('account-alerts monitoring queries (Postgres)', () => {
   });
 
   beforeEach(async () => {
-    if (dbAvailable) await clearAll();
+    if (dbAvailable) await cleanupCreated();
   });
 
   afterAll(async () => {
-    if (dbAvailable) await clearAll();
+    if (dbAvailable) await cleanupCreated();
   });
 
   describe('getBalanceDriftAlerts', () => {
     it('flags exactly the divergent accounts, worst |drift| first, with correct numbers', async () => {
       if (!dbAvailable) return;
       // d_ok: grant 1000 − usage 300 = expected 700; materialized 700 → drift 0 (within 10¢).
-      const ok = await factories.createUser();
+      const ok = await mkUser();
       await db.insert(creditBalances).values({
         userId: ok.id, monthlyRemainingCents: 700, monthlyAllowanceCents: 1000, topupRemainingCents: 0,
       });
@@ -68,7 +90,7 @@ describe('account-alerts monitoring queries (Postgres)', () => {
       await insertLedger({ userId: ok.id, entryType: 'usage', bucket: 'monthly', amountCents: -300, appliedCents: -300 });
 
       // d_flag: expected 700; materialized 800 → drift +100.
-      const flag = await factories.createUser();
+      const flag = await mkUser();
       await db.insert(creditBalances).values({
         userId: flag.id, monthlyRemainingCents: 800, monthlyAllowanceCents: 1000, topupRemainingCents: 0,
       });
@@ -77,7 +99,7 @@ describe('account-alerts monitoring queries (Postgres)', () => {
 
       // d_buckets: grant 500(monthly)+1000(topup)=1500 − usage 200 + adjustment 50 = expected 1350;
       // materialized 1000+300=1300 → drift −50. Exercises every entryType bucket of the CASE WHENs.
-      const buckets = await factories.createUser();
+      const buckets = await mkUser();
       await db.insert(creditBalances).values({
         userId: buckets.id, monthlyRemainingCents: 1000, monthlyAllowanceCents: 1500, topupRemainingCents: 300,
       });
@@ -86,20 +108,24 @@ describe('account-alerts monitoring queries (Postgres)', () => {
       await insertLedger({ userId: buckets.id, entryType: 'usage', bucket: 'monthly', amountCents: -200, appliedCents: -200 });
       await insertLedger({ userId: buckets.id, entryType: 'adjustment', bucket: 'monthly', amountCents: 50, appliedCents: 50 });
 
-      const rows = await getBalanceDriftAlerts(); // default 10¢ tolerance
+      const mine = new Set(createdUserIds);
+      const rows = await getBalanceDriftAlerts(undefined, BIG_LIMIT); // default 10¢ tolerance
+      const mineRows = rows.filter((r) => mine.has(r.userId));
 
-      expect(rows.map((r) => r.userId)).toEqual([flag.id, buckets.id]); // sorted by |drift| desc
-      expect(rows[0]).toMatchObject({
+      expect(mineRows.map((r) => r.userId)).toEqual([flag.id, buckets.id]); // sorted by |drift| desc
+      expect(mineRows[0]).toMatchObject({
         userId: flag.id, expectedSpendableCents: 700, materializedSpendableCents: 800, driftCents: 100,
       });
-      expect(rows[1]).toMatchObject({
+      expect(mineRows[1]).toMatchObject({
         userId: buckets.id, expectedSpendableCents: 1350, materializedSpendableCents: 1300, driftCents: -50,
       });
+      // The within-tolerance account is not flagged at all.
+      expect(rows.some((r) => r.userId === ok.id)).toBe(false);
     });
 
-    it('returns nothing when every account is within tolerance', async () => {
+    it('does not flag an account within tolerance', async () => {
       if (!dbAvailable) return;
-      const u = await factories.createUser();
+      const u = await mkUser();
       // expected 700, materialized 705 → drift 5 ≤ 10¢ tolerance.
       await db.insert(creditBalances).values({
         userId: u.id, monthlyRemainingCents: 705, monthlyAllowanceCents: 1000, topupRemainingCents: 0,
@@ -107,7 +133,8 @@ describe('account-alerts monitoring queries (Postgres)', () => {
       await insertLedger({ userId: u.id, entryType: 'monthly_grant', bucket: 'monthly', amountCents: 1000 });
       await insertLedger({ userId: u.id, entryType: 'usage', bucket: 'monthly', amountCents: -300, appliedCents: -300 });
 
-      expect(await getBalanceDriftAlerts()).toEqual([]);
+      const rows = await getBalanceDriftAlerts(undefined, BIG_LIMIT);
+      expect(rows.some((r) => r.userId === u.id)).toBe(false);
     });
   });
 
@@ -118,7 +145,7 @@ describe('account-alerts monitoring queries (Postgres)', () => {
       realCostCentsFallback: number; // creditLedger.realCostCents (used when cost is NULL)
       chargedCents: number;
     }): Promise<string> {
-      const user = await factories.createUser();
+      const user = await mkUser();
       let aiUsageLogId: string | undefined;
       if (opts.realCostDollars !== null) {
         const [log] = await db
@@ -157,20 +184,23 @@ describe('account-alerts monitoring queries (Postgres)', () => {
         [zero]: { real: 0, charged: 0 },
       };
 
-      const rows = await getNegativeMarginAccounts(undefined, undefined, 0);
+      const mine = new Set(createdUserIds);
+      const rows = await getNegativeMarginAccounts(undefined, undefined, 0, BIG_LIMIT);
+      const mineRows = rows.filter((r) => mine.has(r.userId));
 
-      // The query's flagged set must equal what the pure helper would flag on the same data.
+      // The query's flagged set (restricted to this test's users) must equal what the pure
+      // helper would flag on the same data.
       const jsFlagged = Object.entries(cases)
         .filter(([, c]) => isNegativeMargin(c.real, c.charged, 0))
         .map(([id]) => id)
         .sort();
-      expect([...rows.map((r) => r.userId)].sort()).toEqual(jsFlagged);
-      expect(jsFlagged.sort()).toEqual([neg, purged].sort());
+      expect([...mineRows.map((r) => r.userId)].sort()).toEqual(jsFlagged);
+      expect(jsFlagged).toEqual([neg, purged].sort());
 
       // Worst (most negative) margin first, and the numbers are right.
-      expect(rows.map((r) => r.userId)).toEqual([purged, neg]); // -20 before -10
-      expect(rows.find((r) => r.userId === neg)).toMatchObject({ realCostCents: 100, chargedCents: 90, marginCents: -10, marginPct: -10 });
-      expect(rows.find((r) => r.userId === purged)).toMatchObject({ realCostCents: 100, chargedCents: 80, marginCents: -20 });
+      expect(mineRows.map((r) => r.userId)).toEqual([purged, neg]); // -20 before -10
+      expect(mineRows.find((r) => r.userId === neg)).toMatchObject({ realCostCents: 100, chargedCents: 90, marginCents: -10, marginPct: -10 });
+      expect(mineRows.find((r) => r.userId === purged)).toMatchObject({ realCostCents: 100, chargedCents: 80, marginCents: -20 });
     });
 
     it('a margin floor demands headroom: a thin-but-positive account is flagged at a positive floor', async () => {
@@ -178,9 +208,12 @@ describe('account-alerts monitoring queries (Postgres)', () => {
       // charged 105 vs real 100 = +5% margin. Clears floor 0, fails a 10% (1000bps) floor.
       const thin = await seedUsage({ realCostDollars: 1.0, realCostCentsFallback: 100, chargedCents: 105 });
 
-      expect((await getNegativeMarginAccounts(undefined, undefined, 0)).map((r) => r.userId)).toEqual([]);
-      const flagged = await getNegativeMarginAccounts(undefined, undefined, 1000);
-      expect(flagged.map((r) => r.userId)).toEqual([thin]);
+      const atFloor0 = await getNegativeMarginAccounts(undefined, undefined, 0, BIG_LIMIT);
+      expect(atFloor0.some((r) => r.userId === thin)).toBe(false);
+
+      const atFloor1000 = await getNegativeMarginAccounts(undefined, undefined, 1000, BIG_LIMIT);
+      expect(atFloor1000.some((r) => r.userId === thin)).toBe(true);
+
       // SQL HAVING and the JS re-check agree at this floor too.
       expect(isNegativeMargin(100, 105, 1000)).toBe(true);
     });

--- a/apps/web/src/lib/monitoring/__tests__/account-alerts-queries.integration.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/account-alerts-queries.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Monitoring account-alerts queries — real Postgres integration tests.
+ *
+ * Real-DB sibling of account-alerts-queries.test.ts (which mocks db.select and feeds
+ * canned rows — it proves the JS sort/filter/map, but the actual SQL never runs). The
+ * money risk in getBalanceDriftAlerts / getNegativeMarginAccounts lives in their SQL:
+ * the per-entryType CASE WHEN aggregates, the COALESCE(...)::int casts, and the
+ * `HAVING chargedSum < realCostSum * (1 + bps)`. This file inserts real credit_ledger /
+ * credit_balances / ai_usage_logs rows and runs the ACTUAL queries so that SQL is
+ * exercised, then asserts the flagged accounts + numbers, and that the SQL HAVING and the
+ * JS isNegativeMargin re-check agree on real data.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { creditLedger, creditBalances, creditHolds } from '@pagespace/db/schema/credits';
+import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
+import { factories } from '@pagespace/db/test/factories';
+import { isNegativeMargin } from '@pagespace/lib/billing/credit-core';
+import { getBalanceDriftAlerts, getNegativeMarginAccounts } from '../monitoring-queries';
+
+let dbAvailable = false;
+
+async function clearAll(): Promise<void> {
+  // No FK between these and each other; only to users (which we leave in place — stray
+  // users without ledger/balance rows can't appear in either query's joins).
+  await db.delete(creditHolds);
+  await db.delete(creditLedger);
+  await db.delete(creditBalances);
+  await db.delete(aiUsageLogs);
+}
+
+type LedgerRow = typeof creditLedger.$inferInsert;
+async function insertLedger(row: LedgerRow): Promise<void> {
+  await db.insert(creditLedger).values(row);
+}
+
+describe('account-alerts monitoring queries (Postgres)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(creditBalances).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  beforeEach(async () => {
+    if (dbAvailable) await clearAll();
+  });
+
+  afterAll(async () => {
+    if (dbAvailable) await clearAll();
+  });
+
+  describe('getBalanceDriftAlerts', () => {
+    it('flags exactly the divergent accounts, worst |drift| first, with correct numbers', async () => {
+      if (!dbAvailable) return;
+      // d_ok: grant 1000 − usage 300 = expected 700; materialized 700 → drift 0 (within 10¢).
+      const ok = await factories.createUser();
+      await db.insert(creditBalances).values({
+        userId: ok.id, monthlyRemainingCents: 700, monthlyAllowanceCents: 1000, topupRemainingCents: 0,
+      });
+      await insertLedger({ userId: ok.id, entryType: 'monthly_grant', bucket: 'monthly', amountCents: 1000 });
+      await insertLedger({ userId: ok.id, entryType: 'usage', bucket: 'monthly', amountCents: -300, appliedCents: -300 });
+
+      // d_flag: expected 700; materialized 800 → drift +100.
+      const flag = await factories.createUser();
+      await db.insert(creditBalances).values({
+        userId: flag.id, monthlyRemainingCents: 800, monthlyAllowanceCents: 1000, topupRemainingCents: 0,
+      });
+      await insertLedger({ userId: flag.id, entryType: 'monthly_grant', bucket: 'monthly', amountCents: 1000 });
+      await insertLedger({ userId: flag.id, entryType: 'usage', bucket: 'monthly', amountCents: -300, appliedCents: -300 });
+
+      // d_buckets: grant 500(monthly)+1000(topup)=1500 − usage 200 + adjustment 50 = expected 1350;
+      // materialized 1000+300=1300 → drift −50. Exercises every entryType bucket of the CASE WHENs.
+      const buckets = await factories.createUser();
+      await db.insert(creditBalances).values({
+        userId: buckets.id, monthlyRemainingCents: 1000, monthlyAllowanceCents: 1500, topupRemainingCents: 300,
+      });
+      await insertLedger({ userId: buckets.id, entryType: 'monthly_grant', bucket: 'monthly', amountCents: 500 });
+      await insertLedger({ userId: buckets.id, entryType: 'topup_purchase', bucket: 'topup', amountCents: 1000 });
+      await insertLedger({ userId: buckets.id, entryType: 'usage', bucket: 'monthly', amountCents: -200, appliedCents: -200 });
+      await insertLedger({ userId: buckets.id, entryType: 'adjustment', bucket: 'monthly', amountCents: 50, appliedCents: 50 });
+
+      const rows = await getBalanceDriftAlerts(); // default 10¢ tolerance
+
+      expect(rows.map((r) => r.userId)).toEqual([flag.id, buckets.id]); // sorted by |drift| desc
+      expect(rows[0]).toMatchObject({
+        userId: flag.id, expectedSpendableCents: 700, materializedSpendableCents: 800, driftCents: 100,
+      });
+      expect(rows[1]).toMatchObject({
+        userId: buckets.id, expectedSpendableCents: 1350, materializedSpendableCents: 1300, driftCents: -50,
+      });
+    });
+
+    it('returns nothing when every account is within tolerance', async () => {
+      if (!dbAvailable) return;
+      const u = await factories.createUser();
+      // expected 700, materialized 705 → drift 5 ≤ 10¢ tolerance.
+      await db.insert(creditBalances).values({
+        userId: u.id, monthlyRemainingCents: 705, monthlyAllowanceCents: 1000, topupRemainingCents: 0,
+      });
+      await insertLedger({ userId: u.id, entryType: 'monthly_grant', bucket: 'monthly', amountCents: 1000 });
+      await insertLedger({ userId: u.id, entryType: 'usage', bucket: 'monthly', amountCents: -300, appliedCents: -300 });
+
+      expect(await getBalanceDriftAlerts()).toEqual([]);
+    });
+  });
+
+  describe('getNegativeMarginAccounts', () => {
+    /** Seed one usage ledger row; optionally a linked ai_usage_logs row carrying real cost. */
+    async function seedUsage(opts: {
+      realCostDollars: number | null; // null → no ai_usage_logs row (purge case → falls back to realCostCents)
+      realCostCentsFallback: number; // creditLedger.realCostCents (used when cost is NULL)
+      chargedCents: number;
+    }): Promise<string> {
+      const user = await factories.createUser();
+      let aiUsageLogId: string | undefined;
+      if (opts.realCostDollars !== null) {
+        const [log] = await db
+          .insert(aiUsageLogs)
+          .values({ userId: user.id, provider: 'openrouter', model: 'e2e/stub', cost: opts.realCostDollars })
+          .returning({ id: aiUsageLogs.id });
+        aiUsageLogId = log.id;
+      }
+      await insertLedger({
+        userId: user.id,
+        entryType: 'usage',
+        bucket: 'monthly',
+        amountCents: -opts.chargedCents,
+        appliedCents: -opts.chargedCents,
+        chargeMillicents: opts.chargedCents * 1000,
+        realCostCents: opts.realCostCentsFallback,
+        aiUsageLogId,
+      });
+      return user.id;
+    }
+
+    it('keeps exactly the accounts whose charged credits fail to cover real cost; SQL HAVING agrees with isNegativeMargin', async () => {
+      if (!dbAvailable) return;
+      // Each tuple: [real cents, charged cents]. Build users covering every branch.
+      const neg = await seedUsage({ realCostDollars: 1.0, realCostCentsFallback: 100, chargedCents: 90 }); // -10 → flag
+      const pos = await seedUsage({ realCostDollars: 1.0, realCostCentsFallback: 100, chargedCents: 150 }); // +50 → no
+      const even = await seedUsage({ realCostDollars: 1.0, realCostCentsFallback: 100, chargedCents: 100 }); // 0 → no (100<100 false)
+      const purged = await seedUsage({ realCostDollars: null, realCostCentsFallback: 100, chargedCents: 80 }); // -20 via ELSE branch → flag
+      const zero = await seedUsage({ realCostDollars: 0.0, realCostCentsFallback: 0, chargedCents: 0 }); // real 0 → excluded
+
+      const cases: Record<string, { real: number; charged: number }> = {
+        [neg]: { real: 100, charged: 90 },
+        [pos]: { real: 100, charged: 150 },
+        [even]: { real: 100, charged: 100 },
+        [purged]: { real: 100, charged: 80 },
+        [zero]: { real: 0, charged: 0 },
+      };
+
+      const rows = await getNegativeMarginAccounts(undefined, undefined, 0);
+
+      // The query's flagged set must equal what the pure helper would flag on the same data.
+      const jsFlagged = Object.entries(cases)
+        .filter(([, c]) => isNegativeMargin(c.real, c.charged, 0))
+        .map(([id]) => id)
+        .sort();
+      expect([...rows.map((r) => r.userId)].sort()).toEqual(jsFlagged);
+      expect(jsFlagged.sort()).toEqual([neg, purged].sort());
+
+      // Worst (most negative) margin first, and the numbers are right.
+      expect(rows.map((r) => r.userId)).toEqual([purged, neg]); // -20 before -10
+      expect(rows.find((r) => r.userId === neg)).toMatchObject({ realCostCents: 100, chargedCents: 90, marginCents: -10, marginPct: -10 });
+      expect(rows.find((r) => r.userId === purged)).toMatchObject({ realCostCents: 100, chargedCents: 80, marginCents: -20 });
+    });
+
+    it('a margin floor demands headroom: a thin-but-positive account is flagged at a positive floor', async () => {
+      if (!dbAvailable) return;
+      // charged 105 vs real 100 = +5% margin. Clears floor 0, fails a 10% (1000bps) floor.
+      const thin = await seedUsage({ realCostDollars: 1.0, realCostCentsFallback: 100, chargedCents: 105 });
+
+      expect((await getNegativeMarginAccounts(undefined, undefined, 0)).map((r) => r.userId)).toEqual([]);
+      const flagged = await getNegativeMarginAccounts(undefined, undefined, 1000);
+      expect(flagged.map((r) => r.userId)).toEqual([thin]);
+      // SQL HAVING and the JS re-check agree at this floor too.
+      expect(isNegativeMargin(100, 105, 1000)).toBe(true);
+    });
+  });
+});

--- a/packages/lib/src/billing/__tests__/cost-reconcile.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/cost-reconcile.integration.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Cost-reconcile transaction-atomicity integration test (real Postgres).
+ *
+ * applyCorrection (cost-reconcile.ts) claims an `adjustment` ledger row and moves the
+ * balance in ONE transaction under a row lock. The in-memory DB fake the other reconcile
+ * tests use doesn't model rollback, so it can't prove the claim row is rolled back when
+ * the balance UPDATE fails mid-transaction. Here we drive the real public entry point
+ * (reconcileOpenRouterCosts) against real Postgres and force the balance UPDATE to throw
+ * by parking debtCents at INT_MAX so the undercharge debit (debtCents + shortfall)
+ * overflows int4 — a genuine mid-transaction DB error. The property: NO orphan adjustment
+ * row survives and the balance is untouched.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { creditBalances, creditLedger, creditHolds } from '@pagespace/db/schema/credits';
+import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
+import { factories } from '@pagespace/db/test/factories';
+import { reconcileOpenRouterCosts, type GenerationFetcher } from '../cost-reconcile';
+
+const INT4_MAX = 2_147_483_647;
+let dbAvailable = false;
+
+const originalEnforcement = process.env.CREDITS_ENFORCEMENT_ENABLED;
+
+async function cleanup(userId: string): Promise<void> {
+  await db.delete(creditHolds).where(eq(creditHolds.userId, userId));
+  await db.delete(creditLedger).where(eq(creditLedger.userId, userId));
+  await db.delete(creditBalances).where(eq(creditBalances.userId, userId));
+  await db.delete(aiUsageLogs).where(eq(aiUsageLogs.userId, userId));
+}
+
+describe('applyCorrection transaction atomicity (Postgres)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(creditBalances).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  beforeEach(() => {
+    // isBillingEnabled() must be true (cloud default) for reconcile to do anything; the
+    // reconcile path itself is independent of the enforcement flag, but keep it explicit.
+    process.env.CREDITS_ENFORCEMENT_ENABLED = 'true';
+  });
+
+  afterAll(() => {
+    if (originalEnforcement === undefined) delete process.env.CREDITS_ENFORCEMENT_ENABLED;
+    else process.env.CREDITS_ENFORCEMENT_ENABLED = originalEnforcement;
+  });
+
+  it('rolls back the claimed adjustment row when the balance UPDATE throws mid-transaction', async () => {
+    if (!dbAvailable) return;
+    const user = await factories.createUser({ subscriptionTier: 'pro' });
+    try {
+      // Empty buckets + debt parked at INT_MAX: an undercharge correction debits the extra
+      // monthly-first, finds nothing, and accrues the shortfall as `debtCents + shortfall`,
+      // which overflows the int4 column → the UPDATE throws inside the transaction.
+      await db.insert(creditBalances).values({
+        userId: user.id,
+        monthlyRemainingCents: 0,
+        monthlyAllowanceCents: 0,
+        topupRemainingCents: 0,
+        debtCents: INT4_MAX,
+        pendingMillicents: 0,
+      });
+
+      // A billed-at-$0 OpenRouter call still pending reconcile, old enough to clear the grace
+      // window, carrying a generation id. Its base `usage` ledger row must exist (reconcile
+      // only corrects an already-billed call).
+      const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
+      const [log] = await db
+        .insert(aiUsageLogs)
+        .values({
+          userId: user.id,
+          provider: 'openrouter',
+          model: 'e2e/stub',
+          cost: 0,
+          timestamp: tenMinAgo,
+          reconcileStatus: 'pending',
+          reconcileAttempts: 0,
+          metadata: { generationIds: ['gen-rollback-1'] },
+        })
+        .returning({ id: aiUsageLogs.id });
+
+      await db.insert(creditLedger).values({
+        userId: user.id,
+        entryType: 'usage',
+        bucket: 'monthly',
+        amountCents: 0,
+        appliedCents: 0,
+        chargeMillicents: 0,
+        realCostCents: 0,
+        aiUsageLogId: log.id,
+      });
+
+      // Authoritative cost $1.00 vs billed $0 → a large positive drift → undercharge debit.
+      const fetcher: GenerationFetcher = async () => ({ totalCost: 1.0 });
+
+      const result = await reconcileOpenRouterCosts({ fetcher });
+
+      // The row's correction threw and was swallowed by the cron's per-row guard, so no
+      // correction was counted and the row stays pending for a later run.
+      expect(result.corrected).toBe(0);
+
+      // ATOMICITY: the claimed adjustment ledger row was rolled back — no orphan.
+      const adjustments = await db
+        .select()
+        .from(creditLedger)
+        .where(and(eq(creditLedger.userId, user.id), eq(creditLedger.entryType, 'adjustment')));
+      expect(adjustments).toHaveLength(0);
+
+      // The balance is exactly as seeded — the failed UPDATE moved nothing.
+      const [bal] = await db.select().from(creditBalances).where(eq(creditBalances.userId, user.id));
+      expect(bal).toMatchObject({ debtCents: INT4_MAX, monthlyRemainingCents: 0, topupRemainingCents: 0 });
+
+      // The base usage row (written before the transaction) is untouched.
+      const usage = await db
+        .select()
+        .from(creditLedger)
+        .where(and(eq(creditLedger.userId, user.id), eq(creditLedger.entryType, 'usage')));
+      expect(usage).toHaveLength(1);
+    } finally {
+      await cleanup(user.id);
+    }
+  });
+});

--- a/packages/lib/src/billing/__tests__/cost-reconcile.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/cost-reconcile.integration.test.ts
@@ -101,13 +101,19 @@ describe('applyCorrection transaction atomicity (Postgres)', () => {
       });
 
       // Authoritative cost $1.00 vs billed $0 → a large positive drift → undercharge debit.
-      const fetcher: GenerationFetcher = async () => ({ totalCost: 1.0 });
+      // Scoped to OUR generation id (any other pending row a shared DB might hold resolves
+      // 'not_found', so this run never corrects or asserts against foreign data).
+      const fetcher: GenerationFetcher = async (id) =>
+        id === 'gen-rollback-1' ? { totalCost: 1.0 } : 'not_found';
 
-      const result = await reconcileOpenRouterCosts({ fetcher });
+      await reconcileOpenRouterCosts({ fetcher });
 
-      // The row's correction threw and was swallowed by the cron's per-row guard, so no
-      // correction was counted and the row stays pending for a later run.
-      expect(result.corrected).toBe(0);
+      // Our row's correction threw inside applyCorrection and was swallowed by the cron's
+      // per-row guard, so it was never marked 'reconciled' — it stays 'pending' for a later
+      // run. (Scoped to our own row, not the global corrected count, so the assertion holds
+      // regardless of any other pending rows on a shared DB.)
+      const [logAfter] = await db.select().from(aiUsageLogs).where(eq(aiUsageLogs.id, log.id));
+      expect(logAfter.reconcileStatus).toBe('pending');
 
       // ATOMICITY: the claimed adjustment ledger row was rolled back — no orphan.
       const adjustments = await db

--- a/packages/lib/src/billing/__tests__/credit-gate-concurrency.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate-concurrency.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Credit-gate concurrency integration tests (real Postgres).
+ *
+ * Drives the REAL canConsumeAI (credit-gate.ts) against a real database — no fake DB,
+ * no vi.mock. The property under test is the one the in-memory fake CANNOT prove: the
+ * `.for('update')` row lock that serializes a single user's concurrent gate checks so
+ * they observe each other's holds. Every existing credit-gate test calls serially; here
+ * we fire N gate checks at once (`Promise.all`) against the shared pool and assert that
+ * exactly one slips through when the balance covers only one call.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied (scripts/test-with-db.sh,
+ * port 5433). Skipped when no DB is reachable.
+ *
+ * NOTE (manual lock proof): temporarily delete `.for('update')` from canConsumeAI's
+ * balance read and the first test below should FAIL (multiple calls allowed / multiple
+ * holds inserted) — that confirms the test actually exercises the lock. Restore after.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { creditBalances, creditHolds, creditLedger } from '@pagespace/db/schema/credits';
+import { factories } from '@pagespace/db/test/factories';
+import { canConsumeAI, addOneMonth } from '../credit-gate';
+import { RESERVE_FLOOR_CENTS, CREDIT_HOLD_ESTIMATE_CENTS } from '../credit-pricing';
+
+let dbAvailable = false;
+
+const originalEnforcement = process.env.CREDITS_ENFORCEMENT_ENABLED;
+const originalProCap = process.env.DAILY_CAP_PRO_CENTS;
+
+/** Insert a balance row directly (bypassing the gate's lazy-init) with a live monthly window. */
+async function seedBalance(userId: string, monthlyRemainingCents: number): Promise<void> {
+  const now = new Date();
+  await db.insert(creditBalances).values({
+    userId,
+    monthlyRemainingCents,
+    monthlyAllowanceCents: monthlyRemainingCents,
+    topupRemainingCents: 0,
+    debtCents: 0,
+    pendingMillicents: 0,
+    monthlyPeriodStart: now,
+    monthlyPeriodEnd: addOneMonth(now),
+  });
+}
+
+async function cleanup(userId: string): Promise<void> {
+  // FK-safe order: holds + ledger reference the user; delete them before the balance/user.
+  await db.delete(creditHolds).where(eq(creditHolds.userId, userId));
+  await db.delete(creditLedger).where(eq(creditLedger.userId, userId));
+  await db.delete(creditBalances).where(eq(creditBalances.userId, userId));
+}
+
+describe('canConsumeAI concurrency (Postgres row lock)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(creditBalances).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  beforeEach(() => {
+    // The gate only DENIES when enforcement is on; otherwise a would-be denial is
+    // downgraded to allowed. The double-spend property lives in the deny path.
+    process.env.CREDITS_ENFORCEMENT_ENABLED = 'true';
+    delete process.env.DAILY_CAP_PRO_CENTS;
+  });
+
+  afterAll(() => {
+    if (originalEnforcement === undefined) delete process.env.CREDITS_ENFORCEMENT_ENABLED;
+    else process.env.CREDITS_ENFORCEMENT_ENABLED = originalEnforcement;
+    if (originalProCap === undefined) delete process.env.DAILY_CAP_PRO_CENTS;
+    else process.env.DAILY_CAP_PRO_CENTS = originalProCap;
+  });
+
+  it('serializes a concurrent burst: balance covering one call → exactly one allowed, N-1 denied, one hold', async () => {
+    if (!dbAvailable) return;
+    const user = await factories.createUser({ subscriptionTier: 'pro' });
+    try {
+      // Sized so exactly ONE call's reservation fits above the reserve floor:
+      //   first call:  60 − 0(reserved) − 25(est)  = 35 > 25 floor → allowed, inserts a 25¢ hold
+      //   any other:   60 − 25(that hold) − 25(est) = 10 ≯ 25 floor → out_of_credits
+      // (est defaults to CREDIT_HOLD_ESTIMATE_CENTS = 25; pro tier ⇒ no in-flight cap, so
+      // the denial is purely the credit decision the lock must serialize.)
+      expect(CREDIT_HOLD_ESTIMATE_CENTS).toBe(25);
+      expect(RESERVE_FLOOR_CENTS).toBe(25);
+      await seedBalance(user.id, 60);
+
+      const N = 8;
+      const results = await Promise.all(
+        Array.from({ length: N }, () => canConsumeAI(user.id, 'pro')),
+      );
+
+      const allowed = results.filter((r) => r.allowed);
+      const denied = results.filter((r) => !r.allowed);
+      expect(allowed).toHaveLength(1);
+      expect(denied).toHaveLength(N - 1);
+      expect(denied.every((r) => r.reason === 'out_of_credits')).toBe(true);
+
+      // The lock's observable proof: exactly one reservation row exists. Without
+      // serialization, multiple concurrent checks would each read the pre-hold balance
+      // and all insert a hold.
+      const holds = await db.select().from(creditHolds).where(eq(creditHolds.userId, user.id));
+      expect(holds).toHaveLength(1);
+      expect(allowed[0].holdId).toBe(holds[0].id);
+    } finally {
+      await cleanup(user.id);
+    }
+  });
+
+  it('a concurrent burst never lets holds + charged spend exceed the daily exposure cap', async () => {
+    if (!dbAvailable) return;
+    process.env.DAILY_CAP_PRO_CENTS = '50';
+    const user = await factories.createUser({ subscriptionTier: 'pro' });
+    try {
+      // Credits are abundant (so the balance gate never trips); the daily cap is the only
+      // limiter. Each allowed call reserves a 25¢ hold counted toward the cap, so:
+      //   call 1: 0(charged) + 0(reserved) + 25(est) = 25 ≤ 50 → allowed
+      //   call 2: 0          + 25          + 25       = 50 ≤ 50 → allowed
+      //   call 3: 0          + 50          + 25       = 75 >  50 → daily_cap_exceeded
+      await seedBalance(user.id, 100_000);
+
+      const N = 8;
+      const results = await Promise.all(
+        Array.from({ length: N }, () => canConsumeAI(user.id, 'pro')),
+      );
+
+      const allowed = results.filter((r) => r.allowed);
+      const denied = results.filter((r) => !r.allowed);
+      expect(allowed).toHaveLength(2);
+      expect(denied.every((r) => r.reason === 'daily_cap_exceeded')).toBe(true);
+
+      // The invariant the cap protects: total reserved (held) spend never exceeds the cap.
+      const holds = await db.select().from(creditHolds).where(eq(creditHolds.userId, user.id));
+      const heldCents = holds.reduce((sum, h) => sum + h.estCents, 0);
+      expect(holds).toHaveLength(2);
+      expect(heldCents).toBeLessThanOrEqual(50);
+    } finally {
+      await cleanup(user.id);
+    }
+  });
+});

--- a/packages/lib/src/billing/__tests__/merge-guards.test.ts
+++ b/packages/lib/src/billing/__tests__/merge-guards.test.ts
@@ -1,8 +1,21 @@
 /**
  * Merge guards over the billing layer's structural invariants. Source-scan assertions
  * that fail the build when a regression breaks a property the runtime depends on but that
- * no single unit test would catch — the gate using NET balance, the daily cap living at
- * the one choke point, the reconcile correction staying idempotent.
+ * no single unit test would catch.
+ *
+ * Two former scans have been RETIRED now that real-DB behavioral tests supersede them
+ * (they exercise the property instead of grepping for the line that implements it):
+ *   - "gate subtracts debt (NET balance)" → evaluateGate's debt subtraction is proven
+ *     behaviorally in credit-core.test.ts ("subtracts outstanding debt from spendable",
+ *     "treats debt that drags net to/under the floor as out_of_credits").
+ *   - "reconcile correction is idempotent (onConflictDoNothing on the generation key)" →
+ *     proven behaviorally against real Postgres / the real cron in
+ *     cost-reconcile.integration.test.ts (transaction atomicity) and the e2e
+ *     13-metering-reconcile.spec.ts (a duplicate generation set + a re-run never
+ *     double-correct).
+ *
+ * What remains here are properties NOT yet covered by a behavioral test: the displayed
+ * balance staying gross of holds, and the daily-cap wiring/units at the gate.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -11,14 +24,6 @@ import { fileURLToPath } from 'node:url';
 const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
 
 describe('billing merge guards', () => {
-  it('the gate decision subtracts debt (NET balance), so an in-debt user is denied', () => {
-    const core = read('../credit-core.ts');
-    // evaluateGate's spendable must net out debt; without the `- debt` term a user in the
-    // red could keep spending. (The displayed balance is intentionally GROSS — see below.)
-    const gate = core.slice(core.indexOf('export function evaluateGate'));
-    expect(gate).toMatch(/spendable\s*=[^;]*-\s*debt/);
-  });
-
   it('the displayed balance is GROSS of holds (display ≠ gate)', () => {
     // The gate subtracts reserved holds from spendable; the display must NOT, or the
     // navbar would dip on call start and pop back at settle (the flicker we removed).
@@ -33,13 +38,6 @@ describe('billing merge guards', () => {
     expect(gate).toMatch(/evaluateDailyCap\(/);
     // And it must read the configured cap (not a hard-coded number).
     expect(gate).toMatch(/dailyExposureCapForTier\(/);
-  });
-
-  it('the reconcile correction is idempotent (onConflictDoNothing on the generation key)', () => {
-    const reconcile = read('../cost-reconcile.ts');
-    const insert = reconcile.slice(reconcile.indexOf('.insert(creditLedger)'));
-    expect(insert).toMatch(/onConflictDoNothing/);
-    expect(insert).toMatch(/reconcileGenerationKey/);
   });
 
   it('the daily-cap sum counts the full intended charge (chargeMillicents, not appliedCents)', () => {


### PR DESCRIPTION
## Why

The AI-metering defense-in-depth (#1533: cost reconcile, drift/negative-margin alerts, per-user/day exposure cap) merged with its **money arithmetic** exhaustively covered (the pure `credit-core.ts` layer). But three properties a *safe* metering system actually rests on were proven only by a hand-rolled in-memory DB fake (whose `.for('update')` is a **no-op**) or by source-text greps — never by real Postgres:

1. **Concurrent no-double-spend** — `canConsumeAI` serializes a user's concurrent requests via a `.for('update')` row lock. The fake can't prove serialization; every prior test called serially.
2. **Monitoring SQL correctness** — `getBalanceDriftAlerts` / `getNegativeMarginAccounts` carry the real risk (`CASE WHEN entryType IN (...)`, `HAVING chargedSum < realSum*(1+bps)`, `COALESCE(...)::int`); the prior test mocked `db.select` so the SQL never ran.
3. **Transaction atomicity** — `applyCorrection` claims a row then moves the balance in one txn; the fake's `transaction()` doesn't model rollback.

Plus the two new subsystems (reconcile cron, daily cap) had integration coverage but no e2e. This PR moves those properties onto **real Postgres + real routes**, then retires the source-scan greps a behavioral test now supersedes. **Tests only** (+ one mock endpoint); no feature code changed.

## What

| Item | File |
|------|------|
| **P0-A** concurrent double-spend gate (real lock) | `packages/lib/src/billing/__tests__/credit-gate-concurrency.integration.test.ts` |
| **P0-B** real-DB monitoring SQL | `apps/web/src/lib/monitoring/__tests__/account-alerts-queries.integration.test.ts` |
| **P1-A** e2e cost-reconcile cron + mock `/generation` | `apps/e2e/tests/13-metering-reconcile.spec.ts`, `apps/e2e/support/mock-openrouter.ts` |
| **P1-B** e2e daily-cap 429 at the route | `apps/e2e/tests/14-metering-daily-cap.spec.ts` |
| **P1-C** reconcile txn atomicity/rollback | `packages/lib/src/billing/__tests__/cost-reconcile.integration.test.ts` |
| **P2** retire redundant merge-guard greps | `packages/lib/src/billing/__tests__/merge-guards.test.ts` |

Supporting e2e helpers: `seedPendingReconcileCall` / `getAiUsageLog` (`support/db.ts`), `setGenerationCost` (`support/http.ts`); `README.metering.md` updated with the new specs + required app-launch env.

### Notes on each
- **P0-A** fires `Promise.all` of N gate checks against the shared pool; with a balance covering one call it asserts exactly one `allowed`, N−1 `out_of_credits`, and a single `credit_holds` row. A second test proves a concurrent burst never lets holds exceed `DAILY_CAP`. **Manually verified the lock is real**: deleting `.for('update')` fails the suite (8 allowed instead of 2); restored exactly (credit-gate.ts unchanged in this PR).
- **P0-B** inserts real ledger/balance/usage rows and runs the actual queries; asserts the flagged accounts + drift/margin numbers, that the SQL `HAVING` and the JS `isNegativeMargin` re-check **agree on real data**, and that every `entryType` is bucketed correctly. Keeps the existing mocked unit test for the JS sort/filter/map.
- **P1-A** mock now serves `GET /generation?id=` returning `{ data: { total_cost } }`, overridable per-id via `POST /__set-generation-cost`. Verified in isolation. Idempotency covered via a duplicate generation set (one adjustment) + a re-run.
- **P1-B** uses the `business` tier so its `DAILY_CAP_BUSINESS_CENTS` doesn't perturb the other metering specs; the cap env must be set at app launch (read at call time), documented in `README.metering.md`.
- **P1-C** forces the in-transaction balance UPDATE to overflow `int4` (debt parked at INT_MAX) — a genuine mid-txn DB error — and asserts the claimed `adjustment` row rolled back and the balance is untouched.
- **P2** retired only the two scans now superseded behaviorally (gate-subtracts-debt → covered in `credit-core.test.ts`; reconcile `onConflictDoNothing` → covered by 13-metering-reconcile + cost-reconcile.integration). Kept the display-gross-of-holds guard, the daily-cap wiring/units guards, and the whole-codebase `gate-callsites.guard.test.ts` architectural-fitness scans (untouched).

## Verification

- `*.integration.test.ts` run against real Postgres on :5433 (migrations applied): **P0-A (2), P0-B (4), P1-C (1) green**; full `packages/lib/src/billing` suite **225 passing**.
- Graceful skip without a DB (the `test:unit` path) confirmed for the new integration files.
- `typecheck` green (lib, web, e2e); `lint` green (only pre-existing warnings in unrelated files).
- New mock `/generation` + `/__set-generation-cost` exercised directly.
- **Not run in this environment** (require a running Next app + the documented launch env): the two Playwright specs (`13`, `14`). They follow the established metering-spec patterns, typecheck clean, and their mock/DB scaffolding is validated above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily exposure cap enforcement: business tier users now receive 429 responses when daily limits are exceeded
  * Enhanced cost reconciliation with idempotency protection against duplicate generation billing

* **Documentation**
  * Updated metering end-to-end test documentation with new reconciliation and daily cap coverage

* **Tests**
  * Added comprehensive integration and e2e tests for cost reconciliation, daily cap enforcement, and account monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-ups

- **Codex (P1) — "Avoid clearing all billing tables in integration setup"** (resolved, 849993e8): the monitoring integration test no longer wipes whole `credit_balances`/`credit_ledger`/`credit_holds`/`ai_usage_logs` tables. Cleanup is scoped to the users the test creates (FK-safe per-user deletes), and each assertion filters the global drift/margin query result to the test's own users with a large `limit` — making it non-destructive to any `DATABASE_URL` and robust to pre-existing rows. Verified on real Postgres: 4/4 pass; a pre-seeded stray flagged balance survives cleanup and doesn't perturb assertions.
- **CodeRabbit**: check is green but it could not produce findings — the org hit its CodeRabbit usage/rate limit (external billing constraint). The PR does not depend on it.
