### PR TITLE
fix(channel-input): sync line-height on textarea and mention overlay

### DIFF
--- a/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
@@ -14,6 +14,11 @@ import { useMentionOverlay } from '@/hooks/useMentionOverlay';
 import { useMentionTracker } from '@/hooks/useMentionTracker';
 import { useEnterToSend } from '@/hooks/useEnterToSend';
 
+// Typography classes applied to both the textarea and the mention overlay.
+// They must stay in sync — mismatched line-height causes the overlay text to
+// drift relative to the caret with each newline.
+const CHAT_TYPOGRAPHY = 'text-base md:text-sm leading-relaxed';
+
 export interface ChatTextareaProps {
   /** Current input value (markdown format with @[label](id:type) mentions) */
   value: string;
@@ -161,7 +166,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
           disabled={disabled}
           className={cn(
             'min-h-[36px] max-h-48 resize-none break-words',
-            'text-base md:text-sm leading-relaxed',
+            CHAT_TYPOGRAPHY,
             // Context-aware background:
             // - main: transparent to blend with InputCard, no shadow in light mode for flush look
             // - sidebar: white in light mode for contrast, slight gray lift in dark mode
@@ -185,7 +190,8 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
             value={displayText}
             mentions={mentions}
             className={cn(
-              'px-3 py-2 text-base md:text-sm leading-relaxed',
+              'px-3 py-2',
+              CHAT_TYPOGRAPHY,
               'text-foreground',
               'min-h-[36px] max-h-48'
             )}

--- a/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
@@ -161,6 +161,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
           disabled={disabled}
           className={cn(
             'min-h-[36px] max-h-48 resize-none break-words',
+            'text-base md:text-sm leading-relaxed',
             // Context-aware background:
             // - main: transparent to blend with InputCard, no shadow in light mode for flush look
             // - sidebar: white in light mode for contrast, slight gray lift in dark mode
@@ -184,7 +185,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
             value={displayText}
             mentions={mentions}
             className={cn(
-              'px-3 py-2 text-base md:text-sm',
+              'px-3 py-2 text-base md:text-sm leading-relaxed',
               'text-foreground',
               'min-h-[36px] max-h-48'
             )}


### PR DESCRIPTION
## Summary

- Cursor appeared one line above the actual insertion point when `@mentions` were present in channel/DM inputs and the text spanned multiple lines
- Root cause: `MentionHighlightOverlay` className was hardcoded without a `leading-*` class, so adding line spacing to the `<Textarea>` caused the overlay text to drift by one line per newline
- Fix: add `leading-relaxed` explicitly to both the `<Textarea>` and the `<MentionHighlightOverlay>` in `ChatTextarea.tsx`, keeping them in lockstep

## Test plan

- [ ] Open a channel, type a multi-line message (Shift+Enter) — cursor tracks correctly at every line
- [ ] @mention someone, add several newlines — overlay highlight stays aligned with the caret
- [ ] Repeat in a DM conversation
- [ ] Spot-check AI chat input for no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)