### PR TITLE
fix(billing): use resolvedModelName in error path

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -105,6 +105,7 @@ export async function POST(request: Request) {
   // summed usage/steps for billing plus the success flag, abort detection, and retry
   // observability — so no separate usage/steps promises are needed.
   let agentRun: RunAgentWithRetryResult | undefined;
+  let resolvedModelName: string | undefined;
   let lifecycle: StreamLifecycleHandle | undefined;
   let activeStreamId: string | undefined;
   let serverAssistantMessageId: string | undefined;
@@ -532,7 +533,8 @@ export async function POST(request: Request) {
 
     // Use the resolved model name for billing. providerResult.modelName is the
     // real OpenRouter model id sent to the backend.
-    const { model, modelName: resolvedModelName } = providerResult;
+    const { model } = providerResult;
+    resolvedModelName = providerResult.modelName;
 
     // Update user's current provider/model if changed
     await updateUserProviderSettings(userId, selectedProvider, selectedModel);
@@ -880,7 +882,7 @@ export async function POST(request: Request) {
           // Gate tools on the CONCRETE backend model id (resolvedModelName), not the
           // PageSpace alias in currentModel — vision/tool detection pattern-matches the
           // model string, so an alias yields wrong capability flags.
-          const modelCapabilitiesForTools = await getModelCapabilities(resolvedModelName, currentProvider);
+          const modelCapabilitiesForTools = await getModelCapabilities(resolvedModelName!, currentProvider);
           // Server-side, in-request retry: if an attempt drops mid-loop (OpenRouter
           // disconnect) or ends mid-tool without the finish tool, transparently
           // re-drive the loop under one message envelope. The loop lives inside
@@ -1055,7 +1057,7 @@ export async function POST(request: Request) {
             await AIMonitoring.trackUsage({
               userId: userId!,
               provider: currentProvider,
-              model: resolvedModelName,
+              model: resolvedModelName!,
               source: 'chat',
               inputTokens,
               outputTokens,
@@ -1096,7 +1098,7 @@ export async function POST(request: Request) {
                 await AIMonitoring.trackToolUsage({
                   userId: userId!,
                   provider: currentProvider,
-                  model: resolvedModelName,
+                  model: resolvedModelName!,
                   toolName: toolCall.toolName,
                   toolId: toolCall.toolCallId,
                   args: undefined,
@@ -1169,7 +1171,7 @@ export async function POST(request: Request) {
     await AIMonitoring.trackUsage({
       userId: userId || 'unknown',
       provider: selectedProvider || 'unknown',
-      model: selectedModel || 'unknown',
+      model: resolvedModelName ?? selectedModel ?? 'unknown',
       source: 'chat',
       inputTokens: usage?.inputTokens ?? undefined,
       outputTokens: usage?.outputTokens ?? undefined,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -105,6 +105,8 @@ export async function POST(request: Request) {
   // summed usage/steps for billing plus the success flag, abort detection, and retry
   // observability — so no separate usage/steps promises are needed.
   let agentRun: RunAgentWithRetryResult | undefined;
+  // Hoisted to outer scope so the catch-path trackUsage call bills on the real
+  // backend model id rather than the client-supplied alias (selectedModel).
   let resolvedModelName: string | undefined;
   let lifecycle: StreamLifecycleHandle | undefined;
   let activeStreamId: string | undefined;

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -654,7 +654,7 @@ describe('trackAIUsage', () => {
     await trackAIUsage({
       userId: 'user-1',
       provider: 'openai',
-      model: 'openai/some-model',
+      model: 'openai/o3',
       inputTokens: 10,
       outputTokens: 10,
     });

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -135,18 +135,9 @@ describe('calculateCost', () => {
     expect(calculateCost('completely-unknown-model', 1_000_000, 1_000_000)).toBe(0);
   });
 
-  it('emits warn when unknown model has non-zero tokens', () => {
+  it('does not warn for unknown model (warning lives in trackAIUsage with provider context)', () => {
     vi.clearAllMocks();
     calculateCost('completely-unknown-model', 1_000_000, 500_000);
-    expect(mockAiLogger.warn).toHaveBeenCalledWith(
-      'calculateCost: unknown model, billing $0',
-      { model: 'completely-unknown-model', inputTokens: 1_000_000, outputTokens: 500_000 }
-    );
-  });
-
-  it('does not warn when unknown model has zero tokens', () => {
-    vi.clearAllMocks();
-    calculateCost('completely-unknown-model', 0, 0);
     expect(mockAiLogger.warn).not.toHaveBeenCalled();
   });
 
@@ -689,6 +680,45 @@ describe('trackAIUsage', () => {
       'openrouter cost metadata missing; falling back to estimate',
       expect.anything(),
     );
+  });
+
+  it('warns when a cloud provider uses an unknown model with non-zero tokens', async () => {
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'completely-unknown-model',
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+    });
+    expect(mockAiLogger.warn).toHaveBeenCalledWith(
+      'unknown model pricing, billing $0',
+      expect.objectContaining({ model: 'completely-unknown-model', provider: 'anthropic' }),
+    );
+  });
+
+  it('does not warn when a local provider uses an unknown model (expected $0)', async () => {
+    vi.clearAllMocks();
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'ollama',
+      model: 'qwen3',
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+    });
+    expect(mockAiLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when a real OpenRouter cost is present (no estimate fallback)', async () => {
+    vi.clearAllMocks();
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'completely-unknown-model',
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      providerCostDollars: 0.42,
+    });
+    expect(mockAiLogger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -11,6 +11,7 @@ const mockConsumeCredits = vi.hoisted(() => vi.fn().mockResolvedValue(undefined)
 const mockAiLogger = vi.hoisted(() => ({
   debug: vi.fn(),
   error: vi.fn(),
+  warn: vi.fn(),
 }));
 const mockDbSelectFn = vi.hoisted(() => vi.fn());
 
@@ -130,8 +131,23 @@ describe('calculateCost', () => {
     expect(calculateCost('llama3.2', 100_000, 100_000)).toBe(0);
   });
 
-  it('should fall back to default pricing (0,0) for unknown model', () => {
+  it('should return 0 for unknown model', () => {
     expect(calculateCost('completely-unknown-model', 1_000_000, 1_000_000)).toBe(0);
+  });
+
+  it('emits warn when unknown model has non-zero tokens', () => {
+    vi.clearAllMocks();
+    calculateCost('completely-unknown-model', 1_000_000, 500_000);
+    expect(mockAiLogger.warn).toHaveBeenCalledWith(
+      'calculateCost: unknown model, billing $0',
+      { model: 'completely-unknown-model', inputTokens: 1_000_000, outputTokens: 500_000 }
+    );
+  });
+
+  it('does not warn when unknown model has zero tokens', () => {
+    vi.clearAllMocks();
+    calculateCost('completely-unknown-model', 0, 0);
+    expect(mockAiLogger.warn).not.toHaveBeenCalled();
   });
 
   // Regression guard: the retired GLM model ids must stay priced as a legacy billing
@@ -227,7 +243,7 @@ describe('calculateCost', () => {
     ).toBe(calculateCost('gpt-4o', 1_000_000, 1_000_000));
   });
 
-  it('unknown model still uses default pricing with opts', () => {
+  it('unknown model returns 0 regardless of opts', () => {
     expect(
       calculateCost('completely-unknown-model', 1_000_000, 0, { reasoningTokens: 1_000_000 })
     ).toBe(0);

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -621,7 +621,13 @@ export function calculateCost(
   outputTokens: number = 0,
   opts: { cachedInputTokens?: number; reasoningTokens?: number } = {}
 ): number {
-  const pricing = AI_PRICING[model as keyof typeof AI_PRICING] || AI_PRICING.default;
+  const pricing = AI_PRICING[model as keyof typeof AI_PRICING];
+  if (!pricing) {
+    if (inputTokens > 0 || outputTokens > 0) {
+      loggers.ai.warn('calculateCost: unknown model, billing $0', { model, inputTokens, outputTokens });
+    }
+    return 0;
+  }
 
   // Cached tokens are a subset of input; clamp to [0, inputTokens] so bad metadata
   // can't drive the cost negative or above the full-input cost. Fresh input bills at

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -623,9 +623,6 @@ export function calculateCost(
 ): number {
   const pricing = AI_PRICING[model as keyof typeof AI_PRICING];
   if (!pricing) {
-    if (inputTokens > 0 || outputTokens > 0) {
-      loggers.ai.warn('calculateCost: unknown model, billing $0', { model, inputTokens, outputTokens });
-    }
     return 0;
   }
 
@@ -840,6 +837,18 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
     // Every cloud vendor is served through OpenRouter; only the providers on the
     // explicit non-OpenRouter allowlist (local runtimes + direct voice) are not.
     const isOpenRouter = !NON_OPENROUTER_AI_PROVIDERS.has(data.provider);
+    // Flag unknown pricing only for cloud providers where missing AI_PRICING is a
+    // real coverage gap. Local providers (ollama, lmstudio) run arbitrary models
+    // absent from the static list, so $0 cost there is expected — not an alarm.
+    if (!hasRealCost && isOpenRouter && fallbackCost === 0 &&
+        ((inputTokens ?? 0) + (outputTokens ?? 0)) > 0) {
+      loggers.ai.warn('unknown model pricing, billing $0', {
+        model: data.model,
+        provider: data.provider,
+        inputTokens,
+        outputTokens,
+      });
+    }
     if (!hasRealCost && isOpenRouter) {
       // An OpenRouter call that should have carried cost metadata didn't — log
       // and fall back so we still bill (durability), but flag the coverage gap.

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -837,25 +837,25 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
     // Every cloud vendor is served through OpenRouter; only the providers on the
     // explicit non-OpenRouter allowlist (local runtimes + direct voice) are not.
     const isOpenRouter = !NON_OPENROUTER_AI_PROVIDERS.has(data.provider);
-    // Flag unknown pricing only for cloud providers where missing AI_PRICING is a
-    // real coverage gap. Local providers (ollama, lmstudio) run arbitrary models
-    // absent from the static list, so $0 cost there is expected — not an alarm.
-    if (!hasRealCost && isOpenRouter && fallbackCost === 0 &&
-        ((inputTokens ?? 0) + (outputTokens ?? 0)) > 0) {
-      loggers.ai.warn('unknown model pricing, billing $0', {
-        model: data.model,
-        provider: data.provider,
-        inputTokens,
-        outputTokens,
-      });
-    }
     if (!hasRealCost && isOpenRouter) {
-      // An OpenRouter call that should have carried cost metadata didn't — log
-      // and fall back so we still bill (durability), but flag the coverage gap.
-      loggers.ai.debug('openrouter cost metadata missing; falling back to estimate', {
-        model: data.model,
-        provider: data.provider,
-      });
+      if (fallbackCost === 0 && ((inputTokens ?? 0) + (outputTokens ?? 0)) > 0) {
+        // Model absent from AI_PRICING for a cloud provider — real coverage gap.
+        // Local providers (ollama, lmstudio) run arbitrary model ids not in the
+        // static list, so $0 there is expected; isOpenRouter already excludes them.
+        loggers.ai.warn('unknown model pricing, billing $0', {
+          model: data.model,
+          provider: data.provider,
+          inputTokens,
+          outputTokens,
+        });
+      } else {
+        // Known model but OpenRouter didn't return cost metadata — fall back to
+        // the static estimate so billing is durable.
+        loggers.ai.debug('openrouter cost metadata missing; falling back to estimate', {
+          model: data.model,
+          provider: data.provider,
+        });
+      }
     }
     const success = data.success !== false;
 


### PR DESCRIPTION
## Summary

- **Fix 1 (chat/route.ts):** Hoist \`resolvedModelName\` to outer scope so the catch-path \`AIMonitoring.trackUsage\` call uses the real backend model id (\`resolvedModelName ?? selectedModel ?? 'unknown'\`) instead of the raw client-supplied \`selectedModel\` string. On non-OpenRouter providers, \`selectedModel\` could be an alias that misses \`AI_PRICING\`, silently billing \$0 for partial completions.

- **Fix 2 (ai-monitoring.ts):** \`calculateCost\` no longer silently falls through to \`AI_PRICING.default = {input:0, output:0}\` for unknown models — it returns \`0\` directly. The observability warning is emitted in \`trackAIUsage\` (where \`provider\` is available), gated on \`!NON_OPENROUTER_AI_PROVIDERS.has(data.provider)\` so local runtimes (ollama, lmstudio) that legitimately run arbitrary model ids absent from the static pricing list don't generate false billing alarms.

- **Fix 3 (tests):** New tests in \`calculateCost\` (no warn, just returns 0) and \`trackAIUsage\` (cloud + unknown model warns; local provider + unknown model silent; real \`providerCostDollars\` present → no warn).

## Test plan

- [x] \`bun run test:unit\` — all \`calculateCost\` + new \`trackAIUsage\` tests pass
- [x] Error-path \`trackUsage\` in \`chat/route.ts\` line ~1174 uses \`resolvedModelName ?? selectedModel ?? 'unknown'\`
- [x] Warning fires only for cloud providers where missing AI_PRICING is a genuine coverage gap
- [x] Local providers (ollama, lmstudio, azure_openai, openai_voice) remain silent for unknown models
- [x] No new type errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)