### PR TITLE
Make canvas publish header mobile-friendly

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -158,7 +158,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
 
   return (
     <div ref={containerRef} className="h-full flex flex-col relative">
-      <div className="relative flex items-center border-b">
+      <div className="relative flex flex-wrap items-center border-b">
         <button
           className={`px-4 py-2 ${activeTab === 'code' ? 'border-b-2 border-blue-500' : ''}`}
           onClick={() => setActiveTab('code')}
@@ -171,7 +171,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
         >
           View
         </button>
-        <div className="ml-auto">
+        <div className="ml-auto min-w-0 max-w-full">
           <CanvasPublishControls pageId={pageId} />
         </div>
       </div>

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
@@ -128,26 +128,28 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
   }
 
   return (
-    <div className="flex items-center gap-2 px-2">
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-2 py-1 max-w-full">
       <a
         href={state.url}
         target="_blank"
         rel="noreferrer"
-        className="max-w-[16rem] truncate text-sm text-blue-500 hover:underline"
+        className="min-w-0 max-w-[10rem] sm:max-w-[16rem] truncate text-sm text-blue-500 hover:underline"
         title={state.url}
       >
         {state.url}
       </a>
-      <button className="px-2 py-2 text-sm" onClick={handleCopy}>
-        Copy link
-      </button>
-      <button
-        className="px-2 py-2 text-sm text-red-500 disabled:opacity-50"
-        onClick={handleUnpublish}
-        disabled={isBusy}
-      >
-        {isBusy ? 'Unpublishing…' : 'Unpublish'}
-      </button>
+      <div className="flex items-center gap-2">
+        <button className="px-2 py-2 text-sm whitespace-nowrap" onClick={handleCopy}>
+          Copy link
+        </button>
+        <button
+          className="px-2 py-2 text-sm whitespace-nowrap text-red-500 disabled:opacity-50"
+          onClick={handleUnpublish}
+          disabled={isBusy}
+        >
+          {isBusy ? 'Unpublishing…' : 'Unpublish'}
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
The published canvas page header overflowed horizontally on mobile
because the publish link and its action buttons sat in a single
non-wrapping flex row with a fixed 16rem link width.

- Allow the tab/controls header row to wrap (flex-wrap)
- Let the publish controls wrap and shrink: narrower link on mobile
  (max-w-[10rem], sm:max-w-[16rem]), min-w-0 so it can truncate, and
  the Copy/Unpublish buttons grouped so they wrap as a unit
- Constrain the controls container with min-w-0/max-w-full so it never
  forces the page wider than the viewport

https://claude.ai/code/session_01VV5wR48KYb1Z7J6qCApWsw