### PR TITLE
feat(ai): restore GLM direct provider as admin-only with full model family

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,11 +69,13 @@ ORIGIN_VALIDATION_MODE=block
 # not via OpenRouter). Also reused if we add native OpenAI routing later.
 # OPENAI_DEFAULT_API_KEY=your_openai_api_key_here
 
-# Optional direct/native provider keys. Not used by the OpenRouter-backed picker
-# today; kept for future native (non-OpenRouter) provider routing.
+# Optional direct/native provider keys. Not used by the OpenRouter-backed picker.
 # ANTHROPIC_DEFAULT_API_KEY=your_anthropic_api_key_here
 # GOOGLE_AI_DEFAULT_API_KEY=your_google_ai_api_key_here
 # XAI_DEFAULT_API_KEY=your_xai_api_key_here
+
+# Z.ai GLM Coder Plan — direct OpenAI-compatible API (admin-only in the model picker).
+# Set this to enable the "Z.ai (GLM)" provider group for admin users.
 # GLM_CODER_DEFAULT_API_KEY=your_z_ai_coder_plan_key_here
 # MINIMAX_DEFAULT_API_KEY=your_minimax_api_key_here
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -234,6 +234,7 @@ vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   isModelAllowedForTier: vi.fn().mockReturnValue(true),
   ONPREM_ALLOWED_PROVIDERS: new Set<string>(['ollama', 'lmstudio', 'azure_openai']),
   DYNAMIC_MODEL_PROVIDERS: new Set<string>(['ollama', 'lmstudio']),
+  ADMIN_ONLY_PROVIDERS: new Set<string>([]),
   DEFAULT_PROVIDER: 'openai',
   DEFAULT_MODEL: 'openai/gpt-5.3-chat',
 }));

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -10,7 +10,7 @@ import {
   type TextUIPart,
   type ToolSet,
 } from 'ai';
-import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
+import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { ALL_PROVIDER_NAMES } from '@/lib/ai/core/ai-utils';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
@@ -455,9 +455,13 @@ export async function POST(request: Request) {
       .catch(() => [] as { displayName: string | null }[]);
 
     // Subscription gate: free users are limited to the free-model allowlist.
-    const { requiresProSubscription, createSubscriptionRequiredResponse } = await import('@/lib/subscription/rate-limit-middleware');
+    const { requiresProSubscription, createSubscriptionRequiredResponse, createAdminRestrictedResponse } = await import('@/lib/subscription/rate-limit-middleware');
 
     const isAdminUser = user?.role === 'admin';
+
+    if (ADMIN_ONLY_PROVIDERS.has(currentProvider) && !isAdminUser) {
+      return createAdminRestrictedResponse();
+    }
 
     // Check if the selected model requires a paid plan
     if (requiresProSubscription(currentProvider, currentModel, user?.subscriptionTier, isAdminUser)) {
@@ -1300,6 +1304,9 @@ async function validateProviderModel(
   try {
     const [user] = await db.select().from(users).where(eq(users.id, userId));
     const isAdminUser = user?.role === 'admin';
+    if (ADMIN_ONLY_PROVIDERS.has(provider) && !isAdminUser) {
+      return { valid: false, reason: 'This provider is restricted to administrators.' };
+    }
     if (requiresProSubscription(provider, model, user?.subscriptionTier, isAdminUser)) {
       return {
         valid: false,

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -236,6 +236,7 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({
 }));
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   isModelAllowedForTier: vi.fn().mockReturnValue(true),
+  ADMIN_ONLY_PROVIDERS: new Set<string>([]),
 }));
 vi.mock('@/lib/ai/core/tool-utils', () => ({
   mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })),

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -285,6 +285,7 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({
 
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   isModelAllowedForTier: vi.fn().mockReturnValue(true),
+  ADMIN_ONLY_PROVIDERS: new Set<string>([]),
 }));
 
 vi.mock('@/lib/ai/core/tool-utils', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { streamText, convertToModelMessages, stepCountIs, hasToolCall, UIMessage, createUIMessageStream, createUIMessageStreamResponse, type ToolSet } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
-import { requiresProSubscription, createSubscriptionRequiredResponse } from '@/lib/subscription/rate-limit-middleware';
+import { requiresProSubscription, createSubscriptionRequiredResponse, createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
+import { ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
@@ -419,6 +420,9 @@ export async function POST(
 
     // Free users are limited to the free-model allowlist; defends against a model id
     // submitted directly in the request bypassing the settings-time gate.
+    if (ADMIN_ONLY_PROVIDERS.has(currentProvider) && auth.role !== 'admin') {
+      return createAdminRestrictedResponse();
+    }
     if (requiresProSubscription(currentProvider, currentModel, userSubscriptionTier, auth.role === 'admin')) {
       loggers.api.warn('Global Assistant Chat API: paid plan required for model', {
         userId: maskIdentifier(userId),

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -45,13 +45,19 @@ vi.mock('@pagespace/lib/deployment-mode', () => ({
 
 vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
   requiresProSubscription: vi.fn(() => false),
+  createAdminRestrictedResponse: vi.fn(() =>
+    new Response(
+      JSON.stringify({ error: 'Provider restricted', message: 'This provider is restricted to administrators.' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } }
+    )
+  ),
 }));
 
 import { GET, POST, PATCH, DELETE } from '../route';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
-import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
+import { requiresProSubscription, createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
 
 const ENV_KEYS = [
   'OPENROUTER_DEFAULT_API_KEY',
@@ -60,6 +66,7 @@ const ENV_KEYS = [
   'LMSTUDIO_BASE_URL',
   'AZURE_OPENAI_API_KEY',
   'AZURE_OPENAI_ENDPOINT',
+  'GLM_CODER_DEFAULT_API_KEY',
 ] as const;
 
 const mockUserId = 'user_123';
@@ -137,19 +144,43 @@ describe('AI settings route', () => {
       expect(body.pageSpaceBackend).toBeUndefined();
     });
 
-    it('exposes all vendor providers in cloud mode (no admin-only masking) when configured', async () => {
+    it('exposes all OpenRouter-backed vendor providers in cloud mode when configured', async () => {
       process.env.OPENROUTER_DEFAULT_API_KEY = 'or-key';
 
       const response = await GET(makeRequest('GET'));
       const body = await response.json();
 
-      // Cloud mode exposes every vendor provider once OpenRouter is configured —
-      // there is no per-provider admin masking anymore.
+      // Cloud mode: every OpenRouter-backed vendor shows up once the key is set.
+      // GLM (direct/admin-only) has its own separate key gate.
       expect(body.providers.anthropic.isAvailable).toBe(true);
       expect(body.providers.openai.isAvailable).toBe(true);
       expect(body.providers.google.isAvailable).toBe(true);
       expect(body.providers.xai.isAvailable).toBe(true);
       expect(body.providers.mistral.isAvailable).toBe(true);
+    });
+
+    it('returns isAdmin: false for regular users', async () => {
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).isAdmin).toBe(false);
+    });
+
+    it('returns isAdmin: true for admin users', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockSession(mockUserId, 'admin'));
+
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).isAdmin).toBe(true);
+    });
+
+    it('reports glm unavailable when GLM_CODER_DEFAULT_API_KEY is unset', async () => {
+      process.env.OPENROUTER_DEFAULT_API_KEY = 'or-key';
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).providers.glm.isAvailable).toBe(false);
+    });
+
+    it('reports glm available when GLM_CODER_DEFAULT_API_KEY is set', async () => {
+      process.env.GLM_CODER_DEFAULT_API_KEY = 'glm-key';
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).providers.glm.isAvailable).toBe(true);
     });
 
     it('does not expose a paid `openrouter` or `pagespace` provider key', async () => {
@@ -378,6 +409,37 @@ describe('AI settings route', () => {
       }));
 
       expect(response.status).toBe(200);
+    });
+
+    it('returns 403 when a non-admin selects an admin-only provider (glm)', async () => {
+      process.env.GLM_CODER_DEFAULT_API_KEY = 'glm-key';
+
+      const response = await PATCH(makeRequest('PATCH', {
+        provider: 'glm',
+        model: 'glm-4.6',
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.message).toContain('restricted to administrators');
+      expect(createAdminRestrictedResponse).toHaveBeenCalled();
+      expect(aiSettingsRepository.updateProviderSettings).not.toHaveBeenCalled();
+    });
+
+    it('allows an admin to select an admin-only provider (glm)', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockSession(mockUserId, 'admin'));
+      process.env.GLM_CODER_DEFAULT_API_KEY = 'glm-key';
+
+      const response = await PATCH(makeRequest('PATCH', {
+        provider: 'glm',
+        model: 'glm-4.6',
+      }));
+
+      expect(response.status).toBe(200);
+      expect(aiSettingsRepository.updateProviderSettings).toHaveBeenCalledWith(mockUserId, {
+        provider: 'glm',
+        model: 'glm-4.6',
+      });
     });
   });
 });

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -416,7 +416,7 @@ describe('AI settings route', () => {
 
       const response = await PATCH(makeRequest('PATCH', {
         provider: 'glm',
-        model: 'glm-4.6',
+        model: 'glm-4.5-air',
       }));
       const body = await response.json();
 
@@ -432,13 +432,13 @@ describe('AI settings route', () => {
 
       const response = await PATCH(makeRequest('PATCH', {
         provider: 'glm',
-        model: 'glm-4.6',
+        model: 'glm-4.5-air',
       }));
 
       expect(response.status).toBe(200);
       expect(aiSettingsRepository.updateProviderSettings).toHaveBeenCalledWith(mockUserId, {
         provider: 'glm',
-        model: 'glm-4.6',
+        model: 'glm-4.5-air',
       });
     });
   });

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -7,9 +7,9 @@ import {
   buildProviderAvailabilityMap,
   isProviderAvailable,
 } from '@/lib/ai/core/ai-utils';
-import { ONPREM_ALLOWED_PROVIDERS, DYNAMIC_MODEL_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, isValidModel } from '@/lib/ai/core/ai-providers-config';
+import { ONPREM_ALLOWED_PROVIDERS, DYNAMIC_MODEL_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, isValidModel, ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
-import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
+import { requiresProSubscription, createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -49,6 +49,7 @@ export async function GET(request: Request) {
       currentProvider: user?.currentAiProvider || DEFAULT_PROVIDER,
       currentModel: user?.currentAiModel || DEFAULT_MODEL,
       userSubscriptionTier: user?.subscriptionTier || 'free',
+      isAdmin: auth.role === 'admin',
       providers,
       isAnyProviderConfigured: Object.values(providers).some((p) => p.isAvailable),
     });
@@ -133,6 +134,10 @@ export async function PATCH(request: Request) {
         { error: 'User not found' },
         { status: 404 }
       );
+    }
+
+    if (ADMIN_ONLY_PROVIDERS.has(provider) && auth.role !== 'admin') {
+      return createAdminRestrictedResponse();
     }
 
     if (requiresProSubscription(provider, model, user.subscriptionTier ?? undefined, auth.role === 'admin')) {

--- a/apps/web/src/components/ai/chat/input/ProviderModelSelector.tsx
+++ b/apps/web/src/components/ai/chat/input/ProviderModelSelector.tsx
@@ -19,6 +19,7 @@ import {
   getDefaultModel,
   getVisibleProviders,
   isModelAllowedForTier,
+  ADMIN_ONLY_PROVIDERS,
 } from '@/lib/ai/core/ai-providers-config';
 
 interface ProviderStatus {
@@ -30,6 +31,7 @@ interface ProviderSettings {
   currentModel: string;
   providers: Record<string, ProviderStatus>;
   userSubscriptionTier?: string;
+  isAdmin?: boolean;
 }
 
 /** Providers served from a local server (model lists fetched at runtime). */
@@ -190,6 +192,7 @@ export function ProviderModelSelector({
   }, [provider, ollamaModels, lmstudioModels, fetchOllamaModels, fetchLMStudioModels]);
 
   const subscriptionTier = providerSettings?.userSubscriptionTier;
+  const isAdmin = providerSettings?.isAdmin ?? false;
 
   // Get display names
   const providerDisplayName = useMemo(() => {
@@ -340,7 +343,9 @@ export function ProviderModelSelector({
               {PROVIDER_GROUPS
                 .map((group) => ({
                   ...group,
-                  providers: group.providers.filter((p) => isProviderAvailable(p.id)),
+                  providers: group.providers.filter((p) =>
+                    isProviderAvailable(p.id) && (!ADMIN_ONLY_PROVIDERS.has(p.id) || isAdmin)
+                  ),
                 }))
                 .filter((group) => group.providers.length > 0)
                 .map((group) => (

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -17,25 +17,33 @@ import {
 
 describe('ai-providers-config', () => {
   describe('catalog shape', () => {
-    it('groups models under real vendor providers (no pagespace/glm/openrouter)', () => {
+    it('groups models under real vendor providers (no retired pagespace/openrouter virtuals)', () => {
       expect(AI_PROVIDERS).toHaveProperty('openai');
       expect(AI_PROVIDERS).toHaveProperty('anthropic');
       expect(AI_PROVIDERS).toHaveProperty('google');
       expect(AI_PROVIDERS).not.toHaveProperty('pagespace');
       expect(AI_PROVIDERS).not.toHaveProperty('openrouter');
       expect(AI_PROVIDERS).not.toHaveProperty('openrouter_free');
-      expect(AI_PROVIDERS).not.toHaveProperty('glm');
     });
 
-    it('uses full OpenRouter model ids as keys', () => {
+    it('includes the glm direct provider with Coder Plan models', () => {
+      expect(AI_PROVIDERS).toHaveProperty('glm');
+      expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5.1');
+      expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5-turbo');
+      expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-4.7');
+      expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-4.5-air');
+    });
+
+    it('uses full OpenRouter model ids as keys for cloud vendors', () => {
       expect(AI_PROVIDERS.openai.models).toHaveProperty('openai/gpt-5.3-chat');
       expect(AI_PROVIDERS.anthropic.models).toHaveProperty('anthropic/claude-haiku-4.5');
       expect(AI_PROVIDERS.minimax.models).toHaveProperty('minimax/minimax-m3');
     });
 
-    it('drops all GLM (z-ai) models', () => {
+    it('has no z-ai/ OpenRouter-prefixed model ids in the catalog', () => {
+      // Cloud vendors use vendor/model-id format; glm direct uses bare glm-* native ids
       const allModels = Object.values(AI_PROVIDERS).flatMap((p) => Object.keys(p.models));
-      expect(allModels.some((m) => m.startsWith('z-ai/') || m.startsWith('glm-'))).toBe(false);
+      expect(allModels.some((m) => m.startsWith('z-ai/'))).toBe(false);
     });
   });
 
@@ -98,6 +106,10 @@ describe('ai-providers-config', () => {
       expect(getBackendProvider('ollama')).toBe('ollama');
       expect(getBackendProvider('lmstudio')).toBe('lmstudio');
       expect(getBackendProvider('azure_openai')).toBe('azure_openai');
+    });
+
+    it('routes glm direct (not through openrouter)', () => {
+      expect(getBackendProvider('glm')).toBe('glm');
     });
   });
 

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -41,6 +41,14 @@ export const BACKGROUND_LIGHT_MODEL = 'anthropic/claude-haiku-4.5';
 export const BACKGROUND_HEAVY_MODEL = 'anthropic/claude-sonnet-4.6';
 
 /**
+ * Providers restricted to admin users. These require a separate subscription
+ * (not on PageSpace's OpenRouter quota) and route directly to the provider's API.
+ * Non-admins receive a 403 "provider restricted" response rather than a subscription
+ * upgrade prompt.
+ */
+export const ADMIN_ONLY_PROVIDERS = new Set<string>(['glm']);
+
+/**
  * Models available to the FREE subscription tier. Every paid tier
  * (`pro`/`founder`/`business`) gets the full catalog; free users are limited to
  * this curated set of cheaper models. `DEFAULT_MODEL` must be a member.
@@ -245,6 +253,23 @@ export const AI_PROVIDERS = {
     name: 'Writer',
     models: {
       'writer/palmyra-x5': 'Palmyra X5',
+    },
+  },
+  glm: {
+    name: 'Z.ai (GLM)',
+    models: {
+      'glm-5.1':       'GLM-5.1',
+      'glm-5v-turbo':  'GLM-5V Turbo',
+      'glm-5-turbo':   'GLM-5 Turbo',
+      'glm-5':         'GLM-5',
+      'glm-4.7':       'GLM-4.7',
+      'glm-4.7-flash': 'GLM-4.7 Flash',
+      'glm-4.6v':      'GLM-4.6V',
+      'glm-4.6':       'GLM-4.6',
+      'glm-4.5v':      'GLM-4.5V',
+      'glm-4.5':       'GLM-4.5',
+      'glm-4.5-air':   'GLM-4.5 Air',
+      'glm-4-32b':     'GLM-4 32B',
     },
   },
   ollama: {

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -257,19 +257,13 @@ export const AI_PROVIDERS = {
   },
   glm: {
     name: 'Z.ai (GLM)',
+    // Models officially supported by the GLM Coder Plan endpoint (api.z.ai/api/coding/paas/v4).
+    // Other GLM models are available on the general Z.ai API but not through this plan.
     models: {
-      'glm-5.1':       'GLM-5.1',
-      'glm-5v-turbo':  'GLM-5V Turbo',
-      'glm-5-turbo':   'GLM-5 Turbo',
-      'glm-5':         'GLM-5',
-      'glm-4.7':       'GLM-4.7',
-      'glm-4.7-flash': 'GLM-4.7 Flash',
-      'glm-4.6v':      'GLM-4.6V',
-      'glm-4.6':       'GLM-4.6',
-      'glm-4.5v':      'GLM-4.5V',
-      'glm-4.5':       'GLM-4.5',
-      'glm-4.5-air':   'GLM-4.5 Air',
-      'glm-4-32b':     'GLM-4 32B',
+      'glm-5.1':     'GLM-5.1',
+      'glm-5-turbo': 'GLM-5 Turbo',
+      'glm-4.7':     'GLM-4.7',
+      'glm-4.5-air': 'GLM-4.5 Air',
     },
   },
   ollama: {

--- a/apps/web/src/lib/ai/core/ai-utils.ts
+++ b/apps/web/src/lib/ai/core/ai-utils.ts
@@ -46,6 +46,10 @@ export function getManagedProviderKey(provider: string): ManagedProviderKey | nu
       const baseUrl = process.env.AZURE_OPENAI_ENDPOINT;
       return apiKey && baseUrl ? { apiKey, baseUrl } : null;
     }
+    case 'glm': {
+      const apiKey = process.env.GLM_CODER_DEFAULT_API_KEY;
+      return apiKey ? { apiKey } : null;
+    }
     default:
       return null;
   }
@@ -75,6 +79,8 @@ export const ALL_PROVIDER_NAMES = [
   'ollama',
   'lmstudio',
   'azure_openai',
+  // Direct providers (own credentials, not OpenRouter-backed)
+  'glm',
 ] as const;
 export type ProviderName = (typeof ALL_PROVIDER_NAMES)[number];
 

--- a/apps/web/src/lib/ai/core/provider-factory.ts
+++ b/apps/web/src/lib/ai/core/provider-factory.ts
@@ -173,6 +173,15 @@ export async function createAIProvider(
         baseURL: managed.baseUrl,
       });
       model = azureProvider(currentModel);
+    } else if (currentProvider === 'glm') {
+      const managed = getManagedProviderKey('glm');
+      if (!managed?.apiKey) return notConfigured('GLM Coder Plan');
+      const glmProvider = createOpenAICompatible({
+        name: 'glm',
+        apiKey: managed.apiKey,
+        baseURL: 'https://api.z.ai/api/coding/paas/v4',
+      });
+      model = glmProvider(currentModel);
     } else {
       // Every cloud vendor is served through OpenRouter. The model id already
       // carries its vendor prefix (openai/…, anthropic/…) and is forwarded as-is.

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -127,6 +127,9 @@ export const AI_PRICING = {
   'glm-5-turbo': { input: 1.20, output: 4.00 },
   'glm-4.7':     { input: 0.39, output: 1.90 },
   'glm-4.5-air': { input: 0.35, output: 1.55 },
+  // Legacy fallback: historical ai_usage rows recorded under 'glm-5' before the
+  // OpenRouter migration; must stay priced so old rows don't zero-cost.
+  'glm-5':       { input: 1.00, output: 3.20 },
 
   // OpenRouter - Chinese/Asian (source: openrouter.ai/api/v1/models)
   'z-ai/glm-5.1': { input: 0.98, output: 3.08 },
@@ -413,6 +416,7 @@ export const MODEL_CONTEXT_WINDOWS = {
   'glm-5-turbo': 202752,
   'glm-4.7':     200000,
   'glm-4.5-air': 128000,
+  'glm-5':       202752, // legacy fallback for historical billing rows
 
   // OpenRouter Models - Chinese/Asian
   'z-ai/glm-5.1': 202752,

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -122,19 +122,11 @@ export const AI_PRICING = {
   'mistralai/devstral-medium': { input: 0.40, output: 2.00 },
   'mistralai/devstral-small': { input: 0.10, output: 0.30 },
 
-  // Z.ai GLM direct (source: z.ai pricing; native model IDs used by GLM Coder Plan direct API)
-  'glm-5.1':       { input: 0.98, output: 3.08 },
-  'glm-5v-turbo':  { input: 1.20, output: 4.00 },
-  'glm-5-turbo':   { input: 1.20, output: 4.00 },
-  'glm-5':         { input: 0.80, output: 2.56 },
-  'glm-4.7':       { input: 0.39, output: 1.90 },
-  'glm-4.7-flash': { input: 0.06, output: 0.40 },
-  'glm-4.6v':      { input: 0.30, output: 0.90 },
-  'glm-4.6':       { input: 0.43, output: 1.74 },
-  'glm-4.5v':      { input: 0.48, output: 1.44 },
-  'glm-4.5':       { input: 0.48, output: 1.44 },
-  'glm-4.5-air':   { input: 0.35, output: 1.55 },
-  'glm-4-32b':     { input: 0.35, output: 1.55 },
+  // Z.ai GLM direct — GLM Coder Plan supported models only (source: z.ai/guides/overview/pricing)
+  'glm-5.1':     { input: 1.40, output: 4.40 },
+  'glm-5-turbo': { input: 1.20, output: 4.00 },
+  'glm-4.7':     { input: 0.39, output: 1.90 },
+  'glm-4.5-air': { input: 0.35, output: 1.55 },
 
   // OpenRouter - Chinese/Asian (source: openrouter.ai/api/v1/models)
   'z-ai/glm-5.1': { input: 0.98, output: 3.08 },
@@ -416,19 +408,11 @@ export const MODEL_CONTEXT_WINDOWS = {
   'mistralai/devstral-medium': 128000,
   'mistralai/devstral-small': 128000,
 
-  // Z.ai GLM direct (native model IDs)
-  'glm-5.1':       202752,
-  'glm-5v-turbo':  202752,
-  'glm-5-turbo':   202752,
-  'glm-5':         202752,
-  'glm-4.7':       200000,
-  'glm-4.7-flash': 202752,
-  'glm-4.6v':      131072,
-  'glm-4.6':       202752,
-  'glm-4.5v':      128000,
-  'glm-4.5':       128000,
-  'glm-4.5-air':   128000,
-  'glm-4-32b':     128000,
+  // Z.ai GLM direct — GLM Coder Plan supported models only
+  'glm-5.1':     202752,
+  'glm-5-turbo': 202752,
+  'glm-4.7':     200000,
+  'glm-4.5-air': 128000,
 
   // OpenRouter Models - Chinese/Asian
   'z-ai/glm-5.1': 202752,

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -302,13 +302,6 @@ export const AI_PRICING = {
   'MiniMax-M2': { input: 0.30, output: 1.20 },
   'MiniMax-M2-Stable': { input: 0.30, output: 1.20 },
 
-  // Retired GLM model ids — legacy billing fallback only (no longer in the catalog;
-  // kept so historical ai_usage rows recorded under these bare ids still cost correctly).
-  'glm-5': { input: 1.00, output: 3.20 },
-  'glm-4.7': { input: 0.39, output: 1.90 },
-  'glm-4.6': { input: 0.39, output: 1.90 },
-  'glm-4.5-air': { input: 0.35, output: 1.55 },
-
   // MiniMax Direct Models (Native)
   'MiniMax-M2.5': { input: 0.30, output: 1.20 },
 
@@ -601,13 +594,6 @@ export const MODEL_CONTEXT_WINDOWS = {
   'MiniMax-M2.1': 128000,
   'MiniMax-M2': 128000,
   'MiniMax-M2-Stable': 128000,
-
-  // Retired GLM model ids — legacy fallback for historical rows (not in the catalog).
-  'glm-5': 200000,
-  'glm-4.7': 200000,
-  'glm-4.6': 200000,
-  'glm-4.5': 128000,
-  'glm-4.5-air': 128000,
 
   // Ollama (local) - context varies by model and configuration
   'llama3.2': 128000,

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -122,6 +122,20 @@ export const AI_PRICING = {
   'mistralai/devstral-medium': { input: 0.40, output: 2.00 },
   'mistralai/devstral-small': { input: 0.10, output: 0.30 },
 
+  // Z.ai GLM direct (source: z.ai pricing; native model IDs used by GLM Coder Plan direct API)
+  'glm-5.1':       { input: 0.98, output: 3.08 },
+  'glm-5v-turbo':  { input: 1.20, output: 4.00 },
+  'glm-5-turbo':   { input: 1.20, output: 4.00 },
+  'glm-5':         { input: 0.80, output: 2.56 },
+  'glm-4.7':       { input: 0.39, output: 1.90 },
+  'glm-4.7-flash': { input: 0.06, output: 0.40 },
+  'glm-4.6v':      { input: 0.30, output: 0.90 },
+  'glm-4.6':       { input: 0.43, output: 1.74 },
+  'glm-4.5v':      { input: 0.48, output: 1.44 },
+  'glm-4.5':       { input: 0.48, output: 1.44 },
+  'glm-4.5-air':   { input: 0.35, output: 1.55 },
+  'glm-4-32b':     { input: 0.35, output: 1.55 },
+
   // OpenRouter - Chinese/Asian (source: openrouter.ai/api/v1/models)
   'z-ai/glm-5.1': { input: 0.98, output: 3.08 },
   'z-ai/glm-5-turbo': { input: 1.20, output: 4.00 },
@@ -408,6 +422,20 @@ export const MODEL_CONTEXT_WINDOWS = {
   'mistralai/codestral-2508': 32000,
   'mistralai/devstral-medium': 128000,
   'mistralai/devstral-small': 128000,
+
+  // Z.ai GLM direct (native model IDs)
+  'glm-5.1':       202752,
+  'glm-5v-turbo':  202752,
+  'glm-5-turbo':   202752,
+  'glm-5':         202752,
+  'glm-4.7':       200000,
+  'glm-4.7-flash': 202752,
+  'glm-4.6v':      131072,
+  'glm-4.6':       202752,
+  'glm-4.5v':      128000,
+  'glm-4.5':       128000,
+  'glm-4.5-air':   128000,
+  'glm-4-32b':     128000,
 
   // OpenRouter Models - Chinese/Asian
   'z-ai/glm-5.1': 202752,


### PR DESCRIPTION
## Summary

- Restores the `glm` direct provider (Z.ai GLM Coder Plan) as an **admin-only** option, routing directly to `api.z.ai/api/coding/paas/v4` via `GLM_CODER_DEFAULT_API_KEY` — never touching the OpenRouter quota
- Adds 4 models officially supported by the GLM Coding Plan endpoint: **GLM-5.1, GLM-5 Turbo, GLM-4.7, GLM-4.5 Air**
- Admin gate enforced at settings PATCH, AI chat, and global agent routes; non-admins get a clean 403 (not a subscription upgrade prompt)
- `isAdmin` added to GET `/api/ai/settings` response so the model picker can hide admin-only providers from non-admins
- Pricing updated from official Z.ai rates (GLM-5.1: $1.40/$4.40 /M tokens) for accurate cost attribution on direct calls
- Existing OpenRouter-backed provider/model behavior is completely unchanged

## Test plan

- [x] Settings route tests: `isAdmin` field, GLM availability, non-admin 403, admin 200 (27 tests pass)
- [ ] Admin login → model picker → "Z.ai (GLM)" group with 4 models
- [ ] Non-admin → model picker → Z.ai group absent
- [ ] `PATCH /api/ai/settings` with `provider: 'glm'` as non-admin → 403 "restricted to administrators"
- [ ] Admin with `GLM_CODER_DEFAULT_API_KEY` set → chat routes to `api.z.ai` (verify in network log)
- [ ] OpenRouter chat unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)