### PR TITLE
feat(admin): build global prompt viewer in admin app

### DIFF
--- a/apps/admin/src/app/(admin)/global-prompt/page.tsx
+++ b/apps/admin/src/app/(admin)/global-prompt/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, type ReactNode } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -73,7 +73,7 @@ function ToolsTable({ tools }: { tools: ToolSchemaInfo[] }) {
   );
 }
 
-function JsonBlock({ label, value }: { label: string; value: unknown }) {
+function CollapsibleBlock({ label, children }: { label: string; children: ReactNode }) {
   const [open, setOpen] = useState(false);
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -83,9 +83,7 @@ function JsonBlock({ label, value }: { label: string; value: unknown }) {
       </CollapsibleTrigger>
       <CollapsibleContent>
         <ScrollArea className="h-64 mt-1 mb-2">
-          <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
-            {JSON.stringify(value, null, 2)}
-          </pre>
+          {children}
         </ScrollArea>
       </CollapsibleContent>
     </Collapsible>
@@ -137,29 +135,22 @@ function ModePanel({ data, tools }: { data: RolePromptData; tools: ToolSchemaInf
       {data.completePayload?.request.experimental_context && (
         <>
           <Separator />
-          <JsonBlock label="Experimental Context" value={data.completePayload.request.experimental_context} />
+          <CollapsibleBlock label="Experimental Context">
+            <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
+              {JSON.stringify(data.completePayload.request.experimental_context, null, 2)}
+            </pre>
+          </CollapsibleBlock>
         </>
       )}
 
       {data.completePayload?.formattedString && (
         <>
           <Separator />
-          <Collapsible>
-            <CollapsibleTrigger className="flex items-center gap-2 py-2 text-sm hover:bg-muted/50 px-2 rounded w-full">
-              <ChevronRight className="h-3 w-3" />
-              <span className="font-medium">Complete Payload (raw)</span>
-              <span className="text-xs text-muted-foreground ml-auto">
-                {fmt(data.completePayload.tokenEstimates?.total ?? 0)} tok total
-              </span>
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <ScrollArea className="h-96 mt-1">
-                <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
-                  {data.completePayload.formattedString}
-                </pre>
-              </ScrollArea>
-            </CollapsibleContent>
-          </Collapsible>
+          <CollapsibleBlock label={`Complete Payload (raw) — ${fmt(data.completePayload.tokenEstimates.total)} tok`}>
+            <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
+              {data.completePayload.formattedString}
+            </pre>
+          </CollapsibleBlock>
         </>
       )}
     </div>
@@ -212,10 +203,7 @@ export default function GlobalPromptPage() {
   }
 
   const availableDrives = data?.availableDrives ?? [];
-  const availablePages = (data?.availablePages ?? []).filter(
-    (p) => !selectedDriveId || p.path.startsWith("/")
-  );
-
+  const availablePages = data?.availablePages ?? [];
   const modes = data ? Object.keys(data.promptData) : [];
   const tools = data?.toolSchemas ?? [];
   const contextLabel = data?.metadata.contextType ?? "dashboard";

--- a/apps/admin/src/app/(admin)/global-prompt/page.tsx
+++ b/apps/admin/src/app/(admin)/global-prompt/page.tsx
@@ -1,33 +1,325 @@
 "use client";
 
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { MessageSquare, ExternalLink } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AlertCircle, ChevronDown, ChevronRight, MessageSquare, RefreshCw, Wrench } from "lucide-react";
+import { fetchWithAuth } from "@/lib/auth/auth-fetch";
+import type { GlobalPromptResponse, RolePromptData, PromptSection, ToolSchemaInfo } from "./types";
 
-export default function AdminGlobalPromptPage() {
-  const webAppUrl = process.env.NEXT_PUBLIC_WEB_APP_URL ?? 'http://localhost:3000';
+function fmt(n: number) {
+  return n.toLocaleString();
+}
+
+function SectionBlock({ section }: { section: PromptSection }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center justify-between py-2 text-sm hover:bg-muted/50 px-2 rounded">
+        <div className="flex items-center gap-2 min-w-0">
+          {open ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
+          <span className="font-medium truncate">{section.name}</span>
+          <Badge variant="outline" className="text-xs shrink-0">{section.source}</Badge>
+        </div>
+        <span className="text-xs text-muted-foreground shrink-0 ml-2">{fmt(section.tokens)} tok</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <ScrollArea className="h-64 mt-1 mb-2">
+          <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
+            {section.content}
+          </pre>
+        </ScrollArea>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function ToolsTable({ tools }: { tools: ToolSchemaInfo[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Tool</TableHead>
+          <TableHead className="w-20 text-right">Tokens</TableHead>
+          <TableHead>Description</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {tools.map((tool) => (
+          <TableRow key={tool.name}>
+            <TableCell className="font-mono text-xs font-medium">{tool.name}</TableCell>
+            <TableCell className="text-right text-xs text-muted-foreground">{fmt(tool.tokenEstimate)}</TableCell>
+            <TableCell className="text-xs text-muted-foreground max-w-sm truncate">{tool.description}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function JsonBlock({ label, value }: { label: string; value: unknown }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex items-center gap-2 py-2 text-sm hover:bg-muted/50 px-2 rounded w-full">
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        <span className="font-medium">{label}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <ScrollArea className="h-64 mt-1 mb-2">
+          <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
+            {JSON.stringify(value, null, 2)}
+          </pre>
+        </ScrollArea>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function ModePanel({ data, tools }: { data: RolePromptData; tools: ToolSchemaInfo[] }) {
+  const totalToolTokens = tools.reduce((s, t) => s + t.tokenEstimate, 0);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <MessageSquare className="h-5 w-5" />
-          Global Prompt Viewer
-        </CardTitle>
-        <CardDescription>
-          The global prompt inspector is part of the main web application since it inspects the web app&apos;s AI context directly.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground mb-4">
-          View the complete system prompt and tool definitions sent to the AI from within the web app admin section.
-        </p>
-        <Button asChild variant="outline">
-          <a href={`${webAppUrl}/admin/global-prompt`} target="_blank" rel="noopener noreferrer">
-            Open in Web App <ExternalLink className="ml-2 h-4 w-4" />
-          </a>
-        </Button>
-      </CardContent>
-    </Card>
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2 text-sm">
+        <Badge variant="secondary">{fmt(data.totalTokens)} prompt tokens</Badge>
+        <Badge variant="secondary">{fmt(totalToolTokens)} tool tokens</Badge>
+        <Badge variant="secondary">{data.sections.length} sections</Badge>
+        <Badge variant="secondary">{data.toolsAllowed.length} tools allowed</Badge>
+        {data.toolsDenied.length > 0 && (
+          <Badge variant="destructive">{data.toolsDenied.length} tools denied</Badge>
+        )}
+      </div>
+
+      <Separator />
+
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <MessageSquare className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-semibold">Prompt Sections</span>
+        </div>
+        <div className="space-y-0.5">
+          {data.sections.map((s) => (
+            <SectionBlock key={s.name} section={s} />
+          ))}
+        </div>
+      </div>
+
+      {tools.length > 0 && (
+        <>
+          <Separator />
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <Wrench className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm font-semibold">Tools ({tools.length})</span>
+            </div>
+            <ToolsTable tools={tools} />
+          </div>
+        </>
+      )}
+
+      {data.completePayload?.request.experimental_context && (
+        <>
+          <Separator />
+          <JsonBlock label="Experimental Context" value={data.completePayload.request.experimental_context} />
+        </>
+      )}
+
+      {data.completePayload?.formattedString && (
+        <>
+          <Separator />
+          <Collapsible>
+            <CollapsibleTrigger className="flex items-center gap-2 py-2 text-sm hover:bg-muted/50 px-2 rounded w-full">
+              <ChevronRight className="h-3 w-3" />
+              <span className="font-medium">Complete Payload (raw)</span>
+              <span className="text-xs text-muted-foreground ml-auto">
+                {fmt(data.completePayload.tokenEstimates?.total ?? 0)} tok total
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <ScrollArea className="h-96 mt-1">
+                <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
+                  {data.completePayload.formattedString}
+                </pre>
+              </ScrollArea>
+            </CollapsibleContent>
+          </Collapsible>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function GlobalPromptPage() {
+  const [data, setData] = useState<GlobalPromptResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedDriveId, setSelectedDriveId] = useState<string>("");
+  const [selectedPageId, setSelectedPageId] = useState<string>("");
+
+  const fetchData = useCallback(async (driveId: string, pageId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (driveId) params.set("driveId", driveId);
+      if (pageId) params.set("pageId", pageId);
+      const qs = params.toString();
+      const res = await fetchWithAuth(`/api/admin/global-prompt${qs ? `?${qs}` : ""}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error ?? `HTTP ${res.status}`);
+      }
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load prompt data");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData("", "");
+  }, [fetchData]);
+
+  function handleDriveChange(val: string) {
+    const driveId = val === "__none__" ? "" : val;
+    setSelectedDriveId(driveId);
+    setSelectedPageId("");
+    fetchData(driveId, "");
+  }
+
+  function handlePageChange(val: string) {
+    const pageId = val === "__none__" ? "" : val;
+    setSelectedPageId(pageId);
+    fetchData(selectedDriveId, pageId);
+  }
+
+  const availableDrives = data?.availableDrives ?? [];
+  const availablePages = (data?.availablePages ?? []).filter(
+    (p) => !selectedDriveId || p.path.startsWith("/")
+  );
+
+  const modes = data ? Object.keys(data.promptData) : [];
+  const tools = data?.toolSchemas ?? [];
+  const contextLabel = data?.metadata.contextType ?? "dashboard";
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <MessageSquare className="h-4 w-4" />
+              Global Prompt Viewer
+            </CardTitle>
+            <Badge variant="outline" className="capitalize">{contextLabel} context</Badge>
+            {data && (
+              <span className="text-xs text-muted-foreground ml-auto">
+                {new Date(data.metadata.generatedAt).toLocaleTimeString()}
+              </span>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchData(selectedDriveId, selectedPageId)}
+              disabled={loading}
+            >
+              <RefreshCw className={`h-3 w-3 mr-1 ${loading ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex flex-wrap gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">Drive</span>
+              <Select value={selectedDriveId || "__none__"} onValueChange={handleDriveChange} disabled={loading}>
+                <SelectTrigger className="w-48 h-8 text-xs">
+                  <SelectValue placeholder="Dashboard (no drive)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">Dashboard (no drive)</SelectItem>
+                  {availableDrives.map((d) => (
+                    <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {selectedDriveId && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Page</span>
+                <Select value={selectedPageId || "__none__"} onValueChange={handlePageChange} disabled={loading}>
+                  <SelectTrigger className="w-56 h-8 text-xs">
+                    <SelectValue placeholder="Drive root" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">Drive root</SelectItem>
+                    {availablePages.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>{p.title}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {loading && (
+        <Card>
+          <CardContent className="pt-6 space-y-3">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-32 w-full" />
+          </CardContent>
+        </Card>
+      )}
+
+      {!loading && data && modes.length > 0 && (
+        <Card>
+          <CardContent className="pt-4">
+            <Tabs defaultValue={modes[0]}>
+              <TabsList>
+                {modes.map((mode) => (
+                  <TabsTrigger key={mode} value={mode} className="capitalize">
+                    {mode === "fullAccess" ? "Full Access" : "Read Only"}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {modes.map((mode) => (
+                <TabsContent key={mode} value={mode} className="mt-4">
+                  <ModePanel data={data.promptData[mode]} tools={tools} />
+                </TabsContent>
+              ))}
+            </Tabs>
+          </CardContent>
+        </Card>
+      )}
+    </div>
   );
 }

--- a/apps/admin/src/app/(admin)/global-prompt/page.tsx
+++ b/apps/admin/src/app/(admin)/global-prompt/page.tsx
@@ -91,7 +91,9 @@ function CollapsibleBlock({ label, children }: { label: string; children: ReactN
 }
 
 function ModePanel({ data, tools }: { data: RolePromptData; tools: ToolSchemaInfo[] }) {
-  const totalToolTokens = tools.reduce((s, t) => s + t.tokenEstimate, 0);
+  const allowedNames = new Set(data.toolsAllowed);
+  const modeTools = tools.filter((t) => allowedNames.has(t.name));
+  const totalToolTokens = modeTools.reduce((s, t) => s + t.tokenEstimate, 0);
 
   return (
     <div className="space-y-4">
@@ -119,15 +121,15 @@ function ModePanel({ data, tools }: { data: RolePromptData; tools: ToolSchemaInf
         </div>
       </div>
 
-      {tools.length > 0 && (
+      {modeTools.length > 0 && (
         <>
           <Separator />
           <div>
             <div className="flex items-center gap-2 mb-2">
               <Wrench className="h-4 w-4 text-muted-foreground" />
-              <span className="text-sm font-semibold">Tools ({tools.length})</span>
+              <span className="text-sm font-semibold">Tools ({modeTools.length})</span>
             </div>
-            <ToolsTable tools={tools} />
+            <ToolsTable tools={modeTools} />
           </div>
         </>
       )}

--- a/apps/admin/src/app/(admin)/global-prompt/page.tsx
+++ b/apps/admin/src/app/(admin)/global-prompt/page.tsx
@@ -73,7 +73,7 @@ function ToolsTable({ tools }: { tools: ToolSchemaInfo[] }) {
   );
 }
 
-function CollapsibleBlock({ label, children }: { label: string; children: ReactNode }) {
+function CollapsibleBlock({ label, children, height = "h-64" }: { label: string; children: ReactNode; height?: string }) {
   const [open, setOpen] = useState(false);
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -82,7 +82,7 @@ function CollapsibleBlock({ label, children }: { label: string; children: ReactN
         <span className="font-medium">{label}</span>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <ScrollArea className="h-64 mt-1 mb-2">
+        <ScrollArea className={`${height} mt-1 mb-2`}>
           {children}
         </ScrollArea>
       </CollapsibleContent>
@@ -148,7 +148,7 @@ function ModePanel({ data, tools }: { data: RolePromptData; tools: ToolSchemaInf
       {data.completePayload?.formattedString && (
         <>
           <Separator />
-          <CollapsibleBlock label={`Complete Payload (raw) — ${fmt(data.completePayload.tokenEstimates.total)} tok`}>
+          <CollapsibleBlock label={`Complete Payload (raw) — ${fmt(data.completePayload.tokenEstimates.total)} tok`} height="h-96">
             <pre className="text-xs bg-muted/50 rounded p-3 whitespace-pre-wrap break-words font-mono leading-relaxed">
               {data.completePayload.formattedString}
             </pre>

--- a/apps/admin/src/app/(admin)/global-prompt/types.ts
+++ b/apps/admin/src/app/(admin)/global-prompt/types.ts
@@ -1,0 +1,138 @@
+// Local copy of types from apps/web/src/lib/ai/types/global-prompt.ts
+// Keep in sync if the API response shape changes.
+
+export interface JsonSchemaProperty {
+  type: string;
+  description?: string;
+  enum?: string[];
+  items?: JsonSchemaProperty;
+  properties?: Record<string, JsonSchemaProperty>;
+  required?: string[];
+  default?: unknown;
+  optional?: boolean;
+}
+
+export interface JsonSchema {
+  type: string;
+  properties: Record<string, JsonSchemaProperty>;
+  required: string[];
+  description?: string;
+}
+
+export interface ToolSchemaInfo {
+  name: string;
+  description: string;
+  parameters: JsonSchema;
+  tokenEstimate: number;
+}
+
+export interface PromptSection {
+  name: string;
+  content: string;
+  source: string;
+  lines?: string;
+  tokens: number;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: JsonSchema;
+}
+
+export interface CompleteAIRequest {
+  model: string;
+  system: string;
+  tools: ToolDefinition[];
+  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+  experimental_context: Record<string, unknown>;
+}
+
+export interface TokenEstimates {
+  systemPrompt: number;
+  tools: number;
+  experimentalContext: number;
+  total: number;
+}
+
+export interface CompletePayloadResult {
+  request: CompleteAIRequest;
+  formattedString: string;
+  tokenEstimates: TokenEstimates;
+  nonCoreToolNames: string[];
+}
+
+export interface RolePromptData {
+  mode: 'fullAccess' | 'readOnly';
+  fullPrompt: string;
+  sections: PromptSection[];
+  totalTokens: number;
+  toolsAllowed: string[];
+  toolsDenied: string[];
+  nonCoreToolNames: string[];
+  permissions: {
+    canRead: boolean;
+    canWrite: boolean;
+    canDelete: boolean;
+    canOrganize: boolean;
+  };
+  completePayload?: CompletePayloadResult;
+}
+
+export interface DriveInfo {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+}
+
+export interface PageInfo {
+  id: string;
+  title: string;
+  type: string;
+  path: string;
+  parentId: string | null;
+}
+
+export interface ExperimentalContext {
+  userId: string;
+  timezone: string | undefined;
+  aiProvider: string;
+  aiModel: string;
+  conversationId: string;
+  modelCapabilities: {
+    hasVision: boolean;
+    hasTools: boolean;
+    model: string;
+    provider: string;
+  };
+  locationContext: {
+    currentDrive?: { id: string; name: string; slug: string };
+    currentPage?: { id: string; title: string; type: string; path: string };
+    breadcrumbs?: Array<{ id: string; title: string }>;
+  } | null;
+  chatSource: { type: 'global' };
+  enabledTools: string[] | null;
+}
+
+export interface GlobalPromptResponse {
+  promptData: Record<string, RolePromptData>;
+  toolSchemas?: ToolSchemaInfo[];
+  totalToolTokens?: number;
+  experimentalContext?: ExperimentalContext;
+  availableDrives?: DriveInfo[];
+  availablePages?: PageInfo[];
+  nonCoreToolNames?: string[];
+  metadata: {
+    generatedAt: string;
+    adminUser: { id: string; role: 'user' | 'admin' };
+    locationContext?: {
+      currentDrive?: { id: string; name: string; slug: string };
+      currentPage?: { id: string; title: string; type: string; path: string };
+      breadcrumbs?: Array<{ id: string; title: string }>;
+    };
+    selectedDriveId: string | null;
+    selectedPageId: string | null;
+    contextType?: 'dashboard' | 'drive' | 'page';
+  };
+}


### PR DESCRIPTION
## Summary

- Replaces the stub \`/global-prompt\` page in \`apps/admin\` with a fully functional system prompt inspector
- The old stub just linked back to the web app, which itself redirects \`/admin\` to the admin app — a dead end
- Fetches from the existing admin proxy API (\`/api/admin/global-prompt\` → web app via service auth)

## What's in the UI

- Drive + page context pickers — select any drive/page to see the prompt for that location, or leave blank for dashboard context
- Full Access / Read Only mode tabs — each tab filters tools to only those allowed for that mode
- Collapsible prompt sections with token counts and source badges
- Tools table scoped to the mode's allowed tools (denied tools excluded from each tab)
- Collapsible experimental context (JSON) and complete raw payload blocks with correct chevron toggle state
- Skeleton loading state and inline error display

## Fixes applied

| Issue | Fix |
|-------|-----|
| Page selector showed no pages when drive selected | Removed no-op filter (`p.path.startsWith("/")` always true); pages come from API |
| Complete payload chevron never flipped | Replaced uncontrolled Collapsible with shared `CollapsibleBlock` (controlled state) |
| Tools table showed denied tools in Read Only tab | Filter tools against `data.toolsAllowed` per mode before rendering |
| Spurious optional chain on required field | `tokenEstimates.total` (not `?.total`) |
| Complete payload scroll area too short | `CollapsibleBlock` accepts `height` prop; payload uses `h-96` |

## Files changed

| File | Change |
|------|--------|
| \`apps/admin/src/app/(admin)/global-prompt/page.tsx\` | Replace stub with full viewer component |
| \`apps/admin/src/app/(admin)/global-prompt/types.ts\` | Local type copies (source of truth stays in \`apps/web/src/lib/ai/types/global-prompt.ts\`) |

No changes to the API layer — the web app API route and admin proxy are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)