### PR TITLE
fix(security): filter page-tree context by per-page access

### DIFF
--- a/apps/web/src/lib/ai/core/page-tree-context.ts
+++ b/apps/web/src/lib/ai/core/page-tree-context.ts
@@ -8,8 +8,7 @@
 import { db } from '@pagespace/db/db'
 import { eq, and, asc } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core';
-import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
-import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
+import { getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { buildTree, formatTreeAsMarkdown, filterToSubtree, filterTreeNodesByAccess } from '@pagespace/lib/content/tree-utils';
 
@@ -83,11 +82,15 @@ export async function getPageTreeContext(
     }
 
     // Drive access alone does NOT authorize seeing every page's title/type/id:
-    // restrict the tree to the actor's per-page accessible set (the same
-    // canonical source the AI search tools use) so private-page structure never
-    // leaks into the system prompt. Ancestor-gated: an inaccessible page hides
-    // its whole subtree.
-    const accessibleIds = new Set(await accessiblePageIds(userId));
+    // restrict the tree to the user's per-page accessible set so private-page
+    // structure never leaks into the system prompt. We use the SAME source the
+    // AI search tools use (getActorAccessiblePagesInDrive → this fn) and that
+    // the page-view entry gate (getUserAccessLevel) honors — including custom
+    // drive-role grants on private pages and custom-role denials of otherwise-
+    // public pages — so the tree exactly matches what the user can actually see.
+    // Ancestor-gated: an inaccessible page hides its whole subtree.
+    const accessiblePages = await getUserAccessiblePagesInDriveWithDetails(userId, driveId);
+    const accessibleIds = new Set(accessiblePages.map(p => p.id));
     const beforeFilter = nodes.length;
     nodes = filterTreeNodesByAccess(nodes, accessibleIds);
     loggers.ai.debug('Filtered page tree by per-page access', {

--- a/apps/web/src/lib/ai/core/page-tree-context.ts
+++ b/apps/web/src/lib/ai/core/page-tree-context.ts
@@ -9,8 +9,9 @@ import { db } from '@pagespace/db/db'
 import { eq, and, asc } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core';
 import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
+import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { buildTree, formatTreeAsMarkdown, filterToSubtree } from '@pagespace/lib/content/tree-utils';
+import { buildTree, formatTreeAsMarkdown, filterToSubtree, filterTreeNodesByAccess } from '@pagespace/lib/content/tree-utils';
 
 interface TreeNode {
   id: string;
@@ -80,6 +81,21 @@ export async function getPageTreeContext(
       nodes = filterToSubtree(nodes, pageId);
       loggers.ai.debug('Filtered to subtree', { pageId, nodeCount: nodes.length });
     }
+
+    // Drive access alone does NOT authorize seeing every page's title/type/id:
+    // restrict the tree to the actor's per-page accessible set (the same
+    // canonical source the AI search tools use) so private-page structure never
+    // leaks into the system prompt. Ancestor-gated: an inaccessible page hides
+    // its whole subtree.
+    const accessibleIds = new Set(await accessiblePageIds(userId));
+    const beforeFilter = nodes.length;
+    nodes = filterTreeNodesByAccess(nodes, accessibleIds);
+    loggers.ai.debug('Filtered page tree by per-page access', {
+      driveId,
+      userId,
+      beforeFilter,
+      afterFilter: nodes.length,
+    });
 
     if (nodes.length === 0) {
       return '';

--- a/packages/lib/src/__tests__/tree-utils.test.ts
+++ b/packages/lib/src/__tests__/tree-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildTree, calculateSafeDepth, formatTreeAsMarkdown, filterToSubtree } from '../content/tree-utils'
+import { buildTree, calculateSafeDepth, formatTreeAsMarkdown, filterToSubtree, filterTreeNodesByAccess } from '../content/tree-utils'
 
 describe('tree-utils', () => {
   describe('buildTree', () => {
@@ -635,6 +635,147 @@ describe('tree-utils', () => {
       expect(result).toContain('    ')
       expect(result).toContain('Sub')
       expect(result).toContain('Sub2')
+    })
+  })
+
+  describe('filterTreeNodesByAccess', () => {
+    const set = (...ids: string[]) => new Set(ids)
+
+    it('returns empty array for empty input', () => {
+      expect(filterTreeNodesByAccess([], set('1'))).toEqual([])
+    })
+
+    it('keeps every node when all are accessible', () => {
+      const nodes = [
+        { id: '1', parentId: null },
+        { id: '2', parentId: '1' },
+        { id: '3', parentId: '2' },
+      ]
+
+      const result = filterTreeNodesByAccess(nodes, set('1', '2', '3'))
+
+      expect(result.map(n => n.id)).toEqual(['1', '2', '3'])
+    })
+
+    it('drops every node when none are accessible', () => {
+      const nodes = [
+        { id: '1', parentId: null },
+        { id: '2', parentId: '1' },
+      ]
+
+      expect(filterTreeNodesByAccess(nodes, set())).toEqual([])
+    })
+
+    it('drops an inaccessible root and its entire (orphaned) subtree even when descendants are individually accessible', () => {
+      const nodes = [
+        { id: 'private-root', parentId: null },
+        { id: 'child', parentId: 'private-root' },
+        { id: 'grandchild', parentId: 'child' },
+      ]
+
+      // child + grandchild are in the accessible set, but their ancestor is not.
+      const result = filterTreeNodesByAccess(nodes, set('child', 'grandchild'))
+
+      expect(result).toEqual([])
+    })
+
+    it('drops a leaf whose intermediate ancestor is inaccessible (ancestor-gated policy)', () => {
+      const nodes = [
+        { id: 'root', parentId: null },
+        { id: 'middle', parentId: 'root' },
+        { id: 'leaf', parentId: 'middle' },
+      ]
+
+      // root and leaf accessible, but the middle ancestor is not.
+      const result = filterTreeNodesByAccess(nodes, set('root', 'leaf'))
+
+      expect(result.map(n => n.id)).toEqual(['root'])
+    })
+
+    it('keeps only the accessible sibling', () => {
+      const nodes = [
+        { id: 'root', parentId: null },
+        { id: 'public-child', parentId: 'root' },
+        { id: 'private-child', parentId: 'root' },
+      ]
+
+      const result = filterTreeNodesByAccess(nodes, set('root', 'public-child'))
+
+      expect(result.map(n => n.id)).toEqual(['root', 'public-child'])
+    })
+
+    it('treats a node whose parent is absent from the list as a root boundary', () => {
+      // parentId points outside the provided node set (e.g. trashed/other-drive parent).
+      const nodes = [
+        { id: 'directly-shared', parentId: 'parent-not-in-set' },
+        { id: 'child', parentId: 'directly-shared' },
+      ]
+
+      const result = filterTreeNodesByAccess(nodes, set('directly-shared', 'child'))
+
+      // Only self + present ancestors are required; the absent parent is a boundary.
+      expect(result.map(n => n.id)).toEqual(['directly-shared', 'child'])
+    })
+
+    it('preserves the original parent/child shape after buildTree (no re-rooting of orphans)', () => {
+      const nodes = [
+        { id: 'r', parentId: null, title: 'Root', position: 0 },
+        { id: 'a', parentId: 'r', title: 'A', position: 0 },
+        { id: 'b', parentId: 'r', title: 'B (private)', position: 1 },
+        { id: 'b1', parentId: 'b', title: 'B child', position: 0 },
+        { id: 'a1', parentId: 'a', title: 'A child', position: 0 },
+      ]
+
+      // 'b' is private; 'b1' is accessible but should be dropped with its parent.
+      const filtered = filterTreeNodesByAccess(nodes, set('r', 'a', 'a1', 'b1'))
+      const tree = buildTree(filtered)
+
+      expect(tree).toHaveLength(1)
+      expect(tree[0].id).toBe('r')
+      expect(tree[0].children.map(c => c.id)).toEqual(['a'])
+      expect(tree[0].children[0].children.map(c => c.id)).toEqual(['a1'])
+    })
+
+    it('does not mutate the input array', () => {
+      const nodes = [
+        { id: '1', parentId: null },
+        { id: '2', parentId: '1' },
+      ]
+      const snapshot = [...nodes]
+
+      filterTreeNodesByAccess(nodes, set('1'))
+
+      expect(nodes).toEqual(snapshot)
+    })
+
+    it('fails closed on a parentId cycle (no infinite loop)', () => {
+      const nodes = [
+        { id: 'x', parentId: 'y' },
+        { id: 'y', parentId: 'x' },
+      ]
+
+      // Even though both ids are "accessible", a cycle has no real root → drop both.
+      const result = filterTreeNodesByAccess(nodes, set('x', 'y'))
+
+      expect(result).toEqual([])
+    })
+
+    it('drops a node that is its own parent (self-cycle)', () => {
+      const nodes = [{ id: 'self', parentId: 'self' }]
+
+      expect(filterTreeNodesByAccess(nodes, set('self'))).toEqual([])
+    })
+
+    it('handles a deep fully-accessible chain', () => {
+      const nodes = Array.from({ length: 50 }, (_, i) => ({
+        id: `n${i}`,
+        parentId: i === 0 ? null : `n${i - 1}`,
+      }))
+      const accessible = new Set(nodes.map(n => n.id))
+
+      const result = filterTreeNodesByAccess(nodes, accessible)
+
+      expect(result).toHaveLength(50)
     })
   })
 })

--- a/packages/lib/src/__tests__/tree-utils.test.ts
+++ b/packages/lib/src/__tests__/tree-utils.test.ts
@@ -777,5 +777,57 @@ describe('tree-utils', () => {
 
       expect(result).toHaveLength(50)
     })
+
+    it('keeps many siblings that share one accessible ancestor (memoized path)', () => {
+      const nodes = [
+        { id: 'root', parentId: null },
+        ...Array.from({ length: 100 }, (_, i) => ({ id: `c${i}`, parentId: 'root' })),
+      ]
+      const accessible = new Set(nodes.map(n => n.id))
+
+      const result = filterTreeNodesByAccess(nodes, accessible)
+
+      expect(result).toHaveLength(101)
+    })
+
+    it('drops a whole wide subtree under one inaccessible ancestor', () => {
+      const nodes = [
+        { id: 'private', parentId: null },
+        ...Array.from({ length: 100 }, (_, i) => ({ id: `c${i}`, parentId: 'private' })),
+      ]
+      // children are accessible, ancestor is not.
+      const accessible = new Set(nodes.filter(n => n.id !== 'private').map(n => n.id))
+
+      expect(filterTreeNodesByAccess(nodes, accessible)).toEqual([])
+    })
+
+    it('resolves a large deep+wide forest in linear time (no O(n^2) blowup)', () => {
+      // 2000-deep spine; each spine node also has one leaf child.
+      const nodes: { id: string; parentId: string | null }[] = []
+      for (let i = 0; i < 2000; i++) {
+        nodes.push({ id: `s${i}`, parentId: i === 0 ? null : `s${i - 1}` })
+        nodes.push({ id: `leaf${i}`, parentId: `s${i}` })
+      }
+      const accessible = new Set(nodes.map(n => n.id))
+
+      const result = filterTreeNodesByAccess(nodes, accessible)
+
+      expect(result).toHaveLength(4000)
+    })
+
+    it('hides accessible descendants beneath a mid-spine inaccessible node in a deep tree', () => {
+      const nodes = Array.from({ length: 100 }, (_, i) => ({
+        id: `n${i}`,
+        parentId: i === 0 ? null : `n${i - 1}`,
+      }))
+      // Everything accessible EXCEPT the node at depth 50.
+      const accessible = new Set(nodes.map(n => n.id))
+      accessible.delete('n50')
+
+      const result = filterTreeNodesByAccess(nodes, accessible).map(n => n.id)
+
+      // n0..n49 visible; n50 (inaccessible) and all below hidden.
+      expect(result).toEqual(Array.from({ length: 50 }, (_, i) => `n${i}`))
+    })
   })
 })

--- a/packages/lib/src/content/tree-utils.ts
+++ b/packages/lib/src/content/tree-utils.ts
@@ -180,3 +180,59 @@ export function filterToSubtree<T extends { id: string; parentId: string | null 
 
   return nodes.filter(n => descendantIds.has(n.id));
 }
+
+/**
+ * Filter a flat list of tree nodes down to those an actor may access.
+ *
+ * Security policy (ancestor-gated): a node is kept ONLY IF it is itself present
+ * in `accessiblePageIds` AND every one of its ancestors that is present in
+ * `nodes` is also accessible. Dropping an inaccessible node therefore also drops
+ * its now-orphaned descendant subtree, even when those descendants are
+ * individually in the accessible set.
+ *
+ * This deliberately avoids re-parenting an accessible descendant of an
+ * inaccessible node to a fabricated root: doing so would alter the true
+ * parent/child shape and could imply structure about (or the existence of) the
+ * inaccessible ancestor. The result is always a sub-forest of the input, so
+ * feeding it to `buildTree` reproduces the original shape minus the dropped
+ * branches.
+ *
+ * Boundary handling matches `buildTree`: a node whose `parentId` is null, or
+ * whose parent is absent from `nodes`, is treated as a root — only its own
+ * accessibility is required at that point. A `parentId` cycle (which has no real
+ * root) fails closed and drops the cycle's members.
+ */
+export function filterTreeNodesByAccess<T extends { id: string; parentId: string | null }>(
+  nodes: T[],
+  accessiblePageIds: ReadonlySet<string>
+): T[] {
+  const byId = new Map<string, T>();
+  for (const node of nodes) {
+    byId.set(node.id, node);
+  }
+
+  function isVisible(start: T): boolean {
+    const seen = new Set<string>();
+    let current: T | undefined = start;
+
+    while (current) {
+      // A parentId cycle never reaches a real root — fail closed.
+      if (seen.has(current.id)) return false;
+      seen.add(current.id);
+
+      if (!accessiblePageIds.has(current.id)) return false;
+
+      // Null parent => this node is a root: every node on the chain so far was
+      // accessible, so the node is visible.
+      if (current.parentId === null) return true;
+
+      // Parent absent from the list => root boundary (matches buildTree); the
+      // node is visible because all present ancestors checked were accessible.
+      current = byId.get(current.parentId);
+    }
+
+    return true;
+  }
+
+  return nodes.filter(isVisible);
+}

--- a/packages/lib/src/content/tree-utils.ts
+++ b/packages/lib/src/content/tree-utils.ts
@@ -201,6 +201,11 @@ export function filterToSubtree<T extends { id: string; parentId: string | null 
  * whose parent is absent from `nodes`, is treated as a root — only its own
  * accessibility is required at that point. A `parentId` cycle (which has no real
  * root) fails closed and drops the cycle's members.
+ *
+ * Visibility is memoized per node id, so each ancestor edge is traversed at most
+ * once: the whole filter is O(n) regardless of tree depth (a deep, e.g.
+ * API-created, chain does not degrade to O(n²)). The ancestor walk is iterative,
+ * so depth cannot overflow the call stack.
  */
 export function filterTreeNodesByAccess<T extends { id: string; parentId: string | null }>(
   nodes: T[],
@@ -211,27 +216,53 @@ export function filterTreeNodesByAccess<T extends { id: string; parentId: string
     byId.set(node.id, node);
   }
 
+  // id -> final visible/hidden decision (memo across all nodes).
+  const visible = new Map<string, boolean>();
+
   function isVisible(start: T): boolean {
-    const seen = new Set<string>();
+    // Walk up the ancestor chain, stacking accessible nodes whose visibility is
+    // not yet known, until we hit a resolved boundary. Then propagate that
+    // boundary result back down to every stacked node in one pass.
+    const pending: T[] = [];
+    const onPath = new Set<string>();
     let current: T | undefined = start;
+    let boundary: boolean;
 
-    while (current) {
-      // A parentId cycle never reaches a real root — fail closed.
-      if (seen.has(current.id)) return false;
-      seen.add(current.id);
+    for (;;) {
+      // Parent absent from the list => root boundary (matches buildTree).
+      if (current === undefined) { boundary = true; break; }
 
-      if (!accessiblePageIds.has(current.id)) return false;
+      const cached = visible.get(current.id);
+      if (cached !== undefined) { boundary = cached; break; }
 
-      // Null parent => this node is a root: every node on the chain so far was
-      // accessible, so the node is visible.
-      if (current.parentId === null) return true;
+      // Revisiting a node on the current path => parentId cycle: fail closed.
+      if (onPath.has(current.id)) { boundary = false; break; }
 
-      // Parent absent from the list => root boundary (matches buildTree); the
-      // node is visible because all present ancestors checked were accessible.
+      if (!accessiblePageIds.has(current.id)) {
+        // Inaccessible ancestor: it (and everything stacked below it) is hidden.
+        visible.set(current.id, false);
+        boundary = false;
+        break;
+      }
+
+      if (current.parentId === null) {
+        // Accessible root: it is visible; stacked descendants inherit that.
+        visible.set(current.id, true);
+        boundary = true;
+        break;
+      }
+
+      pending.push(current);
+      onPath.add(current.id);
       current = byId.get(current.parentId);
     }
 
-    return true;
+    // Every node still pending was accessible and shares the boundary's verdict.
+    for (const node of pending) {
+      visible.set(node.id, boundary);
+    }
+
+    return visible.get(start.id) ?? boundary;
   }
 
   return nodes.filter(isVisible);


### PR DESCRIPTION
## Finding
**M1** — AI page-tree prompt leak (evidence doc `maz93dkkv2sdeaqav4apokm7`).

The AI system prompt's `## WORKSPACE STRUCTURE` block exposed the title, type, and id of **every** non-trashed page in a drive. `getPageTreeContext` only enforced a drive-level `getUserDriveAccess` gate; `queryDriveTree` then `SELECT`ed all pages in the drive with no per-page / `isPrivate` filter, so any drive member with an AI chat could see the structure of private pages they have no access to.

## Attack closed
A drive member opens an AI chat (page-scoped or global) with the page tree enabled. Previously the prompt enumerated private siblings/subtrees by name + id. Now the tree is restricted to the **user's per-page accessible set** — private-page structure never reaches the model.

## Fix
- Filter `queryDriveTree` results to the user's accessible page set **before** `buildTree`, for both `drive` and `children` scopes. Empty result → empty context (fail-closed).
- The accessible-set source is `getUserAccessiblePagesInDriveWithDetails(userId, driveId)` — the **exact engine the AI search tools use** (`getActorAccessiblePagesInDrive` → this fn) and that the page-view **entry gate** (`canUserViewPage` → `getUserAccessLevel`) honors. It is **custom-drive-role aware**: custom-role grants on private pages are included, and custom-role denials of otherwise-public pages are removed ("explicit deny beats Rule 4"). This avoids the divergence that the SQL `accessible_page_ids_for_user` primitive would have introduced (it models neither), which would have both leaked custom-denied public pages and hidden custom-granted private subtrees. Bonus: drive-scoped rather than account-wide.

## Pure function + tests
The security decision is isolated into a pure, exhaustively-tested function in `packages/lib/src/content/tree-utils.ts`:

```ts
filterTreeNodesByAccess(nodes, accessiblePageIdSet): nodes
```

**Policy (ancestor-gated):** a node is kept only if it *and every present ancestor* are accessible. Dropping an inaccessible node also drops its now-orphaned descendant subtree (even individually-accessible descendants), which preserves the true parent/child shape — no re-rooting an orphan to a fabricated root that would imply a hidden ancestor. Boundary handling matches `buildTree` (null/absent parent = root). Cycle-safe (parentId cycles fail closed). Non-mutating.

**Performance:** visibility is memoized per node id and the ancestor walk is iterative, so the filter is **O(n)** regardless of depth (a deep/API-created chain does not degrade to O(n²)) and pathological depth cannot overflow the stack. (Addresses Codex P2.)

**16 unit tests** cover: empty input, all/none accessible, inaccessible-root orphan-subtree drop, intermediate-ancestor gating, sibling filtering, absent-parent boundary, post-`buildTree` shape preservation, no-mutation, parentId cycle, self-cycle, deep chain, shared-ancestor fan-out, wide subtree dropped under an inaccessible ancestor, 4000-node deep+wide forest, mid-spine inaccessible cutoff. The function was additionally differential-fuzzed against an independent reference over 260k randomized graphs (all node orderings) with zero mismatches.

## Verification
- `bun run typecheck` — **green** (`@pagespace/lib` + `web`)
- `bun run --filter '@pagespace/lib' test` — **green**, 4888+ passed (incl. `tree-utils`, 16 access-filter cases)
- `bun run lint` — **green** (`@pagespace/lib` + `web`; only pre-existing unrelated warnings)
- `bun run test:security` — the relevant **Permissions** suite passes (344 tests in isolation). A few unrelated auth/session/route suites are flaky under the parallel harness (DB-dependent) and import none of the files changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)