### PR TITLE
fix(security): device-token revocation on logout, strict device rebind, narrow ws-token

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
@@ -357,8 +357,10 @@ describe('/api/auth/device/refresh', () => {
       expect(body.error).toBe('Device token does not match this device.');
     });
 
-    it('allows deviceId correction for legacy OAuth devices with "unknown" deviceId', async () => {
-      // Arrange - legacy device from OAuth migration
+    it('rejects legacy "unknown" deviceId tokens with 401 instead of rebinding (L4)', async () => {
+      // Arrange - legacy device from OAuth migration with an unbound deviceId.
+      // SECURITY (L4): this must be a HARD failure (force full re-auth), NOT an
+      // auto-rebind to the attacker-supplied deviceId.
       const legacyDeviceRecord = { ...mockDeviceRecord, deviceId: 'unknown' };
       vi.mocked(validateDeviceToken).mockResolvedValue(legacyDeviceRecord as never);
 
@@ -373,17 +375,19 @@ describe('/api/auth/device/refresh', () => {
 
       // Act
       const response = await POST(request);
+      const body = await response.json();
 
-      // Assert
-      expect(response.status).toBe(200);
+      // Assert - forced re-auth, no session minted, no rebind
+      expect(response.status).toBe(401);
+      expect(body.error).toBe('Device must be re-registered. Please sign in again.');
+      expect(sessionService.createSession).not.toHaveBeenCalled();
       expect(loggers.auth.warn).toHaveBeenCalledWith(
-        'Correcting device token deviceId from OAuth migration',
-        {
-          deviceTokenId: 'device-token-record-id',
-          oldDeviceId: 'unknown',
-          newDeviceId: 'new-device-id',
+        'Device token has no bound deviceId - forcing re-auth',
+        expect.objectContaining({
+          storedDeviceId: 'unknown',
+          providedDeviceId: 'new-device-id',
           userId: 'test-user-id',
-        }
+        })
       );
     });
 

--- a/apps/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/logout.test.ts
@@ -33,6 +33,12 @@ vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
   generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 
+// Device-token revocation seam (M9)
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+  revokeDeviceTokenByValue: vi.fn().mockResolvedValue(true),
+  revokeDeviceTokensByDevice: vi.fn().mockResolvedValue(1),
+}));
+
 // Mock cookie utilities
 vi.mock('@/lib/auth/cookie-config', () => ({
   getSessionFromCookies: vi.fn().mockReturnValue('ps_sess_mock_session_token'),
@@ -67,6 +73,10 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 import { sessionService } from '@pagespace/lib/auth/session-service';
+import {
+  revokeDeviceTokenByValue,
+  revokeDeviceTokensByDevice,
+} from '@pagespace/lib/auth/device-auth-utils';
 import { getSessionFromCookies, appendClearCookies } from '@/lib/auth/cookie-config';
 import { getClientIP } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -268,6 +278,104 @@ describe('/api/auth/logout', () => {
       // Should not log when no user ID
       expect(auditRequest).not.toHaveBeenCalled();
       expect(trackAuthEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('device token revocation on logout (M9)', () => {
+    it('revokes the device token by value when the client sends one', async () => {
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceToken: 'ps_dev_caller_token' }),
+      });
+
+      await POST(request);
+
+      expect(revokeDeviceTokenByValue).toHaveBeenCalledWith('ps_dev_caller_token', 'logout');
+      expect(revokeDeviceTokensByDevice).not.toHaveBeenCalled();
+    });
+
+    it('revokes by userId + deviceId + platform when no token value is sent (desktop logout)', async () => {
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceId: 'device-abc', platform: 'desktop' }),
+      });
+
+      await POST(request);
+
+      expect(revokeDeviceTokensByDevice).toHaveBeenCalledWith(
+        'test-user-id',
+        'device-abc',
+        'desktop',
+        'logout'
+      );
+      expect(revokeDeviceTokenByValue).not.toHaveBeenCalled();
+    });
+
+    it('emits a device token.revoked audit event when a device token is revoked', async () => {
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceId: 'device-abc', platform: 'desktop' }),
+      });
+
+      await POST(request);
+
+      expect(auditRequest).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          eventType: 'auth.token.revoked',
+          userId: 'test-user-id',
+          details: { tokenType: 'device', reason: 'user_logout' },
+        })
+      );
+    });
+
+    it('does not revoke any device token for a plain web logout (no device context)', async () => {
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      await POST(request);
+
+      expect(revokeDeviceTokenByValue).not.toHaveBeenCalled();
+      expect(revokeDeviceTokensByDevice).not.toHaveBeenCalled();
+    });
+
+    it('still logs out successfully (200) if device token revocation throws', async () => {
+      vi.mocked(revokeDeviceTokenByValue).mockRejectedValueOnce(new Error('db down'));
+
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceToken: 'ps_dev_caller_token' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.message).toBe('Logged out successfully');
+      expect(appendClearCookies).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not attempt device revocation when there is no valid session/user', async () => {
+      vi.mocked(sessionService.validateSession).mockResolvedValue(null);
+
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // deviceId+platform present but no token value → would be by-device,
+        // which requires a userId we don't have.
+        body: JSON.stringify({ deviceId: 'device-abc', platform: 'desktop' }),
+      });
+
+      await POST(request);
+
+      expect(revokeDeviceTokensByDevice).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/logout.test.ts
@@ -362,6 +362,28 @@ describe('/api/auth/logout', () => {
       expect(appendClearCookies).toHaveBeenCalledTimes(1);
     });
 
+    it('revokes the device token by value even when the session cookie is missing/expired', async () => {
+      // SECURITY (M9): an expired session must not block revoking the still-valid
+      // long-lived device token — by-value revocation needs no active session.
+      vi.mocked(getSessionFromCookies).mockReturnValue(null);
+
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deviceToken: 'ps_dev_orphaned_token' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.message).toBe('Logged out successfully');
+      // Device token revoked by value despite no session…
+      expect(revokeDeviceTokenByValue).toHaveBeenCalledWith('ps_dev_orphaned_token', 'logout');
+      // …and no session revoke attempted (there was none).
+      expect(sessionService.revokeSession).not.toHaveBeenCalled();
+    });
+
     it('does not attempt device revocation when there is no valid session/user', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue(null);
 

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -105,7 +105,6 @@ vi.mock('@/lib/auth', () => ({
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionRepository } from '@/lib/repositories/session-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
 import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
@@ -277,77 +276,44 @@ describe('POST /api/auth/device/refresh', () => {
       );
     });
 
-    it('corrects legacy unknown deviceId', async () => {
+    // SECURITY (L4): a legacy 'unknown' / missing stored deviceId is a HARD
+    // failure (force full re-auth), NOT an auto-rebind to the supplied id.
+    it('returns 401 and forces re-auth for legacy "unknown" deviceId (no rebind)', async () => {
       vi.mocked(validateDeviceToken).mockResolvedValue({
         ...mockDeviceRecord,
         deviceId: 'unknown',
       } as never);
 
-      vi.mocked(sessionRepository.updateDeviceTokenDeviceId).mockResolvedValue({ id: 'device-token-record-id', deviceId: 'device-123' } as never);
-
       const request = createRefreshRequest(validRefreshPayload);
       const response = await POST(request);
+      const body = await response.json();
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(401);
+      expect(body.error).toContain('re-register');
+      expect(sessionService.createSession).not.toHaveBeenCalled();
       expect(loggers.auth.warn).toHaveBeenCalledWith(
-        'Correcting device token deviceId from OAuth migration',
-        {
-          deviceTokenId: 'device-token-record-id',
-          oldDeviceId: 'unknown',
-          newDeviceId: 'device-123',
+        'Device token has no bound deviceId - forcing re-auth',
+        expect.objectContaining({
+          storedDeviceId: 'unknown',
+          providedDeviceId: 'device-123',
           userId: 'user-123',
-        }
+        })
       );
     });
 
-    it('corrects legacy null/empty deviceId', async () => {
+    it('returns 401 and forces re-auth for legacy null/empty stored deviceId (no rebind)', async () => {
       vi.mocked(validateDeviceToken).mockResolvedValue({
         ...mockDeviceRecord,
         deviceId: null,
       } as never);
 
-      vi.mocked(sessionRepository.updateDeviceTokenDeviceId).mockResolvedValue({ id: 'device-token-record-id', deviceId: 'device-123' } as never);
-
-      const request = createRefreshRequest(validRefreshPayload);
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-    });
-
-    it('returns 500 when legacy device update returns no result', async () => {
-      vi.mocked(validateDeviceToken).mockResolvedValue({
-        ...mockDeviceRecord,
-        deviceId: 'unknown',
-      } as never);
-
-      vi.mocked(sessionRepository.updateDeviceTokenDeviceId).mockResolvedValue(null);
-
       const request = createRefreshRequest(validRefreshPayload);
       const response = await POST(request);
       const body = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(body.error).toContain('Failed to update device');
-    });
-
-    it('returns 500 when legacy device update throws', async () => {
-      vi.mocked(validateDeviceToken).mockResolvedValue({
-        ...mockDeviceRecord,
-        deviceId: 'unknown',
-      } as never);
-
-      vi.mocked(sessionRepository.updateDeviceTokenDeviceId).mockRejectedValueOnce(new Error('DB error'));
-
-      const request = createRefreshRequest(validRefreshPayload);
-      const response = await POST(request);
-      const body = await response.json();
-
-      expect(response.status).toBe(500);
-      expect(body.error).toContain('Failed to update device');
-      expect(loggers.auth.error).toHaveBeenCalledWith(
-        'Error correcting device token deviceId',
-        expect.objectContaining({ error: expect.objectContaining({ message: 'DB error' }) })
-      );
+      expect(response.status).toBe(401);
+      expect(body.error).toContain('re-register');
+      expect(sessionService.createSession).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod/v4';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionRepository } from '@/lib/repositories/session-repository';
 import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { shouldAllowDeviceRefresh } from '@pagespace/lib/auth/token-lifecycle-policy';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import {
   checkDistributedRateLimit,
@@ -64,48 +64,32 @@ export async function POST(req: Request) {
       return Response.json({ error: 'Invalid or expired device token.' }, { status: 401 });
     }
 
-    if (deviceRecord.deviceId !== deviceId) {
-      // Check if this is a legacy device from OAuth with 'unknown' deviceId
-      // Allow one-time correction if the device token is otherwise valid
-      if (deviceRecord.deviceId === 'unknown' || !deviceRecord.deviceId) {
-        loggers.auth.warn('Correcting device token deviceId from OAuth migration', {
+    // SECURITY (L4): strict device-binding check. A stored deviceId that is
+    // missing or the legacy 'unknown' sentinel is a HARD failure — we force a
+    // full re-auth rather than silently rebinding the token to whatever deviceId
+    // the request supplies (which would defeat the stolen-token binding check).
+    const refreshDecision = shouldAllowDeviceRefresh(deviceRecord, deviceId);
+    if (!refreshDecision.ok) {
+      if (refreshDecision.reason === 'unknown_stored_device') {
+        loggers.auth.warn('Device token has no bound deviceId - forcing re-auth', {
           deviceTokenId: deviceRecord.id,
-          oldDeviceId: deviceRecord.deviceId,
-          newDeviceId: deviceId,
-          userId: deviceRecord.userId,
-        });
-
-        // Update device record with correct deviceId (one-time migration)
-        try {
-          const updatedDevice = await sessionRepository.updateDeviceTokenDeviceId(
-            deviceRecord.id,
-            deviceId
-          );
-
-          if (!updatedDevice) {
-            loggers.auth.error('Failed to update device token deviceId', {
-              deviceTokenId: deviceRecord.id,
-            });
-            return Response.json({ error: 'Failed to update device.' }, { status: 500 });
-          }
-
-          // Update local deviceRecord for continued processing
-          deviceRecord.deviceId = deviceId;
-        } catch (error) {
-          loggers.auth.error('Error correcting device token deviceId', { error: error as Error });
-          return Response.json({ error: 'Failed to update device.' }, { status: 500 });
-        }
-
-        // Continue with refresh using corrected device
-      } else {
-        // Strict mismatch - different device attempting to use this token
-        loggers.auth.warn('Device token mismatch detected - possible stolen token', {
-          tokenDeviceId: deviceRecord.deviceId,
+          storedDeviceId: deviceRecord.deviceId,
           providedDeviceId: deviceId,
           userId: deviceRecord.userId,
         });
-        return Response.json({ error: 'Device token does not match this device.' }, { status: 401 });
+        return Response.json(
+          { error: 'Device must be re-registered. Please sign in again.' },
+          { status: 401 }
+        );
       }
+
+      // Mismatch (or missing supplied id) - different device attempting to use this token
+      loggers.auth.warn('Device token mismatch detected - possible stolen token', {
+        tokenDeviceId: deviceRecord.deviceId,
+        providedDeviceId: deviceId,
+        userId: deviceRecord.userId,
+      });
+      return Response.json({ error: 'Device token does not match this device.' }, { status: 401 });
     }
 
     const user = await authRepository.findUserById(deviceRecord.userId);

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -15,19 +15,11 @@ export async function POST(req: Request) {
   const cookieHeader = req.headers.get('cookie');
   const sessionToken = getSessionFromCookies(cookieHeader);
 
-  if (!sessionToken) {
-    // No session to logout from
-    const headers = new Headers();
-    appendClearCookies(headers);
-    return Response.json({ message: 'Logged out successfully' }, { status: 200, headers });
-  }
-
-  // Validate session to get user ID for logging
-  const sessionClaims = await sessionService.validateSession(sessionToken);
-  const userId = sessionClaims?.userId;
-
-  // The client may include device context so we can revoke the long-lived
-  // device token alongside the session (M9). Web logout sends no body.
+  // Parse device context up front. SECURITY (M9): we must be able to revoke a
+  // long-lived device token *by value* even when the session cookie is already
+  // missing or expired — that is exactly when the still-valid device token is
+  // the only credential left and must be invalidated. So this runs before any
+  // no-session short-circuit. Web logout may send no body.
   const body = await req.json().catch(() => ({}));
   const { deviceToken, deviceId, platform } = (body ?? {}) as {
     deviceToken?: unknown;
@@ -35,21 +27,30 @@ export async function POST(req: Request) {
     platform?: unknown;
   };
 
-  // Revoke the session
-  let revokeSucceeded = false;
-  try {
-    await sessionService.revokeSession(sessionToken, 'logout');
-    revokeSucceeded = true;
-    loggers.auth.debug('Session revoked on logout', { userId });
-  } catch (error) {
-    loggers.auth.error('Failed to revoke session on logout', {
-      error: error instanceof Error ? error.message : String(error),
-      userId,
-    });
+  // Validate + revoke the session when one is present.
+  let userId: string | undefined;
+  let sessionId: string | undefined;
+  let sessionRevokeSucceeded = false;
+  if (sessionToken) {
+    const sessionClaims = await sessionService.validateSession(sessionToken);
+    userId = sessionClaims?.userId;
+    sessionId = sessionClaims?.sessionId;
+    try {
+      await sessionService.revokeSession(sessionToken, 'logout');
+      sessionRevokeSucceeded = true;
+      loggers.auth.debug('Session revoked on logout', { userId });
+    } catch (error) {
+      loggers.auth.error('Failed to revoke session on logout', {
+        error: error instanceof Error ? error.message : String(error),
+        userId,
+      });
+    }
   }
 
   // SECURITY (M9): logout must also revoke the caller's 90-day device token,
   // otherwise device/refresh can silently re-mint sessions after "logout".
+  // By-value revocation needs no authenticated session; by-device requires the
+  // session-derived userId (so it only fires for the caller's own device).
   // A failure here must never break logout itself.
   const revocationPlan = planLogoutDeviceRevocation({
     deviceToken: typeof deviceToken === 'string' ? deviceToken : null,
@@ -89,12 +90,12 @@ export async function POST(req: Request) {
     }
   }
 
-  // Only emit audit/track events after a successful revoke
-  if (userId && revokeSucceeded) {
+  // Only emit session audit/track events after a successful session revoke
+  if (userId && sessionRevokeSucceeded) {
     auditRequest(req, {
       eventType: 'auth.logout',
       userId,
-      sessionId: sessionClaims?.sessionId ?? 'unknown',
+      sessionId: sessionId ?? 'unknown',
     });
     auditRequest(req, {
       eventType: 'auth.token.revoked',

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -52,12 +52,7 @@ export async function POST(req: Request) {
   // By-value revocation needs no authenticated session; by-device requires the
   // session-derived userId (so it only fires for the caller's own device).
   // A failure here must never break logout itself.
-  const revocationPlan = planLogoutDeviceRevocation({
-    deviceToken: typeof deviceToken === 'string' ? deviceToken : null,
-    userId,
-    deviceId: typeof deviceId === 'string' ? deviceId : null,
-    platform,
-  });
+  const revocationPlan = planLogoutDeviceRevocation({ deviceToken, userId, deviceId, platform });
 
   if (revocationPlan.strategy !== 'none') {
     try {
@@ -74,12 +69,20 @@ export async function POST(req: Request) {
         deviceTokensRevoked = count > 0;
       }
 
-      if (deviceTokensRevoked && userId) {
-        auditRequest(req, {
-          eventType: 'auth.token.revoked',
-          userId,
-          details: { tokenType: 'device', reason: 'user_logout' },
-        });
+      if (deviceTokensRevoked) {
+        if (userId) {
+          auditRequest(req, {
+            eventType: 'auth.token.revoked',
+            userId,
+            details: { tokenType: 'device', reason: 'user_logout' },
+          });
+        } else {
+          // By-value revocation without an active session (expired-session
+          // logout). No userId for an audit row, but record a trail.
+          loggers.auth.info('Device token revoked on logout without active session', {
+            strategy: revocationPlan.strategy,
+          });
+        }
       }
     } catch (error) {
       loggers.auth.error('Failed to revoke device token on logout', {

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,4 +1,9 @@
 import { sessionService } from '@pagespace/lib/auth/session-service';
+import {
+  revokeDeviceTokenByValue,
+  revokeDeviceTokensByDevice,
+} from '@pagespace/lib/auth/device-auth-utils';
+import { planLogoutDeviceRevocation } from '@pagespace/lib/auth/token-lifecycle-policy';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
@@ -21,6 +26,15 @@ export async function POST(req: Request) {
   const sessionClaims = await sessionService.validateSession(sessionToken);
   const userId = sessionClaims?.userId;
 
+  // The client may include device context so we can revoke the long-lived
+  // device token alongside the session (M9). Web logout sends no body.
+  const body = await req.json().catch(() => ({}));
+  const { deviceToken, deviceId, platform } = (body ?? {}) as {
+    deviceToken?: unknown;
+    deviceId?: unknown;
+    platform?: unknown;
+  };
+
   // Revoke the session
   let revokeSucceeded = false;
   try {
@@ -32,6 +46,47 @@ export async function POST(req: Request) {
       error: error instanceof Error ? error.message : String(error),
       userId,
     });
+  }
+
+  // SECURITY (M9): logout must also revoke the caller's 90-day device token,
+  // otherwise device/refresh can silently re-mint sessions after "logout".
+  // A failure here must never break logout itself.
+  const revocationPlan = planLogoutDeviceRevocation({
+    deviceToken: typeof deviceToken === 'string' ? deviceToken : null,
+    userId,
+    deviceId: typeof deviceId === 'string' ? deviceId : null,
+    platform,
+  });
+
+  if (revocationPlan.strategy !== 'none') {
+    try {
+      let deviceTokensRevoked = false;
+      if (revocationPlan.strategy === 'by-value') {
+        deviceTokensRevoked = await revokeDeviceTokenByValue(revocationPlan.deviceToken, 'logout');
+      } else {
+        const count = await revokeDeviceTokensByDevice(
+          revocationPlan.userId,
+          revocationPlan.deviceId,
+          revocationPlan.platform,
+          'logout',
+        );
+        deviceTokensRevoked = count > 0;
+      }
+
+      if (deviceTokensRevoked && userId) {
+        auditRequest(req, {
+          eventType: 'auth.token.revoked',
+          userId,
+          details: { tokenType: 'device', reason: 'user_logout' },
+        });
+      }
+    } catch (error) {
+      loggers.auth.error('Failed to revoke device token on logout', {
+        error: error instanceof Error ? error.message : String(error),
+        userId,
+        strategy: revocationPlan.strategy,
+      });
+    }
   }
 
   // Only emit audit/track events after a successful revoke

--- a/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
@@ -112,7 +112,7 @@ describe('/api/auth/ws-token', () => {
         userId: 'test-user-id',
         type: 'mcp',
         scopes: ['mcp:ws'],
-        expiresInMs: 24 * 60 * 60 * 1000,
+        expiresInMs: 7 * 24 * 60 * 60 * 1000,
         createdByService: 'desktop',
         createdByIp: '192.168.1.100',
       });

--- a/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
@@ -106,15 +106,34 @@ describe('/api/auth/ws-token', () => {
       // Act
       await POST(request);
 
-      // Assert
+      // Assert — SECURITY (L5): narrow, user-scoped, short-lived token (NOT a
+      // 90-day type:'service' mcp:* token the processor would also accept).
       expect(sessionService.createSession).toHaveBeenCalledWith({
         userId: 'test-user-id',
-        type: 'service',
-        scopes: ['mcp:*'],
-        expiresInMs: 90 * 24 * 60 * 60 * 1000,
+        type: 'mcp',
+        scopes: ['mcp:ws'],
+        expiresInMs: 24 * 60 * 60 * 1000,
         createdByService: 'desktop',
         createdByIp: '192.168.1.100',
       });
+    });
+
+    it('POST_doesNotMintServiceTypeOrWildcardScopeOr90DayTtl', async () => {
+      // Arrange
+      const request = new Request('http://localhost/api/auth/ws-token', {
+        method: 'POST',
+        headers: { Cookie: 'session=valid-token' },
+      });
+
+      // Act
+      await POST(request);
+
+      // Assert — regression guard against the L5 finding
+      const args = vi.mocked(sessionService.createSession).mock.calls[0][0];
+      expect(args.type).not.toBe('service');
+      expect(args.scopes).not.toContain('mcp:*');
+      expect(args.scopes).not.toContain('*');
+      expect(args.expiresInMs).toBeLessThan(90 * 24 * 60 * 60 * 1000);
     });
 
     it('POST_withValidSession_checksRateLimitForUser', async () => {

--- a/apps/web/src/app/api/auth/ws-token/route.ts
+++ b/apps/web/src/app/api/auth/ws-token/route.ts
@@ -2,12 +2,14 @@ import { NextResponse } from 'next/server';
 import { verifyAuth, getClientIP } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { sessionService } from '@pagespace/lib/auth/session-service';
+import { getWsTokenPolicy } from '@pagespace/lib/auth/token-lifecycle-policy';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
-// WS tokens for desktop/mobile persistent connections need long TTL to match device sessions.
-// The connection is persistent and authenticated - we don't want to kick users mid-interaction.
-// Security is maintained through: session validation, fingerprint checks, and stale connection cleanup.
-const WS_TOKEN_EXPIRY_MS = 90 * 24 * 60 * 60 * 1000; // 90 days - matches device session lifetime
+// SECURITY (L5): ws-tokens are narrow, user-scoped, short-lived tokens dedicated
+// to desktop websocket auth — NOT a 90-day `type:'service'` `mcp:*` token (which
+// the processor's service-to-service middleware would also accept). The desktop
+// client re-fetches a fresh ws-token automatically on (re)connect, so a short
+// TTL costs nothing operationally. See getWsTokenPolicy().
 
 // Rate limit: 10 token requests per minute per user
 const WS_TOKEN_RATE_LIMIT = {
@@ -43,11 +45,12 @@ export async function POST(request: Request) {
   }
 
   const clientIP = getClientIP(request);
+  const wsPolicy = getWsTokenPolicy();
   const token = await sessionService.createSession({
     userId: user.id,
-    type: 'service',
-    scopes: ['mcp:*'],
-    expiresInMs: WS_TOKEN_EXPIRY_MS,
+    type: wsPolicy.type,
+    scopes: wsPolicy.scopes,
+    expiresInMs: wsPolicy.ttlMs,
     createdByService: 'desktop',
     createdByIp: clientIP,
   });

--- a/apps/web/src/app/api/mcp-ws/route.ts
+++ b/apps/web/src/app/api/mcp-ws/route.ts
@@ -25,6 +25,7 @@ import {
   isFetchResponseErrorMessage,
 } from '@/lib/websocket';
 import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { WS_TOKEN_SCOPE } from '@pagespace/lib/auth/token-lifecycle-policy';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Initialize cleanup interval on module load
@@ -122,8 +123,14 @@ export async function UPGRADE(
 
   const userId = claims.userId;
 
-  // SECURITY CHECK 3: Verify scope allows MCP operations
-  if (!claims.scopes.includes('mcp:*') && !claims.scopes.includes('*')) {
+  // SECURITY CHECK 3: Verify scope allows MCP operations.
+  // Accepts the narrow ws-token scope (WS_TOKEN_SCOPE = 'mcp:ws') as well as the
+  // broader 'mcp:*'/'*' wildcards used by other MCP-capable sessions.
+  if (
+    !claims.scopes.includes(WS_TOKEN_SCOPE) &&
+    !claims.scopes.includes('mcp:*') &&
+    !claims.scopes.includes('*')
+  ) {
     auditRequest(request, {
       eventType: 'authz.access.denied',
       userId,

--- a/apps/web/src/components/shared/AuthButtons.tsx
+++ b/apps/web/src/components/shared/AuthButtons.tsx
@@ -11,15 +11,21 @@ export default function AuthButtons() {
   const router = useRouter();
 
   const handleSignOut = async () => {
-    const isDesktop = typeof window !== 'undefined' && window.electron?.isDesktop;
-    let body = {};
-
-    if (isDesktop && window.electron) {
-      const deviceInfo = await window.electron.auth.getDeviceInfo();
+    // SECURITY (M9): send device context so the server revokes the long-lived
+    // device token, not just the session. Prefer the token value (works on any
+    // platform); deviceId+platform is the fallback. Never block sign-out on it.
+    let body: Record<string, unknown> = {};
+    try {
+      const { getPlatformStorage } = await import('@/lib/auth/platform-storage');
+      const storage = getPlatformStorage();
+      const stored = await storage.getStoredSession();
       body = {
-        deviceId: deviceInfo.deviceId,
-        platform: 'desktop' as const,
+        deviceToken: stored?.deviceToken ?? undefined,
+        deviceId: stored?.deviceId ?? undefined,
+        platform: storage.platform,
       };
+    } catch (err) {
+      console.error('Failed to read device context for sign-out', err);
     }
 
     await post('/api/auth/logout', body);

--- a/apps/web/src/components/shared/AuthButtons.tsx
+++ b/apps/web/src/components/shared/AuthButtons.tsx
@@ -1,36 +1,17 @@
 "use client";
 
 import { useAuth } from "@/hooks/useAuth";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { post } from '@/lib/auth/auth-fetch';
 
 export default function AuthButtons() {
-  const { isAuthenticated, user } = useAuth();
-  const router = useRouter();
+  const { isAuthenticated, user, actions } = useAuth();
 
-  const handleSignOut = async () => {
-    // SECURITY (M9): send device context so the server revokes the long-lived
-    // device token, not just the session. Prefer the token value (works on any
-    // platform); deviceId+platform is the fallback. Never block sign-out on it.
-    let body: Record<string, unknown> = {};
-    try {
-      const { getPlatformStorage } = await import('@/lib/auth/platform-storage');
-      const storage = getPlatformStorage();
-      const stored = await storage.getStoredSession();
-      body = {
-        deviceToken: stored?.deviceToken ?? undefined,
-        deviceId: stored?.deviceId ?? undefined,
-        platform: storage.platform,
-      };
-    } catch (err) {
-      console.error('Failed to read device context for sign-out', err);
-    }
-
-    await post('/api/auth/logout', body);
-    router.push('/auth/signin');
-  };
+  // Delegate to the shared logout action so sign-out runs the full client
+  // teardown (device-context send for M9 server-side device-token revocation,
+  // secure-storage/localStorage clear, store reset, redirect) in one place
+  // instead of a parallel, less-complete copy.
+  const handleSignOut = () => actions.logout();
 
   if (isAuthenticated && user) {
     return (

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -65,7 +65,26 @@ export function useAuth(): {
   // Logout function
   const logout = useCallback(async () => {
     try {
-      await post('/api/auth/logout');
+      // SECURITY (M9): send the device context so the server can revoke the
+      // long-lived (90-day) device token, not just the session. Otherwise
+      // device/refresh could silently re-mint sessions after "logout". We
+      // prefer the device token value (works on every platform via by-value
+      // revocation) and include deviceId+platform as a fallback. Reading
+      // device context must never block logout.
+      let logoutBody: Record<string, unknown> = {};
+      try {
+        const { getPlatformStorage } = await import('@/lib/auth/platform-storage');
+        const storage = getPlatformStorage();
+        const stored = await storage.getStoredSession();
+        logoutBody = {
+          deviceToken: stored?.deviceToken ?? undefined,
+          deviceId: stored?.deviceId ?? undefined,
+          platform: storage.platform,
+        };
+      } catch (err) {
+        console.error('Failed to read device context for logout', err);
+      }
+      await post('/api/auth/logout', logoutBody);
     } catch (error) {
       console.error('Logout error:', error);
     } finally {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -162,6 +162,11 @@
       "import": "./dist/auth/device-auth-utils.js",
       "require": "./dist/auth/device-auth-utils.js"
     },
+    "./auth/token-lifecycle-policy": {
+      "types": "./dist/auth/token-lifecycle-policy.d.ts",
+      "import": "./dist/auth/token-lifecycle-policy.js",
+      "require": "./dist/auth/token-lifecycle-policy.js"
+    },
     "./auth/device-fingerprint-utils": {
       "types": "./dist/auth/device-fingerprint-utils.d.ts",
       "import": "./dist/auth/device-fingerprint-utils.js",

--- a/packages/lib/src/auth/__tests__/token-lifecycle-policy.test.ts
+++ b/packages/lib/src/auth/__tests__/token-lifecycle-policy.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  shouldAllowDeviceRefresh,
+  getWsTokenPolicy,
+  planLogoutDeviceRevocation,
+  isDevicePlatform,
+  WS_TOKEN_TTL_MS,
+  WS_TOKEN_SCOPE,
+} from '../token-lifecycle-policy';
+
+describe('shouldAllowDeviceRefresh (L4)', () => {
+  it('allows refresh when the stored deviceId exactly matches the supplied id', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: 'device-123' }, 'device-123')).toEqual({ ok: true });
+  });
+
+  it('rejects when stored deviceId is the legacy "unknown" sentinel (no auto-rebind)', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: 'unknown' }, 'attacker-device')).toEqual({
+      ok: false,
+      reason: 'unknown_stored_device',
+    });
+  });
+
+  it('rejects when stored deviceId is null', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: null }, 'attacker-device')).toEqual({
+      ok: false,
+      reason: 'unknown_stored_device',
+    });
+  });
+
+  it('rejects when stored deviceId is undefined', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: undefined }, 'attacker-device')).toEqual({
+      ok: false,
+      reason: 'unknown_stored_device',
+    });
+  });
+
+  it('rejects when stored deviceId is an empty string', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: '' }, 'attacker-device')).toEqual({
+      ok: false,
+      reason: 'unknown_stored_device',
+    });
+  });
+
+  it('rejects on mismatch between a real stored deviceId and a different supplied id', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: 'device-123' }, 'device-456')).toEqual({
+      ok: false,
+      reason: 'device_mismatch',
+    });
+  });
+
+  it('rejects when the supplied deviceId is missing even though the stored id is real', () => {
+    expect(shouldAllowDeviceRefresh({ deviceId: 'device-123' }, '')).toEqual({
+      ok: false,
+      reason: 'missing_supplied_device',
+    });
+    expect(shouldAllowDeviceRefresh({ deviceId: 'device-123' }, null)).toEqual({
+      ok: false,
+      reason: 'missing_supplied_device',
+    });
+  });
+
+  it('does NOT rebind: an unknown stored id never matches by adopting the supplied id', () => {
+    // Even if the supplied id is literally 'unknown', a missing binding stays a hard failure.
+    expect(shouldAllowDeviceRefresh({ deviceId: 'unknown' }, 'unknown')).toEqual({
+      ok: false,
+      reason: 'unknown_stored_device',
+    });
+  });
+});
+
+describe('getWsTokenPolicy (L5)', () => {
+  const policy = getWsTokenPolicy();
+
+  it('does not mint a service-type token (so the processor service middleware rejects it)', () => {
+    expect(policy.type).not.toBe('service');
+    expect(policy.type).toBe('mcp');
+  });
+
+  it('does not grant the broad mcp:* wildcard scope', () => {
+    expect(policy.scopes).not.toContain('mcp:*');
+    expect(policy.scopes).not.toContain('*');
+  });
+
+  it('grants only the narrow websocket scope', () => {
+    expect(policy.scopes).toEqual([WS_TOKEN_SCOPE]);
+    expect(WS_TOKEN_SCOPE).toBe('mcp:ws');
+  });
+
+  it('uses a TTL substantially shorter than the previous 90-day lifetime', () => {
+    const ninetyDays = 90 * 24 * 60 * 60 * 1000;
+    expect(policy.ttlMs).toBe(WS_TOKEN_TTL_MS);
+    expect(policy.ttlMs).toBeLessThan(ninetyDays);
+    // "Substantially" shorter: at most a tenth of the old lifetime.
+    expect(policy.ttlMs).toBeLessThanOrEqual(ninetyDays / 10);
+    expect(policy.ttlMs).toBeGreaterThan(0);
+  });
+});
+
+describe('planLogoutDeviceRevocation (M9)', () => {
+  it('revokes by value when the client sends a raw device token', () => {
+    expect(
+      planLogoutDeviceRevocation({
+        deviceToken: 'ps_dev_abc',
+        userId: 'user-1',
+        deviceId: 'device-1',
+        platform: 'desktop',
+      }),
+    ).toEqual({ strategy: 'by-value', deviceToken: 'ps_dev_abc' });
+  });
+
+  it('trims the supplied device token value', () => {
+    expect(planLogoutDeviceRevocation({ deviceToken: '  ps_dev_abc  ' })).toEqual({
+      strategy: 'by-value',
+      deviceToken: 'ps_dev_abc',
+    });
+  });
+
+  it('revokes by device when no token value but userId + deviceId + valid platform are present', () => {
+    expect(
+      planLogoutDeviceRevocation({ userId: 'user-1', deviceId: 'device-1', platform: 'desktop' }),
+    ).toEqual({ strategy: 'by-device', userId: 'user-1', deviceId: 'device-1', platform: 'desktop' });
+  });
+
+  it('returns none for a plain web logout with no device context', () => {
+    expect(planLogoutDeviceRevocation({ userId: 'user-1' })).toEqual({ strategy: 'none' });
+  });
+
+  it('returns none when deviceId is present but platform is missing or invalid', () => {
+    expect(planLogoutDeviceRevocation({ userId: 'user-1', deviceId: 'device-1' })).toEqual({
+      strategy: 'none',
+    });
+    expect(
+      planLogoutDeviceRevocation({ userId: 'user-1', deviceId: 'device-1', platform: 'bogus' }),
+    ).toEqual({ strategy: 'none' });
+  });
+
+  it('returns none when userId is missing (cannot safely target by device)', () => {
+    expect(
+      planLogoutDeviceRevocation({ deviceId: 'device-1', platform: 'desktop' }),
+    ).toEqual({ strategy: 'none' });
+  });
+
+  it('ignores empty/whitespace device token and falls through to by-device', () => {
+    expect(
+      planLogoutDeviceRevocation({
+        deviceToken: '   ',
+        userId: 'user-1',
+        deviceId: 'device-1',
+        platform: 'ios',
+      }),
+    ).toEqual({ strategy: 'by-device', userId: 'user-1', deviceId: 'device-1', platform: 'ios' });
+  });
+});
+
+describe('isDevicePlatform', () => {
+  it('accepts the four known platforms', () => {
+    for (const p of ['web', 'desktop', 'ios', 'android']) {
+      expect(isDevicePlatform(p)).toBe(true);
+    }
+  });
+
+  it('rejects unknown values', () => {
+    expect(isDevicePlatform('mobile')).toBe(false);
+    expect(isDevicePlatform('')).toBe(false);
+    expect(isDevicePlatform(undefined)).toBe(false);
+    expect(isDevicePlatform(null)).toBe(false);
+    expect(isDevicePlatform(42)).toBe(false);
+  });
+});

--- a/packages/lib/src/auth/token-lifecycle-policy.ts
+++ b/packages/lib/src/auth/token-lifecycle-policy.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure token-lifecycle policy decisions for the session/device token area.
+ *
+ * These functions contain NO I/O — they are the isolated decision points behind
+ * three auth routes so the rules can be unit-tested in isolation and the route
+ * shells stay thin:
+ *
+ *  - {@link shouldAllowDeviceRefresh} — device/refresh rebind guard (closes L4:
+ *    a legacy `'unknown'` stored deviceId must force full re-auth, never silently
+ *    rebind to an attacker-supplied id).
+ *  - {@link getWsTokenPolicy} — the issued ws-token's {type, scopes, ttl} (closes
+ *    L5: a narrow, user-scoped, short-lived token dedicated to desktop websocket
+ *    auth instead of a 90-day `type:'service'` `mcp:*` token the processor's
+ *    service middleware would also accept).
+ *  - {@link planLogoutDeviceRevocation} — which device-token revocation a logout
+ *    should perform (closes M9: logout must revoke the 90-day device token, not
+ *    just the session).
+ */
+
+export type DevicePlatform = 'web' | 'desktop' | 'ios' | 'android';
+
+const DEVICE_PLATFORMS: readonly DevicePlatform[] = ['web', 'desktop', 'ios', 'android'];
+
+export function isDevicePlatform(value: unknown): value is DevicePlatform {
+  return typeof value === 'string' && (DEVICE_PLATFORMS as readonly string[]).includes(value);
+}
+
+// ---------------------------------------------------------------------------
+// L4 — device/refresh rebind guard
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a device-token record needed to decide a refresh. */
+export interface DeviceRefreshRecord {
+  deviceId: string | null | undefined;
+}
+
+export type DeviceRefreshDenialReason =
+  | 'unknown_stored_device'
+  | 'missing_supplied_device'
+  | 'device_mismatch';
+
+export type DeviceRefreshDecision =
+  | { ok: true }
+  | { ok: false; reason: DeviceRefreshDenialReason };
+
+/**
+ * Decide whether a device-token refresh may proceed for the supplied device id.
+ *
+ * SECURITY (L4): a stored deviceId that is missing or the legacy sentinel
+ * `'unknown'` is a HARD failure — the caller must perform a full re-auth. We do
+ * NOT auto-rebind the record to whatever deviceId the request supplies, because
+ * that would let a stolen-but-legacy token be re-bound to the attacker's device
+ * and bypass the device-binding check entirely.
+ */
+export function shouldAllowDeviceRefresh(
+  record: DeviceRefreshRecord,
+  suppliedDeviceId: string | null | undefined,
+): DeviceRefreshDecision {
+  const stored = record.deviceId;
+
+  // Missing or legacy 'unknown' stored deviceId → force full re-auth.
+  if (!stored || stored === 'unknown') {
+    return { ok: false, reason: 'unknown_stored_device' };
+  }
+
+  if (!suppliedDeviceId) {
+    return { ok: false, reason: 'missing_supplied_device' };
+  }
+
+  if (stored !== suppliedDeviceId) {
+    return { ok: false, reason: 'device_mismatch' };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// L5 — ws-token policy
+// ---------------------------------------------------------------------------
+
+/**
+ * TTL for desktop websocket tokens. Substantially shorter than the previous
+ * 90-day lifetime: the desktop client re-fetches a ws-token automatically on
+ * (re)connect, so a short-lived token costs nothing operationally while sharply
+ * limiting the blast radius of a leaked token.
+ */
+export const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** Narrow scope dedicated to desktop websocket auth (not the `mcp:*` wildcard). */
+export const WS_TOKEN_SCOPE = 'mcp:ws';
+
+export interface WsTokenPolicy {
+  /** User-scoped session type, NOT `'service'` — the processor's service
+   * middleware requires `type === 'service'`, so this token can no longer be
+   * replayed against service-to-service endpoints. */
+  type: 'mcp';
+  scopes: [typeof WS_TOKEN_SCOPE];
+  ttlMs: number;
+}
+
+/**
+ * The policy for a desktop websocket token (L5).
+ *
+ * Returns a narrow, user-scoped, short-lived token dedicated to websocket auth
+ * instead of reusing a long-lived `type:'service'` `mcp:*` token.
+ */
+export function getWsTokenPolicy(): WsTokenPolicy {
+  return {
+    type: 'mcp',
+    scopes: [WS_TOKEN_SCOPE],
+    ttlMs: WS_TOKEN_TTL_MS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// M9 — logout device-token revocation plan
+// ---------------------------------------------------------------------------
+
+export interface LogoutRevocationInput {
+  /** Raw device token value, if the client sends it on logout. */
+  deviceToken?: string | null;
+  /** Authenticated user id from the session. */
+  userId?: string | null;
+  /** Device fingerprint the client claims to be logging out. */
+  deviceId?: string | null;
+  /** Device platform the client claims to be logging out. */
+  platform?: unknown;
+}
+
+export type LogoutRevocationPlan =
+  | { strategy: 'by-value'; deviceToken: string }
+  | { strategy: 'by-device'; userId: string; deviceId: string; platform: DevicePlatform }
+  | { strategy: 'none' };
+
+/**
+ * Decide how a logout should revoke the caller's device token(s) (M9).
+ *
+ * Preference order:
+ *  1. If the client sends the raw device token value, revoke exactly that token.
+ *  2. Otherwise, if we have the authenticated userId plus a deviceId and a valid
+ *     platform, revoke that user's device token(s) for that device.
+ *  3. Otherwise there is nothing safe to target (e.g. a plain web logout with no
+ *     device context) — revoke nothing beyond the session.
+ */
+export function planLogoutDeviceRevocation(input: LogoutRevocationInput): LogoutRevocationPlan {
+  const deviceToken = typeof input.deviceToken === 'string' ? input.deviceToken.trim() : '';
+  if (deviceToken.length > 0) {
+    return { strategy: 'by-value', deviceToken };
+  }
+
+  const userId = typeof input.userId === 'string' ? input.userId.trim() : '';
+  const deviceId = typeof input.deviceId === 'string' ? input.deviceId.trim() : '';
+  if (userId.length > 0 && deviceId.length > 0 && isDevicePlatform(input.platform)) {
+    return { strategy: 'by-device', userId, deviceId, platform: input.platform };
+  }
+
+  return { strategy: 'none' };
+}

--- a/packages/lib/src/auth/token-lifecycle-policy.ts
+++ b/packages/lib/src/auth/token-lifecycle-policy.ts
@@ -80,11 +80,14 @@ export function shouldAllowDeviceRefresh(
 
 /**
  * TTL for desktop websocket tokens. Substantially shorter than the previous
- * 90-day lifetime: the desktop client re-fetches a ws-token automatically on
- * (re)connect, so a short-lived token costs nothing operationally while sharply
- * limiting the blast radius of a leaked token.
+ * 90-day lifetime (~13× shorter) while avoiding frequent reconnects on
+ * always-on desktops: the server already revalidates every live ws connection
+ * against the session store every few minutes, so an actual revocation/logout
+ * is detected long before this cap regardless of its value — the TTL is just
+ * the hard ceiling on a leaked token's blast radius. The desktop client
+ * re-fetches a ws-token automatically on (re)connect.
  */
-export const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const WS_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 /** Narrow scope dedicated to desktop websocket auth (not the `mcp:*` wildcard). */
 export const WS_TOKEN_SCOPE = 'mcp:ws';
@@ -117,12 +120,14 @@ export function getWsTokenPolicy(): WsTokenPolicy {
 // ---------------------------------------------------------------------------
 
 export interface LogoutRevocationInput {
-  /** Raw device token value, if the client sends it on logout. */
-  deviceToken?: string | null;
+  /** Raw device token value, if the client sends it on logout. Accepts
+   * `unknown` so callers can pass un-narrowed request-body fields directly —
+   * this function does all the type narrowing. */
+  deviceToken?: unknown;
   /** Authenticated user id from the session. */
   userId?: string | null;
   /** Device fingerprint the client claims to be logging out. */
-  deviceId?: string | null;
+  deviceId?: unknown;
   /** Device platform the client claims to be logging out. */
   platform?: unknown;
 }


### PR DESCRIPTION
Closes three findings from the 2026-06-09 auth/token security audit: **M9, L4, L5**. All in the session/device token lifecycle area.

## Findings & attacks closed

### M9 — Logout didn't revoke the 90-day device token
Logout revoked only the session. `device/refresh` re-mints sessions from a still-valid device token, so a "logged out" device could resurrect a live session at will.

- **Server:** logout now **also revokes the caller's device token(s)** via the previously-unwired `revokeDeviceTokenByValue` / `revokeDeviceTokensByDevice` helpers — by token value if the client sends one, else by `userId + deviceId + platform`. `userId` always comes from the authenticated session, so a caller can only revoke their own device tokens. Device-token revocation runs **even when the session cookie is missing/expired** (by-value needs no session), which is exactly when the long-lived token is the only credential left. Revocation failures never break logout.
- **Client (end-to-end closure):** the in-app logout (`useAuth.logout`, used by the user menu) now reads stored device context via the unified `platform-storage` abstraction (web `localStorage` + desktop/iOS secure storage) and sends `{ deviceToken, deviceId, platform }`. `AuthButtons` sign-out now **delegates to that same shared action** (one logout path; full client teardown). The server prefers by-value revocation, which works on every platform. Reading device context is failure-safe and never blocks logout.

### L4 — `device/refresh` rebound a legacy `'unknown'` deviceId to any attacker-supplied id
A stored deviceId of `'unknown'`/missing was silently auto-rebound to whatever the request supplied, bypassing the stolen-token device-binding check. Now a missing binding is a **HARD failure (401, force full re-auth)** — never a rebind.

### L5 — `ws-token` minted a 90-day `type:'service'` `mcp:*` token for any user
That token was accepted by the processor's service-to-service middleware (`authenticateService` requires `type === 'service'`), so a websocket token could be replayed against service endpoints. Now ws-token issues a **narrow, user-scoped, short-lived** token: `type:'mcp'`, scope `'mcp:ws'`, **7-day TTL** (~13× shorter than 90 days; avoids forcing daily reconnects on always-on desktop sockets — the server already revalidates every live ws connection against the session store every few minutes, so real revocations are caught well before the cap). Changing the type off `'service'` closes the processor-acceptance vector; the narrowed scope + TTL are defense in depth. The `mcp-ws` consumer accepts the narrow scope additively (still accepts `mcp:*`/`*`).

## Pure functions + tests (strict TDD)
Each decision is isolated into a pure, I/O-free function in the new `packages/lib/src/auth/token-lifecycle-policy.ts`, with thin route shells calling them:
- `shouldAllowDeviceRefresh(record, suppliedDeviceId) → {ok, reason}` (L4)
- `getWsTokenPolicy() → {type, scopes, ttl}` (L5)
- `planLogoutDeviceRevocation(input) → {strategy, …}` (M9) — does all input narrowing internally

21 new unit tests cover every branch; route-level contract tests updated to assert the new secure behavior (legacy-rebind → 401; ws-token policy + regression guard; M9 logout device-revocation incl. the session-less by-value path).

## Files
- `packages/lib/src/auth/token-lifecycle-policy.ts` (+ `package.json` export) — pure policy functions
- `apps/web/src/app/api/auth/logout/route.ts` — M9 server revocation (session-independent)
- `apps/web/src/app/api/auth/device/refresh/route.ts` — L4 strict rebind guard
- `apps/web/src/app/api/auth/ws-token/route.ts` — L5 narrow token policy
- `apps/web/src/app/api/mcp-ws/route.ts` — accept narrow `mcp:ws` scope (additive)
- `apps/web/src/hooks/useAuth.ts` — M9 client wiring (send device context on logout)
- `apps/web/src/components/shared/AuthButtons.tsx` — delegate to the shared logout action

## Verification
- `bun run typecheck` — green (`@pagespace/lib`, `web`)
- `bun run lint` — clean (exit 0, both packages)
- Tests green: `packages/lib` `src/auth` + 21 new pure-function tests; `apps/web` `src/app/api/auth` (966) + `mcp-ws` security (20)
- Branch merged up to date with `master` (zero conflicts)

## Review
Both Codex P1 comments addressed and resolved (primary-logout device context; revoke-before-no-session-return). A proactive multi-angle self-review then drove the AuthButtons centralization and the 7-day TTL.

> The two client React files (`useAuth.ts`, `AuthButtons.tsx`) are validated via typecheck + review; their hook tests run in CI. The device-context read is failure-safe, so logout behavior is unchanged if it ever fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)