### PR TITLE
fix(security): filter get_activity by per-page access

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/activity-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/activity-tools.test.ts
@@ -16,7 +16,7 @@ vi.mock('@pagespace/lib/services/page-content-store', () => ({
     readPageContent: vi.fn(),
 }));
 
-import { activityTools } from '../activity-tools';
+import { activityTools, filterAccessibleActivities } from '../activity-tools';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core/types';
 
@@ -113,6 +113,85 @@ describe('activity-tools', () => {
       await expect(
         activityTools.get_activity.execute!(createTestInput({ includeContentDiffs: true }), context)
       ).rejects.toThrow('User authentication required');
+    });
+  });
+
+  // Security finding H2: get_activity authorized only at the DRIVE level, so a
+  // plain member received titles + content deltas for pages they cannot view.
+  // The access decision is isolated in this pure function and exhaustively
+  // unit-tested here; the execute() shell just builds the accessible-page set.
+  describe('filterAccessibleActivities', () => {
+    type Row = { id: string; pageId: string | null; driveId?: string | null };
+    const row = (id: string, pageId: string | null): Row => ({ id, pageId, driveId: 'drive-1' });
+
+    it('removes rows whose pageId is NOT in the accessible set (the leak)', () => {
+      const rows = [row('a', 'page-public'), row('b', 'page-private')];
+      const accessible = new Set(['page-public']);
+
+      const result = filterAccessibleActivities(rows, accessible);
+
+      expect(result.map((r) => r.id)).toEqual(['a']);
+      expect(result.some((r) => r.pageId === 'page-private')).toBe(false);
+    });
+
+    it('keeps rows whose pageId IS in the accessible set', () => {
+      const rows = [row('a', 'page-1'), row('b', 'page-2')];
+      const accessible = new Set(['page-1', 'page-2']);
+
+      const result = filterAccessibleActivities(rows, accessible);
+
+      expect(result.map((r) => r.id)).toEqual(['a', 'b']);
+    });
+
+    it('RETAINS rows with a null pageId — drive-scoped activity has no page content to leak', () => {
+      const rows = [row('member-add', null), row('perm-change', null)];
+      const accessible = new Set<string>(); // empty: the actor can view no pages
+
+      const result = filterAccessibleActivities(rows, accessible);
+
+      expect(result.map((r) => r.id)).toEqual(['member-add', 'perm-change']);
+    });
+
+    it('RETAINS rows with an absent (undefined) pageId per the same policy', () => {
+      const rows = [{ id: 'no-page' } as Row];
+      const result = filterAccessibleActivities(rows, new Set(['page-1']));
+      expect(result.map((r) => r.id)).toEqual(['no-page']);
+    });
+
+    it('drops ALL page-scoped rows when the accessible set is empty, but keeps drive-scoped rows', () => {
+      const rows = [row('a', 'page-1'), row('b', null), row('c', 'page-2')];
+
+      const result = filterAccessibleActivities(rows, new Set<string>());
+
+      expect(result.map((r) => r.id)).toEqual(['b']);
+    });
+
+    it('handles a mixed batch: viewable pages pass, private pages dropped, drive rows kept', () => {
+      const rows = [
+        row('view-1', 'p1'),
+        row('private', 'p-secret'),
+        row('drive-op', null),
+        row('view-2', 'p2'),
+      ];
+      const accessible = new Set(['p1', 'p2']);
+
+      const result = filterAccessibleActivities(rows, accessible);
+
+      expect(result.map((r) => r.id)).toEqual(['view-1', 'drive-op', 'view-2']);
+    });
+
+    it('returns a new array and does not mutate its input', () => {
+      const rows = [row('a', 'p1'), row('b', 'p-secret')];
+      const snapshot = [...rows];
+
+      const result = filterAccessibleActivities(rows, new Set(['p1']));
+
+      expect(result).not.toBe(rows);
+      expect(rows).toEqual(snapshot); // input untouched
+    });
+
+    it('returns an empty array for empty input', () => {
+      expect(filterAccessibleActivities([], new Set(['p1']))).toEqual([]);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/activity-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/activity-tools.test.ts
@@ -16,7 +16,7 @@ vi.mock('@pagespace/lib/services/page-content-store', () => ({
     readPageContent: vi.fn(),
 }));
 
-import { activityTools, filterAccessibleActivities } from '../activity-tools';
+import { activityTools, filterAccessibleActivities, shouldContinuePaging } from '../activity-tools';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core/types';
 
@@ -192,6 +192,53 @@ describe('activity-tools', () => {
 
     it('returns an empty array for empty input', () => {
       expect(filterAccessibleActivities([], new Set(['p1']))).toEqual([]);
+    });
+  });
+
+  // Access filtering runs AFTER the DB applies its row cap, so the tool
+  // over-fetches and pages the window until it has `limit` VISIBLE rows —
+  // otherwise inaccessible private-page rows would consume the caller's cap
+  // (PR review feedback). This predicate decides when to stop paging.
+  describe('shouldContinuePaging', () => {
+    const base = {
+      collected: 0,
+      limit: 50,
+      scanned: 0,
+      maxScanned: 2000,
+      lastBatchSize: 200,
+      batchSize: 200,
+    };
+
+    it('continues when below limit, under the scan ceiling, and the last batch was full', () => {
+      expect(shouldContinuePaging(base)).toBe(true);
+    });
+
+    it('stops once enough visible rows have been collected', () => {
+      expect(shouldContinuePaging({ ...base, collected: 50 })).toBe(false);
+      expect(shouldContinuePaging({ ...base, collected: 73 })).toBe(false);
+    });
+
+    it('stops when the scan ceiling is reached (bounds DB work)', () => {
+      expect(shouldContinuePaging({ ...base, scanned: 2000 })).toBe(false);
+      expect(shouldContinuePaging({ ...base, scanned: 2400 })).toBe(false);
+    });
+
+    it('stops when the previous batch was smaller than requested — window exhausted', () => {
+      expect(shouldContinuePaging({ ...base, lastBatchSize: 120 })).toBe(false);
+    });
+
+    it('stops when the previous batch was empty', () => {
+      expect(shouldContinuePaging({ ...base, lastBatchSize: 0 })).toBe(false);
+    });
+
+    it('continues when partially filled but the last batch was still full', () => {
+      expect(shouldContinuePaging({ ...base, collected: 30, scanned: 200 })).toBe(true);
+    });
+
+    it('the limit check takes priority even if a full batch was just fetched', () => {
+      expect(
+        shouldContinuePaging({ ...base, collected: 50, lastBatchSize: 200, batchSize: 200 })
+      ).toBe(false);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -182,6 +182,85 @@ function createCompactDelta(
   return Object.keys(delta).length > 0 ? delta : undefined;
 }
 
+/**
+ * Pure access-control decision for activity rows (security finding H2).
+ *
+ * `get_activity` previously authorized only at the DRIVE level, so a plain
+ * member received `resourceTitle`, `pageId`, and content deltas for EVERY row
+ * in the drive — including pages they cannot view. Drive membership is not
+ * page-level view access.
+ *
+ * Given the actor's set of viewable page IDs, drop every row that targets a
+ * page outside that set, before any title / delta / content diff is emitted.
+ *
+ * Policy for rows with NO pageId (null or absent): RETAINED. These are
+ * drive-scoped activities (membership / permission / drive operations) that
+ * carry no page content and are already authorized by the drive-level gate
+ * upstream. Filtering them out would silently hide legitimate drive activity.
+ *
+ * Pure: no I/O, no mutation of the input array.
+ */
+export function filterAccessibleActivities<T extends { pageId: string | null }>(
+  rows: readonly T[],
+  accessiblePageIds: ReadonlySet<string>,
+): T[] {
+  return rows.filter((row) =>
+    row.pageId == null ? true : accessiblePageIds.has(row.pageId)
+  );
+}
+
+/**
+ * Shell (impure): resolves the actor's set of viewable page IDs across the
+ * pages referenced by `activities`, reusing the same per-page view check the
+ * content-diff path already applies.
+ *
+ * `getBatchPagePermissions` excludes trashed pages even for owners/admins, so
+ * (as elsewhere in this file) we add an owner/admin override to keep their full
+ * visibility into their own drives — including trash/delete activity.
+ */
+async function buildAccessiblePageIdSet(
+  userId: string,
+  activities: { pageId: string | null; driveId: string | null }[],
+): Promise<Set<string>> {
+  const uniquePageIds = [
+    ...new Set(activities.map((a) => a.pageId).filter((id): id is string => Boolean(id))),
+  ];
+
+  if (uniquePageIds.length === 0) {
+    return new Set<string>();
+  }
+
+  const permissions = await getBatchPagePermissions(userId, uniquePageIds);
+  const accessible = new Set<string>(
+    Array.from(permissions.entries())
+      .filter(([, perm]) => perm?.canView)
+      .map(([pageId]) => pageId)
+  );
+
+  // Drive owners/admins can view every page in their drives (incl. private and
+  // trashed). getBatchPagePermissions drops trashed rows, so re-add them here.
+  const uniqueDriveIds = [
+    ...new Set(
+      activities
+        .filter((a) => a.pageId)
+        .map((a) => a.driveId)
+        .filter((id): id is string => Boolean(id))
+    ),
+  ];
+
+  for (const driveId of uniqueDriveIds) {
+    if (await isDriveOwnerOrAdmin(userId, driveId)) {
+      for (const a of activities) {
+        if (a.driveId === driveId && a.pageId) {
+          accessible.add(a.pageId);
+        }
+      }
+    }
+  }
+
+  return accessible;
+}
+
 export const activityTools = {
   /**
    * Get recent activity across workspaces
@@ -475,12 +554,21 @@ When summarizing multiple changes, group them thematically and describe the over
           limit,
         });
 
+        // Security (H2): the drive-level gate above is NOT page-level view
+        // access. Resolve the actor's accessible page set and drop rows for
+        // pages they cannot view BEFORE any title / delta / content diff is
+        // emitted. Everything downstream (actors, drive groups, content diffs,
+        // totals) is derived from this filtered list, so the filter is applied
+        // once here at the source.
+        const accessiblePageIds = await buildAccessiblePageIdSet(userId, activities);
+        const visibleActivities = filterAccessibleActivities(activities, accessiblePageIds);
+
         // Build actor index for deduplication (saves tokens by not repeating actor info)
         // Store actor reference directly so count updates are shared
         const actorMap = new Map<string, { idx: number; actor: CompactActor }>();
         const actorsList: CompactActor[] = [];
 
-        for (const activity of activities) {
+        for (const activity of visibleActivities) {
           const email = activity.actorEmail;
           let entry = actorMap.get(email);
           if (!entry) {
@@ -502,7 +590,7 @@ When summarizing multiple changes, group them thematically and describe the over
         // Group activities by drive using compact format
         const driveGroupsMap = new Map<string, CompactDriveGroup>();
 
-        for (const activity of activities) {
+        for (const activity of visibleActivities) {
           if (!activity.driveId || !activity.drive) continue;
 
           let group = driveGroupsMap.get(activity.driveId);
@@ -575,47 +663,17 @@ When summarizing multiple changes, group them thematically and describe the over
           // P2 Budget: Use maxOutputChars parameter to calculate proportional budget
           const diffBudget = calculateDiffBudget(maxOutputChars);
 
-          // Collect all activities with page content changes
-          let pageActivities = activities.filter(
+          // Collect all activities with page content changes.
+          // Source list is `visibleActivities`, already filtered to pages the
+          // actor can view (security finding H2), so no per-page re-check is
+          // needed here — drive membership alone never reaches this point.
+          const pageActivities = visibleActivities.filter(
             (a) =>
               a.pageId &&
               a.resourceType === 'page' &&
               (a.operation === 'update' || a.operation === 'create') &&
               (a.contentRef || a.contentSnapshot)
           );
-
-          // P1 Security: Filter to pages user has permission to view
-          // Drive membership alone doesn't grant page-level content access
-          if (pageActivities.length > 0) {
-            const uniquePageIds = [...new Set(pageActivities.map(a => a.pageId).filter(Boolean))] as string[];
-            const permissions = await getBatchPagePermissions(userId, uniquePageIds);
-
-            // Filter to pages user can view
-            const viewablePageIds = new Set(
-              Array.from(permissions.entries())
-                .filter(([, perm]) => perm?.canView)
-                .map(([pageId]) => pageId)
-            );
-
-            // Drive admins have view access to all pages in their drives
-            const uniqueDriveIds = [...new Set(
-              pageActivities.map(a => a.driveId).filter(Boolean)
-            )] as string[];
-
-            for (const driveId of uniqueDriveIds) {
-              if (await isDriveOwnerOrAdmin(userId, driveId)) {
-                for (const activity of pageActivities) {
-                  if (activity.driveId === driveId && activity.pageId) {
-                    viewablePageIds.add(activity.pageId);
-                  }
-                }
-              }
-            }
-
-            pageActivities = pageActivities.filter(
-              a => a.pageId && viewablePageIds.has(a.pageId)
-            );
-          }
 
           if (pageActivities.length > 0) {
             // Convert to ActivityForDiff format
@@ -752,9 +810,9 @@ When summarizing multiple changes, group them thematically and describe the over
           }
         }
 
-        // Calculate overall summary
-        const totalActivities = activities.length;
-        const totalAiGenerated = activities.filter((a) => a.isAiGenerated).length;
+        // Calculate overall summary (over the access-filtered list)
+        const totalActivities = visibleActivities.length;
+        const totalAiGenerated = visibleActivities.filter((a) => a.isAiGenerated).length;
 
         // Build initial response
         const response: {

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -605,9 +605,12 @@ When summarizing multiple changes, group them thematically and describe the over
         // through the window in batches, applying the access filter, until we
         // have up to `limit` VISIBLE rows or run out of rows / hit a scan
         // ceiling that bounds DB work.
-        const FETCH_BATCH = Math.min(200, Math.max(limit, limit * 4));
+        // Over-fetch up to 4× the cap per batch (clamped) — usually one batch
+        // already yields `limit` visible rows; MAX_SCANNED bounds worst-case work.
+        const FETCH_BATCH = Math.min(200, limit * 4);
         const MAX_SCANNED = 2000;
         const adminDriveCache = new Map<string, boolean>();
+        const seenIds = new Set<string>(); // guard against offset drift from concurrent writes
         const collected: ActivityRow[] = [];
         let offset = 0;
         let scanned = 0;
@@ -630,7 +633,11 @@ When summarizing multiple changes, group them thematically and describe the over
           offset += batch.length;
 
           const batchAccessible = await buildAccessiblePageIdSet(userId, batch, adminDriveCache);
-          collected.push(...filterAccessibleActivities(batch, batchAccessible));
+          for (const row of filterAccessibleActivities(batch, batchAccessible)) {
+            if (seenIds.has(row.id)) continue; // de-dupe rows shifted across batch boundaries
+            seenIds.add(row.id);
+            collected.push(row);
+          }
         }
 
         // Honor the caller's requested cap on VISIBLE rows.

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -1,13 +1,13 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, desc, gte, ne, isNull, isNotNull, inArray } from '@pagespace/db/operators'
+import { eq, and, or, desc, gte, lt, ne, isNull, isNotNull, inArray } from '@pagespace/db/operators'
 import { sessions } from '@pagespace/db/schema/sessions'
 import { drives } from '@pagespace/db/schema/core'
 import { users } from '@pagespace/db/schema/auth'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
 import { driveMembers } from '@pagespace/db/schema/members';
-import { isUserDriveMember, getBatchPagePermissions, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import {
   groupActivitiesForDiff,
   type ActivityForDiff,
@@ -20,7 +20,7 @@ import {
 } from '@pagespace/lib/content/diff-generator';
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import type { ToolExecutionContext } from '../core/types';
-import { filterDriveIdsByMcpScope } from './actor-permissions';
+import { filterDriveIdsByMcpScope, canActorViewPage } from './actor-permissions';
 
 /**
  * Activity tools for AI agents
@@ -237,63 +237,40 @@ export function shouldContinuePaging(args: {
 }
 
 /**
- * Shell (impure): resolves the actor's set of viewable page IDs across the
- * pages referenced by `activities`, reusing the same per-page view check the
- * content-diff path already applies.
+ * Shell (impure): resolves which of the pages referenced by `rows` the ACTOR
+ * can view, returning the set of viewable page IDs.
  *
- * `getBatchPagePermissions` excludes trashed pages even for owners/admins, so
- * (as elsewhere in this file) we add an owner/admin override to keep their full
- * visibility into their own drives — including trash/delete activity.
+ * Uses `canActorViewPage` — the same actor-aware view check the other AI tools
+ * (page-read, task, agent-communication) use. This de-privileges agent actors
+ * to their own ACL (not the session user's) and applies any MCP page scope,
+ * and it is trash-agnostic: owners/admins and explicit grant-holders still see
+ * activity for pages that have since been trashed (so trash/delete rows are not
+ * silently dropped from their feed).
  *
- * `adminDriveCache` memoizes the per-drive owner/admin check so paginated calls
- * don't re-query the same drives on every batch.
+ * `viewableCache` memoizes the per-page decision so paginated calls don't
+ * re-check a page already resolved in an earlier batch.
  */
-async function buildAccessiblePageIdSet(
-  userId: string,
-  activities: { pageId: string | null; driveId: string | null }[],
-  adminDriveCache?: Map<string, boolean>,
+async function resolveActorViewablePageIds(
+  context: ToolExecutionContext,
+  rows: { pageId: string | null }[],
+  viewableCache: Map<string, boolean>,
 ): Promise<Set<string>> {
   const uniquePageIds = [
-    ...new Set(activities.map((a) => a.pageId).filter((id): id is string => Boolean(id))),
+    ...new Set(rows.map((r) => r.pageId).filter((id): id is string => Boolean(id))),
   ];
 
-  if (uniquePageIds.length === 0) {
-    return new Set<string>();
-  }
-
-  const permissions = await getBatchPagePermissions(userId, uniquePageIds);
-  const accessible = new Set<string>(
-    Array.from(permissions.entries())
-      .filter(([, perm]) => perm?.canView)
-      .map(([pageId]) => pageId)
+  // Resolve only pages not already decided in a prior batch.
+  const unresolved = uniquePageIds.filter((id) => !viewableCache.has(id));
+  await Promise.all(
+    unresolved.map(async (pageId) => {
+      viewableCache.set(pageId, await canActorViewPage(context, pageId));
+    })
   );
 
-  // Drive owners/admins can view every page in their drives (incl. private and
-  // trashed). getBatchPagePermissions drops trashed rows, so re-add them here.
-  const uniqueDriveIds = [
-    ...new Set(
-      activities
-        .filter((a) => a.pageId)
-        .map((a) => a.driveId)
-        .filter((id): id is string => Boolean(id))
-    ),
-  ];
-
-  for (const driveId of uniqueDriveIds) {
-    let isAdmin = adminDriveCache?.get(driveId);
-    if (isAdmin === undefined) {
-      isAdmin = await isDriveOwnerOrAdmin(userId, driveId);
-      adminDriveCache?.set(driveId, isAdmin);
-    }
-    if (isAdmin) {
-      for (const a of activities) {
-        if (a.driveId === driveId && a.pageId) {
-          accessible.add(a.pageId);
-        }
-      }
-    }
+  const accessible = new Set<string>();
+  for (const pageId of uniquePageIds) {
+    if (viewableCache.get(pageId)) accessible.add(pageId);
   }
-
   return accessible;
 }
 
@@ -575,11 +552,28 @@ When summarizing multiple changes, group them thematically and describe the over
           );
         }
 
-        // Fetch a batch of activity rows at a given offset. A composite
-        // (timestamp, id) ordering makes pagination deterministic across ties.
-        const fetchActivityBatch = (offset: number, take: number) =>
+        // Fetch a batch of activity rows starting strictly after `cursor` in
+        // (timestamp desc, id desc) order. Keyset pagination (vs OFFSET) is
+        // stable under concurrent inserts/deletes: rows already returned can't
+        // shift into or out of a later page, so no row is double-counted or
+        // skipped mid-scan.
+        const fetchActivityBatch = (
+          cursor: { timestamp: Date; id: string } | null,
+          take: number,
+        ) =>
           db.query.activityLogs.findMany({
-            where: and(...conditions),
+            where: cursor
+              ? and(
+                  ...conditions,
+                  or(
+                    lt(activityLogs.timestamp, cursor.timestamp),
+                    and(
+                      eq(activityLogs.timestamp, cursor.timestamp),
+                      lt(activityLogs.id, cursor.id)
+                    )
+                  )
+                )
+              : and(...conditions),
             with: {
               user: {
                 columns: { id: true, name: true, email: true },
@@ -590,7 +584,6 @@ When summarizing multiple changes, group them thematically and describe the over
             },
             orderBy: [desc(activityLogs.timestamp), desc(activityLogs.id)],
             limit: take,
-            offset,
           });
         type ActivityRow = Awaited<ReturnType<typeof fetchActivityBatch>>[number];
 
@@ -609,10 +602,9 @@ When summarizing multiple changes, group them thematically and describe the over
         // already yields `limit` visible rows; MAX_SCANNED bounds worst-case work.
         const FETCH_BATCH = Math.min(200, limit * 4);
         const MAX_SCANNED = 2000;
-        const adminDriveCache = new Map<string, boolean>();
-        const seenIds = new Set<string>(); // guard against offset drift from concurrent writes
+        const viewableCache = new Map<string, boolean>();
         const collected: ActivityRow[] = [];
-        let offset = 0;
+        let cursor: { timestamp: Date; id: string } | null = null;
         let scanned = 0;
         let lastBatchSize = FETCH_BATCH; // assume a full batch so the loop is entered
 
@@ -626,19 +618,24 @@ When summarizing multiple changes, group them thematically and describe the over
             batchSize: FETCH_BATCH,
           })
         ) {
-          const batch = await fetchActivityBatch(offset, FETCH_BATCH);
+          const batch = await fetchActivityBatch(cursor, FETCH_BATCH);
           lastBatchSize = batch.length;
           if (batch.length === 0) break;
           scanned += batch.length;
-          offset += batch.length;
+          const tail = batch[batch.length - 1];
+          cursor = { timestamp: tail.timestamp, id: tail.id };
 
-          const batchAccessible = await buildAccessiblePageIdSet(userId, batch, adminDriveCache);
-          for (const row of filterAccessibleActivities(batch, batchAccessible)) {
-            if (seenIds.has(row.id)) continue; // de-dupe rows shifted across batch boundaries
-            seenIds.add(row.id);
-            collected.push(row);
-          }
+          const batchViewable = await resolveActorViewablePageIds(
+            context as ToolExecutionContext,
+            batch,
+            viewableCache
+          );
+          collected.push(...filterAccessibleActivities(batch, batchViewable));
         }
+
+        // True when we stopped because of the scan ceiling while still short of
+        // `limit` — the feed may be incomplete and the caller should know.
+        const scanCeilingReached = scanned >= MAX_SCANNED && collected.length < limit;
 
         // Honor the caller's requested cap on VISIBLE rows.
         const visibleActivities = collected.slice(0, limit);
@@ -906,6 +903,10 @@ When summarizing multiple changes, group them thematically and describe the over
             from: string;
             lastVisit: string | null;
             excludedSelf: boolean;
+            // Set when the access-filtered scan hit its row ceiling before
+            // collecting `limit` visible rows: the feed may be incomplete, so
+            // the caller should not treat it as "all activity in the window".
+            scanLimited?: boolean;
             truncated?: { droppedDeltas?: boolean; droppedActivities?: number; hardCapExceeded?: boolean };
           };
         } = {
@@ -919,6 +920,7 @@ When summarizing multiple changes, group them thematically and describe the over
             from: timeWindowStart.toISOString(),
             lastVisit: lastVisitTime?.toISOString() || null,
             excludedSelf: excludeOwnActivity,
+            ...(scanCeilingReached ? { scanLimited: true } : {}),
           },
         };
 

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -210,6 +210,33 @@ export function filterAccessibleActivities<T extends { pageId: string | null }>(
 }
 
 /**
+ * Pure paging-termination decision for the access-filtered fetch loop.
+ *
+ * Because access filtering happens AFTER the DB applies its row cap, the tool
+ * over-fetches and pages the window until it has collected up to `limit`
+ * VISIBLE rows. Stop paging when any of these hold:
+ *  - we already have `limit` visible rows;
+ *  - we've scanned the ceiling that bounds DB work;
+ *  - the previous batch came back smaller than requested (window exhausted —
+ *    a partial or empty batch means there are no more rows to page).
+ *
+ * Pure: depends only on its numeric arguments.
+ */
+export function shouldContinuePaging(args: {
+  collected: number;
+  limit: number;
+  scanned: number;
+  maxScanned: number;
+  lastBatchSize: number;
+  batchSize: number;
+}): boolean {
+  if (args.collected >= args.limit) return false;
+  if (args.scanned >= args.maxScanned) return false;
+  if (args.lastBatchSize < args.batchSize) return false;
+  return true;
+}
+
+/**
  * Shell (impure): resolves the actor's set of viewable page IDs across the
  * pages referenced by `activities`, reusing the same per-page view check the
  * content-diff path already applies.
@@ -217,10 +244,14 @@ export function filterAccessibleActivities<T extends { pageId: string | null }>(
  * `getBatchPagePermissions` excludes trashed pages even for owners/admins, so
  * (as elsewhere in this file) we add an owner/admin override to keep their full
  * visibility into their own drives — including trash/delete activity.
+ *
+ * `adminDriveCache` memoizes the per-drive owner/admin check so paginated calls
+ * don't re-query the same drives on every batch.
  */
 async function buildAccessiblePageIdSet(
   userId: string,
   activities: { pageId: string | null; driveId: string | null }[],
+  adminDriveCache?: Map<string, boolean>,
 ): Promise<Set<string>> {
   const uniquePageIds = [
     ...new Set(activities.map((a) => a.pageId).filter((id): id is string => Boolean(id))),
@@ -249,7 +280,12 @@ async function buildAccessiblePageIdSet(
   ];
 
   for (const driveId of uniqueDriveIds) {
-    if (await isDriveOwnerOrAdmin(userId, driveId)) {
+    let isAdmin = adminDriveCache?.get(driveId);
+    if (isAdmin === undefined) {
+      isAdmin = await isDriveOwnerOrAdmin(userId, driveId);
+      adminDriveCache?.set(driveId, isAdmin);
+    }
+    if (isAdmin) {
       for (const a of activities) {
         if (a.driveId === driveId && a.pageId) {
           accessible.add(a.pageId);
@@ -539,29 +575,66 @@ When summarizing multiple changes, group them thematically and describe the over
           );
         }
 
-        // Fetch activities
-        const activities = await db.query.activityLogs.findMany({
-          where: and(...conditions),
-          with: {
-            user: {
-              columns: { id: true, name: true, email: true },
+        // Fetch a batch of activity rows at a given offset. A composite
+        // (timestamp, id) ordering makes pagination deterministic across ties.
+        const fetchActivityBatch = (offset: number, take: number) =>
+          db.query.activityLogs.findMany({
+            where: and(...conditions),
+            with: {
+              user: {
+                columns: { id: true, name: true, email: true },
+              },
+              drive: {
+                columns: { id: true, name: true, slug: true, drivePrompt: true },
+              },
             },
-            drive: {
-              columns: { id: true, name: true, slug: true, drivePrompt: true },
-            },
-          },
-          orderBy: [desc(activityLogs.timestamp)],
-          limit,
-        });
+            orderBy: [desc(activityLogs.timestamp), desc(activityLogs.id)],
+            limit: take,
+            offset,
+          });
+        type ActivityRow = Awaited<ReturnType<typeof fetchActivityBatch>>[number];
 
         // Security (H2): the drive-level gate above is NOT page-level view
-        // access. Resolve the actor's accessible page set and drop rows for
-        // pages they cannot view BEFORE any title / delta / content diff is
-        // emitted. Everything downstream (actors, drive groups, content diffs,
-        // totals) is derived from this filtered list, so the filter is applied
-        // once here at the source.
-        const accessiblePageIds = await buildAccessiblePageIdSet(userId, activities);
-        const visibleActivities = filterAccessibleActivities(activities, accessiblePageIds);
+        // access. We must drop rows for pages the actor cannot view BEFORE any
+        // title / delta / content diff is emitted.
+        //
+        // The DB applies `limit` before that filter, so inaccessible private-
+        // page rows would otherwise consume the caller's result cap — a drive
+        // with many recent private changes could return an almost-empty feed
+        // even though older viewable activity exists in the window. So page
+        // through the window in batches, applying the access filter, until we
+        // have up to `limit` VISIBLE rows or run out of rows / hit a scan
+        // ceiling that bounds DB work.
+        const FETCH_BATCH = Math.min(200, Math.max(limit, limit * 4));
+        const MAX_SCANNED = 2000;
+        const adminDriveCache = new Map<string, boolean>();
+        const collected: ActivityRow[] = [];
+        let offset = 0;
+        let scanned = 0;
+        let lastBatchSize = FETCH_BATCH; // assume a full batch so the loop is entered
+
+        while (
+          shouldContinuePaging({
+            collected: collected.length,
+            limit,
+            scanned,
+            maxScanned: MAX_SCANNED,
+            lastBatchSize,
+            batchSize: FETCH_BATCH,
+          })
+        ) {
+          const batch = await fetchActivityBatch(offset, FETCH_BATCH);
+          lastBatchSize = batch.length;
+          if (batch.length === 0) break;
+          scanned += batch.length;
+          offset += batch.length;
+
+          const batchAccessible = await buildAccessiblePageIdSet(userId, batch, adminDriveCache);
+          collected.push(...filterAccessibleActivities(batch, batchAccessible));
+        }
+
+        // Honor the caller's requested cap on VISIBLE rows.
+        const visibleActivities = collected.slice(0, limit);
 
         // Build actor index for deduplication (saves tokens by not repeating actor info)
         // Store actor reference directly so count updates are shared

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -607,6 +607,7 @@ When summarizing multiple changes, group them thematically and describe the over
         let cursor: { timestamp: Date; id: string } | null = null;
         let scanned = 0;
         let lastBatchSize = FETCH_BATCH; // assume a full batch so the loop is entered
+        let lastRequestedBatchSize = FETCH_BATCH; // what we asked the DB for (may be clamped)
 
         while (
           shouldContinuePaging({
@@ -615,10 +616,17 @@ When summarizing multiple changes, group them thematically and describe the over
             scanned,
             maxScanned: MAX_SCANNED,
             lastBatchSize,
-            batchSize: FETCH_BATCH,
+            // Compare exhaustion against what we actually requested — the final
+            // batch is clamped to the remaining scan budget below.
+            batchSize: lastRequestedBatchSize,
           })
         ) {
-          const batch = await fetchActivityBatch(cursor, FETCH_BATCH);
+          // Clamp the final fetch so we never overshoot MAX_SCANNED by up to a
+          // full batch (shouldContinuePaging guarantees scanned < MAX_SCANNED
+          // here, so `take` is always >= 1).
+          const take = Math.min(FETCH_BATCH, MAX_SCANNED - scanned);
+          lastRequestedBatchSize = take;
+          const batch = await fetchActivityBatch(cursor, take);
           lastBatchSize = batch.length;
           if (batch.length === 0) break;
           scanned += batch.length;


### PR DESCRIPTION
## Finding
**H2** — AI `get_activity` tool leaks private-page titles + content diffs to non-privileged drive members.

`apps/web/src/lib/ai/tools/activity-tools.ts` authorized only at the **drive** level (`isUserDriveMember`) and returned `resourceTitle`, `pageId`, and `createCompactDelta(updatedFields, previousValues, newValues)` for **every** activity row in the drive — including pages the actor cannot view. For content operations the delta carries title from/to values and field-level change data.

## Attack closed
A plain MEMBER of a drive (no view permission on private pages) asks the assistant for "recent activity" and receives private-page titles and change diffs. Per-page filtering existed for the optional content-diff section, but **not** for the main activity list (titles + deltas + pageIds) — that was the actual leak.

## Pure functions + tests
The access decision is isolated into a pure function `filterAccessibleActivities(rows, accessiblePageIdSet)`:
- Drops rows whose `pageId` is not in the actor's viewable set.
- **Retains** rows with a null/absent `pageId` (drive-scoped membership/permission/drive operations — no page content, already authorized by the drive gate). Explicit, tested policy.
- Pure: no I/O, no input mutation.

A second pure function `shouldContinuePaging(...)` decides when the over-fetch loop stops.

## Actor-aware access (not just session-user)
The viewable-page set is resolved with `canActorViewPage` — the same actor-aware check the page-read / task / agent-communication tools use. This de-privileges **agent actors** to their own ACL (and honors MCP page scope), so an agent with a narrower ACL than the invoking session user can't receive page titles/deltas it shouldn't. `canActorViewPage` is trash-agnostic, so owners/admins and explicit grant-holders retain visibility of trash/delete activity. Per-page decisions are memoized across batches.

## Result-cap correctness + stable paging
The DB applies `limit` **before** the access filter, so inaccessible private-page rows would consume the caller's result cap (a drive with many recent private changes could return an almost-empty feed even when older viewable activity exists). Fixed by paging the window until up to `limit` **visible** rows are collected or a scan ceiling (`MAX_SCANNED = 2000`) bounds DB work. Pagination is **keyset** (`(timestamp, id)` cursor), which is stable under concurrent inserts/deletes mid-scan — no skipped or double-counted rows. When the scan ceiling truncates the feed, `meta.scanLimited = true` signals the result may be incomplete.

## Tests
16 RED-first unit tests in `activity-tools.test.ts`:
- `filterAccessibleActivities` (9): non-viewable rows removed, viewable rows kept, null/absent `pageId` retained, empty accessible set, mixed batches, empty input, input immutability.
- `shouldContinuePaging` (7): continues while under limit/ceiling with a full last batch; stops on limit reached, scan ceiling, partial/empty last batch (window exhausted), limit-priority.

## Verification
- `bun run typecheck` — green.
- web unit tests — 16 new tests pass. The 1 failing test (`throws error when specified drive access denied`) is a **pre-existing** real-DB test (`role "test" does not exist`) that cannot run in the worktree; it fails identically on the base commit (verified via `git stash`) and is unrelated to this change.
- `bun run lint` — green (only pre-existing warnings, none in the changed files).
- CI: `ci / Lint & TypeScript Check` and `ci / Unit Tests` green.

## Review feedback addressed
- **Codex P2 (apply limit after access filtering):** fixed via the over-fetch/keyset paging loop.
- **Proactive self-review:** actor-aware filtering, keyset pagination, and the `scanLimited` truncation signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened activity feed access control by enforcing page-level permissions earlier during data retrieval, ensuring results consistently respect user permissions.

* **New Features**
  * Added optional metadata indicator showing when activity feed results are limited by the system's scan ceiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->