### PR TITLE
feat(backups): view contents, restore to snapshot, named downloads

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -99,7 +99,9 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['share/[token]', 'Token info read — session-auth required; reads only publicly-shareable link metadata, no user data written, low-risk read'],
 
   // --- Drive backup sub-routes ---
+  ['drives/[driveId]/backups/[backupId]', 'Read-only backup detail (pages/members/roles/files) — no data written, covered by isDriveOwnerOrAdmin check'],
   ['drives/[driveId]/backups/[backupId]/diff', 'Read-only diff preview — no data written, covered by parent backup auth'],
+  ['drives/[driveId]/backups/[backupId]/download', 'Read-only JSON download — no data written, covered by getDriveBackupDetail authz'],
   ['drives/[driveId]/backups/[backupId]/export', 'Read-only ZIP download — no data written, covered by streamBackupExport authz'],
   ['drives/[driveId]/backups/[backupId]/pages', 'Read-only snapshot page tree — no data written, covered by isDriveOwnerOrAdmin check'],
 

--- a/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/download/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/download/route.ts
@@ -1,0 +1,48 @@
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getDriveBackupDetail } from '@/services/api/drive-backup-service';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+function safeFilePart(s: string | null | undefined): string {
+  return (s ?? '').replace(/[^a-zA-Z0-9_-]/g, '-').replace(/-+/g, '-').slice(0, 40).replace(/^-|-$/g, '');
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ driveId: string; backupId: string }> },
+) {
+  const { driveId, backupId } = await params;
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+
+  try {
+    const result = await getDriveBackupDetail(backupId, driveId, auth.userId);
+    if (!result.success || !result.detail) {
+      return new Response(JSON.stringify({ error: result.error }), {
+        status: result.status ?? 403,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { detail } = result;
+    const datePart = detail.createdAt.toISOString().slice(0, 10);
+    const slugPart = safeFilePart(detail.driveSlug ?? detail.driveName);
+    const labelPart = safeFilePart(detail.label ?? detail.id);
+    const filename = [slugPart, datePart, labelPart].filter(Boolean).join('_') + '.json';
+
+    return new Response(JSON.stringify(detail, null, 2), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    loggers.api.error('Error downloading backup', error as Error);
+    return new Response(JSON.stringify({ error: 'Failed to download backup' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getDriveBackupDetail } from '@/services/api/drive-backup-service';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ driveId: string; backupId: string }> },
+) {
+  const { driveId, backupId } = await params;
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+
+  try {
+    const result = await getDriveBackupDetail(backupId, driveId, auth.userId);
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: result.status ?? 403 });
+    }
+    return NextResponse.json(result.detail);
+  } catch (error) {
+    loggers.api.error('Error fetching backup detail', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch backup detail' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { toast } from 'sonner';
-import { ArrowLeft, Download, HardDrive, Loader2, Plus } from 'lucide-react';
+import { ArrowLeft, Download, Eye, HardDrive, Loader2, Plus, RotateCcw } from 'lucide-react';
 import useSWR from 'swr';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import { Separator } from '@/components/ui/separator';
@@ -146,7 +146,7 @@ export default function BackupsPage() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = getExportFilename(backup.id, backup.label);
+      a.download = getExportFilename(backup.id, backup.label, backup.driveSlug);
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -347,14 +347,62 @@ export default function BackupsPage() {
                         <p className="text-xs text-destructive">{backup.failureReason}</p>
                       )}
                     </div>
-                    <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex items-center gap-1 shrink-0">
                       <div
-                        className="text-right text-sm text-muted-foreground"
+                        className="text-right text-sm text-muted-foreground mr-1"
                         title={format(new Date(backup.createdAt), 'PPpp')}
                       >
                         {formatDistanceToNow(new Date(backup.createdAt), { addSuffix: true })}
                       </div>
-                      {backup.status !== 'ready' ? (
+                      {backup.status === 'ready' && (
+                        <>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7"
+                                onClick={() => router.push(`/settings/backups/${backup.id}/snapshot`)}
+                              >
+                                <Eye className="h-4 w-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>View snapshot</TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7"
+                                disabled={!!downloadingId}
+                                onClick={() => handleDownload(backup)}
+                              >
+                                {downloadingId === backup.id ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Download className="h-4 w-4" />
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>{getDownloadButtonLabel(downloadingId === backup.id)}</TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-7 w-7"
+                                onClick={() => router.push(`/settings/backups?restore=${backup.id}`)}
+                              >
+                                <RotateCcw className="h-4 w-4" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Restore drive to this backup</TooltipContent>
+                          </Tooltip>
+                        </>
+                      )}
+                      {backup.status !== 'ready' && (
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span>
@@ -366,20 +414,6 @@ export default function BackupsPage() {
                           </TooltipTrigger>
                           <TooltipContent>Backup not ready</TooltipContent>
                         </Tooltip>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          disabled={!!downloadingId}
-                          onClick={() => handleDownload(backup)}
-                        >
-                          {downloadingId === backup.id ? (
-                            <Loader2 className="h-3 w-3 mr-1.5 animate-spin" />
-                          ) : (
-                            <Download className="h-3 w-3 mr-1.5" />
-                          )}
-                          {getDownloadButtonLabel(downloadingId === backup.id)}
-                        </Button>
                       )}
                     </div>
                   </div>

--- a/apps/web/src/app/settings/backups/utils.ts
+++ b/apps/web/src/app/settings/backups/utils.ts
@@ -1,5 +1,10 @@
-export function getExportFilename(backupId: string, label: string | null | undefined): string {
-  return label ? `${label}.zip` : `backup-${backupId}.zip`;
+export function getExportFilename(
+  backupId: string,
+  label: string | null | undefined,
+  driveSlug?: string | null,
+): string {
+  const slug = driveSlug ? `${driveSlug}-` : '';
+  return label ? `${slug}${label}.zip` : `${slug}backup-${backupId}.zip`;
 }
 
 export function getDownloadButtonLabel(isDownloading: boolean): string {

--- a/apps/web/src/services/api/drive-backup-service.ts
+++ b/apps/web/src/services/api/drive-backup-service.ts
@@ -1,14 +1,12 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, inArray, isNotNull, not, desc, sql } from '@pagespace/db/operators'
+import { eq, and, inArray, isNotNull, desc, sql } from '@pagespace/db/operators'
 import { drives, pages } from '@pagespace/db/schema/core'
-import type { PageTypeEnum } from '@pagespace/db/schema/core'
 import { pagePermissions, driveMembers, driveRoles } from '@pagespace/db/schema/members'
 import { files } from '@pagespace/db/schema/storage'
-import { driveBackups, driveBackupPages, driveBackupPermissions, driveBackupMembers, driveBackupRoles, driveBackupFiles, pageVersions } from '@pagespace/db/schema/versioning';
+import { driveBackups, driveBackupPages, driveBackupPermissions, driveBackupMembers, driveBackupRoles, driveBackupFiles } from '@pagespace/db/schema/versioning';
 import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { computePageStateHash, createPageVersion } from '@pagespace/lib/services/page-version-service'
-import { readPageContent } from '@pagespace/lib/services/page-content-store'
 import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils';
 import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format';
 
@@ -72,13 +70,6 @@ export interface DriveBackupDetail extends DriveBackupSummary {
   files: { fileId: string; mimeType: string | null; sizeBytes: number | null }[];
 }
 
-export interface RestoreDriveBackupResult {
-  success: boolean;
-  preRestoreBackupId?: string;
-  restoredPages?: number;
-  error?: string;
-  status?: number;
-}
 
 export async function listAllUserBackups(
   userId: string,
@@ -490,166 +481,3 @@ export async function getDriveBackupDetail(
   };
 }
 
-export async function restoreDriveToBackup(
-  backupId: string,
-  driveId: string,
-  userId: string,
-): Promise<RestoreDriveBackupResult> {
-  const canManage = await isDriveOwnerOrAdmin(userId, driveId);
-  if (!canManage) {
-    return { success: false, error: 'Only drive owners and admins can restore backups', status: 403 };
-  }
-
-  const [backup] = await db
-    .select()
-    .from(driveBackups)
-    .where(and(eq(driveBackups.id, backupId), eq(driveBackups.driveId, driveId)));
-
-  if (!backup) return { success: false, error: 'Backup not found', status: 404 };
-  if (backup.status !== 'ready') return { success: false, error: 'Backup is not ready', status: 400 };
-
-  // Always snapshot current state before overwriting
-  const preRestore = await createDriveBackup(driveId, userId, {
-    source: 'pre_restore',
-    reason: `Pre-restore snapshot before restoring backup ${backupId}`,
-  });
-  if (!preRestore.success) {
-    return { success: false, error: 'Failed to create pre-restore backup', status: 500 };
-  }
-
-  return db.transaction(async (tx) => {
-    const [bPages, bMembers, bRoles, bPermissions] = await Promise.all([
-      tx.select().from(driveBackupPages).where(eq(driveBackupPages.backupId, backupId)),
-      tx.select().from(driveBackupMembers).where(eq(driveBackupMembers.backupId, backupId)),
-      tx.select().from(driveBackupRoles).where(eq(driveBackupRoles.backupId, backupId)),
-      tx.select().from(driveBackupPermissions).where(eq(driveBackupPermissions.backupId, backupId)),
-    ]);
-
-    const currentPages = await tx
-      .select({ id: pages.id })
-      .from(pages)
-      .where(eq(pages.driveId, driveId));
-
-    const currentPageIds = new Set(currentPages.map((p) => p.id));
-    const backupPageIds = new Set(bPages.map((p) => p.pageId));
-
-    // Fetch content for pages that have a version reference
-    const versionIds = bPages.flatMap((p) => p.pageVersionId ? [p.pageVersionId] : []);
-    const contentByVersionId = new Map<string, string>();
-
-    if (versionIds.length > 0) {
-      const versions = await tx
-        .select({ id: pageVersions.id, contentRef: pageVersions.contentRef })
-        .from(pageVersions)
-        .where(inArray(pageVersions.id, versionIds));
-
-      await Promise.all(
-        versions.map(async (v) => {
-          if (!v.contentRef) return;
-          try {
-            const content = await readPageContent(v.contentRef);
-            contentByVersionId.set(v.id, content);
-          } catch {
-            // Version content expired — restore structure only
-          }
-        })
-      );
-    }
-
-    // Restore each backed-up page
-    for (const bp of bPages) {
-      const content = bp.pageVersionId ? (contentByVersionId.get(bp.pageVersionId) ?? '') : '';
-      const commonFields = {
-        title: bp.title ?? 'Untitled',
-        parentId: bp.parentId,
-        originalParentId: bp.originalParentId,
-        position: bp.position ?? 0,
-        isTrashed: bp.isTrashed,
-        trashedAt: bp.trashedAt,
-        content,
-      };
-
-      if (currentPageIds.has(bp.pageId)) {
-        await tx
-          .update(pages)
-          .set({ ...commonFields, revision: sql`revision + 1` })
-          .where(and(eq(pages.id, bp.pageId), eq(pages.driveId, driveId)));
-      } else {
-        await tx.insert(pages).values({
-          id: bp.pageId,
-          driveId,
-          type: (bp.type ?? 'DOCUMENT') as PageTypeEnum,
-          revision: 0,
-          ...commonFields,
-        });
-      }
-    }
-
-    // Trash pages that exist now but were not in the backup
-    const idsToTrash = [...currentPageIds].filter((id) => !backupPageIds.has(id));
-    if (idsToTrash.length > 0) {
-      await tx
-        .update(pages)
-        .set({ isTrashed: true, trashedAt: new Date() })
-        .where(and(eq(pages.driveId, driveId), inArray(pages.id, idsToTrash)));
-    }
-
-    // Restore page permissions: drop current, insert backup
-    if (bPermissions.length > 0) {
-      const affectedPageIds = [...new Set(bPermissions.map((p) => p.pageId))];
-      await tx.delete(pagePermissions).where(inArray(pagePermissions.pageId, affectedPageIds));
-      await tx.insert(pagePermissions).values(
-        bPermissions.map((p) => ({
-          pageId: p.pageId,
-          userId: p.userId,
-          canView: p.canView,
-          canEdit: p.canEdit,
-          canShare: p.canShare,
-          canDelete: p.canDelete,
-          grantedBy: p.grantedBy,
-          note: p.note,
-          expiresAt: p.expiresAt,
-        }))
-      );
-    }
-
-    // Restore drive members
-    await tx.delete(driveMembers).where(eq(driveMembers.driveId, driveId));
-    if (bMembers.length > 0) {
-      await tx.insert(driveMembers).values(
-        bMembers.map((m) => ({
-          driveId,
-          userId: m.userId,
-          role: (m.role ?? 'MEMBER') as 'OWNER' | 'ADMIN' | 'MEMBER',
-          customRoleId: m.customRoleId,
-          invitedBy: m.invitedBy,
-          invitedAt: m.invitedAt ?? new Date(),
-          acceptedAt: m.acceptedAt,
-        }))
-      );
-    }
-
-    // Restore custom roles
-    await tx.delete(driveRoles).where(eq(driveRoles.driveId, driveId));
-    if (bRoles.length > 0) {
-      await tx.insert(driveRoles).values(
-        bRoles.map((r) => ({
-          id: r.roleId,
-          driveId,
-          name: r.name ?? 'Untitled Role',
-          description: r.description,
-          color: r.color,
-          isDefault: r.isDefault,
-          permissions: (r.permissions ?? {}) as Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }>,
-          position: Math.round(r.position ?? 0),
-        }))
-      );
-    }
-
-    return {
-      success: true,
-      preRestoreBackupId: preRestore.backupId,
-      restoredPages: bPages.length,
-    };
-  });
-}

--- a/apps/web/src/services/api/drive-backup-service.ts
+++ b/apps/web/src/services/api/drive-backup-service.ts
@@ -1,12 +1,14 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, inArray, isNotNull, desc, sql } from '@pagespace/db/operators'
+import { eq, and, inArray, isNotNull, not, desc, sql } from '@pagespace/db/operators'
 import { drives, pages } from '@pagespace/db/schema/core'
+import type { PageTypeEnum } from '@pagespace/db/schema/core'
 import { pagePermissions, driveMembers, driveRoles } from '@pagespace/db/schema/members'
 import { files } from '@pagespace/db/schema/storage'
-import { driveBackups, driveBackupPages, driveBackupPermissions, driveBackupMembers, driveBackupRoles, driveBackupFiles } from '@pagespace/db/schema/versioning';
+import { driveBackups, driveBackupPages, driveBackupPermissions, driveBackupMembers, driveBackupRoles, driveBackupFiles, pageVersions } from '@pagespace/db/schema/versioning';
 import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { computePageStateHash, createPageVersion } from '@pagespace/lib/services/page-version-service'
+import { readPageContent } from '@pagespace/lib/services/page-content-store'
 import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils';
 import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format';
 
@@ -50,7 +52,33 @@ export interface CreateDriveBackupResult {
   };
 }
 
-export type DriveBackupWithDriveName = DriveBackupSummary & { driveName: string | null };
+export type DriveBackupWithDriveName = DriveBackupSummary & { driveName: string | null; driveSlug: string | null };
+
+export interface DriveBackupPage {
+  pageId: string;
+  title: string | null;
+  type: string | null;
+  parentId: string | null;
+  position: number | null;
+  isTrashed: boolean;
+}
+
+export interface DriveBackupDetail extends DriveBackupSummary {
+  driveName: string | null;
+  driveSlug: string | null;
+  pages: DriveBackupPage[];
+  members: { userId: string; role: string | null }[];
+  roles: { roleId: string; name: string | null }[];
+  files: { fileId: string; mimeType: string | null; sizeBytes: number | null }[];
+}
+
+export interface RestoreDriveBackupResult {
+  success: boolean;
+  preRestoreBackupId?: string;
+  restoredPages?: number;
+  error?: string;
+  status?: number;
+}
 
 export async function listAllUserBackups(
   userId: string,
@@ -84,7 +112,7 @@ export async function listAllUserBackups(
 
   const [rows, countRows] = await Promise.all([
     db
-      .select({ backup: driveBackups, driveName: drives.name })
+      .select({ backup: driveBackups, driveName: drives.name, driveSlug: drives.slug })
       .from(driveBackups)
       .innerJoin(drives, eq(driveBackups.driveId, drives.id))
       .where(inArray(driveBackups.driveId, driveIds))
@@ -113,6 +141,7 @@ export async function listAllUserBackups(
       failedAt: r.backup.failedAt,
       failureReason: r.backup.failureReason,
       driveName: r.driveName,
+      driveSlug: r.driveSlug,
     })),
   };
 }
@@ -400,5 +429,227 @@ export async function createDriveBackup(
         error: failureReason,
       };
     }
+  });
+}
+
+export async function getDriveBackupDetail(
+  backupId: string,
+  driveId: string,
+  userId: string,
+): Promise<{ success: boolean; detail?: DriveBackupDetail; error?: string; status?: number }> {
+  const canManage = await isDriveOwnerOrAdmin(userId, driveId);
+  if (!canManage) {
+    return { success: false, error: 'Only drive owners and admins can view backups', status: 403 };
+  }
+
+  const [backup] = await db
+    .select({ backup: driveBackups, driveName: drives.name, driveSlug: drives.slug })
+    .from(driveBackups)
+    .innerJoin(drives, eq(driveBackups.driveId, drives.id))
+    .where(and(eq(driveBackups.id, backupId), eq(driveBackups.driveId, driveId)));
+
+  if (!backup) {
+    return { success: false, error: 'Backup not found', status: 404 };
+  }
+
+  const [bPages, bMembers, bRoles, bFiles] = await Promise.all([
+    db.select().from(driveBackupPages).where(eq(driveBackupPages.backupId, backupId)),
+    db.select().from(driveBackupMembers).where(eq(driveBackupMembers.backupId, backupId)),
+    db.select().from(driveBackupRoles).where(eq(driveBackupRoles.backupId, backupId)),
+    db.select().from(driveBackupFiles).where(eq(driveBackupFiles.backupId, backupId)),
+  ]);
+
+  return {
+    success: true,
+    detail: {
+      id: backup.backup.id,
+      driveId: backup.backup.driveId,
+      createdAt: backup.backup.createdAt,
+      createdBy: backup.backup.createdBy,
+      source: backup.backup.source as DriveBackupSource,
+      status: backup.backup.status as DriveBackupSummary['status'],
+      label: backup.backup.label,
+      reason: backup.backup.reason,
+      completedAt: backup.backup.completedAt,
+      failedAt: backup.backup.failedAt,
+      failureReason: backup.backup.failureReason,
+      driveName: backup.driveName,
+      driveSlug: backup.driveSlug,
+      pages: bPages.map((p) => ({
+        pageId: p.pageId,
+        title: p.title,
+        type: p.type,
+        parentId: p.parentId,
+        position: p.position,
+        isTrashed: p.isTrashed,
+      })),
+      members: bMembers.map((m) => ({ userId: m.userId, role: m.role })),
+      roles: bRoles.map((r) => ({ roleId: r.roleId, name: r.name })),
+      files: bFiles.map((f) => ({ fileId: f.fileId, mimeType: f.mimeType, sizeBytes: f.sizeBytes })),
+    },
+  };
+}
+
+export async function restoreDriveToBackup(
+  backupId: string,
+  driveId: string,
+  userId: string,
+): Promise<RestoreDriveBackupResult> {
+  const canManage = await isDriveOwnerOrAdmin(userId, driveId);
+  if (!canManage) {
+    return { success: false, error: 'Only drive owners and admins can restore backups', status: 403 };
+  }
+
+  const [backup] = await db
+    .select()
+    .from(driveBackups)
+    .where(and(eq(driveBackups.id, backupId), eq(driveBackups.driveId, driveId)));
+
+  if (!backup) return { success: false, error: 'Backup not found', status: 404 };
+  if (backup.status !== 'ready') return { success: false, error: 'Backup is not ready', status: 400 };
+
+  // Always snapshot current state before overwriting
+  const preRestore = await createDriveBackup(driveId, userId, {
+    source: 'pre_restore',
+    reason: `Pre-restore snapshot before restoring backup ${backupId}`,
+  });
+  if (!preRestore.success) {
+    return { success: false, error: 'Failed to create pre-restore backup', status: 500 };
+  }
+
+  return db.transaction(async (tx) => {
+    const [bPages, bMembers, bRoles, bPermissions] = await Promise.all([
+      tx.select().from(driveBackupPages).where(eq(driveBackupPages.backupId, backupId)),
+      tx.select().from(driveBackupMembers).where(eq(driveBackupMembers.backupId, backupId)),
+      tx.select().from(driveBackupRoles).where(eq(driveBackupRoles.backupId, backupId)),
+      tx.select().from(driveBackupPermissions).where(eq(driveBackupPermissions.backupId, backupId)),
+    ]);
+
+    const currentPages = await tx
+      .select({ id: pages.id })
+      .from(pages)
+      .where(eq(pages.driveId, driveId));
+
+    const currentPageIds = new Set(currentPages.map((p) => p.id));
+    const backupPageIds = new Set(bPages.map((p) => p.pageId));
+
+    // Fetch content for pages that have a version reference
+    const versionIds = bPages.flatMap((p) => p.pageVersionId ? [p.pageVersionId] : []);
+    const contentByVersionId = new Map<string, string>();
+
+    if (versionIds.length > 0) {
+      const versions = await tx
+        .select({ id: pageVersions.id, contentRef: pageVersions.contentRef })
+        .from(pageVersions)
+        .where(inArray(pageVersions.id, versionIds));
+
+      await Promise.all(
+        versions.map(async (v) => {
+          if (!v.contentRef) return;
+          try {
+            const content = await readPageContent(v.contentRef);
+            contentByVersionId.set(v.id, content);
+          } catch {
+            // Version content expired — restore structure only
+          }
+        })
+      );
+    }
+
+    // Restore each backed-up page
+    for (const bp of bPages) {
+      const content = bp.pageVersionId ? (contentByVersionId.get(bp.pageVersionId) ?? '') : '';
+      const commonFields = {
+        title: bp.title ?? 'Untitled',
+        parentId: bp.parentId,
+        originalParentId: bp.originalParentId,
+        position: bp.position ?? 0,
+        isTrashed: bp.isTrashed,
+        trashedAt: bp.trashedAt,
+        content,
+      };
+
+      if (currentPageIds.has(bp.pageId)) {
+        await tx
+          .update(pages)
+          .set({ ...commonFields, revision: sql`revision + 1` })
+          .where(and(eq(pages.id, bp.pageId), eq(pages.driveId, driveId)));
+      } else {
+        await tx.insert(pages).values({
+          id: bp.pageId,
+          driveId,
+          type: (bp.type ?? 'DOCUMENT') as PageTypeEnum,
+          revision: 0,
+          ...commonFields,
+        });
+      }
+    }
+
+    // Trash pages that exist now but were not in the backup
+    const idsToTrash = [...currentPageIds].filter((id) => !backupPageIds.has(id));
+    if (idsToTrash.length > 0) {
+      await tx
+        .update(pages)
+        .set({ isTrashed: true, trashedAt: new Date() })
+        .where(and(eq(pages.driveId, driveId), inArray(pages.id, idsToTrash)));
+    }
+
+    // Restore page permissions: drop current, insert backup
+    if (bPermissions.length > 0) {
+      const affectedPageIds = [...new Set(bPermissions.map((p) => p.pageId))];
+      await tx.delete(pagePermissions).where(inArray(pagePermissions.pageId, affectedPageIds));
+      await tx.insert(pagePermissions).values(
+        bPermissions.map((p) => ({
+          pageId: p.pageId,
+          userId: p.userId,
+          canView: p.canView,
+          canEdit: p.canEdit,
+          canShare: p.canShare,
+          canDelete: p.canDelete,
+          grantedBy: p.grantedBy,
+          note: p.note,
+          expiresAt: p.expiresAt,
+        }))
+      );
+    }
+
+    // Restore drive members
+    await tx.delete(driveMembers).where(eq(driveMembers.driveId, driveId));
+    if (bMembers.length > 0) {
+      await tx.insert(driveMembers).values(
+        bMembers.map((m) => ({
+          driveId,
+          userId: m.userId,
+          role: (m.role ?? 'MEMBER') as 'OWNER' | 'ADMIN' | 'MEMBER',
+          customRoleId: m.customRoleId,
+          invitedBy: m.invitedBy,
+          invitedAt: m.invitedAt ?? new Date(),
+          acceptedAt: m.acceptedAt,
+        }))
+      );
+    }
+
+    // Restore custom roles
+    await tx.delete(driveRoles).where(eq(driveRoles.driveId, driveId));
+    if (bRoles.length > 0) {
+      await tx.insert(driveRoles).values(
+        bRoles.map((r) => ({
+          id: r.roleId,
+          driveId,
+          name: r.name ?? 'Untitled Role',
+          description: r.description,
+          color: r.color,
+          isDefault: r.isDefault,
+          permissions: (r.permissions ?? {}) as Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }>,
+          position: Math.round(r.position ?? 0),
+        }))
+      );
+    }
+
+    return {
+      success: true,
+      preRestoreBackupId: preRestore.backupId,
+      restoredPages: bPages.length,
+    };
   });
 }


### PR DESCRIPTION
## Summary

- **View**: each ready backup now has an eye icon that navigates to `/settings/backups/{id}/snapshot` (the existing snapshot viewer page) showing the full page tree, members, roles, and file counts
- **Download**: download icon exports backup detail as a JSON file named `{drive-slug}_{date}_{label-or-id}.json` so users immediately know what they downloaded and can browse it locally
- **Restore**: restore icon sets `?restore={id}` in the URL, which triggers the existing `BackupDiffPreview` inline diff flow — shows a diff of what will change and posts to `restore/route.ts` on confirm; always creates a `pre_restore` backup first

## Changed files

| File | Change |
|------|--------|
| `services/api/drive-backup-service.ts` | Add `driveSlug` to `DriveBackupWithDriveName`; add `DriveBackupDetail` type + `getDriveBackupDetail()` |
| `app/api/drives/[driveId]/backups/[backupId]/route.ts` | **New** — GET backup detail (pages, members, roles, files) |
| `app/api/drives/[driveId]/backups/[backupId]/download/route.ts` | **New** — GET JSON download with human-readable filename |
| `app/settings/backups/page.tsx` | Add View (Eye), Download, Restore (RotateCcw) icon buttons per ready backup; pass `driveSlug` to filename util |
| `app/settings/backups/utils.ts` | Add optional `driveSlug` param to `getExportFilename` |
| `app/api/__tests__/security-audit-coverage.test.ts` | Add the two new read-only routes to exempt list (consistent with diff/export/pages) |

## How restore works

The restore button navigates to `?restore={backupId}`, which triggers the `BackupDiffPreview` component already present in master. That component fetches the diff, shows what will change (pages to create/overwrite/trash), and on confirm POSTs to the existing `restore/route.ts` which:
1. Verifies user is owner/admin
2. Runs `runPreRestoreSnapshot` outside the transaction (pre-restore backup safety net)
3. In a transaction: diff-based page ops, full permission replacement for all affected pages, roles then members (correct FK order)

No new restore logic is introduced by this PR — only the UI button to trigger the existing flow.

## Test plan

- [ ] Create a backup, click View (eye icon) — confirm snapshot page opens with page tree and member list
- [ ] Click Download — confirm filename is `{slug}_{date}_{label}.json` and file contains pages/members/roles/files
- [ ] Add pages to a drive, back it up, add more pages, then click Restore — confirm diff preview shows, extra pages are trashed after confirm, and a `pre_restore` backup appears at the top of the list
- [ ] Attempt download/view as non-owner — confirm 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)