### PR TITLE
feat(api): accept client-side tools in /v1/chat/completions

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { streamText, convertToModelMessages, hasToolCall, stepCountIs } from 'ai';
+import { streamText, convertToModelMessages, hasToolCall, stepCountIs, tool, jsonSchema } from 'ai';
 import type { ToolSet } from 'ai';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
@@ -73,7 +73,21 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: validation.error }, { status: validation.status });
   }
 
-  const { pageId, model: modelName, messages, driveContext: _driveContext, conversationId: incomingConversationId } = validation.data;
+  const { pageId, model: modelName, messages, driveContext: _driveContext, conversationId: incomingConversationId, clientTools: rawClientTools, disableServerTools } = validation.data;
+
+  // Build the caller's client-side tool set. Tools registered without `execute` are returned
+  // to the caller as native tool_calls — the SDK pauses, the caller executes locally, and the
+  // conversation resumes via role:tool messages (see multi-turn conversation API, PR #1552).
+  const clientToolSet: ToolSet = {};
+  for (const def of rawClientTools ?? []) {
+    clientToolSet[def.function.name] = tool({
+      description: def.function.description ?? '',
+      parameters: jsonSchema(def.function.parameters ?? { type: 'object', properties: {} }),
+      // No execute — signals to the SDK to return this call to the caller.
+    });
+  }
+  const hasClientTools = Object.keys(clientToolSet).length > 0;
+  const useServerTools = !disableServerTools;
 
   // 3. MCP drive-scope check
   const scopeError = await checkMCPPageScope(authResult, pageId);
@@ -144,26 +158,51 @@ export async function POST(request: Request): Promise<Response> {
   const systemPrompt = page.systemPrompt
     ?? buildSystemPrompt('page', undefined, false);
 
-  // 7b. Build the agent's server-side tool set (mirrors /api/ai/chat).
-  // The OpenAI request shape carries no read-only / web-search toggles, so
-  // read-only defaults to false; web_search falls through the allowlist.
-  const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
-  // Per-agent allowlist: null/undefined = unrestricted; [] = none; [names] = only those.
+  // 7b. Build the final tool set and stop conditions based on the request mode:
+  //   server-only (!hasClientTools)  — full PageSpace tools + finish tool (unchanged default)
+  //   client-only (hasClientTools && !useServerTools) — caller tools only, no finish tool
+  //   both        (hasClientTools &&  useServerTools) — merged; client wins on name collision, no finish tool
+  // Client modes skip the finish tool because the caller controls the conversation externally;
+  // each round-trip is a new request and the finish tool would conflict with that flow.
   const agentEnabledTools = page.enabledTools as string[] | null;
-  let filteredTools: ToolSet =
-    agentEnabledTools != null
-      ? (Object.fromEntries(
-          Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
-        ) as ToolSet)
-      : (baseTools as ToolSet);
-  // Exposure mode: 'upfront' (default) hands every tool over; 'search' defers
-  // non-core tools behind tool_search/execute_tool.
   const toolExposureMode = (page.toolExposureMode as 'upfront' | 'search' | null) ?? 'upfront';
-  const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
-  filteredTools = exposure.tools;
-  const toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
-  // Always inject the finish tool so the agentic loop can terminate cleanly.
-  filteredTools = { ...filteredTools, ...finishTool } as ToolSet;
+
+  let finalTools: ToolSet;
+  let toolDiscoveryPrompt = '';
+  const stopConditions = hasClientTools
+    ? [stepCountIs(100)]
+    : [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)];
+
+  if (!hasClientTools) {
+    // server-only: existing pipeline unchanged
+    const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
+    let filteredTools: ToolSet =
+      agentEnabledTools != null
+        ? (Object.fromEntries(
+            Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
+          ) as ToolSet)
+        : (baseTools as ToolSet);
+    const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
+    filteredTools = exposure.tools;
+    toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
+    finalTools = { ...filteredTools, ...finishTool } as ToolSet;
+  } else if (!useServerTools) {
+    // client-only: caller tools only
+    finalTools = clientToolSet;
+  } else {
+    // both: server tools + client tools; client wins on name collision
+    const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
+    let filteredTools: ToolSet =
+      agentEnabledTools != null
+        ? (Object.fromEntries(
+            Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
+          ) as ToolSet)
+        : (baseTools as ToolSet);
+    const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
+    filteredTools = exposure.tools;
+    toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
+    finalTools = { ...filteredTools, ...clientToolSet } as ToolSet;
+  }
 
   // Load the caller's timezone so time-aware tools (calendar, task triggers)
   // resolve dates in the user's zone instead of defaulting to UTC, matching
@@ -289,8 +328,8 @@ export async function POST(request: Request): Promise<Response> {
     model: providerResult.model,
     system: systemPrompt + (callerSystemPrompt ? `\n\n${callerSystemPrompt}` : '') + toolDiscoveryPrompt,
     messages: convertToModelMessages(sanitized),
-    tools: filteredTools,
-    stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)],
+    tools: finalTools,
+    stopWhen: stopConditions,
     // Aborts when the consumer closes the connection (see abortController above).
     abortSignal: abortController.signal,
     experimental_context: {
@@ -322,6 +361,11 @@ export async function POST(request: Request): Promise<Response> {
       // Per-step tool call state: tracks tool index and presence for finish-step finish_reason
       let stepToolCallIndex = 0;
       let stepHadToolCalls = false;
+      // Client-tool tracking: detect when the stream ends on a client-side tool call so we
+      // can emit finish_reason:'tool_calls' instead of 'stop' on the final finish chunk.
+      const clientToolNames = new Set(Object.keys(clientToolSet));
+      let hadClientToolThisStep = false;
+      let streamEndedOnClientTool = false;
 
       try {
         for await (const chunk of aiResult.toUIMessageStream()) {
@@ -331,6 +375,7 @@ export async function POST(request: Request): Promise<Response> {
           if (chunk.type === 'start-step') {
             stepToolCallIndex = 0;
             stepHadToolCalls = false;
+            hadClientToolThisStep = false;
           }
 
           // Capture index before increment so the emitted chunk gets the right index
@@ -338,6 +383,13 @@ export async function POST(request: Request): Promise<Response> {
           if (chunk.type === 'tool-input-available') {
             stepHadToolCalls = true;
             stepToolCallIndex++;
+            if (clientToolNames.has(chunk.toolName)) {
+              hadClientToolThisStep = true;
+            }
+          }
+
+          if (chunk.type === 'finish-step' && hadClientToolThisStep) {
+            streamEndedOnClientTool = true;
           }
 
           const line = adaptToOpenAIChunk(chunk, {
@@ -346,6 +398,7 @@ export async function POST(request: Request): Promise<Response> {
             created,
             toolCallIndex,
             hadToolCallsInStep: stepHadToolCalls,
+            overrideFinishReason: chunk.type === 'finish' && streamEndedOnClientTool ? 'tool_calls' : undefined,
           });
           if (line) {
             controller.enqueue(encoder.encode(line + '\n\n'));

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -82,9 +82,9 @@ export async function POST(request: Request): Promise<Response> {
   for (const def of rawClientTools ?? []) {
     clientToolSet[def.function.name] = tool({
       description: def.function.description ?? '',
-      parameters: jsonSchema(def.function.parameters ?? { type: 'object', properties: {} }),
+      inputSchema: jsonSchema(def.function.parameters ?? { type: 'object', properties: {} }),
       // No execute — signals to the SDK to return this call to the caller.
-    });
+    }) as ToolSet[string];
   }
   const hasClientTools = Object.keys(clientToolSet).length > 0;
   const useServerTools = !disableServerTools;
@@ -159,21 +159,25 @@ export async function POST(request: Request): Promise<Response> {
     ?? buildSystemPrompt('page', undefined, false);
 
   // 7b. Build the final tool set and stop conditions based on the request mode:
-  //   server-only (!hasClientTools)  — full PageSpace tools + finish tool (unchanged default)
-  //   client-only (hasClientTools && !useServerTools) — caller tools only, no finish tool
-  //   both        (hasClientTools &&  useServerTools) — merged; client wins on name collision, no finish tool
+  //   server-only (useServerTools && !hasClientTools)  — full PageSpace tools + finish tool (default)
+  //   client-only (!useServerTools) — caller tools only, or empty if no client tools provided
+  //   both        (useServerTools && hasClientTools) — merged; client wins on name collision
   // Client modes skip the finish tool because the caller controls the conversation externally;
   // each round-trip is a new request and the finish tool would conflict with that flow.
+  // disable_server_tools is honoured independently of whether client tools are present:
+  //   disable_server_tools:true with no tools → no tools at all (model generates text only).
   const agentEnabledTools = page.enabledTools as string[] | null;
   const toolExposureMode = (page.toolExposureMode as 'upfront' | 'search' | null) ?? 'upfront';
 
+  const inServerOnlyMode = useServerTools && !hasClientTools;
+
   let finalTools: ToolSet;
   let toolDiscoveryPrompt = '';
-  const stopConditions = hasClientTools
-    ? [stepCountIs(100)]
-    : [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)];
+  const stopConditions = inServerOnlyMode
+    ? [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)]
+    : [stepCountIs(100)];
 
-  if (!hasClientTools) {
+  if (inServerOnlyMode) {
     // server-only: existing pipeline unchanged
     const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
     let filteredTools: ToolSet =
@@ -187,7 +191,7 @@ export async function POST(request: Request): Promise<Response> {
     toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
     finalTools = { ...filteredTools, ...finishTool } as ToolSet;
   } else if (!useServerTools) {
-    // client-only: caller tools only
+    // client-only or no-tools: just client tools (may be empty when disable_server_tools=true but no tools provided)
     finalTools = clientToolSet;
   } else {
     // both: server tools + client tools; client wins on name collision

--- a/apps/web/src/lib/ai/openai-api/__tests__/adapt-to-openai-chunk.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/adapt-to-openai-chunk.test.ts
@@ -188,4 +188,24 @@ describe('adaptToOpenAIChunk', () => {
       expected: { id: 'cmpl-abc', model: 'ps-agent://page-123', created: 1000000000 },
     });
   });
+
+  test('finish chunk with overrideFinishReason:tool_calls emits finish_reason:tool_calls', () => {
+    const result = adaptToOpenAIChunk({ type: 'finish' }, { ...baseOpts, overrideFinishReason: 'tool_calls' });
+    assert({
+      given: 'a finish chunk with overrideFinishReason set to tool_calls',
+      should: 'emit finish_reason:tool_calls so the caller knows to execute the tool locally',
+      actual: result ? parseSSE(result).choices[0].finish_reason : null,
+      expected: 'tool_calls',
+    });
+  });
+
+  test('finish chunk with overrideFinishReason undefined defaults to stop', () => {
+    const result = adaptToOpenAIChunk({ type: 'finish' }, { ...baseOpts, overrideFinishReason: undefined });
+    assert({
+      given: 'a finish chunk with overrideFinishReason undefined',
+      should: 'emit finish_reason:stop (unchanged default)',
+      actual: result ? parseSSE(result).choices[0].finish_reason : null,
+      expected: 'stop',
+    });
+  });
 });

--- a/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
@@ -300,4 +300,72 @@ describe('validateInferenceRequest', () => {
       expected: 'read_file',
     });
   });
+
+  test('assistant message with tool_calls (content null) is normalized to tool part', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'tc-1', type: 'function', function: { name: 'bash', arguments: '{"cmd":"ls"}' } }],
+      }],
+    };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'an assistant message with tool_calls and null content',
+      should: 'normalize to a UIMessage with a tool-bash part at input-available state',
+      actual: result.ok
+        ? { ok: true, partType: (result.data.messages[0].parts[0] as Record<string, unknown>)?.type, partState: (result.data.messages[0].parts[0] as Record<string, unknown>)?.state }
+        : { ok: false },
+      expected: { ok: true, partType: 'tool-bash', partState: 'input-available' },
+    });
+  });
+
+  test('assistant tool_calls paired with role:tool result normalized to output-available', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [
+        { role: 'user', id: 'msg-1', content: 'run ls', parts: [{ type: 'text', text: 'run ls' }] },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{ id: 'tc-1', type: 'function', function: { name: 'bash', arguments: '{"cmd":"ls"}' } }],
+        },
+        { role: 'tool', tool_call_id: 'tc-1', content: 'file1.txt\nfile2.txt' },
+      ],
+    };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'assistant tool_calls followed by a matching role:tool result',
+      should: 'collapse into a single assistant UIMessage with output-available part (not two separate messages)',
+      actual: result.ok
+        ? {
+            messageCount: result.data.messages.length,
+            secondRole: result.data.messages[1]?.role,
+            partState: (result.data.messages[1]?.parts[0] as Record<string, unknown>)?.state,
+            partOutput: (result.data.messages[1]?.parts[0] as Record<string, unknown>)?.output,
+          }
+        : { ok: false },
+      expected: { messageCount: 2, secondRole: 'assistant', partState: 'output-available', partOutput: 'file1.txt\nfile2.txt' },
+    });
+  });
+
+  test('standalone role:tool message without preceding assistant is skipped', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [
+        { role: 'user', id: 'msg-1', content: 'hi', parts: [{ type: 'text', text: 'hi' }] },
+        { role: 'tool', tool_call_id: 'orphan', content: 'some result' },
+      ],
+    };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a role:tool message with no preceding assistant tool_calls',
+      should: 'skip it and return ok:true with only the user message',
+      actual: result.ok
+        ? { ok: true, messageCount: result.data.messages.length }
+        : { ok: false },
+      expected: { ok: true, messageCount: 1 },
+    });
+  });
 });

--- a/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
@@ -11,7 +11,7 @@ describe('validateInferenceRequest', () => {
       given: 'a valid ps-agent model URI and non-empty messages array',
       should: 'return ok:true with the parsed pageId, messages, stream:true, and no driveContext',
       actual: result,
-      expected: { ok: true, data: { pageId: 'page-123', model: 'ps-agent://page-123', messages, stream: true, driveContext: undefined } },
+      expected: { ok: true, data: { pageId: 'page-123', model: 'ps-agent://page-123', messages, stream: true, driveContext: undefined, clientTools: undefined, disableServerTools: false } },
     });
   });
 
@@ -213,6 +213,91 @@ describe('validateInferenceRequest', () => {
       should: 'return undefined for conversationId',
       actual: result.ok ? result.data.conversationId : 'error',
       expected: undefined,
+    });
+  });
+
+  test('valid tools array is parsed into clientTools', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const tools = [{ type: 'function', function: { name: 'bash', description: 'Run a shell command', parameters: { type: 'object', properties: { cmd: { type: 'string' } } } } }];
+    const body = { model: 'ps-agent://page-123', messages, tools };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a valid tools array with type:function and function.name',
+      should: 'return ok:true with clientTools populated',
+      actual: result.ok ? result.data.clientTools : undefined,
+      expected: [{ type: 'function', function: { name: 'bash', description: 'Run a shell command', parameters: { type: 'object', properties: { cmd: { type: 'string' } } } } }],
+    });
+  });
+
+  test('tool entry missing function.name returns 400', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, tools: [{ type: 'function', function: { description: 'no name' } }] };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a tools array with an entry missing function.name',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('tool entry with non-function type returns 400', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, tools: [{ type: 'retrieval', function: { name: 'search' } }] };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a tools array with an entry whose type is not "function"',
+      should: 'return ok:false with status 400',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('empty tools array treats clientTools as undefined', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, tools: [] };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'an empty tools array',
+      should: 'return clientTools as undefined',
+      actual: result.ok ? result.data.clientTools : 'error',
+      expected: undefined,
+    });
+  });
+
+  test('disable_server_tools:true sets disableServerTools', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, disable_server_tools: true };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'disable_server_tools:true in the body',
+      should: 'return disableServerTools:true',
+      actual: result.ok ? result.data.disableServerTools : undefined,
+      expected: true,
+    });
+  });
+
+  test('disable_server_tools absent defaults to false', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'disable_server_tools absent from the body',
+      should: 'return disableServerTools:false',
+      actual: result.ok ? result.data.disableServerTools : undefined,
+      expected: false,
+    });
+  });
+
+  test('tool without description or parameters is accepted', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, tools: [{ type: 'function', function: { name: 'read_file' } }] };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a tool with only name (no description or parameters)',
+      should: 'return ok:true with the tool in clientTools',
+      actual: result.ok ? result.data.clientTools?.[0]?.function.name : undefined,
+      expected: 'read_file',
     });
   });
 });

--- a/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
@@ -368,4 +368,43 @@ describe('validateInferenceRequest', () => {
       expected: { ok: true, messageCount: 1 },
     });
   });
+
+  test('malformed tool_calls entry returns 400 instead of 500', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'assistant',
+        content: null,
+        tool_calls: [{}],
+      }],
+    };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'an assistant message with a tool_calls entry missing id and function',
+      should: 'return ok:false with status 400 (not throw a 500)',
+      actual: { ok: result.ok, status: result.ok ? undefined : result.status },
+      expected: { ok: false, status: 400 },
+    });
+  });
+
+  test('assistant message with content and tool_calls preserves text as first part', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'assistant',
+        content: "I'll run bash for you.",
+        tool_calls: [{ id: 'tc-1', type: 'function', function: { name: 'bash', arguments: '{"cmd":"ls"}' } }],
+      }],
+    };
+    const result = validateInferenceRequest(body);
+    const parts = result.ok ? result.data.messages[0].parts as Array<Record<string, unknown>> : [];
+    assert({
+      given: 'an assistant message with both string content and tool_calls',
+      should: 'include a text part before the tool part so the natural-language context is preserved',
+      actual: result.ok
+        ? { ok: true, partCount: parts.length, firstType: parts[0]?.type, firstText: parts[0]?.text, secondType: parts[1]?.type }
+        : { ok: false },
+      expected: { ok: true, partCount: 2, firstType: 'text', firstText: "I'll run bash for you.", secondType: 'tool-bash' },
+    });
+  });
 });

--- a/apps/web/src/lib/ai/openai-api/adapt-to-openai-chunk.ts
+++ b/apps/web/src/lib/ai/openai-api/adapt-to-openai-chunk.ts
@@ -11,6 +11,8 @@ export type AdaptOptions = {
   toolCallIndex?: number;
   /** Whether the current step has had any tool calls (for finish-step chunks) */
   hadToolCallsInStep?: boolean;
+  /** Override the finish_reason emitted on the 'finish' chunk (e.g. 'tool_calls' for client-tool stops) */
+  overrideFinishReason?: string;
 };
 
 const makeChunk = (options: AdaptOptions, delta: Record<string, unknown>, finishReason: string | null) => ({
@@ -48,7 +50,7 @@ export const adaptToOpenAIChunk = (chunk: UIMessageChunk, options: AdaptOptions)
 
     case 'finish':
       // [DONE] is emitted by the route after buildToolSummaryEvent
-      return toSSE(makeChunk(options, {}, 'stop'));
+      return toSSE(makeChunk(options, {}, options.overrideFinishReason ?? 'stop'));
 
     default:
       return null;

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -53,6 +53,68 @@ const normalizeMessage = (msg: Record<string, unknown>): UIMessage => {
   return { id, role, parts: [] } as unknown as UIMessage;
 };
 
+// Normalizes a flat OpenAI-format messages array into UIMessage[].
+// Handles the multi-turn client-tool pattern: an assistant message with `tool_calls`
+// followed by one or more `role:"tool"` messages is collapsed into a single assistant
+// UIMessage whose parts carry `type:"tool-<name>"` / `state:"output-available"` data
+// (the same shape the streaming pipeline produces for server-side tools).
+// Standalone role:tool messages with no preceding matched assistant are skipped.
+const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] => {
+  const result: UIMessage[] = [];
+  let i = 0;
+
+  while (i < rawMessages.length) {
+    const msg = rawMessages[i];
+    const role = msg.role as string;
+
+    if (role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+      const toolCalls = msg.tool_calls as Array<{
+        id: string;
+        function: { name: string; arguments: string };
+      }>;
+
+      // Collect immediately following role:tool messages and build a result map.
+      const toolResults: Record<string, string> = {};
+      let j = i + 1;
+      while (j < rawMessages.length && rawMessages[j].role === 'tool') {
+        const toolMsg = rawMessages[j];
+        const toolCallId = typeof toolMsg.tool_call_id === 'string' ? toolMsg.tool_call_id : undefined;
+        if (toolCallId) {
+          toolResults[toolCallId] = typeof toolMsg.content === 'string' ? toolMsg.content : '';
+        }
+        j++;
+      }
+
+      const parts = toolCalls.map(tc => {
+        let input: Record<string, unknown> = {};
+        try { input = JSON.parse(tc.function.arguments) as Record<string, unknown>; } catch { /* leave empty on bad JSON */ }
+        const toolName = tc.function.name;
+
+        if (toolResults[tc.id] !== undefined) {
+          return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'output-available' as const, output: toolResults[tc.id] };
+        }
+        return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'input-available' as const };
+      });
+
+      const id = typeof msg.id === 'string' ? msg.id : createId();
+      result.push({ id, role: 'assistant', parts } as unknown as UIMessage);
+      i = j; // skip the consumed role:tool messages
+      continue;
+    }
+
+    // Standalone role:tool message without a preceding matched assistant — skip.
+    if (role === 'tool') {
+      i++;
+      continue;
+    }
+
+    result.push(normalizeMessage(msg));
+    i++;
+  }
+
+  return result;
+};
+
 export const validateInferenceRequest = (body: unknown): ValidationResult => {
   if (typeof body !== 'object' || body === null) {
     return { ok: false, status: 400, error: 'request body must be a JSON object' };
@@ -88,7 +150,7 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
     }
   }
 
-  const normalized = (messages as Record<string, unknown>[]).map(normalizeMessage);
+  const normalized = normalizeMessages(messages as Record<string, unknown>[]);
 
   for (const msg of normalized) {
     if (!Array.isArray(msg.parts) || msg.parts.length === 0) {

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -1,6 +1,15 @@
 import type { UIMessage } from 'ai';
 import { createId } from '@paralleldrive/cuid2';
 
+export interface OpenAIToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
 export interface ValidatedInferenceRequest {
   pageId: string;
   model: string;
@@ -8,6 +17,8 @@ export interface ValidatedInferenceRequest {
   stream: true;
   driveContext?: string;
   conversationId?: string;
+  clientTools?: OpenAIToolDefinition[];
+  disableServerTools?: boolean;
 }
 
 export type ValidationResult =
@@ -89,6 +100,44 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
 
   const conversationId = (typeof raw.conversation_id === 'string' && raw.conversation_id.trim()) || undefined;
 
+  let clientTools: OpenAIToolDefinition[] | undefined;
+  if (raw.tools !== undefined) {
+    if (!Array.isArray(raw.tools)) {
+      return { ok: false, status: 400, error: 'tools must be an array' };
+    }
+    const tools: OpenAIToolDefinition[] = [];
+    for (const t of raw.tools as unknown[]) {
+      if (typeof t !== 'object' || t === null) {
+        return { ok: false, status: 400, error: 'each tool must be an object' };
+      }
+      const entry = t as Record<string, unknown>;
+      if (entry.type !== 'function') {
+        return { ok: false, status: 400, error: "tool type must be 'function'" };
+      }
+      const fn = entry.function;
+      if (typeof fn !== 'object' || fn === null) {
+        return { ok: false, status: 400, error: 'each tool must have a function object' };
+      }
+      const fnObj = fn as Record<string, unknown>;
+      if (typeof fnObj.name !== 'string' || !fnObj.name) {
+        return { ok: false, status: 400, error: 'each tool must have a function.name string' };
+      }
+      tools.push({
+        type: 'function',
+        function: {
+          name: fnObj.name,
+          description: typeof fnObj.description === 'string' ? fnObj.description : undefined,
+          parameters: (typeof fnObj.parameters === 'object' && fnObj.parameters !== null)
+            ? fnObj.parameters as Record<string, unknown>
+            : undefined,
+        },
+      });
+    }
+    clientTools = tools.length > 0 ? tools : undefined;
+  }
+
+  const disableServerTools = raw.disable_server_tools === true;
+
   return {
     ok: true,
     data: {
@@ -98,6 +147,8 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
       stream: true,
       driveContext,
       conversationId,
+      clientTools,
+      disableServerTools,
     },
   };
 };

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -53,13 +53,17 @@ const normalizeMessage = (msg: Record<string, unknown>): UIMessage => {
   return { id, role, parts: [] } as unknown as UIMessage;
 };
 
+type NormalizeResult =
+  | { ok: true; messages: UIMessage[] }
+  | { ok: false; error: string };
+
 // Normalizes a flat OpenAI-format messages array into UIMessage[].
 // Handles the multi-turn client-tool pattern: an assistant message with `tool_calls`
 // followed by one or more `role:"tool"` messages is collapsed into a single assistant
 // UIMessage whose parts carry `type:"tool-<name>"` / `state:"output-available"` data
 // (the same shape the streaming pipeline produces for server-side tools).
 // Standalone role:tool messages with no preceding matched assistant are skipped.
-const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] => {
+const normalizeMessages = (rawMessages: Record<string, unknown>[]): NormalizeResult => {
   const result: UIMessage[] = [];
   let i = 0;
 
@@ -68,7 +72,24 @@ const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] 
     const role = msg.role as string;
 
     if (role === 'assistant' && Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
-      const toolCalls = msg.tool_calls as Array<{
+      const rawToolCalls = msg.tool_calls as Array<unknown>;
+
+      // Validate each entry before dereferencing — malformed entries return 400, not 500.
+      for (let idx = 0; idx < rawToolCalls.length; idx++) {
+        const tc = rawToolCalls[idx] as Record<string, unknown>;
+        const fn = tc?.function as Record<string, unknown> | undefined;
+        if (
+          typeof tc !== 'object' || tc === null ||
+          typeof tc.id !== 'string' ||
+          typeof fn !== 'object' || fn === null ||
+          typeof fn.name !== 'string' ||
+          typeof fn.arguments !== 'string'
+        ) {
+          return { ok: false, error: `tool_calls[${idx}] must have id (string), function.name (string), and function.arguments (string)` };
+        }
+      }
+
+      const toolCalls = rawToolCalls as Array<{
         id: string;
         function: { name: string; arguments: string };
       }>;
@@ -87,16 +108,31 @@ const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] 
         j++;
       }
 
-      const parts = toolCalls.map(tc => {
+      // Build parts: preserve any natural-language content first, then tool call parts.
+      // OpenAI permits assistant messages with both `content` and `tool_calls`; dropping
+      // the text would remove context that follow-up requests depend on.
+      const parts: Array<Record<string, unknown>> = [];
+      if (typeof msg.content === 'string' && msg.content) {
+        parts.push({ type: 'text', text: msg.content });
+      } else if (Array.isArray(msg.content)) {
+        for (const c of msg.content as Array<Record<string, unknown>>) {
+          if (c.type === 'text' && typeof c.text === 'string' && c.text) {
+            parts.push({ type: 'text', text: c.text });
+          }
+        }
+      }
+
+      for (const tc of toolCalls) {
         let input: Record<string, unknown> = {};
         try { input = JSON.parse(tc.function.arguments) as Record<string, unknown>; } catch { /* leave empty on bad JSON */ }
         const toolName = tc.function.name;
 
         if (toolResults.has(tc.id)) {
-          return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'output-available' as const, output: toolResults.get(tc.id) };
+          parts.push({ type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'output-available', output: toolResults.get(tc.id) });
+        } else {
+          parts.push({ type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'input-available' });
         }
-        return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'input-available' as const };
-      });
+      }
 
       const id = typeof msg.id === 'string' ? msg.id : createId();
       result.push({ id, role: 'assistant', parts } as unknown as UIMessage);
@@ -114,7 +150,7 @@ const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] 
     i++;
   }
 
-  return result;
+  return { ok: true, messages: result };
 };
 
 export const validateInferenceRequest = (body: unknown): ValidationResult => {
@@ -152,7 +188,11 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
     }
   }
 
-  const normalized = normalizeMessages(messages as Record<string, unknown>[]);
+  const normalizeResult = normalizeMessages(messages as Record<string, unknown>[]);
+  if (!normalizeResult.ok) {
+    return { ok: false, status: 400, error: normalizeResult.error };
+  }
+  const normalized = normalizeResult.messages;
 
   for (const msg of normalized) {
     if (!Array.isArray(msg.parts) || msg.parts.length === 0) {

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -74,13 +74,15 @@ const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] 
       }>;
 
       // Collect immediately following role:tool messages and build a result map.
-      const toolResults: Record<string, string> = {};
+      // Use Map (not plain object) so user-supplied tool_call_id values cannot
+      // pollute Object.prototype via keys like "__proto__".
+      const toolResults = new Map<string, string>();
       let j = i + 1;
       while (j < rawMessages.length && rawMessages[j].role === 'tool') {
         const toolMsg = rawMessages[j];
         const toolCallId = typeof toolMsg.tool_call_id === 'string' ? toolMsg.tool_call_id : undefined;
         if (toolCallId) {
-          toolResults[toolCallId] = typeof toolMsg.content === 'string' ? toolMsg.content : '';
+          toolResults.set(toolCallId, typeof toolMsg.content === 'string' ? toolMsg.content : '');
         }
         j++;
       }
@@ -90,8 +92,8 @@ const normalizeMessages = (rawMessages: Record<string, unknown>[]): UIMessage[] 
         try { input = JSON.parse(tc.function.arguments) as Record<string, unknown>; } catch { /* leave empty on bad JSON */ }
         const toolName = tc.function.name;
 
-        if (toolResults[tc.id] !== undefined) {
-          return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'output-available' as const, output: toolResults[tc.id] };
+        if (toolResults.has(tc.id)) {
+          return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'output-available' as const, output: toolResults.get(tc.id) };
         }
         return { type: `tool-${toolName}`, toolCallId: tc.id, toolName, input, state: 'input-available' as const };
       });


### PR DESCRIPTION
## Summary

- Adds `tools` and `disable_server_tools` fields to the `/v1/chat/completions` request body (OpenAI-compatible format)
- Tools registered without `execute` are returned to the caller as native `tool_calls` — the Vercel AI SDK's built-in client-side-tool pattern
- Emits correct `finish_reason: tool_calls` on the final SSE chunk when the stream ends on a client tool call
- Adds `normalizeMessages` to handle multi-turn tool call continuations (pairs `role:"tool"` result messages with their `tool_calls` assistant messages)
- Uses `Map` (not plain object) for tool result lookup in `normalizeMessages` to prevent prototype pollution via user-supplied `tool_call_id` keys

## Three modes (opt-in, zero change to existing callers)

| Request | Server tools | Client tools | Finish tool |
|---------|-------------|-------------|-------------|
| No `tools` (default) | ✓ | — | ✓ |
| `tools` present | ✓ | ✓ (client wins collisions) | ✗ |
| `tools` + `disable_server_tools: true` | — | ✓ | ✗ |
| `disable_server_tools: true`, no `tools` | — | — | ✗ (text-only) |

The finish tool is omitted in client modes because the caller controls the conversation loop externally — each round-trip is a new request.

## Multi-turn tool call flow

When the model calls a client tool, the stream emits:
1. `tool-input-available` chunk (tool call delta)
2. `finish-step` with `finish_reason: tool_calls`
3. `finish` with `finish_reason: tool_calls` (override)
4. `[DONE]`

Caller executes the tool locally, then resumes with a new request. The continuation messages:
- `role: "assistant"` with `tool_calls` array
- `role: "tool"` with `tool_call_id` and `content`

These are normalized by `normalizeMessages()` in `validate-inference-request.ts`: consecutive role:tool messages are paired with the preceding assistant's tool_calls and collapsed into a single UIMessage with `type:"tool-<name>"` / `state:"output-available"` parts — the same shape the streaming pipeline produces for server-side tools.

## Files changed

- `apps/web/src/lib/ai/openai-api/validate-inference-request.ts` — new `OpenAIToolDefinition` interface, `clientTools`/`disableServerTools` parsing, `normalizeMessages()` for tool_call/role:tool pairing using `Map` for safe key lookups
- `apps/web/src/app/api/v1/chat/completions/route.ts` — client tool set construction (`inputSchema:` not `parameters:`), three-mode tool assembly with `inServerOnlyMode`, `streamEndedOnClientTool` tracking
- `apps/web/src/lib/ai/openai-api/adapt-to-openai-chunk.ts` — `overrideFinishReason` option on finish chunk
- Tests for all new logic

## Test plan

- [x] `bun run typecheck` — clean
- [x] openai-api test suite (104 tests) — all pass
- [x] Security tests — pass
- [x] CI: Lint & TypeScript Check
- [x] CI: Unit Tests