### PR TITLE
fix(registry): pi tool names are lowercase — fix CLI renderer keys and guard

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-cli-tools.test.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-cli-tools.test.ts
@@ -21,54 +21,63 @@ describe('CLI tool renderers (pi)', () => {
     }
   });
 
-  it('Read: returns null when output is not a string', () => {
-    const result = toolRenderers['Read'](makeCtx('Read', { path: 'foo.ts' }, null));
+  it('read: returns null when output is not a string', () => {
+    const result = toolRenderers['read'](makeCtx('read', { path: 'foo.ts' }, null));
     expect(result).toBeNull();
   });
 
-  it('Read: returns non-null node for valid string output (pi uses path key)', () => {
-    const result = toolRenderers['Read'](makeCtx('Read', { path: 'foo.ts' }, 'line 1\nline 2'));
+  it('read: returns non-null node for valid string output (pi uses path key)', () => {
+    const result = toolRenderers['read'](makeCtx('read', { path: 'foo.ts' }, 'line 1\nline 2'));
     expect(result).not.toBeNull();
   });
 
-  it('Read: falls back to file_path key when path is absent', () => {
-    const result = toolRenderers['Read'](makeCtx('Read', { file_path: 'bar.ts' }, 'content'));
+  it('read: falls back to file_path key when path is absent', () => {
+    const result = toolRenderers['read'](makeCtx('read', { file_path: 'bar.ts' }, 'content'));
     expect(result).not.toBeNull();
   });
 
-  it('Bash: returns null when both command and output are absent', () => {
-    const result = toolRenderers['Bash'](makeCtx('Bash', {}, null));
+  it('bash: returns null when both command and output are absent', () => {
+    const result = toolRenderers['bash'](makeCtx('bash', {}, null));
     expect(result).toBeNull();
   });
 
-  it('Bash: returns non-null node when command is present', () => {
-    const result = toolRenderers['Bash'](makeCtx('Bash', { command: 'ls -la' }, 'foo.ts\nbar.ts'));
+  it('bash: returns non-null node when command is present', () => {
+    const result = toolRenderers['bash'](makeCtx('bash', { command: 'ls -la' }, 'foo.ts\nbar.ts'));
     expect(result).not.toBeNull();
   });
 
-  it('Glob: returns null when output is not a string', () => {
-    const result = toolRenderers['Glob'](makeCtx('Glob', { pattern: '**/*.ts' }, null));
+  it('find: returns null when output is not a string', () => {
+    const result = toolRenderers['find'](makeCtx('find', { pattern: '**/*.ts' }, null));
     expect(result).toBeNull();
   });
 
-  it('Glob: returns non-null node for valid string output', () => {
-    const result = toolRenderers['Glob'](makeCtx('Glob', { pattern: '**/*.ts' }, 'src/foo.ts\nsrc/bar.ts'));
+  it('find: returns non-null node for valid string output', () => {
+    const result = toolRenderers['find'](makeCtx('find', { pattern: '**/*.ts' }, 'src/foo.ts\nsrc/bar.ts'));
     expect(result).not.toBeNull();
   });
 
-  it('Grep: returns null when output is not a string', () => {
-    const result = toolRenderers['Grep'](makeCtx('Grep', { pattern: 'TODO' }, null));
+  it('grep: returns null when output is not a string', () => {
+    const result = toolRenderers['grep'](makeCtx('grep', { pattern: 'TODO' }, null));
     expect(result).toBeNull();
   });
 
-  it('Grep: returns non-null node for valid string output', () => {
-    const result = toolRenderers['Grep'](makeCtx('Grep', { pattern: 'TODO' }, 'foo.ts:42: // TODO fix'));
+  it('grep: returns non-null node for valid string output', () => {
+    const result = toolRenderers['grep'](makeCtx('grep', { pattern: 'TODO' }, 'foo.ts:42: // TODO fix'));
     expect(result).not.toBeNull();
   });
 
-  it('Write/Edit/MultiEdit: return non-null nodes even with null output', () => {
-    expect(toolRenderers['Write'](makeCtx('Write', { file_path: 'foo.ts' }, null))).not.toBeNull();
-    expect(toolRenderers['Edit'](makeCtx('Edit', { file_path: 'foo.ts' }, null))).not.toBeNull();
-    expect(toolRenderers['MultiEdit'](makeCtx('MultiEdit', { file_path: 'foo.ts' }, null))).not.toBeNull();
+  it('write/edit: return non-null nodes even with null output', () => {
+    expect(toolRenderers['write'](makeCtx('write', { file_path: 'foo.ts' }, null))).not.toBeNull();
+    expect(toolRenderers['edit'](makeCtx('edit', { file_path: 'foo.ts' }, null))).not.toBeNull();
+  });
+
+  it('ls: returns null when output is not a string', () => {
+    const result = toolRenderers['ls'](makeCtx('ls', { path: '.' }, null));
+    expect(result).toBeNull();
+  });
+
+  it('ls: returns non-null node for valid string output', () => {
+    const result = toolRenderers['ls'](makeCtx('ls', { path: 'src/' }, 'foo.ts\nbar.ts'));
+    expect(result).not.toBeNull();
   });
 });

--- a/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-cli-tools.test.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/__tests__/registry-cli-tools.test.ts
@@ -66,9 +66,14 @@ describe('CLI tool renderers (pi)', () => {
     expect(result).not.toBeNull();
   });
 
-  it('write/edit: return non-null nodes even with null output', () => {
-    expect(toolRenderers['write'](makeCtx('write', { file_path: 'foo.ts' }, null))).not.toBeNull();
-    expect(toolRenderers['edit'](makeCtx('edit', { file_path: 'foo.ts' }, null))).not.toBeNull();
+  it('write/edit: return null when output is null (tool still pending — no premature success card)', () => {
+    expect(toolRenderers['write'](makeCtx('write', { file_path: 'foo.ts' }, null))).toBeNull();
+    expect(toolRenderers['edit'](makeCtx('edit', { file_path: 'foo.ts' }, null))).toBeNull();
+  });
+
+  it('write/edit: return non-null success card when output is available', () => {
+    expect(toolRenderers['write'](makeCtx('write', { file_path: 'foo.ts' }, 'ok'))).not.toBeNull();
+    expect(toolRenderers['edit'](makeCtx('edit', { file_path: 'foo.ts' }, 'ok'))).not.toBeNull();
   });
 
   it('ls: returns null when output is not a string', () => {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -179,7 +179,8 @@ export const SPECIAL_HANDLED_TOOLS: Set<string> = new Set<string>([
   'ask_agent',
 ]);
 
-export const CLI_TOOL_NAMES = ['Read', 'Write', 'Edit', 'MultiEdit', 'Bash', 'Glob', 'Grep'] as const;
+// pi uses lowercase tool names — these must match exactly what the pi coding agent sends.
+export const CLI_TOOL_NAMES = ['read', 'write', 'edit', 'bash', 'find', 'grep', 'ls'] as const;
 
 export const toolRenderers: Record<string, ToolRenderer> = {
   // === DRIVE TOOLS ===
@@ -842,10 +843,11 @@ export const toolRenderers: Record<string, ToolRenderer> = {
   ),
 
   // === CLI TOOLS (pi / pagespace-cli) ===
-  // pi tools return plain strings, not JSON objects, so `output` carries the content
-  // and `parsedOutput` is {}. Renderers must read from `output` directly.
+  // pi tool names are lowercase (read, write, edit, bash, find, grep, ls).
+  // These tools return plain strings so `output` carries the content and `parsedOutput` is {}.
+  // Renderers must read from `output` directly.
 
-  Read: ({ parsedInput, output }) => {
+  read: ({ parsedInput, output }) => {
     const path = (parsedInput?.path ?? parsedInput?.file_path) as string | undefined;
     const content = typeof output === 'string' ? output : null;
     if (!content) return null;
@@ -854,7 +856,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     return <RichContentRenderer title={path ?? 'File'} content={preview} />;
   },
 
-  Write: ({ parsedInput }) => (
+  write: ({ parsedInput }) => (
     <ActionResultRenderer
       actionType="create"
       success={true}
@@ -862,7 +864,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     />
   ),
 
-  Edit: ({ parsedInput }) => (
+  edit: ({ parsedInput }) => (
     <ActionResultRenderer
       actionType="update"
       success={true}
@@ -870,15 +872,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     />
   ),
 
-  MultiEdit: ({ parsedInput }) => (
-    <ActionResultRenderer
-      actionType="update"
-      success={true}
-      title={parsedInput?.file_path as string | undefined}
-    />
-  ),
-
-  Bash: ({ parsedInput, output }) => {
+  bash: ({ parsedInput, output }) => {
     const command = parsedInput?.command as string | undefined;
     const stdout = typeof output === 'string' ? output : null;
     if (!command && !stdout) return null;
@@ -890,18 +884,25 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     return <RichContentRenderer title="Bash" content={content} />;
   },
 
-  Glob: ({ parsedInput, output }) => {
+  find: ({ parsedInput, output }) => {
     const pattern = parsedInput?.pattern as string | undefined;
     const content = typeof output === 'string' ? output : null;
     if (!content) return null;
-    return <RichContentRenderer title={pattern ? `Glob: ${pattern}` : 'Glob'} content={content} />;
+    return <RichContentRenderer title={pattern ? `Find: ${pattern}` : 'Find'} content={content} />;
   },
 
-  Grep: ({ parsedInput, output }) => {
+  grep: ({ parsedInput, output }) => {
     const pattern = parsedInput?.pattern as string | undefined;
     const content = typeof output === 'string' ? output : null;
     if (!content) return null;
     return <RichContentRenderer title={pattern ? `Grep: ${pattern}` : 'Grep'} content={content} />;
+  },
+
+  ls: ({ parsedInput, output }) => {
+    const path = parsedInput?.path as string | undefined;
+    const content = typeof output === 'string' ? output : null;
+    if (!content) return null;
+    return <RichContentRenderer title={path ?? 'Directory'} content={content} />;
   },
 };
 
@@ -930,12 +931,13 @@ export function renderToolContent(ctx: {
     );
   }
 
-  // CLI tool renderers (PascalCase names) receive plain-string output so parsedOutput
-  // is always {}; they must run before the null guard. Server tool renderers (snake_case)
-  // only run when parsedOutput is present — otherwise a pending tool would appear completed.
+  // CLI tool renderers receive plain-string output so parsedOutput is always {};
+  // they must run before the null guard. Server tool renderers only run when
+  // parsedOutput is present — otherwise a pending tool would appear completed.
+  const CLI_SET = new Set<string>(CLI_TOOL_NAMES);
   const renderer = toolRenderers[toolName];
   if (renderer) {
-    const isCliTool = /^[A-Z]/.test(toolName);
+    const isCliTool = CLI_SET.has(toolName);
     if (isCliTool || parsedOutput) {
       const node = renderer({ toolName, parsedInput, parsedOutput: parsedOutput ?? {}, output, error });
       if (node != null) return node;

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -856,21 +856,27 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     return <RichContentRenderer title={path ?? 'File'} content={preview} />;
   },
 
-  write: ({ parsedInput }) => (
-    <ActionResultRenderer
-      actionType="create"
-      success={true}
-      title={parsedInput?.file_path as string | undefined}
-    />
-  ),
+  write: ({ parsedInput, output }) => {
+    if (output == null) return null;
+    return (
+      <ActionResultRenderer
+        actionType="create"
+        success={true}
+        title={parsedInput?.file_path as string | undefined}
+      />
+    );
+  },
 
-  edit: ({ parsedInput }) => (
-    <ActionResultRenderer
-      actionType="update"
-      success={true}
-      title={parsedInput?.file_path as string | undefined}
-    />
-  ),
+  edit: ({ parsedInput, output }) => {
+    if (output == null) return null;
+    return (
+      <ActionResultRenderer
+        actionType="update"
+        success={true}
+        title={parsedInput?.file_path as string | undefined}
+      />
+    );
+  },
 
   bash: ({ parsedInput, output }) => {
     const command = parsedInput?.command as string | undefined;
@@ -931,14 +937,16 @@ export function renderToolContent(ctx: {
     );
   }
 
-  // CLI tool renderers receive plain-string output so parsedOutput is always {};
-  // they must run before the null guard. Server tool renderers only run when
-  // parsedOutput is present — otherwise a pending tool would appear completed.
+  // CLI tool renderers receive plain-string output so parsedOutput is always {}.
+  // Only bypass the parsedOutput null-guard when a result is actually available
+  // (output != null) — otherwise a pending write/edit would show a premature
+  // success card before the client has executed the tool. Server tool renderers
+  // only run when parsedOutput is present for the same reason.
   const CLI_SET = new Set<string>(CLI_TOOL_NAMES);
   const renderer = toolRenderers[toolName];
   if (renderer) {
     const isCliTool = CLI_SET.has(toolName);
-    if (isCliTool || parsedOutput) {
+    if ((isCliTool && output != null) || parsedOutput) {
       const node = renderer({ toolName, parsedInput, parsedOutput: parsedOutput ?? {}, output, error });
       if (node != null) return node;
     }


### PR DESCRIPTION
## Summary

Tool calls from pagespace-cli were rendering as blank in conversation history. Two bugs:

**Bug 1 — wrong registry keys:** Renderers were registered as `Read`, `Bash`, `Glob`, `MultiEdit` (PascalCase), but pi uses lowercase: `read`, `bash`, `find`, `ls`. So `toolRenderers[toolName]` was always `undefined`.

**Bug 2 — guard never fired:** `isCliTool = /^[A-Z]/.test(toolName)` is always `false` for lowercase tool names, so even if a renderer were found, it would be skipped when `parsedOutput` is null (which it always is for conversation-history tool calls).

**Fixes:**
- Registry keys changed to lowercase: `Read→read`, `Write→write`, `Edit→edit`, `Bash→bash`, `Grep→grep`
- `Glob` removed (no pi equivalent); replaced with `find` (pi's path-search tool)
- `MultiEdit` removed (not a pi tool)
- `ls` renderer added (pi's directory listing tool)
- `isCliTool` guard changed from PascalCase regex to `CLI_SET.has(toolName)` using the `CLI_TOOL_NAMES` allowlist
- `CLI_TOOL_NAMES` updated to the real lowercase set

## Test plan

- [ ] `registry-cli-tools.test.ts` — 13 tests pass
- [ ] `registry-coverage.test.ts` — 3 tests pass (orphan guard still clean)
- [ ] pi tool calls (read, edit, bash, etc.) now render in PageSpace conversation history

🤖 Generated with [Claude Code](https://claude.com/claude-code)