### PR TITLE
fix(backups): snapshot viewer stuck loading, restore constraint crash, pre_restore label

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -104,6 +104,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['drives/[driveId]/backups/[backupId]/download', 'Read-only JSON download — no data written, covered by getDriveBackupDetail authz'],
   ['drives/[driveId]/backups/[backupId]/export', 'Read-only ZIP download — no data written, covered by streamBackupExport authz'],
   ['drives/[driveId]/backups/[backupId]/pages', 'Read-only snapshot page tree — no data written, covered by isDriveOwnerOrAdmin check'],
+  ['backups/[backupId]/pages', 'Read-only snapshot page tree (global route, settings context) — no data written, covered by isDriveOwnerOrAdmin check on backup.driveId'],
 
   // --- Drive sub-routes (read-only data fetches, covered by parent drive audit) ---
   // TODO: Add audit coverage in follow-up PR

--- a/apps/web/src/app/api/backups/[backupId]/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/backups/[backupId]/pages/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isDriveOwnerOrAdmin: vi.fn(),
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      driveBackups: { findFirst: vi.fn() },
+    },
+    select: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/lib/services/page-content-store', () => ({
+  readPageContent: vi.fn(),
+}));
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
+import { db } from '@pagespace/db/db';
+import { readPageContent } from '@pagespace/lib/services/page-content-store';
+
+const mockAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sid',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const makeRequest = (backupId: string, query = '') =>
+  new Request(`https://example.com/api/backups/${backupId}/pages${query}`);
+
+const makeParams = (backupId: string) => ({
+  params: Promise.resolve({ backupId }),
+});
+
+const readyBackup = { id: 'backup_1', driveId: 'drive_1', status: 'ready', label: null, source: 'manual', createdAt: new Date() };
+
+const pageRow = (pageId: string, parentId: string | null = null) => ({
+  pageId,
+  title: `Page ${pageId}`,
+  type: 'document',
+  parentId,
+  position: 0,
+  isTrashed: false,
+  stateHash: null,
+  contentRef: null,
+});
+
+function mockSelectChain(rows: unknown[]) {
+  const where = vi.fn().mockResolvedValue(rows);
+  const leftJoin = vi.fn().mockReturnValue({ where });
+  const from = vi.fn().mockReturnValue({ leftJoin });
+  vi.mocked(db.select).mockReturnValue({ from } as never);
+}
+
+describe('GET /api/backups/[backupId]/pages', () => {
+  const userId = 'user_1';
+  const backupId = 'backup_1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth(userId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isDriveOwnerOrAdmin).mockResolvedValue(true);
+    vi.mocked(db.query.driveBackups.findFirst).mockResolvedValue(readyBackup as never);
+    mockSelectChain([pageRow('p1')]);
+    vi.mocked(readPageContent).mockResolvedValue('page content');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+    const res = await GET(makeRequest(backupId), makeParams(backupId));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when not drive owner or admin', async () => {
+    vi.mocked(isDriveOwnerOrAdmin).mockResolvedValue(false);
+    const res = await GET(makeRequest(backupId), makeParams(backupId));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when backup not found', async () => {
+    vi.mocked(db.query.driveBackups.findFirst).mockResolvedValue(undefined as never);
+    const res = await GET(makeRequest(backupId), makeParams(backupId));
+    expect(res.status).toBe(404);
+  });
+
+  it('uses backup.driveId for permission check (not a URL param)', async () => {
+    const res = await GET(makeRequest(backupId), makeParams(backupId));
+    expect(res.status).toBe(200);
+    expect(isDriveOwnerOrAdmin).toHaveBeenCalledWith(userId, readyBackup.driveId);
+  });
+
+  it('includeContent omitted → content field absent on nodes', async () => {
+    mockSelectChain([{ ...pageRow('p1'), contentRef: 'ref-1' }]);
+    const res = await GET(makeRequest(backupId), makeParams(backupId));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(readPageContent).not.toHaveBeenCalled();
+    expect(body.pages[0]).not.toHaveProperty('content');
+  });
+
+  it('includeContent=true → content field present, readPageContent called per page', async () => {
+    mockSelectChain([{ ...pageRow('p1'), contentRef: 'ref-1' }]);
+    vi.mocked(readPageContent).mockResolvedValue('hello world');
+    const res = await GET(makeRequest(backupId, '?includeContent=true'), makeParams(backupId));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(readPageContent).toHaveBeenCalledWith('ref-1');
+    expect(body.pages[0].content).toBe('hello world');
+  });
+
+  it('returns 200 with pages array and backup metadata on success', async () => {
+    const res = await GET(makeRequest(backupId), makeParams(backupId));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('pages');
+    expect(Array.isArray(body.pages)).toBe(true);
+    expect(body.backup).toMatchObject({ id: backupId });
+  });
+});

--- a/apps/web/src/app/api/backups/[backupId]/pages/route.ts
+++ b/apps/web/src/app/api/backups/[backupId]/pages/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { driveBackups, driveBackupPages, pageVersions } from '@pagespace/db/schema/versioning';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
+import { readPageContent } from '@pagespace/lib/services/page-content-store';
+import { buildSnapshotPageTree } from '@/services/api/snapshot-pages-service';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+const CONCURRENCY_CAP = 10;
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ backupId: string }> },
+) {
+  const { backupId } = await context.params;
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) {
+    return auth.error;
+  }
+
+  const backup = await db.query.driveBackups.findFirst({
+    where: eq(driveBackups.id, backupId),
+  });
+
+  if (!backup) {
+    return NextResponse.json({ error: 'Backup not found' }, { status: 404 });
+  }
+
+  const isAdmin = await isDriveOwnerOrAdmin(auth.userId, backup.driveId);
+  if (!isAdmin) {
+    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+
+  const pageRows = await db
+    .select({
+      pageId: driveBackupPages.pageId,
+      title: driveBackupPages.title,
+      type: driveBackupPages.type,
+      parentId: driveBackupPages.parentId,
+      position: driveBackupPages.position,
+      isTrashed: driveBackupPages.isTrashed,
+      stateHash: pageVersions.stateHash,
+      contentRef: pageVersions.contentRef,
+    })
+    .from(driveBackupPages)
+    .leftJoin(pageVersions, eq(driveBackupPages.pageVersionId, pageVersions.id))
+    .where(eq(driveBackupPages.backupId, backupId));
+
+  const url = new URL(request.url);
+  const includeContent = url.searchParams.get('includeContent') === 'true';
+  const filterPageId = url.searchParams.get('pageId') ?? null;
+
+  type RowWithContent = (typeof pageRows)[number] & { content?: string };
+  const rowsWithContent: RowWithContent[] = pageRows.map((r): RowWithContent => ({ ...r }));
+
+  if (includeContent) {
+    const rowsToFetch = filterPageId
+      ? rowsWithContent.filter(r => r.pageId === filterPageId)
+      : rowsWithContent;
+
+    const queue = [...rowsToFetch];
+    const workers = Array.from({ length: Math.min(CONCURRENCY_CAP, queue.length) }, async () => {
+      while (queue.length > 0) {
+        const row = queue.shift();
+        if (!row) continue;
+        if (!row.contentRef) continue;
+        try {
+          row.content = await readPageContent(row.contentRef);
+        } catch {
+          // S3 failure — omit content for this page
+        }
+      }
+    });
+    await Promise.all(workers);
+  }
+
+  const pages = buildSnapshotPageTree(rowsWithContent);
+  return NextResponse.json({
+    backup: {
+      id: backup.id,
+      label: backup.label,
+      source: backup.source,
+      status: backup.status,
+      createdAt: backup.createdAt,
+    },
+    pages,
+  });
+}

--- a/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/restore/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/restore/__tests__/route.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/services/api/restore-backup-service', () => ({
 }));
 vi.mock('@pagespace/lib/monitoring/change-group', () => ({
   createChangeGroupId: vi.fn().mockReturnValue('cg-1'),
+  inferChangeGroupType: vi.fn().mockReturnValue('user'),
 }));
 
 import { POST } from '../route';

--- a/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/restore/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/[backupId]/restore/route.ts
@@ -6,7 +6,7 @@ import { pagePermissions, driveMembers, driveRoles } from '@pagespace/db/schema/
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
+import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { fetchAndComputeRestoreDiff } from '@/services/api/restore-diff-service';
 import { planPageRestoreOps, applyPageRestoreOps } from '@/services/api/restore-pages-service';
@@ -62,6 +62,7 @@ export async function POST(
     }
 
     const changeGroupId = createChangeGroupId();
+    const changeGroupType = inferChangeGroupType({ isAiGenerated: false });
 
     // 5. Restore transaction
     const counts = await db.transaction(async tx => {
@@ -126,7 +127,7 @@ export async function POST(
       ]);
 
       const ops = planPageRestoreOps(diff, backupPageMap);
-      await applyPageRestoreOps(ops, driveId, auth.userId, backupId, changeGroupId, tx as never);
+      await applyPageRestoreOps(ops, driveId, auth.userId, backupId, changeGroupId, changeGroupType, tx as never);
 
       const permOps = planPermissionRestoreOps(backupPermRows as never[], currentPermRows, affectedPageIds);
       const memberOps = planMemberRestoreOps(backupMemberRows as never[], currentMemberRows);

--- a/apps/web/src/app/settings/backups/[backupId]/snapshot/page.tsx
+++ b/apps/web/src/app/settings/backups/[backupId]/snapshot/page.tsx
@@ -8,7 +8,6 @@ import { ArrowLeft, File, FileCode, FileImage, FileSpreadsheet, FileText, Folder
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { useDriveStore } from '@/hooks/useDrive';
 import type { SnapshotPageNode } from '@/services/api/snapshot-pages-service';
 import { formatSnapshotLabel, flattenTree, getNodeIcon } from './utils';
 
@@ -53,7 +52,6 @@ export default function SnapshotPage({
   params: Promise<{ backupId: string }>;
 }) {
   const router = useRouter();
-  const driveId = useDriveStore((s) => s.currentDriveId);
 
   const [resolvedBackupId, setResolvedBackupId] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<(SnapshotPageNode & { depth: number }) | null>(null);
@@ -65,9 +63,7 @@ export default function SnapshotPage({
     params.then(({ backupId }) => setResolvedBackupId(backupId));
   }, [params]);
 
-  const swrKey = driveId && resolvedBackupId
-    ? `/api/drives/${driveId}/backups/${resolvedBackupId}/pages`
-    : null;
+  const swrKey = resolvedBackupId ? `/api/backups/${resolvedBackupId}/pages` : null;
 
   const { data, isLoading, error, mutate } = useSWR<PagesResponse>(swrKey, fetcher, {
     revalidateOnFocus: false,
@@ -76,12 +72,12 @@ export default function SnapshotPage({
   const handleRowClick = async (node: SnapshotPageNode & { depth: number }) => {
     setSelectedNode(node);
     if (contentMap.has(node.pageId)) return;
-    if (!driveId || !resolvedBackupId) return;
+    if (!resolvedBackupId) return;
 
     setLoadingPageIds(prev => new Set(prev).add(node.pageId));
     try {
       const r = await fetchWithAuth(
-        `/api/drives/${driveId}/backups/${resolvedBackupId}/pages?includeContent=true&pageId=${node.pageId}`,
+        `/api/backups/${resolvedBackupId}/pages?includeContent=true&pageId=${node.pageId}`,
       );
       if (!r.ok) return;
       const result = (await r.json()) as PagesResponse;
@@ -99,7 +95,7 @@ export default function SnapshotPage({
     }
   };
 
-  if (!driveId || isLoading || !resolvedBackupId) {
+  if (isLoading || !resolvedBackupId) {
     return (
       <div className="container max-w-4xl mx-auto py-10 px-10 flex items-center justify-center min-h-[400px]">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/apps/web/src/app/settings/backups/[backupId]/snapshot/page.tsx
+++ b/apps/web/src/app/settings/backups/[backupId]/snapshot/page.tsx
@@ -52,7 +52,6 @@ export default function SnapshotPage({
   params: Promise<{ backupId: string }>;
 }) {
   const router = useRouter();
-
   const [resolvedBackupId, setResolvedBackupId] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<(SnapshotPageNode & { depth: number }) | null>(null);
   const [contentMap, setContentMap] = useState<Map<string, string>>(new Map());

--- a/apps/web/src/app/settings/backups/page.tsx
+++ b/apps/web/src/app/settings/backups/page.tsx
@@ -55,6 +55,13 @@ const fetcher = async (url: string): Promise<BackupListResponse> => {
   return r.json();
 };
 
+function sourceLabel(source: string): string {
+  if (source === 'pre_restore') return 'Safety snapshot';
+  if (source === 'scheduled') return 'Scheduled';
+  if (source === 'system') return 'System';
+  return source;
+}
+
 function statusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
   if (status === 'ready') return 'default';
   if (status === 'failed') return 'destructive';
@@ -335,7 +342,7 @@ export default function BackupsPage() {
                     <div className="space-y-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
                         <Badge variant={statusVariant(backup.status)}>{backup.status}</Badge>
-                        <Badge variant="outline">{backup.source}</Badge>
+                        <Badge variant="outline">{sourceLabel(backup.source)}</Badge>
                         {backup.driveName && (
                           <span className="text-sm text-muted-foreground">{backup.driveName}</span>
                         )}

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -181,6 +181,7 @@ export const SPECIAL_HANDLED_TOOLS: Set<string> = new Set<string>([
 
 // pi uses lowercase tool names — these must match exactly what the pi coding agent sends.
 export const CLI_TOOL_NAMES = ['read', 'write', 'edit', 'bash', 'find', 'grep', 'ls'] as const;
+export const CLI_TOOL_SET = new Set<string>(CLI_TOOL_NAMES);
 
 export const toolRenderers: Record<string, ToolRenderer> = {
   // === DRIVE TOOLS ===
@@ -942,10 +943,9 @@ export function renderToolContent(ctx: {
   // (output != null) — otherwise a pending write/edit would show a premature
   // success card before the client has executed the tool. Server tool renderers
   // only run when parsedOutput is present for the same reason.
-  const CLI_SET = new Set<string>(CLI_TOOL_NAMES);
   const renderer = toolRenderers[toolName];
   if (renderer) {
-    const isCliTool = CLI_SET.has(toolName);
+    const isCliTool = CLI_TOOL_SET.has(toolName);
     if ((isCliTool && output != null) || parsedOutput) {
       const node = renderer({ toolName, parsedInput, parsedOutput: parsedOutput ?? {}, output, error });
       if (node != null) return node;

--- a/apps/web/src/services/api/__tests__/restore-pages.test.ts
+++ b/apps/web/src/services/api/__tests__/restore-pages.test.ts
@@ -134,6 +134,7 @@ describe('applyPageRestoreOps', () => {
   const userId = 'user_1';
   const backupId = 'backup_1';
   const changeGroupId = 'cg_1';
+  const changeGroupType = 'user' as const;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -164,7 +165,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [makeOp({ op: 'create', pageId: 'p1', contentRef: 'ref-1' })];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     expect(readPageContent).toHaveBeenCalledWith('ref-1');
     expect(createPageVersion).toHaveBeenCalledWith(
@@ -177,7 +178,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [makeOp({ op: 'create', pageId: 'p2', contentRef: null })];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     expect(readPageContent).not.toHaveBeenCalled();
     expect(createPageVersion).toHaveBeenCalledWith(
@@ -191,7 +192,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [makeOp({ op: 'overwrite', pageId: 'p3', contentRef: 'ref-3' })];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     expect(tx.update).toHaveBeenCalled();
     const setArgs = tx.update.mock.results[0].value.set.mock.calls[0][0] as Record<string, unknown>;
@@ -207,7 +208,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [makeOp({ op: 'create', pageId: 'p1' })];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     const insertArgs = tx.insert.mock.results[0].value.values.mock.calls[0][0] as Record<string, unknown>;
     expect(insertArgs).toHaveProperty('stateHash', 'hash-xyz');
@@ -219,7 +220,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [makeOp({ op: 'create', pageId: 'p1', contentRef: null, isTrashed: true, trashedAt })];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     const insertArgs = tx.insert.mock.results[0].value.values.mock.calls[0][0] as Record<string, unknown>;
     expect(insertArgs.isTrashed).toBe(true);
@@ -230,7 +231,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [{ op: 'soft-delete' as const, pageId: 'p4' }];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     expect(tx.update).toHaveBeenCalled();
     expect(readPageContent).not.toHaveBeenCalled();
@@ -242,7 +243,7 @@ describe('applyPageRestoreOps', () => {
     const ops = [makeOp({ op: 'create', pageId: 'p5', contentRef: 'ref-5' })];
     const tx = makeTx();
 
-    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, tx as never);
+    await applyPageRestoreOps(ops, driveId, userId, backupId, changeGroupId, changeGroupType, tx as never);
 
     expect(createPageVersion).toHaveBeenCalledWith(
       expect.objectContaining({ pageId: 'p5', content: '' }),

--- a/apps/web/src/services/api/restore-pages-service.ts
+++ b/apps/web/src/services/api/restore-pages-service.ts
@@ -2,6 +2,7 @@ import { eq, sql } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { createPageVersion, computePageStateHash } from '@pagespace/lib/services/page-version-service';
+import type { ChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import type { RestoreDiff, BackupPageRow } from './restore-diff-service';
 
 export type PageRestoreOp =
@@ -71,6 +72,7 @@ export async function applyPageRestoreOps(
   userId: string,
   backupId: string,
   changeGroupId: string,
+  changeGroupType: ChangeGroupType,
   tx: DbLike,
 ): Promise<void> {
   // Pre-fetch all S3 content before entering DB writes so the transaction loop
@@ -158,6 +160,7 @@ export async function applyPageRestoreOps(
         pageRevision: 0,
         stateHash,
         changeGroupId,
+        changeGroupType,
         metadata: { backupId },
       },
       { tx: tx as never },


### PR DESCRIPTION
## Summary

- **Snapshot viewer stuck loading**: Settings is a global context — the snapshot page was reading `currentDriveId` from the drive store to build its API URL, which fails when no drive is selected or the selected drive differs from the backup's drive. Added a new global route `GET /api/backups/[backupId]/pages` that resolves the drive from the backup record itself, and removed the `useDriveStore` dependency from the snapshot page entirely.
- **Restore crashes with DB constraint violation**: `applyPageRestoreOps` was calling `createPageVersion` with `changeGroupId` but without `changeGroupType`. The `page_versions_change_group_pair` check constraint requires both to be null or both non-null — every restore rolled back with this error. Added `changeGroupType` to the call chain.
- **`pre_restore` source badge**: Auto-snapshots created before restores displayed a raw `pre_restore` enum value. Now renders as "Safety snapshot".

## Test plan

- [ ] Navigate to Settings → Backups — list loads
- [ ] Click Eye icon on a backup whose drive is not the currently-active drive — snapshot viewer loads without getting stuck
- [ ] Click Restore on a ready backup — completes successfully, toast shows "Drive restored successfully"
- [ ] After restore, the new safety snapshot entry shows "Safety snapshot" badge instead of "pre_restore"

🤖 Generated with [Claude Code](https://claude.com/claude-code)