### PR TITLE
fix(security): release/settle credit holds on v1 chat error paths

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -135,6 +135,10 @@ vi.mock('@pagespace/lib/billing/credit-gate', () => ({
   canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
 }));
 
+vi.mock('@pagespace/lib/billing/credit-consume', () => ({
+  releaseHold: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('ai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('ai')>();
   return {
@@ -165,6 +169,7 @@ import { chatMessageRepository } from '@/lib/repositories/chat-message-repositor
 import { sanitizeMessagesForModel, extractMessageContent, saveMessageToDatabase } from '@/lib/ai/core/message-utils';
 import type { UIMessage } from 'ai';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const mcpAuth = {
@@ -893,6 +898,121 @@ describe('POST /api/v1/chat/completions', () => {
         hasToolCalls: Array.isArray(assistantSave?.[0]?.toolCalls) && (assistantSave![0].toolCalls as unknown[]).length > 0,
       },
       expected: { saved: true, hasToolCalls: true },
+    });
+  });
+
+  // --- Credit-hold leak regressions (audit findings L6, L7) ---
+
+  test('L6: a pre-stream setup throw releases the hold and never reaches the model', async () => {
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-setup' });
+    // Persisting the user message is the last awaited setup step before streamText. A failure
+    // here must NOT strand the gate's hold + in-flight slot until TTL.
+    vi.mocked(saveMessageToDatabase).mockRejectedValueOnce(new Error('db write failed'));
+
+    const response = await POST(makeRequest(validBody));
+
+    assert({
+      given: 'a throw during pre-stream setup (user-message persistence) after the hold is placed',
+      should: 'return 500, release the hold exactly once, never call streamText, and never settle usage',
+      actual: {
+        status: response.status,
+        releaseCalls: vi.mocked(releaseHold).mock.calls.length,
+        releasedHoldId: vi.mocked(releaseHold).mock.calls[0]?.[0],
+        streamTextCalls: vi.mocked(streamText).mock.calls.length,
+        trackUsageCalls: vi.mocked(AIMonitoring.trackUsage).mock.calls.length,
+      },
+      expected: {
+        status: 500,
+        releaseCalls: 1,
+        releasedHoldId: 'hold-setup',
+        streamTextCalls: 0,
+        trackUsageCalls: 0,
+      },
+    });
+  });
+
+  test('L6: a successful stream hands the hold off — the setup finally does not release it', async () => {
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-ok' });
+
+    const response = await POST(makeRequest(validBody));
+    await response.text();
+
+    assert({
+      given: 'a request that reaches the streaming Response',
+      should: 'hand the hold to the stream lifecycle (settle billed it) and not double-release in finally',
+      actual: {
+        status: response.status,
+        releaseCalls: vi.mocked(releaseHold).mock.calls.length,
+        trackUsageHoldId: vi.mocked(AIMonitoring.trackUsage).mock.calls[0]?.[0]?.holdId,
+      },
+      expected: { status: 200, releaseCalls: 0, trackUsageHoldId: 'hold-ok' },
+    });
+  });
+
+  test('L7: a mid-stream (non-abort) error settles partial usage as a failure before releasing', async () => {
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-l7' });
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      // Partial spend the provider already burned before the error.
+      totalUsage: Promise.resolve({ inputTokens: 12, outputTokens: 4 }),
+      steps: Promise.resolve([]),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        yield { type: 'text-delta', id: 't1', delta: 'Half a thought' };
+        // A genuine provider error mid-stream (NOT a consumer abort).
+        throw new Error('provider exploded mid-stream');
+      },
+    })) as unknown as typeof streamText);
+
+    const response = await POST(makeRequest(validBody));
+    // The route propagates the error via controller.error after settling; draining throws.
+    await response.text().catch(() => undefined);
+
+    const calls = vi.mocked(AIMonitoring.trackUsage).mock.calls;
+    assert({
+      given: 'a provider error mid-stream after tokens were burned',
+      should: 'bill the partial usage once as a failed run (success=false, errored) with the holdId, and NOT release the hold (settle consumes it)',
+      actual: {
+        trackUsageCalls: calls.length,
+        holdId: calls[0]?.[0]?.holdId,
+        success: calls[0]?.[0]?.success,
+        inputTokens: calls[0]?.[0]?.inputTokens,
+        errored: (calls[0]?.[0]?.metadata as Record<string, unknown> | undefined)?.errored,
+        releaseCalls: vi.mocked(releaseHold).mock.calls.length,
+      },
+      expected: {
+        trackUsageCalls: 1,
+        holdId: 'hold-l7',
+        success: false,
+        inputTokens: 12,
+        errored: true,
+        releaseCalls: 0,
+      },
+    });
+  });
+
+  test('L7: a mid-stream error with no burned usage releases the hold without billing', async () => {
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-empty' });
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      // No usage/steps ever materialised before the failure.
+      totalUsage: Promise.reject(new Error('no usage')),
+      steps: Promise.reject(new Error('no steps')),
+      toUIMessageStream: async function* () {
+        throw new Error('failed before any output');
+      },
+    })) as unknown as typeof streamText);
+
+    const response = await POST(makeRequest(validBody));
+    await response.text().catch(() => undefined);
+
+    assert({
+      given: 'a mid-stream error before any tokens were burned',
+      should: 'release the hold once with its id and record no usage',
+      actual: {
+        releaseCalls: vi.mocked(releaseHold).mock.calls.length,
+        releasedHoldId: vi.mocked(releaseHold).mock.calls[0]?.[0],
+        trackUsageCalls: vi.mocked(AIMonitoring.trackUsage).mock.calls.length,
+      },
+      expected: { releaseCalls: 1, releasedHoldId: 'hold-empty', trackUsageCalls: 0 },
     });
   });
 });

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -1015,4 +1015,58 @@ describe('POST /api/v1/chat/completions', () => {
       expected: { releaseCalls: 1, releasedHoldId: 'hold-empty', trackUsageCalls: 0 },
     });
   });
+
+  test('L7: streamed text with no token counts releases the hold instead of settling a $0 row', async () => {
+    // Codex P1: a partial-output error where text was emitted but the usage/steps promises
+    // reject leaves NO billable token counts. Settling here would record a misleading $0 usage
+    // row (trackUsage skips consumeCredits for a failed run with totalTokens===0) — so the
+    // disposition must be a plain release, NOT settle-partial, even though text streamed.
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-textonly' });
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      totalUsage: Promise.reject(new Error('usage unavailable')),
+      steps: Promise.reject(new Error('steps unavailable')),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        yield { type: 'text-delta', id: 't1', delta: 'A partial answer with no accounting' };
+        throw new Error('provider dropped after partial text');
+      },
+    })) as unknown as typeof streamText);
+
+    const response = await POST(makeRequest(validBody));
+    await response.text().catch(() => undefined);
+
+    assert({
+      given: 'a mid-stream error after streaming text but with no recoverable token counts',
+      should: 'release the hold once and NOT call trackUsage (no misleading $0 settle)',
+      actual: {
+        releaseCalls: vi.mocked(releaseHold).mock.calls.length,
+        releasedHoldId: vi.mocked(releaseHold).mock.calls[0]?.[0],
+        trackUsageCalls: vi.mocked(AIMonitoring.trackUsage).mock.calls.length,
+      },
+      expected: { releaseCalls: 1, releasedHoldId: 'hold-textonly', trackUsageCalls: 0 },
+    });
+  });
+
+  test('L6: the setup-phase hold release is awaited before the 500 returns (not fire-and-forget)', async () => {
+    // Codex P2: the setup-error path returns a plain JSON 500 with no stream keeping the
+    // runtime alive, so the release must be awaited — a fire-and-forget release could be
+    // abandoned if a serverless runtime freezes after the response. We prove the await by
+    // resolving releaseHold only after a deferred tick and asserting it has settled by the
+    // time POST resolves.
+    vi.mocked(canConsumeAI).mockResolvedValueOnce({ allowed: true, reason: 'unlimited', holdId: 'hold-awaited' });
+    vi.mocked(saveMessageToDatabase).mockRejectedValueOnce(new Error('db write failed'));
+    let released = false;
+    vi.mocked(releaseHold).mockImplementationOnce(
+      () => new Promise<void>((resolve) => setTimeout(() => { released = true; resolve(); }, 0)),
+    );
+
+    const response = await POST(makeRequest(validBody));
+
+    assert({
+      given: 'a pre-stream setup failure whose hold release resolves on a later tick',
+      should: 'await the release so it has completed by the time the 500 response is returned',
+      actual: { status: response.status, released },
+      expected: { status: 500, released: true },
+    });
+  });
 });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -29,6 +29,7 @@ import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
 import { buildToolSummaryEvent } from '@/lib/ai/openai-api/build-tool-summary-event';
 import { validateConversationAccess } from '@/lib/ai/openai-api/v1-conversations';
 import { extractToolCallsFromSteps } from '@/lib/ai/openai-api/extract-tool-calls-from-steps';
+import { resolveHoldDisposition } from '@/lib/ai/openai-api/resolve-hold-disposition';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { AIMonitoring, extractOpenRouterCostDollars, extractOpenRouterGenerationIds } from '@pagespace/lib/monitoring/ai-monitoring';
@@ -176,354 +177,398 @@ export async function POST(request: Request): Promise<Response> {
   // The gate's reservation for this call, released when usage is billed in onFinish.
   const holdId = creditGate.holdId;
 
-  // 7. Build system prompt from agent page config
-  const systemPrompt = page.systemPrompt
-    ?? buildSystemPrompt('page', undefined, false);
+  // Ownership of the hold transfers to the streaming lifecycle only once we return the
+  // streaming Response (set just before `return new Response`). Until then, ANY throw in the
+  // setup below — capabilities lookup, convertToModelMessages, message persistence — must
+  // free the hold, or a pre-stream failure strands the user's credits plus an in-flight slot
+  // until CREDIT_HOLD_TTL_SECONDS expires (L6). The finally enforces that.
+  let holdHandedOff = false;
+  try {
+    // 7. Build system prompt from agent page config
+    const systemPrompt = page.systemPrompt
+      ?? buildSystemPrompt('page', undefined, false);
 
-  // 7b. Build the final tool set and stop conditions based on the request mode:
-  //   server-only (useServerTools && !hasClientTools)  — full PageSpace tools + finish tool (default)
-  //   client-only (!useServerTools) — caller tools only, or empty if no client tools provided
-  //   both        (useServerTools && hasClientTools) — merged; client wins on name collision
-  // Client modes skip the finish tool because the caller controls the conversation externally;
-  // each round-trip is a new request and the finish tool would conflict with that flow.
-  // disable_server_tools is honoured independently of whether client tools are present:
-  //   disable_server_tools:true with no tools → no tools at all (model generates text only).
-  const agentEnabledTools = page.enabledTools as string[] | null;
-  const toolExposureMode = (page.toolExposureMode as 'upfront' | 'search' | null) ?? 'upfront';
+    // 7b. Build the final tool set and stop conditions based on the request mode:
+    //   server-only (useServerTools && !hasClientTools)  — full PageSpace tools + finish tool (default)
+    //   client-only (!useServerTools) — caller tools only, or empty if no client tools provided
+    //   both        (useServerTools && hasClientTools) — merged; client wins on name collision
+    // Client modes skip the finish tool because the caller controls the conversation externally;
+    // each round-trip is a new request and the finish tool would conflict with that flow.
+    // disable_server_tools is honoured independently of whether client tools are present:
+    //   disable_server_tools:true with no tools → no tools at all (model generates text only).
+    const agentEnabledTools = page.enabledTools as string[] | null;
+    const toolExposureMode = (page.toolExposureMode as 'upfront' | 'search' | null) ?? 'upfront';
 
-  const inServerOnlyMode = useServerTools && !hasClientTools;
+    const inServerOnlyMode = useServerTools && !hasClientTools;
 
-  let finalTools: ToolSet;
-  let toolDiscoveryPrompt = '';
-  const stopConditions = inServerOnlyMode
-    ? [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)]
-    : [stepCountIs(100)];
+    let finalTools: ToolSet;
+    let toolDiscoveryPrompt = '';
+    const stopConditions = inServerOnlyMode
+      ? [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)]
+      : [stepCountIs(100)];
 
-  if (inServerOnlyMode) {
-    // server-only: existing pipeline unchanged
-    const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
-    let filteredTools: ToolSet =
-      agentEnabledTools != null
-        ? (Object.fromEntries(
-            Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
-          ) as ToolSet)
-        : (baseTools as ToolSet);
-    const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
-    filteredTools = exposure.tools;
-    toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
-    finalTools = { ...filteredTools, ...finishTool } as ToolSet;
-  } else if (!useServerTools) {
-    // client-only or no-tools: just client tools (may be empty when disable_server_tools=true but no tools provided)
-    finalTools = clientToolSet;
-  } else {
-    // both: server tools + client tools; client wins on name collision
-    const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
-    let filteredTools: ToolSet =
-      agentEnabledTools != null
-        ? (Object.fromEntries(
-            Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
-          ) as ToolSet)
-        : (baseTools as ToolSet);
-    const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
-    filteredTools = exposure.tools;
-    toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
-    finalTools = { ...filteredTools, ...clientToolSet } as ToolSet;
-  }
+    if (inServerOnlyMode) {
+      // server-only: existing pipeline unchanged
+      const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
+      let filteredTools: ToolSet =
+        agentEnabledTools != null
+          ? (Object.fromEntries(
+              Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
+            ) as ToolSet)
+          : (baseTools as ToolSet);
+      const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
+      filteredTools = exposure.tools;
+      toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
+      finalTools = { ...filteredTools, ...finishTool } as ToolSet;
+    } else if (!useServerTools) {
+      // client-only or no-tools: just client tools (may be empty when disable_server_tools=true but no tools provided)
+      finalTools = clientToolSet;
+    } else {
+      // both: server tools + client tools; client wins on name collision
+      const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
+      let filteredTools: ToolSet =
+        agentEnabledTools != null
+          ? (Object.fromEntries(
+              Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
+            ) as ToolSet)
+          : (baseTools as ToolSet);
+      const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
+      filteredTools = exposure.tools;
+      toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
+      finalTools = { ...filteredTools, ...clientToolSet } as ToolSet;
+    }
 
-  // Load the caller's timezone so time-aware tools (calendar, task triggers)
-  // resolve dates in the user's zone instead of defaulting to UTC, matching
-  // the in-app page chat (apps/web/src/app/api/ai/chat/route.ts:833).
-  const [user] = await db
-    .select({ timezone: users.timezone })
-    .from(users)
-    .where(eq(users.id, authResult.userId));
-  const userTimezone = user?.timezone ?? undefined;
+    // Load the caller's timezone so time-aware tools (calendar, task triggers)
+    // resolve dates in the user's zone instead of defaulting to UTC, matching
+    // the in-app page chat (apps/web/src/app/api/ai/chat/route.ts:833).
+    const [user] = await db
+      .select({ timezone: users.timezone })
+      .from(users)
+      .where(eq(users.id, authResult.userId));
+    const userTimezone = user?.timezone ?? undefined;
 
-  // 8. Build message context and save new user message
-  const isThreadMode = incomingConversationId !== undefined;
-  const conversationId = isThreadMode ? incomingConversationId : createId();
-  const userMessage = messages[messages.length - 1];
+    // 8. Build message context and save new user message
+    const isThreadMode = incomingConversationId !== undefined;
+    const conversationId = isThreadMode ? incomingConversationId : createId();
+    const userMessage = messages[messages.length - 1];
 
-  let inferenceMessages = messages;
-  if (isThreadMode && !clientManagesHistory) {
-    const dbMessages = await chatMessageRepository.getMessagesForPage(pageId, conversationId);
-    inferenceMessages = [...dbMessages.map(convertDbMessageToUIMessage), userMessage];
-  }
+    let inferenceMessages = messages;
+    if (isThreadMode && !clientManagesHistory) {
+      const dbMessages = await chatMessageRepository.getMessagesForPage(pageId, conversationId);
+      inferenceMessages = [...dbMessages.map(convertDbMessageToUIMessage), userMessage];
+    }
 
-  // Back-fill: when the client manages full history, persist tool results that arrived
-  // in role:tool messages (normalizeMessages collapsed them into assistant UIMessage parts).
-  // We cannot use msg.id — pagespace-cli sends OpenAI-format messages without id fields, so
-  // normalizeMessages assigns a random createId(). Instead we match DB assistant rows by
-  // tool_call_id, which is a stable key present in both the request body and the DB toolCalls.
-  if (clientManagesHistory && isThreadMode) {
-    const resultsByCallId = new Map<string, ReturnType<typeof extractToolResults>[number]>();
-    for (const msg of messages.slice(0, -1)) {
-      if (msg.role !== 'assistant') continue;
-      for (const result of extractToolResults(msg)) {
-        resultsByCallId.set(result.toolCallId, result);
+    // Back-fill: when the client manages full history, persist tool results that arrived
+    // in role:tool messages (normalizeMessages collapsed them into assistant UIMessage parts).
+    // We cannot use msg.id — pagespace-cli sends OpenAI-format messages without id fields, so
+    // normalizeMessages assigns a random createId(). Instead we match DB assistant rows by
+    // tool_call_id, which is a stable key present in both the request body and the DB toolCalls.
+    if (clientManagesHistory && isThreadMode) {
+      const resultsByCallId = new Map<string, ReturnType<typeof extractToolResults>[number]>();
+      for (const msg of messages.slice(0, -1)) {
+        if (msg.role !== 'assistant') continue;
+        for (const result of extractToolResults(msg)) {
+          resultsByCallId.set(result.toolCallId, result);
+        }
+      }
+      if (resultsByCallId.size > 0) {
+        // Fire-and-forget — the response does not wait for back-fill to complete.
+        // Best-effort: a failure is logged but does not affect the streaming reply.
+        chatMessageRepository.getMessagesByConversationId(conversationId)
+          .then(dbRows => {
+            for (const row of dbRows) {
+              if (row.role !== 'assistant' || !row.isActive) continue;
+              const rawArr: unknown[] = Array.isArray(row.toolCalls)
+                ? row.toolCalls
+                : (() => {
+                    try { const p = JSON.parse(row.toolCalls as string); return Array.isArray(p) ? p : []; }
+                    catch { return []; }
+                  })();
+              const matched = rawArr
+                .filter((tc): tc is Record<string, unknown> =>
+                  typeof tc === 'object' && tc !== null &&
+                  typeof (tc as Record<string, unknown>).toolCallId === 'string' &&
+                  resultsByCallId.has((tc as Record<string, unknown>).toolCallId as string)
+                )
+                .map(tc => resultsByCallId.get(tc.toolCallId as string)!);
+              if (matched.length > 0) {
+                chatMessageRepository.updateMessageToolResults(row.id, conversationId, matched)
+                  .catch((err: unknown) => loggers.ai.error('OpenAI API: failed to back-fill tool results', err as Error));
+              }
+            }
+          })
+          .catch((err: unknown) => loggers.ai.error('OpenAI API: failed to load rows for tool-result back-fill', err as Error));
       }
     }
-    if (resultsByCallId.size > 0) {
-      // Fire-and-forget — the response does not wait for back-fill to complete.
-      // Best-effort: a failure is logged but does not affect the streaming reply.
-      chatMessageRepository.getMessagesByConversationId(conversationId)
-        .then(dbRows => {
-          for (const row of dbRows) {
-            if (row.role !== 'assistant' || !row.isActive) continue;
-            const rawArr: unknown[] = Array.isArray(row.toolCalls)
-              ? row.toolCalls
-              : (() => {
-                  try { const p = JSON.parse(row.toolCalls as string); return Array.isArray(p) ? p : []; }
-                  catch { return []; }
-                })();
-            const matched = rawArr
-              .filter((tc): tc is Record<string, unknown> =>
-                typeof tc === 'object' && tc !== null &&
-                typeof (tc as Record<string, unknown>).toolCallId === 'string' &&
-                resultsByCallId.has((tc as Record<string, unknown>).toolCallId as string)
-              )
-              .map(tc => resultsByCallId.get(tc.toolCallId as string)!);
-            if (matched.length > 0) {
-              chatMessageRepository.updateMessageToolResults(row.id, conversationId, matched)
-                .catch((err: unknown) => loggers.ai.error('OpenAI API: failed to back-fill tool results', err as Error));
-            }
-          }
-        })
-        .catch((err: unknown) => loggers.ai.error('OpenAI API: failed to load rows for tool-result back-fill', err as Error));
-    }
-  }
 
-  const userMessageId = userMessage.id;
-  if (userMessage && userMessage.role === 'user') {
-    await saveMessageToDatabase({
-      messageId: userMessageId,
-      pageId,
-      conversationId,
-      userId: authResult.userId,
-      role: 'user',
-      content: extractMessageContent(userMessage),
-      uiMessage: userMessage,
-    });
-  }
-
-  auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { model: modelName, conversationId }, riskScore: 0 });
-
-  // 9. Run inference — no UI coupling (no WebSocket, no stream lifecycle, no session ID)
-  const startTime = Date.now();
-
-  // OpenAI-style callers may supply their own system message(s) in the request.
-  // sanitizeMessagesForModel strips system-role messages from the array (system content
-  // must ride in the `system:` option, not messages[], per AI SDK prompt-injection
-  // hardening), so hoist any caller system instructions into the system prompt first —
-  // dropping them silently would break standard OpenAI clients.
-  const callerSystemPrompt = inferenceMessages
-    .filter(m => m.role === 'system')
-    .map(extractMessageContent)
-    .filter(Boolean)
-    .join('\n\n');
-  const sanitized = sanitizeMessagesForModel(inferenceMessages);
-
-  // Standard OpenAI-style cancel: the consumer closing the HTTP connection stops generation.
-  // Next.js fires request.signal on disconnect; the ReadableStream's cancel() (below) is a
-  // belt-and-suspenders path for disconnects detected at the response-stream layer.
-  const abortController = new AbortController();
-  if (request.signal.aborted) {
-    // The consumer already dropped the connection during the pre-stream setup above.
-    // addEventListener won't replay a past abort, so trip the controller now — otherwise
-    // streamText would receive a non-aborted signal and burn tokens for a gone client.
-    abortController.abort();
-  } else {
-    request.signal.addEventListener('abort', () => abortController.abort(), { once: true });
-  }
-
-  // Settle billing exactly once. streamText.onFinish does NOT fire on abort (onAbort does),
-  // so both callbacks funnel through here. Tokens burned before an abort are real provider
-  // spend, so we bill them and release the gate's hold in the same path.
-  let settled = false;
-  let assistantText = '';
-  const settle = async ({ aborted, text, totalUsage, steps }: {
-    aborted: boolean;
-    text?: string;
-    totalUsage?: { inputTokens?: number; outputTokens?: number; cachedInputTokens?: number; reasoningTokens?: number };
-    steps?: unknown[];
-  }) => {
-    if (settled) return;
-    settled = true;
-
-    const assistantId = createId();
-    const extracted = extractToolCallsFromSteps(steps ?? []);
-    const hasContent = text !== undefined || extracted.toolCalls.length > 0;
-    if (hasContent) {
+    const userMessageId = userMessage.id;
+    if (userMessage && userMessage.role === 'user') {
       await saveMessageToDatabase({
-        messageId: assistantId,
+        messageId: userMessageId,
         pageId,
         conversationId,
-        userId: null,
-        role: 'assistant',
-        content: text ?? '',
-        toolCalls: extracted.toolCalls.length > 0 ? extracted.toolCalls : undefined,
-        toolResults: extracted.toolResults.length > 0 ? extracted.toolResults : undefined,
-      }).catch((err: unknown) => {
-        loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
+        userId: authResult.userId,
+        role: 'user',
+        content: extractMessageContent(userMessage),
+        uiMessage: userMessage,
       });
     }
 
-    // trackUsage -> consumeCredits decrements the balance and deletes the hold in one
-    // transaction (idempotent if the hold is already gone).
-    await AIMonitoring.trackUsage({
-      userId: authResult.userId,
-      provider: providerResult.provider,
-      model: providerResult.modelName,
-      source: 'chat',
-      inputTokens: totalUsage?.inputTokens,
-      outputTokens: totalUsage?.outputTokens,
-      cachedInputTokens: totalUsage?.cachedInputTokens,
-      reasoningTokens: totalUsage?.reasoningTokens,
-      providerCostDollars: extractOpenRouterCostDollars(steps as Parameters<typeof extractOpenRouterCostDollars>[0]),
-      openrouterGenerationIds: extractOpenRouterGenerationIds(steps as Parameters<typeof extractOpenRouterGenerationIds>[0]),
-      duration: Date.now() - startTime,
-      conversationId,
-      messageId: assistantId,
-      pageId,
-      success: !aborted,
-      holdId,
-      metadata: { via: 'openai_api_v1', ...(aborted ? { aborted: true } : {}) },
-    }).catch((err: unknown) => {
-      loggers.ai.error('OpenAI API: failed to track usage', err as Error);
+    auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { model: modelName, conversationId }, riskScore: 0 });
+
+    // 9. Run inference — no UI coupling (no WebSocket, no stream lifecycle, no session ID)
+    const startTime = Date.now();
+
+    // OpenAI-style callers may supply their own system message(s) in the request.
+    // sanitizeMessagesForModel strips system-role messages from the array (system content
+    // must ride in the `system:` option, not messages[], per AI SDK prompt-injection
+    // hardening), so hoist any caller system instructions into the system prompt first —
+    // dropping them silently would break standard OpenAI clients.
+    const callerSystemPrompt = inferenceMessages
+      .filter(m => m.role === 'system')
+      .map(extractMessageContent)
+      .filter(Boolean)
+      .join('\n\n');
+    const sanitized = sanitizeMessagesForModel(inferenceMessages);
+
+    // Standard OpenAI-style cancel: the consumer closing the HTTP connection stops generation.
+    // Next.js fires request.signal on disconnect; the ReadableStream's cancel() (below) is a
+    // belt-and-suspenders path for disconnects detected at the response-stream layer.
+    const abortController = new AbortController();
+    if (request.signal.aborted) {
+      // The consumer already dropped the connection during the pre-stream setup above.
+      // addEventListener won't replay a past abort, so trip the controller now — otherwise
+      // streamText would receive a non-aborted signal and burn tokens for a gone client.
+      abortController.abort();
+    } else {
+      request.signal.addEventListener('abort', () => abortController.abort(), { once: true });
+    }
+
+    // Settle billing exactly once. streamText.onFinish does NOT fire on abort (onAbort does),
+    // so both callbacks funnel through here. Tokens burned before an abort are real provider
+    // spend, so we bill them and release the gate's hold in the same path. A mid-stream error
+    // passes errored:true so the burned tokens are billed as a failure (success:false) — like
+    // ai/chat's error-path trackUsage — instead of being released and lost (L7).
+    let settled = false;
+    let assistantText = '';
+    const settle = async ({ aborted, errored = false, text, totalUsage, steps }: {
+      aborted: boolean;
+      errored?: boolean;
+      text?: string;
+      totalUsage?: { inputTokens?: number; outputTokens?: number; cachedInputTokens?: number; reasoningTokens?: number };
+      steps?: unknown[];
+    }) => {
+      if (settled) return;
+      settled = true;
+
+      const assistantId = createId();
+      const extracted = extractToolCallsFromSteps(steps ?? []);
+      const hasContent = text !== undefined || extracted.toolCalls.length > 0;
+      if (hasContent) {
+        await saveMessageToDatabase({
+          messageId: assistantId,
+          pageId,
+          conversationId,
+          userId: null,
+          role: 'assistant',
+          content: text ?? '',
+          toolCalls: extracted.toolCalls.length > 0 ? extracted.toolCalls : undefined,
+          toolResults: extracted.toolResults.length > 0 ? extracted.toolResults : undefined,
+        }).catch((err: unknown) => {
+          loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
+        });
+      }
+
+      // trackUsage -> consumeCredits decrements the balance and deletes the hold in one
+      // transaction (idempotent if the hold is already gone). success:false on abort/error
+      // still bills burned tokens while marking the run unsuccessful.
+      await AIMonitoring.trackUsage({
+        userId: authResult.userId,
+        provider: providerResult.provider,
+        model: providerResult.modelName,
+        source: 'chat',
+        inputTokens: totalUsage?.inputTokens,
+        outputTokens: totalUsage?.outputTokens,
+        cachedInputTokens: totalUsage?.cachedInputTokens,
+        reasoningTokens: totalUsage?.reasoningTokens,
+        providerCostDollars: extractOpenRouterCostDollars(steps as Parameters<typeof extractOpenRouterCostDollars>[0]),
+        openrouterGenerationIds: extractOpenRouterGenerationIds(steps as Parameters<typeof extractOpenRouterGenerationIds>[0]),
+        duration: Date.now() - startTime,
+        conversationId,
+        messageId: assistantId,
+        pageId,
+        success: !aborted && !errored,
+        holdId,
+        metadata: { via: 'openai_api_v1', ...(aborted ? { aborted: true } : {}), ...(errored ? { errored: true } : {}) },
+      }).catch((err: unknown) => {
+        loggers.ai.error('OpenAI API: failed to track usage', err as Error);
+      });
+    };
+
+    const aiResult = streamText({
+      model: providerResult.model,
+      system: systemPrompt + (callerSystemPrompt ? `\n\n${callerSystemPrompt}` : '') + toolDiscoveryPrompt,
+      messages: convertToModelMessages(sanitized),
+      tools: finalTools,
+      stopWhen: stopConditions,
+      // Aborts when the consumer closes the connection (see abortController above).
+      abortSignal: abortController.signal,
+      experimental_context: {
+        userId: authResult.userId,
+        conversationId,
+        timezone: userTimezone,
+        aiProvider: page.aiProvider ?? undefined,
+        aiModel: page.aiModel ?? undefined,
+        modelCapabilities: await getModelCapabilities(
+          providerResult.modelName,
+          providerResult.provider,
+        ),
+        chatSource: { type: 'page' as const, agentPageId: pageId, agentTitle: page.title },
+        enabledTools: agentEnabledTools ?? null,
+        // Bind tool execution to the MCP token's drive scope so a scoped token
+        // cannot reach drives outside its scope via the agent's broader ACL.
+        mcpAllowedDriveIds: getAllowedDriveIds(authResult),
+      },
+      maxRetries: 20,
     });
-  };
 
-  const aiResult = streamText({
-    model: providerResult.model,
-    system: systemPrompt + (callerSystemPrompt ? `\n\n${callerSystemPrompt}` : '') + toolDiscoveryPrompt,
-    messages: convertToModelMessages(sanitized),
-    tools: finalTools,
-    stopWhen: stopConditions,
-    // Aborts when the consumer closes the connection (see abortController above).
-    abortSignal: abortController.signal,
-    experimental_context: {
-      userId: authResult.userId,
-      conversationId,
-      timezone: userTimezone,
-      aiProvider: page.aiProvider ?? undefined,
-      aiModel: page.aiModel ?? undefined,
-      modelCapabilities: await getModelCapabilities(
-        providerResult.modelName,
-        providerResult.provider,
-      ),
-      chatSource: { type: 'page' as const, agentPageId: pageId, agentTitle: page.title },
-      enabledTools: agentEnabledTools ?? null,
-      // Bind tool execution to the MCP token's drive scope so a scoped token
-      // cannot reach drives outside its scope via the agent's broader ACL.
-      mcpAllowedDriveIds: getAllowedDriveIds(authResult),
-    },
-    maxRetries: 20,
-  });
+    // 10. Stream response as OpenAI SSE
+    const completionId = `chatcmpl-${createId()}`;
+    const created = Math.floor(Date.now() / 1000);
+    const encoder = new TextEncoder();
 
-  // 10. Stream response as OpenAI SSE
-  const completionId = `chatcmpl-${createId()}`;
-  const created = Math.floor(Date.now() / 1000);
-  const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      async start(controller) {
+        // Per-step tool call state: tracks tool index and presence for finish-step finish_reason
+        let stepToolCallIndex = 0;
+        let stepHadToolCalls = false;
+        // Client-tool tracking: detect when the stream ends on a client-side tool call so we
+        // can emit finish_reason:'tool_calls' instead of 'stop' on the final finish chunk.
+        const clientToolNames = new Set(Object.keys(clientToolSet));
+        let hadClientToolThisStep = false;
+        let streamEndedOnClientTool = false;
 
-  const stream = new ReadableStream({
-    async start(controller) {
-      // Per-step tool call state: tracks tool index and presence for finish-step finish_reason
-      let stepToolCallIndex = 0;
-      let stepHadToolCalls = false;
-      // Client-tool tracking: detect when the stream ends on a client-side tool call so we
-      // can emit finish_reason:'tool_calls' instead of 'stop' on the final finish chunk.
-      const clientToolNames = new Set(Object.keys(clientToolSet));
-      let hadClientToolThisStep = false;
-      let streamEndedOnClientTool = false;
+        try {
+          for await (const chunk of aiResult.toUIMessageStream()) {
+            if (chunk.type === 'text-delta') assistantText += chunk.delta;
 
-      try {
-        for await (const chunk of aiResult.toUIMessageStream()) {
-          if (chunk.type === 'text-delta') assistantText += chunk.delta;
+            // Reset per-step state at the start of each inference step
+            if (chunk.type === 'start-step') {
+              stepToolCallIndex = 0;
+              stepHadToolCalls = false;
+              hadClientToolThisStep = false;
+            }
 
-          // Reset per-step state at the start of each inference step
-          if (chunk.type === 'start-step') {
-            stepToolCallIndex = 0;
-            stepHadToolCalls = false;
-            hadClientToolThisStep = false;
-          }
+            // Capture index before increment so the emitted chunk gets the right index
+            const toolCallIndex = stepToolCallIndex;
+            if (chunk.type === 'tool-input-available') {
+              stepHadToolCalls = true;
+              stepToolCallIndex++;
+              if (clientToolNames.has(chunk.toolName)) {
+                hadClientToolThisStep = true;
+              }
+            }
 
-          // Capture index before increment so the emitted chunk gets the right index
-          const toolCallIndex = stepToolCallIndex;
-          if (chunk.type === 'tool-input-available') {
-            stepHadToolCalls = true;
-            stepToolCallIndex++;
-            if (clientToolNames.has(chunk.toolName)) {
-              hadClientToolThisStep = true;
+            if (chunk.type === 'finish-step' && hadClientToolThisStep) {
+              streamEndedOnClientTool = true;
+            }
+
+            const line = adaptToOpenAIChunk(chunk, {
+              id: completionId,
+              model: modelName,
+              created,
+              toolCallIndex,
+              hadToolCallsInStep: stepHadToolCalls,
+              overrideFinishReason: chunk.type === 'finish' && streamEndedOnClientTool ? 'tool_calls' : undefined,
+            });
+            if (line) {
+              controller.enqueue(encoder.encode(line + '\n\n'));
             }
           }
-
-          if (chunk.type === 'finish-step' && hadClientToolThisStep) {
-            streamEndedOnClientTool = true;
+          // A consumer abort ends the stream gracefully (the SDK emits an abort part) rather
+          // than throwing, so settlement happens here for both normal finish and abort. Doing
+          // it inside the stream lifecycle — and awaiting it before closing — ensures billing
+          // and hold release complete before the response ends, instead of racing a detached
+          // callback that a serverless runtime may freeze after the connection drops.
+          const aborted = abortController.signal.aborted;
+          if (aborted) {
+            loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
           }
-
-          const line = adaptToOpenAIChunk(chunk, {
-            id: completionId,
-            model: modelName,
-            created,
-            toolCallIndex,
-            hadToolCallsInStep: stepHadToolCalls,
-            overrideFinishReason: chunk.type === 'finish' && streamEndedOnClientTool ? 'tool_calls' : undefined,
-          });
-          if (line) {
-            controller.enqueue(encoder.encode(line + '\n\n'));
-          }
-        }
-        // A consumer abort ends the stream gracefully (the SDK emits an abort part) rather
-        // than throwing, so settlement happens here for both normal finish and abort. Doing
-        // it inside the stream lifecycle — and awaiting it before closing — ensures billing
-        // and hold release complete before the response ends, instead of racing a detached
-        // callback that a serverless runtime may freeze after the connection drops.
-        const aborted = abortController.signal.aborted;
-        if (aborted) {
-          loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
-        }
-        const totalUsage = await aiResult.totalUsage.catch(() => undefined);
-        const steps = await aiResult.steps.catch(() => undefined);
-        await settle({ aborted, text: assistantText || undefined, totalUsage, steps });
-        if (!aborted) {
-          const toolSummary = buildToolSummaryEvent(steps ?? []);
-          if (toolSummary) {
-            controller.enqueue(encoder.encode(toolSummary + '\n\n'));
-          }
-          controller.enqueue(encoder.encode('data: [DONE]\n\n'));
-        }
-        controller.close();
-      } catch (err) {
-        // Some providers surface an abort as a thrown AbortError instead. Treat it as a
-        // clean stop and settle the partial usage the same way.
-        if (abortController.signal.aborted) {
-          loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
           const totalUsage = await aiResult.totalUsage.catch(() => undefined);
           const steps = await aiResult.steps.catch(() => undefined);
-          await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
+          await settle({ aborted, text: assistantText || undefined, totalUsage, steps });
+          if (!aborted) {
+            const toolSummary = buildToolSummaryEvent(steps ?? []);
+            if (toolSummary) {
+              controller.enqueue(encoder.encode(toolSummary + '\n\n'));
+            }
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+          }
           controller.close();
-          return;
-        }
-        loggers.ai.error('OpenAI API: stream failed', err as Error);
-        // The stream errored before settlement, so the gate's reservation would otherwise
-        // linger until TTL/reconcile — leaving the user artificially short on credits.
-        // Release it now (idempotent if already settled).
-        if (!settled && holdId) await releaseHold(holdId).catch(() => {});
-        controller.error(err);
-      }
-    },
-    cancel() {
-      // Consumer closed the connection mid-stream: stop the model.
-      abortController.abort();
-    },
-  });
+        } catch (err) {
+          const aborted = abortController.signal.aborted;
+          // Gather whatever partial usage/spend the stream produced before failing so the
+          // disposition can bill it rather than drop it. totalUsage/steps reject if the
+          // stream never produced them — treat that as "nothing burned".
+          const totalUsage = await aiResult.totalUsage.catch(() => undefined);
+          const steps = await aiResult.steps.catch(() => undefined);
+          const hasUsage =
+            !!(totalUsage && (totalUsage.inputTokens || totalUsage.outputTokens || totalUsage.cachedInputTokens || totalUsage.reasoningTokens)) ||
+            (Array.isArray(steps) && steps.length > 0) ||
+            assistantText.length > 0;
+          const disposition = resolveHoldDisposition({ phase: 'streaming', aborted, usage: hasUsage });
 
-  return new Response(stream, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-    },
-  });
+          if (aborted) {
+            // Some providers surface an abort as a thrown AbortError instead of ending the
+            // stream gracefully. Treat it as a clean stop: settle the partial usage the same
+            // way the normal finish path does (disposition === 'handed-off').
+            loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
+            await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
+            controller.close();
+            return;
+          }
+
+          loggers.ai.error('OpenAI API: stream failed', err as Error);
+          if (disposition === 'settle-partial') {
+            // Mid-stream error with real spend: bill the burned tokens best-effort as a failed
+            // run (success:false) BEFORE the hold is gone, so reconcile/backfill has the real
+            // spend to recover. settle() consumes the hold in the same transaction (L7).
+            await settle({ aborted: false, errored: true, text: assistantText || undefined, totalUsage, steps });
+          } else if (!settled && holdId) {
+            // Nothing was burned: just free the reservation so it doesn't linger to TTL.
+            // Idempotent if settlement already happened.
+            await releaseHold(holdId).catch(() => {});
+          }
+          controller.error(err);
+        }
+      },
+      cancel() {
+        // Consumer closed the connection mid-stream: stop the model.
+        abortController.abort();
+      },
+    });
+
+    // The streaming lifecycle (settle / the stream's error handler) now owns the hold, so the
+    // setup finally below must not release it.
+    holdHandedOff = true;
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  } catch (setupError) {
+    // Pre-stream failure (capabilities / convertToModelMessages / persistence). No provider
+    // tokens were billed; the finally frees the hold. Return 500 like the in-app chat route.
+    loggers.ai.error('OpenAI API: request setup failed before streaming', setupError as Error, { pageId });
+    return NextResponse.json({ error: 'Failed to process chat request. Please try again.' }, { status: 500 });
+  } finally {
+    // Setup-phase disposition is always 'release' (resolveHoldDisposition); only act when the
+    // stream never took ownership of the hold. Idempotent and best-effort.
+    if (holdId && !holdHandedOff && resolveHoldDisposition({ phase: 'setup', aborted: false, usage: false }) === 'release') {
+      void releaseHold(holdId).catch(() => {});
+    }
+  }
 }

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -512,10 +512,18 @@ export async function POST(request: Request): Promise<Response> {
           // stream never produced them — treat that as "nothing burned".
           const totalUsage = await aiResult.totalUsage.catch(() => undefined);
           const steps = await aiResult.steps.catch(() => undefined);
-          const hasUsage =
-            !!(totalUsage && (totalUsage.inputTokens || totalUsage.outputTokens || totalUsage.cachedInputTokens || totalUsage.reasoningTokens)) ||
-            (Array.isArray(steps) && steps.length > 0) ||
-            assistantText.length > 0;
+          // "Billable usage" is strictly real token counts. For a FAILED run, trackUsage only
+          // reaches consumeCredits when totalTokens > 0 (ai-monitoring.ts:942) and otherwise
+          // just releases the hold. So streamed text or provider cost WITHOUT token counts
+          // would settle a misleading $0 row and release anyway — no better than a plain
+          // release, but noisier. We therefore only settle-partial when tokens were actually
+          // captured; with none, we release the hold directly (Codex P1).
+          const hasUsage = !!(totalUsage && (
+            (totalUsage.inputTokens ?? 0) > 0 ||
+            (totalUsage.outputTokens ?? 0) > 0 ||
+            (totalUsage.cachedInputTokens ?? 0) > 0 ||
+            (totalUsage.reasoningTokens ?? 0) > 0
+          ));
           const disposition = resolveHoldDisposition({ phase: 'streaming', aborted, usage: hasUsage });
 
           if (aborted) {
@@ -566,9 +574,12 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'Failed to process chat request. Please try again.' }, { status: 500 });
   } finally {
     // Setup-phase disposition is always 'release' (resolveHoldDisposition); only act when the
-    // stream never took ownership of the hold. Idempotent and best-effort.
+    // stream never took ownership of the hold. AWAIT the release here: this path returns a
+    // plain JSON 500 with no stream to keep the runtime alive, so a fire-and-forget release
+    // could be abandoned if a serverless runtime freezes after the response — the exact leak
+    // this change closes (Codex P2). Idempotent and best-effort.
     if (holdId && !holdHandedOff && resolveHoldDisposition({ phase: 'setup', aborted: false, usage: false }) === 'release') {
-      void releaseHold(holdId).catch(() => {});
+      await releaseHold(holdId).catch(() => {});
     }
   }
 }

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -507,11 +507,23 @@ export async function POST(request: Request): Promise<Response> {
           controller.close();
         } catch (err) {
           const aborted = abortController.signal.aborted;
-          // Gather whatever partial usage/spend the stream produced before failing so the
-          // disposition can bill it rather than drop it. totalUsage/steps reject if the
-          // stream never produced them — treat that as "nothing burned".
+          // Gather whatever partial usage/spend the stream produced before failing.
+          // totalUsage/steps reject if the stream never produced them — treat that as
+          // "nothing burned".
           const totalUsage = await aiResult.totalUsage.catch(() => undefined);
           const steps = await aiResult.steps.catch(() => undefined);
+
+          if (aborted) {
+            // Some providers surface an abort as a thrown AbortError instead of ending the
+            // stream gracefully. Treat it as a clean stop: settle the partial usage the same
+            // way the normal finish path does (resolveHoldDisposition would return 'handed-off'
+            // for an aborted streaming phase).
+            loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
+            await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
+            controller.close();
+            return;
+          }
+
           // "Billable usage" is strictly real token counts. For a FAILED run, trackUsage only
           // reaches consumeCredits when totalTokens > 0 (ai-monitoring.ts:942) and otherwise
           // just releases the hold. So streamed text or provider cost WITHOUT token counts
@@ -524,17 +536,7 @@ export async function POST(request: Request): Promise<Response> {
             (totalUsage.cachedInputTokens ?? 0) > 0 ||
             (totalUsage.reasoningTokens ?? 0) > 0
           ));
-          const disposition = resolveHoldDisposition({ phase: 'streaming', aborted, usage: hasUsage });
-
-          if (aborted) {
-            // Some providers surface an abort as a thrown AbortError instead of ending the
-            // stream gracefully. Treat it as a clean stop: settle the partial usage the same
-            // way the normal finish path does (disposition === 'handed-off').
-            loggers.ai.info('OpenAI API: stream aborted by consumer', { pageId, conversationId });
-            await settle({ aborted: true, text: assistantText || undefined, totalUsage, steps });
-            controller.close();
-            return;
-          }
+          const disposition = resolveHoldDisposition({ phase: 'streaming', aborted: false, usage: hasUsage });
 
           loggers.ai.error('OpenAI API: stream failed', err as Error);
           if (disposition === 'settle-partial') {

--- a/apps/web/src/lib/ai/openai-api/__tests__/resolve-hold-disposition.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/resolve-hold-disposition.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { resolveHoldDisposition } from '../resolve-hold-disposition';
+
+describe('resolveHoldDisposition', () => {
+  test('setup-phase failure always releases the hold (L6)', () => {
+    assert({
+      given: 'phase=setup — a throw before streamText took over the hold',
+      should: 'release the hold outright: no provider tokens were ever billed',
+      actual: resolveHoldDisposition({ phase: 'setup', aborted: false, usage: false }),
+      expected: 'release',
+    });
+  });
+
+  test('setup-phase release wins even if usage/abort flags are set', () => {
+    assert({
+      given: 'phase=setup with aborted=true and usage=true',
+      should: 'still release — setup means streamText never ran, nothing to settle',
+      actual: resolveHoldDisposition({ phase: 'setup', aborted: true, usage: true }),
+      expected: 'release',
+    });
+  });
+
+  test('consumer abort during streaming is owned by the stream lifecycle', () => {
+    assert({
+      given: 'phase=streaming with aborted=true and usage=true',
+      should: 'return handed-off — the abort path settles burned tokens itself',
+      actual: resolveHoldDisposition({ phase: 'streaming', aborted: true, usage: true }),
+      expected: 'handed-off',
+    });
+  });
+
+  test('abort with no usage is still handed off, not released by the error path', () => {
+    assert({
+      given: 'phase=streaming with aborted=true and usage=false',
+      should: 'return handed-off — the error handler must not touch an aborted hold',
+      actual: resolveHoldDisposition({ phase: 'streaming', aborted: true, usage: false }),
+      expected: 'handed-off',
+    });
+  });
+
+  test('mid-stream error with burned tokens settles partial usage before release (L7)', () => {
+    assert({
+      given: 'phase=streaming with aborted=false and usage=true',
+      should: 'return settle-partial — bill best-effort spend instead of dropping it',
+      actual: resolveHoldDisposition({ phase: 'streaming', aborted: false, usage: true }),
+      expected: 'settle-partial',
+    });
+  });
+
+  test('mid-stream error with nothing burned just releases the hold', () => {
+    assert({
+      given: 'phase=streaming with aborted=false and usage=false',
+      should: 'return release — no spend to record, so free the hold directly',
+      actual: resolveHoldDisposition({ phase: 'streaming', aborted: false, usage: false }),
+      expected: 'release',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/resolve-hold-disposition.ts
+++ b/apps/web/src/lib/ai/openai-api/resolve-hold-disposition.ts
@@ -22,7 +22,12 @@ export interface HoldDispositionInput {
   phase: HoldPhase;
   /** Whether the consumer aborted the connection (vs a genuine error). */
   aborted: boolean;
-  /** Whether any partial usage/spend was captured and is worth billing. */
+  /**
+   * Whether real, billable token usage was captured. This must reflect token counts the
+   * failed-run billing path will actually charge (trackUsage only bills an unsuccessful run
+   * when totalTokens > 0) — NOT streamed text or provider cost without tokens, which would
+   * settle a misleading $0 row. When false, the hold is released directly instead.
+   */
   usage: boolean;
 }
 

--- a/apps/web/src/lib/ai/openai-api/resolve-hold-disposition.ts
+++ b/apps/web/src/lib/ai/openai-api/resolve-hold-disposition.ts
@@ -1,0 +1,52 @@
+/**
+ * Decide what should happen to a chat credit hold when a v1 request leaves the normal
+ * "stream finished and settled itself" path. Extracted as a pure function so the
+ * OpenAI-compat streaming shell (apps/web/src/app/api/v1/chat/completions/route.ts)
+ * stays thin and the hold-disposition decision is unit-testable in isolation.
+ *
+ * Background: the gate reserves a credit hold + an in-flight slot before any model call.
+ * Leaving it un-disposed strands the user's credits and one of MAX_CHAT_INFLIGHT slots
+ * until the hold's TTL expires — the leak this function exists to close.
+ *
+ * Phases:
+ *  - 'setup'     — a throw before streamText took over the hold (capabilities /
+ *                  convertToModelMessages / persistence). No provider tokens were ever
+ *                  billed, so the hold is freed outright.
+ *  - 'streaming' — an error or abort surfaced while consuming the model stream. The hold
+ *                  is still live and is disposed of based on what actually happened.
+ */
+export type HoldPhase = 'setup' | 'streaming';
+
+export interface HoldDispositionInput {
+  /** Where in the request lifecycle the disposition is being decided. */
+  phase: HoldPhase;
+  /** Whether the consumer aborted the connection (vs a genuine error). */
+  aborted: boolean;
+  /** Whether any partial usage/spend was captured and is worth billing. */
+  usage: boolean;
+}
+
+/**
+ *  - 'release'        — free the hold without billing (nothing was spent).
+ *  - 'settle-partial' — bill best-effort partial usage (success:false), which also
+ *                       consumes the hold; do this before any release so burned tokens
+ *                       are recorded instead of silently dropped.
+ *  - 'handed-off'     — the normal stream lifecycle owns settlement (abort path); the
+ *                       error handler must not touch the hold.
+ */
+export type HoldDisposition = 'release' | 'settle-partial' | 'handed-off';
+
+export const resolveHoldDisposition = ({
+  phase,
+  aborted,
+  usage,
+}: HoldDispositionInput): HoldDisposition => {
+  // Pre-stream failure: streamText never ran, so no tokens were billed — just free the hold.
+  if (phase === 'setup') return 'release';
+  // Consumer abort: the stream lifecycle settles burned tokens itself; don't double-handle.
+  if (aborted) return 'handed-off';
+  // Mid-stream error with real spend: bill it best-effort before the hold is consumed.
+  if (usage) return 'settle-partial';
+  // Mid-stream error with nothing burned: no usage to record, just release the hold.
+  return 'release';
+};


### PR DESCRIPTION
## Summary

The v1 OpenAI-compatible chat route (`apps/web/src/app/api/v1/chat/completions/route.ts`) places a prepaid **credit hold** plus an **in-flight slot** before any model call, but left both stranded on two error paths. This PR closes audit findings **L6** and **L7** from the 2026-06-09 security audit.

## Findings closed

### L6 — pre-stream exceptions leaked the hold
Setup work between placing the hold (`~177`) and calling `streamText` (`~396`) — model-capabilities lookup, `convertToModelMessages`, message persistence — ran with **no `try/finally`**. A throw returned `500` while the hold + an in-flight slot lingered until `CREDIT_HOLD_TTL_SECONDS`. Two such failures lock a free user (`MAX_FREE_INFLIGHT=2`) out of AI for ~15 min.

**Fix:** wrap setup in `try/catch/finally` with a `holdHandedOff` flag, transferring hold ownership to the streaming lifecycle only at the `return new Response(...)`. The `finally` releases the hold on any pre-stream exit — the exact pattern used by `apps/web/src/app/api/ai/chat/route.ts:1216-1219`.

### L7 — mid-stream error released the hold without settling
A mid-stream (non-abort) error at `~496-512` called `releaseHold` + `controller.error()` **without `settle()`** — tokens the provider had already burned were never billed, and backfill/reconcile had nothing to recover.

**Fix:** settle best-effort partial usage as a **failed run** (`success:false`) **before** releasing, mirroring `ai/chat`'s error-path `trackUsage` (`~1182-1208`). `settle()` consumes the hold in the same transaction.

## Approach — pure function + thin shell (strict TDD)

The hold-disposition decision is isolated in a pure, unit-tested function:

```ts
resolveHoldDisposition({ phase, aborted, usage })
  -> 'release' | 'settle-partial' | 'handed-off'
```

- `phase:'setup'` → `release` (streamText never ran; no tokens billed)
- `phase:'streaming'` + `aborted` → `handed-off` (normal lifecycle settles)
- `phase:'streaming'` + burned usage → `settle-partial` (bill then consume)
- `phase:'streaming'` + nothing burned → `release`

The streaming shell stays thin; `settle()` gained an `errored` flag so a mid-stream failure bills with `success:false`.

## Tests (RED → GREEN)

- **`resolve-hold-disposition.test.ts`** — 6 cases covering every phase/abort/usage combination.
- **`route.test.ts`** — 4 new regression tests:
  - L6: a pre-stream setup throw releases the hold once, never reaches the model, never settles.
  - L6: a successful stream hands the hold off — the finally does not double-release.
  - L7: a mid-stream error settles partial usage as `success:false`/`errored` with the holdId and does **not** release.
  - L7: a mid-stream error with no burned usage releases the hold without billing.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — no new findings (only pre-existing warnings in unrelated files)
- openai-api suite: **124/124 green** (incl. 6 pure-fn + 4 route regressions)
- The two pre-existing `AbortSignal` cross-realm failures in `route.test.ts` are a worktree jsdom-environment issue (fail identically on clean `HEAD`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-ups (Codex)

Two automated review findings on `c4ad2e2`, both addressed:

- **P1 — billable usage must be real token counts.** `hasUsage` originally counted streamed `assistantText` as "usage", which routed a partial-text error into `settle-partial`. But for a *failed* run `trackUsage` only reaches `consumeCredits` when `totalTokens > 0` (`ai-monitoring.ts:942`) — otherwise it just releases the hold. So text-without-tokens settled a misleading $0 row and released anyway. Reworked `hasUsage` to reflect positive token counts from `totalUsage` only; with none captured we `release` directly. Estimating tokens from text was deliberately rejected (the billing basis here is *actual* provider cost — fabricating an estimate would charge for unmeasured spend). Added a regression test. (commit `057d74188`)
- **P2 — await the setup-phase release.** The setup `finally` used fire-and-forget `void releaseHold(...)`. Unlike `ai/chat` (whose streaming Response keeps the function alive), the v1 setup-error path returns a plain JSON 500 with no stream, so the release could be abandoned if the runtime freezes after the response — re-opening the very leak L6 closes. Now `await`ed (only on the error path; success skips it via `holdHandedOff`). Added a test proving the await. (commit `057d74188`)
- Clarity refactor: disposition computed only on the non-abort error path. (commit `8b5f45774`)
