### PR TITLE
fix(security): lock credit row before monthly refill

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-core.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-core.test.ts
@@ -445,6 +445,36 @@ describe('computeMonthlyRefill', () => {
     expect(computeMonthlyRefill('enterprise' as SubscriptionTier, ALLOWANCE))
       .toEqual({ monthlyRemainingCents: 50, monthlyAllowanceCents: 50, debtCents: 0 });
   });
+
+  it('treats a negative debt input as no debt (no phantom credit from a negative)', () => {
+    // A negative debt must not inflate the carry. netCarried = max(0, -100) ignored →
+    // 100 remaining + 500 allowance = 600, identical to passing 0 debt.
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 100, -100)).toEqual({
+      monthlyRemainingCents: 600,
+      monthlyAllowanceCents: 500,
+      debtCents: 0,
+    });
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 100, -100))
+      .toEqual(computeMonthlyRefill('free', FLAT_ALLOWANCE, 100, 0));
+  });
+
+  it('exactly nets debt to zero carry, then adds the allowance (period rollover boundary)', () => {
+    // 500¢ remaining exactly cancels 500¢ debt → net carry 0 → 0 + 500 allowance = 500.
+    expect(computeMonthlyRefill('free', FLAT_ALLOWANCE, 500, 500)).toEqual({
+      monthlyRemainingCents: 500,
+      monthlyAllowanceCents: 500,
+      debtCents: 0,
+    });
+  });
+
+  it('rolls a large carried balance forward across the period (accumulation, no cap)', () => {
+    // Credits never expire: 100_000¢ carried + 1500 pro allowance = 101_500.
+    expect(computeMonthlyRefill('pro', ALLOWANCE, 100_000)).toEqual({
+      monthlyRemainingCents: 101_500,
+      monthlyAllowanceCents: 1500,
+      debtCents: 0,
+    });
+  });
 });
 
 describe('applyPaymentToDebt', () => {

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -113,25 +113,42 @@ function mockLazyInitTransaction(
 
 /**
  * Mock the reset transaction (first db.transaction call when the period has expired).
- * Captures the set payload and ledger values. `didUpdate` controls whether the
- * UPDATE .returning() reports a match (true = reset ran, false = concurrent already ran).
+ * The fixed transaction re-reads the balance under `FOR UPDATE` INSIDE the txn and
+ * computes the refill from THAT locked row — never from the unlocked pre-read. The
+ * `lockedRow` argument is what that in-transaction `select(...).for('update')`
+ * resolves to; it is the source of truth for the refill arithmetic, so a test can
+ * make it diverge from the pre-read snapshot to prove the ordering. A null/empty
+ * `lockedRow` (or one whose window is no longer expired) models a concurrent reset
+ * that already rolled the window forward: the fix must skip the UPDATE + ledger write.
+ * Captures the set payload and ledger values.
  */
 function mockResetTransaction(
-  sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {},
-  didUpdate = true,
+  sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {},
+  lockedRow: Record<string, unknown> | null = null,
 ) {
   mockDb.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<unknown>) => {
     const tx = {
-      update: vi.fn(() => ({
-        set: (v: Record<string, unknown>) => {
-          sink.set = v;
-          return {
-            where: () => ({
-              returning: () => Promise.resolve(didUpdate ? [{ userId: 'ignored' }] : []),
-            }),
-          };
-        },
+      select: vi.fn(() => ({
+        from: () => ({ where: () => ({ for: () => Promise.resolve(lockedRow ? [lockedRow] : []) }) }),
       })),
+      update: vi.fn(() => {
+        sink.updateCalled = true;
+        return {
+          set: (v: Record<string, unknown>) => {
+            sink.set = v;
+            // The fixed UPDATE targets by userId only (the row lock + post-lock predicate
+            // recheck handle the race), so it is awaited directly. Expose a thenable that
+            // also answers .returning() so a pre-fix implementation calling .returning()
+            // surfaces a clean assertion mismatch rather than a TypeError.
+            return {
+              where: () => ({
+                returning: () => Promise.resolve([{ userId: 'ignored' }]),
+                then: (resolve: (v: unknown) => unknown) => resolve(undefined),
+              }),
+            };
+          },
+        };
+      }),
       insert: vi.fn(() => ({
         values: (v: Record<string, unknown>) => {
           sink.ledgerValues = v;
@@ -312,7 +329,7 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockResetTransaction(sink);
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST });
     mockTransaction({ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
@@ -385,7 +402,7 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockResetTransaction(sink);
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
     mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
@@ -401,7 +418,7 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 700, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockResetTransaction(sink);
+    mockResetTransaction(sink, { monthlyRemainingCents: 200, debtCents: 0, monthlyPeriodEnd: PAST });
     mockTransaction({ monthlyRemainingCents: 700, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
@@ -415,7 +432,7 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 2500, monthlyPeriodEnd: null }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown> } = {};
-    mockResetTransaction(sink);
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: null });
     mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 2500, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'free');
@@ -515,7 +532,7 @@ describe('canConsumeAI', () => {
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
       .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
     const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {};
-    mockResetTransaction(sink);
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
     mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
 
     await canConsumeAI('u1', 'free');
@@ -531,6 +548,85 @@ describe('canConsumeAI', () => {
     // key; concurrent resets within the same millisecond de-duplicate via the index.
     expect(typeof sink.ledgerValues?.stripeRef).toBe('string');
     expect((sink.ledgerValues?.stripeRef as string).startsWith('free-reset-u1-')).toBe(true);
+  });
+
+  // ── Locked-read ordering (M7 race fix) ──────────────────────────────────────
+  // The refill MUST be computed from the balance read FOR UPDATE inside the reset
+  // transaction, never from the unlocked pre-transaction snapshot. Otherwise a
+  // mutation committed between the two reads is clobbered by the reset.
+
+  it('computes the refill from the post-lock read, NOT the unlocked pre-read snapshot', async () => {
+    // Pre-transaction snapshot is stale: it shows 200¢ remaining. A concurrent settle
+    // commits before we take the row lock, leaving only 50¢. The locked read inside the
+    // txn must drive the refill: 50 + 500 = 550 (NOT the stale 200 + 500 = 700, which
+    // would silently un-bill the concurrent spend).
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 200, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 550, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown>; updateCalled?: boolean } = {};
+    // Locked row diverges from the pre-read: only 50¢ left.
+    mockResetTransaction(sink, { monthlyRemainingCents: 50, debtCents: 0, monthlyPeriodEnd: PAST });
+    mockTransaction({ monthlyRemainingCents: 550, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    // 550, not 700 — proves the refill used the locked read.
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 550, monthlyAllowanceCents: 500, debtCents: 0 });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('nets debt from the LOCKED row so a concurrent debt-clearing top-up is not collected twice', async () => {
+    // Pre-read snapshot shows 300¢ debt. A concurrent top-up pays it off before we lock,
+    // so the locked read shows 0 debt. The refill must net against the locked debt (0):
+    // 0 + 500 = 500. Using the stale 300¢ debt would re-collect already-paid debt
+    // (0 − 300 + 500 = 200), shorting the user 300¢.
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, debtCents: 300, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown> } = {};
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 500, debtCents: 0 });
+    expect(r.allowed).toBe(true);
+  });
+
+  it('skips the UPDATE + grant when the locked read shows the window already rolled forward (concurrent reset won)', async () => {
+    // The unlocked pre-read still shows an expired window, so we open the reset txn —
+    // but by the time we hold the lock a concurrent reset has rolled the window into the
+    // FUTURE. We must NOT update or write a grant; just re-read and proceed.
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {};
+    // Locked window is FUTURE → predicate recheck fails → skip.
+    mockResetTransaction(sink, { monthlyRemainingCents: 500, debtCents: 0, monthlyPeriodEnd: FUTURE });
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    expect(sink.updateCalled).toBeFalsy();
+    expect(sink.set).toBeUndefined();
+    expect(sink.ledgerValues).toBeUndefined();
+    // The post-reset re-read picks up the concurrently-rolled balance and the gate allows.
+    expect(r.allowed).toBe(true);
+  });
+
+  it('skips the UPDATE + grant when the locked read finds no row (row removed before the lock)', async () => {
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {};
+    mockResetTransaction(sink, null); // locked read returns []
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    expect(sink.updateCalled).toBeFalsy();
+    expect(sink.ledgerValues).toBeUndefined();
+    expect(r.allowed).toBe(true);
   });
 });
 

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -16,7 +16,7 @@
 
 import { db } from '@pagespace/db/db';
 import { creditBalances, creditHolds, creditLedger } from '@pagespace/db/schema/credits';
-import { and, eq, gt, gte, lt, or, isNull, inArray, sql } from '@pagespace/db/operators';
+import { and, eq, gt, gte, inArray, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import {
   evaluateGate,
@@ -136,17 +136,54 @@ export async function canConsumeAI(
   // subscription-backed balance here would over-grant if a renewal invoice is late
   // or retried after the period end — the gate would refill, the user could spend,
   // then the webhook would refill again. A paid user with an expired window is
-  // therefore (correctly) blocked until their renewal lands. The UPDATE re-checks
-  // the same predicate in its WHERE, so a concurrent reset/refill that rolled the
-  // window forward between our read and write matches zero rows and we re-read.
+  // therefore (correctly) blocked until their renewal lands.
+  //
+  // The unlocked `row` read above is only a cheap pre-check: it decides whether a
+  // reset is even worth attempting (don't open a transaction when the window is
+  // clearly still active). The authoritative balance read + refill computation happen
+  // INSIDE the transaction under `FOR UPDATE`, mirroring applyMonthlyRefill in
+  // credit-funding.ts. Computing the refill from this pre-transaction snapshot races
+  // any concurrent mutation committed between the read and the write: a concurrent
+  // settle would have its spend silently un-billed (the reset would overwrite the
+  // drawn-down balance with stale_remaining + allowance), and a concurrent
+  // debt-clearing top-up would have its debt collected twice (the reset re-nets the
+  // already-paid debt). Reading the row under the lock closes both interleavings.
   if (tier === 'free' && row && (row.monthlyPeriodEnd === null || row.monthlyPeriodEnd < now)) {
-    // Pass the current remaining so unspent credits roll over into the new period
-    // (matching the paid invoice.paid path). The WHERE re-checks the predicate to
-    // handle a concurrent reset that already rolled the window forward.
-    const refill = computeMonthlyRefill(tier, TIER_MONTHLY_ALLOWANCE_CENTS, row.monthlyRemainingCents ?? 0, row.debtCents ?? 0);
     const newEnd = addOneMonth(now);
     await db.transaction(async (tx) => {
-      const updated = await tx
+      // Lock the balance row and RE-READ the current monthly/debt values inside the
+      // transaction. The lock serialises concurrent resets for this user and forces
+      // us to observe any settle/top-up that committed since the unlocked pre-check.
+      const lockedRows = await tx
+        .select({
+          monthlyRemainingCents: creditBalances.monthlyRemainingCents,
+          debtCents: creditBalances.debtCents,
+          monthlyPeriodEnd: creditBalances.monthlyPeriodEnd,
+        })
+        .from(creditBalances)
+        .where(eq(creditBalances.userId, userId))
+        .for('update');
+      const locked = lockedRows[0] ?? null;
+
+      // Re-check the reset predicate against the LOCKED row. A concurrent reset may
+      // have rolled the window forward (or the row may have vanished) between our
+      // unlocked pre-check and acquiring the lock; if the window is no longer expired,
+      // that other request already granted this period — skip to avoid a double grant.
+      if (!locked || !(locked.monthlyPeriodEnd === null || locked.monthlyPeriodEnd < now)) {
+        return;
+      }
+
+      // Compute the refill from the LOCKED, current balance so unspent credits roll
+      // over and outstanding debt is netted against the up-to-date carry (matching the
+      // paid invoice.paid path), not against the stale pre-transaction snapshot.
+      const refill = computeMonthlyRefill(
+        tier,
+        TIER_MONTHLY_ALLOWANCE_CENTS,
+        locked.monthlyRemainingCents ?? 0,
+        locked.debtCents ?? 0,
+      );
+
+      await tx
         .update(creditBalances)
         .set({
           monthlyRemainingCents: refill.monthlyRemainingCents,
@@ -157,27 +194,22 @@ export async function canConsumeAI(
           monthlyPeriodStart: now,
           monthlyPeriodEnd: newEnd,
         })
-        .where(and(
-          eq(creditBalances.userId, userId),
-          or(isNull(creditBalances.monthlyPeriodEnd), lt(creditBalances.monthlyPeriodEnd, now)),
-        ))
-        .returning({ userId: creditBalances.userId });
-      // Only record the grant when this call won the race — if a concurrent reset
-      // already rolled the window forward, updated is empty and we skip the ledger
-      // write to avoid a phantom grant entry.
-      if (updated.length > 0) {
-        await tx
-          .insert(creditLedger)
-          .values({
-            userId,
-            entryType: 'monthly_grant',
-            bucket: 'monthly',
-            amountCents: refill.monthlyAllowanceCents,
-            stripeRef: `free-reset-${userId}-${now.toISOString()}`,
-            consumeStatus: 'applied',
-          })
-          .onConflictDoNothing(STRIPE_REF_ARBITER);
-      }
+        .where(eq(creditBalances.userId, userId));
+
+      // Record the grant. We only reach here holding the lock with a confirmed-expired
+      // window, so this call owns the reset; onConflictDoNothing on the period-keyed
+      // stripeRef is a belt-and-suspenders guard against a same-instant duplicate key.
+      await tx
+        .insert(creditLedger)
+        .values({
+          userId,
+          entryType: 'monthly_grant',
+          bucket: 'monthly',
+          amountCents: refill.monthlyAllowanceCents,
+          stripeRef: `free-reset-${userId}-${now.toISOString()}`,
+          consumeStatus: 'applied',
+        })
+        .onConflictDoNothing(STRIPE_REF_ARBITER);
     });
     row = await readBalance();
   }


### PR DESCRIPTION
## Finding: M7 — Free-tier monthly reset computes balance from an unlocked pre-transaction read

Audit (2026-06-09), `packages/lib/src/billing/credit-gate.ts`. The free/no-subscription gate-driven monthly reset read the balance with a plain non-locking `select`, computed `computeMonthlyRefill` **outside** the transaction from that stale snapshot, and the `UPDATE`'s `WHERE` only rechecked period expiry — never balance staleness. Any mutation committed between the read and the write was clobbered by the reset.

### Race closed
- **Concurrent settle → spend silently un-billed.** A `consumeCredits` settle drew the monthly balance down between the read and the write; the reset overwrote it with `stale_remaining + allowance`, restoring the spent amount.
- **Concurrent debt-clearing top-up → debt collected twice.** A top-up paid down `debtCents`; the reset re-netted the already-paid debt (`stale_remaining − stale_debt + allowance`), shorting the user.

### Fix
Move the balance read + `computeMonthlyRefill` **inside** the reset transaction under `.for('update')`, mirroring `applyMonthlyRefill` in `credit-funding.ts:205-212`. The refill is now computed from the locked, current row. The reset predicate is re-checked against the locked row and the `UPDATE` + grant are skipped when a concurrent reset already rolled the window forward (or the row vanished) — replacing the prior `returning()`-based race check, which the row lock + post-lock recheck now subsume. `computeMonthlyRefill` stays pure; integer cents only; `-0`/clamp guards preserved.

### Tests (strict TDD, RED-first)
- 4 new ordering tests in `credit-gate.test.ts` — each **fails against the pre-fix code** and passes after:
  - refill computed from the post-lock read, not the unlocked pre-read snapshot (lost-spend interleaving: 550 not 700)
  - debt netted from the locked row so a concurrent debt-clearing top-up isn't collected twice
  - skip `UPDATE` + grant when the locked read shows the window already rolled forward
  - skip when the locked read finds no row
- Strengthened `computeMonthlyRefill` unit cases (`credit-core.test.ts`): negative-debt treated as no debt, exact net-zero carry, large carryover rollover.

### Verification
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bunx vitest run src/billing` — **243 passed** (incl. `credit-gate-concurrency` + `cost-reconcile` integration after building `@pagespace/db`)
- RED proof: the 4 new tests fail against the pre-fix `credit-gate.ts` (verified via stash), pass after.
- `test:security` not applicable — no security suite references the credit gate (it targets auth/permission surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)