### PR TITLE
feat(completions): client_manages_history — pi-compatible conversation tracking

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/lib/repositories/conversation-repository', () => ({
       createdAt: new Date(),
       updatedAt: new Date(),
     }),
+    createConversation: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -624,6 +625,105 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'skip the ownership check and return 200',
       actual: response.status,
       expected: 200,
+    });
+  });
+
+  test('client_manages_history: new conversation auto-creates row and uses client messages', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce(null);
+    const fullHistory = [
+      { role: 'user', id: 'msg-0', content: 'First', parts: [{ type: 'text', text: 'First' }] },
+      { role: 'assistant', id: 'msg-1', content: 'Hi', parts: [{ type: 'text', text: 'Hi' }] },
+      { role: 'user', id: 'msg-2', content: 'Second', parts: [{ type: 'text', text: 'Second' }] },
+    ];
+    const response = await POST(makeRequest({
+      ...validBody,
+      messages: fullHistory,
+      conversation_id: 'new-session-uuid',
+      client_manages_history: true,
+    }));
+    assert({
+      given: 'client_manages_history=true with a brand-new conversation_id',
+      should: 'return 200',
+      actual: response.status,
+      expected: 200,
+    });
+    assert({
+      given: 'client_manages_history=true with a brand-new conversation_id',
+      should: 'auto-create the conversations row',
+      actual: vi.mocked(conversationRepository.createConversation).mock.calls.length,
+      expected: 1,
+    });
+    const [streamCall] = vi.mocked(streamText).mock.calls;
+    const passedMessages = (streamCall[0] as { messages: unknown[] }).messages;
+    assert({
+      given: 'client_manages_history=true',
+      should: 'pass the full client message array to streamText (not just the last message)',
+      actual: passedMessages.length,
+      expected: fullHistory.length,
+    });
+  });
+
+  test('client_manages_history: existing conversation owned by caller proceeds without DB history load', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce({
+      id: 'conv-abc',
+      userId: 'user-1',
+      isActive: true,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isShared: false,
+      type: 'page',
+      lastMessageAt: null,
+    });
+    const fullHistory = [
+      { role: 'user', id: 'h-1', content: 'Turn 1', parts: [{ type: 'text', text: 'Turn 1' }] },
+      { role: 'assistant', id: 'h-2', content: 'Reply', parts: [{ type: 'text', text: 'Reply' }] },
+      { role: 'user', id: 'h-3', content: 'Turn 2', parts: [{ type: 'text', text: 'Turn 2' }] },
+    ];
+    const response = await POST(makeRequest({
+      ...validBody,
+      messages: fullHistory,
+      conversation_id: 'conv-abc',
+      client_manages_history: true,
+    }));
+    assert({
+      given: 'client_manages_history=true and an existing conversation owned by the caller',
+      should: 'return 200',
+      actual: response.status,
+      expected: 200,
+    });
+    assert({
+      given: 'client_manages_history=true',
+      should: 'not call chatMessageRepository.getMessagesForPage (no DB history load)',
+      actual: vi.mocked(chatMessageRepository.getMessagesForPage).mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  test('client_manages_history: returns 403 when conversation belongs to a different user', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce({
+      id: 'conv-other',
+      userId: 'other-user',
+      isActive: true,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isShared: false,
+      type: 'page',
+      lastMessageAt: null,
+    });
+    const response = await POST(makeRequest({
+      ...validBody,
+      conversation_id: 'conv-other',
+      client_manages_history: true,
+    }));
+    assert({
+      given: 'client_manages_history=true but conversation_id belongs to a different user',
+      should: 'return 403',
+      actual: response.status,
+      expected: 403,
     });
   });
 

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -629,7 +629,22 @@ describe('POST /api/v1/chat/completions', () => {
   });
 
   test('client_manages_history: new conversation auto-creates row and uses client messages', async () => {
-    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce(null);
+    // First getConversation call (ownership check): null — new session
+    // Second getConversation call (TOCTOU verify after create): owned by caller
+    vi.mocked(conversationRepository.getConversation)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'new-session-uuid',
+        userId: 'user-1',
+        isActive: true,
+        title: null,
+        contextId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isShared: false,
+        type: 'page',
+        lastMessageAt: null,
+      });
     const fullHistory = [
       { role: 'user', id: 'msg-0', content: 'First', parts: [{ type: 'text', text: 'First' }] },
       { role: 'assistant', id: 'msg-1', content: 'Hi', parts: [{ type: 'text', text: 'Hi' }] },
@@ -722,6 +737,62 @@ describe('POST /api/v1/chat/completions', () => {
     assert({
       given: 'client_manages_history=true but conversation_id belongs to a different user',
       should: 'return 403',
+      actual: response.status,
+      expected: 403,
+    });
+  });
+
+  test('client_manages_history: returns 404 when conversation row is inactive (soft-deleted)', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce({
+      id: 'conv-deleted',
+      userId: 'user-1',
+      isActive: false,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isShared: false,
+      type: 'page',
+      lastMessageAt: null,
+    });
+    const response = await POST(makeRequest({
+      ...validBody,
+      conversation_id: 'conv-deleted',
+      client_manages_history: true,
+    }));
+    assert({
+      given: 'client_manages_history=true and the conversation row exists but isActive=false',
+      should: 'return 404, matching the normal thread-mode behaviour for inactive conversations',
+      actual: response.status,
+      expected: 404,
+    });
+  });
+
+  test('client_manages_history: returns 403 when TOCTOU race means create was won by another user', async () => {
+    // First read: null (our request sees no row)
+    // After createConversation, second read: owned by a different user (race lost)
+    vi.mocked(conversationRepository.getConversation)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'race-uuid',
+        userId: 'other-user',
+        isActive: true,
+        title: null,
+        contextId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        isShared: false,
+        type: 'page',
+        lastMessageAt: null,
+      });
+    const response = await POST(makeRequest({
+      ...validBody,
+      conversation_id: 'race-uuid',
+      client_manages_history: true,
+    }));
+    assert({
+      given: 'a TOCTOU race where another user\'s insert won before the ownership re-read',
+      should: 'return 403 rather than silently appending messages to the wrong conversation',
       actual: response.status,
       expected: 403,
     });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -115,15 +115,29 @@ export async function POST(request: Request): Promise<Response> {
   // must own the conversations row. This prevents one user from appending messages
   // into another user's thread.
   //
-  // client_manages_history callers (e.g. pi) send the full context themselves on every
-  // request. They may supply a brand-new conversation_id that doesn't exist yet — we
-  // auto-create the row below instead of 404ing. We still 403 if the row belongs to
-  // someone else (ID collision / cross-user attempt).
+  // client_manages_history callers (e.g. pi) manage their own context window and may
+  // supply a brand-new conversation_id. When the row doesn't exist yet we auto-create it
+  // here (not deferred) so we can immediately re-read and catch a TOCTOU race where two
+  // requests collide on the same new ID. We still 403 on wrong owner and 404 on inactive.
   if (incomingConversationId) {
     const conv = await conversationRepository.getConversation(incomingConversationId);
     if (clientManagesHistory) {
-      if (conv && conv.userId !== authResult.userId) {
-        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      if (conv) {
+        // Row exists — apply the same isActive + ownership checks as the normal path.
+        if (!conv.isActive) {
+          return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+        }
+        if (conv.userId !== authResult.userId) {
+          return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+        }
+      } else {
+        // First use: create the row then re-read to verify ownership, guarding against
+        // the unlikely TOCTOU case where two requests race on the same new UUID.
+        await conversationRepository.createConversation(incomingConversationId, authResult.userId, pageId);
+        const owned = await conversationRepository.getConversation(incomingConversationId);
+        if (!owned || owned.userId !== authResult.userId) {
+          return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+        }
       }
     } else {
       const convAccess = validateConversationAccess(conv, authResult.userId);
@@ -234,11 +248,6 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   const userMessageId = userMessage.id;
-  if (isThreadMode && clientManagesHistory) {
-    // Auto-create the conversations row the first time this session ID is used.
-    // createConversation uses onConflictDoNothing, so subsequent turns are no-ops.
-    await conversationRepository.createConversation(conversationId, authResult.userId, pageId);
-  }
   if (userMessage && userMessage.role === 'user') {
     await saveMessageToDatabase({
       messageId: userMessageId,

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: validation.error }, { status: validation.status });
   }
 
-  const { pageId, model: modelName, messages, driveContext: _driveContext, conversationId: incomingConversationId, clientTools: rawClientTools, disableServerTools } = validation.data;
+  const { pageId, model: modelName, messages, driveContext: _driveContext, conversationId: incomingConversationId, clientTools: rawClientTools, disableServerTools, clientManagesHistory } = validation.data;
 
   // Build the caller's client-side tool set. Tools registered without `execute` are returned
   // to the caller as native tool_calls — the SDK pauses, the caller executes locally, and the
@@ -114,11 +114,22 @@ export async function POST(request: Request): Promise<Response> {
   // 5b. Conversation ownership check — if a conversation_id is provided the caller
   // must own the conversations row. This prevents one user from appending messages
   // into another user's thread.
+  //
+  // client_manages_history callers (e.g. pi) send the full context themselves on every
+  // request. They may supply a brand-new conversation_id that doesn't exist yet — we
+  // auto-create the row below instead of 404ing. We still 403 if the row belongs to
+  // someone else (ID collision / cross-user attempt).
   if (incomingConversationId) {
     const conv = await conversationRepository.getConversation(incomingConversationId);
-    const convAccess = validateConversationAccess(conv, authResult.userId);
-    if (!convAccess.ok) {
-      return NextResponse.json({ error: convAccess.message }, { status: convAccess.status });
+    if (clientManagesHistory) {
+      if (conv && conv.userId !== authResult.userId) {
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+      }
+    } else {
+      const convAccess = validateConversationAccess(conv, authResult.userId);
+      if (!convAccess.ok) {
+        return NextResponse.json({ error: convAccess.message }, { status: convAccess.status });
+      }
     }
   }
 
@@ -217,12 +228,17 @@ export async function POST(request: Request): Promise<Response> {
   const userMessage = messages[messages.length - 1];
 
   let inferenceMessages = messages;
-  if (isThreadMode) {
+  if (isThreadMode && !clientManagesHistory) {
     const dbMessages = await chatMessageRepository.getMessagesForPage(pageId, conversationId);
     inferenceMessages = [...dbMessages.map(convertDbMessageToUIMessage), userMessage];
   }
 
   const userMessageId = userMessage.id;
+  if (isThreadMode && clientManagesHistory) {
+    // Auto-create the conversations row the first time this session ID is used.
+    // createConversation uses onConflictDoNothing, so subsequent turns are no-ops.
+    await conversationRepository.createConversation(conversationId, authResult.userId, pageId);
+  }
   if (userMessage && userMessage.role === 'user') {
     await saveMessageToDatabase({
       messageId: userMessageId,

--- a/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
@@ -11,7 +11,7 @@ describe('validateInferenceRequest', () => {
       given: 'a valid ps-agent model URI and non-empty messages array',
       should: 'return ok:true with the parsed pageId, messages, stream:true, and no driveContext',
       actual: result,
-      expected: { ok: true, data: { pageId: 'page-123', model: 'ps-agent://page-123', messages, stream: true, driveContext: undefined, clientTools: undefined, disableServerTools: false } },
+      expected: { ok: true, data: { pageId: 'page-123', model: 'ps-agent://page-123', messages, stream: true, driveContext: undefined, clientTools: undefined, disableServerTools: false, clientManagesHistory: false } },
     });
   });
 
@@ -285,6 +285,30 @@ describe('validateInferenceRequest', () => {
       given: 'disable_server_tools absent from the body',
       should: 'return disableServerTools:false',
       actual: result.ok ? result.data.disableServerTools : undefined,
+      expected: false,
+    });
+  });
+
+  test('client_manages_history:true sets clientManagesHistory', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, client_manages_history: true };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'client_manages_history:true in the body',
+      should: 'return clientManagesHistory:true',
+      actual: result.ok ? result.data.clientManagesHistory : undefined,
+      expected: true,
+    });
+  });
+
+  test('client_manages_history absent defaults to false', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'client_manages_history absent from the body',
+      should: 'return clientManagesHistory:false',
+      actual: result.ok ? result.data.clientManagesHistory : undefined,
       expected: false,
     });
   });

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -19,6 +19,7 @@ export interface ValidatedInferenceRequest {
   conversationId?: string;
   clientTools?: OpenAIToolDefinition[];
   disableServerTools?: boolean;
+  clientManagesHistory?: boolean;
 }
 
 export type ValidationResult =

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -242,6 +242,8 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
 
   const disableServerTools = raw.disable_server_tools === true;
 
+  const clientManagesHistory = raw.client_manages_history === true;
+
   return {
     ok: true,
     data: {
@@ -253,6 +255,7 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
       conversationId,
       clientTools,
       disableServerTools,
+      clientManagesHistory,
     },
   };
 };


### PR DESCRIPTION
## Summary

- Adds `client_manages_history: true` flag to `POST /api/v1/chat/completions`
- When set alongside `conversation_id`, the server uses the caller's full message array as-is (skips the DB history load that thread mode normally does)
- Messages are still persisted under the conversation ID — pi sessions become browseable conversations in PageSpace
- Auto-creates the `conversations` row on first use inside the ownership-check block, immediately followed by a re-read to guard the TOCTOU race where two requests collide on the same new UUID
- Inactive conversations (`isActive=false`) correctly return 404, matching `validateConversationAccess` behaviour
- `ValidatedInferenceRequest` interface updated with `clientManagesHistory?: boolean`

## Why

Thread mode (`conversation_id` supplied) replaces the client's message array with `[...dbMessages, lastUserMessage]`. This breaks pi (pagespace-cli), which is its own source of truth for context — it sends the full history on every request. This flag lets pi attach a stable session ID for persistence without having the server clobber its context window.

The companion pagespace-cli changes (config + provider + extension) are in a separate PR in that repo.

## Test plan

- [ ] `bun run test src/app/api/v1/chat/completions/__tests__/route.test.ts` — 32 pass (34 total; 2 pre-existing AbortSignal/jsdom failures unaffected)
- [ ] `bun run test src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts` — 30/30 pass
- [ ] New conversation + `client_manages_history=true` → 200, auto-creates conv row, full client messages passed to model
- [ ] Existing own conversation + flag → 200, no DB history load
- [ ] Cross-user conversation + flag → 403
- [ ] Inactive conversation + flag → 404 (matches normal thread-mode behaviour)
- [ ] TOCTOU race (another user's insert won) → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)