### PR TITLE
fix(ai): gate price estimates to admin users only

### DIFF
--- a/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
@@ -59,14 +59,16 @@ import { getContextWindow } from '@pagespace/lib/monitoring/ai-monitoring';
 const mockUserId = 'user_123';
 const mockConversationId = 'conv_123';
 
-const mockWebAuth = (userId: string): SessionAuthResult => ({
+const mockWebAuth = (userId: string, role: 'user' | 'admin' = 'user'): SessionAuthResult => ({
   userId,
   tokenVersion: 0,
   tokenType: 'session',
   sessionId: 'test-session-id',
-  role: 'user',
+  role,
   adminRoleVersion: 0,
 });
+
+const mockAdminAuth = (userId: string): SessionAuthResult => mockWebAuth(userId, 'admin');
 
 const mockAuthError = (status = 401): AuthError => ({
   error: NextResponse.json({ error: 'Unauthorized' }, { status }),
@@ -213,7 +215,8 @@ describe('GET /api/ai/global/[id]/usage', () => {
   });
 
   describe('successful retrieval', () => {
-    it('should return usage statistics for conversation', async () => {
+    it('should return usage statistics including cost for admin', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAdminAuth(mockUserId));
       const usageLogs = [
         mockUsageLog({ inputTokens: 1000, outputTokens: 500 }),
         mockUsageLog({ inputTokens: 2000, outputTokens: 800 }),
@@ -229,13 +232,30 @@ describe('GET /api/ai/global/[id]/usage', () => {
 
       expect(response.status).toBe(200);
       expect(Array.isArray(body.logs)).toBe(true);
-      expect(body.summary).toEqual(mockUsageSummary());
       expect(body.summary.billing).toEqual({
         totalInputTokens: 3000,
         totalOutputTokens: 1300,
         totalTokens: 4300,
         totalCost: 0.03,
       });
+      // Admin sees real cost in logs
+      expect(body.logs[0].cost).toBe(0.015);
+    });
+
+    it('should strip cost from non-admin responses', async () => {
+      const usageLogs = [mockUsageLog({ cost: 0.015 })];
+      vi.mocked(globalConversationRepository.getUsageLogs).mockResolvedValue(usageLogs);
+      vi.mocked(mockedCalculateUsageSummary).mockReturnValue(mockUsageSummary());
+
+      const request = createRequest(mockConversationId);
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.summary.billing.totalCost).toBe(0);
+      expect(body.logs[0].cost).toBeNull();
     });
 
     it('should call repository methods with correct arguments', async () => {

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -23,7 +23,8 @@ export async function GET(
       auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_usage', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
       return auth.error;
     }
-    const userId = auth.userId;
+    const { userId, role } = auth;
+    const isAdmin = role === 'admin';
 
     const { id } = await context.params;
 
@@ -41,13 +42,19 @@ export async function GET(
     // Calculate summary statistics (pure function)
     const summary = calculateUsageSummary(logs, getContextWindow);
 
+    // Strip cost data from non-admin responses
+    const responseLogs = isAdmin ? logs : logs.map(log => ({ ...log, cost: null }));
+    const responseSummary = isAdmin
+      ? summary
+      : { ...summary, billing: { ...summary.billing, totalCost: 0 } };
+
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'global_chat_usage', resourceId: id, details: {
       action: 'view_usage',
     } });
 
     return NextResponse.json({
-      logs,
-      summary,
+      logs: responseLogs,
+      summary: responseSummary,
     });
   } catch (error) {
     loggers.api.error('Error fetching AI usage:', error as Error);

--- a/apps/web/src/app/api/pages/[pageId]/ai-usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/ai-usage/__tests__/route.test.ts
@@ -99,14 +99,16 @@ import { GET } from '../../ai-usage/route';
 const mockUserId = 'user_123';
 const mockPageId = 'page_123';
 
-const mockWebAuth = (userId: string): SessionAuthResult => ({
+const mockWebAuth = (userId: string, role: 'user' | 'admin' = 'user'): SessionAuthResult => ({
   userId,
   tokenVersion: 0,
   tokenType: 'session',
   sessionId: 'test-session-id',
-  role: 'user',
+  role,
   adminRoleVersion: 0,
 });
+
+const mockAdminAuth = (userId: string): SessionAuthResult => mockWebAuth(userId, 'admin');
 
 const mockAuthError = (status = 401): AuthError => ({
   error: NextResponse.json({ error: 'Unauthorized' }, { status }),
@@ -251,7 +253,9 @@ describe('GET /api/pages/[pageId]/ai-usage', () => {
   });
 
   describe('usage statistics', () => {
-    it('returns logs and summary with aggregated billing metrics', async () => {
+    it('returns logs and summary with aggregated billing metrics for admin', async () => {
+      mockAuthenticateRequest.mockResolvedValue(mockAdminAuth(mockUserId));
+
       const response = await GET(createRequest(), mockParams);
       const body = await response.json();
 
@@ -261,6 +265,21 @@ describe('GET /api/pages/[pageId]/ai-usage', () => {
       expect(body.summary.billing.totalOutputTokens).toBe(900);
       expect(body.summary.billing.totalTokens).toBe(2700);
       expect(body.summary.billing.totalCost).toBe(0.075);
+      // Admin sees cost in logs
+      expect(body.logs[0].cost).toBe(0.045);
+    });
+
+    it('strips cost from non-admin responses', async () => {
+      const response = await GET(createRequest(), mockParams);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.logs).toHaveLength(2);
+      expect(body.summary.billing.totalInputTokens).toBe(1800);
+      expect(body.summary.billing.totalCost).toBe(0);
+      // Non-admin gets null cost in each log
+      expect(body.logs[0].cost).toBeNull();
+      expect(body.logs[1].cost).toBeNull();
     });
 
     it('returns most recent model and provider from first log', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/ai-usage/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/ai-usage/route.ts
@@ -21,7 +21,8 @@ export async function GET(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;
-    const userId = auth.userId;
+    const { userId, role } = auth;
+    const isAdmin = role === 'admin';
 
     const { pageId } = await context.params;
 
@@ -103,15 +104,18 @@ export async function GET(
 
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'ai_usage', resourceId: pageId, details: { action: 'view_ai_usage', logCount: logs.length } });
 
+    // Strip cost from logs for non-admins
+    const responseLogs = isAdmin ? logs : logs.map(log => ({ ...log, cost: null }));
+
     return NextResponse.json({
-      logs,
+      logs: responseLogs,
       summary: {
         // Billing metrics (cumulative across all calls)
         billing: {
           totalInputTokens,
           totalOutputTokens,
           totalTokens,
-          totalCost: Number(totalCost.toFixed(6)),
+          totalCost: isAdmin ? Number(totalCost.toFixed(6)) : 0,
         },
 
         // Context metrics (current conversation state)

--- a/apps/web/src/app/settings/display/page.tsx
+++ b/apps/web/src/app/settings/display/page.tsx
@@ -31,7 +31,7 @@ const INTERFACE_SETTINGS: DisplaySetting[] = [
   {
     id: 'SHOW_TOKEN_COUNTS',
     label: 'Show AI token counts',
-    description: 'Display context window usage and cost information in AI chats',
+    description: 'Display context window usage in AI chats',
     preferenceKey: 'showTokenCounts',
   },
   {

--- a/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
+++ b/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useAuth } from '@/hooks/useAuth';
 import { useAiUsage, usePageAiUsage } from '@/hooks/useAiUsage';
 import { Progress } from '@/components/ui/progress';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -28,6 +29,8 @@ interface AiUsageMonitorProps {
  * - For Page AI: pass both `conversationId` and `pageId` (will prioritize conversationId)
  */
 export function AiUsageMonitor({ conversationId, pageId, className, compact = false }: AiUsageMonitorProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const connect = useSocketStore((state) => state.connect);
   const socket = useSocketStore((state) => state.socket);
 
@@ -152,8 +155,8 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
             </TooltipContent>
           </Tooltip>
 
-          {/* Session Cost */}
-          {usage.billing.cost > 0 && (
+          {/* Session Cost — admin only */}
+          {isAdmin && usage.billing.cost > 0 && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center gap-1">
@@ -241,8 +244,8 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
             </Tooltip>
           </div>
 
-          {/* Cost (if applicable) */}
-          {usage.billing.cost > 0 && (
+          {/* Cost — admin only */}
+          {isAdmin && usage.billing.cost > 0 && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center justify-between pt-1 text-xs">


### PR DESCRIPTION
## Summary

- Cost estimates (\`$X.XX\`) are now hidden from non-admin users — enforced at **both** the API and UI layers
- Token/context window counts (\`123K/200K\`) remain visible to all users when the toggle is on
- Updated the \"Show AI token counts\" setting description to remove mention of cost info

## How it works

**API layer** (primary enforcement): Both usage routes (\`/api/ai/global/[id]/usage\` and \`/api/pages/[pageId]/ai-usage\`) check \`auth.role === 'admin'\`. Non-admin responses receive \`totalCost: 0\` in the billing summary and \`cost: null\` on each log entry — cost data never leaves the server for non-admins.

**UI layer** (defense in depth): \`AiUsageMonitor\` calls \`useAuth()\` and gates both the compact cost badge and the full-view \"Total Cost\" row behind \`user?.role === 'admin'\`.

## Test plan

- [ ] Non-admin with toggle ON: sees token counts, no \`$X.XX\`, cost is 0/null in network response
- [ ] Admin with toggle ON: sees token counts AND \`$X.XX\`
- [ ] Toggle OFF: shows nothing for either role
- [ ] Route tests: admin path returns real cost; non-admin path returns 0/null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Cost information visibility is now restricted to admin users; non-admin users will see zero billing costs and null per-log costs in AI usage reports.

* **Tests**
  * Updated authentication fixtures and test cases to verify role-based cost visibility behavior for both admin and non-admin users.

* **Documentation**
  * Clarified settings description for context window usage display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->