### PR TITLE
feat(settings): drive settings hub with categorized sub-routes

### DIFF
--- a/apps/web/src/app/dashboard/[driveId]/settings/backups/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/backups/page.tsx
@@ -71,7 +71,7 @@ export default function DriveBackupsPage() {
   const drive = drives.find((d) => d.id === driveId);
   const canManage = drive?.isOwned || drive?.role === 'ADMIN';
 
-  const swrKey = drive
+  const swrKey = drive && canManage
     ? `/api/drives/${driveId}/backups?limit=${PAGE_SIZE}&offset=0`
     : null;
   const { data, isLoading: isLoadingBackups, error, mutate } = useSWR<BackupListResponse>(

--- a/apps/web/src/app/dashboard/[driveId]/settings/backups/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/backups/page.tsx
@@ -28,7 +28,7 @@ type SerializedBackup = {
   failedAt: string | null;
 };
 
-type BackupListResponse = { backups: SerializedBackup[]; total?: number };
+type BackupListResponse = { backups: SerializedBackup[] };
 
 type CreateBackupResult = {
   backupId: string;
@@ -62,6 +62,7 @@ export default function DriveBackupsPage() {
   const [accumulatedBackups, setAccumulatedBackups] = useState<SerializedBackup[]>([]);
   const [offset, setOffset] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
 
   useEffect(() => {
     fetchDrives();
@@ -83,6 +84,7 @@ export default function DriveBackupsPage() {
     if (data) {
       setAccumulatedBackups(data.backups);
       setOffset(data.backups.length);
+      setHasMore(data.backups.length === PAGE_SIZE);
     }
   }, [data]);
 
@@ -97,6 +99,7 @@ export default function DriveBackupsPage() {
       const result = (await r.json()) as BackupListResponse;
       setAccumulatedBackups((prev) => [...prev, ...result.backups]);
       setOffset((prev) => prev + result.backups.length);
+      setHasMore(result.backups.length === PAGE_SIZE);
     } catch {
       toast.error('Failed to load more backups');
     } finally {
@@ -153,9 +156,6 @@ export default function DriveBackupsPage() {
       </div>
     );
   }
-
-  const total = data?.total ?? accumulatedBackups.length;
-  const hasMore = accumulatedBackups.length < total;
 
   return (
     <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
@@ -265,10 +265,10 @@ export default function DriveBackupsPage() {
                     )}
                     {backup.status === 'ready' && (
                       <a
-                        href={`/settings/backups?driveId=${driveId}`}
+                        href="/settings/backups"
                         className="text-xs text-primary hover:underline"
                       >
-                        Restore…
+                        Restore from Settings
                       </a>
                     )}
                   </div>
@@ -281,10 +281,7 @@ export default function DriveBackupsPage() {
                 </div>
               ))}
               {hasMore && (
-                <div className="flex items-center justify-between pt-3">
-                  <span className="text-xs text-muted-foreground">
-                    Showing {accumulatedBackups.length} of {total}
-                  </span>
+                <div className="flex justify-end pt-3">
                   <Button
                     variant="ghost"
                     size="sm"

--- a/apps/web/src/app/dashboard/[driveId]/settings/backups/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/backups/page.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronLeft, Shield, Plus, Loader2 } from 'lucide-react';
+import { useDriveStore } from '@/hooks/useDrive';
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
+import useSWR from 'swr';
+import { format, formatDistanceToNow } from 'date-fns';
+
+const PAGE_SIZE = 10;
+
+type SerializedBackup = {
+  id: string;
+  label: string | null;
+  source: string;
+  status: string;
+  failureReason?: string | null;
+  createdAt: string;
+  completedAt: string | null;
+  failedAt: string | null;
+};
+
+type BackupListResponse = { backups: SerializedBackup[]; total?: number };
+
+type CreateBackupResult = {
+  backupId: string;
+  status: string;
+  counts: { pages: number; permissions: number; members: number; roles: number; files: number };
+};
+
+function statusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'ready') return 'default';
+  if (status === 'failed') return 'destructive';
+  return 'secondary';
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then((r) => {
+    if (!r.ok) throw new Error('Failed to fetch backups');
+    return r.json();
+  });
+
+export default function DriveBackupsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const driveId = params.driveId as string;
+  const drives = useDriveStore((state) => state.drives);
+  const isLoading = useDriveStore((state) => state.isLoading);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  const [newLabel, setNewLabel] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [accumulatedBackups, setAccumulatedBackups] = useState<SerializedBackup[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const drive = drives.find((d) => d.id === driveId);
+  const canManage = drive?.isOwned || drive?.role === 'ADMIN';
+
+  const swrKey = drive
+    ? `/api/drives/${driveId}/backups?limit=${PAGE_SIZE}&offset=0`
+    : null;
+  const { data, isLoading: isLoadingBackups, error, mutate } = useSWR<BackupListResponse>(
+    swrKey,
+    fetcher,
+    { revalidateOnFocus: false }
+  );
+
+  useEffect(() => {
+    if (data) {
+      setAccumulatedBackups(data.backups);
+      setOffset(data.backups.length);
+    }
+  }, [data]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (isLoadingMore) return;
+    setIsLoadingMore(true);
+    try {
+      const r = await fetchWithAuth(
+        `/api/drives/${driveId}/backups?limit=${PAGE_SIZE}&offset=${offset}`
+      );
+      if (!r.ok) throw new Error('Failed to load more');
+      const result = (await r.json()) as BackupListResponse;
+      setAccumulatedBackups((prev) => [...prev, ...result.backups]);
+      setOffset((prev) => prev + result.backups.length);
+    } catch {
+      toast.error('Failed to load more backups');
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [driveId, isLoadingMore, offset]);
+
+  const handleCreateBackup = async () => {
+    if (isCreating) return;
+    setIsCreating(true);
+    try {
+      const result = await post<CreateBackupResult>(`/api/drives/${driveId}/backups`, {
+        source: 'manual',
+        label: newLabel.trim() || undefined,
+      });
+      toast.success(`Backup created — ${result.counts.pages} pages snapshotted`);
+      setNewLabel('');
+      setShowCreateForm(false);
+      setAccumulatedBackups([]);
+      setOffset(0);
+      mutate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to create backup');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!drive || !canManage) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <Shield className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+          <h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground">Only drive owners and admins can access settings.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => router.push(`/dashboard/${driveId}`)}
+          >
+            Go Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const total = data?.total ?? accumulatedBackups.length;
+  const hasMore = accumulatedBackups.length < total;
+
+  return (
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold mb-1">Backups</h1>
+        <p className="text-muted-foreground">
+          Create and restore snapshots of this drive&apos;s pages, members, and roles.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between space-y-0">
+          <div>
+            <CardTitle>Create Backup</CardTitle>
+            <CardDescription>Snapshot the current state of this drive</CardDescription>
+          </div>
+          {!showCreateForm && (
+            <Button size="sm" onClick={() => setShowCreateForm(true)}>
+              <Plus className="h-4 w-4 mr-2" />
+              Create Backup
+            </Button>
+          )}
+        </CardHeader>
+        {showCreateForm && (
+          <CardContent className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="backup-label">
+                Label{' '}
+                <span className="text-muted-foreground font-normal">(optional)</span>
+              </Label>
+              <Input
+                id="backup-label"
+                placeholder="e.g. Before Q2 restructure"
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateBackup();
+                  if (e.key === 'Escape') {
+                    setShowCreateForm(false);
+                    setNewLabel('');
+                  }
+                }}
+                disabled={isCreating}
+                autoFocus
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleCreateBackup} disabled={isCreating}>
+                {isCreating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Snapshot Now
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setShowCreateForm(false);
+                  setNewLabel('');
+                }}
+                disabled={isCreating}
+              >
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        )}
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Backup History</CardTitle>
+          <CardDescription>All backups for {drive.name}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error ? (
+            <p className="text-sm text-muted-foreground py-4">Failed to load backups.</p>
+          ) : isLoadingBackups ? (
+            <div className="flex items-center gap-2 text-muted-foreground py-4">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Loading backups…</span>
+            </div>
+          ) : accumulatedBackups.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4">
+              No backups yet. Create one above to protect this drive.
+            </p>
+          ) : (
+            <div className="divide-y">
+              {accumulatedBackups.map((backup) => (
+                <div key={backup.id} className="flex items-start justify-between py-3 gap-4">
+                  <div className="space-y-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
+                      <Badge variant="outline">{backup.source}</Badge>
+                      {backup.label && (
+                        <span className="text-sm font-medium truncate">{backup.label}</span>
+                      )}
+                    </div>
+                    {backup.failureReason && (
+                      <p className="text-xs text-destructive">{backup.failureReason}</p>
+                    )}
+                    {backup.status === 'ready' && (
+                      <a
+                        href={`/settings/backups?driveId=${driveId}`}
+                        className="text-xs text-primary hover:underline"
+                      >
+                        Restore…
+                      </a>
+                    )}
+                  </div>
+                  <div
+                    className="text-right text-sm text-muted-foreground shrink-0"
+                    title={format(new Date(backup.createdAt), 'PPpp')}
+                  >
+                    {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
+                  </div>
+                </div>
+              ))}
+              {hasMore && (
+                <div className="flex items-center justify-between pt-3">
+                  <span className="text-xs text-muted-foreground">
+                    Showing {accumulatedBackups.length} of {total}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleLoadMore}
+                    disabled={isLoadingMore}
+                  >
+                    {isLoadingMore && <Loader2 className="h-3 w-3 mr-2 animate-spin" />}
+                    Load more
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/[driveId]/settings/context/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/context/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronLeft, Shield } from 'lucide-react';
+import { useDriveStore } from '@/hooks/useDrive';
+import { DriveAISettings } from '@/components/settings/DriveAISettings';
+
+export default function ContextSettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const driveId = params.driveId as string;
+  const drives = useDriveStore((state) => state.drives);
+  const isLoading = useDriveStore((state) => state.isLoading);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const drive = drives.find((d) => d.id === driveId);
+  const canManage = drive?.isOwned || drive?.role === 'ADMIN';
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-64 mb-8" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!drive || !canManage) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <Shield className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+          <h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground">Only drive owners and admins can access settings.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => router.push(`/dashboard/${driveId}`)}
+          >
+            Go Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold mb-1">Drive Context</h1>
+        <p className="text-muted-foreground">
+          Set workspace memory that AI uses as context in every conversation in this drive.
+        </p>
+      </div>
+
+      <DriveAISettings driveId={driveId} />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/[driveId]/settings/danger/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/danger/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronLeft, Shield } from 'lucide-react';
+import { useDriveStore } from '@/hooks/useDrive';
+import { DriveDeleteSection } from '@/components/settings/DriveDeleteSection';
+
+export default function DangerZonePage() {
+  const params = useParams();
+  const router = useRouter();
+  const driveId = params.driveId as string;
+  const drives = useDriveStore((state) => state.drives);
+  const isLoading = useDriveStore((state) => state.isLoading);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const drive = drives.find((d) => d.id === driveId);
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-64 mb-8" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!drive || !drive.isOwned) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <Shield className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+          <h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground">Only the drive owner can access this section.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          >
+            Back to Settings
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold mb-1 text-destructive">Danger Zone</h1>
+        <p className="text-muted-foreground">Irreversible actions for this drive.</p>
+      </div>
+
+      <DriveDeleteSection driveId={driveId} driveName={drive.name} />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
@@ -21,6 +21,18 @@ interface DriveMember {
   profile?: { username?: string; avatar?: string | null };
 }
 
+interface MembersResponse {
+  members: DriveMember[];
+}
+
+interface AgentMembersResponse {
+  agentMembers: { id: string }[];
+}
+
+interface AppMembersResponse {
+  appMembers: { id: string }[];
+}
+
 const fetcher = (url: string) => fetchWithAuth(url).then((r) => r.json());
 
 export default function GeneralSettingsPage() {
@@ -45,15 +57,15 @@ export default function GeneralSettingsPage() {
     if (drive) setName(drive.name);
   }, [drive]);
 
-  const { data: members } = useSWR<DriveMember[]>(
+  const { data: membersData } = useSWR<MembersResponse>(
     drive ? `/api/drives/${driveId}/members` : null,
     fetcher
   );
-  const { data: agentMembers } = useSWR<{ id: string }[]>(
+  const { data: agentMembersData } = useSWR<AgentMembersResponse>(
     drive ? `/api/drives/${driveId}/agents/members` : null,
     fetcher
   );
-  const { data: appMembers } = useSWR<{ id: string }[]>(
+  const { data: appMembersData } = useSWR<AppMembersResponse>(
     drive ? `/api/drives/${driveId}/apps/members` : null,
     fetcher
   );
@@ -101,10 +113,10 @@ export default function GeneralSettingsPage() {
     );
   }
 
-  const humanCount = members?.length ?? 0;
-  const agentCount = agentMembers?.length ?? 0;
-  const appCount = appMembers?.length ?? 0;
-  const topAvatars = (members ?? []).slice(0, 5);
+  const humanCount = membersData?.members?.length ?? 0;
+  const agentCount = agentMembersData?.agentMembers?.length ?? 0;
+  const appCount = appMembersData?.appMembers?.length ?? 0;
+  const topAvatars = (membersData?.members ?? []).slice(0, 5);
 
   return (
     <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">

--- a/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronLeft, Shield, Users, Bot, Plug2, Loader2 } from 'lucide-react';
+import { useDriveStore } from '@/hooks/useDrive';
+import { toast } from 'sonner';
+import { fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
+import useSWR from 'swr';
+
+interface DriveMember {
+  id: string;
+  userId: string;
+  user: { id: string; email: string; name?: string };
+  profile?: { username?: string; avatar?: string | null };
+}
+
+const fetcher = (url: string) => fetchWithAuth(url).then((r) => r.json());
+
+export default function GeneralSettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const driveId = params.driveId as string;
+  const drives = useDriveStore((state) => state.drives);
+  const isLoading = useDriveStore((state) => state.isLoading);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  const [name, setName] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const drive = drives.find((d) => d.id === driveId);
+  const canManage = drive?.isOwned || drive?.role === 'ADMIN';
+
+  useEffect(() => {
+    if (drive) setName(drive.name);
+  }, [drive]);
+
+  const { data: members } = useSWR<DriveMember[]>(
+    drive ? `/api/drives/${driveId}/members` : null,
+    fetcher
+  );
+  const { data: agentMembers } = useSWR<{ id: string }[]>(
+    drive ? `/api/drives/${driveId}/agents/members` : null,
+    fetcher
+  );
+  const { data: appMembers } = useSWR<{ id: string }[]>(
+    drive ? `/api/drives/${driveId}/apps/members` : null,
+    fetcher
+  );
+
+  const handleSave = async () => {
+    if (isSaving || !name.trim()) return;
+    setIsSaving(true);
+    try {
+      await patch(`/api/drives/${driveId}`, { name: name.trim() });
+      await fetchDrives();
+      toast.success('Drive renamed');
+    } catch {
+      toast.error('Failed to rename drive');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (!drive || !canManage) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <Shield className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+          <h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground">Only drive owners and admins can access settings.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => router.push(`/dashboard/${driveId}`)}
+          >
+            Go Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const humanCount = members?.length ?? 0;
+  const agentCount = agentMembers?.length ?? 0;
+  const appCount = appMembers?.length ?? 0;
+  const topAvatars = (members ?? []).slice(0, 5);
+
+  return (
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold mb-1">General</h1>
+        <p className="text-muted-foreground">Basic drive settings</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Drive Name</CardTitle>
+          <CardDescription>Update the display name for this drive</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="drive-name">Name</Label>
+            <Input
+              id="drive-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+              placeholder="Drive name"
+            />
+          </div>
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || !name.trim() || name.trim() === drive.name}
+          >
+            {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Save
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Members Overview</CardTitle>
+          <CardDescription>Current members of this drive</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex gap-6">
+            <div className="flex items-center gap-2 text-sm">
+              <Users className="h-4 w-4 text-muted-foreground" />
+              <span>
+                {humanCount} {humanCount === 1 ? 'member' : 'members'}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <Bot className="h-4 w-4 text-muted-foreground" />
+              <span>
+                {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <Plug2 className="h-4 w-4 text-muted-foreground" />
+              <span>
+                {appCount} {appCount === 1 ? 'app' : 'apps'}
+              </span>
+            </div>
+          </div>
+          {topAvatars.length > 0 && (
+            <div className="flex -space-x-2">
+              {topAvatars.map((m) => (
+                <Avatar key={m.id} className="h-8 w-8 border-2 border-background">
+                  <AvatarImage
+                    src={m.profile?.avatar ?? undefined}
+                    alt={m.user.name ?? m.user.email}
+                  />
+                  <AvatarFallback className="text-xs">
+                    {(m.user.name ?? m.user.email).slice(0, 2).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+              ))}
+            </div>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => router.push(`/dashboard/${driveId}/members`)}
+          >
+            Manage Members
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
@@ -10,6 +10,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ChevronLeft, Shield, Users, Bot, Plug2, Loader2 } from 'lucide-react';
 import { useDriveStore } from '@/hooks/useDrive';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { toast } from 'sonner';
 import { fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
 import useSWR from 'swr';
@@ -45,6 +46,12 @@ export default function GeneralSettingsPage() {
 
   const [name, setName] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  const startEditing = useEditingStore((s) => s.startEditing);
+  const endEditing = useEditingStore((s) => s.endEditing);
+
+  useEffect(() => {
+    return () => endEditing('drive-settings-rename');
+  }, [endEditing]);
 
   useEffect(() => {
     fetchDrives();
@@ -54,7 +61,7 @@ export default function GeneralSettingsPage() {
   const canManage = drive?.isOwned || drive?.role === 'ADMIN';
 
   useEffect(() => {
-    if (drive) setName(drive.name);
+    if (drive && !useEditingStore.getState().isAnyEditing()) setName(drive.name);
   }, [drive]);
 
   const { data: membersData } = useSWR<MembersResponse>(
@@ -71,10 +78,11 @@ export default function GeneralSettingsPage() {
   );
 
   const handleSave = async () => {
-    if (isSaving || !name.trim()) return;
+    const nextName = name.trim();
+    if (isSaving || !nextName || nextName === drive?.name) return;
     setIsSaving(true);
     try {
-      await patch(`/api/drives/${driveId}`, { name: name.trim() });
+      await patch(`/api/drives/${driveId}`, { name: nextName });
       await fetchDrives();
       toast.success('Drive renamed');
     } catch {
@@ -146,6 +154,8 @@ export default function GeneralSettingsPage() {
               id="drive-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
+              onFocus={() => startEditing('drive-settings-rename', 'form', { componentName: 'GeneralSettingsPage' })}
+              onBlur={() => endEditing('drive-settings-rename')}
               onKeyDown={(e) => e.key === 'Enter' && handleSave()}
               placeholder="Drive name"
             />

--- a/apps/web/src/app/dashboard/[driveId]/settings/integrations/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/integrations/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronLeft, Shield } from 'lucide-react';
+import { useDriveStore } from '@/hooks/useDrive';
+import { DriveIntegrations } from '@/components/settings/DriveIntegrations';
+import { IntegrationAuditLog } from '@/components/settings/IntegrationAuditLog';
+
+export default function IntegrationsSettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const driveId = params.driveId as string;
+  const drives = useDriveStore((state) => state.drives);
+  const isLoading = useDriveStore((state) => state.isLoading);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const drive = drives.find((d) => d.id === driveId);
+  const canManage = drive?.isOwned || drive?.role === 'ADMIN';
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-64 mb-8" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!drive || !canManage) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <Shield className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+          <h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground">Only drive owners and admins can access settings.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => router.push(`/dashboard/${driveId}`)}
+          >
+            Go Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold mb-1">Integrations</h1>
+        <p className="text-muted-foreground">
+          Connect external services and view agent API activity.
+        </p>
+      </div>
+
+      <DriveIntegrations driveId={driveId} />
+      <IntegrationAuditLog driveId={driveId} />
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/[driveId]/settings/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/page.tsx
@@ -1,16 +1,18 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ChevronLeft, Shield } from 'lucide-react';
+import { ChevronLeft, Shield, Users, Brain, Cable, HardDrive, Trash2 } from 'lucide-react';
 import { useDriveStore } from '@/hooks/useDrive';
-import { RolesManager } from '@/components/settings/RolesManager';
-import { DriveAISettings } from '@/components/settings/DriveAISettings';
-import { DriveDeleteSection } from '@/components/settings/DriveDeleteSection';
-import { DriveIntegrations } from '@/components/settings/DriveIntegrations';
-import { IntegrationAuditLog } from '@/components/settings/IntegrationAuditLog';
+import { SettingsRow, type SettingsItem } from '@/app/settings/SettingsRow';
+
+interface SettingsSection {
+  title: string;
+  items: SettingsItem[];
+}
 
 export default function DriveSettingsPage() {
   const params = useParams();
@@ -24,17 +26,15 @@ export default function DriveSettingsPage() {
     fetchDrives();
   }, [fetchDrives]);
 
-  const drive = drives.find(d => d.id === driveId);
+  const drive = drives.find((d) => d.id === driveId);
   const canManage = drive?.isOwned || drive?.role === 'ADMIN';
 
   if (isLoading) {
     return (
-      <div className="h-full overflow-auto">
-        <div className="max-w-6xl mx-auto p-6">
-          <Skeleton className="h-8 w-48 mb-2" />
-          <Skeleton className="h-4 w-64 mb-6" />
-          <Skeleton className="h-96 w-full" />
-        </div>
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-64 mb-8" />
+        <Skeleton className="h-64 w-full" />
       </div>
     );
   }
@@ -66,39 +66,106 @@ export default function DriveSettingsPage() {
     );
   }
 
+  const settingsSections: SettingsSection[] = [
+    {
+      title: 'Drive',
+      items: [
+        {
+          title: 'General',
+          description: 'Drive name and member overview',
+          icon: Shield,
+          href: `/dashboard/${driveId}/settings/general`,
+          available: true,
+        },
+        {
+          title: 'Roles',
+          description: 'Custom roles and permissions',
+          icon: Users,
+          href: `/dashboard/${driveId}/settings/roles`,
+          available: true,
+        },
+        {
+          title: 'Context',
+          description: 'Workspace memory for AI',
+          icon: Brain,
+          href: `/dashboard/${driveId}/settings/context`,
+          available: true,
+        },
+      ],
+    },
+    {
+      title: 'Connections',
+      items: [
+        {
+          title: 'Integrations',
+          description: 'External services and API connections',
+          icon: Cable,
+          href: `/dashboard/${driveId}/settings/integrations`,
+          available: true,
+        },
+      ],
+    },
+    {
+      title: 'Data',
+      items: [
+        {
+          title: 'Backups',
+          description: 'Snapshots of pages, members, and roles',
+          icon: HardDrive,
+          href: `/dashboard/${driveId}/settings/backups`,
+          available: true,
+        },
+      ],
+    },
+    ...(drive.isOwned
+      ? [
+          {
+            title: 'Administration',
+            items: [
+              {
+                title: 'Danger Zone',
+                description: 'Delete or transfer this drive',
+                icon: Trash2,
+                href: `/dashboard/${driveId}/settings/danger`,
+                available: true,
+              },
+            ],
+          },
+        ]
+      : []),
+  ];
+
   return (
-    <div className="h-full overflow-auto">
-      <div className="max-w-6xl mx-auto p-6">
-        {/* Header */}
-        <div className="mb-6">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => router.push(`/dashboard/${driveId}/members`)}
-            className="mb-4"
-          >
-            <ChevronLeft className="w-4 h-4 mr-1" />
-            Back to Members
-          </Button>
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl">
+      <div className="mb-8">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/members`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Members
+        </Button>
+        <h1 className="text-3xl font-bold mb-2">Drive Settings</h1>
+        <p className="text-muted-foreground">Configure settings for {drive.name}</p>
+      </div>
 
-          <h1 className="text-2xl font-bold">Drive Settings</h1>
-          <p className="text-muted-foreground mt-1">
-            Configure settings for {drive.name}
-          </p>
-        </div>
-
-        {/* Settings Cards */}
-        <div className="space-y-6">
-          <RolesManager driveId={driveId} />
-          <DriveAISettings driveId={driveId} />
-          <DriveIntegrations driveId={driveId} />
-          <IntegrationAuditLog driveId={driveId} />
-
-          {/* Danger Zone - Only show to owners */}
-          {drive.isOwned && (
-            <DriveDeleteSection driveId={driveId} driveName={drive.name} />
-          )}
-        </div>
+      <div className="space-y-8">
+        {settingsSections.map((section) => (
+          <div key={section.title}>
+            <h2 className="text-sm font-medium text-muted-foreground mb-2 px-1">
+              {section.title}
+            </h2>
+            <div className="rounded-lg border bg-card overflow-hidden">
+              {section.items.map((item, index) => (
+                <Link key={item.href} href={item.href}>
+                  <SettingsRow item={item} index={index} />
+                </Link>
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/app/dashboard/[driveId]/settings/roles/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/roles/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ChevronLeft, Shield } from 'lucide-react';
+import { useDriveStore } from '@/hooks/useDrive';
+import { RolesManager } from '@/components/settings/RolesManager';
+
+export default function RolesSettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const driveId = params.driveId as string;
+  const drives = useDriveStore((state) => state.drives);
+  const isLoading = useDriveStore((state) => state.isLoading);
+  const fetchDrives = useDriveStore((state) => state.fetchDrives);
+
+  useEffect(() => {
+    fetchDrives();
+  }, [fetchDrives]);
+
+  const drive = drives.find((d) => d.id === driveId);
+  const canManage = drive?.isOwned || drive?.role === 'ADMIN';
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl">
+        <Skeleton className="h-8 w-48 mb-2" />
+        <Skeleton className="h-4 w-64 mb-8" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (!drive || !canManage) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center">
+          <Shield className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
+          <h2 className="text-lg font-semibold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground">Only drive owners and admins can access settings.</p>
+          <Button
+            variant="outline"
+            className="mt-4"
+            onClick={() => router.push(`/dashboard/${driveId}`)}
+          >
+            Go Back
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-2xl space-y-6">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push(`/dashboard/${driveId}/settings`)}
+          className="mb-4"
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Back to Settings
+        </Button>
+        <h1 className="text-3xl font-bold mb-1">Roles</h1>
+        <p className="text-muted-foreground">
+          Create and manage custom roles and permissions for this drive.
+        </p>
+      </div>
+
+      <RolesManager driveId={driveId} />
+    </div>
+  );
+}

--- a/apps/web/src/components/integrations/ConnectIntegrationDialog.tsx
+++ b/apps/web/src/components/integrations/ConnectIntegrationDialog.tsx
@@ -64,7 +64,7 @@ export function ConnectIntegrationDialog({
         providerId: provider.id,
         name: connectionName,
         returnUrl: scope === 'drive' && driveId
-          ? `/dashboard/${driveId}/settings`
+          ? `/dashboard/${driveId}/settings/integrations`
           : '/settings/integrations',
       };
 


### PR DESCRIPTION
## Summary

- **Hub page** rewritten as a categorized settings menu (4 sections: Drive, Connections, Data, Administration) mirroring `/settings`, using shared `SettingsRow`/`SettingsItem` components
- **6 new sub-route pages** under `/dashboard/[driveId]/settings/`:
  - `general/` — drive rename + members overview (human/agent/app counts, avatar stack)
  - `roles/` — thin wrapper around existing `RolesManager`
  - `context/` — thin wrapper around existing `DriveAISettings`
  - `integrations/` — `DriveIntegrations` + `IntegrationAuditLog` together
  - `backups/` — drive-scoped backup list + create, using `/api/drives/[driveId]/backups`
  - `danger/` — owner-only (`drive.isOwned`), red header, `DriveDeleteSection`
- **OAuth redirect fix** in `ConnectIntegrationDialog`: `returnUrl` now points to `/dashboard/[driveId]/settings/integrations` instead of the old settings root

## Access control

| Page | Guard |
|------|-------|
| Hub, General, Roles, Context, Integrations, Backups | `isOwned \|\| role === 'ADMIN'` |
| Danger Zone | `isOwned` only (stricter; admins see no menu item) |

## Test plan

- [ ] Owner visits `/dashboard/[driveId]/settings` — sees all 6 items across 4 sections
- [ ] Admin (non-owner) visits — sees 5 items, no Administration section
- [ ] Unauthorized user visits — sees Access Denied with back button
- [ ] General page: rename drive → PATCH fires, store refreshes, toast appears
- [ ] General page: clear name field → Save button disabled
- [ ] Backups page: create backup → POST fires, new entry appears as pending
- [ ] Danger Zone: admin navigates directly → owner-only Access Denied message
- [ ] OAuth connect flow → redirects back to `/integrations` sub-page, not settings root

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drive Backups: Create backups with optional labels, view detailed history with status indicators, and restore from ready backups.
  * Reorganized drive settings into dedicated pages (General, Roles, Integrations, AI Context, Danger Zone) for improved navigation and usability.
  * Integration connection flow now returns to integrations settings page for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->