### PR TITLE
feat(billing): calcStepCostDollars + shouldAbortAfterStep pure functions

### DIFF
--- a/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
@@ -93,6 +93,7 @@ describe('calcStepCostDollars', () => {
   it('returns 0 for an unknown model (calculateCost returns 0)', () => {
     mockCalculateCost.mockReturnValue(0);
     const result = calcStepCostDollars('some/unknown-model', { promptTokens: 1000, completionTokens: 500 });
+    expect(mockCalculateCost).toHaveBeenCalledWith('some/unknown-model', 1000, 500);
     expect(result).toBe(0);
   });
 

--- a/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/chat-pricing.test.ts
@@ -15,7 +15,7 @@ vi.mock('../ai-monitoring', () => ({
   },
 }));
 
-import { estimateChatHoldCentsForModel } from '../chat-pricing';
+import { estimateChatHoldCentsForModel, calcStepCostDollars, shouldAbortAfterStep } from '../chat-pricing';
 import {
   CHAT_HOLD_ASSUMED_INPUT_TOKENS,
   CHAT_HOLD_ASSUMED_OUTPUT_TOKENS,
@@ -79,5 +79,103 @@ describe('estimateChatHoldCentsForModel', () => {
     expect(estimateChatHoldCentsForModel('toString')).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
     expect(estimateChatHoldCentsForModel('constructor')).toBe(CREDIT_HOLD_ESTIMATE_CENTS);
     expect(mockCalculateCost).not.toHaveBeenCalled();
+  });
+});
+
+describe('calcStepCostDollars', () => {
+  it('returns the dollar cost from calculateCost for a known model with realistic tokens', () => {
+    mockCalculateCost.mockReturnValue(0.10);
+    const result = calcStepCostDollars('anthropic/claude-opus-4.8', { promptTokens: 1000, completionTokens: 500 });
+    expect(mockCalculateCost).toHaveBeenCalledWith('anthropic/claude-opus-4.8', 1000, 500);
+    expect(result).toBe(0.10);
+  });
+
+  it('returns 0 for an unknown model (calculateCost returns 0)', () => {
+    mockCalculateCost.mockReturnValue(0);
+    const result = calcStepCostDollars('some/unknown-model', { promptTokens: 1000, completionTokens: 500 });
+    expect(result).toBe(0);
+  });
+
+  it('returns 0 when both token counts are zero', () => {
+    mockCalculateCost.mockReturnValue(0);
+    const result = calcStepCostDollars('anthropic/claude-opus-4.8', { promptTokens: 0, completionTokens: 0 });
+    expect(result).toBe(0);
+  });
+
+  it('returns non-zero when only completionTokens are present for a known model', () => {
+    mockCalculateCost.mockReturnValue(0.05);
+    const result = calcStepCostDollars('openai/gpt-5', { promptTokens: 0, completionTokens: 2000 });
+    expect(mockCalculateCost).toHaveBeenCalledWith('openai/gpt-5', 0, 2000);
+    expect(result).toBe(0.05);
+  });
+
+  it('returns 0 if calculateCost throws', () => {
+    mockCalculateCost.mockImplementation(() => { throw new Error('pricing error'); });
+    expect(calcStepCostDollars('anthropic/claude-opus-4.8', { promptTokens: 1000, completionTokens: 500 })).toBe(0);
+  });
+});
+
+describe('shouldAbortAfterStep', () => {
+  // markupCents(0.10, 15000) = round(0.10 * 1.5 * 100) = 15¢
+  // spendable = 500 - 15 = 485 > 25 → false
+  it('returns false when spendable after markup exceeds reserve floor', () => {
+    expect(shouldAbortAfterStep({
+      cumulativeCostDollars: 0.10,
+      balanceCents: 500,
+      markupBps: 15000,
+      reserveFloorCents: 25,
+    })).toBe(false);
+  });
+
+  // markupCents(0.10, 15000) = 15¢; spendable = 30 - 15 = 15 <= 25 → true
+  it('returns true when spendable after markup is below reserve floor', () => {
+    expect(shouldAbortAfterStep({
+      cumulativeCostDollars: 0.10,
+      balanceCents: 30,
+      markupBps: 15000,
+      reserveFloorCents: 25,
+    })).toBe(true);
+  });
+
+  // markupCents(0.10, 15000) = 15¢; spendable = 40 - 15 = 25 <= 25 → true (exact floor = abort)
+  it('returns true when spendable equals the reserve floor exactly', () => {
+    expect(shouldAbortAfterStep({
+      cumulativeCostDollars: 0.10,
+      balanceCents: 40,
+      markupBps: 15000,
+      reserveFloorCents: 25,
+    })).toBe(true);
+  });
+
+  // balance=0 → always abort regardless of cost
+  it('returns true when balance is zero', () => {
+    expect(shouldAbortAfterStep({
+      cumulativeCostDollars: 0.01,
+      balanceCents: 0,
+      markupBps: 15000,
+      reserveFloorCents: 25,
+    })).toBe(true);
+  });
+
+  // markupCents(0, 15000) = 0; spendable = 100 - 0 = 100 > 25 → false
+  it('returns false when cumulative cost is zero and balance exceeds floor', () => {
+    expect(shouldAbortAfterStep({
+      cumulativeCostDollars: 0,
+      balanceCents: 100,
+      markupBps: 15000,
+      reserveFloorCents: 25,
+    })).toBe(false);
+  });
+
+  // Multi-step: balance=100, floor=25, markup=15000
+  // cumulative $0.10→15¢ charged, $0.20→30¢, $0.30→45¢, $0.40→60¢, $0.50→75¢
+  // 100-15=85>25 false, 100-30=70>25 false, 100-45=55>25 false, 100-60=40>25 false, 100-75=25<=25 true
+  it('transitions from false to true at the correct cumulative step', () => {
+    const base = { balanceCents: 100, markupBps: 15000, reserveFloorCents: 25 };
+    expect(shouldAbortAfterStep({ ...base, cumulativeCostDollars: 0.10 })).toBe(false);
+    expect(shouldAbortAfterStep({ ...base, cumulativeCostDollars: 0.20 })).toBe(false);
+    expect(shouldAbortAfterStep({ ...base, cumulativeCostDollars: 0.30 })).toBe(false);
+    expect(shouldAbortAfterStep({ ...base, cumulativeCostDollars: 0.40 })).toBe(false);
+    expect(shouldAbortAfterStep({ ...base, cumulativeCostDollars: 0.50 })).toBe(true);
   });
 });

--- a/packages/lib/src/monitoring/chat-pricing.ts
+++ b/packages/lib/src/monitoring/chat-pricing.ts
@@ -15,7 +15,7 @@
  */
 
 import { calculateCost, AI_PRICING } from './ai-monitoring';
-import { estimateChatHoldCents } from '../billing/credit-core';
+import { estimateChatHoldCents, markupCents } from '../billing/credit-core';
 import {
   MARKUP_BPS,
   CHAT_HOLD_FLOOR_CENTS,
@@ -36,6 +36,37 @@ import {
  * a real call down to the floor and weaken the gate. A KNOWN free model (input/output
  * both $0, e.g. gpt-oss) legitimately prices to the floor — that's fine.
  */
+/**
+ * Cost in dollars for one AI SDK step, using the static pricing fallback.
+ * Returns 0 for unknown models (calculateCost returns 0) or if pricing throws.
+ * Pure — no side effects.
+ */
+export function calcStepCostDollars(
+  model: string,
+  usage: { promptTokens: number; completionTokens: number },
+): number {
+  try {
+    return calculateCost(model, usage.promptTokens, usage.completionTokens);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * True when the user's remaining spendable credits (after applying the markup on
+ * cumulative cost so far) are at or below the reserve floor. Abort the stream.
+ * Pure — no side effects.
+ */
+export function shouldAbortAfterStep(input: {
+  cumulativeCostDollars: number;
+  balanceCents: number;
+  markupBps: number;
+  reserveFloorCents: number;
+}): boolean {
+  const chargedSoFarCents = markupCents(input.cumulativeCostDollars, input.markupBps);
+  return input.balanceCents - chargedSoFarCents <= input.reserveFloorCents;
+}
+
 export function estimateChatHoldCentsForModel(
   model: string | undefined,
   opts: { inputTokens?: number } = {},

--- a/packages/lib/src/monitoring/chat-pricing.ts
+++ b/packages/lib/src/monitoring/chat-pricing.ts
@@ -25,18 +25,6 @@ import {
 } from '../billing/credit-pricing';
 
 /**
- * Whole-cent hold reservation for one chat call against `model`. Prices the assumed
- * per-call token budget (or a caller-supplied `inputTokens` estimate, when cheaply
- * available) at the catalog rate, applies the markup, and clamps to
- * [CHAT_HOLD_FLOOR_CENTS, CREDIT_HOLD_ESTIMATE_CENTS] — never below a sane minimum nor
- * above the legacy flat chat hold.
- *
- * An UNKNOWN or absent model (not in the catalog) falls back to the legacy flat hold
- * rather than being priced: the catalog default rate is $0, which would otherwise clamp
- * a real call down to the floor and weaken the gate. A KNOWN free model (input/output
- * both $0, e.g. gpt-oss) legitimately prices to the floor — that's fine.
- */
-/**
  * Cost in dollars for one AI SDK step, using the static pricing fallback.
  * Returns 0 for unknown models (calculateCost returns 0) or if pricing throws.
  * Pure — no side effects.
@@ -67,6 +55,18 @@ export function shouldAbortAfterStep(input: {
   return input.balanceCents - chargedSoFarCents <= input.reserveFloorCents;
 }
 
+/**
+ * Whole-cent hold reservation for one chat call against `model`. Prices the assumed
+ * per-call token budget (or a caller-supplied `inputTokens` estimate, when cheaply
+ * available) at the catalog rate, applies the markup, and clamps to
+ * [CHAT_HOLD_FLOOR_CENTS, CREDIT_HOLD_ESTIMATE_CENTS] — never below a sane minimum nor
+ * above the legacy flat chat hold.
+ *
+ * An UNKNOWN or absent model (not in the catalog) falls back to the legacy flat hold
+ * rather than being priced: the catalog default rate is $0, which would otherwise clamp
+ * a real call down to the floor and weaken the gate. A KNOWN free model (input/output
+ * both $0, e.g. gpt-oss) legitimately prices to the floor — that's fine.
+ */
 export function estimateChatHoldCentsForModel(
   model: string | undefined,
   opts: { inputTokens?: number } = {},


### PR DESCRIPTION
## Summary

- Adds `calcStepCostDollars(model, usage)` to `packages/lib/src/monitoring/chat-pricing.ts` — wraps `calculateCost` with a try/catch; returns the step cost in dollars, or 0 for unknown models / on throw
- Adds `shouldAbortAfterStep(input)` — converts cumulative cost to charged cents via `markupCents()`, returns `true` when `balanceCents − chargedSoFarCents ≤ reserveFloorCents` (exact floor = abort)
- Both are pure functions (no I/O, no side effects) ready to be wired into the `onStepFinish` callback in the chat route (Tasks 1.3+)

## Test plan

- [x] 11 new tests written RED before any implementation
- [x] All 19 tests in `chat-pricing.test.ts` GREEN after implementation
- [x] No new type errors in `packages/lib/src/monitoring/chat-pricing.ts`
- [x] `calcStepCostDollars`: known model, unknown model, zero tokens, completion-only, throw recovery
- [x] `shouldAbortAfterStep`: below floor, above floor, exact floor boundary, zero balance, zero cost, 5-step cumulative simulation crossing the tipping point

🤖 Generated with [Claude Code](https://claude.com/claude-code)