### PR TITLE
fix(logging): normalize LOG_DESTINATION=stdout to console

### DIFF
--- a/packages/lib/src/logging/logger.ts
+++ b/packages/lib/src/logging/logger.ts
@@ -78,9 +78,12 @@ class Logger {
   private startTime: number = Date.now();
 
   private constructor(config: Partial<LoggerConfig> = {}) {
-    const configuredDestination = (process.env.LOG_DESTINATION || '').trim();
-    const destination = (configuredDestination as 'console' | 'database' | 'both') ||
-      (process.env.MONITORING_INGEST_KEY ? 'both' : 'console');
+    const rawDestination = (process.env.LOG_DESTINATION || '').trim().toLowerCase();
+    // 'stdout' is an alias for 'console' (Fly/Docker convention)
+    const normalizedDestination = rawDestination === 'stdout' || rawDestination === 'stderr' ? 'console' : rawDestination;
+    const destination = (['console', 'database', 'both'].includes(normalizedDestination)
+      ? normalizedDestination
+      : (process.env.MONITORING_INGEST_KEY ? 'both' : 'console')) as 'console' | 'database' | 'both';
 
     this.config = {
       level: this.parseLogLevel(process.env.LOG_LEVEL || 'info'),


### PR DESCRIPTION
## Summary
- Fly/Docker deployments conventionally set `LOG_DESTINATION=stdout` or `stderr`, but the logger only accepted `'console'`/`'database'`/`'both'` as valid values
- Any other value (including `stdout`) silently fell through to buffering — logs were never written and `fly logs` showed nothing
- Normalizes `stdout`/`stderr` → `console` before the validity check

## Why this matters
This was masking all application errors in the admin Fly deployment. The `pagespace-admin` Fly app sets `LOG_DESTINATION=stdout`, so zero logs were surfacing — including the errors that led to the AI billing and unit economics pages appearing broken.

## Test plan
- [ ] `fly logs -a pagespace-admin` shows structured JSON log output after deploy
- [ ] No change in behavior when `LOG_DESTINATION=console`, `database`, or `both`

🤖 Generated with [Claude Code](https://claude.com/claude-code)