### PR TITLE
fix(threads): enable @mention autocomplete in thread replies

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -601,6 +601,7 @@ function ChannelView({ page }: ChannelViewProps) {
       contextId={page.id}
       parentId={threadPanelParentId}
       currentUserId={user?.id ?? null}
+      driveId={page.driveId}
       parentSlot={renderParentSlot()}
       resolveAuthor={resolveThreadAuthor}
       replyCountHint={threadParent?.replyCount}

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -73,6 +73,8 @@ export interface ThreadPanelProps {
   contextId: string;
   parentId: string;
   currentUserId: string | null;
+  /** Drive ID — required for channel threads to enable @mention autocomplete */
+  driveId?: string;
   /** Pre-rendered parent message header (page provides; preserves consistency with the main list) */
   parentSlot: ReactNode;
   /** Resolve a reply's author to a display name + avatar */
@@ -162,6 +164,7 @@ export function ThreadPanel({
   contextId,
   parentId,
   currentUserId,
+  driveId,
   parentSlot,
   resolveAuthor,
   replyCountHint,
@@ -877,6 +880,7 @@ export function ThreadPanel({
           source={source}
           contextId={contextId}
           parentId={parentId}
+          driveId={driveId}
           showAlsoSendToParent
           value={draft}
           onChange={setDraft}


### PR DESCRIPTION
## Summary

- `ThreadPanel` was not passing `driveId` to `MessageInput`, leaving the mention suggestion system with no drive scope
- Typing `@` in a thread reply produced no autocomplete results; users could only type plain text that the server couldn't parse as mentions
- Added `driveId?: string` to `ThreadPanelProps` and forwarded it through to `MessageInput`; `ChannelView` now passes `page.driveId` when mounting the panel

## Root cause

The mention suggestion chain is: `ThreadPanel → MessageInput → ChannelInput → ChatTextarea → useSuggestion({ driveId }) → GET /api/mentions/search?driveId=…`

Without `driveId`, `useSuggestion` fires no request and the picker never opens. The server-side mention processing (notifications + inbox bumps for thread replies) was already correct — it just never had properly-structured mention markup to parse.

## Not changed

- DM threads: `source="dm"` already uses `crossDrive` mode; no `driveId` needed
- Server-side: `expandMentionsToUserIds` + `createMentionNotification` in the channel messages route were already correct

## Test plan

- [ ] Open a channel → open a thread → type `@` in the reply composer → autocomplete picker appears with drive members/pages
- [ ] Send a thread reply with an @mention → mentioned user receives a MENTION notification
- [ ] Root-level channel message @mentions still work (no change to that path)
- [ ] DM thread replies unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)