### PR TITLE
fix(ai-chat): eliminate screen flash, fix drive context loss, fix transport mismatch

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -219,13 +219,13 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   const chatConfig = useMemo(
     () => !transport ? null : ({
-      id: streamTrackingId,
+      id: page.id,
       messages: EMPTY_MESSAGES,
       transport,
       experimental_throttle: 100,
       onError: handleChatError,
     }),
-    [streamTrackingId, transport, handleChatError]
+    [page.id, transport, handleChatError]
   );
 
   const { messages, sendMessage, status, error, regenerate, setMessages, stop: chatStop } =
@@ -415,8 +415,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       return;
     }
     // No assistant id yet (submitted, before first chunk): fall back to the chatId map.
+    // The transport's chatId is always page.id (Chat never recreates on conversation switch),
+    // so try streamTrackingId first (desired key) then page.id (actual registration key).
     if (streamTrackingId) void abortActiveStream({ chatId: streamTrackingId });
-  }, [chatStop, ownStreamMessageId, isStreaming, lastAssistantMessageId, streamTrackingId]);
+    if (streamTrackingId !== page.id) void abortActiveStream({ chatId: page.id });
+  }, [chatStop, ownStreamMessageId, isStreaming, lastAssistantMessageId, streamTrackingId, page.id]);
 
   usePageSocketRoom(page.id);
   useChannelStreamSocket(page.id, {

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -16,8 +16,8 @@ import { Loader2, Settings, MessageSquare, History, Plus, Save } from 'lucide-re
 import { UIMessage } from 'ai';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
-import { buildPagePath } from '@/lib/tree/tree-utils';
 import { useDriveStore } from '@/hooks/useDrive';
+import { buildPageContext } from '@/lib/ai/shared/buildPageContext';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 import { PageAgentSettingsTab, PageAgentHistoryTab, type PageAgentSettingsTabRef } from '@/components/ai/page-agents';
@@ -219,13 +219,13 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   const chatConfig = useMemo(
     () => !transport ? null : ({
-      id: page.id,
+      id: streamTrackingId,
       messages: EMPTY_MESSAGES,
       transport,
       experimental_throttle: 100,
       onError: handleChatError,
     }),
-    [page.id, transport, handleChatError]
+    [streamTrackingId, transport, handleChatError]
   );
 
   const { messages, sendMessage, status, error, regenerate, setMessages, stop: chatStop } =
@@ -546,112 +546,74 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // HANDLERS
   // ============================================
 
-  const buildFreshPageContext = useCallback(async () => {
-    const currentDrive = drives.find((drive) => drive.id === driveId);
+  const buildFreshPageContext = useCallback(() => {
     const treeCacheKey = `/api/drives/${encodeURIComponent(driveId)}/pages`;
     const treeCacheValue = cache.get(treeCacheKey) as { data?: TreePage[] } | undefined;
     const cachedTree = Array.isArray(treeCacheValue?.data) ? treeCacheValue.data : [];
-    const pagePathInfo = buildPagePath(cachedTree, page.id, driveId);
-    let breadcrumbs: string[] = pagePathInfo?.breadcrumbs || [driveId, page.title];
-    let pagePath = pagePathInfo?.path || `/${driveId}/${page.title}`;
-    let parentPath = pagePathInfo?.parentPath || `/${driveId}`;
-
-    if (!pagePathInfo) {
-      try {
-        const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${page.id}/breadcrumbs`);
-        if (breadcrumbsResponse.ok) {
-          const breadcrumbItems = (await breadcrumbsResponse.json()) as Array<{ title?: string }>;
-          const breadcrumbTitles = breadcrumbItems
-            .map((item) => item.title?.trim())
-            .filter((title): title is string => Boolean(title));
-
-          if (breadcrumbTitles.length > 0) {
-            breadcrumbs = [driveId, ...breadcrumbTitles];
-            pagePath = `/${driveId}/${breadcrumbTitles.map((title) => encodeURIComponent(title)).join('/')}`;
-            if (breadcrumbTitles.length > 1) {
-              parentPath = `/${driveId}/${breadcrumbTitles
-                .slice(0, -1)
-                .map((title) => encodeURIComponent(title))
-                .join('/')}`;
-            }
-          }
-        }
-      } catch (error) {
-        console.warn('Failed to fetch breadcrumbs for AI page context:', error);
-      }
-    }
-
-    return {
-      pageId: page.id,
-      pageTitle: page.title,
-      pageType: page.type,
-      pagePath,
-      parentPath,
-      breadcrumbs,
-      driveId: currentDrive?.id,
-      driveName: currentDrive?.name || driveId,
-      driveSlug: currentDrive?.slug,
-    };
+    return buildPageContext({
+      page: { id: page.id, title: page.title, type: page.type },
+      driveId,
+      drives,
+      cachedTree,
+      fetchBreadcrumbs: async (pageId) => {
+        const res = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
+        if (!res.ok) return [];
+        return res.json();
+      },
+    });
   }, [cache, drives, driveId, page.id, page.title, page.type]);
-
-  const sendMessageWithContext = useCallback(async (text: string) => {
-    const trimmed = text.trim();
-    const files = getFilesForSend();
-    if (!trimmed && files.length === 0) {
-      return;
-    }
-
-    const pageContext = await buildFreshPageContext();
-
-    sendMessage(
-      { text: trimmed, files: files.length > 0 ? files : undefined },
-      {
-        body: {
-          chatId: page.id,
-          conversationId: currentConversationId,
-          selectedProvider,
-          selectedModel,
-          isReadOnly,
-          webSearchEnabled,
-          mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
-          pageContext,
-        },
-      }
-    );
-  }, [
-    buildFreshPageContext,
-    sendMessage,
-    page.id,
-    currentConversationId,
-    selectedProvider,
-    selectedModel,
-    isReadOnly,
-    webSearchEnabled,
-    mcpToolSchemas,
-    getFilesForSend,
-  ]);
 
   const handleSendMessage = useCallback(() => {
     if (isReadOnly) {
       toast.error('You do not have permission to send messages in this AI chat');
       return;
     }
-    if (!input.trim() && attachments.length === 0) return;
+    const trimmed = input.trim();
+    const files = getFilesForSend();
+    if (!trimmed && files.length === 0) return;
     if (!currentConversationId) return;
 
-    // wrapSend handles pendingSend registration and cleanup when streaming starts
-    wrapSend(() => sendMessageWithContext(input));
+    // Start context fetch eagerly — runs in parallel with input clear so the
+    // async wait doesn't delay sendMessage (and the optimistic bubble).
+    const contextPromise = buildFreshPageContext();
+
     clearInputDraft();
     clearFiles();
     inputRef.current?.clear();
-    // Note: scrollToBottom is now handled by use-stick-to-bottom when pinned
+
+    wrapSend(async () => {
+      const pageContext = await contextPromise;
+      sendMessage(
+        { text: trimmed, files: files.length > 0 ? files : undefined },
+        {
+          body: {
+            chatId: page.id,
+            conversationId: currentConversationId,
+            selectedProvider,
+            selectedModel,
+            isReadOnly,
+            webSearchEnabled,
+            mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
+            pageContext,
+          },
+        }
+      );
+    });
   }, [
     isReadOnly,
     input,
     attachments.length,
     currentConversationId,
-    sendMessageWithContext,
+    buildFreshPageContext,
+    getFilesForSend,
+    clearInputDraft,
     clearFiles,
+    sendMessage,
+    page.id,
+    selectedProvider,
+    selectedModel,
+    webSearchEnabled,
+    mcpToolSchemas,
     wrapSend,
   ]);
 
@@ -664,12 +626,35 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     if (!text.trim()) return;
     if (!currentConversationId) return;
 
-    // wrapSend handles pendingSend registration and cleanup when streaming starts
-    wrapSend(() => sendMessageWithContext(text));
+    const contextPromise = buildFreshPageContext();
+    wrapSend(async () => {
+      const pageContext = await contextPromise;
+      sendMessage(
+        { text: text.trim() },
+        {
+          body: {
+            chatId: page.id,
+            conversationId: currentConversationId,
+            selectedProvider,
+            selectedModel,
+            isReadOnly,
+            webSearchEnabled,
+            mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
+            pageContext,
+          },
+        }
+      );
+    });
   }, [
     isReadOnly,
     currentConversationId,
-    sendMessageWithContext,
+    buildFreshPageContext,
+    sendMessage,
+    page.id,
+    selectedProvider,
+    selectedModel,
+    webSearchEnabled,
+    mcpToolSchemas,
     wrapSend,
   ]);
 

--- a/apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildPageContext } from '../buildPageContext';
+import type { PageContextInput } from '../buildPageContext';
+
+const PAGE = { id: 'page1', title: 'My Page', type: 'AI_CHAT' as const };
+const DRIVE_ID = 'drive-abc';
+const DRIVE = { id: 'drive-abc', name: 'My Drive', slug: 'my-drive' };
+
+function makeInput(overrides: Partial<PageContextInput> = {}): PageContextInput {
+  return {
+    page: PAGE,
+    driveId: DRIVE_ID,
+    drives: [DRIVE],
+    cachedTree: [],
+    fetchBreadcrumbs: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe('buildPageContext', () => {
+  describe('drive context', () => {
+    it('uses drive from drives array when found', async () => {
+      const result = await buildPageContext(makeInput({ drives: [DRIVE] }));
+      expect(result.driveId).toBe('drive-abc');
+      expect(result.driveName).toBe('My Drive');
+      expect(result.driveSlug).toBe('my-drive');
+    });
+
+    it('falls back to driveId string when drives array is empty', async () => {
+      const result = await buildPageContext(makeInput({ drives: [] }));
+      expect(result.driveId).toBe(DRIVE_ID);
+      expect(result.driveName).toBe(DRIVE_ID);
+      expect(result.driveSlug).toBeUndefined();
+    });
+
+    it('falls back to driveId string when drive is not in the array', async () => {
+      const otherDrive = { id: 'other-drive', name: 'Other', slug: 'other' };
+      const result = await buildPageContext(makeInput({ drives: [otherDrive] }));
+      expect(result.driveId).toBe(DRIVE_ID);
+    });
+  });
+
+  describe('page identity fields', () => {
+    it('always includes page id, title, and type', async () => {
+      const result = await buildPageContext(makeInput());
+      expect(result.pageId).toBe('page1');
+      expect(result.pageTitle).toBe('My Page');
+      expect(result.pageType).toBe('AI_CHAT');
+    });
+  });
+
+  describe('path from tree cache', () => {
+    it('derives path from cached tree without calling fetchBreadcrumbs', async () => {
+      const cachedTree = [
+        {
+          id: 'folder1',
+          title: 'Folder',
+          children: [
+            { id: 'page1', title: 'My Page', children: [] },
+          ],
+        },
+      ];
+      const fetchBreadcrumbs = vi.fn();
+      const result = await buildPageContext(makeInput({ cachedTree, fetchBreadcrumbs }));
+      expect(result.pagePath).toBe(`/${DRIVE_ID}/Folder/My Page`);
+      expect(result.parentPath).toBe(`/${DRIVE_ID}/Folder`);
+      expect(result.breadcrumbs).toEqual([DRIVE_ID, 'Folder', 'My Page']);
+      expect(fetchBreadcrumbs).not.toHaveBeenCalled();
+    });
+
+    it('falls back to safe defaults when page is not in empty tree', async () => {
+      const fetchBreadcrumbs = vi.fn().mockResolvedValue([]);
+      const result = await buildPageContext(makeInput({ cachedTree: [], fetchBreadcrumbs }));
+      expect(result.pagePath).toBe(`/${DRIVE_ID}/My Page`);
+      expect(result.parentPath).toBe(`/${DRIVE_ID}`);
+      expect(result.breadcrumbs).toEqual([DRIVE_ID, 'My Page']);
+    });
+  });
+
+  describe('breadcrumbs fallback', () => {
+    it('calls fetchBreadcrumbs when page is not in cached tree', async () => {
+      const fetchBreadcrumbs = vi.fn().mockResolvedValue([
+        { title: 'Parent Folder' },
+        { title: 'My Page' },
+      ]);
+      await buildPageContext(makeInput({ cachedTree: [], fetchBreadcrumbs }));
+      expect(fetchBreadcrumbs).toHaveBeenCalledWith('page1');
+    });
+
+    it('builds path from breadcrumbs API response', async () => {
+      const fetchBreadcrumbs = vi.fn().mockResolvedValue([
+        { title: 'Parent Folder' },
+        { title: 'My Page' },
+      ]);
+      const result = await buildPageContext(makeInput({ cachedTree: [], fetchBreadcrumbs }));
+      expect(result.pagePath).toBe(`/${DRIVE_ID}/Parent%20Folder/My%20Page`);
+      expect(result.parentPath).toBe(`/${DRIVE_ID}/Parent%20Folder`);
+      expect(result.breadcrumbs).toEqual([DRIVE_ID, 'Parent Folder', 'My Page']);
+    });
+
+    it('uses safe defaults when fetchBreadcrumbs throws', async () => {
+      const fetchBreadcrumbs = vi.fn().mockRejectedValue(new Error('network error'));
+      const result = await buildPageContext(makeInput({ cachedTree: [], fetchBreadcrumbs }));
+      expect(result.pagePath).toBe(`/${DRIVE_ID}/My Page`);
+      expect(result.breadcrumbs).toEqual([DRIVE_ID, 'My Page']);
+    });
+
+    it('uses safe defaults when fetchBreadcrumbs returns empty array', async () => {
+      const fetchBreadcrumbs = vi.fn().mockResolvedValue([]);
+      const result = await buildPageContext(makeInput({ cachedTree: [], fetchBreadcrumbs }));
+      expect(result.pagePath).toBe(`/${DRIVE_ID}/My Page`);
+    });
+
+    it('filters out breadcrumb items with no title', async () => {
+      const fetchBreadcrumbs = vi.fn().mockResolvedValue([
+        { title: '' },
+        { title: 'Real Folder' },
+        { title: 'My Page' },
+      ]);
+      const result = await buildPageContext(makeInput({ cachedTree: [], fetchBreadcrumbs }));
+      expect(result.breadcrumbs).toEqual([DRIVE_ID, 'Real Folder', 'My Page']);
+    });
+  });
+});

--- a/apps/web/src/lib/ai/shared/buildPageContext.ts
+++ b/apps/web/src/lib/ai/shared/buildPageContext.ts
@@ -1,9 +1,11 @@
 import { buildPagePath } from '@/lib/tree/tree-utils';
+import type { TreePage } from '@/hooks/usePageTree';
 
 export type PageContextInput = {
   page: { id: string; title: string; type: string };
   driveId: string;
   drives: Array<{ id: string; name: string; slug?: string }>;
+  /** Structural subset of TreePage[] — only id/title/children are accessed by buildPagePath */
   cachedTree: Array<{ id: string; title: string; children?: unknown[] }>;
   fetchBreadcrumbs: (pageId: string) => Promise<Array<{ title?: string }>>;
 };
@@ -25,8 +27,7 @@ export async function buildPageContext(input: PageContextInput): Promise<PageCon
 
   const currentDrive = drives.find((d) => d.id === driveId);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const pagePathInfo = buildPagePath(cachedTree as any, page.id, driveId);
+  const pagePathInfo = buildPagePath(cachedTree as unknown as TreePage[], page.id, driveId);
 
   let breadcrumbs: string[] = pagePathInfo?.breadcrumbs ?? [driveId, page.title];
   let pagePath: string = pagePathInfo?.path ?? `/${driveId}/${page.title}`;

--- a/apps/web/src/lib/ai/shared/buildPageContext.ts
+++ b/apps/web/src/lib/ai/shared/buildPageContext.ts
@@ -1,0 +1,66 @@
+import { buildPagePath } from '@/lib/tree/tree-utils';
+
+export type PageContextInput = {
+  page: { id: string; title: string; type: string };
+  driveId: string;
+  drives: Array<{ id: string; name: string; slug?: string }>;
+  cachedTree: Array<{ id: string; title: string; children?: unknown[] }>;
+  fetchBreadcrumbs: (pageId: string) => Promise<Array<{ title?: string }>>;
+};
+
+export type PageContext = {
+  pageId: string;
+  pageTitle: string;
+  pageType: string;
+  pagePath: string;
+  parentPath: string;
+  breadcrumbs: string[];
+  driveId: string;
+  driveName: string;
+  driveSlug: string | undefined;
+};
+
+export async function buildPageContext(input: PageContextInput): Promise<PageContext> {
+  const { page, driveId, drives, cachedTree, fetchBreadcrumbs } = input;
+
+  const currentDrive = drives.find((d) => d.id === driveId);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pagePathInfo = buildPagePath(cachedTree as any, page.id, driveId);
+
+  let breadcrumbs: string[] = pagePathInfo?.breadcrumbs ?? [driveId, page.title];
+  let pagePath: string = pagePathInfo?.path ?? `/${driveId}/${page.title}`;
+  let parentPath: string = pagePathInfo?.parentPath ?? `/${driveId}`;
+
+  if (!pagePathInfo) {
+    try {
+      const breadcrumbItems = await fetchBreadcrumbs(page.id);
+      const titles = breadcrumbItems
+        .map((item) => item.title?.trim())
+        .filter((t): t is string => Boolean(t));
+
+      if (titles.length > 0) {
+        breadcrumbs = [driveId, ...titles];
+        pagePath = `/${driveId}/${titles.map((t) => encodeURIComponent(t)).join('/')}`;
+        parentPath =
+          titles.length > 1
+            ? `/${driveId}/${titles.slice(0, -1).map((t) => encodeURIComponent(t)).join('/')}`
+            : `/${driveId}`;
+      }
+    } catch {
+      // keep defaults
+    }
+  }
+
+  return {
+    pageId: page.id,
+    pageTitle: page.title,
+    pageType: page.type,
+    pagePath,
+    parentPath,
+    breadcrumbs,
+    driveId: currentDrive?.id ?? driveId,
+    driveName: currentDrive?.name ?? driveId,
+    driveSlug: currentDrive?.slug,
+  };
+}


### PR DESCRIPTION
## Summary

Three bugs in `AiChatView` (AI Chat page type):

- **Screen flash / message not sending**: `handleSendMessage` now captures files synchronously and starts `buildFreshPageContext()` eagerly *before* clearing the input. `sendMessage` fires as soon as context resolves — no async gap where the input is empty but the optimistic user bubble hasn't appeared yet.
- **Drive context loss**: Extracted `buildPageContext()` pure utility uses `currentDrive?.id ?? driveId` so the server always receives a defined `driveId` even when the drives SWR store hasn't loaded yet.
- **Stream abort fallback**: The AI SDK `Chat` object is intentionally stable (keyed on `page.id`) so conversation switches don't reset messages. The transport registers its stream under `page.id`. `effectiveStop` now tries both `streamTrackingId` and `page.id` in the chatId fallback path so the abort reaches the registered stream.

## Changes

- `apps/web/src/lib/ai/shared/buildPageContext.ts` — new pure utility extracted from `AiChatView`, typed against a structural subset of `TreePage`
- `apps/web/src/lib/ai/shared/__tests__/buildPageContext.test.ts` — 11 tests (drive fallback, path-from-cache, breadcrumbs API fallback, error handling)
- `apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx` — all three fixes applied; `sendMessageWithContext` inlined into `handleSendMessage`/`handleVoiceSend`; `chatConfig.id` kept stable as `page.id`

## Test plan

- [ ] Send first message on an AI Chat page (no existing conversation) — input clears, optimistic bubble appears immediately with no flash, AI streams normally, no retry button
- [ ] Send subsequent messages — same behaviour
- [ ] Hard refresh, send before drives SWR loads — network tab shows `driveId` is set (not `undefined`) in request body
- [ ] Start a stream and click Stop — stream aborts cleanly; no regression on conversation history loading
- [ ] `bun run vitest run src/lib/ai/shared/__tests__/buildPageContext.test.ts` → 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)