### PR TITLE
fix(billing): write monthly_grant ledger rows on lazy-init and free-tier reset

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -18,7 +18,11 @@ vi.mock('@pagespace/db/schema/credits', () => ({
   creditLedger: {
     userId: 'cl.userId',
     entryType: 'cl.entryType',
+    bucket: 'cl.bucket',
+    amountCents: 'cl.amountCents',
     chargeMillicents: 'cl.chargeMillicents',
+    stripeRef: 'cl.stripeRef',
+    consumeStatus: 'cl.consumeStatus',
     createdAt: 'cl.createdAt',
   },
 }));
@@ -71,8 +75,63 @@ function selectReturning(rows: unknown[]) {
 function insertChain() {
   return { values: () => ({ onConflictDoNothing: () => Promise.resolve(undefined) }) };
 }
-function updateCapturing(sink: { set?: Record<string, unknown> }) {
-  return { set: (v: Record<string, unknown>) => { sink.set = v; return { where: () => Promise.resolve(undefined) }; } };
+
+/**
+ * Mock the lazy-init transaction (first db.transaction call when no balance row exists).
+ * Captures the values passed to both tx.insert calls (balance and ledger).
+ */
+function mockLazyInitTransaction(
+  sink: { balanceValues?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {},
+) {
+  let insertCount = 0;
+  mockDb.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<unknown>) => {
+    const tx = {
+      insert: vi.fn(() => {
+        insertCount++;
+        const callNum = insertCount;
+        return {
+          values: (v: Record<string, unknown>) => {
+            if (callNum === 1) sink.balanceValues = v;
+            else sink.ledgerValues = v;
+            return { onConflictDoNothing: () => Promise.resolve(undefined) };
+          },
+        };
+      }),
+    };
+    return cb(tx);
+  });
+}
+
+/**
+ * Mock the reset transaction (first db.transaction call when the period has expired).
+ * Captures the set payload and ledger values. `didUpdate` controls whether the
+ * UPDATE .returning() reports a match (true = reset ran, false = concurrent already ran).
+ */
+function mockResetTransaction(
+  sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {},
+  didUpdate = true,
+) {
+  mockDb.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<unknown>) => {
+    const tx = {
+      update: vi.fn(() => ({
+        set: (v: Record<string, unknown>) => {
+          sink.set = v;
+          return {
+            where: () => ({
+              returning: () => Promise.resolve(didUpdate ? [{ userId: 'ignored' }] : []),
+            }),
+          };
+        },
+      })),
+      insert: vi.fn(() => ({
+        values: (v: Record<string, unknown>) => {
+          sink.ledgerValues = v;
+          return { onConflictDoNothing: () => Promise.resolve(undefined) };
+        },
+      })),
+    };
+    return cb(tx);
+  });
 }
 
 /**
@@ -244,7 +303,7 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockDb.update.mockReturnValue(updateCapturing(sink));
+    mockResetTransaction(sink);
     mockTransaction({ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
@@ -286,27 +345,25 @@ describe('canConsumeAI', () => {
   });
 
   it('lazy-inits a balance row from tier defaults on first request, then allows with a hold', async () => {
-    // 1st select: no row. After insert, the transaction's locked read sees the persisted row.
+    // 1st select: no row. After the init transaction, the auth transaction's locked read
+    // sees the persisted row.
     mockDb.select.mockReturnValueOnce(selectReturning([]));
-    let initValues: Record<string, unknown> | undefined;
-    mockDb.insert.mockReturnValue({
-      values: (v: Record<string, unknown>) => { initValues = v; return { onConflictDoNothing: () => Promise.resolve(undefined) }; },
-    });
+    const initSink: { balanceValues?: Record<string, unknown> } = {};
+    mockLazyInitTransaction(initSink);
     mockTransaction({ monthlyRemainingCents: 1500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'pro');
 
-    expect(mockDb.insert).toHaveBeenCalledTimes(1);
-    expect(initValues?.monthlyPeriodStart).toBeInstanceOf(Date);
-    expect(initValues?.monthlyPeriodEnd).toBeInstanceOf(Date);
+    expect(initSink.balanceValues?.monthlyPeriodStart).toBeInstanceOf(Date);
+    expect(initSink.balanceValues?.monthlyPeriodEnd).toBeInstanceOf(Date);
     expect(r.allowed).toBe(true);
     expect(r.holdId).toBe('hold_1');
   });
 
   it('re-evaluates against the persisted (drained) row after a concurrent init — no false allow', async () => {
     mockDb.select.mockReturnValueOnce(selectReturning([]));
-    mockDb.insert.mockReturnValue(insertChain());
-    // The locked read inside the transaction sees an empty balance (a racing request drained it).
+    mockLazyInitTransaction();
+    // The locked read inside the auth transaction sees an empty balance (a racing request drained it).
     mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'pro');
@@ -319,12 +376,11 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockDb.update.mockReturnValue(updateCapturing(sink));
+    mockResetTransaction(sink);
     mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    expect(mockDb.update).toHaveBeenCalledTimes(1);
     expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, monthlyAllowanceCents: 500 });
     expect(r.allowed).toBe(true);
     expect(r.reason).toBe('ok');
@@ -336,12 +392,11 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 700, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockDb.update.mockReturnValue(updateCapturing(sink));
+    mockResetTransaction(sink);
     mockTransaction({ monthlyRemainingCents: 700, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    expect(mockDb.update).toHaveBeenCalledTimes(1);
     expect(sink.set).toMatchObject({ monthlyRemainingCents: 700, monthlyAllowanceCents: 500 });
     expect(r.allowed).toBe(true);
   });
@@ -351,12 +406,11 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockDb.update.mockReturnValue(updateCapturing(sink));
+    mockResetTransaction(sink);
     mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
 
-    expect(mockDb.update).toHaveBeenCalledTimes(1);
     expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, monthlyAllowanceCents: 500 });
     expect(r.allowed).toBe(true);
   });
@@ -395,8 +449,65 @@ describe('canConsumeAI', () => {
     mockTransaction({ monthlyRemainingCents: 800, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
-    expect(mockDb.update).not.toHaveBeenCalled();
     expect(r.allowed).toBe(true);
+  });
+
+  // ── Ledger write tests ────────────────────────────────────────────────────
+
+  it('lazy-init writes a monthly_grant ledger row alongside the balance row', async () => {
+    mockDb.select.mockReturnValueOnce(selectReturning([]));
+    const sink: { balanceValues?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {};
+    mockLazyInitTransaction(sink);
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    await canConsumeAI('u1', 'free');
+
+    expect(sink.ledgerValues).toMatchObject({
+      userId: 'u1',
+      entryType: 'monthly_grant',
+      bucket: 'monthly',
+      amountCents: 500,
+      consumeStatus: 'applied',
+    });
+  });
+
+  it('concurrent lazy-init produces exactly ONE grant row — stripeRef is user-scoped (no timestamp)', async () => {
+    // The unique index on stripeRef rejects a second insert with the same key.
+    // A timestamp-based key would let two concurrent inits produce two different
+    // stripeRefs and both insert, causing phantom grants. Verify the key is stable.
+    mockDb.select.mockReturnValueOnce(selectReturning([]));
+    const sink: { ledgerValues?: Record<string, unknown> } = {};
+    mockLazyInitTransaction(sink);
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    await canConsumeAI('u1', 'free');
+
+    // The key contains no timestamp — both concurrent inits produce the same
+    // stripeRef, so the unique index silently drops the second via onConflictDoNothing.
+    expect(sink.ledgerValues?.stripeRef).toBe('free-init-u1');
+  });
+
+  it('free-tier monthly reset writes a monthly_grant ledger row with the period-keyed stripeRef', async () => {
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {};
+    mockResetTransaction(sink);
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    await canConsumeAI('u1', 'free');
+
+    expect(sink.ledgerValues).toMatchObject({
+      userId: 'u1',
+      entryType: 'monthly_grant',
+      bucket: 'monthly',
+      amountCents: 500,
+      consumeStatus: 'applied',
+    });
+    // The stripeRef includes the period timestamp so each rollover gets a unique
+    // key; concurrent resets within the same millisecond de-duplicate via the index.
+    expect(typeof sink.ledgerValues?.stripeRef).toBe('string');
+    expect((sink.ledgerValues?.stripeRef as string).startsWith('free-reset-u1-')).toBe(true);
   });
 });
 

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -79,9 +79,12 @@ function insertChain() {
 /**
  * Mock the lazy-init transaction (first db.transaction call when no balance row exists).
  * Captures the values passed to both tx.insert calls (balance and ledger).
+ * `balanceCreated` controls whether the balance insert's .returning() reports a new row
+ * (true = this call created it; false = concurrent path already created it, insert was a no-op).
  */
 function mockLazyInitTransaction(
   sink: { balanceValues?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {},
+  balanceCreated = true,
 ) {
   let insertCount = 0;
   mockDb.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<unknown>) => {
@@ -93,7 +96,13 @@ function mockLazyInitTransaction(
           values: (v: Record<string, unknown>) => {
             if (callNum === 1) sink.balanceValues = v;
             else sink.ledgerValues = v;
-            return { onConflictDoNothing: () => Promise.resolve(undefined) };
+            return {
+              onConflictDoNothing: () => ({
+                returning: () => Promise.resolve(
+                  callNum === 1 && balanceCreated ? [{ userId: 'u1' }] : [],
+                ),
+              }),
+            };
           },
         };
       }),
@@ -485,6 +494,20 @@ describe('canConsumeAI', () => {
     // The key contains no timestamp — both concurrent inits produce the same
     // stripeRef, so the unique index silently drops the second via onConflictDoNothing.
     expect(sink.ledgerValues?.stripeRef).toBe('free-init-u1');
+  });
+
+  it('lazy-init skips ledger write when balance insert conflicts (concurrent top-up/invoice already created the row)', async () => {
+    // If a top-up or invoice.paid creates the balance between readBalance() and the lazy-init
+    // transaction, the balance INSERT conflicts and returns nothing. We must NOT write
+    // a phantom grant row — that path already wrote its own grant/purchase entry.
+    mockDb.select.mockReturnValueOnce(selectReturning([]));
+    const sink: { ledgerValues?: Record<string, unknown> } = {};
+    mockLazyInitTransaction(sink, false /* balanceCreated = false, simulates conflict */);
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    await canConsumeAI('u1', 'free');
+
+    expect(sink.ledgerValues).toBeUndefined();
   });
 
   it('free-tier monthly reset writes a monthly_grant ledger row with the period-keyed stripeRef', async () => {

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -349,6 +349,7 @@ const H = vi.hoisted(() => {
       set(v: Row) {
         return {
           where(p: Pred) {
+            const matched: Row[] = [];
             for (const r of store[table]) {
               if (evalPred(p, { [table]: r } as Ctx)) {
                 // Resolve any SQL-expression set values (e.g. debtCents + shortfall)
@@ -359,9 +360,16 @@ const H = vi.hoisted(() => {
                 }
                 Object.assign(r, resolved);
                 if (table === 'creditBalances') enforceBalanceInvariants(r);
+                matched.push(r);
               }
             }
-            return Promise.resolve(undefined);
+            const result = matched;
+            return {
+              then: (resolve: (v: unknown) => unknown) => Promise.resolve(undefined).then(resolve),
+              returning(_proj?: Record<string, Col>) {
+                return Promise.resolve(result);
+              },
+            };
           },
         };
       },

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -192,7 +192,7 @@ export async function canConsumeAI(
   if (!row) {
     const monthly = TIER_MONTHLY_ALLOWANCE_CENTS[tier] ?? TIER_MONTHLY_ALLOWANCE_CENTS.free;
     await db.transaction(async (tx) => {
-      await tx
+      const balanceInserted = await tx
         .insert(creditBalances)
         .values({
           userId,
@@ -202,22 +202,26 @@ export async function canConsumeAI(
           monthlyPeriodStart: now,
           monthlyPeriodEnd: addOneMonth(now),
         })
-        .onConflictDoNothing({ target: creditBalances.userId });
-      // Record the initial grant so the balance drift formula can account for it.
-      // stripeRef is user-scoped (no timestamp) so concurrent inits de-duplicate:
-      // the unique index rejects the second insert and the balance row already
-      // exists from the first, leaving exactly one grant row per user lifetime.
-      await tx
-        .insert(creditLedger)
-        .values({
-          userId,
-          entryType: 'monthly_grant',
-          bucket: 'monthly',
-          amountCents: monthly,
-          stripeRef: `free-init-${userId}`,
-          consumeStatus: 'applied',
-        })
-        .onConflictDoNothing(STRIPE_REF_ARBITER);
+        .onConflictDoNothing({ target: creditBalances.userId })
+        .returning({ userId: creditBalances.userId });
+      // Only record the grant when THIS transaction created the balance row.
+      // If a concurrent top-up or invoice.paid already created the row between
+      // readBalance() and here, balanceInserted is empty and we skip the ledger
+      // write — that path writes its own grant/purchase entry, and a phantom
+      // monthly_grant here would overstate the user's credits in the drift formula.
+      if (balanceInserted.length > 0) {
+        await tx
+          .insert(creditLedger)
+          .values({
+            userId,
+            entryType: 'monthly_grant',
+            bucket: 'monthly',
+            amountCents: monthly,
+            stripeRef: `free-init-${userId}`,
+            consumeStatus: 'applied',
+          })
+          .onConflictDoNothing(STRIPE_REF_ARBITER);
+      }
     });
   }
 

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -36,6 +36,14 @@ import {
 } from './credit-pricing';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
+// The partial unique index credit_ledger_stripe_ref_unique is defined WHERE
+// stripeRef IS NOT NULL; Postgres only infers it as the ON CONFLICT arbiter when
+// we restate that predicate (mirrors the same constant in credit-funding.ts).
+const STRIPE_REF_ARBITER = {
+  target: creditLedger.stripeRef,
+  where: sql`${creditLedger.stripeRef} IS NOT NULL`,
+} as const;
+
 /**
  * One calendar month after `from`, clamped to the last valid day of the target
  * month so a month-end start doesn't overflow. Naive `setUTCMonth(+1)` turns
@@ -137,21 +145,40 @@ export async function canConsumeAI(
     // handle a concurrent reset that already rolled the window forward.
     const refill = computeMonthlyRefill(tier, TIER_MONTHLY_ALLOWANCE_CENTS, row.monthlyRemainingCents ?? 0, row.debtCents ?? 0);
     const newEnd = addOneMonth(now);
-    await db
-      .update(creditBalances)
-      .set({
-        monthlyRemainingCents: refill.monthlyRemainingCents,
-        monthlyAllowanceCents: refill.monthlyAllowanceCents,
-        // The renewal-equivalent for free/no-sub users: debt is netted against the
-        // carried balance before the allowance is added (refill.debtCents === 0).
-        debtCents: refill.debtCents,
-        monthlyPeriodStart: now,
-        monthlyPeriodEnd: newEnd,
-      })
-      .where(and(
-        eq(creditBalances.userId, userId),
-        or(isNull(creditBalances.monthlyPeriodEnd), lt(creditBalances.monthlyPeriodEnd, now)),
-      ));
+    await db.transaction(async (tx) => {
+      const updated = await tx
+        .update(creditBalances)
+        .set({
+          monthlyRemainingCents: refill.monthlyRemainingCents,
+          monthlyAllowanceCents: refill.monthlyAllowanceCents,
+          // The renewal-equivalent for free/no-sub users: debt is netted against the
+          // carried balance before the allowance is added (refill.debtCents === 0).
+          debtCents: refill.debtCents,
+          monthlyPeriodStart: now,
+          monthlyPeriodEnd: newEnd,
+        })
+        .where(and(
+          eq(creditBalances.userId, userId),
+          or(isNull(creditBalances.monthlyPeriodEnd), lt(creditBalances.monthlyPeriodEnd, now)),
+        ))
+        .returning({ userId: creditBalances.userId });
+      // Only record the grant when this call won the race — if a concurrent reset
+      // already rolled the window forward, updated is empty and we skip the ledger
+      // write to avoid a phantom grant entry.
+      if (updated.length > 0) {
+        await tx
+          .insert(creditLedger)
+          .values({
+            userId,
+            entryType: 'monthly_grant',
+            bucket: 'monthly',
+            amountCents: refill.monthlyAllowanceCents,
+            stripeRef: `free-reset-${userId}-${now.toISOString()}`,
+            consumeStatus: 'applied',
+          })
+          .onConflictDoNothing(STRIPE_REF_ARBITER);
+      }
+    });
     row = await readBalance();
   }
 
@@ -164,17 +191,34 @@ export async function canConsumeAI(
   // so we can't allow when a racing request already drew the row down.
   if (!row) {
     const monthly = TIER_MONTHLY_ALLOWANCE_CENTS[tier] ?? TIER_MONTHLY_ALLOWANCE_CENTS.free;
-    await db
-      .insert(creditBalances)
-      .values({
-        userId,
-        monthlyRemainingCents: monthly,
-        monthlyAllowanceCents: monthly,
-        topupRemainingCents: 0,
-        monthlyPeriodStart: now,
-        monthlyPeriodEnd: addOneMonth(now),
-      })
-      .onConflictDoNothing({ target: creditBalances.userId });
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(creditBalances)
+        .values({
+          userId,
+          monthlyRemainingCents: monthly,
+          monthlyAllowanceCents: monthly,
+          topupRemainingCents: 0,
+          monthlyPeriodStart: now,
+          monthlyPeriodEnd: addOneMonth(now),
+        })
+        .onConflictDoNothing({ target: creditBalances.userId });
+      // Record the initial grant so the balance drift formula can account for it.
+      // stripeRef is user-scoped (no timestamp) so concurrent inits de-duplicate:
+      // the unique index rejects the second insert and the balance row already
+      // exists from the first, leaving exactly one grant row per user lifetime.
+      await tx
+        .insert(creditLedger)
+        .values({
+          userId,
+          entryType: 'monthly_grant',
+          bucket: 'monthly',
+          amountCents: monthly,
+          stripeRef: `free-init-${userId}`,
+          consumeStatus: 'applied',
+        })
+        .onConflictDoNothing(STRIPE_REF_ARBITER);
+    });
   }
 
   const estCost = reservationCents(opts.estCostCents ?? CREDIT_HOLD_ESTIMATE_CENTS);

--- a/scripts/backfill-credit-ledger.ts
+++ b/scripts/backfill-credit-ledger.ts
@@ -1,0 +1,82 @@
+import 'dotenv/config';
+import { db } from '@pagespace/db/db';
+import { creditBalances, creditLedger } from '@pagespace/db/schema/credits';
+import { users } from '@pagespace/db/schema/auth';
+import { eq, sql } from '@pagespace/db/operators';
+
+// Mirror the STRIPE_REF_ARBITER from credit-gate / credit-funding (same partial index).
+const STRIPE_REF_ARBITER = {
+  target: creditLedger.stripeRef,
+  where: sql`${creditLedger.stripeRef} IS NOT NULL`,
+} as const;
+
+const TOLERANCE_CENTS = 10;
+
+async function main(): Promise<void> {
+  // Compute drift per user: same formula as getBalanceDriftAlerts in monitoring-queries.ts.
+  const rows = await db
+    .select({
+      userId: creditBalances.userId,
+      userEmail: users.email,
+      materializedSpendableCents: sql<number>`(${creditBalances.monthlyRemainingCents} + ${creditBalances.topupRemainingCents})::int`,
+      grantCents: sql<number>`COALESCE(SUM(CASE WHEN ${creditLedger.entryType} IN ('monthly_grant', 'topup_purchase') THEN ${creditLedger.amountCents} ELSE 0 END), 0)::int`,
+      appliedUsageCents: sql<number>`COALESCE(SUM(CASE WHEN ${creditLedger.entryType} = 'usage' THEN ABS(${creditLedger.appliedCents}) ELSE 0 END), 0)::int`,
+      adjustmentCents: sql<number>`COALESCE(SUM(CASE WHEN ${creditLedger.entryType} = 'adjustment' THEN COALESCE(${creditLedger.appliedCents}, 0) ELSE 0 END), 0)::int`,
+    })
+    .from(creditBalances)
+    .innerJoin(users, eq(creditBalances.userId, users.id))
+    .leftJoin(creditLedger, eq(creditLedger.userId, creditBalances.userId))
+    .groupBy(
+      creditBalances.userId,
+      users.email,
+      creditBalances.monthlyRemainingCents,
+      creditBalances.topupRemainingCents,
+    );
+
+  let found = 0;
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const r of rows) {
+    // Mirrors computeBalanceDrift in credit-core.ts: debtCents is NOT part of the
+    // bucket equation (it is reported alongside but lives in its own column).
+    const expectedSpendableCents = r.grantCents - r.appliedUsageCents + r.adjustmentCents;
+    const driftCents = r.materializedSpendableCents - expectedSpendableCents;
+
+    if (Math.abs(driftCents) <= TOLERANCE_CENTS) continue;
+
+    found++;
+    console.log(
+      `  ${r.userEmail ?? r.userId}: materialized=${r.materializedSpendableCents}¢, expected=${expectedSpendableCents}¢, drift=${driftCents}¢`,
+    );
+
+    const result = await db
+      .insert(creditLedger)
+      .values({
+        userId: r.userId,
+        entryType: 'adjustment',
+        bucket: 'monthly',
+        amountCents: driftCents,
+        appliedCents: driftCents,
+        stripeRef: `backfill-2026-06-07-${r.userId}`,
+        consumeStatus: 'applied',
+      })
+      .onConflictDoNothing(STRIPE_REF_ARBITER)
+      .returning({ id: creditLedger.id });
+
+    if (result.length > 0) {
+      inserted++;
+      console.log(`    → inserted adjustment`);
+    } else {
+      skipped++;
+      console.log(`    → skipped (already backfilled)`);
+    }
+  }
+
+  console.log(`\nSummary: ${found} users with drift, ${inserted} entries inserted, ${skipped} skipped`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-credit-ledger.ts
+++ b/scripts/backfill-credit-ledger.ts
@@ -1,7 +1,6 @@
 import 'dotenv/config';
 import { db } from '@pagespace/db/db';
 import { creditBalances, creditLedger } from '@pagespace/db/schema/credits';
-import { users } from '@pagespace/db/schema/auth';
 import { eq, sql } from '@pagespace/db/operators';
 
 // Mirror the STRIPE_REF_ARBITER from credit-gate / credit-funding (same partial index).
@@ -17,18 +16,15 @@ async function main(): Promise<void> {
   const rows = await db
     .select({
       userId: creditBalances.userId,
-      userEmail: users.email,
       materializedSpendableCents: sql<number>`(${creditBalances.monthlyRemainingCents} + ${creditBalances.topupRemainingCents})::int`,
       grantCents: sql<number>`COALESCE(SUM(CASE WHEN ${creditLedger.entryType} IN ('monthly_grant', 'topup_purchase') THEN ${creditLedger.amountCents} ELSE 0 END), 0)::int`,
       appliedUsageCents: sql<number>`COALESCE(SUM(CASE WHEN ${creditLedger.entryType} = 'usage' THEN ABS(${creditLedger.appliedCents}) ELSE 0 END), 0)::int`,
       adjustmentCents: sql<number>`COALESCE(SUM(CASE WHEN ${creditLedger.entryType} = 'adjustment' THEN COALESCE(${creditLedger.appliedCents}, 0) ELSE 0 END), 0)::int`,
     })
     .from(creditBalances)
-    .innerJoin(users, eq(creditBalances.userId, users.id))
     .leftJoin(creditLedger, eq(creditLedger.userId, creditBalances.userId))
     .groupBy(
       creditBalances.userId,
-      users.email,
       creditBalances.monthlyRemainingCents,
       creditBalances.topupRemainingCents,
     );
@@ -47,7 +43,7 @@ async function main(): Promise<void> {
 
     found++;
     console.log(
-      `  ${r.userEmail ?? r.userId}: materialized=${r.materializedSpendableCents}¢, expected=${expectedSpendableCents}¢, drift=${driftCents}¢`,
+      `  ${r.userId}: materialized=${r.materializedSpendableCents}¢, expected=${expectedSpendableCents}¢, drift=${driftCents}¢`,
     );
 
     const result = await db


### PR DESCRIPTION
## Problem

The admin AI billing tab's **Balance Drift** alert table flagged every user in the system with red drift, making it useless as a diagnostic. Root cause: two paths in `credit-gate.ts` mutated `credit_balances` without writing a corresponding `credit_ledger` row, so the drift formula (`materialized − (grants − usage + adjustments)`) always found unexplained balance.

**Lazy-init path** (`!row` block): when a free user's first AI call created their balance row, it inserted `monthlyRemainingCents = 500` with no `monthly_grant` ledger entry → every free user showed exactly **$5.00 drift** forever.

**Free-tier monthly reset path**: when a free user's period expired, the gate `UPDATE`d the balance but wrote no `monthly_grant` entry → drift accumulated with each rollover.

This explained the observed pattern:
- All free users: exactly $5.00 drift (their seed)
- Noah/Eric (downgraded business accounts): $100.00 drift
- Jono: $200.00 drift (manual token reset)

## Changes

### `packages/lib/src/billing/credit-gate.ts`

- **Lazy-init**: wrapped balance `INSERT` + new `monthly_grant` ledger row in a single transaction. `stripeRef = free-init-{userId}` (no timestamp) — concurrent inits produce the same key, so the unique index silently drops the second via `onConflictDoNothing`, leaving exactly one grant row per user lifetime.

- **Free-tier reset**: wrapped balance `UPDATE` + new `monthly_grant` ledger row in a single transaction. Added `.returning()` on the `UPDATE` — the ledger write is skipped if the `UPDATE` matched zero rows (a concurrent reset already won), preventing phantom grant entries from race losers.

- Added `STRIPE_REF_ARBITER` constant (mirrors `credit-funding.ts`).

### `packages/lib/src/billing/__tests__/credit-gate.test.ts`

- Added `mockLazyInitTransaction` and `mockResetTransaction` helpers for the new two-transaction flows.
- Updated 6 existing tests (lazy-init and reset suites) to use the new helpers.
- **4 new tests**: lazy-init writes a `monthly_grant` ledger row; concurrent lazy-init idempotency via user-scoped `stripeRef` (no timestamp → same key → unique index drops the duplicate); lazy-init skips ledger write when balance INSERT conflicts (concurrent top-up/invoice already created the row); free-tier reset writes a `monthly_grant` ledger row with period-keyed `stripeRef`.

### `packages/lib/src/billing/__tests__/credits-flow.integration.test.ts`

- Extended `makeUpdate`'s `.where()` chain to support `.returning()` — required for the reset path's race-guard check.

### `scripts/backfill-credit-ledger.ts` (new)

Backfill script to reconcile existing users. For each user with `|drift| > 10¢`, inserts one `adjustment` ledger row for `driftCents`, keyed on `backfill-2026-06-07-{userId}` (idempotent via `onConflictDoNothing`). Uses the same drift formula as `computeBalanceDrift` in `credit-core.ts`.

Run with:
```
bun run scripts/backfill-credit-ledger.ts
```

## Test plan

- [ ] All 61 billing tests pass (35 unit in `credit-gate.test.ts` + 26 integration in `credits-flow`)
- [ ] All 4 new ledger-write tests pass
- [ ] No existing billing tests regressed (`credit-core`, `credit-funding`, `credit-consume`)
- [ ] After deploying + running backfill: balance drift table shows no users above tolerance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credit ledger entries now recorded during monthly balance grants and initial balance setup for improved transaction auditing.

* **Bug Fixes**
  * Added balance drift detection and correction capability.
  * Improved handling of concurrent balance resets to prevent duplicate grant entries.

* **Chores**
  * Added backfill utility to correct historical balance discrepancies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->