### PR TITLE
fix(security): SSRF-safe web_fetch with per-hop redirect validation

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/web-fetch-ssrf.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-fetch-ssrf.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPublicIp,
+  isAllowedFetchTarget,
+  isIpLiteral,
+  parseIpv4,
+  PRIVATE_HOST_MESSAGE,
+} from '../web-fetch-ssrf';
+
+describe('web-fetch-ssrf — pure decision functions', () => {
+  describe('parseIpv4', () => {
+    it.each([
+      ['dotted decimal', '127.0.0.1', 0x7f000001],
+      ['decimal integer (127.0.0.1)', '2130706433', 0x7f000001],
+      ['hex integer', '0x7f000001', 0x7f000001],
+      ['octal dotted', '0177.0.0.1', 0x7f000001],
+      ['hex dotted', '0x7f.0.0.1', 0x7f000001],
+      ['short form 127.1', '127.1', 0x7f000001],
+      ['metadata IP', '169.254.169.254', 0xa9fea9fe],
+      ['broadcast', '255.255.255.255', 0xffffffff],
+    ])('parses %s', (_label, input, expected) => {
+      expect(parseIpv4(input)).toBe(expected >>> 0);
+    });
+
+    it.each([
+      ['hostname', 'example.com'],
+      ['too many parts', '1.2.3.4.5'],
+      ['byte overflow', '256.1.1.1'],
+      ['empty part', '1..2.3'],
+      ['ipv6', '::1'],
+      ['out of range integer', '4294967296'],
+    ])('rejects %s', (_label, input) => {
+      expect(parseIpv4(input)).toBeNull();
+    });
+  });
+
+  describe('isPublicIp — blocks private / reserved IPv4', () => {
+    it.each([
+      ['loopback', '127.0.0.1'],
+      ['loopback range', '127.10.20.30'],
+      ['0.0.0.0', '0.0.0.0'],
+      ['this-network range', '0.1.2.3'],
+      ['RFC1918 /8', '10.0.0.1'],
+      ['RFC1918 /12 low', '172.16.0.1'],
+      ['RFC1918 /12 high', '172.31.255.255'],
+      ['RFC1918 /16', '192.168.1.1'],
+      ['link-local / metadata', '169.254.169.254'],
+      ['carrier-grade NAT', '100.64.0.1'],
+      ['IETF protocol', '192.0.0.1'],
+      ['TEST-NET-1', '192.0.2.5'],
+      ['benchmarking', '198.18.0.1'],
+      ['TEST-NET-2', '198.51.100.7'],
+      ['TEST-NET-3', '203.0.113.7'],
+      ['multicast', '224.0.0.1'],
+      ['reserved', '240.0.0.1'],
+      ['broadcast', '255.255.255.255'],
+      ['decimal-encoded loopback', '2130706433'],
+      ['hex-encoded loopback', '0x7f000001'],
+      ['octal-encoded loopback', '0177.0.0.1'],
+      ['decimal-encoded metadata', '2852039166'],
+    ])('blocks %s', (_label, ip) => {
+      expect(isPublicIp(ip)).toBe(false);
+    });
+  });
+
+  describe('isPublicIp — blocks private / reserved IPv6', () => {
+    it.each([
+      ['loopback', '::1'],
+      ['unspecified', '::'],
+      ['unique-local fc00::/7', 'fc00::1'],
+      ['unique-local fd', 'fd12:3456::1'],
+      ['link-local fe80::/10', 'fe80::1'],
+      ['site-local fec0::/10', 'fec0::1'],
+      ['multicast ff00::/8', 'ff02::1'],
+      ['IPv4-mapped metadata (dotted)', '::ffff:169.254.169.254'],
+      ['IPv4-mapped metadata (hextet)', '::ffff:a9fe:a9fe'],
+      ['IPv4-mapped loopback', '::ffff:127.0.0.1'],
+      ['bracketed loopback', '[::1]'],
+      ['NAT64', '64:ff9b::a9fe:a9fe'],
+    ])('blocks %s', (_label, ip) => {
+      expect(isPublicIp(ip)).toBe(false);
+    });
+  });
+
+  describe('isPublicIp — allows public IPs', () => {
+    it.each([
+      ['public IPv4', '93.184.216.34'],
+      ['public IPv4 (8.8.8.8)', '8.8.8.8'],
+      ['public IPv6', '2606:4700:4700::1111'],
+      ['IPv4-mapped public', '::ffff:93.184.216.34'],
+    ])('allows %s', (_label, ip) => {
+      expect(isPublicIp(ip)).toBe(true);
+    });
+
+    it('returns false for non-IP strings (fail-closed)', () => {
+      expect(isPublicIp('example.com')).toBe(false);
+      expect(isPublicIp('')).toBe(false);
+      expect(isPublicIp('not-an-ip')).toBe(false);
+    });
+  });
+
+  describe('isIpLiteral', () => {
+    it.each([
+      ['dotted v4', '127.0.0.1', true],
+      ['decimal v4', '2130706433', true],
+      ['ipv6', '::1', true],
+      ['bracketed ipv6', '[2606:4700::1]', true],
+      ['hostname', 'example.com', false],
+      ['empty', '', false],
+    ])('%s', (_label, host, expected) => {
+      expect(isIpLiteral(host)).toBe(expected);
+    });
+  });
+
+  describe('isAllowedFetchTarget', () => {
+    it('allows a normal public https hostname (DNS validated downstream)', () => {
+      expect(isAllowedFetchTarget('https://example.com/path')).toEqual({ ok: true });
+    });
+
+    it('allows a public https IP literal', () => {
+      expect(isAllowedFetchTarget('https://93.184.216.34/')).toEqual({ ok: true });
+    });
+
+    it.each([
+      ['http scheme', 'http://example.com'],
+      ['ftp scheme', 'ftp://example.com'],
+      ['file scheme', 'file:///etc/passwd'],
+      ['gopher scheme', 'gopher://example.com'],
+    ])('rejects non-https %s', (_label, url) => {
+      const decision = isAllowedFetchTarget(url);
+      expect(decision.ok).toBe(false);
+      expect(decision.reason).toMatch(/https/i);
+    });
+
+    it.each([
+      ['loopback literal', 'https://127.0.0.1/'],
+      ['metadata literal', 'https://169.254.169.254/latest/meta-data'],
+      ['decimal-encoded loopback', 'https://2130706433/'],
+      ['hex-encoded loopback', 'https://0x7f000001/'],
+      ['RFC1918 literal', 'https://10.0.0.1/'],
+      ['bracketed ipv6 loopback', 'https://[::1]/'],
+      ['ipv4-mapped metadata', 'https://[::ffff:a9fe:a9fe]/'],
+      ['localhost', 'https://localhost/'],
+      ['*.localhost', 'https://api.localhost/'],
+    ])('rejects private/internal %s', (_label, url) => {
+      const decision = isAllowedFetchTarget(url);
+      expect(decision.ok).toBe(false);
+      expect(decision.reason).toBe(PRIVATE_HOST_MESSAGE);
+    });
+
+    it('rejects an unparseable URL', () => {
+      const decision = isAllowedFetchTarget('not a url');
+      expect(decision.ok).toBe(false);
+      expect(decision.reason).toMatch(/invalid url/i);
+    });
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -300,6 +300,19 @@ function mockFetchResponse(
   };
 }
 
+/** Build a redirect Response (manual mode) with a Location header and an empty body. */
+function mockRedirectResponse(location: string, status = 302) {
+  const headers = new Map<string, string>([['location', location]]);
+  const stream = new ReadableStream<Uint8Array>({ start(c) { c.close(); } });
+  return {
+    ok: false,
+    status,
+    statusText: 'Found',
+    headers: { get: (name: string) => headers.get(name) ?? null },
+    body: stream,
+  };
+}
+
 describe('web_fetch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -449,6 +462,98 @@ describe('web_fetch', () => {
       ) as Record<string, unknown>;
       expect(result.success).toBe(true);
       expect(result.truncated).toBe(false);
+    });
+  });
+
+  describe('redirect SSRF protection (M2)', () => {
+    it('uses manual redirect handling (does not delegate redirects to fetch)', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockFetchResponse('<p>ok</p>')
+      );
+      await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      );
+      const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(init.redirect).toBe('manual');
+    });
+
+    it('follows a public → public redirect and returns the final content', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(mockRedirectResponse('https://www.example.com/final'))
+        .mockResolvedValueOnce(mockFetchResponse('<h1>Final</h1>'));
+
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+
+      expect(result.success).toBe(true);
+      expect(String(result.content)).toContain('Final');
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    });
+
+    it('blocks a redirect to the cloud-metadata IP literal', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(mockRedirectResponse('https://169.254.169.254/latest/meta-data/'));
+
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/private|internal/i);
+      // Only the first hop is fetched; the metadata hop is rejected before connect.
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    });
+
+    it('blocks a redirect to a non-https (http) metadata URL', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(mockRedirectResponse('http://169.254.169.254/latest/meta-data/'));
+
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/https/i);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    });
+
+    it('blocks a redirect to a public-looking host that resolves to a private IP (rebinding)', async () => {
+      mockLookupFn.mockImplementation(async (hostname: string) =>
+        hostname.includes('evil')
+          ? [{ address: '10.0.0.1', family: 4 }]
+          : [{ address: '93.184.216.34', family: 4 }]
+      );
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(mockRedirectResponse('https://evil.example.com/internal'));
+
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/private|internal/i);
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    });
+
+    it('rejects after exceeding the redirect cap', async () => {
+      let n = 0;
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(async () =>
+        mockRedirectResponse(`https://hop${n++}.example.com/`)
+      );
+
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/too many redirects/i);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Agent } from 'undici';
 
 // Mock dependencies
 const mockLookupFn = vi.hoisted(() => vi.fn());
@@ -557,8 +556,7 @@ describe('web_fetch', () => {
       expect(String(result.error)).toMatch(/too many redirects/i);
     });
 
-    it('closes the pinned dispatcher when fetch rejects (no socket/agent leak)', async () => {
-      const closeSpy = vi.spyOn(Agent.prototype, 'close');
+    it('returns a graceful error result when fetch rejects (network error)', async () => {
       (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('ECONNRESET'));
 
       const result = await webSearchTools.web_fetch!.execute!(
@@ -567,10 +565,7 @@ describe('web_fetch', () => {
       ) as Record<string, unknown>;
 
       expect(result.success).toBe(false);
-      // The per-hop dispatcher is created then closed on the fetch rejection path,
-      // not leaked (the caller's finally never sees it because we never returned).
-      expect(closeSpy).toHaveBeenCalled();
-      closeSpy.mockRestore();
+      expect(String(result.error)).toMatch(/ECONNRESET/);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from 'undici';
 
 // Mock dependencies
 const mockLookupFn = vi.hoisted(() => vi.fn());
@@ -554,6 +555,22 @@ describe('web_fetch', () => {
 
       expect(result.success).toBe(false);
       expect(String(result.error)).toMatch(/too many redirects/i);
+    });
+
+    it('closes the pinned dispatcher when fetch rejects (no socket/agent leak)', async () => {
+      const closeSpy = vi.spyOn(Agent.prototype, 'close');
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('ECONNRESET'));
+
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+
+      expect(result.success).toBe(false);
+      // The per-hop dispatcher is created then closed on the fetch rejection path,
+      // not leaked (the caller's finally never sees it because we never returned).
+      expect(closeSpy).toHaveBeenCalled();
+      closeSpy.mockRestore();
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/web-fetch-ssrf.ts
+++ b/apps/web/src/lib/ai/tools/web-fetch-ssrf.ts
@@ -1,0 +1,190 @@
+/**
+ * Pure SSRF-guard decision functions for the `web_fetch` AI tool.
+ *
+ * These are intentionally side-effect free (no DNS, no network) so the security
+ * decision can be exhaustively unit-tested with table-driven cases. The network
+ * shell in `web-search-tools.ts` resolves hostnames and re-applies `isPublicIp`
+ * to every resolved address and every redirect hop.
+ *
+ * Threat model (audit finding M2): an attacker-controlled public URL can 302 to
+ * `http://169.254.169.254/...` (cloud metadata) or an internal host, or use a
+ * hostname that resolves to a private IP (DNS rebinding). The initial-host-only
+ * check is insufficient, so every hop is revalidated and pinned downstream.
+ */
+
+/** Human-readable reason returned for any private/internal/reserved target. */
+export const PRIVATE_HOST_MESSAGE = 'Fetching private or internal hosts is not allowed';
+
+export interface FetchTargetDecision {
+  ok: boolean;
+  reason?: string;
+}
+
+/** Parse a single dotted part as decimal, hex (0x…) or octal (0…). Returns null if invalid. */
+function parseIpv4Part(part: string): number | null {
+  if (part === '') return null;
+  let n: number;
+  if (/^0x[0-9a-f]+$/i.test(part)) {
+    n = parseInt(part.slice(2), 16);
+  } else if (/^0[0-7]+$/.test(part)) {
+    n = parseInt(part, 8);
+  } else if (/^[0-9]+$/.test(part)) {
+    n = parseInt(part, 10);
+  } else {
+    return null;
+  }
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
+ * Parse an IPv4 address in any inet_aton form (dotted decimal/hex/octal, or a
+ * single decimal/hex integer) into a 32-bit unsigned integer. Returns null when
+ * the string is not a valid IPv4 literal.
+ */
+export function parseIpv4(host: string): number | null {
+  const rawParts = host.split('.');
+  if (rawParts.length < 1 || rawParts.length > 4) return null;
+
+  const parts: number[] = [];
+  for (const raw of rawParts) {
+    const n = parseIpv4Part(raw);
+    if (n === null) return null;
+    parts.push(n);
+  }
+
+  const last = parts.length - 1;
+  // Every part except the last must fit in a single byte.
+  for (let i = 0; i < last; i++) {
+    if (parts[i] > 0xff) return null;
+  }
+  // The last part absorbs the remaining bytes (e.g. "127.1" => 127.0.0.1).
+  const maxLast = Math.pow(256, 4 - last) - 1;
+  if (parts[last] > maxLast) return null;
+
+  let result = parts[last];
+  for (let i = 0; i < last; i++) {
+    result += parts[i] * Math.pow(256, 3 - i);
+  }
+  if (result < 0 || result > 0xffffffff) return null;
+  return result >>> 0;
+}
+
+/** True only when the 32-bit IPv4 value is globally routable (not private/reserved). */
+function isPublicIpv4(n: number): boolean {
+  const a = (n >>> 24) & 0xff;
+  const b = (n >>> 16) & 0xff;
+  const c = (n >>> 8) & 0xff;
+
+  if (a === 0) return false;                              // 0.0.0.0/8 "this network"
+  if (a === 10) return false;                             // 10.0.0.0/8 private
+  if (a === 127) return false;                            // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return false;               // 169.254.0.0/16 link-local + cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return false;      // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return false;               // 192.168.0.0/16 private
+  if (a === 100 && b >= 64 && b <= 127) return false;     // 100.64.0.0/10 carrier-grade NAT
+  if (a === 192 && b === 0 && c === 0) return false;      // 192.0.0.0/24 IETF protocol assignments
+  if (a === 192 && b === 0 && c === 2) return false;      // 192.0.2.0/24 TEST-NET-1
+  if (a === 198 && (b === 18 || b === 19)) return false;  // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && c === 100) return false;   // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return false;    // 203.0.113.0/24 TEST-NET-3
+  if (a >= 224) return false;                             // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + 255.255.255.255
+  return true;
+}
+
+/**
+ * Extract an embedded IPv4 value (as a 32-bit int) from an IPv6 string when it
+ * is an IPv4-mapped/compatible address. Handles both dotted (`::ffff:1.2.3.4`)
+ * and hextet (`::ffff:a9fe:a9fe`, the WHATWG-normalized form) representations.
+ * Returns null when there is no embedded IPv4.
+ */
+function extractEmbeddedIpv4(h: string): number | null {
+  // ::ffff:1.2.3.4  or  ::1.2.3.4 (deprecated IPv4-compatible)
+  const dotted = h.match(/^::(?:ffff:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotted) return parseIpv4(dotted[1]);
+
+  // ::ffff:a9fe:a9fe  (WHATWG normalizes ::ffff:169.254.169.254 to this)
+  const hextets = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hextets) {
+    const hi = parseInt(hextets[1], 16);
+    const lo = parseInt(hextets[2], 16);
+    return (((hi << 16) >>> 0) + lo) >>> 0;
+  }
+  return null;
+}
+
+/** True only when the IPv6 address is globally routable (not loopback/private/reserved). */
+function isPublicIpv6(host: string): boolean {
+  let h = host.toLowerCase();
+  const zone = h.indexOf('%');
+  if (zone !== -1) h = h.slice(0, zone);
+
+  if (h === '::' || h === '::1') return false;            // unspecified / loopback
+  if (h.startsWith('64:ff9b:')) return false;             // NAT64 — embeds arbitrary (possibly private) IPv4
+
+  const embedded = extractEmbeddedIpv4(h);
+  if (embedded !== null) return isPublicIpv4(embedded);
+
+  if (h.startsWith('fc') || h.startsWith('fd')) return false;   // fc00::/7 unique-local
+  if (/^fe[89ab]/.test(h)) return false;                        // fe80::/10 link-local
+  if (/^fe[cdef]/.test(h)) return false;                        // fec0::/10 site-local (deprecated)
+  if (h.startsWith('ff')) return false;                         // ff00::/8 multicast
+  return true;
+}
+
+/** True when the bare host (no brackets) is an IP literal in any IPv4 or IPv6 form. */
+export function isIpLiteral(host: string): boolean {
+  const bare = host.replace(/^\[|\]$/g, '');
+  if (bare === '') return false;
+  if (parseIpv4(bare) !== null) return true;
+  return bare.includes(':');
+}
+
+/**
+ * True only for a globally routable public IP address. Returns false for any
+ * private/loopback/link-local/reserved IP, and false for non-IP strings
+ * (fail-closed). Accepts decimal/hex/octal-encoded IPv4 and bracketed IPv6.
+ */
+export function isPublicIp(ip: string): boolean {
+  const bare = ip.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  if (bare === '') return false;
+  const v4 = parseIpv4(bare);
+  if (v4 !== null) return isPublicIpv4(v4);
+  if (bare.includes(':')) return isPublicIpv6(bare);
+  return false;
+}
+
+/**
+ * Decide whether a URL is an allowed `web_fetch` target based on scheme and any
+ * literal IP in the host. Pure and DNS-free: hostnames that are not IP literals
+ * return `{ ok: true }` and MUST still be DNS-validated (and pinned) by the
+ * network shell before connecting.
+ */
+export function isAllowedFetchTarget(url: string): FetchTargetDecision {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: 'Invalid URL' };
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'Only HTTPS URLs are supported' };
+  }
+
+  const host = parsed.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (host === '') {
+    return { ok: false, reason: 'URL has no host' };
+  }
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    return { ok: false, reason: PRIVATE_HOST_MESSAGE };
+  }
+
+  if (isIpLiteral(host)) {
+    if (!isPublicIp(host)) {
+      return { ok: false, reason: PRIVATE_HOST_MESSAGE };
+    }
+  }
+
+  return { ok: true };
+}

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -1,5 +1,4 @@
 import { promises as dnsPromises } from 'dns';
-import { Agent } from 'undici';
 import { tool } from 'ai';
 import { z } from 'zod';
 import TurndownService from 'turndown';
@@ -130,25 +129,23 @@ async function performWebSearch({
   }
 }
 
-interface ResolvedAddress {
-  address: string;
-  family: number;
-}
-
 /**
- * Resolves a hostname to all addresses and rejects if ANY is non-public
- * (DNS-rebinding mitigation). IP literals are already validated by
- * {@link isAllowedFetchTarget}, so they skip DNS. Returns the validated
- * addresses so the connection can be pinned to them.
- * Throws on block or DNS failure (fail-closed).
+ * Resolves a hostname and rejects if ANY resolved address is non-public
+ * (DNS-rebinding mitigation), re-running immediately before each connect.
+ * IP literals are already validated by {@link isAllowedFetchTarget}, so they
+ * skip DNS. Throws on block or DNS failure (fail-closed).
+ *
+ * Note: connection-level IP pinning is intentionally omitted — Node's global
+ * `fetch` exposes no per-request `lookup`/dispatcher hook that survives the
+ * Next.js webpack build (a bare `undici` import is not resolvable in this bundle),
+ * so a small validate→connect TOCTOU window remains. Per-hop re-resolution keeps
+ * it narrow and is the standard mitigation.
  */
-async function resolveValidatedAddresses(hostname: string): Promise<ResolvedAddress[]> {
+async function assertResolvesPublic(hostname: string): Promise<void> {
   const bare = hostname.replace(/^\[|\]$/g, '');
-  if (isIpLiteral(bare)) {
-    return [{ address: bare, family: bare.includes(':') ? 6 : 4 }];
-  }
+  if (isIpLiteral(bare)) return; // already validated as a public IP literal
 
-  let addresses: ResolvedAddress[];
+  let addresses: { address: string }[];
   try {
     addresses = await dnsPromises.lookup(hostname, { all: true });
   } catch {
@@ -158,95 +155,37 @@ async function resolveValidatedAddresses(hostname: string): Promise<ResolvedAddr
   for (const { address } of addresses) {
     if (!isPublicIp(address)) throw new Error(PRIVATE_HOST_MESSAGE);
   }
-  return addresses;
-}
-
-/**
- * Builds an undici dispatcher that pins outbound connections to the already
- * validated addresses, closing the TOCTOU window between DNS validation and
- * connect (a public hostname cannot re-resolve to a private IP at connect time).
- * The TLS servername stays the original hostname, preserving SNI/cert checks.
- * Returns undefined if a dispatcher cannot be constructed (revalidation still
- * applies on every hop).
- */
-function createPinnedDispatcher(addresses: ResolvedAddress[]): Agent | undefined {
-  if (!addresses.length) return undefined;
-  try {
-    return new Agent({
-      connect: {
-        lookup: (_hostname, options, callback) => {
-          if (options && options.all) {
-            callback(null, addresses.map((a) => ({ address: a.address, family: a.family })));
-          } else {
-            callback(null, addresses[0].address, addresses[0].family);
-          }
-        },
-      },
-    });
-  } catch {
-    return undefined;
-  }
-}
-
-async function closeDispatcher(dispatcher: Agent | undefined): Promise<void> {
-  try {
-    await dispatcher?.close();
-  } catch {
-    /* best-effort cleanup */
-  }
-}
-
-type PinnedFetchInit = RequestInit & { dispatcher?: Agent };
-
-interface SafeFetchResult {
-  response: Response;
-  dispatcher: Agent | undefined;
 }
 
 /**
  * SSRF-safe fetch: follows redirects MANUALLY (redirect: 'manual'), revalidating
- * scheme + host and re-resolving + pinning DNS on EVERY hop. This closes the M2
- * bypass where an allowed initial URL 302s to cloud-metadata/internal hosts.
- * A single shared `signal` bounds total time across all hops (and the caller's
- * body read), so a redirect chain cannot extend the deadline. The caller owns
- * the returned dispatcher and must close it after reading the body.
+ * scheme + host and re-resolving DNS on EVERY hop. This closes the M2 bypass
+ * where an allowed initial URL 302s to cloud-metadata/internal hosts. A single
+ * shared `signal` bounds total time across all hops (and the caller's body read),
+ * so a redirect chain cannot extend the deadline.
  */
 async function ssrfSafeFetch(
   initialUrl: string,
   headers: Record<string, string>,
   signal: AbortSignal,
-): Promise<SafeFetchResult> {
+): Promise<Response> {
   let currentUrl = initialUrl;
 
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
     const decision = isAllowedFetchTarget(currentUrl);
     if (!decision.ok) throw new Error(decision.reason ?? PRIVATE_HOST_MESSAGE);
 
-    const addresses = await resolveValidatedAddresses(new URL(currentUrl).hostname);
-    const dispatcher = createPinnedDispatcher(addresses);
+    await assertResolvesPublic(new URL(currentUrl).hostname);
 
-    const init: PinnedFetchInit = { headers, redirect: 'manual', signal };
-    if (dispatcher) init.dispatcher = dispatcher;
-
-    let response: Response;
-    try {
-      response = await fetch(currentUrl, init);
-    } catch (err) {
-      // fetch rejected (timeout/TLS/connection reset): this hop's dispatcher is
-      // still local and would leak — the caller only owns the dispatcher we
-      // return on success. Close it here before propagating.
-      await closeDispatcher(dispatcher);
-      throw err;
-    }
+    const response = await fetch(currentUrl, { headers, redirect: 'manual', signal });
 
     if (!REDIRECT_STATUSES.has(response.status)) {
-      return { response, dispatcher };
+      return response;
     }
 
-    // Redirect: discard this hop's body + dispatcher, validate the next target.
+    // Redirect: discard this hop's body, then validate the next target.
     const location = response.headers.get('location');
     await response.body?.cancel().catch(() => { /* ignore */ });
-    await closeDispatcher(dispatcher);
 
     if (!location) throw new Error('Redirect response missing Location header');
     let next: URL;
@@ -378,16 +317,13 @@ Returns the page content converted to readable markdown.`,
         };
       }
 
-      let dispatcher: Agent | undefined;
       try {
         webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url: redactUrl(url) });
 
-        // Follows redirects manually, revalidating + IP-pinning each hop (SSRF-safe).
+        // Follows redirects manually, revalidating scheme/host + re-resolving DNS each hop (SSRF-safe).
         // One shared deadline bounds the whole operation, including the body read below.
         const signal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
-        const safe = await ssrfSafeFetch(url, { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' }, signal);
-        const response = safe.response;
-        dispatcher = safe.dispatcher;
+        const response = await ssrfSafeFetch(url, { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' }, signal);
 
         if (!response.ok) {
           throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
@@ -480,8 +416,6 @@ Returns the page content converted to readable markdown.`,
             'Try web_search to find an alternative source',
           ],
         };
-      } finally {
-        await closeDispatcher(dispatcher);
       }
     },
   }),

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -201,16 +201,21 @@ type PinnedFetchInit = RequestInit & { dispatcher?: Agent };
 interface SafeFetchResult {
   response: Response;
   dispatcher: Agent | undefined;
-  finalUrl: string;
 }
 
 /**
  * SSRF-safe fetch: follows redirects MANUALLY (redirect: 'manual'), revalidating
  * scheme + host and re-resolving + pinning DNS on EVERY hop. This closes the M2
  * bypass where an allowed initial URL 302s to cloud-metadata/internal hosts.
- * The caller owns the returned dispatcher and must close it after reading the body.
+ * A single shared `signal` bounds total time across all hops (and the caller's
+ * body read), so a redirect chain cannot extend the deadline. The caller owns
+ * the returned dispatcher and must close it after reading the body.
  */
-async function ssrfSafeFetch(initialUrl: string, headers: Record<string, string>): Promise<SafeFetchResult> {
+async function ssrfSafeFetch(
+  initialUrl: string,
+  headers: Record<string, string>,
+  signal: AbortSignal,
+): Promise<SafeFetchResult> {
   let currentUrl = initialUrl;
 
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
@@ -220,17 +225,13 @@ async function ssrfSafeFetch(initialUrl: string, headers: Record<string, string>
     const addresses = await resolveValidatedAddresses(new URL(currentUrl).hostname);
     const dispatcher = createPinnedDispatcher(addresses);
 
-    const init: PinnedFetchInit = {
-      headers,
-      redirect: 'manual',
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    };
+    const init: PinnedFetchInit = { headers, redirect: 'manual', signal };
     if (dispatcher) init.dispatcher = dispatcher;
 
     const response = await fetch(currentUrl, init);
 
     if (!REDIRECT_STATUSES.has(response.status)) {
-      return { response, dispatcher, finalUrl: currentUrl };
+      return { response, dispatcher };
     }
 
     // Redirect: discard this hop's body + dispatcher, validate the next target.
@@ -373,7 +374,9 @@ Returns the page content converted to readable markdown.`,
         webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url: redactUrl(url) });
 
         // Follows redirects manually, revalidating + IP-pinning each hop (SSRF-safe).
-        const safe = await ssrfSafeFetch(url, { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' });
+        // One shared deadline bounds the whole operation, including the body read below.
+        const signal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+        const safe = await ssrfSafeFetch(url, { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' }, signal);
         const response = safe.response;
         dispatcher = safe.dispatcher;
 

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -1,15 +1,20 @@
 import { promises as dnsPromises } from 'dns';
+import { Agent } from 'undici';
 import { tool } from 'ai';
 import { z } from 'zod';
 import TurndownService from 'turndown';
 import type { ToolExecutionContext } from '../core/types';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { isPublicIp, isAllowedFetchTarget, isIpLiteral, PRIVATE_HOST_MESSAGE } from './web-fetch-ssrf';
 
 const webSearchLogger = loggers.ai.child({ module: 'web-search-tools' });
 
 const BRAVE_SEARCH_URL = 'https://api.search.brave.com/res/v1/web/search';
 const MAX_FETCH_BYTES = 5 * 1024 * 1024; // 5 MB hard cap on buffered response
+const MAX_REDIRECTS = 5; // cap on manually-followed redirect hops
+const FETCH_TIMEOUT_MS = 15000;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
 function safeHostname(url: string): string {
   try { return new URL(url).hostname; } catch { return ''; }
@@ -125,36 +130,25 @@ async function performWebSearch({
   }
 }
 
-/** Returns true for any IP that must not be fetched (loopback, RFC1918, link-local, IPv6 private). */
-function isPrivateIp(ip: string): boolean {
-  const h = ip.toLowerCase().replace(/^\[|\]$/g, '');
-  if (h === 'localhost' || h === '0.0.0.0') return true;
-  // IPv6
-  if (h === '::1') return true;
-  if (h.startsWith('fe80:')) return true;                   // fe80::/10 link-local
-  if (h.startsWith('fc') || h.startsWith('fd')) return true; // fc00::/7 unique-local
-  if (h.startsWith('::ffff:')) return isPrivateIp(h.slice(7)); // IPv4-mapped
-  // IPv4
-  const ipv4 = h.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
-  if (ipv4) {
-    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
-    if (a === 10) return true;                          // 10.0.0.0/8
-    if (a === 127) return true;                         // 127.0.0.0/8 loopback
-    if (a === 169 && b === 254) return true;            // 169.254.0.0/16 link-local + cloud metadata
-    if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12
-    if (a === 192 && b === 168) return true;            // 192.168.0.0/16
-  }
-  return false;
+interface ResolvedAddress {
+  address: string;
+  family: number;
 }
 
 /**
- * Resolves hostname to all addresses and rejects if any is private.
- * Catches public hostnames that resolve to internal IPs (DNS rebinding mitigation).
+ * Resolves a hostname to all addresses and rejects if ANY is non-public
+ * (DNS-rebinding mitigation). IP literals are already validated by
+ * {@link isAllowedFetchTarget}, so they skip DNS. Returns the validated
+ * addresses so the connection can be pinned to them.
  * Throws on block or DNS failure (fail-closed).
  */
-async function validatePublicHost(hostname: string): Promise<void> {
-  if (isPrivateIp(hostname)) throw new Error('Fetching private or internal hosts is not allowed');
-  let addresses: { address: string; family: number }[];
+async function resolveValidatedAddresses(hostname: string): Promise<ResolvedAddress[]> {
+  const bare = hostname.replace(/^\[|\]$/g, '');
+  if (isIpLiteral(bare)) {
+    return [{ address: bare, family: bare.includes(':') ? 6 : 4 }];
+  }
+
+  let addresses: ResolvedAddress[];
   try {
     addresses = await dnsPromises.lookup(hostname, { all: true });
   } catch {
@@ -162,8 +156,99 @@ async function validatePublicHost(hostname: string): Promise<void> {
   }
   if (!addresses.length) throw new Error('Hostname resolved to no addresses');
   for (const { address } of addresses) {
-    if (isPrivateIp(address)) throw new Error('Fetching private or internal hosts is not allowed');
+    if (!isPublicIp(address)) throw new Error(PRIVATE_HOST_MESSAGE);
   }
+  return addresses;
+}
+
+/**
+ * Builds an undici dispatcher that pins outbound connections to the already
+ * validated addresses, closing the TOCTOU window between DNS validation and
+ * connect (a public hostname cannot re-resolve to a private IP at connect time).
+ * The TLS servername stays the original hostname, preserving SNI/cert checks.
+ * Returns undefined if a dispatcher cannot be constructed (revalidation still
+ * applies on every hop).
+ */
+function createPinnedDispatcher(addresses: ResolvedAddress[]): Agent | undefined {
+  if (!addresses.length) return undefined;
+  try {
+    return new Agent({
+      connect: {
+        lookup: (_hostname, options, callback) => {
+          if (options && options.all) {
+            callback(null, addresses.map((a) => ({ address: a.address, family: a.family })));
+          } else {
+            callback(null, addresses[0].address, addresses[0].family);
+          }
+        },
+      },
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+async function closeDispatcher(dispatcher: Agent | undefined): Promise<void> {
+  try {
+    await dispatcher?.close();
+  } catch {
+    /* best-effort cleanup */
+  }
+}
+
+type PinnedFetchInit = RequestInit & { dispatcher?: Agent };
+
+interface SafeFetchResult {
+  response: Response;
+  dispatcher: Agent | undefined;
+  finalUrl: string;
+}
+
+/**
+ * SSRF-safe fetch: follows redirects MANUALLY (redirect: 'manual'), revalidating
+ * scheme + host and re-resolving + pinning DNS on EVERY hop. This closes the M2
+ * bypass where an allowed initial URL 302s to cloud-metadata/internal hosts.
+ * The caller owns the returned dispatcher and must close it after reading the body.
+ */
+async function ssrfSafeFetch(initialUrl: string, headers: Record<string, string>): Promise<SafeFetchResult> {
+  let currentUrl = initialUrl;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const decision = isAllowedFetchTarget(currentUrl);
+    if (!decision.ok) throw new Error(decision.reason ?? PRIVATE_HOST_MESSAGE);
+
+    const addresses = await resolveValidatedAddresses(new URL(currentUrl).hostname);
+    const dispatcher = createPinnedDispatcher(addresses);
+
+    const init: PinnedFetchInit = {
+      headers,
+      redirect: 'manual',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    };
+    if (dispatcher) init.dispatcher = dispatcher;
+
+    const response = await fetch(currentUrl, init);
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return { response, dispatcher, finalUrl: currentUrl };
+    }
+
+    // Redirect: discard this hop's body + dispatcher, validate the next target.
+    const location = response.headers.get('location');
+    await response.body?.cancel().catch(() => { /* ignore */ });
+    await closeDispatcher(dispatcher);
+
+    if (!location) throw new Error('Redirect response missing Location header');
+    let next: URL;
+    try {
+      next = new URL(location, currentUrl);
+    } catch {
+      throw new Error('Invalid redirect Location');
+    }
+    currentUrl = next.toString();
+  }
+
+  throw new Error('Too many redirects');
 }
 
 export const webSearchTools = {
@@ -271,24 +356,26 @@ Returns the page content converted to readable markdown.`,
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) throw new Error('User authentication required');
 
+      // Pure scheme + literal-IP gate (no DNS, no network) before doing any work.
+      const targetDecision = isAllowedFetchTarget(url);
+      if (!targetDecision.ok) {
+        return {
+          success: false,
+          url,
+          error: targetDecision.reason ?? PRIVATE_HOST_MESSAGE,
+          content: '',
+          nextSteps: ['Provide a publicly accessible https:// URL'],
+        };
+      }
+
+      let dispatcher: Agent | undefined;
       try {
-        const parsed = new URL(url);
-        if (parsed.protocol !== 'https:') {
-          return { success: false, url, error: 'Only HTTPS URLs are supported', content: '', nextSteps: ['Use an https:// URL'] };
-        }
-
-        try {
-          await validatePublicHost(parsed.hostname);
-        } catch (e) {
-          return { success: false, url, error: (e as Error).message, content: '', nextSteps: ['Provide a publicly accessible URL'] };
-        }
-
         webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url: redactUrl(url) });
 
-        const response = await fetch(url, {
-          headers: { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' },
-          signal: AbortSignal.timeout(15000),
-        });
+        // Follows redirects manually, revalidating + IP-pinning each hop (SSRF-safe).
+        const safe = await ssrfSafeFetch(url, { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' });
+        const response = safe.response;
+        dispatcher = safe.dispatcher;
 
         if (!response.ok) {
           throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
@@ -381,6 +468,8 @@ Returns the page content converted to readable markdown.`,
             'Try web_search to find an alternative source',
           ],
         };
+      } finally {
+        await closeDispatcher(dispatcher);
       }
     },
   }),

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -228,7 +228,16 @@ async function ssrfSafeFetch(
     const init: PinnedFetchInit = { headers, redirect: 'manual', signal };
     if (dispatcher) init.dispatcher = dispatcher;
 
-    const response = await fetch(currentUrl, init);
+    let response: Response;
+    try {
+      response = await fetch(currentUrl, init);
+    } catch (err) {
+      // fetch rejected (timeout/TLS/connection reset): this hop's dispatcher is
+      // still local and would leak — the caller only owns the dispatcher we
+      // return on success. Close it here before propagating.
+      await closeDispatcher(dispatcher);
+      throw err;
+    }
 
     if (!REDIRECT_STATUSES.has(response.status)) {
       return { response, dispatcher };

--- a/scripts/test-security.sh
+++ b/scripts/test-security.sh
@@ -146,6 +146,15 @@ echo "-------------------------"
 run_test_suite "MCP WebSocket Route Security" "web" "src/app/api/mcp-ws/__tests__/route.security.test.ts"
 
 # =============================================================================
+# AI Tool Security Tests
+# =============================================================================
+echo "🤖 AI Tool Security"
+echo "-------------------"
+
+run_test_suite "web_fetch SSRF Decision (pure)" "web" "src/lib/ai/tools/__tests__/web-fetch-ssrf.test.ts"
+run_test_suite "web_fetch SSRF (redirect/rebind)" "web" "src/lib/ai/tools/__tests__/web-search-tools.test.ts"
+
+# =============================================================================
 # Processor Security Tests
 # =============================================================================
 echo "⚙️ Processor Security"


### PR DESCRIPTION
## Finding
**M2** (audit 2026-06-09) — `web_fetch` AI tool SSRF via redirect + DNS-rebind bypass of the private-IP guard.

`apps/web/src/lib/ai/tools/web-search-tools.ts` validated only the **initial** URL host, then called `fetch` with the default `redirect: 'follow'`. So an allowed public URL could `302` to `http://169.254.169.254/...` (cloud metadata — returned as `text/plain`, which was on the allowlist) or any internal service. It was also TOCTOU-vulnerable to DNS rebinding (validate the host, then re-resolve at connect time).

## Attack closed
- Public URL → 302 → `169.254.169.254` / internal host → metadata/credential exfiltration.
- Public hostname that re-resolves to a private IP between validation and connect (rebinding).
- `http://` downgrade on a redirect hop.

## Approach — pure functions + thin shell (strict TDD)
New `apps/web/src/lib/ai/tools/web-fetch-ssrf.ts` isolates the security decision into **pure, DNS-free** functions:
- `isPublicIp(ip)` — false for any private/loopback/link-local/reserved IP. Covers IPv4 (`10/8`, `127/8`, `169.254/16`, `172.16/12`, `192.168/16`, `100.64/10` CGNAT, `0/8`, TEST-NETs, multicast/reserved) and IPv6 (`::1`, `::`, `fc00::/7`, `fe80::/10`, `fec0::/10`, `ff00::/8`, IPv4-mapped, NAT64). Handles decimal/hex/octal-encoded IPv4.
- `isAllowedFetchTarget(url)` — rejects non-`https` schemes and literal private/internal IP hosts; returns `{ ok: true }` for real hostnames (DNS-validated downstream).
- Helpers `parseIpv4` / `isIpLiteral`.

Network shell in `web-search-tools.ts`:
- `redirect: 'manual'`, follows hops manually up to **5**, revalidating scheme+host and **re-resolving DNS on every hop** via `assertResolvesPublic` (`dns.lookup` all-addresses; rejects if any resolved address is non-public). This is the DNS-rebinding defense.
- A single shared `AbortSignal` bounds the whole operation (all hops + the streamed body read).
- IP **pinning** (connecting directly to the validated address) was intentionally **not** shipped — it required an undici dispatcher that is unbuildable in the Next.js webpack build / CI clean install (see "CI fix" below). A small validate→connect TOCTOU window therefore remains and is documented in-code as the accepted residual; the per-hop re-resolution above is the primary rebinding mitigation.

## Tests
- `web-fetch-ssrf.test.ts` — **75** table-driven pure-fn cases (IPv4/IPv6 private ranges, `169.254/16`, `::1`, `fc00::/7`, `0.0.0.0`, decimal/hex/octal IPs, IPv4-mapped, non-https schemes).
- `web-search-tools.test.ts` — **35** redirect/rebind shell cases: manual-redirect assertion, public→public follow, metadata-literal block, `http://` downgrade block, rebind-to-private block, redirect-cap, graceful network-error result.
- Both registered in `scripts/test-security.sh` under a new "AI Tool Security" section.

## Verification
- `bun run typecheck` — pass
- `bun run lint` — pass (no new findings)
- new unit + security tests — **110 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-ups
- **Shared deadline** (`f8d4342b3`): replaced the per-hop `AbortSignal.timeout` (which reset on every redirect and didn't cover the body read) with a single shared signal bounding the whole operation — all hops + the streamed body read.
- **Dispatcher leak on fetch rejection** (`64bb4baff`, Codex P2): closed the per-hop undici Agent before rethrowing — later made moot when the dispatcher was removed entirely (see CI fix); the thread is resolved and the leak path no longer exists.

## CI fix (a0efbd868)
First CI run was red on 3 checks — all one root cause: the optional undici IP-pinning dispatcher (`import { Agent } from 'undici'`) is unresolvable in the Next.js webpack build and CI's clean-install typecheck (undici is Node-internal, not a declared apps/web dep; it only resolved locally via a transitive hoist). Removed the dispatcher; kept all substantive M2 protections (manual redirect, per-hop scheme/host revalidation, DNS re-resolution rejecting non-public IPs, shared deadline). A small validate→connect TOCTOU window remains (documented). 110 tests green; all checks green.
