### PR TITLE
feat(ai): split GLM into public (metered) + admin (unmetered) providers

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -237,6 +237,10 @@ vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   ADMIN_ONLY_PROVIDERS: new Set<string>([]),
   DEFAULT_PROVIDER: 'openai',
   DEFAULT_MODEL: 'openai/gpt-5.3-chat',
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
 }));
 
 vi.mock('@/lib/ai/core/tool-utils', () => ({

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -18,6 +18,7 @@ import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
 import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { makeOnStepFinishHandler } from './step-finish-handler';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
@@ -341,24 +342,31 @@ export async function POST(request: Request) {
     // unlimited) and lazy-inits balances. On an allowed request it places a hold
     // (reservation + in-flight marker) whose id is threaded to billing and released
     // at settle; out_of_credits -> 402, the free-tier in-flight cap -> 429.
-    const creditGate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier, {
-      estCostCents: estimateChatHoldCentsForModel(selectedModel),
-      maxInFlight: MAX_CHAT_INFLIGHT,
-    });
-    if (!creditGate.allowed) {
-      loggers.ai.warn('AI Chat API: AI credit gate denied', { userId, reason: creditGate.reason });
-      return creditGateErrorResponse(creditGate.reason);
-    }
-    holdId = creditGate.holdId;
-
-    const creditAbortController = holdId ? new AbortController() : null;
+    // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
+    // subscription, so skip the credit gate entirely — no hold, no balance check —
+    // and never debit at settle (see isMeteringExempt in trackAIUsage).
+    const gateProvider = selectedProvider || user?.currentAiProvider || DEFAULT_PROVIDER;
     // Net spendable after all holds (including this request's) — already computed by
     // the gate so no extra DB read is needed. Each stream guards against its own slice,
     // not the gross balance, preventing concurrent streams from collectively overshooting.
-    const availableBalanceCents =
-      holdId && creditGate.balanceSnapshot
-        ? creditGate.balanceSnapshot.netSpendableCents
-        : null;
+    let availableBalanceCents: number | null = null;
+    if (!isMeteringExempt(gateProvider)) {
+      const creditGate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier, {
+        estCostCents: estimateChatHoldCentsForModel(selectedModel),
+        maxInFlight: MAX_CHAT_INFLIGHT,
+      });
+      if (!creditGate.allowed) {
+        loggers.ai.warn('AI Chat API: AI credit gate denied', { userId, reason: creditGate.reason });
+        return creditGateErrorResponse(creditGate.reason);
+      }
+      holdId = creditGate.holdId;
+      availableBalanceCents =
+        holdId && creditGate.balanceSnapshot
+          ? creditGate.balanceSnapshot.netSpendableCents
+          : null;
+    }
+
+    const creditAbortController = holdId ? new AbortController() : null;
 
     // Eagerly ensure a conversations row exists so the creator can always see
     // their own conversation. isShared defaults to false (private). Idempotent

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -10,7 +10,7 @@ import {
   type TextUIPart,
   type ToolSet,
 } from 'ai';
-import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
+import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, ADMIN_ONLY_PROVIDERS, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
 import { ALL_PROVIDER_NAMES } from '@/lib/ai/core/ai-utils';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
@@ -344,8 +344,11 @@ export async function POST(request: Request) {
     // at settle; out_of_credits -> 402, the free-tier in-flight cap -> 429.
     // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
     // subscription, so skip the credit gate entirely — no hold, no balance check —
-    // and never debit at settle (see isMeteringExempt in trackAIUsage).
-    const gateProvider = selectedProvider || user?.currentAiProvider || DEFAULT_PROVIDER;
+    // and never debit at settle (see isMeteringExempt in trackAIUsage). Key the skip
+    // on the RESOLVED provider (what actually runs): `glm` + an invalid model resolves
+    // to the metered default, which must still be gated.
+    const { provider: gateProvider } = resolveProviderModel(
+      selectedProvider, selectedModel, user?.currentAiProvider, user?.currentAiModel);
     // Net spendable after all holds (including this request's) — already computed by
     // the gate so no extra DB read is needed. Each stream guards against its own slice,
     // not the gross balance, preventing concurrent streams from collectively overshooting.

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -94,6 +94,12 @@ export async function POST(request: Request) {
   // Hoisted to outer scope so the catch-path trackUsage call bills on the real
   // backend model id rather than the client-supplied alias (selectedModel).
   let resolvedModelName: string | undefined;
+  // The provider that ACTUALLY ran, post catalog-substitution (factory's resolution).
+  // Billing settles on this — not the raw requested provider — so the metering
+  // exemption at settle agrees with the credit gate (both key on the resolved
+  // provider). A `glm` + invalid-model request resolves to the metered default, so
+  // it must bill, not be exempted.
+  let resolvedProvider: string | undefined;
   let lifecycle: StreamLifecycleHandle | undefined;
   let activeStreamId: string | undefined;
   let serverAssistantMessageId: string | undefined;
@@ -542,10 +548,11 @@ export async function POST(request: Request) {
       return createProviderErrorResponse(providerResult);
     }
 
-    // Use the resolved model name for billing. providerResult.modelName is the
-    // real OpenRouter model id sent to the backend.
+    // Use the resolved (provider, model) for billing. providerResult carries the
+    // real backend provider/model after the factory's catalog substitution.
     const { model } = providerResult;
     resolvedModelName = providerResult.modelName;
+    resolvedProvider = providerResult.provider;
 
     const onStepFinishForCredits =
       creditAbortController && availableBalanceCents !== null
@@ -1078,7 +1085,7 @@ export async function POST(request: Request) {
             // Use enhanced AI monitoring with token usage from SDK
             await AIMonitoring.trackUsage({
               userId: userId!,
-              provider: currentProvider,
+              provider: resolvedProvider ?? currentProvider,
               model: resolvedModelName!,
               source: 'chat',
               inputTokens,
@@ -1192,7 +1199,7 @@ export async function POST(request: Request) {
     // Note: conversationId might not be available in error path, use chatId as fallback
     await AIMonitoring.trackUsage({
       userId: userId || 'unknown',
-      provider: selectedProvider || 'unknown',
+      provider: (resolvedProvider ?? selectedProvider) || 'unknown',
       model: resolvedModelName ?? selectedModel ?? 'unknown',
       source: 'chat',
       inputTokens: usage?.inputTokens ?? undefined,

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -237,6 +237,10 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   isModelAllowedForTier: vi.fn().mockReturnValue(true),
   ADMIN_ONLY_PROVIDERS: new Set<string>([]),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
 }));
 vi.mock('@/lib/ai/core/tool-utils', () => ({
   mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })),

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -286,6 +286,10 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   isModelAllowedForTier: vi.fn().mockReturnValue(true),
   ADMIN_ONLY_PROVIDERS: new Set<string>([]),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
 }));
 
 vi.mock('@/lib/ai/core/tool-utils', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -6,6 +6,7 @@ import { requiresProSubscription, createSubscriptionRequiredResponse, createAdmi
 import { ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
 import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
@@ -313,23 +314,29 @@ export async function POST(
     let userSubscriptionTier: string | undefined;
     {
       const [gateUser] = await db
-        .select({ subscriptionTier: users.subscriptionTier })
+        .select({ subscriptionTier: users.subscriptionTier, currentAiProvider: users.currentAiProvider })
         .from(users)
         .where(eq(users.id, userId));
       userSubscriptionTier = gateUser?.subscriptionTier ?? undefined;
-      const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
-        estCostCents: estimateChatHoldCentsForModel(selectedModel),
-        maxInFlight: MAX_CHAT_INFLIGHT,
-      });
-      if (!creditGate.allowed) {
-        loggers.api.warn('Global Assistant Chat API: AI credit gate denied', {
-          userId: maskIdentifier(userId),
-          reason: creditGate.reason,
-          conversationId,
+      // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
+      // subscription, so skip the credit gate entirely — no hold, no balance check —
+      // and never debit at settle (see isMeteringExempt in trackAIUsage).
+      const gateProvider = selectedProvider || gateUser?.currentAiProvider;
+      if (!isMeteringExempt(gateProvider)) {
+        const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
+          estCostCents: estimateChatHoldCentsForModel(selectedModel),
+          maxInFlight: MAX_CHAT_INFLIGHT,
         });
-        return creditGateErrorResponse(creditGate.reason);
+        if (!creditGate.allowed) {
+          loggers.api.warn('Global Assistant Chat API: AI credit gate denied', {
+            userId: maskIdentifier(userId),
+            reason: creditGate.reason,
+            conversationId,
+          });
+          return creditGateErrorResponse(creditGate.reason);
+        }
+        holdId = creditGate.holdId;
       }
-      holdId = creditGate.holdId;
     }
 
     // Process @mentions in the user's message

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -3,7 +3,7 @@ import { streamText, convertToModelMessages, stepCountIs, hasToolCall, UIMessage
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { requiresProSubscription, createSubscriptionRequiredResponse, createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
-import { ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
+import { ADMIN_ONLY_PROVIDERS, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
@@ -314,14 +314,21 @@ export async function POST(
     let userSubscriptionTier: string | undefined;
     {
       const [gateUser] = await db
-        .select({ subscriptionTier: users.subscriptionTier, currentAiProvider: users.currentAiProvider })
+        .select({
+          subscriptionTier: users.subscriptionTier,
+          currentAiProvider: users.currentAiProvider,
+          currentAiModel: users.currentAiModel,
+        })
         .from(users)
         .where(eq(users.id, userId));
       userSubscriptionTier = gateUser?.subscriptionTier ?? undefined;
       // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
       // subscription, so skip the credit gate entirely — no hold, no balance check —
-      // and never debit at settle (see isMeteringExempt in trackAIUsage).
-      const gateProvider = selectedProvider || gateUser?.currentAiProvider;
+      // and never debit at settle (see isMeteringExempt in trackAIUsage). Key the skip
+      // on the RESOLVED provider (what actually runs): `glm` + an invalid model resolves
+      // to the metered default, which must still be gated.
+      const { provider: gateProvider } = resolveProviderModel(
+        selectedProvider, selectedModel, gateUser?.currentAiProvider, gateUser?.currentAiModel);
       if (!isMeteringExempt(gateProvider)) {
         const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
           estCostCents: estimateChatHoldCentsForModel(selectedModel),

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
@@ -31,7 +31,9 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 
-const agentPage = { id: 'agent-1', type: 'AI_CHAT', title: 'Helper', driveId: 'drive-1', aiProvider: 'openai', aiModel: 'openai/gpt-5.3-chat', systemPrompt: 'You help.', enabledTools: [] };
+// Single row returned for every query in this test's db mock — so it carries both
+// the agent-page fields and the gate user's subscriptionTier/role.
+const agentPage = { id: 'agent-1', type: 'AI_CHAT', title: 'Helper', driveId: 'drive-1', aiProvider: 'openai', aiModel: 'openai/gpt-5.3-chat', systemPrompt: 'You help.', enabledTools: [], subscriptionTier: 'pro', role: 'user' };
 
 vi.mock('@pagespace/db/db', () => {
   type QueryBuilder = {
@@ -79,6 +81,11 @@ vi.mock('@/lib/ai/core/personalization-utils', () => ({
 vi.mock('@/lib/ai/core/ai-providers-config', () => ({
   DEFAULT_PROVIDER: 'openai',
   DEFAULT_MODEL: 'openai/gpt-5.3-chat',
+  ADMIN_ONLY_PROVIDERS: new Set<string>(['glm']),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
 }));
 
 vi.mock('@/lib/ai/core/tool-utils', () => ({ mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })) }));
@@ -122,6 +129,10 @@ describe('POST /api/ai/page-agents/consult — prepaid credit gate', () => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     vi.mocked(canConsumeAI).mockResolvedValue({ allowed: true, reason: 'unlimited' });
+    // Reset the shared row to a non-admin, public-provider default each test.
+    agentPage.aiProvider = 'openai';
+    agentPage.aiModel = 'openai/gpt-5.3-chat';
+    agentPage.role = 'user';
   });
 
   it('returns 402 out_of_credits and never configures a provider or invokes the model', async () => {
@@ -143,5 +154,32 @@ describe('POST /api/ai/page-agents/consult — prepaid credit gate', () => {
 
     expect(canConsumeAI).toHaveBeenCalled();
     expect(response.status).not.toBe(402);
+  });
+
+  it('rejects a non-admin consulting an admin-only (glm) agent with 403 and never invokes the model', async () => {
+    // P1#2 — the admin Z.ai Coder Plan is unmetered; a non-admin viewer of a
+    // glm-configured shared agent must NOT be able to consume it.
+    agentPage.aiProvider = 'glm';
+    agentPage.aiModel = 'glm-4.7';
+    agentPage.role = 'user';
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(403);
+    expect(canConsumeAI).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  it('lets an admin consult a glm agent and skips the credit gate (unmetered)', async () => {
+    agentPage.aiProvider = 'glm';
+    agentPage.aiModel = 'glm-4.7';
+    agentPage.role = 'admin';
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).not.toBe(403);
+    // Exempt provider: the gate is skipped entirely (no hold, no balance check).
+    expect(canConsumeAI).not.toHaveBeenCalled();
+    expect(generateText).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -21,6 +21,7 @@ import { users } from '@pagespace/db/schema/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
@@ -219,16 +220,21 @@ export async function POST(request: Request) {
       .select({ subscriptionTier: users.subscriptionTier })
       .from(users)
       .where(eq(users.id, userId));
-    const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
-      estCostCents: estimateChatHoldCentsForModel(agent.aiModel ?? undefined),
-      maxInFlight: MAX_CHAT_INFLIGHT,
-    });
-    if (!creditGate.allowed) {
-      loggers.api.warn('Agent consultation: AI credit gate denied', { userId, agentId, reason: creditGate.reason });
-      return creditGateErrorResponse(creditGate.reason);
+    // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
+    // subscription, so skip the gate entirely — no hold, no balance check — and never
+    // debit at settle (see isMeteringExempt in trackAIUsage).
+    if (!isMeteringExempt(agent.aiProvider)) {
+      const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
+        estCostCents: estimateChatHoldCentsForModel(agent.aiModel ?? undefined),
+        maxInFlight: MAX_CHAT_INFLIGHT,
+      });
+      if (!creditGate.allowed) {
+        loggers.api.warn('Agent consultation: AI credit gate denied', { userId, agentId, reason: creditGate.reason });
+        return creditGateErrorResponse(creditGate.reason);
+      }
+      // The gate's reservation for this call, released when usage is billed below.
+      holdId = creditGate.holdId;
     }
-    // The gate's reservation for this call, released when usage is billed below.
-    holdId = creditGate.holdId;
 
     // Get the drive information for context awareness
     const [drive] = await db

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -11,7 +11,8 @@ import { createAIProvider, isProviderError, type ProviderRequest } from '@/lib/a
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
-import { DEFAULT_PROVIDER, DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
+import { DEFAULT_PROVIDER, DEFAULT_MODEL, ADMIN_ONLY_PROVIDERS, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
+import { createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
 import type { ToolExecutionContext } from '@/lib/ai/core/types';
 import { supportsTemperature } from '@/lib/ai/core/model-capabilities';
 import { db } from '@pagespace/db/db'
@@ -217,13 +218,29 @@ export async function POST(request: Request) {
     // Prepaid credit gate: block out-of-credits users before any model invocation.
     // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
     const [gateUser] = await db
-      .select({ subscriptionTier: users.subscriptionTier })
+      .select({ subscriptionTier: users.subscriptionTier, role: users.role })
       .from(users)
       .where(eq(users.id, userId));
+
+    // Resolve the provider that will ACTUALLY run (mirrors getConfiguredModel below):
+    // an agent configured with `glm` + an invalid model resolves to the metered
+    // default, so both the admin gate and the credit gate must key off this, not the
+    // raw agent config.
+    const { provider: effectiveProvider } = resolveProviderModel(agent.aiProvider, agent.aiModel);
+
+    // Admin-only providers (the direct Z.ai Coder Plan) are unmetered and must never
+    // be reachable by a non-admin — otherwise any viewer of a glm-configured shared
+    // agent could consume the admin subscription for free. The interactive chat routes
+    // enforce this; the consult + v1 routes must too.
+    if (ADMIN_ONLY_PROVIDERS.has(effectiveProvider) && gateUser?.role !== 'admin') {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: agentId, details: { reason: 'admin_only_provider', provider: effectiveProvider, action: 'consult', method: 'POST' }, riskScore: 0.5 });
+      return createAdminRestrictedResponse();
+    }
+
     // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
     // subscription, so skip the gate entirely — no hold, no balance check — and never
     // debit at settle (see isMeteringExempt in trackAIUsage).
-    if (!isMeteringExempt(agent.aiProvider)) {
+    if (!isMeteringExempt(effectiveProvider)) {
       const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
         estCostCents: estimateChatHoldCentsForModel(agent.aiModel ?? undefined),
         maxInFlight: MAX_CHAT_INFLIGHT,

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -33,6 +33,7 @@ import { conversationRepository } from '@/lib/repositories/conversation-reposito
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
@@ -165,16 +166,22 @@ export async function POST(request: Request): Promise<Response> {
     .select({ subscriptionTier: users.subscriptionTier })
     .from(users)
     .where(eq(users.id, authResult.userId));
-  const creditGate = await canConsumeAI(authResult.userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
-    estCostCents: estimateChatHoldCentsForModel(page.aiModel ?? undefined),
-    maxInFlight: MAX_CHAT_INFLIGHT,
-  });
-  if (!creditGate.allowed) {
-    auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: creditGate.reason }, riskScore: 0 });
-    return creditGateErrorResponse(creditGate.reason);
-  }
   // The gate's reservation for this call, released when usage is billed in onFinish.
-  const holdId = creditGate.holdId;
+  // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
+  // subscription, so skip the gate entirely — no hold, no balance check — and never
+  // debit at settle (see isMeteringExempt in trackAIUsage).
+  let holdId: string | undefined;
+  if (!isMeteringExempt(page.aiProvider)) {
+    const creditGate = await canConsumeAI(authResult.userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
+      estCostCents: estimateChatHoldCentsForModel(page.aiModel ?? undefined),
+      maxInFlight: MAX_CHAT_INFLIGHT,
+    });
+    if (!creditGate.allowed) {
+      auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: creditGate.reason }, riskScore: 0 });
+      return creditGateErrorResponse(creditGate.reason);
+    }
+    holdId = creditGate.holdId;
+  }
 
   // 7. Build system prompt from agent page config
   const systemPrompt = page.systemPrompt

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -34,6 +34,8 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
+import { ADMIN_ONLY_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
+import { createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { estimateChatHoldCentsForModel } from '@pagespace/lib/monitoring/chat-pricing';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
@@ -160,18 +162,33 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: providerResult.error }, { status: providerResult.status });
   }
 
+  // The resolved provider that will ACTUALLY run (post catalog-substitution): an
+  // agent configured with `glm` + an invalid model resolves to the metered default,
+  // so both the admin gate and the credit gate below key off this, not the raw config.
+  const effectiveProvider = providerResult.provider;
+
   // 6b. Prepaid credit gate: block out-of-credits users before any model invocation.
   // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
   const [gateUser] = await db
-    .select({ subscriptionTier: users.subscriptionTier })
+    .select({ subscriptionTier: users.subscriptionTier, role: users.role })
     .from(users)
     .where(eq(users.id, authResult.userId));
+
+  // Admin-only providers (the direct Z.ai Coder Plan) are unmetered and must never be
+  // reachable by a non-admin — otherwise any user able to drive a glm-configured agent
+  // could consume the admin subscription for free. The interactive chat routes enforce
+  // this; this MCP inference route must too.
+  if (ADMIN_ONLY_PROVIDERS.has(effectiveProvider) && gateUser?.role !== 'admin') {
+    auditRequest(request, { eventType: 'authz.access.denied', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: 'admin_only_provider', provider: effectiveProvider, method: 'POST' }, riskScore: 0.5 });
+    return createAdminRestrictedResponse();
+  }
+
   // The gate's reservation for this call, released when usage is billed in onFinish.
   // Metering-exempt providers (admin Z.ai Coder Plan) bill on a flat-rate external
   // subscription, so skip the gate entirely — no hold, no balance check — and never
   // debit at settle (see isMeteringExempt in trackAIUsage).
   let holdId: string | undefined;
-  if (!isMeteringExempt(page.aiProvider)) {
+  if (!isMeteringExempt(effectiveProvider)) {
     const creditGate = await canConsumeAI(authResult.userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier, {
       estCostCents: estimateChatHoldCentsForModel(page.aiModel ?? undefined),
       maxInFlight: MAX_CHAT_INFLIGHT,

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import {
   ONPREM_ALLOWED_PROVIDERS,
+  ADMIN_ONLY_PROVIDERS,
   AI_PROVIDERS,
   FREE_TIER_MODELS,
   DEFAULT_PROVIDER,
@@ -26,24 +27,36 @@ describe('ai-providers-config', () => {
       expect(AI_PROVIDERS).not.toHaveProperty('openrouter_free');
     });
 
-    it('includes the glm direct provider with Coder Plan models', () => {
+    it('includes the admin glm direct provider with Coder Plan models', () => {
+      // Admin-only direct Z.ai Coder Plan connection: bare glm-* native ids.
       expect(AI_PROVIDERS).toHaveProperty('glm');
+      expect(AI_PROVIDERS.glm.name).toBe('Z.ai (Admin)');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5.1');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-5-turbo');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-4.7');
       expect(AI_PROVIDERS.glm.models).toHaveProperty('glm-4.5-air');
     });
 
+    it('includes the public zai provider with OpenRouter z-ai/ models', () => {
+      // Public, OpenRouter-backed GLM family — metered normally, available to all.
+      expect(AI_PROVIDERS).toHaveProperty('zai');
+      expect(AI_PROVIDERS.zai.name).toBe('Z.ai');
+      expect(AI_PROVIDERS.zai.models).toHaveProperty('z-ai/glm-5.1');
+      expect(AI_PROVIDERS.zai.models).toHaveProperty('z-ai/glm-4.6');
+      expect(AI_PROVIDERS.zai.models).toHaveProperty('z-ai/glm-4.5v');
+      // Public zai keys are vendor-prefixed; every key carries the z-ai/ prefix.
+      expect(Object.keys(AI_PROVIDERS.zai.models).every((m) => m.startsWith('z-ai/'))).toBe(true);
+    });
+
+    it('gates the admin glm provider, not the public zai provider', () => {
+      expect(ADMIN_ONLY_PROVIDERS.has('glm')).toBe(true);
+      expect(ADMIN_ONLY_PROVIDERS.has('zai')).toBe(false);
+    });
+
     it('uses full OpenRouter model ids as keys for cloud vendors', () => {
       expect(AI_PROVIDERS.openai.models).toHaveProperty('openai/gpt-5.3-chat');
       expect(AI_PROVIDERS.anthropic.models).toHaveProperty('anthropic/claude-haiku-4.5');
       expect(AI_PROVIDERS.minimax.models).toHaveProperty('minimax/minimax-m3');
-    });
-
-    it('has no z-ai/ OpenRouter-prefixed model ids in the catalog', () => {
-      // Cloud vendors use vendor/model-id format; glm direct uses bare glm-* native ids
-      const allModels = Object.values(AI_PROVIDERS).flatMap((p) => Object.keys(p.models));
-      expect(allModels.some((m) => m.startsWith('z-ai/'))).toBe(false);
     });
   });
 
@@ -100,6 +113,10 @@ describe('ai-providers-config', () => {
       expect(getBackendProvider('openai')).toBe('openrouter');
       expect(getBackendProvider('anthropic')).toBe('openrouter');
       expect(getBackendProvider('minimax')).toBe('openrouter');
+    });
+
+    it('routes the public zai provider through openrouter', () => {
+      expect(getBackendProvider('zai')).toBe('openrouter');
     });
 
     it('passes local providers through', () => {

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -14,6 +14,7 @@ import {
   getVisibleProviders,
   isDynamicModelProvider,
   validateAgentModelSelection,
+  resolveProviderModel,
 } from '../ai-providers-config';
 
 describe('ai-providers-config', () => {
@@ -127,6 +128,61 @@ describe('ai-providers-config', () => {
 
     it('routes glm direct (not through openrouter)', () => {
       expect(getBackendProvider('glm')).toBe('glm');
+    });
+  });
+
+  describe('resolveProviderModel', () => {
+    it('uses the request pair when both are present and valid', () => {
+      expect(resolveProviderModel('anthropic', 'anthropic/claude-opus-4.8')).toEqual({
+        provider: 'anthropic',
+        model: 'anthropic/claude-opus-4.8',
+      });
+    });
+
+    it('keeps the admin glm provider when the model is a valid glm model', () => {
+      expect(resolveProviderModel('glm', 'glm-4.7')).toEqual({ provider: 'glm', model: 'glm-4.7' });
+    });
+
+    it('SUBSTITUTES the metered default when glm is paired with an invalid model (the P1 gate-bypass)', () => {
+      // This is the exact vector Codex flagged: `glm` + an invalid model must NOT
+      // resolve to glm (which would skip the credit gate) — it falls back to the
+      // metered default, so the gate runs.
+      const resolved = resolveProviderModel('glm', 'not-a-real-model');
+      expect(resolved).toEqual({ provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL });
+    });
+
+    it('substitutes the default for any unknown (provider, model) pair', () => {
+      expect(resolveProviderModel('openai', 'openai/hallucinated')).toEqual({
+        provider: DEFAULT_PROVIDER,
+        model: DEFAULT_MODEL,
+      });
+    });
+
+    it('falls back to the stored pair when the request pair is incomplete', () => {
+      expect(resolveProviderModel(undefined, undefined, 'anthropic', 'anthropic/claude-opus-4.8')).toEqual({
+        provider: 'anthropic',
+        model: 'anthropic/claude-opus-4.8',
+      });
+      // A partial request (provider only) does not combine with a stored model.
+      expect(resolveProviderModel('glm', undefined, 'anthropic', 'anthropic/claude-opus-4.8')).toEqual({
+        provider: 'anthropic',
+        model: 'anthropic/claude-opus-4.8',
+      });
+    });
+
+    it('falls back to the default pair when nothing valid is provided', () => {
+      expect(resolveProviderModel(undefined, undefined)).toEqual({
+        provider: DEFAULT_PROVIDER,
+        model: DEFAULT_MODEL,
+      });
+    });
+
+    it('preserves local/dynamic providers without catalog validation', () => {
+      // ollama serves runtime-discovered models, so its bare model id is not substituted.
+      expect(resolveProviderModel('ollama', 'llama3.1:70b-custom')).toEqual({
+        provider: 'ollama',
+        model: 'llama3.1:70b-custom',
+      });
     });
   });
 

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -255,10 +255,29 @@ export const AI_PROVIDERS = {
       'writer/palmyra-x5': 'Palmyra X5',
     },
   },
+  zai: {
+    name: 'Z.ai',
+    // Public GLM family, served through OpenRouter (`z-ai/*` model ids) and metered
+    // normally. Distinct from the admin-only `glm` provider below, which routes
+    // directly to the Z.ai Coder Plan endpoint and is exempt from billing.
+    models: {
+      'z-ai/glm-5.1':      'GLM-5.1',
+      'z-ai/glm-5-turbo':  'GLM-5 Turbo',
+      'z-ai/glm-5':        'GLM-5',
+      'z-ai/glm-4.7':      'GLM-4.7',
+      'z-ai/glm-4.7-flash':'GLM-4.7 Flash',
+      'z-ai/glm-4.6':      'GLM-4.6',
+      'z-ai/glm-4.5':      'GLM-4.5',
+      'z-ai/glm-4.5-air':  'GLM-4.5 Air',
+      'z-ai/glm-4.5v':     'GLM-4.5V',
+    },
+  },
   glm: {
-    name: 'Z.ai (GLM)',
-    // Models officially supported by the GLM Coder Plan endpoint (api.z.ai/api/coding/paas/v4).
-    // Other GLM models are available on the general Z.ai API but not through this plan.
+    name: 'Z.ai (Admin)',
+    // Admin-only direct connection to the Z.ai Coder Plan endpoint
+    // (api.z.ai/api/coding/paas/v4). Flat-rate subscription, so usage is logged but
+    // NOT billed against the shared credit pool (see METERING_EXEMPT_PROVIDERS).
+    // Models officially supported by that endpoint; bare `glm-*` ids (no vendor prefix).
     models: {
       'glm-5.1':     'GLM-5.1',
       'glm-5-turbo': 'GLM-5 Turbo',
@@ -293,6 +312,7 @@ export const AI_PROVIDERS = {
 const CLOUD_VENDOR_PROVIDERS = new Set<string>([
   'openai', 'anthropic', 'google', 'xai', 'deepseek', 'qwen', 'mistral',
   'moonshot', 'minimax', 'meta', 'bytedance', 'ai21', 'inception', 'writer',
+  'zai',
 ]);
 
 /**

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -446,3 +446,44 @@ export function validateAgentModelSelection(
   }
   return null;
 }
+
+/**
+ * Resolve the (provider, model) pair that will ACTUALLY be used for a request,
+ * exactly as `createAIProvider` does. This is the single source of truth for that
+ * resolution so callers (e.g. the credit gate and admin-only checks) can key their
+ * decisions on what truly runs — never on the raw requested values, which the
+ * factory may substitute.
+ *
+ * Resolution, mirroring the factory:
+ *  1. Atomic pair: prefer the request pair (both present), else the stored pair
+ *     (both present), else the default pair. Never combine a provider from one
+ *     source with a model from another.
+ *  2. Catalog enforcement: a non-local (provider, model) that isn't in the catalog
+ *     is SUBSTITUTED with the default rather than forwarded — so e.g. `glm` + an
+ *     invalid model resolves to the metered default, NOT to `glm`. Local/dynamic
+ *     providers serve runtime-discovered models, so only their name is gated.
+ */
+export function resolveProviderModel(
+  selectedProvider: string | null | undefined,
+  selectedModel: string | null | undefined,
+  storedProvider?: string | null,
+  storedModel?: string | null,
+): { provider: string; model: string } {
+  let provider: string;
+  let model: string;
+  if (selectedProvider && selectedModel) {
+    provider = selectedProvider;
+    model = selectedModel;
+  } else if (storedProvider && storedModel) {
+    provider = storedProvider;
+    model = storedModel;
+  } else {
+    provider = DEFAULT_PROVIDER;
+    model = DEFAULT_MODEL;
+  }
+  if (!ONPREM_ALLOWED_PROVIDERS.has(provider) && !isValidModel(provider, model)) {
+    provider = DEFAULT_PROVIDER;
+    model = DEFAULT_MODEL;
+  }
+  return { provider, model };
+}

--- a/apps/web/src/lib/ai/core/provider-factory.ts
+++ b/apps/web/src/lib/ai/core/provider-factory.ts
@@ -19,7 +19,7 @@ import { eq } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { getManagedProviderKey } from './ai-utils';
-import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, isValidModel } from './ai-providers-config';
+import { ONPREM_ALLOWED_PROVIDERS, resolveProviderModel } from './ai-providers-config';
 
 // The local/on-prem providers (ONPREM_ALLOWED_PROVIDERS = ollama/lmstudio/azure_openai)
 // serve runtime-discovered models that aren't in the static catalog, so catalog
@@ -56,26 +56,23 @@ export async function createAIProvider(
 
   const [user] = await db.select().from(users).where(eq(users.id, userId));
 
-  // Resolve (provider, model) as one atomic pair — never combine a provider from one
-  // source with a model from another. Falling each field back independently
-  // (`selectedProvider || stored || default` for each) could synthesize an impossible
-  // pair like `anthropic` + the default `openai/…` model when only one field is
-  // present, which then silently reroutes to the default below. Prefer the request
-  // pair (both present), else the stored pair (both present), else the default pair.
-  let currentProvider: string;
-  let currentModel: string;
-  if (selectedProvider && selectedModel) {
-    currentProvider = selectedProvider;
-    currentModel = selectedModel;
-  } else if (user?.currentAiProvider && user?.currentAiModel) {
-    currentProvider = user.currentAiProvider;
-    currentModel = user.currentAiModel;
-  } else {
-    currentProvider = DEFAULT_PROVIDER;
-    currentModel = DEFAULT_MODEL;
-  }
+  // Resolve (provider, model) as one atomic pair, with catalog enforcement —
+  // shared with the routes (credit gate, admin-only checks) via resolveProviderModel
+  // so every caller keys off the SAME provider that actually runs. An unknown
+  // (provider, model) is SUBSTITUTED with the default rather than forwarded — so a
+  // selection left on a removed value, or `glm` + an invalid model, degrades to the
+  // working default instead of being sent verbatim to OpenRouter. (Explicit invalid
+  // *selections* are still rejected with a 400 at the settings PATCH boundary.)
+  const resolved = resolveProviderModel(
+    selectedProvider,
+    selectedModel,
+    user?.currentAiProvider,
+    user?.currentAiModel,
+  );
+  const currentProvider = resolved.provider;
+  const currentModel = resolved.model;
 
-  // Deployment policy first: on-prem only permits the local/BAA-eligible providers.
+  // Deployment policy: on-prem only permits the local/BAA-eligible providers.
   if (
     isOnPrem() &&
     !ONPREM_ALLOWED_PROVIDERS.has(currentProvider)
@@ -84,21 +81,6 @@ export async function createAIProvider(
       error: `Provider "${currentProvider}" is not available in on-premise mode.`,
       status: 403,
     };
-  }
-
-  // Catalog enforcement at generation time: any non-local (provider, model) that
-  // isn't in AI_PROVIDERS is SUBSTITUTED with the default rather than forwarded.
-  // We fall back instead of erroring so that selections left on removed values —
-  // a pre-backfill `pagespace`/`glm-*` row, or an agent configured with a bare
-  // model id via the raw API — degrade to the working default instead of failing
-  // the request. The security goal still holds: an arbitrary/unknown model is
-  // never sent to OpenRouter, it resolves to the default. (Explicit invalid
-  // *selections* are rejected with a clear 400 at the settings PATCH boundary.)
-  // Local providers (ollama/lmstudio/azure) serve runtime-discovered models, so
-  // only their provider name is validated (on-prem allowlist + config lookups).
-  if (!ONPREM_ALLOWED_PROVIDERS.has(currentProvider) && !isValidModel(currentProvider, currentModel)) {
-    currentProvider = DEFAULT_PROVIDER;
-    currentModel = DEFAULT_MODEL;
   }
 
   try {

--- a/packages/lib/src/ai/__tests__/model-defaults.test.ts
+++ b/packages/lib/src/ai/__tests__/model-defaults.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_AI_PROVIDER, DEFAULT_AI_MODEL } from '../model-defaults';
+import {
+  DEFAULT_AI_PROVIDER,
+  DEFAULT_AI_MODEL,
+  METERING_EXEMPT_PROVIDERS,
+  isMeteringExempt,
+} from '../model-defaults';
 
 describe('model-defaults', () => {
   it('defaults to the OpenAI GPT-5.3 Chat product default (OpenRouter-backed)', () => {
@@ -9,5 +14,24 @@ describe('model-defaults', () => {
 
   it('uses a vendor-prefixed (OpenRouter) model id', () => {
     expect(DEFAULT_AI_MODEL.startsWith(`${DEFAULT_AI_PROVIDER}/`)).toBe(true);
+  });
+});
+
+describe('isMeteringExempt', () => {
+  it('exempts the admin Z.ai Coder Plan provider (glm)', () => {
+    expect(METERING_EXEMPT_PROVIDERS.has('glm')).toBe(true);
+    expect(isMeteringExempt('glm')).toBe(true);
+  });
+
+  it('does NOT exempt the public OpenRouter-backed Z.ai provider (zai) or other vendors', () => {
+    expect(isMeteringExempt('zai')).toBe(false);
+    expect(isMeteringExempt('openai')).toBe(false);
+    expect(isMeteringExempt('anthropic')).toBe(false);
+  });
+
+  it('treats null/undefined/empty as not exempt', () => {
+    expect(isMeteringExempt(null)).toBe(false);
+    expect(isMeteringExempt(undefined)).toBe(false);
+    expect(isMeteringExempt('')).toBe(false);
   });
 });

--- a/packages/lib/src/ai/model-defaults.ts
+++ b/packages/lib/src/ai/model-defaults.ts
@@ -5,3 +5,20 @@
  */
 export const DEFAULT_AI_PROVIDER = 'openai';
 export const DEFAULT_AI_MODEL = 'openai/gpt-5.3-chat';
+
+/**
+ * Providers whose usage is logged for observability but never billed against the
+ * shared credit pool. The admin-only `glm` provider routes directly to the Z.ai
+ * Coder Plan endpoint — a flat-rate external subscription — so its spend must not
+ * draw down OpenRouter credits. The credit gate is skipped (no hold placed) and
+ * `consumeCredits` is bypassed at settle for these providers.
+ *
+ * Note: this is the *backend* provider id. The public, OpenRouter-backed Z.ai
+ * provider (`zai`, model ids `z-ai/*`) is metered normally and is NOT in this set.
+ */
+export const METERING_EXEMPT_PROVIDERS = new Set<string>(['glm']);
+
+/** Whether a provider's usage is exempt from credit billing (see {@link METERING_EXEMPT_PROVIDERS}). */
+export function isMeteringExempt(provider: string | null | undefined): boolean {
+  return !!provider && METERING_EXEMPT_PROVIDERS.has(provider);
+}

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ── Hoisted mocks ─────────────────────────────────────────────────────────────
 const mockWriteAiUsage = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockConsumeCredits = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockReleaseHold = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockAiLogger = vi.hoisted(() => ({
   debug: vi.fn(),
   error: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock('../../logging/logger-database', () => ({
 
 vi.mock('../../billing/credit-consume', () => ({
   consumeCredits: mockConsumeCredits,
+  releaseHold: mockReleaseHold,
 }));
 
 vi.mock('../../logging/logger-config', () => ({
@@ -296,6 +298,7 @@ describe('trackAIUsage', () => {
     vi.clearAllMocks();
     mockWriteAiUsage.mockResolvedValue(undefined);
     mockConsumeCredits.mockResolvedValue(undefined);
+    mockReleaseHold.mockResolvedValue(undefined);
   });
 
   it('debits credits with the returned usage-log id on a successful call', async () => {
@@ -395,6 +398,55 @@ describe('trackAIUsage', () => {
     await trackAIUsage({ userId: 'user-1', provider: 'openai', model: 'gpt-4o', success: false, error: 'fail' });
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(mockConsumeCredits).not.toHaveBeenCalled();
+  });
+
+  it('logs but does NOT debit credits for a metering-exempt provider (admin glm)', async () => {
+    // The admin Z.ai Coder Plan (`glm`) bills on a flat-rate external subscription:
+    // the usage row is still written for observability, but no credits are debited.
+    mockWriteAiUsage.mockResolvedValueOnce('aul_glm');
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'glm',
+      model: 'glm-4.7',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockWriteAiUsage).toHaveBeenCalledTimes(1); // logged
+    expect(mockConsumeCredits).not.toHaveBeenCalled(); // not billed
+  });
+
+  it('releases a stray hold for an exempt provider without debiting', async () => {
+    // The gate is normally skipped for exempt providers (no hold), but if a hold was
+    // placed anyway it must be released at settle rather than left for the cron.
+    mockWriteAiUsage.mockResolvedValueOnce('aul_glm2');
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'glm',
+      model: 'glm-5.1',
+      inputTokens: 100,
+      outputTokens: 50,
+      holdId: 'hold_glm',
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold_glm');
+    expect(mockConsumeCredits).not.toHaveBeenCalled();
+  });
+
+  it('still bills the public OpenRouter-backed zai provider normally', async () => {
+    mockWriteAiUsage.mockResolvedValueOnce('aul_zai');
+    await trackAIUsage({
+      userId: 'user-1',
+      provider: 'zai',
+      model: 'z-ai/glm-4.6',
+      inputTokens: 1000,
+      outputTokens: 500,
+      providerCostDollars: 0.01,
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockConsumeCredits).toHaveBeenCalledWith(
+      expect.objectContaining({ aiUsageLogId: 'aul_zai', userId: 'user-1' }),
+    );
   });
 
   it('debits credits for an errored call that still consumed tokens (errored-but-real spend)', async () => {

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -11,6 +11,7 @@ import { consumeCredits, releaseHold } from '../billing/credit-consume';
 import { CACHE_READ_DISCOUNT_FACTOR_BPS } from '../billing/credit-pricing';
 import { loggers } from '../logging/logger-config';
 import { normalizeUsageSource, type AIUsageSource } from './usage-source';
+import { isMeteringExempt } from '../ai/model-defaults';
 
 /**
  * Providers NOT served through OpenRouter. Everything else is a cloud vendor
@@ -939,7 +940,13 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
       // failure (pre-generation error) carries 0 tokens and is skipped; a
       // zero-charge call still reaches consumeCredits, which settles it as
       // 'skipped' without churning a $0 ledger transaction.
-      if (aiUsageLogId && (success || (totalTokens ?? 0) > 0)) {
+      if (isMeteringExempt(data.provider)) {
+        // Admin Z.ai Coder Plan (flat-rate external subscription): the usage row
+        // above is kept for observability, but the call never bills against the
+        // shared credit pool. The gate is normally skipped for this provider so no
+        // hold exists; release one defensively if a caller placed it anyway.
+        if (data.holdId) await releaseHold(data.holdId);
+      } else if (aiUsageLogId && (success || (totalTokens ?? 0) > 0)) {
         await consumeCredits({
           aiUsageLogId,
           userId: data.userId,


### PR DESCRIPTION
## Summary

Splits GLM into two distinct provider surfaces so the admin Z.ai **Coder Plan** subscription (flat-rate, direct with Z.ai) no longer counts against the shared credit pool, while OpenRouter's GLM family becomes a normal metered public option.

### 1. Public "Z.ai" provider (`zai`) — metered normally, available to all
- New `zai` entry in `AI_PROVIDERS` exposing the full `z-ai/glm-*` family (GLM-5.1 → GLM-4.5V).
- Registered in `CLOUD_VENDOR_PROVIDERS` → routes through OpenRouter and bills on the real returned cost. Pricing + context windows already existed in `ai-monitoring.ts`.

### 2. Admin "Z.ai (Admin)" provider (`glm`) — admin-only, **not billed**
- Existing direct Z.ai Coder Plan connection (`api.z.ai/api/coding/paas/v4`), relabeled `Z.ai (GLM)` → `Z.ai (Admin)`; stays in `ADMIN_ONLY_PROVIDERS`.
- New `METERING_EXEMPT_PROVIDERS` / `isMeteringExempt()` in `@pagespace/lib/ai/model-defaults`.
- **Settle** (`trackAIUsage`): exempt providers still write the `ai_usage_logs` row (admin-panel observability) but skip `consumeCredits` — no credit debit.
- **Gate**: the four user-facing chat routes (`ai/chat`, `ai/global/[id]/messages`, `v1/chat/completions`, `page-agents/consult`) skip `canConsumeAI` for exempt providers, so no hold is placed and an admin is never balance-blocked.

The model picker needed no change — it derives groups from `getVisibleProviders()` and already hides `ADMIN_ONLY_PROVIDERS` for non-admins (so `zai` shows for everyone, `glm` only for admins).

## Files
| File | Change |
|------|--------|
| `apps/web/src/lib/ai/core/ai-providers-config.ts` | add `zai` provider + to `CLOUD_VENDOR_PROVIDERS`; relabel `glm` → "Z.ai (Admin)" |
| `packages/lib/src/ai/model-defaults.ts` | add `METERING_EXEMPT_PROVIDERS` + `isMeteringExempt` |
| `packages/lib/src/monitoring/ai-monitoring.ts` | skip `consumeCredits` for exempt provider (keep usage log) |
| `apps/web/src/app/api/ai/chat/route.ts` + 3 sibling chat routes | skip credit gate when provider exempt |
| tests (3 files) | update catalog assertion, add exemption + `isMeteringExempt` coverage |

No DB migration. No `provider-factory` change (the `else` branch routes `zai` through OpenRouter). No `model-catalog.ts` change.

## Testing
- ✅ `@pagespace/lib` tests (incl. new `isMeteringExempt` + exemption settle tests)
- ✅ web `ai-providers-config` (34), settings admin-gate (27), route `credit-gate` tests
- ✅ `typecheck` + `lint` clean (web + lib)
- ⚠️ 2 failures in `v1/.../route.test.ts` are a **pre-existing** worktree `AbortSignal` cross-realm error thrown at `new Request(...)` in test setup — confirmed identical with this change stashed out.

## Manual verification checklist
- Non-admin: sees "Z.ai" with `z-ai/glm-*`, **not** "Z.ai (Admin)"; chatting bills normally (hold + ledger debit).
- Admin: sees "Z.ai (Admin)"; chatting writes an `ai_usage_logs` row (visible in `/admin/ai-billing`) but **no** `credit_holds` / `credit_ledger` debit. Non-admin PATCH to `glm` still 403s. Admin with zero/negative balance can still use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Z.ai as a new AI provider option with support for multiple models
  * Implemented metering-exempt provider support: certain AI providers no longer consume prepaid credits when used for AI requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update (1f7a346e3) — review hardening (Codex P1s)

Two P1 review findings addressed:

- **Gate bypass via fallback substitution (P1#1).** `createAIProvider` substitutes the metered default when a `(provider, model)` pair is invalid, so skipping the gate on the *raw* requested provider let `glm`+invalid-model run a metered model with no hold. Extracted the factory's atomic resolution + catalog fallback into a shared pure **`resolveProviderModel()`** (single source of truth; the factory now delegates to it) and key the gate-skip on the **resolved** provider in all four routes.
- **Admin-only provider exposed to non-admins (P1#2).** `consult` and `v1/completions` never enforced `ADMIN_ONLY_PROVIDERS`. Both now return **403** (`createAdminRestrictedResponse`) for non-admin callers of admin-only providers, keyed on the resolved provider — mirroring the interactive chat routes.

Added tests: `resolveProviderModel` unit coverage (incl. the `glm`+invalid-model bypass vector), and consult route tests (non-admin glm → 403; admin glm → gate skipped). `provider-factory` tests stay green (refactor is behavior-preserving).
