### PR TITLE
feat(api): client-managed conversations API + tool call persistence

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -677,4 +677,36 @@ describe('POST /api/v1/chat/completions', () => {
       expected: { toolCalls: undefined, toolResults: undefined },
     });
   });
+
+  test('tool call persistence: saves tool-only turn when no text but steps have tool calls', async () => {
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      totalUsage: Promise.resolve({ inputTokens: 5, outputTokens: 3 }),
+      steps: Promise.resolve([
+        {
+          toolCalls: [{ toolCallId: 'call-only', toolName: 'create_page', input: { title: 'New' } }],
+          toolResults: [{ toolCallId: 'call-only', toolName: 'create_page', output: { id: 'p-2' } }],
+        },
+      ]),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        // No text-delta — tool-only turn
+        yield { type: 'finish' };
+      },
+    })) as unknown as typeof streamText);
+
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
+    await response.text();
+
+    const saveCalls = vi.mocked(saveMessageToDatabase).mock.calls;
+    const assistantSave = saveCalls.find((c) => c[0].role === 'assistant');
+    assert({
+      given: 'a tool-only turn with no text output but steps containing tool calls',
+      should: 'save the assistant message with tool calls persisted',
+      actual: {
+        saved: assistantSave !== undefined,
+        hasToolCalls: Array.isArray(assistantSave?.[0]?.toolCalls) && (assistantSave![0].toolCalls as unknown[]).length > 0,
+      },
+      expected: { saved: true, hasToolCalls: true },
+    });
+  });
 });

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -14,13 +14,29 @@ vi.mock('@pagespace/db/db', () => ({
   db: {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockResolvedValue([]),
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([]),
+        }),
       }),
     }),
     insert: vi.fn().mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
     query: {
       chatMessages: { findMany: vi.fn().mockResolvedValue([]) },
     },
+  },
+}));
+
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    getConversation: vi.fn().mockResolvedValue({
+      id: 'conv-abc',
+      userId: 'user-1',
+      isActive: true,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }),
   },
 }));
 
@@ -130,9 +146,10 @@ import { db } from '@pagespace/db/db';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
-import { sanitizeMessagesForModel, extractMessageContent } from '@/lib/ai/core';
+import { sanitizeMessagesForModel, extractMessageContent, saveMessageToDatabase } from '@/lib/ai/core';
 import type { UIMessage } from 'ai';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const mcpAuth = {
   userId: 'user-1',
@@ -554,6 +571,110 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'pass an already-aborted abortSignal to streamText so no tokens are burned',
       actual: capturedSignalAborted,
       expected: true,
+    });
+  });
+
+  test('conversation ownership: returns 404 when conversation_id points to a non-existent conversation', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce(null);
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'no-such-conv' }));
+    assert({
+      given: 'a conversation_id that has no matching conversations row',
+      should: 'return 404 before starting inference',
+      actual: response.status,
+      expected: 404,
+    });
+  });
+
+  test('conversation ownership: returns 403 when conversation belongs to a different user', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce({
+      id: 'conv-other',
+      userId: 'other-user',
+      isActive: true,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isShared: false,
+      type: 'client',
+      lastMessageAt: null,
+    });
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-other' }));
+    assert({
+      given: 'a conversation_id belonging to a different user',
+      should: 'return 403 before starting inference',
+      actual: response.status,
+      expected: 403,
+    });
+  });
+
+  test('conversation ownership: proceeds when conversation_id is absent', async () => {
+    const response = await POST(makeRequest(validBody));
+    assert({
+      given: 'a request with no conversation_id',
+      should: 'skip the ownership check and return 200',
+      actual: response.status,
+      expected: 200,
+    });
+  });
+
+  test('tool call persistence: saves tool calls and results from steps with assistant message', async () => {
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      totalUsage: Promise.resolve({ inputTokens: 5, outputTokens: 10 }),
+      steps: Promise.resolve([
+        {
+          toolCalls: [{ toolCallId: 'call-1', toolName: 'read_page', input: { pageId: 'p-1' } }],
+          toolResults: [{ toolCallId: 'call-1', toolName: 'read_page', output: 'page content' }],
+        },
+      ]),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        yield { type: 'text-delta', id: 't1', delta: 'Result text' };
+        yield { type: 'finish' };
+      },
+    })) as unknown as typeof streamText);
+
+    const response = await POST(makeRequest(validBody));
+    await response.text();
+
+    const saveCalls = vi.mocked(saveMessageToDatabase).mock.calls;
+    const assistantSave = saveCalls.find((c) => c[0].role === 'assistant');
+    assert({
+      given: 'a stream with a step containing tool calls and results',
+      should: 'save the assistant message with toolCalls and toolResults populated',
+      actual: {
+        hasToolCalls: Array.isArray(assistantSave?.[0]?.toolCalls) && (assistantSave![0].toolCalls as unknown[]).length > 0,
+        hasToolResults: Array.isArray(assistantSave?.[0]?.toolResults) && (assistantSave![0].toolResults as unknown[]).length > 0,
+      },
+      expected: { hasToolCalls: true, hasToolResults: true },
+    });
+  });
+
+  test('tool call persistence: no tool calls in steps means no toolCalls persisted', async () => {
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      totalUsage: Promise.resolve({ inputTokens: 5, outputTokens: 10 }),
+      steps: Promise.resolve([
+        { toolCalls: [], toolResults: [] },
+      ]),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        yield { type: 'text-delta', id: 't1', delta: 'Just text' };
+        yield { type: 'finish' };
+      },
+    })) as unknown as typeof streamText);
+
+    const response = await POST(makeRequest(validBody));
+    await response.text();
+
+    const saveCalls = vi.mocked(saveMessageToDatabase).mock.calls;
+    const assistantSave = saveCalls.find((c) => c[0].role === 'assistant');
+    assert({
+      given: 'a stream with steps but no tool calls',
+      should: 'save the assistant message without toolCalls or toolResults',
+      actual: {
+        toolCalls: assistantSave?.[0]?.toolCalls,
+        toolResults: assistantSave?.[0]?.toolResults,
+      },
+      expected: { toolCalls: undefined, toolResults: undefined },
     });
   });
 });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -33,6 +33,9 @@ import { chatMessageRepository } from '@/lib/repositories/chat-message-repositor
 import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference-request';
 import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
 import { buildToolSummaryEvent } from '@/lib/ai/openai-api/build-tool-summary-event';
+import { validateConversationAccess } from '@/lib/ai/openai-api/v1-conversations';
+import { extractToolCallsFromSteps } from '@/lib/ai/openai-api/extract-tool-calls-from-steps';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
@@ -98,6 +101,17 @@ export async function POST(request: Request): Promise<Response> {
   if (!canEdit) {
     auditRequest(request, { eventType: 'authz.access.denied', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: 'no_edit_permission', method: 'POST' }, riskScore: 0.5 });
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+
+  // 5b. Conversation ownership check — if a conversation_id is provided the caller
+  // must own the conversations row. This prevents one user from appending messages
+  // into another user's thread.
+  if (incomingConversationId) {
+    const conv = await conversationRepository.getConversation(incomingConversationId);
+    const convAccess = validateConversationAccess(conv, authResult.userId);
+    if (!convAccess.ok) {
+      return NextResponse.json({ error: convAccess.message }, { status: convAccess.status });
+    }
   }
 
   // 6. Create AI provider from agent page config
@@ -229,14 +243,17 @@ export async function POST(request: Request): Promise<Response> {
     settled = true;
 
     const assistantId = createId();
-    if (text) {
+    if (text !== undefined) {
+      const extracted = extractToolCallsFromSteps(steps ?? []);
       await saveMessageToDatabase({
         messageId: assistantId,
         pageId,
         conversationId,
         userId: null,
         role: 'assistant',
-        content: text,
+        content: text || '',
+        toolCalls: extracted.toolCalls.length > 0 ? extracted.toolCalls : undefined,
+        toolResults: extracted.toolResults.length > 0 ? extracted.toolResults : undefined,
       }).catch((err: unknown) => {
         loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
       });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -243,15 +243,16 @@ export async function POST(request: Request): Promise<Response> {
     settled = true;
 
     const assistantId = createId();
-    if (text !== undefined) {
-      const extracted = extractToolCallsFromSteps(steps ?? []);
+    const extracted = extractToolCallsFromSteps(steps ?? []);
+    const hasContent = text !== undefined || extracted.toolCalls.length > 0;
+    if (hasContent) {
       await saveMessageToDatabase({
         messageId: assistantId,
         pageId,
         conversationId,
         userId: null,
         role: 'assistant',
-        content: text || '',
+        content: text ?? '',
         toolCalls: extracted.toolCalls.length > 0 ? extracted.toolCalls : undefined,
         toolResults: extracted.toolResults.length > 0 ? extracted.toolResults : undefined,
       }).catch((err: unknown) => {

--- a/apps/web/src/app/api/v1/conversations/[id]/route.ts
+++ b/apps/web/src/app/api/v1/conversations/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { conversations } from '@pagespace/db/schema/conversations';
+import { chatMessages } from '@pagespace/db/schema/core';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+} from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
+import {
+  validateConversationAccess,
+  serializeMessageToOpenAI,
+} from '@/lib/ai/openai-api/v1-conversations';
+
+const AUTH_OPTIONS = { allow: ['mcp'] as const, requireCSRF: false };
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, context: RouteContext): Promise<Response> {
+  const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(authResult)) return authResult.error;
+
+  const { id } = await context.params;
+
+  const conversation = await conversationRepository.getConversation(id);
+  const access = validateConversationAccess(conversation, authResult.userId);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.message }, { status: access.status });
+  }
+
+  const messages = await chatMessageRepository.getMessagesByConversationId(id);
+
+  auditRequest(request, { eventType: 'data.read', userId: authResult.userId, resourceType: 'conversation', resourceId: id, details: {}, riskScore: 0 });
+
+  return NextResponse.json({
+    id,
+    object: 'conversation',
+    created_at: Math.floor(conversation!.createdAt.getTime() / 1000),
+    user_id: conversation!.userId,
+    title: conversation!.title,
+    drive_id: conversation!.contextId,
+    messages: messages.filter((m) => m.isActive).map(serializeMessageToOpenAI),
+  });
+}
+
+export async function DELETE(request: Request, context: RouteContext): Promise<Response> {
+  const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(authResult)) return authResult.error;
+
+  const { id } = await context.params;
+
+  const conversation = await conversationRepository.getConversation(id);
+  const access = validateConversationAccess(conversation, authResult.userId);
+  if (!access.ok) {
+    return NextResponse.json({ error: access.message }, { status: access.status });
+  }
+
+  await db
+    .update(conversations)
+    .set({ isActive: false, updatedAt: new Date() })
+    .where(eq(conversations.id, id));
+
+  await db
+    .update(chatMessages)
+    .set({ isActive: false })
+    .where(and(eq(chatMessages.conversationId, id), eq(chatMessages.isActive, true)));
+
+  auditRequest(request, { eventType: 'data.delete', userId: authResult.userId, resourceType: 'conversation', resourceId: id, details: {}, riskScore: 0 });
+
+  return NextResponse.json({ id, deleted: true });
+}

--- a/apps/web/src/app/api/v1/conversations/[id]/route.ts
+++ b/apps/web/src/app/api/v1/conversations/[id]/route.ts
@@ -6,6 +6,7 @@ import { chatMessages } from '@pagespace/db/schema/core';
 import {
   authenticateRequestWithOptions,
   isAuthError,
+  getAllowedDriveIds,
 } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
@@ -29,6 +30,14 @@ export async function GET(request: Request, context: RouteContext): Promise<Resp
   const access = validateConversationAccess(conversation, authResult.userId);
   if (!access.ok) {
     return NextResponse.json({ error: access.message }, { status: access.status });
+  }
+
+  const allowedDriveIds = getAllowedDriveIds(authResult);
+  if (allowedDriveIds.length > 0) {
+    const contextId = conversation!.contextId;
+    if (contextId === null || !allowedDriveIds.includes(contextId)) {
+      return NextResponse.json({ error: 'Conversation not accessible with this token' }, { status: 403 });
+    }
   }
 
   const messages = await chatMessageRepository.getMessagesByConversationId(id);
@@ -56,6 +65,14 @@ export async function DELETE(request: Request, context: RouteContext): Promise<R
   const access = validateConversationAccess(conversation, authResult.userId);
   if (!access.ok) {
     return NextResponse.json({ error: access.message }, { status: access.status });
+  }
+
+  const allowedDriveIds = getAllowedDriveIds(authResult);
+  if (allowedDriveIds.length > 0) {
+    const contextId = conversation!.contextId;
+    if (contextId === null || !allowedDriveIds.includes(contextId)) {
+      return NextResponse.json({ error: 'Conversation not accessible with this token' }, { status: 403 });
+    }
   }
 
   await db

--- a/apps/web/src/app/api/v1/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/conversations/__tests__/route.test.ts
@@ -1,0 +1,466 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { assert } from '@/lib/ai/openai-api/__tests__/riteway';
+
+// --- module mocks (hoisted before imports) ---
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
+  getAllowedDriveIds: vi.fn(() => []),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_col, val) => ({ __eq: val })),
+  and: vi.fn((...args) => ({ __and: args })),
+  desc: vi.fn((col) => ({ __desc: col })),
+}));
+
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: {
+    id: 'conversations.id',
+    userId: 'conversations.userId',
+    isActive: 'conversations.isActive',
+    contextId: 'conversations.contextId',
+    updatedAt: 'conversations.updatedAt',
+  },
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  chatMessages: {
+    id: 'chatMessages.id',
+    conversationId: 'chatMessages.conversationId',
+    isActive: 'chatMessages.isActive',
+    createdAt: 'chatMessages.createdAt',
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn().mockReturnValue('new-cuid-123'),
+}));
+
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    getConversation: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('@/lib/repositories/chat-message-repository', () => ({
+  chatMessageRepository: {
+    getMessagesByConversationId: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+// --- imports after mocks ---
+import { NextResponse } from 'next/server';
+import { POST, GET } from '../route';
+import { GET as getById, DELETE } from '../[id]/route';
+import { authenticateRequestWithOptions, getAllowedDriveIds } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
+
+const mcpAuth = {
+  userId: 'user-1',
+  tokenType: 'mcp' as const,
+  tokenId: 'token-1',
+  allowedDriveIds: [],
+  role: 'user' as const,
+  tokenVersion: 1,
+  adminRoleVersion: 0,
+};
+
+const makePostRequest = (body: unknown) =>
+  new Request('http://localhost/api/v1/conversations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer mcp_test123' },
+    body: JSON.stringify(body),
+  });
+
+const makeGetRequest = (path = 'http://localhost/api/v1/conversations') =>
+  new Request(path, {
+    method: 'GET',
+    headers: { Authorization: 'Bearer mcp_test123' },
+  });
+
+const makeDeleteRequest = () =>
+  new Request('http://localhost/api/v1/conversations/conv-1', {
+    method: 'DELETE',
+    headers: { Authorization: 'Bearer mcp_test123' },
+  });
+
+const existingConversation = {
+  id: 'conv-1',
+  userId: 'user-1',
+  isActive: true,
+  title: 'Test Chat',
+  contextId: null,
+  type: 'client',
+  createdAt: new Date('2024-01-15T10:00:00.000Z'),
+  updatedAt: new Date('2024-01-15T10:00:00.000Z'),
+  isShared: false,
+  lastMessageAt: null,
+};
+
+describe('POST /api/v1/conversations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
+  });
+
+  test('returns 401 when auth fails', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+    const response = await POST(makePostRequest({}));
+    assert({
+      given: 'a request with no valid MCP token',
+      should: 'return 401',
+      actual: response.status,
+      expected: 401,
+    });
+  });
+
+  test('returns 400 on invalid JSON', async () => {
+    const request = new Request('http://localhost/api/v1/conversations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer mcp_test123' },
+      body: 'not json{',
+    });
+    const response = await POST(request);
+    assert({
+      given: 'a request with malformed JSON body',
+      should: 'return 400',
+      actual: response.status,
+      expected: 400,
+    });
+  });
+
+  test('returns 403 when drive_id is outside MCP token scope', async () => {
+    vi.mocked(getAllowedDriveIds).mockReturnValue(['drive-allowed']);
+    const response = await POST(makePostRequest({ drive_id: 'drive-other' }));
+    assert({
+      given: 'a drive_id not in the MCP token\'s scoped drives',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
+    });
+  });
+
+  test('returns 201 with minimal body (no drive_id, no title)', async () => {
+    const response = await POST(makePostRequest({}));
+    const body = await response.json() as Record<string, unknown>;
+    assert({
+      given: 'a valid empty body',
+      should: 'return 201 with id and object:conversation',
+      actual: { status: response.status, id: body.id, object: body.object },
+      expected: { status: 201, id: 'new-cuid-123', object: 'conversation' },
+    });
+  });
+
+  test('returns 201 with title in the response', async () => {
+    const response = await POST(makePostRequest({ title: 'My Conversation' }));
+    const body = await response.json() as Record<string, unknown>;
+    assert({
+      given: 'a body with a title',
+      should: 'return 201 with the title in the response',
+      actual: { status: response.status, title: body.title },
+      expected: { status: 201, title: 'My Conversation' },
+    });
+  });
+
+  test('returns 201 with drive_id set on unscoped token', async () => {
+    const response = await POST(makePostRequest({ drive_id: 'drive-xyz' }));
+    const body = await response.json() as Record<string, unknown>;
+    assert({
+      given: 'a body with drive_id on an unscoped token',
+      should: 'return 201 with drive_id in the response',
+      actual: { status: response.status, drive_id: body.drive_id },
+      expected: { status: 201, drive_id: 'drive-xyz' },
+    });
+  });
+
+  test('inserts a conversations row', async () => {
+    const insertValues = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(db.insert).mockReturnValue({ values: insertValues } as unknown as ReturnType<typeof db.insert>);
+    await POST(makePostRequest({}));
+    assert({
+      given: 'a valid create request',
+      should: 'call db.insert once',
+      actual: vi.mocked(db.insert).mock.calls.length,
+      expected: 1,
+    });
+  });
+});
+
+describe('GET /api/v1/conversations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof db.select>);
+  });
+
+  test('returns 401 when auth fails', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+    const response = await GET(makeGetRequest());
+    assert({
+      given: 'no valid MCP token',
+      should: 'return 401',
+      actual: response.status,
+      expected: 401,
+    });
+  });
+
+  test('returns 400 with invalid limit', async () => {
+    const response = await GET(makeGetRequest('http://localhost/api/v1/conversations?limit=999'));
+    assert({
+      given: 'limit=999 (over the max of 100)',
+      should: 'return 400',
+      actual: response.status,
+      expected: 400,
+    });
+  });
+
+  test('returns 200 with object:list and data array', async () => {
+    const response = await GET(makeGetRequest());
+    const body = await response.json() as Record<string, unknown>;
+    assert({
+      given: 'a valid list request with no results',
+      should: 'return 200 with object:list and empty data array',
+      actual: { status: response.status, object: body.object, isArray: Array.isArray(body.data) },
+      expected: { status: 200, object: 'list', isArray: true },
+    });
+  });
+
+  test('returns conversations with correct shape', async () => {
+    const convDate = new Date('2024-01-15T10:00:00.000Z');
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            limit: vi.fn().mockReturnValue({
+              offset: vi.fn().mockResolvedValue([existingConversation]),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof db.select>);
+    const response = await GET(makeGetRequest());
+    const body = await response.json() as { data: Array<Record<string, unknown>> };
+    const first = body.data[0];
+    assert({
+      given: 'a list response with one conversation',
+      should: 'serialize the conversation to the OpenAI-shaped format',
+      actual: { id: first?.id, object: first?.object, userId: first?.user_id },
+      expected: { id: 'conv-1', object: 'conversation', userId: 'user-1' },
+    });
+  });
+});
+
+describe('GET /api/v1/conversations/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(null);
+    vi.mocked(chatMessageRepository.getMessagesByConversationId).mockResolvedValue([]);
+  });
+
+  test('returns 401 when auth fails', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+    const response = await getById(makeGetRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'no valid MCP token',
+      should: 'return 401',
+      actual: response.status,
+      expected: 401,
+    });
+  });
+
+  test('returns 404 when conversation does not exist', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(null);
+    const response = await getById(makeGetRequest(), { params: Promise.resolve({ id: 'no-such-conv' }) });
+    assert({
+      given: 'an id that has no matching conversation row',
+      should: 'return 404',
+      actual: response.status,
+      expected: 404,
+    });
+  });
+
+  test('returns 403 when conversation belongs to a different user', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue({
+      ...existingConversation,
+      userId: 'other-user',
+    });
+    const response = await getById(makeGetRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'a conversation owned by a different user',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
+    });
+  });
+
+  test('returns 200 with conversation and messages array', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(existingConversation);
+    vi.mocked(chatMessageRepository.getMessagesByConversationId).mockResolvedValue([
+      {
+        id: 'msg-1',
+        pageId: 'page-1',
+        conversationId: 'conv-1',
+        userId: 'user-1',
+        role: 'user',
+        content: 'Hello',
+        messageType: 'standard' as const,
+        isActive: true,
+        createdAt: new Date('2024-01-15T10:00:00.000Z'),
+        editedAt: null,
+        toolCalls: null,
+        toolResults: null,
+      },
+    ]);
+    const response = await getById(makeGetRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    const body = await response.json() as Record<string, unknown>;
+    assert({
+      given: 'an owned conversation with one message',
+      should: 'return 200 with the conversation and its messages',
+      actual: {
+        status: response.status,
+        id: body.id,
+        hasMessages: Array.isArray(body.messages) && (body.messages as unknown[]).length === 1,
+      },
+      expected: { status: 200, id: 'conv-1', hasMessages: true },
+    });
+  });
+
+  test('returns 200 with empty messages array when no messages exist', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(existingConversation);
+    vi.mocked(chatMessageRepository.getMessagesByConversationId).mockResolvedValue([]);
+    const response = await getById(makeGetRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    const body = await response.json() as Record<string, unknown>;
+    assert({
+      given: 'an owned conversation with no messages',
+      should: 'return 200 with an empty messages array',
+      actual: { status: response.status, messages: body.messages },
+      expected: { status: 200, messages: [] },
+    });
+  });
+});
+
+describe('DELETE /api/v1/conversations/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(null);
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    } as unknown as ReturnType<typeof db.update>);
+  });
+
+  test('returns 401 when auth fails', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+    const response = await DELETE(makeDeleteRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'no valid MCP token',
+      should: 'return 401',
+      actual: response.status,
+      expected: 401,
+    });
+  });
+
+  test('returns 404 when conversation does not exist', async () => {
+    const response = await DELETE(makeDeleteRequest(), { params: Promise.resolve({ id: 'no-conv' }) });
+    assert({
+      given: 'a delete for a non-existent conversation',
+      should: 'return 404',
+      actual: response.status,
+      expected: 404,
+    });
+  });
+
+  test('returns 403 when conversation belongs to a different user', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue({
+      ...existingConversation,
+      userId: 'other-user',
+    });
+    const response = await DELETE(makeDeleteRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'a delete attempt on another user\'s conversation',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
+    });
+  });
+
+  test('returns 200 on successful soft delete', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(existingConversation);
+    const response = await DELETE(makeDeleteRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'a valid delete of an owned conversation',
+      should: 'return 200 with the deleted conversation id',
+      actual: response.status,
+      expected: 200,
+    });
+  });
+
+  test('soft delete calls db.update for the conversations table', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue(existingConversation);
+    await DELETE(makeDeleteRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'a successful delete',
+      should: 'call db.update at least once (to soft-delete the conversations row)',
+      actual: vi.mocked(db.update).mock.calls.length >= 1,
+      expected: true,
+    });
+  });
+});

--- a/apps/web/src/app/api/v1/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/conversations/__tests__/route.test.ts
@@ -37,6 +37,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_col, val) => ({ __eq: val })),
   and: vi.fn((...args) => ({ __and: args })),
   desc: vi.fn((col) => ({ __desc: col })),
+  inArray: vi.fn((_col, vals) => ({ __inArray: vals })),
 }));
 
 vi.mock('@pagespace/db/schema/conversations', () => ({
@@ -229,6 +230,7 @@ describe('GET /api/v1/conversations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -277,7 +279,6 @@ describe('GET /api/v1/conversations', () => {
   });
 
   test('returns conversations with correct shape', async () => {
-    const convDate = new Date('2024-01-15T10:00:00.000Z');
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -299,12 +300,24 @@ describe('GET /api/v1/conversations', () => {
       expected: { id: 'conv-1', object: 'conversation', userId: 'user-1' },
     });
   });
+
+  test('returns 403 when scoped token requests a drive outside its allowed drives', async () => {
+    vi.mocked(getAllowedDriveIds).mockReturnValue(['drive-allowed']);
+    const response = await GET(makeGetRequest('http://localhost/api/v1/conversations?drive_id=drive-other'));
+    assert({
+      given: 'a scoped MCP token with drive_id outside its allowed drives',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
+    });
+  });
 });
 
 describe('GET /api/v1/conversations/[id]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
     vi.mocked(conversationRepository.getConversation).mockResolvedValue(null);
     vi.mocked(chatMessageRepository.getMessagesByConversationId).mockResolvedValue([]);
   });
@@ -391,12 +404,28 @@ describe('GET /api/v1/conversations/[id]', () => {
       expected: { status: 200, messages: [] },
     });
   });
+
+  test('returns 403 when scoped token accesses conversation outside its allowed drives', async () => {
+    vi.mocked(getAllowedDriveIds).mockReturnValue(['drive-allowed']);
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue({
+      ...existingConversation,
+      contextId: 'drive-other',
+    });
+    const response = await getById(makeGetRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'a scoped MCP token reading a conversation tied to a different drive',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
+    });
+  });
 });
 
 describe('DELETE /api/v1/conversations/[id]', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
     vi.mocked(conversationRepository.getConversation).mockResolvedValue(null);
     vi.mocked(db.update).mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -461,6 +490,21 @@ describe('DELETE /api/v1/conversations/[id]', () => {
       should: 'call db.update at least once (to soft-delete the conversations row)',
       actual: vi.mocked(db.update).mock.calls.length >= 1,
       expected: true,
+    });
+  });
+
+  test('returns 403 when scoped token deletes conversation outside its allowed drives', async () => {
+    vi.mocked(getAllowedDriveIds).mockReturnValue(['drive-allowed']);
+    vi.mocked(conversationRepository.getConversation).mockResolvedValue({
+      ...existingConversation,
+      contextId: 'drive-other',
+    });
+    const response = await DELETE(makeDeleteRequest(), { params: Promise.resolve({ id: 'conv-1' }) });
+    assert({
+      given: 'a scoped MCP token deleting a conversation tied to a different drive',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
     });
   });
 });

--- a/apps/web/src/app/api/v1/conversations/route.ts
+++ b/apps/web/src/app/api/v1/conversations/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { eq, and, desc } from '@pagespace/db/operators';
+import { conversations } from '@pagespace/db/schema/conversations';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  getAllowedDriveIds,
+} from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import {
+  buildCreateConversationPayload,
+  buildConversationListQuery,
+} from '@/lib/ai/openai-api/v1-conversations';
+
+const AUTH_OPTIONS = { allow: ['mcp'] as const, requireCSRF: false };
+
+export async function POST(request: Request): Promise<Response> {
+  const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(authResult)) return authResult.error;
+
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const allowedDriveIds = getAllowedDriveIds(authResult);
+  const id = createId();
+  const result = buildCreateConversationPayload(rawBody, authResult.userId, allowedDriveIds, id);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  await db.insert(conversations).values({
+    id: result.data.id,
+    userId: result.data.userId,
+    title: result.data.title,
+    type: result.data.type,
+    contextId: result.data.contextId,
+    updatedAt: result.data.updatedAt,
+  });
+
+  auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'conversation', resourceId: result.data.id, details: { action: 'create' }, riskScore: 0 });
+
+  return NextResponse.json(
+    {
+      id: result.data.id,
+      object: 'conversation',
+      created_at: Math.floor(Date.now() / 1000),
+      user_id: result.data.userId,
+      title: result.data.title,
+      drive_id: result.data.contextId,
+    },
+    { status: 201 },
+  );
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(authResult)) return authResult.error;
+
+  const url = new URL(request.url);
+  const queryResult = buildConversationListQuery(authResult.userId, url.searchParams);
+  if (!queryResult.ok) {
+    return NextResponse.json({ error: queryResult.error }, { status: queryResult.status });
+  }
+
+  const { userId, limit, offset, driveId } = queryResult.data;
+
+  const conditions = [eq(conversations.userId, userId), eq(conversations.isActive, true)];
+  if (driveId !== undefined) {
+    conditions.push(eq(conversations.contextId, driveId));
+  }
+
+  const rows = await db
+    .select()
+    .from(conversations)
+    .where(and(...conditions))
+    .orderBy(desc(conversations.updatedAt))
+    .limit(limit)
+    .offset(offset);
+
+  auditRequest(request, { eventType: 'data.read', userId: authResult.userId, resourceType: 'conversation', resourceId: 'list', details: { driveId: queryResult.data.driveId }, riskScore: 0 });
+
+  return NextResponse.json({
+    object: 'list',
+    data: rows.map((row) => ({
+      id: row.id,
+      object: 'conversation',
+      created_at: Math.floor(row.createdAt.getTime() / 1000),
+      user_id: row.userId,
+      title: row.title,
+      drive_id: row.contextId,
+    })),
+  });
+}

--- a/apps/web/src/app/api/v1/conversations/route.ts
+++ b/apps/web/src/app/api/v1/conversations/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
-import { eq, and, desc } from '@pagespace/db/operators';
+import { eq, and, desc, inArray } from '@pagespace/db/operators';
 import { conversations } from '@pagespace/db/schema/conversations';
 import {
   authenticateRequestWithOptions,
@@ -69,10 +69,18 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const { userId, limit, offset, driveId } = queryResult.data;
+  const allowedDriveIds = getAllowedDriveIds(authResult);
+
+  // Enforce MCP drive scope on listing
+  if (allowedDriveIds.length > 0 && driveId !== undefined && !allowedDriveIds.includes(driveId)) {
+    return NextResponse.json({ error: 'Drive not accessible with this token' }, { status: 403 });
+  }
 
   const conditions = [eq(conversations.userId, userId), eq(conversations.isActive, true)];
   if (driveId !== undefined) {
     conditions.push(eq(conversations.contextId, driveId));
+  } else if (allowedDriveIds.length > 0) {
+    conditions.push(inArray(conversations.contextId, allowedDriveIds));
   }
 
   const rows = await db

--- a/apps/web/src/lib/ai/openai-api/__tests__/extract-tool-calls-from-steps.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/extract-tool-calls-from-steps.test.ts
@@ -1,0 +1,129 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { extractToolCallsFromSteps } from '../extract-tool-calls-from-steps';
+
+const makeStep = (
+  toolCalls: Array<{ toolCallId: string; toolName: string; input: unknown }> = [],
+  toolResults: Array<{ toolCallId: string; toolName: string; output: unknown }> = [],
+) => ({ toolCalls, toolResults });
+
+describe('extractToolCallsFromSteps', () => {
+  test('empty steps returns empty arrays', () => {
+    const result = extractToolCallsFromSteps([]);
+    assert({
+      given: 'an empty steps array',
+      should: 'return empty toolCalls and toolResults arrays',
+      actual: result,
+      expected: { toolCalls: [], toolResults: [] },
+    });
+  });
+
+  test('step with no tool calls returns empty arrays', () => {
+    const result = extractToolCallsFromSteps([makeStep()]);
+    assert({
+      given: 'a step with no tool calls or results',
+      should: 'return empty arrays',
+      actual: result,
+      expected: { toolCalls: [], toolResults: [] },
+    });
+  });
+
+  test('step with tool calls and matching results collects both', () => {
+    const step = makeStep(
+      [{ toolCallId: 'call-1', toolName: 'read_page', input: { pageId: 'p-1' } }],
+      [{ toolCallId: 'call-1', toolName: 'read_page', output: 'page content' }],
+    );
+    const result = extractToolCallsFromSteps([step]);
+    assert({
+      given: 'a step with one tool call and matching result',
+      should: 'return one toolCall with state output-available and one toolResult',
+      actual: {
+        callCount: result.toolCalls.length,
+        resultCount: result.toolResults.length,
+        callState: result.toolCalls[0]?.state,
+        callId: result.toolCalls[0]?.toolCallId,
+        resultOutput: result.toolResults[0]?.output,
+      },
+      expected: {
+        callCount: 1,
+        resultCount: 1,
+        callState: 'output-available',
+        callId: 'call-1',
+        resultOutput: 'page content',
+      },
+    });
+  });
+
+  test('tool call without a result gets state input-available', () => {
+    const step = makeStep(
+      [{ toolCallId: 'call-orphan', toolName: 'create_page', input: { title: 'T' } }],
+      [],
+    );
+    const result = extractToolCallsFromSteps([step]);
+    assert({
+      given: 'a tool call with no matching result',
+      should: 'set state to input-available',
+      actual: result.toolCalls[0]?.state,
+      expected: 'input-available',
+    });
+  });
+
+  test('multiple steps all have their tool calls collected', () => {
+    const steps = [
+      makeStep(
+        [{ toolCallId: 'call-1', toolName: 'read_page', input: {} }],
+        [{ toolCallId: 'call-1', toolName: 'read_page', output: 'r1' }],
+      ),
+      makeStep(
+        [{ toolCallId: 'call-2', toolName: 'create_page', input: {} }],
+        [{ toolCallId: 'call-2', toolName: 'create_page', output: 'r2' }],
+      ),
+    ];
+    const result = extractToolCallsFromSteps(steps);
+    assert({
+      given: 'two steps each with one tool call and result',
+      should: 'return two toolCalls and two toolResults',
+      actual: { callCount: result.toolCalls.length, resultCount: result.toolResults.length },
+      expected: { callCount: 2, resultCount: 2 },
+    });
+  });
+
+  test('non-step-like elements in the array are ignored', () => {
+    const result = extractToolCallsFromSteps([null, undefined, 'string', 42, {}, { toolCalls: 'not-array', toolResults: [] }]);
+    assert({
+      given: 'an array with various non-step-like elements',
+      should: 'ignore them and return empty arrays',
+      actual: result,
+      expected: { toolCalls: [], toolResults: [] },
+    });
+  });
+
+  test('tool call input is preserved with correct type', () => {
+    const input = { pageId: 'p-1', title: 'My Page' };
+    const step = makeStep(
+      [{ toolCallId: 'call-1', toolName: 'update_page', input }],
+      [],
+    );
+    const result = extractToolCallsFromSteps([step]);
+    assert({
+      given: 'a tool call with a structured input object',
+      should: 'preserve the input object',
+      actual: result.toolCalls[0]?.input,
+      expected: input,
+    });
+  });
+
+  test('toolResult state is always output-available', () => {
+    const step = makeStep(
+      [{ toolCallId: 'c1', toolName: 'tool', input: {} }],
+      [{ toolCallId: 'c1', toolName: 'tool', output: 'out' }],
+    );
+    const result = extractToolCallsFromSteps([step]);
+    assert({
+      given: 'a completed tool invocation',
+      should: 'set the toolResult state to output-available',
+      actual: result.toolResults[0]?.state,
+      expected: 'output-available',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/__tests__/v1-conversations.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/v1-conversations.test.ts
@@ -1,0 +1,408 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import {
+  buildCreateConversationPayload,
+  buildConversationListQuery,
+  validateConversationAccess,
+  serializeMessageToOpenAI,
+  type ConversationRow,
+  type MessageRow,
+} from '../v1-conversations';
+
+const FIXED_DATE = new Date('2024-01-15T10:00:00.000Z');
+const FIXED_UNIX = Math.floor(FIXED_DATE.getTime() / 1000);
+
+// ─── buildCreateConversationPayload ───────────────────────────────────────────
+
+describe('buildCreateConversationPayload', () => {
+  test('null body returns 400', () => {
+    const result = buildCreateConversationPayload(null, 'user-1', [], 'id-1');
+    assert({
+      given: 'null as the body',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('non-object body returns 400', () => {
+    const result = buildCreateConversationPayload('a string', 'user-1', [], 'id-1');
+    assert({
+      given: 'a primitive string as the body',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('empty body creates conversation with defaults', () => {
+    const result = buildCreateConversationPayload({}, 'user-1', [], 'cuid-123');
+    assert({
+      given: 'an empty body object',
+      should: 'return ok:true with id, userId, null title, client type, null contextId',
+      actual: result.ok ? { id: result.data.id, userId: result.data.userId, title: result.data.title, type: result.data.type, contextId: result.data.contextId } : 'error',
+      expected: { id: 'cuid-123', userId: 'user-1', title: null, type: 'client', contextId: null },
+    });
+  });
+
+  test('body with title trims and preserves it', () => {
+    const result = buildCreateConversationPayload({ title: '  My Chat  ' }, 'user-1', [], 'id-1');
+    assert({
+      given: 'a body with a padded title',
+      should: 'return ok:true with the title trimmed',
+      actual: result.ok ? result.data.title : 'error',
+      expected: 'My Chat',
+    });
+  });
+
+  test('title trimming to empty string becomes null', () => {
+    const result = buildCreateConversationPayload({ title: '   ' }, 'user-1', [], 'id-1');
+    assert({
+      given: 'a title containing only whitespace',
+      should: 'set title to null',
+      actual: result.ok ? result.data.title : 'error',
+      expected: null,
+    });
+  });
+
+  test('title longer than 255 chars is truncated', () => {
+    const longTitle = 'a'.repeat(300);
+    const result = buildCreateConversationPayload({ title: longTitle }, 'user-1', [], 'id-1');
+    assert({
+      given: 'a title with 300 characters',
+      should: 'truncate to 255 characters',
+      actual: result.ok ? result.data.title?.length : 'error',
+      expected: 255,
+    });
+  });
+
+  test('non-string title returns 400', () => {
+    const result = buildCreateConversationPayload({ title: 42 }, 'user-1', [], 'id-1');
+    assert({
+      given: 'a numeric title',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('drive_id sets contextId', () => {
+    const result = buildCreateConversationPayload({ drive_id: 'drive-abc' }, 'user-1', [], 'id-1');
+    assert({
+      given: 'a body with drive_id and an unscoped token (empty allowedDriveIds)',
+      should: 'return ok:true with contextId set to the drive_id',
+      actual: result.ok ? result.data.contextId : 'error',
+      expected: 'drive-abc',
+    });
+  });
+
+  test('drive_id in allowedDriveIds is accepted', () => {
+    const result = buildCreateConversationPayload({ drive_id: 'drive-abc' }, 'user-1', ['drive-abc', 'drive-xyz'], 'id-1');
+    assert({
+      given: 'a drive_id that appears in the token\'s allowedDriveIds',
+      should: 'return ok:true',
+      actual: result.ok,
+      expected: true,
+    });
+  });
+
+  test('drive_id not in allowedDriveIds returns 403', () => {
+    const result = buildCreateConversationPayload({ drive_id: 'drive-other' }, 'user-1', ['drive-abc'], 'id-1');
+    assert({
+      given: 'a drive_id that is not in the scoped token\'s allowedDriveIds',
+      should: 'return ok:false with status 403',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 403 },
+    });
+  });
+
+  test('empty allowedDriveIds (unscoped token) allows any drive_id', () => {
+    const result = buildCreateConversationPayload({ drive_id: 'any-drive' }, 'user-1', [], 'id-1');
+    assert({
+      given: 'an unscoped token (empty allowedDriveIds array) with any drive_id',
+      should: 'return ok:true — unscoped tokens have access to all drives',
+      actual: result.ok,
+      expected: true,
+    });
+  });
+
+  test('empty string drive_id returns 400', () => {
+    const result = buildCreateConversationPayload({ drive_id: '' }, 'user-1', [], 'id-1');
+    assert({
+      given: 'an empty string drive_id',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('non-string drive_id returns 400', () => {
+    const result = buildCreateConversationPayload({ drive_id: 123 }, 'user-1', [], 'id-1');
+    assert({
+      given: 'a numeric drive_id',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+});
+
+// ─── buildConversationListQuery ───────────────────────────────────────────────
+
+describe('buildConversationListQuery', () => {
+  test('no params returns defaults', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams());
+    assert({
+      given: 'no query params',
+      should: 'return ok:true with limit:20, offset:0, driveId:undefined',
+      actual: result.ok ? result.data : 'error',
+      expected: { userId: 'user-1', limit: 20, offset: 0, driveId: undefined },
+    });
+  });
+
+  test('custom limit and offset are parsed', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('limit=10&offset=5'));
+    assert({
+      given: 'limit=10&offset=5',
+      should: 'return ok:true with limit:10 and offset:5',
+      actual: result.ok ? { limit: result.data.limit, offset: result.data.offset } : 'error',
+      expected: { limit: 10, offset: 5 },
+    });
+  });
+
+  test('limit over 100 returns 400', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('limit=101'));
+    assert({
+      given: 'limit=101',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('limit 0 returns 400', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('limit=0'));
+    assert({
+      given: 'limit=0',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('negative offset returns 400', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('offset=-1'));
+    assert({
+      given: 'offset=-1',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('non-numeric limit returns 400', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('limit=abc'));
+    assert({
+      given: 'limit=abc',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('drive_id param is forwarded as driveId', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('drive_id=drive-xyz'));
+    assert({
+      given: 'drive_id=drive-xyz',
+      should: 'return ok:true with driveId set',
+      actual: result.ok ? result.data.driveId : 'error',
+      expected: 'drive-xyz',
+    });
+  });
+
+  test('missing drive_id param yields undefined driveId', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('limit=5'));
+    assert({
+      given: 'no drive_id param',
+      should: 'return driveId as undefined',
+      actual: result.ok ? result.data.driveId : 'error',
+      expected: undefined,
+    });
+  });
+
+  test('limit exactly 100 is accepted', () => {
+    const result = buildConversationListQuery('user-1', new URLSearchParams('limit=100'));
+    assert({
+      given: 'limit=100',
+      should: 'return ok:true (boundary value)',
+      actual: result.ok,
+      expected: true,
+    });
+  });
+});
+
+// ─── validateConversationAccess ───────────────────────────────────────────────
+
+describe('validateConversationAccess', () => {
+  const makeConversation = (overrides: Partial<ConversationRow> = {}): ConversationRow => ({
+    id: 'conv-1',
+    userId: 'user-1',
+    isActive: true,
+    title: null,
+    contextId: null,
+    createdAt: FIXED_DATE,
+    updatedAt: FIXED_DATE,
+    ...overrides,
+  });
+
+  test('null conversation returns 404', () => {
+    const result = validateConversationAccess(null, 'user-1');
+    assert({
+      given: 'null conversation',
+      should: 'return ok:false with status 404',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 404 },
+    });
+  });
+
+  test('inactive conversation returns 404', () => {
+    const result = validateConversationAccess(makeConversation({ isActive: false }), 'user-1');
+    assert({
+      given: 'an inactive conversation (isActive:false)',
+      should: 'return ok:false with status 404',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 404 },
+    });
+  });
+
+  test('conversation belonging to a different user returns 403', () => {
+    const result = validateConversationAccess(makeConversation({ userId: 'other-user' }), 'user-1');
+    assert({
+      given: 'a conversation owned by a different user',
+      should: 'return ok:false with status 403',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 403 },
+    });
+  });
+
+  test('conversation owned by the requesting user returns ok:true', () => {
+    const result = validateConversationAccess(makeConversation({ userId: 'user-1' }), 'user-1');
+    assert({
+      given: 'an active conversation owned by the requesting user',
+      should: 'return ok:true',
+      actual: result.ok,
+      expected: true,
+    });
+  });
+});
+
+// ─── serializeMessageToOpenAI ─────────────────────────────────────────────────
+
+describe('serializeMessageToOpenAI', () => {
+  const makeRow = (overrides: Partial<MessageRow> = {}): MessageRow => ({
+    id: 'msg-1',
+    role: 'user',
+    content: 'Hello',
+    toolCalls: null,
+    toolResults: null,
+    createdAt: FIXED_DATE,
+    isActive: true,
+    ...overrides,
+  });
+
+  test('plain text user message serializes to OpenAI format', () => {
+    const result = serializeMessageToOpenAI(makeRow({ content: 'Hello' }));
+    assert({
+      given: 'a plain text user message',
+      should: 'return OpenAI message with role, content, and unix created_at',
+      actual: { role: result.role, content: result.content, created_at: result.created_at },
+      expected: { role: 'user', content: 'Hello', created_at: FIXED_UNIX },
+    });
+  });
+
+  test('structured content message extracts plain text', () => {
+    const structured = JSON.stringify({
+      textParts: ['Structured text'],
+      partsOrder: [{ index: 0, type: 'text' }],
+      originalContent: 'Structured text',
+    });
+    const result = serializeMessageToOpenAI(makeRow({ content: structured }));
+    assert({
+      given: 'a message with structured JSON content',
+      should: 'extract the text from originalContent',
+      actual: result.content,
+      expected: 'Structured text',
+    });
+  });
+
+  test('assistant message with tool calls includes tool_calls array', () => {
+    const toolCallsRaw = JSON.stringify([
+      { toolCallId: 'call-1', toolName: 'read_page', input: { pageId: 'p-1' }, state: 'output-available' },
+    ]);
+    const result = serializeMessageToOpenAI(makeRow({ role: 'assistant', content: '', toolCalls: toolCallsRaw }));
+    assert({
+      given: 'an assistant message with serialized tool calls',
+      should: 'include tool_calls in the output with the OpenAI function format',
+      actual: result.tool_calls?.[0],
+      expected: {
+        id: 'call-1',
+        type: 'function',
+        function: { name: 'read_page', arguments: '{"pageId":"p-1"}' },
+      },
+    });
+  });
+
+  test('message without tool calls has no tool_calls field', () => {
+    const result = serializeMessageToOpenAI(makeRow({ toolCalls: null }));
+    assert({
+      given: 'a message with no tool calls',
+      should: 'not include a tool_calls key in the output',
+      actual: 'tool_calls' in result,
+      expected: false,
+    });
+  });
+
+  test('tool calls stored as array (not JSON string) are handled', () => {
+    const toolCallsArray = [
+      { toolCallId: 'call-2', toolName: 'create_page', input: { title: 'T' }, state: 'output-available' },
+    ];
+    const result = serializeMessageToOpenAI(makeRow({ role: 'assistant', content: '', toolCalls: toolCallsArray }));
+    assert({
+      given: 'tool calls stored as a JS array (not a JSON string)',
+      should: 'still produce the correct tool_calls output',
+      actual: result.tool_calls?.[0]?.function.name,
+      expected: 'create_page',
+    });
+  });
+
+  test('empty content becomes null', () => {
+    const result = serializeMessageToOpenAI(makeRow({ content: '' }));
+    assert({
+      given: 'an empty content string',
+      should: 'return content:null',
+      actual: result.content,
+      expected: null,
+    });
+  });
+
+  test('createdAt is converted to unix timestamp in seconds', () => {
+    const date = new Date('2024-06-01T12:00:00.000Z');
+    const result = serializeMessageToOpenAI(makeRow({ createdAt: date }));
+    assert({
+      given: 'a specific createdAt date',
+      should: 'convert to seconds since epoch',
+      actual: result.created_at,
+      expected: Math.floor(date.getTime() / 1000),
+    });
+  });
+
+  test('message id is preserved', () => {
+    const result = serializeMessageToOpenAI(makeRow({ id: 'specific-msg-id' }));
+    assert({
+      given: 'a message with a specific id',
+      should: 'preserve the id in the output',
+      actual: result.id,
+      expected: 'specific-msg-id',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/extract-tool-calls-from-steps.ts
+++ b/apps/web/src/lib/ai/openai-api/extract-tool-calls-from-steps.ts
@@ -1,0 +1,64 @@
+interface ExtractedToolCall {
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  state: 'output-available' | 'input-available';
+}
+
+interface ExtractedToolResult {
+  toolCallId: string;
+  toolName: string;
+  output: unknown;
+  state: 'output-available';
+}
+
+export interface ExtractedToolData {
+  toolCalls: ExtractedToolCall[];
+  toolResults: ExtractedToolResult[];
+}
+
+function isStepLike(step: unknown): step is {
+  toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; input: unknown }>;
+  toolResults: ReadonlyArray<{ toolCallId: string; toolName: string; output: unknown }>;
+} {
+  if (typeof step !== 'object' || step === null) return false;
+  const s = step as Record<string, unknown>;
+  return Array.isArray(s.toolCalls) && Array.isArray(s.toolResults);
+}
+
+export function extractToolCallsFromSteps(steps: ReadonlyArray<unknown>): ExtractedToolData {
+  const toolCalls: ExtractedToolCall[] = [];
+  const toolResults: ExtractedToolResult[] = [];
+
+  for (const step of steps) {
+    if (!isStepLike(step)) continue;
+
+    const resultIds = new Set(
+      step.toolResults
+        .filter((tr) => typeof (tr as Record<string, unknown>).toolCallId === 'string')
+        .map((tr) => (tr as Record<string, unknown>).toolCallId as string),
+    );
+
+    for (const tc of step.toolCalls) {
+      if (typeof tc.toolCallId !== 'string' || typeof tc.toolName !== 'string') continue;
+      toolCalls.push({
+        toolCallId: tc.toolCallId,
+        toolName: tc.toolName,
+        input: (tc.input as Record<string, unknown>) ?? {},
+        state: resultIds.has(tc.toolCallId) ? 'output-available' : 'input-available',
+      });
+    }
+
+    for (const tr of step.toolResults) {
+      if (typeof tr.toolCallId !== 'string' || typeof tr.toolName !== 'string') continue;
+      toolResults.push({
+        toolCallId: tr.toolCallId,
+        toolName: tr.toolName,
+        output: tr.output,
+        state: 'output-available',
+      });
+    }
+  }
+
+  return { toolCalls, toolResults };
+}

--- a/apps/web/src/lib/ai/openai-api/v1-conversations.ts
+++ b/apps/web/src/lib/ai/openai-api/v1-conversations.ts
@@ -1,0 +1,193 @@
+// Types
+
+export interface OpenAIToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export interface OpenAIMessage {
+  id: string;
+  role: 'user' | 'assistant' | 'system';
+  content: string | null;
+  tool_calls?: OpenAIToolCall[];
+  created_at: number;
+}
+
+export interface ConversationRow {
+  id: string;
+  userId: string;
+  isActive: boolean;
+  title: string | null;
+  contextId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface MessageRow {
+  id: string;
+  role: string;
+  content: string;
+  toolCalls: unknown;
+  toolResults: unknown;
+  createdAt: Date;
+  isActive: boolean;
+}
+
+export type CreateConversationResult =
+  | { ok: true; data: { id: string; userId: string; title: string | null; type: 'client'; contextId: string | null; updatedAt: Date } }
+  | { ok: false; status: number; error: string };
+
+export type ConversationListQueryResult =
+  | { ok: true; data: { userId: string; limit: number; offset: number; driveId: string | undefined } }
+  | { ok: false; status: number; error: string };
+
+export type ConversationAccessResult =
+  | { ok: true }
+  | { ok: false; status: number; message: string };
+
+// Pure functions
+
+export function buildCreateConversationPayload(
+  body: unknown,
+  userId: string,
+  allowedDriveIds: string[],
+  id: string,
+): CreateConversationResult {
+  if (typeof body !== 'object' || body === null) {
+    return { ok: false, status: 400, error: 'request body must be a JSON object' };
+  }
+
+  const raw = body as Record<string, unknown>;
+
+  let title: string | null = null;
+  if (raw.title !== undefined) {
+    if (typeof raw.title !== 'string') {
+      return { ok: false, status: 400, error: 'title must be a string' };
+    }
+    title = raw.title.trim().slice(0, 255) || null;
+  }
+
+  let contextId: string | null = null;
+  if (raw.drive_id !== undefined) {
+    if (typeof raw.drive_id !== 'string' || !raw.drive_id.trim()) {
+      return { ok: false, status: 400, error: 'drive_id must be a non-empty string' };
+    }
+    const driveId = raw.drive_id.trim();
+    if (allowedDriveIds.length > 0 && !allowedDriveIds.includes(driveId)) {
+      return { ok: false, status: 403, error: 'MCP token does not have access to the specified drive' };
+    }
+    contextId = driveId;
+  }
+
+  return {
+    ok: true,
+    data: { id, userId, title, type: 'client' as const, contextId, updatedAt: new Date() },
+  };
+}
+
+export function buildConversationListQuery(
+  userId: string,
+  searchParams: URLSearchParams,
+): ConversationListQueryResult {
+  const limitStr = searchParams.get('limit');
+  const offsetStr = searchParams.get('offset');
+
+  const limit = limitStr !== null ? parseInt(limitStr, 10) : 20;
+  const offset = offsetStr !== null ? parseInt(offsetStr, 10) : 0;
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    return { ok: false, status: 400, error: 'limit must be between 1 and 100' };
+  }
+  if (!Number.isInteger(offset) || offset < 0) {
+    return { ok: false, status: 400, error: 'offset must be >= 0' };
+  }
+
+  const driveIdParam = searchParams.get('drive_id');
+  const driveId = driveIdParam !== null ? driveIdParam : undefined;
+
+  return { ok: true, data: { userId, limit, offset, driveId } };
+}
+
+export function validateConversationAccess(
+  conversation: ConversationRow | null,
+  userId: string,
+): ConversationAccessResult {
+  if (!conversation || !conversation.isActive) {
+    return { ok: false, status: 404, message: 'Conversation not found' };
+  }
+  if (conversation.userId !== userId) {
+    return { ok: false, status: 403, message: 'Access denied' };
+  }
+  return { ok: true };
+}
+
+function extractPlainText(content: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    if (typeof parsed === 'object' && !Array.isArray(parsed) && parsed !== null) {
+      if (typeof parsed.originalContent === 'string') return parsed.originalContent;
+      if (Array.isArray(parsed.textParts) && parsed.textParts.length > 0) {
+        return (parsed.textParts as string[]).filter((t): t is string => typeof t === 'string').join('');
+      }
+    }
+  } catch {
+    // plain text
+  }
+  return content;
+}
+
+function parseRawToolCalls(
+  raw: unknown,
+): Array<{ toolCallId: string; toolName: string; input: unknown }> {
+  if (!raw) return [];
+  const arr: unknown[] = Array.isArray(raw)
+    ? raw
+    : (() => {
+        try {
+          const parsed = JSON.parse(raw as string);
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      })();
+  return arr.filter(
+    (tc): tc is { toolCallId: string; toolName: string; input: unknown } =>
+      typeof tc === 'object' &&
+      tc !== null &&
+      typeof (tc as Record<string, unknown>).toolCallId === 'string' &&
+      typeof (tc as Record<string, unknown>).toolName === 'string',
+  );
+}
+
+export function serializeMessageToOpenAI(row: MessageRow): OpenAIMessage {
+  const role = row.role as 'user' | 'assistant' | 'system';
+  const text = extractPlainText(row.content);
+
+  const rawCalls = parseRawToolCalls(row.toolCalls);
+  const toolCalls: OpenAIToolCall[] = rawCalls.map((tc) => ({
+    id: tc.toolCallId,
+    type: 'function' as const,
+    function: {
+      name: tc.toolName,
+      arguments:
+        typeof tc.input === 'string' ? tc.input : JSON.stringify(tc.input ?? {}),
+    },
+  }));
+
+  const msg: OpenAIMessage = {
+    id: row.id,
+    role,
+    content: text || null,
+    created_at: Math.floor(row.createdAt.getTime() / 1000),
+  };
+
+  if (toolCalls.length > 0) {
+    msg.tool_calls = toolCalls;
+  }
+
+  return msg;
+}

--- a/apps/web/src/lib/repositories/chat-message-repository.ts
+++ b/apps/web/src/lib/repositories/chat-message-repository.ts
@@ -141,6 +141,33 @@ export const chatMessageRepository = {
   },
 
   /**
+   * Get all active messages for a conversation by conversationId alone (no pageId filter).
+   * Used by the client-managed conversations API to retrieve full thread history.
+   */
+  async getMessagesByConversationId(conversationId: string): Promise<ChatMessage[]> {
+    const result = await db
+      .select({
+        id: chatMessages.id,
+        pageId: chatMessages.pageId,
+        conversationId: chatMessages.conversationId,
+        userId: chatMessages.userId,
+        role: chatMessages.role,
+        content: chatMessages.content,
+        messageType: chatMessages.messageType,
+        isActive: chatMessages.isActive,
+        createdAt: chatMessages.createdAt,
+        editedAt: chatMessages.editedAt,
+        toolCalls: chatMessages.toolCalls,
+        toolResults: chatMessages.toolResults,
+      })
+      .from(chatMessages)
+      .where(and(eq(chatMessages.conversationId, conversationId), eq(chatMessages.isActive, true)))
+      .orderBy(chatMessages.createdAt);
+
+    return result as ChatMessage[];
+  },
+
+  /**
    * Purge soft-deleted messages older than the cutoff date.
    * Returns the number of rows removed.
    */


### PR DESCRIPTION
## Summary

- Adds \`POST/GET /api/v1/conversations\` and \`GET/DELETE /api/v1/conversations/[id]\` — MCP-token-authenticated CRUD for external clients to own conversation history in PageSpace
- Completions endpoint now validates conversation ownership before consuming credits, and persists tool calls/results to the assistant message when a \`conversation_id\` is in the request; also persists **tool-only turns** (where the assistant executes tools with no text output — previously silently dropped)
- MCP drive scope enforced consistently: scoped tokens can only create/list/read/delete conversations bound to their allowed drives; listing without a \`drive_id\` is filtered to \`contextId IN allowedDriveIds\`
- Pure helper module (\`v1-conversations.ts\`) with \`buildCreateConversationPayload\`, \`buildConversationListQuery\`, \`validateConversationAccess\`, \`serializeMessageToOpenAI\`; new \`extractToolCallsFromSteps\` utility for JSONB-ready tool call extraction from AI SDK step results
- New \`chatMessageRepository.getMessagesByConversationId()\` for conversation-scoped message queries (no pageId filter)

## Test plan

- [x] 34 pure-function tests (\`v1-conversations.test.ts\`) — validation, serialization, edge cases
- [x] 8 tool-extraction tests (\`extract-tool-calls-from-steps.test.ts\`)
- [x] 24 route handler tests (\`conversations/__tests__/route.test.ts\`) — auth, 4xx paths, drive scope enforcement, happy paths, DB calls
- [x] 29 completions route tests (extended) — conversation 404/403, tool call persistence, tool-only turn persistence, no-conversation path
- [x] Security audit coverage gate (all 4 new route files have \`auditRequest(\` calls)
- [x] \`bun run typecheck\` — 0 errors
- [x] All 99 new/modified tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)