### PR TITLE
fix(ci): harden Fly deploy — storage cap bug, single web image, cron + processor reliability

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -31,19 +31,13 @@ jobs:
           - service: web
             dockerfile: apps/web/Dockerfile
             context: .
+            # Realtime is same-origin: Caddy routes pagespace.ai/socket.io/* → realtime.
+            # NEXT_PUBLIC_* are baked at build time — the fly.web.toml runtime [env] cannot
+            # override them, so the storage cap MUST match (1024), not the old VPS-era 20.
             build_args: |
               NEXT_PUBLIC_APP_URL=https://pagespace.ai
               NEXT_PUBLIC_REALTIME_URL=https://pagespace.ai
-              NEXT_PUBLIC_STORAGE_MAX_FILE_SIZE_MB=20
-              NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=636969838408-p2v0ov9j4klle7pj9uedo8339tikl2ii.apps.googleusercontent.com
-              NEXT_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID=636969838408-0jbv7gq9793m0uchdrjlr8v1k6m5lh59.apps.googleusercontent.com
-          - service: web-fly
-            dockerfile: apps/web/Dockerfile
-            context: .
-            build_args: |
-              NEXT_PUBLIC_APP_URL=https://pagespace.ai
-              NEXT_PUBLIC_REALTIME_URL=https://pagespace-proxy.fly.dev
-              NEXT_PUBLIC_STORAGE_MAX_FILE_SIZE_MB=20
+              NEXT_PUBLIC_STORAGE_MAX_FILE_SIZE_MB=1024
               NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=636969838408-p2v0ov9j4klle7pj9uedo8339tikl2ii.apps.googleusercontent.com
               NEXT_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID=636969838408-0jbv7gq9793m0uchdrjlr8v1k6m5lh59.apps.googleusercontent.com
           - service: migrate
@@ -172,8 +166,8 @@ jobs:
 
       - name: Deploy web
         run: |
-          docker pull ghcr.io/2witstudios/pagespace-web-fly:latest
-          docker tag ghcr.io/2witstudios/pagespace-web-fly:latest registry.fly.io/pagespace-web:latest
+          docker pull ghcr.io/2witstudios/pagespace-web:latest
+          docker tag ghcr.io/2witstudios/pagespace-web:latest registry.fly.io/pagespace-web:latest
           docker push registry.fly.io/pagespace-web:latest
           flyctl deploy --app pagespace-web --image registry.fly.io/pagespace-web:latest --wait-timeout 300
         env:
@@ -194,6 +188,15 @@ jobs:
           docker tag ghcr.io/2witstudios/pagespace-processor:latest registry.fly.io/pagespace-processor:latest
           docker push registry.fly.io/pagespace-processor:latest
           flyctl deploy --app pagespace-processor --image registry.fly.io/pagespace-processor:latest --wait-timeout 300
+
+          # The processor has no [http_service], so Fly has no autostart for it and a
+          # `flyctl deploy` against an already-stopped machine re-images it but leaves it
+          # STOPPED. Web reaches it over pagespace-processor.internal:3003 (no auto-start),
+          # so a stopped machine = file uploads silently fail. Guarantee every machine ends
+          # started; already-running machines no-op.
+          for id in $(flyctl machines list --app pagespace-processor --json | jq -r '.[].id'); do
+            flyctl machine start "$id" --app pagespace-processor 2>/dev/null || true
+          done
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -203,5 +206,19 @@ jobs:
           docker tag ghcr.io/2witstudios/pagespace-admin:latest registry.fly.io/pagespace-admin:latest
           docker push registry.fly.io/pagespace-admin:latest
           flyctl deploy --app pagespace-admin --image registry.fly.io/pagespace-admin:latest --wait-timeout 300
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy cron
+        run: |
+          docker pull ghcr.io/2witstudios/pagespace-cron:latest
+          docker tag ghcr.io/2witstudios/pagespace-cron:latest registry.fly.io/pagespace-cron:latest
+          docker push registry.fly.io/pagespace-cron:latest
+          flyctl deploy --app pagespace-cron --image registry.fly.io/pagespace-cron:latest --wait-timeout 300
+
+          # Cron is a SINGLETON scheduler: exactly one machine must run, or scheduled jobs
+          # (memory/pulse crons) double-fire. Reconcile to a single started machine — never
+          # "start all" like the processor guard. scale count 1 keeps it a singleton.
+          flyctl scale count 1 --app pagespace-cron --yes 2>/dev/null || true
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -192,11 +192,22 @@ jobs:
           # The processor has no [http_service], so Fly has no autostart for it and a
           # `flyctl deploy` against an already-stopped machine re-images it but leaves it
           # STOPPED. Web reaches it over pagespace-processor.internal:3003 (no auto-start),
-          # so a stopped machine = file uploads silently fail. Guarantee every machine ends
-          # started; already-running machines no-op.
+          # so a stopped machine = file uploads silently fail. Start every machine
+          # (`|| true` only swallows the benign "already started" error), then VERIFY the
+          # recovery worked — a real Fly start failure must fail the deploy, not pass silently
+          # and leave uploads down.
           for id in $(flyctl machines list --app pagespace-processor --json | jq -r '.[].id'); do
             flyctl machine start "$id" --app pagespace-processor 2>/dev/null || true
           done
+          procs=$(flyctl machines list --app pagespace-processor --json)
+          total=$(echo "$procs" | jq 'length')
+          started=$(echo "$procs" | jq '[.[] | select(.state == "started")] | length')
+          if [ "$total" -eq 0 ] || [ "$started" -ne "$total" ]; then
+            echo "ERROR: processor not fully started ($started/$total)"
+            echo "$procs" | jq -r '.[] | "  \(.id) \(.state)"'
+            exit 1
+          fi
+          echo "processor: $started/$total machines started"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -217,8 +228,21 @@ jobs:
           flyctl deploy --app pagespace-cron --image registry.fly.io/pagespace-cron:latest --wait-timeout 300
 
           # Cron is a SINGLETON scheduler: exactly one machine must run, or scheduled jobs
-          # (memory/pulse crons) double-fire. Reconcile to a single started machine — never
-          # "start all" like the processor guard. scale count 1 keeps it a singleton.
-          flyctl scale count 1 --app pagespace-cron --yes 2>/dev/null || true
+          # (memory/pulse crons) double-fire. Reconcile to one machine, ensure it's started,
+          # then VERIFY the invariant — if it can't be enforced, fail the deploy rather than
+          # silently leave duplicate (double-firing) or stopped (non-firing) cron machines.
+          flyctl scale count 1 --app pagespace-cron --yes
+          for id in $(flyctl machines list --app pagespace-cron --json | jq -r '.[].id'); do
+            flyctl machine start "$id" --app pagespace-cron 2>/dev/null || true
+          done
+          crons=$(flyctl machines list --app pagespace-cron --json)
+          count=$(echo "$crons" | jq 'length')
+          started=$(echo "$crons" | jq '[.[] | select(.state == "started")] | length')
+          if [ "$count" -ne 1 ] || [ "$started" -ne 1 ]; then
+            echo "ERROR: cron must be exactly 1 started machine (count=$count started=$started)"
+            echo "$crons" | jq -r '.[] | "  \(.id) \(.state)"'
+            exit 1
+          fi
+          echo "cron: 1/1 machine started"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Why
Finishing the VPS→Fly cutover. `pagespace.ai` now points at Fly and everything but marketing (Vercel) is migrated, but `docker-images.yml` still carried VPS-era assumptions — including a live client bug and a deploy path that left the processor down.

## What
- **Storage cap bug (real, client-facing).** The web image baked `NEXT_PUBLIC_STORAGE_MAX_FILE_SIZE_MB=20`. It's a build-time `NEXT_PUBLIC_*` var, so `fly.web.toml`'s runtime `=1024` could never override it — the browser enforced a **20 MB** upload cap while the server allowed 1024 MB. Bumped to `1024`.
- **One web image.** Collapsed the duplicate `web` / `web-fly` matrix entries into a single `web` image with `NEXT_PUBLIC_REALTIME_URL=https://pagespace.ai` (Caddy routes `pagespace.ai/socket.io/*` → realtime, so sockets are same-origin). Deploy job now pulls `pagespace-web`, matching `deploy-fly.sh`.
- **cron now deploys via CI.** It was built but never deployed (last shipped May 19). Added a Deploy cron step; reconciles to a **single** running machine (`scale count 1`) since a double-running scheduler double-fires jobs.
- **processor self-heal.** The processor has no `[http_service]`, so `flyctl deploy` against an already-stopped machine re-images it but leaves it **stopped** — which is exactly how file uploads went down on cutover day (web reaches it over `*.internal`, which doesn't auto-start). Deploy now guarantees every processor machine ends `started`.

## Related
Companion PR in PageSpace-Deploy adds the processor `/health` check, proxy + backup CI deploys, and removes the stale VPS files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)