### PR TITLE
fix(ai): skip temperature for reasoning models in page-agent consult

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
@@ -21,7 +21,12 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+    ai: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })) },
   },
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  supportsTemperature: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_MODEL,
   type ToolExecutionContext,
 } from '@/lib/ai/core';
+import { supportsTemperature } from '@/lib/ai/core/model-capabilities';
 import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { pages, drives, chatMessages } from '@pagespace/db/schema/core';
@@ -371,6 +372,8 @@ export async function POST(request: Request) {
         hasDriveContext: !!drive
       });
 
+      const tempSupported = await supportsTemperature(resolvedModelName, resolvedProvider);
+
       const result = Object.keys(toolsForRun).length > 0
         ? await generateText({
             model,
@@ -382,7 +385,7 @@ export async function POST(request: Request) {
             }))),
             tools: { ...toolsForRun, ...finishTool },
             toolChoice: 'auto',
-            temperature: 0.7,
+            ...(tempSupported ? { temperature: 0.7 } : {}),
             maxRetries: 3,
             experimental_context: executionContext,
             stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)],
@@ -404,10 +407,10 @@ export async function POST(request: Request) {
               content: m.content,
               parts: [{ type: 'text', text: m.content }]
             }))),
-            temperature: 0.7,
+            ...(tempSupported ? { temperature: 0.7 } : {}),
             maxRetries: 3,
             experimental_context: executionContext,
-            stopWhen: stepCountIs(100), // Match AI SDK version
+            stopWhen: stepCountIs(100),
           });
 
       // Enhanced debugging: Log the complete result structure

--- a/apps/web/src/lib/ai/core/model-capabilities.ts
+++ b/apps/web/src/lib/ai/core/model-capabilities.ts
@@ -27,7 +27,11 @@ const NON_TOOL_CAPABLE_MODELS: Record<string, boolean> = {
  * Cache for tool capability detection to avoid repeated API calls and errors
  */
 const toolCapabilityCache = new Map<string, boolean>();
+const temperatureCapabilityCache = new Map<string, boolean>();
 const openRouterModelsCache = new Map<string, boolean>();
+// Tracks which OpenRouter models list 'temperature' in supported_parameters.
+// Populated in the same fetch as openRouterModelsCache — no second API call.
+const openRouterTemperatureCache = new Map<string, boolean>();
 let openRouterCacheExpiry = 0;
 
 /**
@@ -66,6 +70,7 @@ async function fetchOpenRouterToolCapabilities(): Promise<Map<string, boolean>> 
       const hasTools = model.supported_parameters?.includes('tools') &&
                       model.supported_parameters?.includes('tool_choice');
       openRouterModelsCache.set(model.id, hasTools || false);
+      openRouterTemperatureCache.set(model.id, model.supported_parameters?.includes('temperature') ?? false);
     });
 
     // Set cache expiry to 1 hour from now
@@ -149,6 +154,67 @@ export function getSuggestedToolCapableModels(provider: string): string[] {
     default:
       return ['openai/gpt-5.3-chat', 'anthropic/claude-haiku-4.5', 'google/gemini-3.5-flash'];
   }
+}
+
+// Known reasoning model bare IDs for non-OpenRouter providers (e.g. direct openai).
+// These models reject the temperature parameter entirely.
+const NON_TEMPERATURE_MODELS = new Set([
+  'o1', 'o1-mini', 'o1-preview', 'o1-pro',
+  'o3', 'o3-mini', 'o3-pro',
+  'o4-mini',
+  'deepseek-r1', 'deepseek-r1-0528',
+]);
+
+/** Strip provider prefix for bare-ID lookups (e.g. "openai/o3" → "o3") */
+const stripModelPrefix = (model: string): string => {
+  const idx = model.indexOf('/');
+  return idx >= 0 ? model.slice(idx + 1) : model;
+};
+
+/**
+ * Returns false for reasoning/thinking models that reject the temperature parameter.
+ * For OpenRouter-backed providers this is authoritative (from supported_parameters).
+ * For direct providers, falls back to a static set + name-based patterns.
+ */
+export async function supportsTemperature(model: string, provider: string): Promise<boolean> {
+  const cacheKey = `${provider}:${model}`;
+  if (temperatureCapabilityCache.has(cacheKey)) {
+    return temperatureCapabilityCache.get(cacheKey)!;
+  }
+
+  if (getBackendProvider(provider) === 'openrouter') {
+    try {
+      await fetchOpenRouterToolCapabilities(); // ensures caches are warm
+      if (openRouterTemperatureCache.has(model)) {
+        const result = openRouterTemperatureCache.get(model)!;
+        temperatureCapabilityCache.set(cacheKey, result);
+        return result;
+      }
+    } catch {
+      // fall through to static detection
+    }
+    // Unknown model on OpenRouter → assume temperature is fine
+    temperatureCapabilityCache.set(cacheKey, true);
+    return true;
+  }
+
+  const bare = stripModelPrefix(model);
+
+  if (NON_TEMPERATURE_MODELS.has(bare)) {
+    temperatureCapabilityCache.set(cacheKey, false);
+    return false;
+  }
+
+  // Pattern-based: -thinking suffix, -r1 suffix, or o1/o3/o4 prefix
+  const lower = bare.toLowerCase();
+  if (lower.includes('-thinking') || lower.includes('-r1') ||
+      lower.startsWith('o1') || lower.startsWith('o3') || lower.startsWith('o4')) {
+    temperatureCapabilityCache.set(cacheKey, false);
+    return false;
+  }
+
+  temperatureCapabilityCache.set(cacheKey, true);
+  return true;
 }
 
 /**

--- a/apps/web/src/lib/ai/core/model-capabilities.ts
+++ b/apps/web/src/lib/ai/core/model-capabilities.ts
@@ -183,19 +183,22 @@ export async function supportsTemperature(model: string, provider: string): Prom
   }
 
   if (getBackendProvider(provider) === 'openrouter') {
+    // fetchOpenRouterToolCapabilities swallows its own errors and returns an empty map,
+    // so this try/catch only guards against unexpected throws. When the fetch fails the
+    // cache stays empty and we fall through to static detection below — which correctly
+    // blocks known reasoning models even during an OpenRouter outage.
     try {
-      await fetchOpenRouterToolCapabilities(); // ensures caches are warm
-      if (openRouterTemperatureCache.has(model)) {
-        const result = openRouterTemperatureCache.get(model)!;
-        temperatureCapabilityCache.set(cacheKey, result);
-        return result;
-      }
+      await fetchOpenRouterToolCapabilities(); // populates openRouterTemperatureCache
     } catch {
       // fall through to static detection
     }
-    // Unknown model on OpenRouter → assume temperature is fine
-    temperatureCapabilityCache.set(cacheKey, true);
-    return true;
+    if (openRouterTemperatureCache.has(model)) {
+      const result = openRouterTemperatureCache.get(model)!;
+      temperatureCapabilityCache.set(cacheKey, result);
+      return result;
+    }
+    // Model not in OpenRouter cache (API unavailable or truly unknown model).
+    // Fall through to static detection so known reasoning model IDs are still blocked.
   }
 
   const bare = stripModelPrefix(model);


### PR DESCRIPTION
## Summary

- `supportsTemperature(model, provider)` added to `model-capabilities.ts` — for OpenRouter providers it reads `supported_parameters` from the already-cached model list (no extra API call); for direct providers it uses a static set of known reasoning model IDs plus name-pattern matching (`-thinking`, `-r1`, `o1`/`o3`/`o4` prefix)
- Both `generateText` call-sites in `/api/ai/page-agents/consult` now spread `temperature: 0.7` conditionally instead of unconditionally
- `supportsTemperature` imported via direct subpath (`@/lib/ai/core/model-capabilities`), not the barrel

## Why

Reasoning/thinking models (OpenAI o1/o3/o4, DeepSeek R1, Qwen thinking, Kimi K2 thinking, etc.) reject the `temperature` parameter — OpenRouter and direct providers return a 500. The `ask_agent` MCP tool hits this route, so any agent configured with a reasoning model was broken.

## Models covered

| Provider | Detection |
|----------|-----------|
| Any via OpenRouter | `supported_parameters` from OR API (authoritative, cached) |
| OpenAI direct | Static set + `o1`/`o3`/`o4` prefix match |
| Any future model | `-thinking` or `-r1` name pattern |

## Test plan

- [ ] Call `ask_agent` with an `o3` or `deepseek-r1` agent → 200, not 500
- [ ] Call `ask_agent` with a Claude or GPT-4 agent → still works (temperature still sent)
- [ ] `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)