### PR TITLE
feat(settings): drive backups page

### DIFF
--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { useDriveStore } from '@/hooks/useDrive';
@@ -63,8 +63,9 @@ export default function BackupsPage() {
   const fetchDrives = useDriveStore((s) => s.fetchDrives);
   const isLoadingDrives = useDriveStore((s) => s.isLoading);
 
-  const adminDrives = drives.filter(
-    (d) => !d.isTrashed && (d.isOwned || d.role === 'OWNER' || d.role === 'ADMIN')
+  const adminDrives = useMemo(
+    () => drives.filter((d) => !d.isTrashed && (d.isOwned || d.role === 'OWNER' || d.role === 'ADMIN')),
+    [drives]
   );
 
   const [selectedDriveId, setSelectedDriveId] = useState('');

--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { useRouter } from 'next/navigation';
+import { useDriveStore } from '@/hooks/useDrive';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+import { ArrowLeft, HardDrive, Loader2, Plus } from 'lucide-react';
+import useSWR from 'swr';
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { format, formatDistanceToNow } from 'date-fns';
+import type { DriveBackupSummary } from '@/services/api/drive-backup-service';
+
+type SerializedBackup = Omit<DriveBackupSummary, 'createdAt' | 'completedAt' | 'failedAt'> & {
+  createdAt: string;
+  completedAt: string | null;
+  failedAt: string | null;
+};
+
+type BackupListResponse = { backups: SerializedBackup[] };
+
+type CreateBackupResult = {
+  backupId: string;
+  status: string;
+  counts: { pages: number; permissions: number; members: number; roles: number; files: number };
+};
+
+const fetcher = async (url: string): Promise<BackupListResponse> => {
+  const r = await fetchWithAuth(url);
+  if (!r.ok) {
+    const data = await r.json().catch(() => ({}));
+    const err = Object.assign(new Error((data as { error?: string }).error ?? 'Failed to fetch'), {
+      status: r.status,
+    });
+    throw err;
+  }
+  return r.json();
+};
+
+function statusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'ready') return 'default';
+  if (status === 'failed') return 'destructive';
+  return 'secondary';
+}
+
+export default function BackupsPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const drives = useDriveStore((s) => s.drives);
+  const currentDriveId = useDriveStore((s) => s.currentDriveId);
+  const fetchDrives = useDriveStore((s) => s.fetchDrives);
+  const isLoadingDrives = useDriveStore((s) => s.isLoading);
+
+  const adminDrives = drives.filter(
+    (d) => !d.isTrashed && (d.isOwned || d.role === 'OWNER' || d.role === 'ADMIN')
+  );
+
+  const [selectedDriveId, setSelectedDriveId] = useState('');
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/auth/signin');
+    }
+  }, [authLoading, user, router]);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  useEffect(() => {
+    if (!selectedDriveId && adminDrives.length > 0) {
+      const preferred =
+        adminDrives.find((d) => d.id === currentDriveId) ?? adminDrives[0];
+      setSelectedDriveId(preferred.id);
+    }
+  }, [adminDrives, currentDriveId, selectedDriveId]);
+
+  const { data, isLoading: isLoadingBackups, mutate, error } = useSWR<BackupListResponse>(
+    selectedDriveId ? `/api/drives/${selectedDriveId}/backups` : null,
+    fetcher
+  );
+
+  const selectedDrive = drives.find((d) => d.id === selectedDriveId);
+
+  const handleCreateBackup = async () => {
+    if (!selectedDriveId || isCreating) return;
+    setIsCreating(true);
+    try {
+      const result = await post<CreateBackupResult>(`/api/drives/${selectedDriveId}/backups`, {
+        source: 'manual',
+        label: newLabel.trim() || undefined,
+      });
+      toast.success(`Backup created — ${result.counts.pages} pages snapshotted`);
+      setNewLabel('');
+      setShowCreateForm(false);
+      mutate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create backup');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <div className="container max-w-4xl mx-auto py-10 px-10 flex items-center justify-center min-h-[400px]">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-4xl mx-auto py-10 px-10 space-y-8">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push('/settings')}
+          className="mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold flex items-center gap-2">
+          <HardDrive className="h-8 w-8" />
+          Drive Backups
+        </h1>
+        <p className="text-muted-foreground mt-2">
+          Create and manage snapshots of your drives. Backups capture all pages, permissions, and members at a point in time.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Select Drive</CardTitle>
+          <CardDescription>
+            Choose a drive you own or administer to view its backups.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoadingDrives ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Loading drives…</span>
+            </div>
+          ) : adminDrives.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              You don&apos;t own or administer any drives.
+            </p>
+          ) : (
+            <Select value={selectedDriveId} onValueChange={setSelectedDriveId}>
+              <SelectTrigger className="w-full max-w-sm">
+                <SelectValue placeholder="Select a drive" />
+              </SelectTrigger>
+              <SelectContent>
+                {adminDrives.map((drive) => (
+                  <SelectItem key={drive.id} value={drive.id}>
+                    {drive.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </CardContent>
+      </Card>
+
+      {selectedDriveId && (
+        <Card>
+          <CardHeader className="flex flex-row items-start justify-between space-y-0">
+            <div>
+              <CardTitle>Backups</CardTitle>
+              <CardDescription>{selectedDrive?.name}</CardDescription>
+            </div>
+            {!showCreateForm && (
+              <Button size="sm" onClick={() => setShowCreateForm(true)}>
+                <Plus className="h-4 w-4 mr-2" />
+                Create Backup
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {showCreateForm && (
+              <div className="flex items-end gap-3 p-4 rounded-lg border bg-muted/40">
+                <div className="flex-1 space-y-1.5">
+                  <Label htmlFor="backup-label">Label <span className="text-muted-foreground font-normal">(optional)</span></Label>
+                  <Input
+                    id="backup-label"
+                    placeholder="e.g. Before Q2 restructure"
+                    value={newLabel}
+                    onChange={(e) => setNewLabel(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleCreateBackup();
+                      if (e.key === 'Escape') { setShowCreateForm(false); setNewLabel(''); }
+                    }}
+                    disabled={isCreating}
+                    autoFocus
+                  />
+                </div>
+                <Button onClick={handleCreateBackup} disabled={isCreating}>
+                  {isCreating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                  Snapshot Now
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => { setShowCreateForm(false); setNewLabel(''); }}
+                  disabled={isCreating}
+                >
+                  Cancel
+                </Button>
+              </div>
+            )}
+
+            {error ? (
+              <p className="text-sm text-muted-foreground py-4">
+                {(error as { status?: number }).status === 403
+                  ? 'You need to be a drive owner or admin to manage backups for this drive.'
+                  : 'Failed to load backups.'}
+              </p>
+            ) : isLoadingBackups ? (
+              <div className="flex items-center gap-2 text-muted-foreground py-4">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="text-sm">Loading backups…</span>
+              </div>
+            ) : !data?.backups.length ? (
+              <p className="text-sm text-muted-foreground py-4">
+                No backups yet. Create one to snapshot this drive&apos;s current state.
+              </p>
+            ) : (
+              <div className="divide-y">
+                {data.backups.map((backup) => (
+                  <div key={backup.id} className="flex items-start justify-between py-3 gap-4">
+                    <div className="space-y-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
+                        <Badge variant="outline">{backup.source}</Badge>
+                        {backup.label && (
+                          <span className="text-sm font-medium truncate">{backup.label}</span>
+                        )}
+                      </div>
+                      {backup.failureReason && (
+                        <p className="text-xs text-destructive">{backup.failureReason}</p>
+                      )}
+                    </div>
+                    <div
+                      className="text-right text-sm text-muted-foreground shrink-0"
+                      title={format(new Date(backup.createdAt), 'PPpp')}
+                    >
+                      {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -96,7 +96,10 @@ export default function BackupsPage() {
     fetcher
   );
 
-  const selectedDrive = drives.find((d) => d.id === selectedDriveId);
+  const selectedDrive = useMemo(
+    () => drives.find((d) => d.id === selectedDriveId),
+    [drives, selectedDriveId]
+  );
 
   const handleCreateBackup = async () => {
     if (!selectedDriveId || isCreating) return;

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -6,7 +6,7 @@ import { useMCP } from "@/hooks/useMCP";
 import { useAuth } from "@/hooks/useAuth";
 import { useBillingVisibility } from "@/hooks/useBillingVisibility";
 import { Button } from "@/components/ui/button";
-import { User, Plug2, Key, ArrowLeft, CreditCard, Bell, Shield, Keyboard, Sparkles, Eye, Cable, Calendar, Scale } from "lucide-react";
+import { User, Plug2, Key, ArrowLeft, CreditCard, Bell, Shield, Keyboard, Sparkles, Eye, Cable, Calendar, Scale, HardDrive } from "lucide-react";
 import { SettingsRow, type SettingsItem } from "./SettingsRow";
 
 const ADMIN_APP_URL = process.env.NEXT_PUBLIC_ADMIN_APP_URL || 'http://localhost:3005';
@@ -60,6 +60,13 @@ export default function SettingsPage() {
           description: "Customize keyboard shortcuts",
           icon: Keyboard,
           href: "/settings/hotkeys",
+          available: true,
+        },
+        {
+          title: "Backups",
+          description: "Create and manage snapshots of your drives",
+          icon: HardDrive,
+          href: "/settings/backups",
           available: true,
         },
         {


### PR DESCRIPTION
## Summary

- Adds `/settings/backups` — a new settings page where drive owners and admins can view existing snapshots and create new ones
- Adds **Backups** entry to the Personal section in `/settings` nav (with `HardDrive` icon)
- The underlying `drive_backups` schema, service, and API (`GET/POST /api/drives/[driveId]/backups`) already existed with no UI surface — this PR surfaces them

## What the page does

- Drive selector filtered to drives the user owns or admins
- Lists backups per drive: status badge (`ready`/`pending`/`failed`), source badge (`manual`/`scheduled`/`system`), optional label, relative timestamp with full date on hover
- **Create Backup** expands an inline form with an optional label field → `POST` to the API → toast with page count + SWR revalidate
- Handles empty state, loading, 403 (permission denied), and failure reason display

## Test plan

- [ ] Navigate to `/settings` — confirm **Backups** entry appears in the Personal section
- [ ] Click through to `/settings/backups` — drive selector loads with owned/admin drives
- [ ] Select a drive you own — backup list fetches (empty state if no prior backups)
- [ ] Click **Create Backup**, optionally set a label, click **Snapshot Now** — toast shows page count, list refreshes with `ready` status
- [ ] Select a drive where you're only a member — 403 error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Backups management page in Settings for comprehensive backup control
  * Create new backups with custom labels for your drives
  * View complete backup history with status indicators and creation timestamps
  * Manage backups across multiple drives with drive selector
  * Added Backups option to main Settings menu for quick access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->