### PR TITLE
fix(billing): net debt against carried balance on monthly refill

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -127,7 +127,10 @@ describe('getCreditBalance', () => {
     expect(b.spendable).toBe(700);
   });
 
-  it('mirrors gate forgiveness for expired free-period debt', async () => {
+  it('shows actual debt for expired free-period; spendable reflects debt that will be netted at reset', async () => {
+    // 0¢ remaining, 300¢ debt, expired period. Gate will apply: max(0, 0−300+500)=200 on next call.
+    // Balance display anticipates the allowance (monthly.remaining = 0+500=500) and shows
+    // actual stored debt (300), so spendable = 500−300 = 200 — the real post-reset outcome.
     balanceRows = [
       {
         monthlyRemainingCents: 0,
@@ -139,8 +142,8 @@ describe('getCreditBalance', () => {
     ];
     const b = await getCreditBalance('u1', 'free');
     expect(b.monthly.remaining).toBe(500);
-    expect(b.debt).toBe(0);
-    expect(b.spendable).toBe(500);
+    expect(b.debt).toBe(300);
+    expect(b.spendable).toBe(200);
   });
 
   it('shows the stored monthly remaining for a paid tier whose period has lapsed (rollover: credits carry forward)', async () => {

--- a/packages/lib/src/billing/__tests__/credit-core.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-core.test.ts
@@ -420,6 +420,21 @@ describe('computeMonthlyRefill', () => {
     });
   });
 
+  it('clamps to 0 when debt exceeds remaining + allowance (DB constraint: monthlyRemainingCents >= 0)', () => {
+    // 100¢ remaining, 700¢ debt, 500¢ allowance → net = 100 − 700 + 500 = −100 → clamped to 0
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 100, 700)).toEqual({
+      monthlyRemainingCents: 0,
+      monthlyAllowanceCents: 500,
+      debtCents: 0,
+    });
+    // 0 remaining, 1000¢ debt, 500¢ allowance → −500 → 0
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 0, 1000)).toEqual({
+      monthlyRemainingCents: 0,
+      monthlyAllowanceCents: 500,
+      debtCents: 0,
+    });
+  });
+
   it('backward compat: omitting currentDebtCents is identical to passing 0 (no debt = pure rollover)', () => {
     const withDefault = computeMonthlyRefill('pro', ALLOWANCE, 600);
     const withZero = computeMonthlyRefill('pro', ALLOWANCE, 600, 0);

--- a/packages/lib/src/billing/__tests__/credit-core.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-core.test.ts
@@ -623,8 +623,8 @@ describe('credit-core debt invariants (property-based, seeded)', () => {
         // (debt shrinks, top-up grows, dollar-for-dollar — nothing vanishes).
         expect(debt + topup).toBe(before + payment);
       } else {
-        // REFILL (renewal): allowance ADDED to carried balance, debt forgiven.
-        const refill = computeMonthlyRefill(TIERS[Math.floor(rand() * TIERS.length)], ALLOW, monthly);
+        // REFILL (renewal): debt netted against carry, allowance added, monthly clamped >= 0.
+        const refill = computeMonthlyRefill(TIERS[Math.floor(rand() * TIERS.length)], ALLOW, monthly, debt);
         monthly = refill.monthlyRemainingCents;
         debt = refill.debtCents;
       }

--- a/packages/lib/src/billing/__tests__/credit-core.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-core.test.ts
@@ -366,6 +366,9 @@ describe('holdExpiresAt', () => {
   });
 });
 
+// 500¢-per-tier fixture used by debt-netting tests so the arithmetic is readable.
+const FLAT_ALLOWANCE: Record<SubscriptionTier, number> = { free: 500, pro: 500, founder: 500, business: 500 };
+
 describe('computeMonthlyRefill', () => {
   it('with no prior balance (default 0) returns the full tier allowance — backward compat', () => {
     expect(computeMonthlyRefill('pro', ALLOWANCE)).toEqual({
@@ -394,12 +397,36 @@ describe('computeMonthlyRefill', () => {
     });
   });
 
-  it('debt is always 0 regardless of currentRemainingCents', () => {
+  it('debtCents is 0 in the return — debt is netted into monthlyRemainingCents', () => {
     expect(computeMonthlyRefill('pro', ALLOWANCE, 600).debtCents).toBe(0);
     expect(computeMonthlyRefill('pro', ALLOWANCE, 9999).debtCents).toBe(0);
   });
 
-  it('falls back to the free allowance for an unknown tier (debt still forgiven)', () => {
+  it('nets debt against carried balance: 100¢ remaining, 200¢ debt, 500¢ allowance → 400¢', () => {
+    // netCarried = 100 − 200 = −100; monthly = −100 + 500 = 400
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 100, 200)).toEqual({
+      monthlyRemainingCents: 400,
+      monthlyAllowanceCents: 500,
+      debtCents: 0,
+    });
+  });
+
+  it('nets debt against carried balance: 100¢ remaining, 300¢ debt, 500¢ allowance → 300¢', () => {
+    // netCarried = 100 − 300 = −200; monthly = −200 + 500 = 300
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 100, 300)).toEqual({
+      monthlyRemainingCents: 300,
+      monthlyAllowanceCents: 500,
+      debtCents: 0,
+    });
+  });
+
+  it('backward compat: omitting currentDebtCents is identical to passing 0 (no debt = pure rollover)', () => {
+    const withDefault = computeMonthlyRefill('pro', ALLOWANCE, 600);
+    const withZero = computeMonthlyRefill('pro', ALLOWANCE, 600, 0);
+    expect(withDefault).toEqual(withZero);
+  });
+
+  it('falls back to the free allowance for an unknown tier', () => {
     expect(computeMonthlyRefill('enterprise' as SubscriptionTier, ALLOWANCE))
       .toEqual({ monthlyRemainingCents: 50, monthlyAllowanceCents: 50, debtCents: 0 });
   });

--- a/packages/lib/src/billing/__tests__/credit-funding.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-funding.test.ts
@@ -67,19 +67,19 @@ function balanceUpsert(cap: Captured) {
 
 // Build a select chain for reading the current creditBalances row inside the tx.
 // Includes the .for('update') call that locks the row before the rollover write.
-function balanceSelectReturning(monthlyRemainingCents: number) {
-  const result = Promise.resolve([{ monthlyRemainingCents }]);
+function balanceSelectReturning(monthlyRemainingCents: number, debtCents = 0) {
+  const result = Promise.resolve([{ monthlyRemainingCents, debtCents }]);
   return { from: () => ({ where: () => ({ for: () => ({ limit: () => result }), limit: () => result }) }) };
 }
 
 // tx for the monthly refill path: ledger insert -> stub-row insert -> select current balance -> balance upsert.
-function refillTx(cap: Captured, ledgerReturned: Array<{ id: string }>, currentRemaining: number) {
+function refillTx(cap: Captured, ledgerReturned: Array<{ id: string }>, currentRemaining: number, currentDebt = 0) {
   return {
     insert: vi.fn()
       .mockReturnValueOnce(ledgerInsert(ledgerReturned, cap))
       .mockReturnValueOnce(ensureRowInsert())   // stub: INSERT ... ON CONFLICT DO NOTHING
       .mockReturnValueOnce(balanceUpsert(cap)),
-    select: vi.fn().mockReturnValueOnce(balanceSelectReturning(currentRemaining)),
+    select: vi.fn().mockReturnValueOnce(balanceSelectReturning(currentRemaining, currentDebt)),
   };
 }
 
@@ -183,7 +183,7 @@ describe('applyStripeFunding', () => {
     expect(cap.balanceSet).toEqual({
       monthlyRemainingCents: allowance,
       monthlyAllowanceCents: allowance,
-      // Renewal forgives any outstanding overage — full allowance, never reduced.
+      // Zero debt: full allowance passes through — net = (0 − 0) + allowance = allowance.
       debtCents: 0,
       monthlyPeriodStart: new Date(1_700_000_000 * 1000),
       monthlyPeriodEnd: new Date(1_702_592_000 * 1000),
@@ -203,6 +203,24 @@ describe('applyStripeFunding', () => {
     const allowance = TIER_MONTHLY_ALLOWANCE_CENTS.pro;
     expect(cap.balanceSet).toMatchObject({
       monthlyRemainingCents: 600 + allowance,
+      monthlyAllowanceCents: allowance,
+      debtCents: 0,
+    });
+  });
+
+  it('invoice.paid nets outstanding debt against carried balance (debt absorbed, not forwarded)', async () => {
+    mockDb.select.mockReturnValue(userSelectReturning(PRO_USER));
+    const cap: Captured = {};
+    // 200¢ carried, 200¢ debt → net = 200 − 200 = 0; monthly = 0 + pro allowance.
+    mockDb.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+      await cb(refillTx(cap, [{ id: 'led_debt_refill' }], 200, 200));
+    });
+
+    await applyStripeFunding(invoiceEvent);
+
+    const allowance = TIER_MONTHLY_ALLOWANCE_CENTS.pro;
+    expect(cap.balanceSet).toMatchObject({
+      monthlyRemainingCents: allowance,
       monthlyAllowanceCents: allowance,
       debtCents: 0,
     });

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -238,18 +238,19 @@ describe('canConsumeAI', () => {
     expect(r.reason).toBe('ok');
   });
 
-  it('forgives outstanding debt at the gate-driven free reset (debtCents -> 0, full allowance)', async () => {
+  it('nets outstanding debt against carry at gate-driven free reset (debt absorbed into monthly balance)', async () => {
+    // 0¢ remaining, 300¢ debt, 500¢ free allowance → net = (0 − 300) + 500 = 200¢.
     mockDb.select
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST }]))
-      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
     mockDb.update.mockReturnValue(updateCapturing(sink));
-    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+    mockTransaction({ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    // Renewal restores the FULL allowance AND wipes the debt.
-    expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, monthlyAllowanceCents: 500, debtCents: 0 });
+    // Debt absorbed: net = 0 − 300 + 500 = 200; debtCents zeroed in the UPDATE.
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 200, monthlyAllowanceCents: 500, debtCents: 0 });
     expect(r.allowed).toBe(true);
     expect(r.reason).toBe('ok');
   });

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -625,7 +625,7 @@ describe('credits flow — negative balance (overage → debt → recover)', () 
     expect(debtRows.map((r) => r.amountCents).sort((a, b) => Number(a) - Number(b))).toEqual([-600, -300]);
     expect(store.creditHolds).toHaveLength(0); // both holds released at settle
 
-    // Net = 0 − 900 < floor → blocked until paid down or forgiven.
+    // Net = 0 − 900 < floor → blocked until paid down (or renewal nets debt below allowance).
     expect((await canConsumeAI('u1', 'pro')).allowed).toBe(false);
   });
 });

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -560,7 +560,7 @@ describe('credits flow — negative balance (overage → debt → recover)', () 
     expect((await canConsumeAI('u1', 'pro')).allowed).toBe(true);
   });
 
-  it('forgives outstanding debt at the next renewal — full allowance, debt wiped', async () => {
+  it('nets outstanding debt against carry at renewal — debt absorbed, monthly reduced accordingly', async () => {
     seedUser('u1', 'cus_1', 'pro');
     await applyStripeFunding(invoicePaid('in_1', 'cus_1', PERIOD_START, PERIOD_END));
 
@@ -569,10 +569,11 @@ describe('credits flow — negative balance (overage → debt → recover)', () 
     expect(balanceOf('u1')!.debtCents).toBe(300);
     expect((await canConsumeAI('u1', 'pro')).allowed).toBe(false); // blocked while in the red
 
-    // ── RENEWAL: invoice.paid restores the FULL allowance and forgives the debt. ──
+    // ── RENEWAL: debt netted against carry before allowance added. ──
+    // monthly = 0, debt = 300; netCarried = 0 − 300 = −300; monthly = −300 + 1500 = 1200.
     await applyStripeFunding(invoicePaid('in_2', 'cus_1', PERIOD_START, PERIOD_END));
-    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(1500); // full, NOT reduced by the 300 debt
-    expect(balanceOf('u1')!.debtCents).toBe(0); // forgiven
+    expect(balanceOf('u1')!.monthlyRemainingCents).toBe(1200); // 1500 − 300 debt absorbed
+    expect(balanceOf('u1')!.debtCents).toBe(0); // absorbed into monthly balance
     expect((await canConsumeAI('u1', 'pro')).allowed).toBe(true);
   });
 

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -136,14 +136,14 @@ export async function getCreditBalance(
   const expired = periodEnd === null || periodEnd < now;
 
   // Rollover: credits never expire. The carry balance is always spendable (both
-  // in the gate and here) — the renewal just adds the new allowance on top.
+  // in the gate and here) — the renewal adds the allowance and nets outstanding debt.
   // Free tiers without a Stripe subscription get their reset via the gate's addOneMonth
-  // path (which adds the allowance to the carry), so for a free user with a lapsed
-  // period we show stored + upcoming allowance (what the gate will write on next call).
-  // For paid tiers the period window has no bearing on spendability — show stored as-is.
+  // path, so for a free user with a lapsed period we surface stored + upcoming allowance
+  // (what the gate will apply on next call). Debt is shown as-is — the gate will net it
+  // against the carry at reset. For paid tiers the period window doesn't affect display.
   let monthlyRemaining: number;
   if (tier === 'free' && expired) {
-    // Gate will ADD the allowance to the carry on next call; surface that total.
+    // Gate will net debt against carry and add the allowance on next call; surface the total.
     monthlyRemaining = row.monthlyRemainingCents + allowance;
   } else {
     monthlyRemaining = row.monthlyRemainingCents;

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -150,7 +150,7 @@ export async function getCreditBalance(
   }
 
   const topupRemaining = row.topupRemainingCents;
-  const debt = tier === 'free' && expired ? 0 : row.debtCents ?? 0;
+  const debt = row.debtCents ?? 0;
   // GROSS of in-flight holds (master semantics: `reserved` is surfaced separately, not
   // netted out, so the headline doesn't dip-then-pop across a call). Clamped at 0 ONLY
   // when there's no debt — outstanding overage pulls spendable negative so the widget

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -48,7 +48,7 @@ export interface CreditBalanceSummary {
   };
   /**
    * Outstanding overage owed (a non-negative magnitude). Accrues when a call's cost
-   * exceeds the buckets; paid down by a purchase; forgiven at the next renewal. When
+   * exceeds the buckets; paid down by a purchase; netted against carry at the next renewal. When
    * > 0 the net `spendable` is dragged down (and can be negative).
    */
   debt: number;

--- a/packages/lib/src/billing/credit-consume.ts
+++ b/packages/lib/src/billing/credit-consume.ts
@@ -59,7 +59,7 @@ type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
  *     monthly + topup − debt, goes negative and the gate blocks further AI) AND written
  *     as an 'adjustment' ledger row (the per-overage incurrence history). The buckets
  *     themselves stay >= 0; the negative lives in `debtCents`, which a purchase pays
- *     down and the next renewal forgives (zeroes).
+ *     down or is netted against carry at the next renewal.
  * If no balance row exists yet, the ledger row is left untouched ('pending') so the
  * reconcile cron settles it once a balance is created. Shared by consumeCredits and
  * settlePendingLedgerRow.
@@ -115,7 +115,7 @@ async function decrementAndSettle(
       pendingMillicents: accrual.newPending,
       // Uncovered cost becomes debt: the net balance (monthly + topup − debt) goes
       // negative and the gate blocks further AI until it's paid down by a purchase or
-      // forgiven at the next renewal. Buckets still floor at 0 (above); debt carries
+      // netted against carry at the next renewal. Buckets still floor at 0 (above); debt carries
       // the overage. No-op when the call was fully covered (shortfallCents === 0).
       ...(spend.shortfallCents > 0
         ? { debtCents: sql`${creditBalances.debtCents} + ${spend.shortfallCents}` }

--- a/packages/lib/src/billing/credit-core.ts
+++ b/packages/lib/src/billing/credit-core.ts
@@ -265,27 +265,28 @@ export interface MonthlyRefill {
   monthlyRemainingCents: number;
   monthlyAllowanceCents: number;
   /**
-   * Always 0: a renewal FORGIVES any outstanding overage. The new allowance is added
-   * on top of the carried balance, debt is wiped. Encoding it here keeps "renewal
-   * forgives debt" a pure, tested invariant the funding/gate shells simply persist,
-   * rather than a magic 0 buried in each shell.
+   * Always 0: debt is netted against the carried balance before the new allowance is
+   * added (see `computeMonthlyRefill`), so it is fully absorbed — never forwarded.
    */
   debtCents: 0;
 }
 
 /**
- * Compute the rollover state for a new billing period: the tier allowance is ADDED
- * to `currentRemainingCents` (credits accumulate across periods — rollover) and any
- * outstanding debt is forgiven (debtCents: 0). Defaults to 0 for backward compat
- * when no prior balance exists. Unknown tiers fall back to the free allowance.
+ * Compute the rollover state for a new billing period: outstanding debt is netted
+ * against the carried balance, then the tier allowance is added. Credits accumulate
+ * across periods (rollover); debt is absorbed into `monthlyRemainingCents`, not
+ * forwarded as a field. Defaults to 0 for backward compat when no prior balance or
+ * debt exists. Unknown tiers fall back to the free allowance.
  */
 export function computeMonthlyRefill(
   tier: SubscriptionTier,
   allowanceTable: Record<SubscriptionTier, number>,
   currentRemainingCents: number = 0,
+  currentDebtCents: number = 0,
 ): MonthlyRefill {
   const allowance = allowanceTable[tier] ?? allowanceTable.free;
-  return { monthlyRemainingCents: currentRemainingCents + allowance, monthlyAllowanceCents: allowance, debtCents: 0 };
+  const netCarried = currentRemainingCents - Math.max(0, currentDebtCents);
+  return { monthlyRemainingCents: netCarried + allowance, monthlyAllowanceCents: allowance, debtCents: 0 };
 }
 
 export interface PaymentToDebtResult {

--- a/packages/lib/src/billing/credit-core.ts
+++ b/packages/lib/src/billing/credit-core.ts
@@ -275,8 +275,11 @@ export interface MonthlyRefill {
  * Compute the rollover state for a new billing period: outstanding debt is netted
  * against the carried balance, then the tier allowance is added. Credits accumulate
  * across periods (rollover); debt is absorbed into `monthlyRemainingCents`, not
- * forwarded as a field. Defaults to 0 for backward compat when no prior balance or
- * debt exists. Unknown tiers fall back to the free allowance.
+ * forwarded as a field. `monthlyRemainingCents` is clamped to 0 — the DB schema
+ * enforces `monthlyRemainingCents >= 0`, and any debt exceeding (remaining + allowance)
+ * is forgiven rather than written as a negative balance. Defaults to 0 for backward
+ * compat when no prior balance or debt exists. Unknown tiers fall back to the free
+ * allowance.
  */
 export function computeMonthlyRefill(
   tier: SubscriptionTier,
@@ -286,7 +289,9 @@ export function computeMonthlyRefill(
 ): MonthlyRefill {
   const allowance = allowanceTable[tier] ?? allowanceTable.free;
   const netCarried = currentRemainingCents - Math.max(0, currentDebtCents);
-  return { monthlyRemainingCents: netCarried + allowance, monthlyAllowanceCents: allowance, debtCents: 0 };
+  // Clamp to 0: the DB schema enforces monthlyRemainingCents >= 0. Excess debt beyond
+  // (remaining + allowance) is absorbed here rather than written as a negative balance.
+  return { monthlyRemainingCents: Math.max(0, netCarried + allowance), monthlyAllowanceCents: allowance, debtCents: 0 };
 }
 
 export interface PaymentToDebtResult {

--- a/packages/lib/src/billing/credit-core.ts
+++ b/packages/lib/src/billing/credit-core.ts
@@ -22,7 +22,7 @@ export interface Balance {
   /**
    * Outstanding overage owed, stored as a NON-NEGATIVE magnitude. Net spendable is
    * `monthly + topup − debt`, so debt drags the net below zero (and the gate denies)
-   * until it's paid down by a purchase or forgiven at the next renewal. Defaults to 0.
+   * until it's paid down by a purchase or netted against carry at the next renewal. Defaults to 0.
    */
   debtCents?: number;
 }
@@ -503,8 +503,8 @@ export interface BalanceDriftResult {
  * Compare a user's MATERIALIZED spendable buckets against what the ledger implies
  * (grants − usage drawn from buckets + applied reconcile corrections). This is a
  * DIVERGENCE SMELL DETECTOR, NOT an exact reconciliation: with rollover, monthly
- * credits carry forward with no ledger row at the boundary, and renewal debt-forgiveness
- * zeroes debt — both legitimately break expected = materialized at period boundaries.
+ * credits carry forward with no ledger row at the boundary, and renewal debt-netting
+ * absorbs debt into monthly — both legitimately break expected = materialized at period boundaries.
  * So the tolerance is generous and a flag means "look at this account", not "the books
  * are wrong". Pure; the shell supplies the SQL aggregates.
  */

--- a/packages/lib/src/billing/credit-funding.ts
+++ b/packages/lib/src/billing/credit-funding.ts
@@ -203,13 +203,13 @@ async function applyMonthlyRefill(event: FundingEvent, tierOverride?: Subscripti
     // writes carried + allowance, the second overwriting the first and losing a grant.
     // The row lock serialises them so both increments apply.
     const [currentRow] = await tx
-      .select({ monthlyRemainingCents: creditBalances.monthlyRemainingCents })
+      .select({ monthlyRemainingCents: creditBalances.monthlyRemainingCents, debtCents: creditBalances.debtCents })
       .from(creditBalances)
       .where(eq(creditBalances.userId, user.id))
       .for('update')
       .limit(1);
     carriedCents = currentRow?.monthlyRemainingCents ?? 0;
-    const refill = computeMonthlyRefill(tier, TIER_MONTHLY_ALLOWANCE_CENTS, carriedCents);
+    const refill = computeMonthlyRefill(tier, TIER_MONTHLY_ALLOWANCE_CENTS, carriedCents, currentRow?.debtCents ?? 0);
 
     await tx
       .insert(creditBalances)
@@ -217,8 +217,8 @@ async function applyMonthlyRefill(event: FundingEvent, tierOverride?: Subscripti
         userId: user.id,
         monthlyRemainingCents: refill.monthlyRemainingCents,
         monthlyAllowanceCents: refill.monthlyAllowanceCents,
-        // Renewal ADDS the allowance to carried balance and FORGIVES outstanding
-        // overage (refill.debtCents === 0): last period's debt never reduces this period.
+        // Renewal nets outstanding debt against the carried balance before adding the
+        // allowance (refill.debtCents === 0 — debt absorbed, not forwarded).
         debtCents: refill.debtCents,
         monthlyPeriodStart: start,
         monthlyPeriodEnd: end,

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -135,16 +135,15 @@ export async function canConsumeAI(
     // Pass the current remaining so unspent credits roll over into the new period
     // (matching the paid invoice.paid path). The WHERE re-checks the predicate to
     // handle a concurrent reset that already rolled the window forward.
-    const refill = computeMonthlyRefill(tier, TIER_MONTHLY_ALLOWANCE_CENTS, row.monthlyRemainingCents ?? 0);
+    const refill = computeMonthlyRefill(tier, TIER_MONTHLY_ALLOWANCE_CENTS, row.monthlyRemainingCents ?? 0, row.debtCents ?? 0);
     const newEnd = addOneMonth(now);
     await db
       .update(creditBalances)
       .set({
         monthlyRemainingCents: refill.monthlyRemainingCents,
         monthlyAllowanceCents: refill.monthlyAllowanceCents,
-        // The renewal-equivalent for free/no-sub users: add the allowance to carried
-        // balance and FORGIVE any outstanding overage (refill.debtCents === 0), so
-        // last period's debt never reduces this period — matching the paid refill.
+        // The renewal-equivalent for free/no-sub users: debt is netted against the
+        // carried balance before the allowance is added (refill.debtCents === 0).
         debtCents: refill.debtCents,
         monthlyPeriodStart: now,
         monthlyPeriodEnd: newEnd,

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -239,8 +239,8 @@ export async function canConsumeAI(
             monthlyCents: bal.monthlyRemainingCents,
             topupCents: bal.topupRemainingCents,
             // Outstanding overage drags net spendable down: a user in the red must get
-            // back to net-positive (buy credits, or wait for the renewal that forgives
-            // it) before the gate allows again.
+            // back to net-positive (buy credits, or wait for the renewal that nets
+            // the debt against carry) before the gate allows again.
             debtCents: bal.debtCents,
           }
         : null,


### PR DESCRIPTION
## Problem

\`computeMonthlyRefill\` hard-coded \`debtCents: 0\` on every renewal, silently forgiving all outstanding overage. A user who ran up debt simply had it wiped at the start of the next billing period — effectively unlimited free usage in the worst case.

## Fix

Debt is now **netted against the carried balance** before the new allowance is added:

\`\`\`
netCarried = currentRemainingCents − max(0, currentDebtCents)
monthlyRemainingCents = max(0, netCarried + allowance)
\`\`\`

The \`Math.max(0, ...)\` clamp guards the \`credit_balances_monthly_remaining_nonneg\` DB constraint: when debt exceeds (remaining + allowance), the excess is forgiven rather than written as a negative balance.

**Example**: 100¢ remaining, 200¢ debt, 500¢ allowance → 400¢ (not 600¢)  
**Example**: 1500¢ pro allowance, 300¢ debt, 0¢ carry → 1200¢ at renewal (not 1500¢)

## Changes

| File | Change |
|------|--------|
| `credit-core.ts` | Add `currentDebtCents: number = 0` param; compute `netCarried`; clamp to 0; update JSDoc |
| `credit-gate.ts` | Pass `row.debtCents ?? 0` to `computeMonthlyRefill`; fix stale "FORGIVE" comment |
| `credit-funding.ts` | Add `debtCents` to FOR UPDATE select; pass it through; fix stale comment |
| `credit-balance.ts` | Remove free-tier anticipatory debt-forgiveness special case; update comments |
| `credit-core.test.ts` | 5 new tests (debt-netting, catastrophic-debt clamp, backward-compat); property test passes debt; test renames |
| `credit-funding.test.ts` | Update mock to include `debtCents`; new debt-netting test; fix stale comment |
| `credit-gate.test.ts` | Fix stale forgiveness test → correct netting expectation (0−300+500=200) |
| `credits-flow.integration.test.ts` | Update renewal test: 300¢ debt → 1200¢ post-renewal (not 1500¢) |
| `credit-balance.test.ts` | Update balance display test: expired free debt shown as-is (300¢), spendable=200 |

## Test plan

- [x] New unit tests: 100¢ remaining + 200¢ debt + 500¢ allowance → 400¢
- [x] New unit tests: 100¢ remaining + 300¢ debt + 500¢ allowance → 300¢
- [x] Catastrophic-debt clamp: debt > remaining+allowance → 0¢ (not negative)
- [x] Backward-compat: omitting `currentDebtCents` identical to passing 0
- [x] Property test: 5000 random spend/pay/refill sequences — all invariants hold with debt passed
- [x] Funding test: `invoice.paid` with 200¢ debt → monthly reduced by 200¢
- [x] Gate test: free reset with 300¢ debt → 200¢ balance (not 500¢)
- [x] Integration test: pro renewal with 300¢ debt → 1200¢ (not 1500¢)
- [x] Balance display: expired free debt shown truthfully; spendable = anticipated monthly − debt
- [x] All 229 billing tests green
- [x] No new typecheck errors in billing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)