### PR TITLE
fix(tasks): broadcast page:updated on agent title rename

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -102,6 +102,7 @@ import { db } from '@pagespace/db/db';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
 import { checkSubTasksComplete } from '@/lib/tasks/completion-guard';
+import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
 const mockDb = vi.mocked(db);
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
@@ -366,6 +367,133 @@ describe('task-management-tools', () => {
             tasks: expect.any(Array),
           }),
         );
+      });
+
+      it('broadcasts page:updated when title changes', async () => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-1',
+          pageId: 'doc-page-1',
+          status: 'pending',
+          priority: 'medium',
+          assigneeId: null,
+          assigneeAgentId: null,
+          dueDate: null,
+          completedAt: null,
+          metadata: null,
+          page: { title: 'Old Title', parentId: 'task-list-page-1' },
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'task-list-page-1',
+          userId: 'user-123',
+          title: 'My Tasks',
+          description: null,
+          status: 'pending',
+        });
+        mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+        mockDb.query.taskStatusConfigs.findMany = vi.fn().mockResolvedValue([]);
+        mockCanUserEditPage.mockResolvedValue(true);
+
+        mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+          const tx = {
+            select: vi.fn(() => ({
+              from: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  limit: vi.fn().mockResolvedValue([{ revision: 5 }]),
+                })),
+              })),
+            })),
+            update: vi.fn(() => ({
+              set: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  returning: vi.fn().mockResolvedValue([{
+                    id: 'task-1', pageId: 'doc-page-1', status: 'pending',
+                    priority: 'medium', position: 0, dueDate: null,
+                    assigneeId: null, assigneeAgentId: null, completedAt: null,
+                  }]),
+                })),
+              })),
+            })),
+            delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+            insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+          };
+          return cb(tx);
+        }) as unknown as typeof mockDb.transaction;
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await taskManagementTools.update_task.execute!(
+          { taskId: 'task-1', title: 'New Title' },
+          context
+        );
+
+        // driveId comes from applyPageMutation mock which returns driveId: 'd'
+        expect(vi.mocked(createPageEventPayload)).toHaveBeenCalledWith(
+          'd', 'doc-page-1', 'updated', { title: 'New Title' }
+        );
+        expect(vi.mocked(broadcastPageEvent)).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not broadcast page:updated when no title is provided', async () => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-1',
+          pageId: 'doc-page-1',
+          status: 'pending',
+          priority: 'medium',
+          assigneeId: null,
+          assigneeAgentId: null,
+          dueDate: null,
+          completedAt: null,
+          metadata: null,
+          page: { title: 'My Task', parentId: 'task-list-page-1' },
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'task-list-page-1',
+          userId: 'user-123',
+          title: 'My Tasks',
+          description: null,
+          status: 'pending',
+        });
+        mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+        mockDb.query.taskStatusConfigs.findMany = vi.fn().mockResolvedValue([]);
+        mockCanUserEditPage.mockResolvedValue(true);
+
+        mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+          const tx = {
+            update: vi.fn(() => ({
+              set: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  returning: vi.fn().mockResolvedValue([{
+                    id: 'task-1', pageId: 'doc-page-1', status: 'pending',
+                    priority: 'high', position: 0, dueDate: null,
+                    assigneeId: null, assigneeAgentId: null, completedAt: null,
+                  }]),
+                })),
+              })),
+            })),
+            delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+            insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+          };
+          return cb(tx);
+        }) as unknown as typeof mockDb.transaction;
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await taskManagementTools.update_task.execute!(
+          { taskId: 'task-1', priority: 'high' },
+          context
+        );
+
+        expect(vi.mocked(broadcastPageEvent)).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -5,7 +5,7 @@ import { eq, and, desc, asc, isNull, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { type ToolExecutionContext } from '../core';
-import { broadcastTaskEvent } from '@/lib/websocket';
+import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { canActorViewPage, canActorAccessDrive } from './actor-permissions';
 import { canActorEditPage } from './actor-permissions';
 import { PageType } from '@pagespace/lib/utils/enums';
@@ -192,6 +192,7 @@ Agent Triggers:
         }
 
         let updateTitleDeferred: DeferredWorkflowTrigger | undefined;
+        let linkedPageDriveId: string | undefined;
         const aiContextForTitle = trimmedTitle !== undefined
           ? await getAiContextWithActor(context as ToolExecutionContext)
           : null;
@@ -238,6 +239,7 @@ Agent Triggers:
                   tx,
                 });
                 updateTitleDeferred = mutationResult.deferredTrigger;
+                linkedPageDriveId = mutationResult.driveId;
               }
             }
 
@@ -247,6 +249,13 @@ Agent Triggers:
             return updatedTask;
           });
           updateTitleDeferred?.();
+          if (trimmedTitle !== undefined && linkedPageDriveId && existingTask.pageId) {
+            void broadcastPageEvent(
+              createPageEventPayload(linkedPageDriveId, existingTask.pageId, 'updated', {
+                title: trimmedTitle,
+              }),
+            );
+          }
         } catch (error) {
           if (error instanceof PageRevisionMismatchError) {
             throw new Error(`Linked page was modified concurrently — retry the update: ${error.message}`);


### PR DESCRIPTION
## Summary

- `update_task` (AI tool) was correctly persisting the new title to the DB via `applyPageMutation`, but never emitting a `broadcastPageEvent` after the transaction committed
- Real-time clients subscribed to page events (sidebar, page tree) therefore kept showing the stale task name until a full reload
- The REST PATCH route (`/api/pages/[pageId]/tasks/[taskId]`) already emits both `task_updated` and `page:updated` — this PR brings the AI tool path to parity

## Changes

`apps/web/src/lib/ai/tools/task-management-tools.ts`
- Import `broadcastPageEvent` + `createPageEventPayload` from `@/lib/websocket`
- Capture `driveId` from the `applyPageMutation` result
- After the transaction commits, emit `page:updated` for the linked task page when the title changed

## Test plan

- [ ] All 11 existing `task-management-tools` unit tests pass
- [ ] Agent calls `update_task` with a new title → page tree / sidebar reflects the rename in real-time without a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed tasks now automatically update their linked page titles in real-time so changes propagate across open sessions.

* **Tests**
  * Added test coverage verifying real-time title-update notifications are sent on rename and not sent when no title change occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->