### PR TITLE
fix(security): enforce delete permission on page restore

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/restore/__tests__/restore-authorization.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/__tests__/restore-authorization.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the pure restore-authorization decision (security finding H1).
+ *
+ * The IDOR fix hinges entirely on this decision: any authenticated user could
+ * previously restore any trashed page in any drive. These tests pin the
+ * decision exhaustively — by role and by MCP token scope — independently of the
+ * route shell that resolves the facts.
+ */
+import { describe, it, expect } from 'vitest';
+import { canRestorePage, type RestoreAuthFacts } from '../restore-authorization';
+
+const facts = (overrides: Partial<RestoreAuthFacts> = {}): RestoreAuthFacts => ({
+  canDelete: true,
+  withinTokenScope: true,
+  ...overrides,
+});
+
+describe('canRestorePage', () => {
+  describe('role-based delete permission', () => {
+    it('allows a caller with delete permission (owner/admin/editor)', () => {
+      expect(canRestorePage(facts({ canDelete: true }))).toBe(true);
+    });
+
+    it('denies a caller without delete permission (viewer/non-member)', () => {
+      expect(canRestorePage(facts({ canDelete: false }))).toBe(false);
+    });
+  });
+
+  describe('MCP token scope', () => {
+    it('denies an out-of-scope MCP token even when the user could delete', () => {
+      expect(canRestorePage(facts({ canDelete: true, withinTokenScope: false }))).toBe(false);
+    });
+
+    it('allows an in-scope token with delete permission', () => {
+      expect(canRestorePage(facts({ canDelete: true, withinTokenScope: true }))).toBe(true);
+    });
+  });
+
+  describe('exhaustive fact matrix', () => {
+    it.each([
+      { canDelete: false, withinTokenScope: false, expected: false },
+      { canDelete: false, withinTokenScope: true, expected: false },
+      { canDelete: true, withinTokenScope: false, expected: false },
+      { canDelete: true, withinTokenScope: true, expected: true },
+    ])(
+      'canDelete=$canDelete withinTokenScope=$withinTokenScope -> $expected',
+      ({ canDelete, withinTokenScope, expected }) => {
+        expect(canRestorePage({ canDelete, withinTokenScope })).toBe(expected);
+      },
+    );
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/restore/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/__tests__/route.test.ts
@@ -20,6 +20,7 @@ const {
   mockIsAuthError,
   mockIsMCPAuthResult,
   mockCheckMCPPageScope,
+  mockCanUserDeletePage,
   mockBroadcastPageEvent,
   mockCreatePageEventPayload,
   mockPagesFindFirst,
@@ -35,6 +36,7 @@ const {
   mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
   mockIsMCPAuthResult: vi.fn().mockReturnValue(false),
   mockCheckMCPPageScope: vi.fn().mockResolvedValue(null),
+  mockCanUserDeletePage: vi.fn().mockResolvedValue(true),
   mockBroadcastPageEvent: vi.fn(),
   mockCreatePageEventPayload: vi.fn((driveId: string, pageId: string, type: string, data: Record<string, unknown>) => ({
     driveId, pageId, type, ...data,
@@ -64,6 +66,10 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: (result: unknown) => mockIsAuthError(result),
   isMCPAuthResult: (result: unknown) => mockIsMCPAuthResult(result),
   checkMCPPageScope: (...args: unknown[]) => mockCheckMCPPageScope(...args),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserDeletePage: (...args: unknown[]) => mockCanUserDeletePage(...args),
 }));
 
 vi.mock('@/lib/websocket', () => ({
@@ -246,6 +252,7 @@ describe('POST /api/pages/[pageId]/restore', () => {
     mockIsAuthError.mockImplementation((result: unknown) => result != null && typeof result === 'object' && 'error' in result);
     mockIsMCPAuthResult.mockReturnValue(false);
     mockCheckMCPPageScope.mockResolvedValue(null);
+    mockCanUserDeletePage.mockResolvedValue(true);
     mockPagesFindFirst.mockResolvedValue(mockTrashedPage);
     mockApplyPageMutation.mockResolvedValue({ deferredTrigger: null });
     mockGetActorInfo.mockResolvedValue({
@@ -279,6 +286,52 @@ describe('POST /api/pages/[pageId]/restore', () => {
       expect(response.status).toBe(403);
       const body = await response.json();
       expect(body.error).toBe('Scope denied');
+    });
+  });
+
+  describe('authorization (IDOR — finding H1)', () => {
+    it('returns 403 and performs NO restore when caller lacks delete permission', async () => {
+      mockCanUserDeletePage.mockResolvedValue(false);
+
+      const response = await POST(createRequest(), mockParams);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toMatch(/forbidden/i);
+      // No mutation, no transaction, no broadcast, no trigger tracking.
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+      expect(mockBroadcastPageEvent).not.toHaveBeenCalled();
+      expect(mockTrackPageOperation).not.toHaveBeenCalled();
+    });
+
+    it('checks delete permission against the target page for the authenticated user', async () => {
+      await POST(createRequest(), mockParams);
+
+      expect(mockCanUserDeletePage).toHaveBeenCalledWith(mockUserId, mockPageId);
+    });
+
+    it('returns 200 and restores when caller has delete permission', async () => {
+      mockCanUserDeletePage.mockResolvedValue(true);
+
+      const response = await POST(createRequest(), mockParams);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.message).toMatch(/restored/i);
+      expect(mockApplyPageMutation).toHaveBeenCalled();
+    });
+
+    it('enforces scoped MCP tokens before authorization (out-of-scope -> 403, no permission lookup)', async () => {
+      mockCheckMCPPageScope.mockResolvedValue(
+        NextResponse.json({ error: 'This token does not have access to this drive' }, { status: 403 }),
+      );
+
+      const response = await POST(createRequest(), mockParams);
+
+      expect(response.status).toBe(403);
+      expect(mockCanUserDeletePage).not.toHaveBeenCalled();
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/pages/[pageId]/restore/restore-authorization.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/restore-authorization.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure authorization decision for page restore (security finding H1).
+ *
+ * The restore endpoint historically performed NO resource authorization: it
+ * authenticated the caller, ran a no-op MCP scope check for session auth, and
+ * then restored the page. Any authenticated user could restore any trashed page
+ * in any drive (IDOR).
+ *
+ * This module isolates the security DECISION into a pure, side-effect-free
+ * function. The route shell resolves the facts (await params, authenticate,
+ * look up delete permission and MCP token scope) and then calls this function.
+ * Keeping the decision pure makes it deterministic and exhaustively testable.
+ */
+
+export interface RestoreAuthFacts {
+  /**
+   * Whether the caller has delete/manage permission on the target page.
+   * Resolved via the same guard the sibling trash endpoint uses —
+   * `canUserDeletePage(userId, pageId)`. Owner/admin/editor → true;
+   * viewer/non-member → false.
+   */
+  canDelete: boolean;
+  /**
+   * Whether the caller's token is in scope for the page's drive.
+   * Session auth always has full scope (true). A scoped MCP token is only in
+   * scope when the page's drive is in its allow-list. An out-of-scope MCP token
+   * must be denied regardless of the underlying user's delete permission.
+   */
+  withinTokenScope: boolean;
+}
+
+/**
+ * Decide whether a caller may restore a trashed page.
+ *
+ * Both conditions must hold:
+ *  - the caller's token is in scope for the page's drive, AND
+ *  - the caller has delete/manage permission on the page.
+ */
+export function canRestorePage(facts: RestoreAuthFacts): boolean {
+  return facts.withinTokenScope && facts.canDelete;
+}

--- a/apps/web/src/app/api/pages/[pageId]/restore/restore-authorization.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/restore-authorization.ts
@@ -1,10 +1,10 @@
 /**
  * Pure authorization decision for page restore (security finding H1).
  *
- * The restore endpoint historically performed NO resource authorization: it
- * authenticated the caller, ran a no-op MCP scope check for session auth, and
- * then restored the page. Any authenticated user could restore any trashed page
- * in any drive (IDOR).
+ * The restore endpoint historically performed NO resource (delete) authorization:
+ * it authenticated the caller and checked only MCP token scope — which is a no-op
+ * for session auth (sessions get full access) — then restored the page. Any
+ * authenticated user could restore any trashed page in any drive (IDOR).
  *
  * This module isolates the security DECISION into a pure, side-effect-free
  * function. The route shell resolves the facts (await params, authenticate,

--- a/apps/web/src/app/api/pages/[pageId]/restore/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/route.ts
@@ -115,6 +115,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     // authenticated caller could restore any trashed page in any drive (IDOR).
     // The decision itself is the pure `canRestorePage`; this shell only resolves
     // the facts it consumes.
+    // `withinTokenScope` is always true here because `checkMCPPageScope` above
+    // already returned on an out-of-scope token; we still pass it so the pure
+    // decision models the full rule (defense-in-depth) rather than assuming it.
     const canDelete = await canUserDeletePage(auth.userId, pageId);
     if (!canRestorePage({ canDelete, withinTokenScope: scopeError === null })) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });

--- a/apps/web/src/app/api/pages/[pageId]/restore/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/route.ts
@@ -8,6 +8,8 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope } from '@/lib/auth';
+import { canUserDeletePage } from '@pagespace/lib/permissions/permissions';
+import { canRestorePage } from './restore-authorization';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import { ensureTaskItemForPage } from '@/services/api/task-sync-service';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
@@ -90,7 +92,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   }
 
   try {
-    // Check MCP token scope before page access
+    // Check MCP token scope before page access. Keeps scoped MCP tokens bounded
+    // to their drives (returns 403/404). Session auth and unscoped tokens pass.
     const scopeError = await checkMCPPageScope(auth, pageId);
     if (scopeError) return scopeError;
 
@@ -105,6 +108,16 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
 
     if (!page || !page.isTrashed) {
       return NextResponse.json({ error: 'Page is not in trash' }, { status: 400 });
+    }
+
+    // Resource authorization (security finding H1): require the SAME delete/manage
+    // permission the sibling trash endpoint enforces. Without this, any
+    // authenticated caller could restore any trashed page in any drive (IDOR).
+    // The decision itself is the pure `canRestorePage`; this shell only resolves
+    // the facts it consumes.
+    const canDelete = await canUserDeletePage(auth.userId, pageId);
+    if (!canRestorePage({ canDelete, withinTokenScope: scopeError === null })) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     const actorInfo = await getActorInfo(auth.userId);


### PR DESCRIPTION
## Finding: H1 — IDOR in page restore

`POST /api/pages/[pageId]/restore` authenticated the caller, ran a no-op MCP scope check (`checkMCPPageScope` is a pass-through for session auth — sessions get full access), and verified the page existed and was trashed. It performed **no resource authorization**.

### Attack closed
Any authenticated user could restore **any** trashed page in **any** drive — recursively restoring its children, re-parenting orphans, firing deferred workflow triggers, and broadcasting a `restored` realtime event into the victim's drive. The sibling permanent-delete endpoint (`/api/trash/[pageId]`) gates on `canUserDeletePage`; restore did not.

### Fix
Before any mutation, require the **same** guard the trash endpoint uses — `canUserDeletePage(userId, pageId)` from `@pagespace/lib` permissions — and return **403** if false. Scoped MCP token enforcement (`checkMCPPageScope`) stays intact, so scoped tokens remain bounded to their drives.

### Pure function + tests
The security decision is isolated into a pure, side-effect-free helper:

- `canRestorePage({ canDelete, withinTokenScope }): boolean` in `restore-authorization.ts` — `withinTokenScope && canDelete`. The route shell resolves the facts (await params, authenticate, MCP scope, delete-permission lookup) then calls it.

Tests added:
- **`restore-authorization.test.ts`** (pure fn, 8 cases): owner/admin/editor allowed; viewer/non-member denied; out-of-scope MCP token denied even when the user could delete; exhaustive 2×2 fact matrix.
- **`route.test.ts`** (handler, mocked auth + permissions + db): unauthorized caller → **403** with **no** transaction / mutation / broadcast / trigger tracking; permission checked against `(userId, pageId)`; authorized caller → **200** restore; scoped MCP token rejected before the permission lookup.

### Verification
- `bun run --filter 'web' typecheck` → exit 0
- `bunx vitest run "src/app/api/pages/[pageId]/restore/"` → **28 passed** (8 pure-fn + 20 handler)
- `bun run --filter 'web' lint` → exit 0 (only pre-existing warnings in unrelated files)
- `bun run --filter 'web' test -- security-audit-coverage.test.ts` → **4 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)