### PR TITLE
fix(backups): show all drive backups without per-drive selection

### DIFF
--- a/apps/web/src/app/api/backups/route.ts
+++ b/apps/web/src/app/api/backups/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { listAllUserBackups } from '@/services/api/drive-backup-service';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -28,6 +29,13 @@ export async function GET(request: Request) {
     const result = await listAllUserBackups(auth.userId, {
       limit: parsedLimit ?? undefined,
       offset: parsedOffset ?? undefined,
+    });
+
+    auditRequest(request, {
+      eventType: 'data.read',
+      userId: auth.userId,
+      resourceType: 'backup',
+      details: { operation: 'list_all_backups', count: result.backups.length },
     });
 
     return NextResponse.json({ backups: result.backups });

--- a/apps/web/src/app/api/backups/route.ts
+++ b/apps/web/src/app/api/backups/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { listAllUserBackups } from '@/services/api/drive-backup-service';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) {
+    return auth.error;
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = searchParams.get('limit');
+    const offset = searchParams.get('offset');
+    const parsedLimit = limit !== null ? Number.parseInt(limit, 10) : null;
+    const parsedOffset = offset !== null ? Number.parseInt(offset, 10) : null;
+
+    if (parsedLimit !== null && (Number.isNaN(parsedLimit) || parsedLimit < 0)) {
+      return NextResponse.json({ error: 'Invalid limit parameter' }, { status: 400 });
+    }
+    if (parsedOffset !== null && (Number.isNaN(parsedOffset) || parsedOffset < 0)) {
+      return NextResponse.json({ error: 'Invalid offset parameter' }, { status: 400 });
+    }
+
+    const result = await listAllUserBackups(auth.userId, {
+      limit: parsedLimit ?? undefined,
+      offset: parsedOffset ?? undefined,
+    });
+
+    return NextResponse.json({ backups: result.backups });
+  } catch (error) {
+    loggers.api.error('Error fetching user backups', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch backups' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/backups/route.ts
+++ b/apps/web/src/app/api/backups/route.ts
@@ -38,7 +38,7 @@ export async function GET(request: Request) {
       details: { operation: 'list_all_backups', count: result.backups.length },
     });
 
-    return NextResponse.json({ backups: result.backups });
+    return NextResponse.json({ backups: result.backups, total: result.total });
   } catch (error) {
     loggers.api.error('Error fetching user backups', error as Error);
     return NextResponse.json({ error: 'Failed to fetch backups' }, { status: 500 });

--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { useDriveStore } from '@/hooks/useDrive';
@@ -23,13 +23,15 @@ import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import { format, formatDistanceToNow } from 'date-fns';
 import type { DriveBackupWithDriveName } from '@/services/api/drive-backup-service';
 
+const PAGE_SIZE = 50;
+
 type SerializedBackup = Omit<DriveBackupWithDriveName, 'createdAt' | 'completedAt' | 'failedAt'> & {
   createdAt: string;
   completedAt: string | null;
   failedAt: string | null;
 };
 
-type BackupListResponse = { backups: SerializedBackup[] };
+type BackupListResponse = { backups: SerializedBackup[]; total: number };
 
 type CreateBackupResult = {
   backupId: string;
@@ -72,6 +74,9 @@ export default function BackupsPage() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [newLabel, setNewLabel] = useState('');
   const [isCreating, setIsCreating] = useState(false);
+  const [accumulatedBackups, setAccumulatedBackups] = useState<SerializedBackup[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -91,10 +96,35 @@ export default function BackupsPage() {
     }
   }, [adminDrives, currentDriveId, createDriveId]);
 
+  const swrKey = user ? `/api/backups?limit=${PAGE_SIZE}&offset=0` : null;
   const { data, isLoading: isLoadingBackups, mutate, error } = useSWR<BackupListResponse>(
-    user ? '/api/backups' : null,
-    fetcher
+    swrKey,
+    fetcher,
+    { revalidateOnFocus: false }
   );
+
+  useEffect(() => {
+    if (data) {
+      setAccumulatedBackups(data.backups);
+      setOffset(data.backups.length);
+    }
+  }, [data]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const r = await fetchWithAuth(`/api/backups?limit=${PAGE_SIZE}&offset=${offset}`);
+      if (!r.ok) throw new Error('Failed to load more backups');
+      const result = (await r.json()) as BackupListResponse;
+      setAccumulatedBackups((prev) => [...prev, ...result.backups]);
+      setOffset((prev) => prev + result.backups.length);
+    } catch {
+      toast.error('Failed to load more backups');
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [isLoadingMore, offset]);
 
   const handleCreateBackup = async () => {
     if (!createDriveId || isCreating) return;
@@ -107,6 +137,8 @@ export default function BackupsPage() {
       toast.success(`Backup created — ${result.counts.pages} pages snapshotted`);
       setNewLabel('');
       setShowCreateForm(false);
+      setAccumulatedBackups([]);
+      setOffset(0);
       mutate();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to create backup');
@@ -220,38 +252,56 @@ export default function BackupsPage() {
               <Loader2 className="h-4 w-4 animate-spin" />
               <span className="text-sm">Loading backups…</span>
             </div>
-          ) : !data?.backups.length ? (
+          ) : !accumulatedBackups.length ? (
             <p className="text-sm text-muted-foreground py-4">
               No backups yet. Create one to snapshot a drive&apos;s current state.
             </p>
           ) : (
-            <div className="divide-y">
-              {data.backups.map((backup) => (
-                <div key={backup.id} className="flex items-start justify-between py-3 gap-4">
-                  <div className="space-y-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
-                      <Badge variant="outline">{backup.source}</Badge>
-                      {backup.driveName && (
-                        <span className="text-sm text-muted-foreground">{backup.driveName}</span>
-                      )}
-                      {backup.label && (
-                        <span className="text-sm font-medium truncate">{backup.label}</span>
+            <>
+              <div className="divide-y">
+                {accumulatedBackups.map((backup) => (
+                  <div key={backup.id} className="flex items-start justify-between py-3 gap-4">
+                    <div className="space-y-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
+                        <Badge variant="outline">{backup.source}</Badge>
+                        {backup.driveName && (
+                          <span className="text-sm text-muted-foreground">{backup.driveName}</span>
+                        )}
+                        {backup.label && (
+                          <span className="text-sm font-medium truncate">{backup.label}</span>
+                        )}
+                      </div>
+                      {backup.failureReason && (
+                        <p className="text-xs text-destructive">{backup.failureReason}</p>
                       )}
                     </div>
-                    {backup.failureReason && (
-                      <p className="text-xs text-destructive">{backup.failureReason}</p>
-                    )}
+                    <div
+                      className="text-right text-sm text-muted-foreground shrink-0"
+                      title={format(new Date(backup.createdAt), 'PPpp')}
+                    >
+                      {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
+                    </div>
                   </div>
-                  <div
-                    className="text-right text-sm text-muted-foreground shrink-0"
-                    title={format(new Date(backup.createdAt), 'PPpp')}
+                ))}
+              </div>
+              {data && accumulatedBackups.length < data.total && (
+                <div className="flex items-center justify-between pt-2">
+                  <span className="text-xs text-muted-foreground">
+                    Showing {accumulatedBackups.length} of {data.total}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleLoadMore}
+                    disabled={isLoadingMore}
                   >
-                    {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
-                  </div>
+                    {isLoadingMore && <Loader2 className="h-3 w-3 mr-2 animate-spin" />}
+                    Load more
+                  </Button>
                 </div>
-              ))}
-            </div>
+              )}
+            </>
           )}
         </CardContent>
       </Card>

--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -21,9 +21,9 @@ import { ArrowLeft, HardDrive, Loader2, Plus } from 'lucide-react';
 import useSWR from 'swr';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import { format, formatDistanceToNow } from 'date-fns';
-import type { DriveBackupSummary } from '@/services/api/drive-backup-service';
+import type { DriveBackupWithDriveName } from '@/services/api/drive-backup-service';
 
-type SerializedBackup = Omit<DriveBackupSummary, 'createdAt' | 'completedAt' | 'failedAt'> & {
+type SerializedBackup = Omit<DriveBackupWithDriveName, 'createdAt' | 'completedAt' | 'failedAt'> & {
   createdAt: string;
   completedAt: string | null;
   failedAt: string | null;
@@ -68,7 +68,7 @@ export default function BackupsPage() {
     [drives]
   );
 
-  const [selectedDriveId, setSelectedDriveId] = useState('');
+  const [createDriveId, setCreateDriveId] = useState('');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [newLabel, setNewLabel] = useState('');
   const [isCreating, setIsCreating] = useState(false);
@@ -84,28 +84,23 @@ export default function BackupsPage() {
   }, [fetchDrives]);
 
   useEffect(() => {
-    if (!selectedDriveId && adminDrives.length > 0) {
+    if (!createDriveId && adminDrives.length > 0) {
       const preferred =
         adminDrives.find((d) => d.id === currentDriveId) ?? adminDrives[0];
-      setSelectedDriveId(preferred.id);
+      setCreateDriveId(preferred.id);
     }
-  }, [adminDrives, currentDriveId, selectedDriveId]);
+  }, [adminDrives, currentDriveId, createDriveId]);
 
   const { data, isLoading: isLoadingBackups, mutate, error } = useSWR<BackupListResponse>(
-    selectedDriveId ? `/api/drives/${selectedDriveId}/backups` : null,
+    user ? '/api/backups' : null,
     fetcher
   );
 
-  const selectedDrive = useMemo(
-    () => drives.find((d) => d.id === selectedDriveId),
-    [drives, selectedDriveId]
-  );
-
   const handleCreateBackup = async () => {
-    if (!selectedDriveId || isCreating) return;
+    if (!createDriveId || isCreating) return;
     setIsCreating(true);
     try {
-      const result = await post<CreateBackupResult>(`/api/drives/${selectedDriveId}/backups`, {
+      const result = await post<CreateBackupResult>(`/api/drives/${createDriveId}/backups`, {
         source: 'manual',
         label: newLabel.trim() || undefined,
       });
@@ -150,56 +145,44 @@ export default function BackupsPage() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>Select Drive</CardTitle>
-          <CardDescription>
-            Choose a drive you own or administer to view its backups.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoadingDrives ? (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <span className="text-sm">Loading drives…</span>
-            </div>
-          ) : adminDrives.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              You don&apos;t own or administer any drives.
-            </p>
-          ) : (
-            <Select value={selectedDriveId} onValueChange={setSelectedDriveId}>
-              <SelectTrigger className="w-full max-w-sm">
-                <SelectValue placeholder="Select a drive" />
-              </SelectTrigger>
-              <SelectContent>
-                {adminDrives.map((drive) => (
-                  <SelectItem key={drive.id} value={drive.id}>
-                    {drive.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div>
+            <CardTitle>Backups</CardTitle>
+            <CardDescription>All backups across your drives</CardDescription>
+          </div>
+          {!showCreateForm && (
+            <Button size="sm" onClick={() => setShowCreateForm(true)} disabled={adminDrives.length === 0}>
+              <Plus className="h-4 w-4 mr-2" />
+              Create Backup
+            </Button>
           )}
-        </CardContent>
-      </Card>
-
-      {selectedDriveId && (
-        <Card>
-          <CardHeader className="flex flex-row items-start justify-between space-y-0">
-            <div>
-              <CardTitle>Backups</CardTitle>
-              <CardDescription>{selectedDrive?.name}</CardDescription>
-            </div>
-            {!showCreateForm && (
-              <Button size="sm" onClick={() => setShowCreateForm(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                Create Backup
-              </Button>
-            )}
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {showCreateForm && (
-              <div className="flex items-end gap-3 p-4 rounded-lg border bg-muted/40">
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {showCreateForm && (
+            <div className="space-y-3 p-4 rounded-lg border bg-muted/40">
+              <div className="space-y-1.5">
+                <Label>Drive</Label>
+                {isLoadingDrives ? (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    Loading drives…
+                  </div>
+                ) : (
+                  <Select value={createDriveId} onValueChange={setCreateDriveId}>
+                    <SelectTrigger className="w-full max-w-sm">
+                      <SelectValue placeholder="Select a drive" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {adminDrives.map((drive) => (
+                        <SelectItem key={drive.id} value={drive.id}>
+                          {drive.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              </div>
+              <div className="flex items-end gap-3">
                 <div className="flex-1 space-y-1.5">
                   <Label htmlFor="backup-label">Label <span className="text-muted-foreground font-normal">(optional)</span></Label>
                   <Input
@@ -215,7 +198,7 @@ export default function BackupsPage() {
                     autoFocus
                   />
                 </div>
-                <Button onClick={handleCreateBackup} disabled={isCreating}>
+                <Button onClick={handleCreateBackup} disabled={isCreating || !createDriveId}>
                   {isCreating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
                   Snapshot Now
                 </Button>
@@ -227,52 +210,51 @@ export default function BackupsPage() {
                   Cancel
                 </Button>
               </div>
-            )}
+            </div>
+          )}
 
-            {error ? (
-              <p className="text-sm text-muted-foreground py-4">
-                {(error as { status?: number }).status === 403
-                  ? 'You need to be a drive owner or admin to manage backups for this drive.'
-                  : 'Failed to load backups.'}
-              </p>
-            ) : isLoadingBackups ? (
-              <div className="flex items-center gap-2 text-muted-foreground py-4">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                <span className="text-sm">Loading backups…</span>
-              </div>
-            ) : !data?.backups.length ? (
-              <p className="text-sm text-muted-foreground py-4">
-                No backups yet. Create one to snapshot this drive&apos;s current state.
-              </p>
-            ) : (
-              <div className="divide-y">
-                {data.backups.map((backup) => (
-                  <div key={backup.id} className="flex items-start justify-between py-3 gap-4">
-                    <div className="space-y-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
-                        <Badge variant="outline">{backup.source}</Badge>
-                        {backup.label && (
-                          <span className="text-sm font-medium truncate">{backup.label}</span>
-                        )}
-                      </div>
-                      {backup.failureReason && (
-                        <p className="text-xs text-destructive">{backup.failureReason}</p>
+          {error ? (
+            <p className="text-sm text-muted-foreground py-4">Failed to load backups.</p>
+          ) : isLoadingBackups ? (
+            <div className="flex items-center gap-2 text-muted-foreground py-4">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Loading backups…</span>
+            </div>
+          ) : !data?.backups.length ? (
+            <p className="text-sm text-muted-foreground py-4">
+              No backups yet. Create one to snapshot a drive&apos;s current state.
+            </p>
+          ) : (
+            <div className="divide-y">
+              {data.backups.map((backup) => (
+                <div key={backup.id} className="flex items-start justify-between py-3 gap-4">
+                  <div className="space-y-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
+                      <Badge variant="outline">{backup.source}</Badge>
+                      {backup.driveName && (
+                        <span className="text-sm text-muted-foreground">{backup.driveName}</span>
+                      )}
+                      {backup.label && (
+                        <span className="text-sm font-medium truncate">{backup.label}</span>
                       )}
                     </div>
-                    <div
-                      className="text-right text-sm text-muted-foreground shrink-0"
-                      title={format(new Date(backup.createdAt), 'PPpp')}
-                    >
-                      {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
-                    </div>
+                    {backup.failureReason && (
+                      <p className="text-xs text-destructive">{backup.failureReason}</p>
+                    )}
                   </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      )}
+                  <div
+                    className="text-right text-sm text-muted-foreground shrink-0"
+                    title={format(new Date(backup.createdAt), 'PPpp')}
+                  >
+                    {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/apps/web/src/services/api/drive-backup-service.ts
+++ b/apps/web/src/services/api/drive-backup-service.ts
@@ -1,6 +1,6 @@
 import { db } from '@pagespace/db/db'
-import { eq, inArray, desc } from '@pagespace/db/operators'
-import { pages } from '@pagespace/db/schema/core'
+import { eq, and, inArray, isNotNull, desc } from '@pagespace/db/operators'
+import { drives, pages } from '@pagespace/db/schema/core'
 import { pagePermissions, driveMembers, driveRoles } from '@pagespace/db/schema/members'
 import { files } from '@pagespace/db/schema/storage'
 import { driveBackups, driveBackupPages, driveBackupPermissions, driveBackupMembers, driveBackupRoles, driveBackupFiles } from '@pagespace/db/schema/versioning';
@@ -47,6 +47,61 @@ export interface CreateDriveBackupResult {
     members: number;
     roles: number;
     files: number;
+  };
+}
+
+export type DriveBackupWithDriveName = DriveBackupSummary & { driveName: string | null };
+
+export async function listAllUserBackups(
+  userId: string,
+  options?: { limit?: number; offset?: number }
+): Promise<{ success: boolean; backups: DriveBackupWithDriveName[]; error?: string }> {
+  const ownedDrives = await db.select({ id: drives.id })
+    .from(drives)
+    .where(and(eq(drives.ownerId, userId), eq(drives.isTrashed, false)));
+
+  const adminMemberships = await db.select({ driveId: driveMembers.driveId })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.userId, userId),
+      eq(driveMembers.role, 'ADMIN'),
+      isNotNull(driveMembers.acceptedAt)
+    ));
+
+  const driveIds = [
+    ...ownedDrives.map((d) => d.id),
+    ...adminMemberships.map((d) => d.driveId),
+  ];
+
+  if (driveIds.length === 0) {
+    return { success: true, backups: [] };
+  }
+
+  const rows = await db
+    .select({ backup: driveBackups, driveName: drives.name })
+    .from(driveBackups)
+    .innerJoin(drives, eq(driveBackups.driveId, drives.id))
+    .where(inArray(driveBackups.driveId, driveIds))
+    .orderBy(desc(driveBackups.createdAt))
+    .limit(options?.limit ?? 50)
+    .offset(options?.offset ?? 0);
+
+  return {
+    success: true,
+    backups: rows.map((r) => ({
+      id: r.backup.id,
+      driveId: r.backup.driveId,
+      createdAt: r.backup.createdAt,
+      createdBy: r.backup.createdBy,
+      source: r.backup.source as DriveBackupSource,
+      status: r.backup.status as DriveBackupSummary['status'],
+      label: r.backup.label,
+      reason: r.backup.reason,
+      completedAt: r.backup.completedAt,
+      failedAt: r.backup.failedAt,
+      failureReason: r.backup.failureReason,
+      driveName: r.driveName,
+    })),
   };
 }
 

--- a/apps/web/src/services/api/drive-backup-service.ts
+++ b/apps/web/src/services/api/drive-backup-service.ts
@@ -60,8 +60,10 @@ export async function listAllUserBackups(
     .from(drives)
     .where(and(eq(drives.ownerId, userId), eq(drives.isTrashed, false)));
 
-  const adminMemberships = await db.select({ driveId: driveMembers.driveId })
+  const adminMemberships = await db
+    .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
+    .innerJoin(drives, and(eq(driveMembers.driveId, drives.id), eq(drives.isTrashed, false)))
     .where(and(
       eq(driveMembers.userId, userId),
       eq(driveMembers.role, 'ADMIN'),

--- a/apps/web/src/services/api/drive-backup-service.ts
+++ b/apps/web/src/services/api/drive-backup-service.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, inArray, isNotNull, desc } from '@pagespace/db/operators'
+import { eq, and, inArray, isNotNull, desc, sql } from '@pagespace/db/operators'
 import { drives, pages } from '@pagespace/db/schema/core'
 import { pagePermissions, driveMembers, driveRoles } from '@pagespace/db/schema/members'
 import { files } from '@pagespace/db/schema/storage'
@@ -55,7 +55,7 @@ export type DriveBackupWithDriveName = DriveBackupSummary & { driveName: string 
 export async function listAllUserBackups(
   userId: string,
   options?: { limit?: number; offset?: number }
-): Promise<{ success: boolean; backups: DriveBackupWithDriveName[]; error?: string }> {
+): Promise<{ success: boolean; backups: DriveBackupWithDriveName[]; total: number; error?: string }> {
   const ownedDrives = await db.select({ id: drives.id })
     .from(drives)
     .where(and(eq(drives.ownerId, userId), eq(drives.isTrashed, false)));
@@ -74,20 +74,30 @@ export async function listAllUserBackups(
   ];
 
   if (driveIds.length === 0) {
-    return { success: true, backups: [] };
+    return { success: true, backups: [], total: 0 };
   }
 
-  const rows = await db
-    .select({ backup: driveBackups, driveName: drives.name })
-    .from(driveBackups)
-    .innerJoin(drives, eq(driveBackups.driveId, drives.id))
-    .where(inArray(driveBackups.driveId, driveIds))
-    .orderBy(desc(driveBackups.createdAt))
-    .limit(options?.limit ?? 50)
-    .offset(options?.offset ?? 0);
+  const limit = options?.limit ?? 50;
+  const offset = options?.offset ?? 0;
+
+  const [rows, countRows] = await Promise.all([
+    db
+      .select({ backup: driveBackups, driveName: drives.name })
+      .from(driveBackups)
+      .innerJoin(drives, eq(driveBackups.driveId, drives.id))
+      .where(inArray(driveBackups.driveId, driveIds))
+      .orderBy(desc(driveBackups.createdAt))
+      .limit(limit)
+      .offset(offset),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(driveBackups)
+      .where(inArray(driveBackups.driveId, driveIds)),
+  ]);
 
   return {
     success: true,
+    total: countRows[0]?.count ?? 0,
     backups: rows.map((r) => ({
       id: r.backup.id,
       driveId: r.backup.driveId,


### PR DESCRIPTION
## Summary

- Drive backups in Settings appeared to vanish on page refresh because the selected drive reverted to the global \`currentDriveId\`, which may not match the drive the backup was created for
- Root cause: the listing depended on a volatile \`selectedDriveId\` piece of React state tied to a per-drive picker
- Fix: show all backups across every drive the user owns or admins in one aggregated list — no drive selection needed for listing

## Changes

- **New \`GET /api/backups\`** — returns all backups across all owner/admin drives for the authenticated user, joined with drive name and total count; security audit emitted via \`auditRequest\`
- **New \`listAllUserBackups()\` service function** — queries owned drives + admin memberships, fetches backups in a single join, returns \`total\` count alongside the page
- **Settings/backups page** — drops the per-drive listing selector; SWR key is now \`/api/backups\` (stateless, survives refresh); each row shows the drive name; drive picker kept inside the Create Backup form
- **Load-more pagination** — "Showing N of total" counter with a **Load more** button; accumulated client-side with \`revalidateOnFocus: false\` so tab switches don't collapse the list back to page 1

## Test plan

- [ ] Create a backup → success toast shows page count
- [ ] Backup appears in list with drive name label
- [ ] Refresh \`/settings/backups\` → backup still visible (no drive selection needed)
- [ ] User with multiple admin drives sees backups from all drives aggregated
- [ ] Create form drive selector still works correctly
- [ ] User with >50 backups sees "Showing 50 of N" with a Load more button that fetches the next page

🤖 Generated with [Claude Code](https://claude.com/claude-code)