### PR TITLE
feat(billing): navbar credit badge shows X.X/100 + prepaid format

### DIFF
--- a/apps/web/src/components/billing/CreditBalance.tsx
+++ b/apps/web/src/components/billing/CreditBalance.tsx
@@ -13,7 +13,7 @@ import { AlertCircle, Coins } from 'lucide-react';
 import { useCreditBalance } from '@/hooks/useCreditBalance';
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
-import { formatCreditUnits, formatCreditUnitsSigned } from '@/lib/subscription/credits';
+import { formatCreditUnits, toDisplayCredits } from '@/lib/subscription/credits';
 
 /** Percentage of monthly allowance remaining below which we warn the user. */
 const LOW_BALANCE_THRESHOLD_PCT = 15;
@@ -46,8 +46,10 @@ export function CreditBalance() {
 
   const { spendable, monthly, topup, reserved, debt } = balance;
   const inDebt = spendable < 0;
-  const remainingPct = monthly.allowance > 0 ? (spendable / monthly.allowance) * 100 : 0;
+  const remainingPct = monthly.allowance > 0 ? (monthly.remaining / monthly.allowance) * 100 : 0;
   const isLow = inDebt || remainingPct <= LOW_BALANCE_THRESHOLD_PCT;
+  const monthlyStr = toDisplayCredits(spendable - topup.remaining, monthly.allowance).toFixed(1);
+  const topupUnits = Math.round(toDisplayCredits(topup.remaining, monthly.allowance));
   // Surface in-flight reservations as a quiet signal, not in the headline number.
   const hasInFlight = reserved > 0;
   const renewDate = monthly.periodEnd ? new Date(monthly.periodEnd) : null;
@@ -78,7 +80,7 @@ export function CreditBalance() {
                 variant={isLow ? 'destructive' : 'secondary'}
                 className="text-xs font-medium tabular-nums"
               >
-                {formatCreditUnitsSigned(spendable, monthly.allowance)}
+                {`${monthlyStr}/100${topupUnits > 0 ? ` +${topupUnits}` : ''}`}
               </Badge>
             </button>
           </TooltipTrigger>


### PR DESCRIPTION
## Summary

- Replaces the flat credit number in the navbar badge with `X.X/100` — monthly remaining on the 0–100 scale, one decimal place
- Appends ` +N` when there are prepaid/top-up credits (e.g. `45.3/100 +12`)
- Debt case now shows as `-34.5/100` (unified format, no branch) rather than a separate signed float
- Fixes `remainingPct` to use `monthly.remaining` instead of `spendable` so the amber low-balance warning triggers on monthly depletion, not topup depletion

## Test plan

- [ ] Full monthly remaining → badge shows `100.0/100`
- [ ] Partial use → badge shows e.g. `45.3/100`
- [ ] With top-up credits → badge shows e.g. `45.3/100 +12`
- [ ] In debt → badge shows e.g. `-34.5/100` in red
- [ ] Below 15% monthly remaining → badge turns amber

🤖 Generated with [Claude Code](https://claude.com/claude-code)