### PR TITLE
feat(canvas): stale badge + inline Update for published canvases

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -335,6 +335,18 @@ describe('GET /api/pages/[pageId]/publish', () => {
     expect(json.isStale).toBe(true);
   });
 
+  it('returns isStale: false when page.updatedAt equals the publish timestamp (not strictly after)', async () => {
+    const ts = new Date('2024-01-01T10:00:00Z');
+    findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome', publishedAt: ts, updatedAt: ts });
+    findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });
+    findFirstPage.mockResolvedValue({ updatedAt: ts }); // same instant — not stale
+
+    const res = await GET(makeReq(), { params });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.isStale).toBe(false);
+  });
+
   it('returns isStale: false when the live page has no updatedAt', async () => {
     findFirstPublished.mockResolvedValue({
       driveId: 'drive-1', path: 'welcome',

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -167,7 +167,8 @@ describe('POST /api/pages/[pageId]/publish', () => {
 
     // validates and persists the NORMALIZED candidate derived from the slug
     expect(validatePublishSubdomain).toHaveBeenCalledWith('acme');
-    expect(updateWhere).toHaveBeenCalledTimes(1);
+    // 2 updates: subdomain allocation + post-upload updatedAt advancement
+    expect(updateWhere).toHaveBeenCalledTimes(2);
 
     expect(renderPublishedPage).toHaveBeenCalledWith({ html: '<p>hi</p>', title: 'Welcome' });
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'acme', path: 'welcome', html: '<html>rendered</html>' });
@@ -212,7 +213,8 @@ describe('POST /api/pages/[pageId]/publish', () => {
 
     // no new allocation when the drive already owns a subdomain
     expect(validatePublishSubdomain).not.toHaveBeenCalled();
-    expect(updateWhere).not.toHaveBeenCalled();
+    // 1 update: post-upload updatedAt advancement only (no subdomain allocation)
+    expect(updateWhere).toHaveBeenCalledTimes(1);
 
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'existing', path: 'welcome', html: '<html>rendered</html>' });
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
@@ -232,6 +234,17 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(res.status).toBe(409);
     // Critical: storage is never written when the path is already owned by another page.
     expect(putPublishedArtifact).not.toHaveBeenCalled();
+  });
+
+  it('does NOT advance updatedAt when the artifact upload fails', async () => {
+    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CANVAS', title: 'Welcome', content: 'x', driveId: 'drive-1' });
+    findFirstDrive.mockResolvedValue({ id: 'drive-1', slug: 'acme', publishSubdomain: 'existing' });
+    putPublishedArtifact.mockRejectedValue(new Error('S3 unavailable'));
+
+    const res = await POST(makeReq({}), { params });
+    expect(res.status).toBe(500);
+    // updatedAt update must be skipped — upload failed, artifact is still old version
+    expect(updateWhere).not.toHaveBeenCalled();
   });
 
   it('deletes the stale artifact when republishing changes the resolved key (P2)', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -290,9 +290,12 @@ describe('GET /api/pages/[pageId]/publish', () => {
     }
   });
 
-  it('returns { published: true, url, available } when a row exists', async () => {
-    findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome' });
+  it('returns { published: true, url, available, isStale: false } when page is up to date', async () => {
+    const publishedAt = new Date('2024-01-01T10:00:00Z');
+    const updatedAt = new Date('2024-01-01T10:00:01Z'); // published AFTER last edit
+    findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome', publishedAt, updatedAt });
     findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });
+    findFirstPage.mockResolvedValue({ updatedAt: new Date('2024-01-01T09:55:00Z') }); // edited before publish
 
     const res = await GET(makeReq(), { params });
     expect(res.status).toBe(200);
@@ -300,10 +303,51 @@ describe('GET /api/pages/[pageId]/publish', () => {
     expect(json).toEqual({
       published: true,
       available: true,
+      isStale: false,
       url: 'https://acme.pagespace.site/welcome',
       subdomain: 'acme',
       path: 'welcome',
     });
+  });
+
+  it('returns isStale: true when the page was edited after its last publish', async () => {
+    const publishedAt = new Date('2024-01-01T10:00:00Z');
+    const updatedAt = new Date('2024-01-01T10:00:00Z');
+    findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome', publishedAt, updatedAt });
+    findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });
+    findFirstPage.mockResolvedValue({ updatedAt: new Date('2024-01-01T11:00:00Z') }); // edited AFTER publish
+
+    const res = await GET(makeReq(), { params });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.isStale).toBe(true);
+  });
+
+  it('falls back to publishedAt when updatedAt is null (legacy row)', async () => {
+    const publishedAt = new Date('2024-01-01T10:00:00Z');
+    findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome', publishedAt, updatedAt: null });
+    findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });
+    findFirstPage.mockResolvedValue({ updatedAt: new Date('2024-01-01T11:00:00Z') }); // edited after first publish
+
+    const res = await GET(makeReq(), { params });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.isStale).toBe(true);
+  });
+
+  it('returns isStale: false when the live page has no updatedAt', async () => {
+    findFirstPublished.mockResolvedValue({
+      driveId: 'drive-1', path: 'welcome',
+      publishedAt: new Date('2024-01-01T10:00:00Z'),
+      updatedAt: new Date('2024-01-01T10:00:00Z'),
+    });
+    findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });
+    findFirstPage.mockResolvedValue({ updatedAt: null });
+
+    const res = await GET(makeReq(), { params });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.isStale).toBe(false);
   });
 });
 

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -53,23 +53,36 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
 
     const row = await db.query.publishedPages.findFirst({
       where: eq(publishedPages.pageId, pageId),
-      columns: { driveId: true, path: true },
+      columns: { driveId: true, path: true, publishedAt: true, updatedAt: true },
     });
 
     if (!row) {
       return NextResponse.json({ published: false, available });
     }
 
-    const drive = await db.query.drives.findFirst({
-      where: eq(drives.id, row.driveId),
-      columns: { publishSubdomain: true },
-    });
+    const [drive, livePage] = await Promise.all([
+      db.query.drives.findFirst({
+        where: eq(drives.id, row.driveId),
+        columns: { publishSubdomain: true },
+      }),
+      db.query.pages.findFirst({
+        where: eq(pages.id, pageId),
+        columns: { updatedAt: true },
+      }),
+    ]);
 
     const subdomain = drive?.publishSubdomain ?? null;
+
+    const lastPublishedAt = row.updatedAt ?? row.publishedAt;
+    const isStale =
+      livePage?.updatedAt != null && lastPublishedAt != null
+        ? livePage.updatedAt > lastPublishedAt
+        : false;
 
     return NextResponse.json({
       published: true,
       available,
+      isStale,
       url: `https://${subdomain}.${PUBLISH_HOST}/${row.path}`,
       subdomain,
       path: row.path,
@@ -190,6 +203,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
           path,
           artifactKey: key,
           publishedBy: userId,
+          updatedAt: new Date(),
         })
         .onConflictDoUpdate({
           target: publishedPages.pageId,

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -194,6 +194,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     // constraint on (driveId, path) rejects a page whose resolved path is already
     // owned by another page, so a colliding publish can never overwrite another
     // page's already-published artifact at the shared key.
+    // updatedAt is intentionally NOT advanced here on conflict — it is updated only
+    // after the artifact write succeeds, so a failed upload never falsely clears
+    // the stale indicator on the next GET.
     try {
       await db
         .insert(publishedPages)
@@ -211,7 +214,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
             path,
             artifactKey: key,
             publishedBy: userId,
-            updatedAt: new Date(),
           },
         });
     } catch (err) {
@@ -223,6 +225,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
 
     // The path is now reserved for this page — safe to write the artifact.
     await putPublishedArtifact({ subdomain, path, html });
+
+    // Advance updatedAt only after the artifact is successfully written. This
+    // ensures GET /publish reports isStale: true if a prior upload attempt failed.
+    await db
+      .update(publishedPages)
+      .set({ updatedAt: new Date() })
+      .where(eq(publishedPages.pageId, pageId));
 
     // Remove the previous artifact when the key changed, so a stale URL is not left
     // publicly servable after a rename/republish.

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -172,7 +172,7 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
           View
         </button>
         <div className="ml-auto min-w-0 max-w-full">
-          <CanvasPublishControls pageId={pageId} />
+          <CanvasPublishControls pageId={pageId} contentDirty={documentState?.isDirty} />
         </div>
       </div>
       {activeTab === 'code' && (

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
@@ -15,6 +15,7 @@ interface PublishState {
   // When false (e.g. a deployment without PUBLISH_BUCKET) the control is hidden
   // rather than offering a Publish button that only ever 503s.
   available: boolean;
+  isStale: boolean;
 }
 
 const readError = async (res: Response): Promise<string> => {
@@ -27,7 +28,7 @@ const readError = async (res: Response): Promise<string> => {
 };
 
 const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
-  const [state, setState] = useState<PublishState>({ published: false, url: null, available: false });
+  const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false });
   const [isLoading, setIsLoading] = useState(true);
   const [isBusy, setIsBusy] = useState(false);
 
@@ -38,19 +39,20 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
       try {
         const res = await fetchWithAuth(`/api/pages/${pageId}/publish`);
         if (!res.ok) {
-          if (!cancelled) setState({ published: false, url: null, available: false });
+          if (!cancelled) setState({ published: false, url: null, available: false, isStale: false });
           return;
         }
-        const data = (await res.json()) as { published: boolean; url?: string; available?: boolean };
+        const data = (await res.json()) as { published: boolean; url?: string; available?: boolean; isStale?: boolean };
         if (!cancelled) {
           setState({
             published: data.published,
             url: data.published ? data.url ?? null : null,
             available: data.available ?? false,
+            isStale: data.isStale ?? false,
           });
         }
       } catch {
-        if (!cancelled) setState({ published: false, url: null, available: false });
+        if (!cancelled) setState({ published: false, url: null, available: false, isStale: false });
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -69,7 +71,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
         return;
       }
       const data = (await res.json()) as { url: string };
-      setState({ published: true, url: data.url, available: true });
+      setState({ published: true, url: data.url, available: true, isStale: false });
       toast.success('Page published');
     } catch {
       toast.error('Failed to publish page');
@@ -138,7 +140,21 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
       >
         {state.url}
       </a>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {state.isStale && (
+          <>
+            <span className="px-2 py-0.5 text-xs rounded-full bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400 whitespace-nowrap">
+              Stale
+            </span>
+            <button
+              className="px-2 py-2 text-sm whitespace-nowrap disabled:opacity-50"
+              onClick={handlePublish}
+              disabled={isBusy}
+            >
+              {isBusy ? 'Updating…' : 'Update'}
+            </button>
+          </>
+        )}
         <button className="px-2 py-2 text-sm whitespace-nowrap" onClick={handleCopy}>
           Copy link
         </button>

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
@@ -62,7 +62,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
     };
   }, [pageId]);
 
-  const handlePublish = useCallback(async () => {
+  const handlePublish = useCallback(async (isUpdate = false) => {
     setIsBusy(true);
     try {
       const res = await fetchWithAuth(`/api/pages/${pageId}/publish`, { method: 'POST' });
@@ -72,7 +72,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
       }
       const data = (await res.json()) as { url: string };
       setState({ published: true, url: data.url, available: true, isStale: false });
-      toast.success('Page published');
+      toast.success(isUpdate ? 'Page updated' : 'Page published');
     } catch {
       toast.error('Failed to publish page');
     } finally {
@@ -88,7 +88,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
         toast.error(await readError(res));
         return;
       }
-      setState((prev) => ({ ...prev, published: false, url: null }));
+      setState((prev) => ({ ...prev, published: false, url: null, isStale: false }));
       toast.success('Page unpublished');
     } catch {
       toast.error('Failed to unpublish page');
@@ -121,7 +121,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
     return (
       <button
         className="px-4 py-2 text-sm disabled:opacity-50"
-        onClick={handlePublish}
+        onClick={() => handlePublish()}
         disabled={isBusy}
       >
         {isBusy ? 'Publishing…' : 'Publish'}
@@ -148,7 +148,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
             </span>
             <button
               className="px-2 py-2 text-sm whitespace-nowrap disabled:opacity-50"
-              onClick={handlePublish}
+              onClick={() => handlePublish(true)}
               disabled={isBusy}
             >
               {isBusy ? 'Updating…' : 'Update'}

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 interface CanvasPublishControlsProps {
   pageId: string;
+  /** Mirrors the canvas document's isDirty flag. When it transitions true→false
+   *  (a save just completed) and the page is published, the control marks itself
+   *  stale so the user sees the Update button without a page reload. */
+  contentDirty?: boolean;
 }
 
 interface PublishState {
@@ -27,10 +31,11 @@ const readError = async (res: Response): Promise<string> => {
   }
 };
 
-const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
+const CanvasPublishControls = ({ pageId, contentDirty }: CanvasPublishControlsProps) => {
   const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false });
   const [isLoading, setIsLoading] = useState(true);
   const [isBusy, setIsBusy] = useState(false);
+  const prevDirtyRef = useRef<boolean | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
@@ -61,6 +66,15 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
       cancelled = true;
     };
   }, [pageId]);
+
+  // When a save completes (dirty → clean), mark the published version as stale
+  // so the Update button appears without requiring a page reload.
+  useEffect(() => {
+    if (prevDirtyRef.current === true && contentDirty === false) {
+      setState(prev => prev.published ? { ...prev, isStale: true } : prev);
+    }
+    prevDirtyRef.current = contentDirty;
+  }, [contentDirty]);
 
   const handlePublish = useCallback(async (isUpdate = false) => {
     setIsBusy(true);


### PR DESCRIPTION
## Summary

- **GET `/api/pages/[pageId]/publish`** returns `isStale: boolean` — true when the live page's `updatedAt` is newer than the last publish timestamp (`updatedAt ?? publishedAt` on the `published_pages` row, so legacy rows without `updatedAt` fall back correctly)
- **POST** fix: `updatedAt` is advanced in a separate UPDATE *after* `putPublishedArtifact` succeeds, so a failed upload can never falsely clear the stale indicator on the next GET; initial insert still sets `updatedAt` so new rows are never null
- **`CanvasPublishControls`** shows a yellow "Stale" pill + "Update" button when the published version is behind; clicking Update says "Page updated" (not "Page published"); button group gains `flex-wrap` for narrow screens
- **Save-triggered stale detection**: `contentDirty` prop wires `CanvasPageView.isDirty` into the controls — when it transitions `true→false` (save complete) while published, the stale badge appears immediately without a page reload

## Test plan

- [ ] Publish a canvas — no Stale badge visible
- [ ] Edit and save the canvas in the same view — Stale badge appears without reload
- [ ] Click Update — badge clears, toast says "Page updated", published site reflects changes
- [ ] Unpublish → republish — no Stale badge immediately after
- [ ] Simulate a failed S3 upload — verify `updatedAt` is not advanced (test coverage added)
- [ ] `bun run test:unit` — 23 publish route tests pass
- [ ] `bun run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)