### PR TITLE
feat(api): surface tool calls in /v1/chat/completions

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -32,6 +32,7 @@ import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference-request';
 import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
+import { buildToolSummaryEvent } from '@/lib/ai/openai-api/build-tool-summary-event';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
@@ -300,10 +301,34 @@ export async function POST(request: Request): Promise<Response> {
 
   const stream = new ReadableStream({
     async start(controller) {
+      // Per-step tool call state: tracks tool index and presence for finish-step finish_reason
+      let stepToolCallIndex = 0;
+      let stepHadToolCalls = false;
+
       try {
         for await (const chunk of aiResult.toUIMessageStream()) {
           if (chunk.type === 'text-delta') assistantText += chunk.delta;
-          const line = adaptToOpenAIChunk(chunk, { id: completionId, model: modelName, created });
+
+          // Reset per-step state at the start of each inference step
+          if (chunk.type === 'start-step') {
+            stepToolCallIndex = 0;
+            stepHadToolCalls = false;
+          }
+
+          // Capture index before increment so the emitted chunk gets the right index
+          const toolCallIndex = stepToolCallIndex;
+          if (chunk.type === 'tool-input-available') {
+            stepHadToolCalls = true;
+            stepToolCallIndex++;
+          }
+
+          const line = adaptToOpenAIChunk(chunk, {
+            id: completionId,
+            model: modelName,
+            created,
+            toolCallIndex,
+            hadToolCallsInStep: stepHadToolCalls,
+          });
           if (line) {
             controller.enqueue(encoder.encode(line + '\n\n'));
           }
@@ -320,6 +345,13 @@ export async function POST(request: Request): Promise<Response> {
         const totalUsage = await aiResult.totalUsage.catch(() => undefined);
         const steps = await aiResult.steps.catch(() => undefined);
         await settle({ aborted, text: assistantText || undefined, totalUsage, steps });
+        if (!aborted) {
+          const toolSummary = buildToolSummaryEvent(steps ?? []);
+          if (toolSummary) {
+            controller.enqueue(encoder.encode(toolSummary + '\n\n'));
+          }
+          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        }
         controller.close();
       } catch (err) {
         // Some providers surface an abort as a thrown AbortError instead. Treat it as a

--- a/apps/web/src/lib/ai/openai-api/__tests__/adapt-to-openai-chunk.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/adapt-to-openai-chunk.test.ts
@@ -106,7 +106,7 @@ describe('adaptToOpenAIChunk', () => {
     );
     assert({
       given: 'a tool-output-available chunk',
-      should: 'produce an SSE line with delta.role=tool and the tool result as content',
+      should: 'produce an SSE line with delta.role=tool and the tool result in tool_result (not content)',
       actual: result ? parseSSE(result) : null,
       expected: {
         id: 'cmpl-abc',
@@ -115,7 +115,7 @@ describe('adaptToOpenAIChunk', () => {
         model: 'ps-agent://page-123',
         choices: [{
           index: 0,
-          delta: { role: 'tool', tool_call_id: 'tc-1', content: 'search result text' },
+          delta: { role: 'tool', tool_call_id: 'tc-1', tool_result: 'search result text' },
           finish_reason: null,
         }],
       },

--- a/apps/web/src/lib/ai/openai-api/__tests__/adapt-to-openai-chunk.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/adapt-to-openai-chunk.test.ts
@@ -39,50 +39,116 @@ describe('adaptToOpenAIChunk', () => {
     });
   });
 
-  test('finish chunk produces stop + DONE sentinel', () => {
+  test('finish chunk produces only the stop chunk (DONE is emitted by route)', () => {
     const result = adaptToOpenAIChunk({ type: 'finish' }, baseOpts);
-    const lines = result ? result.split('\n').filter(Boolean) : [];
     assert({
       given: 'a finish chunk',
-      should: 'produce a stop finish_reason chunk followed by the [DONE] sentinel',
-      actual: {
-        stopChunk: lines[0] ? parseSSE(lines[0]) : null,
-        done: lines[1],
-      },
+      should: 'produce exactly the stop finish_reason SSE chunk — [DONE] is not included here',
+      actual: result ? parseSSE(result) : null,
       expected: {
-        stopChunk: {
-          id: 'cmpl-abc',
-          object: 'chat.completion.chunk',
-          created: 1000000000,
-          model: 'ps-agent://page-123',
-          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
-        },
-        done: 'data: [DONE]',
+        id: 'cmpl-abc',
+        object: 'chat.completion.chunk',
+        created: 1000000000,
+        model: 'ps-agent://page-123',
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
       },
     });
   });
 
-  test('tool-input-available chunk is skipped', () => {
+  test('tool-input-available chunk produces an OpenAI tool call delta', () => {
     const result = adaptToOpenAIChunk(
-      { type: 'tool-input-available', toolCallId: 'tc-1', toolName: 'search', input: {}, dynamic: false },
-      baseOpts,
+      { type: 'tool-input-available', toolCallId: 'tc-1', toolName: 'search', input: { q: 'hello' }, dynamic: false },
+      { ...baseOpts, toolCallIndex: 0 },
     );
     assert({
       given: 'a tool-input-available chunk',
-      should: 'return null — tool calls are not exposed in v1',
-      actual: result,
-      expected: null,
+      should: 'produce an SSE line with delta.tool_calls containing the tool call',
+      actual: result ? parseSSE(result) : null,
+      expected: {
+        id: 'cmpl-abc',
+        object: 'chat.completion.chunk',
+        created: 1000000000,
+        model: 'ps-agent://page-123',
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: 'tc-1',
+              type: 'function',
+              function: { name: 'search', arguments: '{"q":"hello"}' },
+            }],
+          },
+          finish_reason: null,
+        }],
+      },
     });
   });
 
-  test('tool-output-available chunk is skipped', () => {
+  test('second tool-input-available in same step gets incremented tool index', () => {
     const result = adaptToOpenAIChunk(
-      { type: 'tool-output-available', toolCallId: 'tc-1', output: 'result' },
+      { type: 'tool-input-available', toolCallId: 'tc-2', toolName: 'read', input: { id: 'page-1' }, dynamic: false },
+      { ...baseOpts, toolCallIndex: 1 },
+    );
+    const parsed = result ? parseSSE(result) : null;
+    assert({
+      given: 'a second tool-input-available chunk in the same step',
+      should: 'use tool index 1 in tool_calls',
+      actual: parsed?.choices[0]?.delta?.tool_calls?.[0]?.index,
+      expected: 1,
+    });
+  });
+
+  test('tool-output-available chunk produces an OpenAI tool result delta', () => {
+    const result = adaptToOpenAIChunk(
+      { type: 'tool-output-available', toolCallId: 'tc-1', output: 'search result text' },
       baseOpts,
     );
     assert({
       given: 'a tool-output-available chunk',
-      should: 'return null — tool results are not exposed in v1',
+      should: 'produce an SSE line with delta.role=tool and the tool result as content',
+      actual: result ? parseSSE(result) : null,
+      expected: {
+        id: 'cmpl-abc',
+        object: 'chat.completion.chunk',
+        created: 1000000000,
+        model: 'ps-agent://page-123',
+        choices: [{
+          index: 0,
+          delta: { role: 'tool', tool_call_id: 'tc-1', content: 'search result text' },
+          finish_reason: null,
+        }],
+      },
+    });
+  });
+
+  test('finish-step chunk after tool calls emits finish_reason:tool_calls', () => {
+    const result = adaptToOpenAIChunk(
+      { type: 'finish-step' },
+      { ...baseOpts, hadToolCallsInStep: true },
+    );
+    assert({
+      given: 'a finish-step chunk after tool calls in the step',
+      should: 'produce a finish_reason:tool_calls chunk',
+      actual: result ? parseSSE(result) : null,
+      expected: {
+        id: 'cmpl-abc',
+        object: 'chat.completion.chunk',
+        created: 1000000000,
+        model: 'ps-agent://page-123',
+        choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+      },
+    });
+  });
+
+  test('finish-step chunk without tool calls returns null', () => {
+    const result = adaptToOpenAIChunk(
+      { type: 'finish-step' },
+      { ...baseOpts, hadToolCallsInStep: false },
+    );
+    assert({
+      given: 'a finish-step chunk without any tool calls in the step',
+      should: 'return null',
       actual: result,
       expected: null,
     });
@@ -98,17 +164,17 @@ describe('adaptToOpenAIChunk', () => {
     });
   });
 
-  test('finish chunk produces two separate SSE events when stream encoder appends \\n\\n', () => {
+  test('finish chunk produces exactly one SSE event when stream encoder appends \\n\\n', () => {
     const result = adaptToOpenAIChunk({ type: 'finish' }, baseOpts);
-    // The route handler does: controller.enqueue(encoder.encode(line + '\n\n'))
-    // The combined string must split into exactly two SSE events — not one multi-data event.
+    // [DONE] is now emitted separately by the route after buildToolSummaryEvent.
+    // The finish chunk itself is a single stop-reason chunk.
     const encoded = (result ?? '') + '\n\n';
     const events = encoded.split('\n\n').filter(Boolean);
     assert({
       given: 'a finish chunk with the stream encoder\'s \\n\\n appended',
-      should: 'produce exactly two SSE events — stop chunk and [DONE] sentinel — each separated by \\n\\n',
+      should: 'produce exactly one SSE event — the stop-reason chunk (no inline [DONE])',
       actual: events.length,
-      expected: 2,
+      expected: 1,
     });
   });
 

--- a/apps/web/src/lib/ai/openai-api/__tests__/adapt-tool-input-part.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/adapt-tool-input-part.test.ts
@@ -1,0 +1,87 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { adaptToolInputPart } from '../adapt-tool-input-part';
+
+const opts = { chunkId: 'cmpl-abc', model: 'ps-agent://page-123', created: 1000000000 };
+
+describe('adaptToolInputPart', () => {
+  test('returns an OpenAI tool call delta chunk', () => {
+    const part = { toolCallId: 'tc-1', toolName: 'search_web', input: { query: 'weather today' } };
+    const result = adaptToolInputPart(part, opts.chunkId, opts.model, opts.created, 0);
+    assert({
+      given: 'a complete tool-input-available part',
+      should: 'return an OpenAI tool call chunk with id, function name, and serialized arguments',
+      actual: result,
+      expected: {
+        id: 'cmpl-abc',
+        object: 'chat.completion.chunk',
+        created: 1000000000,
+        model: 'ps-agent://page-123',
+        choices: [{
+          index: 0,
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: 'tc-1',
+              type: 'function',
+              function: { name: 'search_web', arguments: '{"query":"weather today"}' },
+            }],
+          },
+          finish_reason: null,
+        }],
+      },
+    });
+  });
+
+  test('serializes complex object input as JSON arguments', () => {
+    const part = { toolCallId: 'tc-2', toolName: 'create_page', input: { title: 'Notes', type: 'document', tags: ['a', 'b'] } };
+    const result = adaptToolInputPart(part, opts.chunkId, opts.model, opts.created, 0);
+    const argsStr = (result as { choices: Array<{ delta: { tool_calls: Array<{ function: { arguments: string } }> } }> })
+      .choices[0].delta.tool_calls[0].function.arguments;
+    assert({
+      given: 'a tool input with nested object',
+      should: 'JSON-serialize the input as the arguments string',
+      actual: JSON.parse(argsStr),
+      expected: { title: 'Notes', type: 'document', tags: ['a', 'b'] },
+    });
+  });
+
+  test('uses provided toolIndex in tool_calls[].index', () => {
+    const part = { toolCallId: 'tc-3', toolName: 'read_page', input: {} };
+    const result = adaptToolInputPart(part, opts.chunkId, opts.model, opts.created, 2);
+    const toolIndex = (result as { choices: Array<{ delta: { tool_calls: Array<{ index: number }> } }> })
+      .choices[0].delta.tool_calls[0].index;
+    assert({
+      given: 'toolIndex=2',
+      should: 'set tool_calls[0].index to 2',
+      actual: toolIndex,
+      expected: 2,
+    });
+  });
+
+  test('preserves chunk metadata (id, model, created)', () => {
+    const part = { toolCallId: 'tc-1', toolName: 'noop', input: {} };
+    const result = adaptToolInputPart(part, 'custom-id', 'my-model', 9999, 0) as {
+      id: string; model: string; created: number;
+    };
+    assert({
+      given: 'custom chunkId, model, and created values',
+      should: 'carry them through to the chunk envelope',
+      actual: { id: result.id, model: result.model, created: result.created },
+      expected: { id: 'custom-id', model: 'my-model', created: 9999 },
+    });
+  });
+
+  test('always sets finish_reason to null', () => {
+    const part = { toolCallId: 'tc-1', toolName: 'noop', input: {} };
+    const result = adaptToolInputPart(part, opts.chunkId, opts.model, opts.created, 0) as {
+      choices: Array<{ finish_reason: unknown }>;
+    };
+    assert({
+      given: 'any tool input part',
+      should: 'set finish_reason to null (tool calls are not a terminal event)',
+      actual: result.choices[0].finish_reason,
+      expected: null,
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/__tests__/adapt-tool-result-part.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/adapt-tool-result-part.test.ts
@@ -10,7 +10,7 @@ describe('adaptToolResultPart', () => {
     const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created);
     assert({
       given: 'a tool-output-available part with string output',
-      should: 'return a chunk with delta.role=tool and output as content',
+      should: 'return a chunk with delta.role=tool and output in tool_result (not content)',
       actual: result,
       expected: {
         id: 'cmpl-abc',
@@ -19,35 +19,35 @@ describe('adaptToolResultPart', () => {
         model: 'ps-agent://page-123',
         choices: [{
           index: 0,
-          delta: { role: 'tool', tool_call_id: 'tc-1', content: 'search results text' },
+          delta: { role: 'tool', tool_call_id: 'tc-1', tool_result: 'search results text' },
           finish_reason: null,
         }],
       },
     });
   });
 
-  test('JSON-serializes object output as content', () => {
+  test('JSON-serializes object output into tool_result', () => {
     const part = { toolCallId: 'tc-2', output: { pages: ['a', 'b'], total: 2 } };
     const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
-      choices: Array<{ delta: { content: string } }>;
+      choices: Array<{ delta: { tool_result: string } }>;
     };
     assert({
       given: 'a tool output with object value',
-      should: 'JSON-serialize the output as content',
-      actual: JSON.parse(result.choices[0].delta.content),
+      should: 'JSON-serialize the output into tool_result',
+      actual: JSON.parse(result.choices[0].delta.tool_result),
       expected: { pages: ['a', 'b'], total: 2 },
     });
   });
 
-  test('JSON-serializes array output as content', () => {
+  test('JSON-serializes array output into tool_result', () => {
     const part = { toolCallId: 'tc-3', output: [1, 2, 3] };
     const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
-      choices: Array<{ delta: { content: string } }>;
+      choices: Array<{ delta: { tool_result: string } }>;
     };
     assert({
       given: 'a tool output with array value',
-      should: 'JSON-serialize the array as content',
-      actual: JSON.parse(result.choices[0].delta.content),
+      should: 'JSON-serialize the array into tool_result',
+      actual: JSON.parse(result.choices[0].delta.tool_result),
       expected: [1, 2, 3],
     });
   });
@@ -75,6 +75,21 @@ describe('adaptToolResultPart', () => {
       should: 'set finish_reason to null',
       actual: result.choices[0].finish_reason,
       expected: null,
+    });
+  });
+
+  test('falls back to String() for non-serializable output', () => {
+    // BigInt cannot be JSON-serialized; serializeOutput must not throw
+    const bigIntVal = BigInt(9007199254740991);
+    const part = { toolCallId: 'tc-4', output: bigIntVal };
+    const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
+      choices: Array<{ delta: { tool_result: string } }>;
+    };
+    assert({
+      given: 'a tool output with a BigInt value that JSON.stringify cannot handle',
+      should: 'fall back to String() rather than throwing',
+      actual: typeof result.choices[0].delta.tool_result,
+      expected: 'string',
     });
   });
 });

--- a/apps/web/src/lib/ai/openai-api/__tests__/adapt-tool-result-part.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/adapt-tool-result-part.test.ts
@@ -1,0 +1,80 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { adaptToolResultPart } from '../adapt-tool-result-part';
+
+const opts = { chunkId: 'cmpl-abc', model: 'ps-agent://page-123', created: 1000000000 };
+
+describe('adaptToolResultPart', () => {
+  test('returns an OpenAI tool result delta chunk for string output', () => {
+    const part = { toolCallId: 'tc-1', output: 'search results text' };
+    const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created);
+    assert({
+      given: 'a tool-output-available part with string output',
+      should: 'return a chunk with delta.role=tool and output as content',
+      actual: result,
+      expected: {
+        id: 'cmpl-abc',
+        object: 'chat.completion.chunk',
+        created: 1000000000,
+        model: 'ps-agent://page-123',
+        choices: [{
+          index: 0,
+          delta: { role: 'tool', tool_call_id: 'tc-1', content: 'search results text' },
+          finish_reason: null,
+        }],
+      },
+    });
+  });
+
+  test('JSON-serializes object output as content', () => {
+    const part = { toolCallId: 'tc-2', output: { pages: ['a', 'b'], total: 2 } };
+    const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
+      choices: Array<{ delta: { content: string } }>;
+    };
+    assert({
+      given: 'a tool output with object value',
+      should: 'JSON-serialize the output as content',
+      actual: JSON.parse(result.choices[0].delta.content),
+      expected: { pages: ['a', 'b'], total: 2 },
+    });
+  });
+
+  test('JSON-serializes array output as content', () => {
+    const part = { toolCallId: 'tc-3', output: [1, 2, 3] };
+    const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
+      choices: Array<{ delta: { content: string } }>;
+    };
+    assert({
+      given: 'a tool output with array value',
+      should: 'JSON-serialize the array as content',
+      actual: JSON.parse(result.choices[0].delta.content),
+      expected: [1, 2, 3],
+    });
+  });
+
+  test('carries tool_call_id through to delta', () => {
+    const part = { toolCallId: 'specific-call-id', output: 'ok' };
+    const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
+      choices: Array<{ delta: { tool_call_id: string } }>;
+    };
+    assert({
+      given: 'a tool output with a specific toolCallId',
+      should: 'set delta.tool_call_id to match',
+      actual: result.choices[0].delta.tool_call_id,
+      expected: 'specific-call-id',
+    });
+  });
+
+  test('always sets finish_reason to null', () => {
+    const part = { toolCallId: 'tc-1', output: 'done' };
+    const result = adaptToolResultPart(part, opts.chunkId, opts.model, opts.created) as {
+      choices: Array<{ finish_reason: unknown }>;
+    };
+    assert({
+      given: 'any tool result part',
+      should: 'set finish_reason to null',
+      actual: result.choices[0].finish_reason,
+      expected: null,
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/__tests__/build-tool-summary-event.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/build-tool-summary-event.test.ts
@@ -1,0 +1,95 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { buildToolSummaryEvent } from '../build-tool-summary-event';
+
+describe('buildToolSummaryEvent', () => {
+  test('returns null when no steps have tool calls', () => {
+    const steps = [
+      { toolCalls: [] },
+      { toolCalls: [] },
+    ];
+    assert({
+      given: 'steps with no tool calls',
+      should: 'return null — no summary to emit',
+      actual: buildToolSummaryEvent(steps),
+      expected: null,
+    });
+  });
+
+  test('returns null for empty steps array', () => {
+    assert({
+      given: 'empty steps array',
+      should: 'return null',
+      actual: buildToolSummaryEvent([]),
+      expected: null,
+    });
+  });
+
+  test('returns PAGESPACE_TOOL_SUMMARY SSE event when tool calls are present', () => {
+    const steps = [
+      { toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] },
+    ];
+    const result = buildToolSummaryEvent(steps);
+    assert({
+      given: 'a step with one tool call',
+      should: 'return an SSE event with event:PAGESPACE_TOOL_SUMMARY',
+      actual: typeof result === 'string' && result.startsWith('event: PAGESPACE_TOOL_SUMMARY'),
+      expected: true,
+    });
+  });
+
+  test('data field contains toolCalls array with toolName and toolCallId', () => {
+    const steps = [
+      { toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] },
+      { toolCalls: [{ toolCallId: 'tc-2', toolName: 'read_page' }] },
+    ];
+    const result = buildToolSummaryEvent(steps);
+    const dataLine = (result ?? '').split('\n').find(l => l.startsWith('data:'));
+    const payload = dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+    assert({
+      given: 'two steps each with one tool call',
+      should: 'include both tool calls in the toolCalls array',
+      actual: payload?.toolCalls,
+      expected: [
+        { toolCallId: 'tc-1', toolName: 'search_web' },
+        { toolCallId: 'tc-2', toolName: 'read_page' },
+      ],
+    });
+  });
+
+  test('data field includes stepCount', () => {
+    const steps = [
+      { toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] },
+      { toolCalls: [] },
+      { toolCalls: [{ toolCallId: 'tc-2', toolName: 'read_page' }] },
+    ];
+    const result = buildToolSummaryEvent(steps);
+    const dataLine = (result ?? '').split('\n').find(l => l.startsWith('data:'));
+    const payload = dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+    assert({
+      given: '3 steps (2 with tool calls, 1 without)',
+      should: 'include stepCount=3 in the payload',
+      actual: payload?.stepCount,
+      expected: 3,
+    });
+  });
+
+  test('aggregates tool calls from multiple steps into flat list', () => {
+    const steps = [
+      { toolCalls: [
+        { toolCallId: 'tc-1', toolName: 'search_web' },
+        { toolCallId: 'tc-2', toolName: 'search_web' },
+      ]},
+      { toolCalls: [{ toolCallId: 'tc-3', toolName: 'read_page' }] },
+    ];
+    const result = buildToolSummaryEvent(steps);
+    const dataLine = (result ?? '').split('\n').find(l => l.startsWith('data:'));
+    const payload = dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+    assert({
+      given: 'two steps with 2 and 1 tool calls respectively',
+      should: 'return 3 tool calls in a flat array',
+      actual: payload?.toolCalls?.length,
+      expected: 3,
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/__tests__/build-tool-summary-event.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/build-tool-summary-event.test.ts
@@ -2,12 +2,15 @@ import { describe, test } from 'vitest';
 import { assert } from './riteway';
 import { buildToolSummaryEvent } from '../build-tool-summary-event';
 
+const parsePayload = (result: string | null) => {
+  if (!result) return null;
+  const dataLine = result.split('\n').find(l => l.startsWith('data:'));
+  return dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+};
+
 describe('buildToolSummaryEvent', () => {
   test('returns null when no steps have tool calls', () => {
-    const steps = [
-      { toolCalls: [] },
-      { toolCalls: [] },
-    ];
+    const steps = [{ toolCalls: [] }, { toolCalls: [] }];
     assert({
       given: 'steps with no tool calls',
       should: 'return null — no summary to emit',
@@ -25,31 +28,48 @@ describe('buildToolSummaryEvent', () => {
     });
   });
 
-  test('returns PAGESPACE_TOOL_SUMMARY SSE event when tool calls are present', () => {
-    const steps = [
-      { toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] },
-    ];
+  test('returns null for a step with missing toolCalls property', () => {
+    const steps = [{}];
+    assert({
+      given: 'a step with no toolCalls property at all',
+      should: 'return null without throwing (treats missing as empty)',
+      actual: buildToolSummaryEvent(steps as never),
+      expected: null,
+    });
+  });
+
+  test('emits a valid choices:[] chunk (not a named SSE event)', () => {
+    const steps = [{ toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] }];
     const result = buildToolSummaryEvent(steps);
     assert({
       given: 'a step with one tool call',
-      should: 'return an SSE event with event:PAGESPACE_TOOL_SUMMARY',
-      actual: typeof result === 'string' && result.startsWith('event: PAGESPACE_TOOL_SUMMARY'),
+      should: 'return a data: line with choices:[] so standard OpenAI clients skip it safely',
+      actual: typeof result === 'string' && result.startsWith('data: ') && !result.startsWith('event:'),
       expected: true,
     });
   });
 
-  test('data field contains toolCalls array with toolName and toolCallId', () => {
+  test('payload has object:chat.completion.chunk and empty choices array', () => {
+    const steps = [{ toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] }];
+    const payload = parsePayload(buildToolSummaryEvent(steps));
+    assert({
+      given: 'a step with one tool call',
+      should: 'include object and choices fields matching OpenAI chunk shape',
+      actual: { object: payload?.object, choices: payload?.choices },
+      expected: { object: 'chat.completion.chunk', choices: [] },
+    });
+  });
+
+  test('x_pagespace_tool_summary contains toolCalls array with toolName and toolCallId', () => {
     const steps = [
       { toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] },
       { toolCalls: [{ toolCallId: 'tc-2', toolName: 'read_page' }] },
     ];
-    const result = buildToolSummaryEvent(steps);
-    const dataLine = (result ?? '').split('\n').find(l => l.startsWith('data:'));
-    const payload = dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+    const payload = parsePayload(buildToolSummaryEvent(steps));
     assert({
       given: 'two steps each with one tool call',
-      should: 'include both tool calls in the toolCalls array',
-      actual: payload?.toolCalls,
+      should: 'include both tool calls in x_pagespace_tool_summary.toolCalls',
+      actual: payload?.x_pagespace_tool_summary?.toolCalls,
       expected: [
         { toolCallId: 'tc-1', toolName: 'search_web' },
         { toolCallId: 'tc-2', toolName: 'read_page' },
@@ -57,19 +77,17 @@ describe('buildToolSummaryEvent', () => {
     });
   });
 
-  test('data field includes stepCount', () => {
+  test('x_pagespace_tool_summary includes stepCount', () => {
     const steps = [
       { toolCalls: [{ toolCallId: 'tc-1', toolName: 'search_web' }] },
       { toolCalls: [] },
       { toolCalls: [{ toolCallId: 'tc-2', toolName: 'read_page' }] },
     ];
-    const result = buildToolSummaryEvent(steps);
-    const dataLine = (result ?? '').split('\n').find(l => l.startsWith('data:'));
-    const payload = dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+    const payload = parsePayload(buildToolSummaryEvent(steps));
     assert({
       given: '3 steps (2 with tool calls, 1 without)',
-      should: 'include stepCount=3 in the payload',
-      actual: payload?.stepCount,
+      should: 'include stepCount=3 in x_pagespace_tool_summary',
+      actual: payload?.x_pagespace_tool_summary?.stepCount,
       expected: 3,
     });
   });
@@ -82,13 +100,11 @@ describe('buildToolSummaryEvent', () => {
       ]},
       { toolCalls: [{ toolCallId: 'tc-3', toolName: 'read_page' }] },
     ];
-    const result = buildToolSummaryEvent(steps);
-    const dataLine = (result ?? '').split('\n').find(l => l.startsWith('data:'));
-    const payload = dataLine ? JSON.parse(dataLine.replace(/^data: /, '')) : null;
+    const payload = parsePayload(buildToolSummaryEvent(steps));
     assert({
       given: 'two steps with 2 and 1 tool calls respectively',
       should: 'return 3 tool calls in a flat array',
-      actual: payload?.toolCalls?.length,
+      actual: payload?.x_pagespace_tool_summary?.toolCalls?.length,
       expected: 3,
     });
   });

--- a/apps/web/src/lib/ai/openai-api/__tests__/resolve-finish-reason.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/resolve-finish-reason.test.ts
@@ -1,0 +1,41 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { resolveFinishReason } from '../resolve-finish-reason';
+
+describe('resolveFinishReason', () => {
+  test('mid-loop step with tool calls returns tool_calls', () => {
+    assert({
+      given: 'hadToolCallInStep=true and isFinalStep=false',
+      should: 'return tool_calls to signal the client to expect tool results',
+      actual: resolveFinishReason(true, false),
+      expected: 'tool_calls',
+    });
+  });
+
+  test('final step returns stop', () => {
+    assert({
+      given: 'isFinalStep=true with no tool calls',
+      should: 'return stop — agent is done',
+      actual: resolveFinishReason(false, true),
+      expected: 'stop',
+    });
+  });
+
+  test('final step with tool calls returns stop', () => {
+    assert({
+      given: 'isFinalStep=true even when the step had tool calls',
+      should: 'return stop — isFinalStep wins',
+      actual: resolveFinishReason(true, true),
+      expected: 'stop',
+    });
+  });
+
+  test('mid-loop step without tool calls returns stop', () => {
+    assert({
+      given: 'hadToolCallInStep=false and isFinalStep=false',
+      should: 'return stop — no tool calls means no pending work',
+      actual: resolveFinishReason(false, false),
+      expected: 'stop',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/adapt-to-openai-chunk.ts
+++ b/apps/web/src/lib/ai/openai-api/adapt-to-openai-chunk.ts
@@ -1,9 +1,16 @@
 import type { UIMessageChunk } from 'ai';
+import { adaptToolInputPart } from './adapt-tool-input-part';
+import { adaptToolResultPart } from './adapt-tool-result-part';
+import { resolveFinishReason } from './resolve-finish-reason';
 
 export type AdaptOptions = {
   id: string;
   model: string;
   created: number;
+  /** 0-based index of this tool call within the current step (for tool-input-available chunks) */
+  toolCallIndex?: number;
+  /** Whether the current step has had any tool calls (for finish-step chunks) */
+  hadToolCallsInStep?: boolean;
 };
 
 const makeChunk = (options: AdaptOptions, delta: Record<string, unknown>, finishReason: string | null) => ({
@@ -24,11 +31,24 @@ export const adaptToOpenAIChunk = (chunk: UIMessageChunk, options: AdaptOptions)
     case 'text-delta':
       return toSSE(makeChunk(options, { content: chunk.delta }, null));
 
+    case 'tool-input-available':
+      return toSSE(
+        adaptToolInputPart(chunk, options.id, options.model, options.created, options.toolCallIndex ?? 0),
+      );
+
+    case 'tool-output-available':
+      return toSSE(adaptToolResultPart(chunk, options.id, options.model, options.created));
+
+    case 'finish-step': {
+      const finishReason = resolveFinishReason(options.hadToolCallsInStep ?? false, false);
+      return finishReason === 'tool_calls'
+        ? toSSE(makeChunk(options, {}, 'tool_calls'))
+        : null;
+    }
+
     case 'finish':
-      return [
-        toSSE(makeChunk(options, {}, 'stop')),
-        'data: [DONE]',
-      ].join('\n\n');
+      // [DONE] is emitted by the route after buildToolSummaryEvent
+      return toSSE(makeChunk(options, {}, 'stop'));
 
     default:
       return null;

--- a/apps/web/src/lib/ai/openai-api/adapt-tool-input-part.ts
+++ b/apps/web/src/lib/ai/openai-api/adapt-tool-input-part.ts
@@ -1,0 +1,56 @@
+type ToolInputPart = {
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+};
+
+type OpenAIChunk = {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      tool_calls: Array<{
+        index: number;
+        id: string;
+        type: 'function';
+        function: { name: string; arguments: string };
+      }>;
+    };
+    finish_reason: null;
+  }>;
+};
+
+export const adaptToolInputPart = (
+  part: ToolInputPart,
+  chunkId: string,
+  model: string,
+  created: number,
+  toolIndex: number,
+): OpenAIChunk => ({
+  id: chunkId,
+  object: 'chat.completion.chunk',
+  created,
+  model,
+  choices: [
+    {
+      index: 0,
+      delta: {
+        tool_calls: [
+          {
+            index: toolIndex,
+            id: part.toolCallId,
+            type: 'function',
+            function: {
+              name: part.toolName,
+              arguments: JSON.stringify(part.input),
+            },
+          },
+        ],
+      },
+      finish_reason: null,
+    },
+  ],
+});

--- a/apps/web/src/lib/ai/openai-api/adapt-tool-result-part.ts
+++ b/apps/web/src/lib/ai/openai-api/adapt-tool-result-part.ts
@@ -1,0 +1,44 @@
+type ToolOutputPart = {
+  toolCallId: string;
+  output: unknown;
+};
+
+type OpenAIChunk = {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: { role: 'tool'; tool_call_id: string; content: string };
+    finish_reason: null;
+  }>;
+};
+
+const serializeOutput = (output: unknown): string => {
+  if (typeof output === 'string') return output;
+  return JSON.stringify(output);
+};
+
+export const adaptToolResultPart = (
+  part: ToolOutputPart,
+  chunkId: string,
+  model: string,
+  created: number,
+): OpenAIChunk => ({
+  id: chunkId,
+  object: 'chat.completion.chunk',
+  created,
+  model,
+  choices: [
+    {
+      index: 0,
+      delta: {
+        role: 'tool',
+        tool_call_id: part.toolCallId,
+        content: serializeOutput(part.output),
+      },
+      finish_reason: null,
+    },
+  ],
+});

--- a/apps/web/src/lib/ai/openai-api/adapt-tool-result-part.ts
+++ b/apps/web/src/lib/ai/openai-api/adapt-tool-result-part.ts
@@ -10,14 +10,22 @@ type OpenAIChunk = {
   model: string;
   choices: Array<{
     index: number;
-    delta: { role: 'tool'; tool_call_id: string; content: string };
+    delta: { role: 'tool'; tool_call_id: string; tool_result: string };
     finish_reason: null;
   }>;
 };
 
+// Uses 'tool_result' instead of 'content' so standard OpenAI clients that
+// concatenate every delta.content field do not mix tool outputs into the
+// displayed assistant text. PageSpace-aware clients read 'tool_result'.
 const serializeOutput = (output: unknown): string => {
   if (typeof output === 'string') return output;
-  return JSON.stringify(output);
+  try {
+    const serialized = JSON.stringify(output);
+    return serialized === undefined ? '' : serialized;
+  } catch {
+    return String(output);
+  }
 };
 
 export const adaptToolResultPart = (
@@ -36,7 +44,7 @@ export const adaptToolResultPart = (
       delta: {
         role: 'tool',
         tool_call_id: part.toolCallId,
-        content: serializeOutput(part.output),
+        tool_result: serializeOutput(part.output),
       },
       finish_reason: null,
     },

--- a/apps/web/src/lib/ai/openai-api/build-tool-summary-event.ts
+++ b/apps/web/src/lib/ai/openai-api/build-tool-summary-event.ts
@@ -4,15 +4,22 @@ type ToolCallEntry = {
 };
 
 type StepWithToolCalls = {
-  toolCalls: ToolCallEntry[];
+  toolCalls?: ToolCallEntry[];
 };
 
+// Uses the choices:[] pattern (same as OpenAI usage chunks) so standard
+// OpenAI client libraries that iterate over choices[] see nothing and skip
+// the event silently. PageSpace-aware clients read x_pagespace_tool_summary.
 export const buildToolSummaryEvent = (steps: StepWithToolCalls[]): string | null => {
   const toolCalls: ToolCallEntry[] = steps.flatMap(step =>
-    step.toolCalls.map(tc => ({ toolCallId: tc.toolCallId, toolName: tc.toolName })),
+    (step.toolCalls ?? []).map(tc => ({ toolCallId: tc.toolCallId, toolName: tc.toolName })),
   );
 
   if (toolCalls.length === 0) return null;
 
-  return `event: PAGESPACE_TOOL_SUMMARY\ndata: ${JSON.stringify({ toolCalls, stepCount: steps.length })}`;
+  return `data: ${JSON.stringify({
+    object: 'chat.completion.chunk',
+    choices: [],
+    x_pagespace_tool_summary: { toolCalls, stepCount: steps.length },
+  })}`;
 };

--- a/apps/web/src/lib/ai/openai-api/build-tool-summary-event.ts
+++ b/apps/web/src/lib/ai/openai-api/build-tool-summary-event.ts
@@ -1,0 +1,18 @@
+type ToolCallEntry = {
+  toolCallId: string;
+  toolName: string;
+};
+
+type StepWithToolCalls = {
+  toolCalls: ToolCallEntry[];
+};
+
+export const buildToolSummaryEvent = (steps: StepWithToolCalls[]): string | null => {
+  const toolCalls: ToolCallEntry[] = steps.flatMap(step =>
+    step.toolCalls.map(tc => ({ toolCallId: tc.toolCallId, toolName: tc.toolName })),
+  );
+
+  if (toolCalls.length === 0) return null;
+
+  return `event: PAGESPACE_TOOL_SUMMARY\ndata: ${JSON.stringify({ toolCalls, stepCount: steps.length })}`;
+};

--- a/apps/web/src/lib/ai/openai-api/resolve-finish-reason.ts
+++ b/apps/web/src/lib/ai/openai-api/resolve-finish-reason.ts
@@ -1,0 +1,7 @@
+export const resolveFinishReason = (
+  hadToolCallInStep: boolean,
+  isFinalStep: boolean,
+): 'tool_calls' | 'stop' => {
+  if (hadToolCallInStep && !isFinalStep) return 'tool_calls';
+  return 'stop';
+};


### PR DESCRIPTION
## Summary

- **Emit tool call chunks** — \`tool-input-available\` stream parts are now adapted to OpenAI \`delta.tool_calls[]\` format, giving clients the tool name, call ID, and serialized arguments
- **Emit tool result chunks** — \`tool-output-available\` stream parts are adapted to \`delta.role='tool'\` chunks using a \`tool_result\` field (not \`content\`) so standard OpenAI clients that concatenate \`delta.content\` do not mix tool outputs into the assistant text stream
- **Correct \`finish_reason\`** — \`finish-step\` events after tool calls emit \`finish_reason: 'tool_calls'\`; the final \`finish\` always emits \`finish_reason: 'stop'\`; \`[DONE]\` moves from the adapter to the route so it comes last
- **Tool summary chunk** — a \`choices:[]\` chunk (same pattern OpenAI uses for usage chunks) carrying \`x_pagespace_tool_summary\` is emitted before \`[DONE]\`, aggregating all tool calls and step count across the agent's full run; standard OpenAI clients iterate over \`choices[]\`, see nothing, and skip it silently

## Architecture

All new logic lives in four pure functions (\`adaptToolInputPart\`, \`adaptToolResultPart\`, \`resolveFinishReason\`, \`buildToolSummaryEvent\`). The route tracks per-step state (\`stepToolCallIndex\`, \`stepHadToolCalls\`) and threads it into the adapter — no side effects in pure helpers.

## Design decisions

- **\`tool_result\` not \`content\`**: OpenAI's streaming protocol concatenates every \`delta.content\` token into the displayed message. Putting tool outputs in \`content\` would inject raw JSON blobs into the visible assistant reply in any generic OpenAI-compatible client. Using a separate \`tool_result\` field keeps the assistant text clean.
- **\`choices:[]\` not a named SSE event**: Named SSE events (\`event: PAGESPACE_TOOL_SUMMARY\`) break OpenAI client libraries that only parse \`data:\` lines. The \`choices:[]\` chunk pattern is already established OpenAI practice (used for their own usage reporting) and is safely skipped by existing client parsers.

## Test plan

- [x] 34 new unit tests pass (\`bun run test:unit\`)
- [x] 0 TypeScript errors in new files
- [ ] Connect pagespace-cli and observe tool call chunks in a real agent run
- [ ] Verify tool summary chunk appears before \`[DONE]\` in the SSE stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)