### PR TITLE
fix(billing): stop double-counting upstreamInferenceCost in OpenRouter cost extraction

### DIFF
--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -741,8 +741,10 @@ describe('extractOpenRouterCostDollars', () => {
     expect(extractOpenRouterCostDollars([step(0.001), step(0.002), step(0.003)])).toBeCloseTo(0.006, 10);
   });
 
-  it('adds BYOK upstream inference cost to the OpenRouter fee', () => {
-    expect(extractOpenRouterCostDollars([step(0.0001, 0.005)])).toBeCloseTo(0.0051, 10);
+  it('ignores upstreamInferenceCost — it is a sub-breakdown of cost, not additive', () => {
+    // usage.cost is the complete OpenRouter charge (inclusive of upstream inference).
+    // Adding upstreamInferenceCost on top would double-count it.
+    expect(extractOpenRouterCostDollars([step(0.24, 0.17)])).toBeCloseTo(0.24, 10);
   });
 
   it('treats a zeroed (cached) cost as a real 0, not a missing value', () => {

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -668,9 +668,15 @@ function asFiniteNumber(value: unknown): number | undefined {
  * OpenRouter returns the real per-request cost under
  * `providerMetadata.openrouter.usage.cost` once usage accounting is enabled
  * (see provider-factory `openrouter.chat(model, { usage: { include: true } })`).
- * For standard routing `usage.cost` is the complete charge (OpenRouter margin +
- * upstream inference) — `usage.costDetails.upstreamInferenceCost` is a sub-breakdown
- * of that total, NOT an additive fee. Adding both double-counts the upstream portion.
+ * For standard (managed-key) routing `usage.cost` is the complete charge (OpenRouter
+ * margin + upstream inference). `usage.costDetails.upstreamInferenceCost` is a
+ * sub-breakdown of that total for auditing — NOT an additive fee. Adding both would
+ * double-count the upstream portion and overcharge users by ~2.5×.
+ *
+ * Note: BYOK (bring-your-own-key) routing — where `cost` is only OpenRouter's small
+ * routing fee and `upstreamInferenceCost` is a separate provider charge — is retired
+ * in this product (provider-factory always uses the platform's managed API key).
+ * If BYOK is ever re-introduced, this function must be revisited.
  *
  * Tool loops (`stepCountIs(n)`) issue one OpenRouter request PER step, each with
  * its own cost, so we sum across every step — mirroring how routes sum tokens via

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -668,8 +668,9 @@ function asFiniteNumber(value: unknown): number | undefined {
  * OpenRouter returns the real per-request cost under
  * `providerMetadata.openrouter.usage.cost` once usage accounting is enabled
  * (see provider-factory `openrouter.chat(model, { usage: { include: true } })`).
- * For BYOK passthrough the upstream provider's charge is reported separately in
- * `usage.costDetails.upstreamInferenceCost`, so we add both to get total real cost.
+ * For standard routing `usage.cost` is the complete charge (OpenRouter margin +
+ * upstream inference) — `usage.costDetails.upstreamInferenceCost` is a sub-breakdown
+ * of that total, NOT an additive fee. Adding both double-counts the upstream portion.
  *
  * Tool loops (`stepCountIs(n)`) issue one OpenRouter request PER step, each with
  * its own cost, so we sum across every step — mirroring how routes sum tokens via
@@ -693,12 +694,11 @@ export function extractOpenRouterCostDollars(
     if (!usage) continue;
 
     const cost = asFiniteNumber(usage.cost);
-    const upstream = asFiniteNumber(asRecord(usage.costDetails)?.upstreamInferenceCost);
 
-    if (cost === undefined && upstream === undefined) continue;
+    if (cost === undefined) continue;
 
     found = true;
-    total += (cost ?? 0) + (upstream ?? 0);
+    total += cost;
   }
 
   return found ? total : undefined;


### PR DESCRIPTION
## Summary

- `extractOpenRouterCostDollars` was adding `usage.cost` + `usage.costDetails.upstreamInferenceCost` together
- For standard OpenRouter routing, `usage.cost` is already the complete charge (OpenRouter margin + upstream inference) — `upstreamInferenceCost` is a sub-breakdown, not additive
- This inflated the cost basis by ~70% before the 1.5× markup, producing an effective ~2.58× markup instead of 1.5×
- Example: $24 real cost → $41 inflated basis → $62 credits charged; should be $36

The BYOK-passthrough comment that justified the addition no longer applies — BYOK is deprecated.

## Test plan

- [ ] `bun run test:unit` — 112 ai-monitoring tests pass, including updated assertion that `upstreamInferenceCost` is ignored
- [ ] Verify credit ledger: `chargeMillicents / 1000 / realCostCents` should now be exactly 1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)