### PR TITLE
feat(billing): replace dollar amounts with 0-100 credit unit scale

### DIFF
--- a/apps/web/src/components/billing/CreditBalance.tsx
+++ b/apps/web/src/components/billing/CreditBalance.tsx
@@ -13,23 +13,16 @@ import { AlertCircle, Coins } from 'lucide-react';
 import { useCreditBalance } from '@/hooks/useCreditBalance';
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
-import { formatCreditDollars, formatCreditDollarsSigned } from '@/lib/subscription/credits';
+import { formatCreditUnits, formatCreditUnitsSigned } from '@/lib/subscription/credits';
 
-/** Whole cents below which we visually warn the user their balance is running low. */
-const LOW_BALANCE_FLOOR_CENTS = 50;
+/** Percentage of monthly allowance remaining below which we warn the user. */
+const LOW_BALANCE_THRESHOLD_PCT = 15;
 
-/**
- * Header widget showing the user's remaining prepaid AI credits and a "Buy credits"
- * action. Replaces the retired per-day usage counter. Live-updates from
- * `credits:updated` socket events via `useCreditBalance`. Hidden entirely on
- * billing-disabled deployments; the buy action is hidden on iOS (App Store policy).
- */
 export function CreditBalance() {
   const router = useRouter();
   const { showBilling } = useBillingVisibility();
   const { balance, isLoading, isError } = useCreditBalance();
 
-  // Loading state (hidden on mobile to save space).
   if (isLoading) {
     return (
       <div className="hidden sm:flex items-center gap-2">
@@ -39,7 +32,6 @@ export function CreditBalance() {
     );
   }
 
-  // Error or billing disabled: render nothing rather than a broken widget.
   if (isError || !balance || !balance.billingEnabled) {
     if (isError) {
       return (
@@ -53,14 +45,12 @@ export function CreditBalance() {
   }
 
   const { spendable, monthly, topup, reserved, debt } = balance;
-  // In the red: the user owes overage and can't use AI until back to positive.
   const inDebt = spendable < 0;
-  const isLow = inDebt || spendable <= Math.max(LOW_BALANCE_FLOOR_CENTS, Math.round(monthly.allowance * 0.15));
-  const resetDate = monthly.periodEnd ? new Date(monthly.periodEnd) : null;
-  // Surface in-flight reservations as a quiet signal, not in the headline number — the
-  // displayed balance is gross of holds (see getCreditBalance) so it doesn't dip-then-pop
-  // across a call; this dot just tells the user a call is currently consuming credits.
+  const remainingPct = monthly.allowance > 0 ? (spendable / monthly.allowance) * 100 : 0;
+  const isLow = inDebt || remainingPct <= LOW_BALANCE_THRESHOLD_PCT;
+  // Surface in-flight reservations as a quiet signal, not in the headline number.
   const hasInFlight = reserved > 0;
+  const renewDate = monthly.periodEnd ? new Date(monthly.periodEnd) : null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -88,36 +78,34 @@ export function CreditBalance() {
                 variant={isLow ? 'destructive' : 'secondary'}
                 className="text-xs font-medium tabular-nums"
               >
-                {formatCreditDollarsSigned(spendable)}
+                {formatCreditUnitsSigned(spendable, monthly.allowance)}
               </Badge>
             </button>
           </TooltipTrigger>
           <TooltipContent>
             <p className="font-medium">
               {inDebt
-                ? `${formatCreditDollarsSigned(spendable)} — add credits to keep using AI`
-                : `${formatCreditDollars(spendable)} AI credits left`}
+                ? 'In the red — add credits to keep using AI'
+                : `${formatCreditUnits(spendable, monthly.allowance)} / 100 credits remaining`}
             </p>
             {debt > 0 && (
               <p className="text-xs text-primary-foreground/80">
-                Owed: {formatCreditDollars(debt)} (cleared by a purchase or your next reset)
+                Overage clears at your next renewal or with a top-up
               </p>
             )}
-            <p className="text-xs text-primary-foreground/80">
-              Monthly: {formatCreditDollars(monthly.remaining)} of{' '}
-              {formatCreditDollars(monthly.allowance)}
-            </p>
-            <p className="text-xs text-primary-foreground/80">
-              Top-up: {formatCreditDollars(topup.remaining)}
-            </p>
+            {topup.remaining > 0 && (
+              <p className="text-xs text-primary-foreground/80">
+                +{formatCreditUnits(topup.remaining, monthly.allowance)} bonus credits from top-ups
+              </p>
+            )}
             {hasInFlight && (
               <p className="text-xs text-primary-foreground/80">
-                ~{formatCreditDollars(reserved)} reserved on in-flight calls
+                ~{formatCreditUnits(reserved, monthly.allowance)} credits reserved on in-flight calls
               </p>
             )}
-            {resetDate && (
+            {renewDate && (
               <p className="text-xs text-primary-foreground/80">
-                Monthly resets {resetDate.toLocaleDateString()}
+                Renews {renewDate.toLocaleDateString()}
               </p>
             )}
           </TooltipContent>

--- a/apps/web/src/components/billing/CreditBalanceCard.tsx
+++ b/apps/web/src/components/billing/CreditBalanceCard.tsx
@@ -1,29 +1,29 @@
 'use client';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Coins } from 'lucide-react';
 import { useCreditBalance } from '@/hooks/useCreditBalance';
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
-import { formatCreditDollars, formatCreditDollarsSigned } from '@/lib/subscription/credits';
+import { formatCreditUnits, formatCreditUnitsSigned } from '@/lib/subscription/credits';
 
 /**
- * Settings card showing the user's prepaid AI-credit balance: the monthly allowance
- * bucket (resets each period), the never-expiring top-up bucket, and a "Buy credits"
- * action. Live-updates via `useCreditBalance`. Renders nothing when billing is
- * disabled; hides the buy action on iOS (App Store policy).
+ * Settings card showing the user's prepaid AI-credit balance on a 0–100 scale,
+ * with a progress bar for monthly consumption and a "Buy credits" action.
+ * Live-updates via `useCreditBalance`. Renders nothing when billing is disabled;
+ * hides the buy action on iOS (App Store policy).
  */
 export function CreditBalanceCard() {
   const { showBilling } = useBillingVisibility();
   const { balance, isLoading, isError } = useCreditBalance();
 
-  // Hidden on billing-disabled deployments.
   if (!isLoading && (!balance || !balance.billingEnabled)) {
     return null;
   }
 
-  const resetDate = balance?.monthly.periodEnd ? new Date(balance.monthly.periodEnd) : null;
+  const renewDate = balance?.monthly.periodEnd ? new Date(balance.monthly.periodEnd) : null;
 
   return (
     <Card>
@@ -33,14 +33,14 @@ export function CreditBalanceCard() {
           AI Credits
         </CardTitle>
         <CardDescription>
-          Credits power AI features and are billed at usage. Your monthly allowance
-          resets each period; purchased top-up credits never expire.
+          Credits power AI features. Your plan includes 100 credits per billing period.
         </CardDescription>
       </CardHeader>
       <CardContent>
         {isLoading ? (
           <div className="space-y-3">
             <Skeleton className="h-8 w-32" />
+            <Skeleton className="h-2 w-full" />
             <Skeleton className="h-4 w-48" />
           </div>
         ) : isError ? (
@@ -49,30 +49,45 @@ export function CreditBalanceCard() {
           </p>
         ) : balance ? (
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-            <div className="space-y-2">
+            <div className="space-y-3 flex-1">
               <div
                 className={`text-3xl font-bold tabular-nums ${
                   balance.spendable < 0 ? 'text-red-600 dark:text-red-400' : ''
                 }`}
               >
-                {formatCreditDollarsSigned(balance.spendable)}
-                <span className="ml-2 text-sm font-normal text-muted-foreground">available</span>
+                {formatCreditUnitsSigned(balance.spendable, balance.monthly.allowance)}
+                <span className="ml-2 text-sm font-normal text-muted-foreground">/ 100 credits</span>
               </div>
+              <Progress
+                value={Math.min(
+                  100,
+                  Math.max(
+                    0,
+                    ((balance.monthly.allowance - balance.monthly.remaining) /
+                      balance.monthly.allowance) *
+                      100,
+                  ),
+                )}
+                className="h-2"
+              />
               <div className="text-sm text-muted-foreground space-y-0.5">
                 {balance.debt > 0 && (
                   <div className="text-red-600 dark:text-red-400">
-                    You owe {formatCreditDollars(balance.debt)} in overage — add credits to keep
-                    using AI (or it clears at your next reset).
+                    In the red — add credits to keep using AI (or it clears at your next renewal).
                   </div>
                 )}
-                <div>
-                  Monthly allowance: {formatCreditDollars(balance.monthly.remaining)} of{' '}
-                  {formatCreditDollars(balance.monthly.allowance)}
-                  {resetDate && <> · resets {resetDate.toLocaleDateString()}</>}
-                </div>
-                <div>Top-up balance: {formatCreditDollars(balance.topup.remaining)}</div>
+                {balance.topup.remaining > 0 && (
+                  <div>
+                    +{formatCreditUnits(balance.topup.remaining, balance.monthly.allowance)} bonus credits from top-ups
+                  </div>
+                )}
                 {balance.reserved > 0 && (
-                  <div>Reserved (in-flight): {formatCreditDollars(balance.reserved)}</div>
+                  <div>
+                    ~{formatCreditUnits(balance.reserved, balance.monthly.allowance)} reserved on in-flight calls
+                  </div>
+                )}
+                {renewDate && (
+                  <div>Renews {renewDate.toLocaleDateString()}</div>
                 )}
               </div>
             </div>

--- a/apps/web/src/components/billing/CreditBalanceCard.tsx
+++ b/apps/web/src/components/billing/CreditBalanceCard.tsx
@@ -58,18 +58,20 @@ export function CreditBalanceCard() {
                 {formatCreditUnitsSigned(balance.spendable, balance.monthly.allowance)}
                 <span className="ml-2 text-sm font-normal text-muted-foreground">/ 100 credits</span>
               </div>
-              <Progress
-                value={Math.min(
-                  100,
-                  Math.max(
-                    0,
-                    ((balance.monthly.allowance - balance.monthly.remaining) /
-                      balance.monthly.allowance) *
-                      100,
-                  ),
-                )}
-                className="h-2"
-              />
+              {balance.monthly.allowance > 0 && (
+                <Progress
+                  value={Math.min(
+                    100,
+                    Math.max(
+                      0,
+                      ((balance.monthly.allowance - balance.monthly.remaining) /
+                        balance.monthly.allowance) *
+                        100,
+                    ),
+                  )}
+                  className="h-2"
+                />
+              )}
               <div className="text-sm text-muted-foreground space-y-0.5">
                 {balance.debt > 0 && (
                   <div className="text-red-600 dark:text-red-400">

--- a/apps/web/src/components/billing/UsageBreakdownCard.tsx
+++ b/apps/web/src/components/billing/UsageBreakdownCard.tsx
@@ -7,8 +7,9 @@ import { Progress } from '@/components/ui/progress';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BarChart3 } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { formatCreditDollars } from '@/lib/subscription/credits';
+import { formatCreditUnits } from '@/lib/subscription/credits';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { useCreditBalance } from '@/hooks/useCreditBalance';
 
 interface FeatureRow {
   source: string;
@@ -58,6 +59,9 @@ const formatTokens = (tokens: number): string => {
 export function UsageBreakdownCard() {
   const socket = useSocketStore((state) => state.socket);
   const connect = useSocketStore((state) => state.connect);
+  // SWR-deduped alongside CreditBalance/CreditBalanceCard — no extra fetch.
+  const { balance } = useCreditBalance();
+  const allowanceCents = balance?.monthly.allowance ?? 0;
 
   const { data, error, isLoading, mutate } = useSWR<UsageBreakdownResponse>(
     '/api/credits/breakdown',
@@ -78,7 +82,7 @@ export function UsageBreakdownCard() {
     };
   }, [socket, mutate]);
 
-  const resetDate = data?.periodEnd ? new Date(data.periodEnd) : null;
+  const renewDate = data?.periodEnd ? new Date(data.periodEnd) : null;
 
   return (
     <Card>
@@ -88,7 +92,7 @@ export function UsageBreakdownCard() {
           Usage this period
         </CardTitle>
         <CardDescription>
-          Where your AI credits are going{resetDate && <> · resets {resetDate.toLocaleDateString()}</>}
+          Where your AI credits are going{renewDate && <> · renews {renewDate.toLocaleDateString()}</>}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -108,13 +112,24 @@ export function UsageBreakdownCard() {
           </p>
         ) : (
           <div className="space-y-6">
-            <div className="text-2xl font-bold tabular-nums">
-              {formatCreditDollars(data.totalSpendCents)}
-              <span className="ml-2 text-sm font-normal text-muted-foreground">spent</span>
-            </div>
+            {allowanceCents > 0 && (
+              <div className="text-2xl font-bold tabular-nums">
+                {formatCreditUnits(data.totalSpendCents, allowanceCents)}
+                <span className="ml-2 text-sm font-normal text-muted-foreground">credits used</span>
+              </div>
+            )}
 
-            <UsageList title="By feature" rows={data.byFeature.map(featureToRow)} />
-            <UsageList title="By model" rows={data.byModel.map(modelToRow)} formatTokens={formatTokens} />
+            <UsageList
+              title="By feature"
+              rows={data.byFeature.map(featureToRow)}
+              allowanceCents={allowanceCents}
+            />
+            <UsageList
+              title="By model"
+              rows={data.byModel.map(modelToRow)}
+              allowanceCents={allowanceCents}
+              formatTokens={formatTokens}
+            />
           </div>
         )}
       </CardContent>
@@ -154,10 +169,12 @@ const modelToRow = (m: ModelRow): DisplayRow => ({
 function UsageList({
   title,
   rows,
+  allowanceCents,
   formatTokens: fmtTokens,
 }: {
   title: string;
   rows: DisplayRow[];
+  allowanceCents: number;
   formatTokens?: (t: number) => string;
 }) {
   if (rows.length === 0) return null;
@@ -174,7 +191,11 @@ function UsageList({
                   <span className="ml-1.5 text-xs font-normal text-muted-foreground">{row.sublabel}</span>
                 )}
               </span>
-              <span className="shrink-0 tabular-nums">{formatCreditDollars(row.spendCents)}</span>
+              {allowanceCents > 0 && (
+                <span className="shrink-0 tabular-nums">
+                  {formatCreditUnits(row.spendCents, allowanceCents)} cr
+                </span>
+              )}
             </div>
             <Progress value={row.sharePct} className="h-2" />
             <div className="text-xs text-muted-foreground tabular-nums">

--- a/apps/web/src/lib/subscription/__tests__/credits.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/credits.test.ts
@@ -28,8 +28,8 @@ describe('toDisplayCredits', () => {
     expect(toDisplayCredits(-300, 1500)).toBeCloseTo(-20, 1);
   });
 
-  it('returns 0 when allowanceCents is 0 (guard against division by zero)', () => {
-    expect(toDisplayCredits(500, 0)).toBe(0);
+  it('returns cents directly when allowanceCents is 0 (no monthly plan)', () => {
+    expect(toDisplayCredits(500, 0)).toBe(500);
   });
 
   it('returns 0 when both cents and allowanceCents are 0', () => {
@@ -58,8 +58,8 @@ describe('formatCreditUnits', () => {
     expect(formatCreditUnits(-150, 1500)).toBe('-10.00');
   });
 
-  it('returns "0.00" when allowanceCents is 0', () => {
-    expect(formatCreditUnits(500, 0)).toBe('0.00');
+  it('returns "500.00" when allowanceCents is 0', () => {
+    expect(formatCreditUnits(500, 0)).toBe('500.00');
   });
 });
 
@@ -76,8 +76,8 @@ describe('formatCreditUnitsSigned', () => {
     expect(formatCreditUnitsSigned(0, 1500)).toBe('0.00');
   });
 
-  it('returns "0.00" when allowanceCents is 0', () => {
-    expect(formatCreditUnitsSigned(500, 0)).toBe('0.00');
+  it('returns "500.00" when allowanceCents is 0', () => {
+    expect(formatCreditUnitsSigned(500, 0)).toBe('500.00');
   });
 });
 

--- a/apps/web/src/lib/subscription/__tests__/credits.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/credits.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toDisplayCredits,
+  formatCreditUnits,
+  formatCreditUnitsSigned,
+  formatCreditDollars,
+  formatCreditDollarsSigned,
+} from '../credits';
+
+describe('toDisplayCredits', () => {
+  it('returns 100 when cents equals allowance', () => {
+    expect(toDisplayCredits(1500, 1500)).toBe(100);
+  });
+
+  it('returns 50 when cents is half the allowance', () => {
+    expect(toDisplayCredits(750, 1500)).toBe(50);
+  });
+
+  it('returns 0 when cents is 0', () => {
+    expect(toDisplayCredits(0, 1500)).toBe(0);
+  });
+
+  it('returns value greater than 100 when top-up pushes balance above allowance', () => {
+    expect(toDisplayCredits(2500, 1500)).toBeCloseTo(166.67, 1);
+  });
+
+  it('returns negative value when spendable is negative (in debt)', () => {
+    expect(toDisplayCredits(-300, 1500)).toBeCloseTo(-20, 1);
+  });
+
+  it('returns 0 when allowanceCents is 0 (guard against division by zero)', () => {
+    expect(toDisplayCredits(500, 0)).toBe(0);
+  });
+
+  it('returns 0 when both cents and allowanceCents are 0', () => {
+    expect(toDisplayCredits(0, 0)).toBe(0);
+  });
+});
+
+describe('formatCreditUnits', () => {
+  it('formats a full balance as "100.00"', () => {
+    expect(formatCreditUnits(1500, 1500)).toBe('100.00');
+  });
+
+  it('formats a partial balance with 2 decimal places', () => {
+    expect(formatCreditUnits(1493, 1500)).toBe('99.53');
+  });
+
+  it('formats zero as "0.00"', () => {
+    expect(formatCreditUnits(0, 1500)).toBe('0.00');
+  });
+
+  it('formats a top-up overflow above 100', () => {
+    expect(formatCreditUnits(3000, 1500)).toBe('200.00');
+  });
+
+  it('formats negative balances as negative strings', () => {
+    expect(formatCreditUnits(-150, 1500)).toBe('-10.00');
+  });
+
+  it('returns "0.00" when allowanceCents is 0', () => {
+    expect(formatCreditUnits(500, 0)).toBe('0.00');
+  });
+});
+
+describe('formatCreditUnitsSigned', () => {
+  it('formats a positive balance without a sign prefix', () => {
+    expect(formatCreditUnitsSigned(1500, 1500)).toBe('100.00');
+  });
+
+  it('prefixes negative balance with a minus sign', () => {
+    expect(formatCreditUnitsSigned(-300, 1500)).toBe('-20.00');
+  });
+
+  it('formats zero as "0.00" without a sign', () => {
+    expect(formatCreditUnitsSigned(0, 1500)).toBe('0.00');
+  });
+
+  it('returns "0.00" when allowanceCents is 0', () => {
+    expect(formatCreditUnitsSigned(500, 0)).toBe('0.00');
+  });
+});
+
+describe('formatCreditDollars (existing helper — regression guard)', () => {
+  it('formats whole dollars without decimals', () => {
+    expect(formatCreditDollars(1000)).toBe('$10');
+  });
+
+  it('formats fractional dollars with 2 decimal places', () => {
+    expect(formatCreditDollars(1050)).toBe('$10.50');
+  });
+
+  it('formats zero as "$0"', () => {
+    expect(formatCreditDollars(0)).toBe('$0');
+  });
+});
+
+describe('formatCreditDollarsSigned (existing helper — regression guard)', () => {
+  it('formats negative cents with leading minus before the dollar sign', () => {
+    expect(formatCreditDollarsSigned(-500)).toBe('-$5');
+  });
+
+  it('formats positive cents without a sign', () => {
+    expect(formatCreditDollarsSigned(500)).toBe('$5');
+  });
+});

--- a/apps/web/src/lib/subscription/credits.ts
+++ b/apps/web/src/lib/subscription/credits.ts
@@ -43,7 +43,7 @@ export function formatCreditDollarsSigned(cents: number): string {
  * Positive top-up balances can push the result above 100.
  */
 export function toDisplayCredits(cents: number, allowanceCents: number): number {
-  if (allowanceCents <= 0) return 0;
+  if (allowanceCents <= 0) return cents;
   return (cents / allowanceCents) * 100;
 }
 

--- a/apps/web/src/lib/subscription/credits.ts
+++ b/apps/web/src/lib/subscription/credits.ts
@@ -38,6 +38,26 @@ export function formatCreditDollarsSigned(cents: number): string {
   return cents < 0 ? `-${formatCreditDollars(-cents)}` : formatCreditDollars(cents);
 }
 
+/**
+ * Convert whole cents to a 0–100 display-credit scale where `allowanceCents` = 100.
+ * Positive top-up balances can push the result above 100.
+ */
+export function toDisplayCredits(cents: number, allowanceCents: number): number {
+  if (allowanceCents <= 0) return 0;
+  return (cents / allowanceCents) * 100;
+}
+
+/** Format cents as a display credit amount on the 0–100 scale (2 decimal places). */
+export function formatCreditUnits(cents: number, allowanceCents: number): string {
+  return toDisplayCredits(cents, allowanceCents).toFixed(2);
+}
+
+/** Like {@link formatCreditUnits} but prefixes negative values with a minus sign. */
+export function formatCreditUnitsSigned(cents: number, allowanceCents: number): string {
+  if (cents < 0) return `-${formatCreditUnits(-cents, allowanceCents)}`;
+  return formatCreditUnits(cents, allowanceCents);
+}
+
 /** Bounds (whole cents) for a custom top-up amount, from the canonical billing config. */
 export const TOPUP_MIN_CENTS = CREDIT_TOPUP_MIN_CENTS;
 export const TOPUP_MAX_CENTS = CREDIT_TOPUP_MAX_CENTS;


### PR DESCRIPTION
## Summary

- Credits UI now shows a normalized **0-100 scale** (monthly plan allowance = 100 credits) instead of dollar amounts — no unit economics exposed, no cash-refund framing
- Header badge shows `73.42` instead of `$1.10`; tooltip shows `73.42 / 100 credits remaining` with renewal date only
- `CreditBalanceCard` (settings page) gets a progress bar showing % consumed + `73.42 / 100 credits` headline; top-up bonus credits shown separately when non-zero
- `UsageBreakdownCard` replaces dollar totals and per-row amounts with credit units, sourcing the allowance from `useCreditBalance` (SWR-deduped, no extra fetch)
- Added `toDisplayCredits()`, `formatCreditUnits()`, `formatCreditUnitsSigned()` helpers to `credits.ts`
- "resets" → "renews" everywhere in the credits UI copy

**Not in this PR (follow-up):** backend change to accumulate monthly credits (add 100 to balance each period) rather than resetting to 100.

## Test plan

- [ ] Navigate to `/settings/billing` — credit balance card shows `X.XX / 100 credits` headline with progress bar; no dollar amounts visible
- [ ] Hover the credits badge in the navbar — tooltip shows `X.XX / 100 credits remaining` and renewal date only
- [ ] If test account has a top-up balance: confirm `+X.XX bonus credits from top-ups` appears below the headline
- [ ] Usage breakdown card shows `X.XX credits used` total and `X.XX cr` per feature/model row
- [ ] Low-balance state (≤15% remaining): badge turns amber/destructive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added low-balance warning system for credit accounts
  * Introduced progress visualization for monthly credit usage

* **Improvements**
  * Updated billing panel display and information layout
  * Renewal date information now prominently shown across billing components
  * Credit display formatting refined for consistent visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->