### PR TITLE
feat(observability): Sentry Phase 2 — global-error boundary + tunnel middleware exclusion

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -162,7 +162,7 @@ export async function middleware(req: NextRequest) {
 export const config = {
   matcher: [
     {
-      source: '/((?!_next/static|_next/image|favicon.ico).*)',
+      source: '/((?!_next/static|_next/image|favicon.ico|sentry-tunnel).*)',
       missing: [
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },

--- a/apps/web/src/app/__tests__/global-error.test.tsx
+++ b/apps/web/src/app/__tests__/global-error.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCaptureException = vi.fn();
+vi.mock('@sentry/nextjs', () => ({ captureException: mockCaptureException }));
+
+describe('GlobalError', () => {
+  beforeEach(() => {
+    mockCaptureException.mockClear();
+  });
+
+  it('exports a default function component', async () => {
+    const mod = await import('../global-error');
+    expect(typeof mod.default).toBe('function');
+  });
+
+  it('component name is GlobalError', async () => {
+    const mod = await import('../global-error');
+    expect(mod.default.name).toBe('GlobalError');
+  });
+});

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -15,7 +15,12 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
   }, [error]);
 
   return (
-    <html>
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Error — PageSpace</title>
+      </head>
       <body
         style={{
           margin: 0,

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { useEffect } from 'react';
+import { AlertTriangle, RefreshCw, Home } from 'lucide-react';
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          backgroundColor: '#0a0a0a',
+          color: '#ededed',
+        }}
+      >
+        <div
+          style={{
+            width: '100%',
+            maxWidth: '512px',
+            padding: '24px',
+            border: '1px solid rgba(255,255,255,0.1)',
+            borderRadius: '8px',
+            backgroundColor: 'rgba(255,255,255,0.03)',
+          }}
+        >
+          <div style={{ textAlign: 'center', marginBottom: '24px' }}>
+            <div
+              style={{
+                width: '48px',
+                height: '48px',
+                borderRadius: '50%',
+                backgroundColor: 'rgba(239,68,68,0.1)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                margin: '0 auto 16px',
+              }}
+            >
+              <AlertTriangle style={{ width: '24px', height: '24px', color: '#ef4444' }} />
+            </div>
+            <h1 style={{ fontSize: '20px', fontWeight: 600, margin: '0 0 8px' }}>
+              Something went wrong
+            </h1>
+            <p style={{ fontSize: '14px', color: 'rgba(255,255,255,0.5)', margin: 0 }}>
+              An unexpected error occurred. Please try again or contact support.
+            </p>
+          </div>
+
+          {error.digest && (
+            <div
+              style={{
+                backgroundColor: 'rgba(255,255,255,0.05)',
+                padding: '12px',
+                borderRadius: '6px',
+                fontSize: '13px',
+                color: 'rgba(255,255,255,0.5)',
+                marginBottom: '16px',
+              }}
+            >
+              Error ID: {error.digest}
+            </div>
+          )}
+
+          {process.env.NODE_ENV === 'development' && (
+            <div
+              style={{
+                backgroundColor: 'rgba(255,255,255,0.05)',
+                padding: '12px',
+                borderRadius: '6px',
+                fontSize: '13px',
+                marginBottom: '16px',
+              }}
+            >
+              <div style={{ fontWeight: 500, marginBottom: '4px' }}>Error Details:</div>
+              <div style={{ color: 'rgba(255,255,255,0.5)', wordBreak: 'break-word' }}>
+                {error.message || 'An unexpected error occurred'}
+              </div>
+            </div>
+          )}
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px' }}>
+            <button
+              onClick={reset}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '8px',
+                padding: '10px 16px',
+                borderRadius: '6px',
+                border: 'none',
+                backgroundColor: '#ededed',
+                color: '#0a0a0a',
+                fontWeight: 500,
+                fontSize: '14px',
+                cursor: 'pointer',
+                width: '100%',
+              }}
+            >
+              <RefreshCw style={{ width: '16px', height: '16px' }} />
+              Try Again
+            </button>
+
+            <button
+              onClick={() => (window.location.href = '/dashboard')}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '8px',
+                padding: '10px 16px',
+                borderRadius: '6px',
+                border: '1px solid rgba(255,255,255,0.15)',
+                backgroundColor: 'transparent',
+                color: '#ededed',
+                fontWeight: 500,
+                fontSize: '14px',
+                cursor: 'pointer',
+                width: '100%',
+              }}
+            >
+              <Home style={{ width: '16px', height: '16px' }} />
+              Go Home
+            </button>
+          </div>
+
+          {process.env.NODE_ENV === 'development' && error.stack && (
+            <details style={{ marginTop: '16px' }}>
+              <summary
+                style={{
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  color: 'rgba(255,255,255,0.5)',
+                }}
+              >
+                Development Details
+              </summary>
+              <div
+                style={{
+                  marginTop: '8px',
+                  padding: '12px',
+                  backgroundColor: 'rgba(255,255,255,0.05)',
+                  borderRadius: '6px',
+                  fontSize: '11px',
+                }}
+              >
+                <pre style={{ whiteSpace: 'pre-wrap', overflowX: 'auto', margin: 0 }}>
+                  {error.stack}
+                </pre>
+              </div>
+            </details>
+          )}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/src/middleware/__tests__/matcher.test.ts
+++ b/apps/web/src/middleware/__tests__/matcher.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock all runtime dependencies so the static `config` export can be imported
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/middleware/monitoring', () => ({ monitoringMiddleware: vi.fn() }));
+vi.mock('@/middleware/security-headers', () => ({
+  createSecureResponse: vi.fn(),
+  createSecureErrorResponse: vi.fn(),
+  isPublicPageRoute: vi.fn(),
+  isPublishedSiteHost: vi.fn(),
+  shouldDisableCOEP: vi.fn(),
+}));
+vi.mock('@/lib/auth', () => ({
+  validateOriginForMiddleware: vi.fn(),
+  isOriginValidationBlocking: vi.fn(),
+}));
+vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn() }));
+
+// Import the live config so this test fails (RED) until middleware.ts is updated
+const { config } = await import('../../../middleware');
+const PATTERN = config.matcher[0].source;
+
+describe('middleware matcher', () => {
+  // Next.js anchors the source pattern against the full pathname — mirror that here.
+  function matches(pattern: string, path: string): boolean {
+    return new RegExp(`^${pattern}$`).test(path);
+  }
+
+  it('excludes /sentry-tunnel', () => {
+    expect(matches(PATTERN, '/sentry-tunnel')).toBe(false);
+  });
+
+  it('excludes /_next/static paths', () => {
+    expect(matches(PATTERN, '/_next/static/chunks/main.js')).toBe(false);
+  });
+
+  it('matches /dashboard routes', () => {
+    expect(matches(PATTERN, '/dashboard/123')).toBe(true);
+  });
+
+  it('matches /api routes', () => {
+    expect(matches(PATTERN, '/api/health')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **`apps/web/src/app/global-error.tsx`** — Root-level React error boundary. Calls `Sentry.captureException(error)` in `useEffect([error])` so unhandled root errors reach Sentry before the fallback UI is shown.
- **`apps/web/middleware.ts`** — One-line addition: adds `sentry-tunnel` to the middleware matcher exclusion so Sentry's tunnel endpoint bypasses auth middleware.
- **`apps/web/src/app/__tests__/global-error.test.tsx`** — TDD: confirmed RED (module not found) before the component existed; confirms the export is a function named `GlobalError`.
- **`apps/web/src/middleware/__tests__/matcher.test.ts`** — TDD: imports `config` live from `middleware.ts` (with runtime mocks); confirmed RED before the `sentry-tunnel` exclusion; exercises all four path categories.

## Why global-error.tsx needs its own `<html>` and `<body>`

`global-error.tsx` is Next.js's root error boundary. When it renders, Next.js has **replaced the entire root layout** — meaning `app/layout.tsx` (which loads Tailwind CSS, fonts, and all providers) is not mounted. The component must be a fully self-contained HTML document. This is also why it uses inline styles instead of Tailwind classes or shadcn/ui components: those stylesheets are not available in this context.

## Why sentry-tunnel must bypass auth middleware

The Sentry SDK is configured with `tunnelRoute: "/sentry-tunnel"` (set in Phase 1's `next.config.ts`). This route proxies browser SDK payloads to Sentry's ingestion endpoint, bypassing ad-blockers that block `*.ingest.sentry.io`. Without the middleware exclusion, unauthenticated browser sessions (login page, first load before cookie is set) would have their error reports blocked by the 401 redirect, defeating the entire purpose of the tunnel. The route itself contains no sensitive data — it only forwards Sentry envelopes.

## Test plan

- [ ] `bun run --filter 'web' test -- src/app/__tests__/global-error.test.tsx` → 2/2 pass
- [ ] `bun run --filter 'web' test -- src/middleware/__tests__/matcher.test.ts` → 4/4 pass
- [ ] `bun run --filter 'web' typecheck` → zero errors
- [ ] Force a root-level throw in dev and confirm Sentry.captureException is called (check Sentry dashboard or console mock)
- [ ] Confirm `/sentry-tunnel` returns 200 without an auth cookie

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global error handling page that displays when something goes wrong, includes "Try Again" and "Go Home" buttons for user action, and shows detailed error information in development mode.

* **Tests**
  * Added test coverage for global error handling and middleware routing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->