### PR TITLE
fix(security): close user-enumeration and email-harvest surfaces

### DIFF
--- a/apps/web/src/app/api/connections/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/search/__tests__/route.test.ts
@@ -1,6 +1,15 @@
 /**
- * Security audit tests for /api/connections/search
- * Verifies auditRequest is called for GET (read).
+ * Tests for /api/connections/search (security audit finding L2).
+ *
+ * Verifies the endpoint returns a single generic `{ user: null }` for every
+ * non-actionable outcome (self-search, no account, or an existing
+ * PENDING/ACCEPTED/BLOCKED relationship) so existence and relationship state
+ * cannot be enumerated — and only surfaces a profile when a connection request
+ * can actually be sent. Also covers per-user rate limiting and the read audit.
+ *
+ * Mocked at the DB seam: each db.select() consumes the next queued result set,
+ * in route order: (1) current-user email, (2) target user, (3) existing
+ * connection.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -8,43 +17,28 @@ vi.mock('@/lib/auth', () => ({
   verifyAuth: vi.fn(),
 }));
 
-vi.mock('@pagespace/db/db', () => ({
-  db: {
-    select: vi.fn().mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          limit: vi.fn().mockResolvedValue([{ email: 'current@test.com' }]),
-        }),
-        innerJoin: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([]),
-          }),
-        }),
-      }),
-    }),
-  },
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: { API: { maxAttempts: 100, windowMs: 60000 } },
 }));
+
+vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn() } }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   or: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
-  users: { id: 'id', email: 'email' },
+  users: { id: 'id', email: 'email', name: 'name' },
 }));
-vi.mock('@pagespace/db/schema/members', () => ({
-  userProfiles: {},
-}));
-vi.mock('@pagespace/db/schema/social', () => ({
-  connections: {},
-}));
+vi.mock('@pagespace/db/schema/members', () => ({ userProfiles: {} }));
+vi.mock('@pagespace/db/schema/social', () => ({ connections: {} }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
@@ -55,21 +49,118 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
+import { db } from '@pagespace/db/db';
 
 const mockUserId = 'user_123';
+const currentEmail = 'current@test.com';
 
-describe('GET /api/connections/search audit', () => {
+function setupSelect(results: unknown[][]) {
+  let i = 0;
+  vi.mocked(db.select).mockImplementation((() => {
+    const result = results[i++] ?? [];
+    const terminal = Promise.resolve(result) as Promise<unknown[]> & {
+      limit: () => Promise<unknown[]>;
+    };
+    terminal.limit = () => Promise.resolve(result);
+    const chain = {
+      from: () => chain,
+      leftJoin: () => chain,
+      where: () => terminal,
+      limit: () => Promise.resolve(result),
+    };
+    return chain as never;
+  }) as never);
+}
+
+const targetRow = {
+  id: 'user_target',
+  name: 'Target',
+  email: 'other@test.com',
+  displayName: 'Target Display',
+  bio: 'bio',
+  avatarUrl: 'https://cdn/a.png',
+};
+
+describe('GET /api/connections/search', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(verifyAuth).mockResolvedValue({ id: mockUserId, email: 'current@test.com' } as unknown as Awaited<ReturnType<typeof verifyAuth>>);
+    vi.mocked(verifyAuth).mockResolvedValue(
+      { id: mockUserId, email: currentEmail } as unknown as Awaited<ReturnType<typeof verifyAuth>>,
+    );
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
+    setupSelect([[{ email: currentEmail }]]);
   });
 
-  it('logs read audit event on connection search', async () => {
-    await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(verifyAuth).mockResolvedValue(null);
+    const response = await GET(new Request('http://localhost/api/connections/search?email=x@test.com'));
+    expect(response.status).toBe(401);
+  });
 
+  it('returns 429 when the per-user rate limit is exceeded', async () => {
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: false, retryAfter: 12 });
+    const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
+    const body = await response.json();
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('12');
+    expect(body.error).toBe('Too many requests');
+  });
+
+  it('logs a read audit event on connection search', async () => {
+    await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
     expect(auditRequest).toHaveBeenCalledWith(
       expect.any(Request),
-      expect.objectContaining({ eventType: 'data.read', userId: mockUserId, resourceType: 'connection_search', resourceId: 'self' })
+      expect.objectContaining({
+        eventType: 'data.read',
+        userId: mockUserId,
+        resourceType: 'connection_search',
+        resourceId: 'self',
+      }),
     );
+  });
+
+  it('returns the actionable user when one can be invited (exists, not self, no connection)', async () => {
+    setupSelect([[{ email: currentEmail }], [targetRow], []]);
+    const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      user: {
+        id: 'user_target',
+        name: 'Target',
+        email: 'other@test.com',
+        displayName: 'Target Display',
+        bio: 'bio',
+        avatarUrl: 'https://cdn/a.png',
+      },
+    });
+  });
+
+  it('collapses self-search into a generic { user: null } with no error', async () => {
+    // email === current user's email
+    setupSelect([[{ email: currentEmail }], [{ ...targetRow, email: currentEmail }], []]);
+    const response = await GET(new Request(`http://localhost/api/connections/search?email=${currentEmail}`));
+    const body = await response.json();
+    expect(body).toEqual({ user: null });
+    expect(body).not.toHaveProperty('error');
+  });
+
+  it('collapses "no account" into a generic { user: null } with no error', async () => {
+    setupSelect([[{ email: currentEmail }], [], []]);
+    const response = await GET(new Request('http://localhost/api/connections/search?email=ghost@test.com'));
+    const body = await response.json();
+    expect(body).toEqual({ user: null });
+    expect(body).not.toHaveProperty('error');
+  });
+
+  it('collapses every existing-relationship state into the SAME generic response', async () => {
+    for (const status of ['PENDING', 'ACCEPTED', 'BLOCKED'] as const) {
+      setupSelect([[{ email: currentEmail }], [targetRow], [{ status }]]);
+      const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
+      const body = await response.json();
+      expect(body, `status=${status}`).toEqual({ user: null });
+      expect(body).not.toHaveProperty('error');
+    }
   });
 });

--- a/apps/web/src/app/api/connections/search/route.ts
+++ b/apps/web/src/app/api/connections/search/route.ts
@@ -7,6 +7,15 @@ import { connections } from '@pagespace/db/schema/social';
 import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+import {
+  buildConnectionSearchResult,
+  type ConnectionStatus,
+  type ConnectionSearchProfile,
+} from '@/lib/users/enumeration-safe';
 
 // GET /api/connections/search - Search for users by email to connect with
 export async function GET(request: Request) {
@@ -14,6 +23,18 @@ export async function GET(request: Request) {
     const user = await verifyAuth(request);
     if (!user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Rate limit per caller — exact-email probe used to enumerate accounts (L2).
+    const rateLimit = await checkDistributedRateLimit(
+      `connections-search:${user.id}`,
+      DISTRIBUTED_RATE_LIMITS.API,
+    );
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfter ?? 60) } },
+      );
     }
 
     auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'connection_search', resourceId: 'self' });
@@ -32,13 +53,7 @@ export async function GET(request: Request) {
       .where(eq(users.id, user.id))
       .limit(1);
 
-    // Check if user is trying to search for themselves
-    if (email === currentUser?.email) {
-      return NextResponse.json({
-        user: null,
-        error: 'Cannot connect with yourself'
-      });
-    }
+    const isSelf = !!currentUser && email === currentUser.email;
 
     // Find user by exact email match
     const [targetUser] = await db
@@ -55,73 +70,46 @@ export async function GET(request: Request) {
       .where(eq(users.email, email))
       .limit(1);
 
-    if (!targetUser) {
-      return NextResponse.json({
-        user: null,
-        error: 'No user found with this email address'
-      });
-    }
+    let existingStatus: ConnectionStatus | null = null;
+    let target: ConnectionSearchProfile | null = null;
 
-    // Check if connection already exists - using basic select that always works
-    const existingConnections = await db
-      .select()  // Select ALL fields to avoid production issues
-      .from(connections)
-      .where(
-        or(
-          and(
-            eq(connections.user1Id, user.id),
-            eq(connections.user2Id, targetUser.id)
-          ),
-          and(
-            eq(connections.user1Id, targetUser.id),
-            eq(connections.user2Id, user.id)
-          )
-        )
-      )
-      .limit(1);
-
-    // Check if connection exists and handle different statuses
-    if (existingConnections.length > 0) {
-      const existingConnection = existingConnections[0];
-
-      // Defensive check to ensure status exists
-      if (!existingConnection || !existingConnection.status) {
-        loggers.api.error('Invalid connection data structure');
-        return NextResponse.json({
-          user: null,
-          error: 'Connection check failed'
-        });
-      }
-
-      if (existingConnection.status === 'ACCEPTED') {
-        return NextResponse.json({
-          user: null,
-          error: 'Already connected with this user'
-        });
-      } else if (existingConnection.status === 'PENDING') {
-        return NextResponse.json({
-          user: null,
-          error: 'Connection request already pending'
-        });
-      } else if (existingConnection.status === 'BLOCKED') {
-        return NextResponse.json({
-          user: null,
-          error: 'Cannot send connection request to this user'
-        });
-      }
-    }
-
-    // Return the user data for connection
-    return NextResponse.json({
-      user: {
+    if (targetUser) {
+      target = {
         id: targetUser.id,
         name: targetUser.name,
         email: targetUser.email,
         displayName: targetUser.displayName || targetUser.name,
         bio: targetUser.bio,
         avatarUrl: targetUser.avatarUrl,
-      }
-    });
+      };
+
+      // Check if a connection already exists - select ALL fields (status enum)
+      const existingConnections = await db
+        .select()
+        .from(connections)
+        .where(
+          or(
+            and(
+              eq(connections.user1Id, user.id),
+              eq(connections.user2Id, targetUser.id)
+            ),
+            and(
+              eq(connections.user1Id, targetUser.id),
+              eq(connections.user2Id, user.id)
+            )
+          )
+        )
+        .limit(1);
+
+      existingStatus = existingConnections[0]?.status ?? null;
+    }
+
+    // Collapse self-search / no-account / any existing-relationship state into a
+    // single generic `{ user: null }` so existence and relationship state are not
+    // distinguishable (L2). A profile is returned only when a request can be sent.
+    return NextResponse.json(
+      buildConnectionSearchResult({ isSelf, target, existingStatus }),
+    );
   } catch (error) {
     loggers.api.error('Error searching for user:', error as Error);
     return NextResponse.json(

--- a/apps/web/src/app/api/users/find/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/find/__tests__/route.test.ts
@@ -30,6 +30,15 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: { API: { maxAttempts: 100, windowMs: 60000 } },
+}));
+
+vi.mock('@/lib/users/visibility', () => ({
+  callerCanViewUser: vi.fn(),
+}));
+
 const mockFindFirst = vi.fn();
 
 vi.mock('@pagespace/db/db', () => ({
@@ -52,6 +61,8 @@ import { GET } from '../route';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
+import { callerCanViewUser } from '@/lib/users/visibility';
 
 // ============================================================================
 // Test Helpers
@@ -81,6 +92,9 @@ describe('GET /api/users/find', () => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
     vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
+    // Default: caller already shares context with the matched user (visible).
+    vi.mocked(callerCanViewUser).mockResolvedValue(true);
     mockFindFirst.mockResolvedValue(null);
   });
 
@@ -139,9 +153,11 @@ describe('GET /api/users/find', () => {
 
       expect(response.status).toBe(404);
       expect(body.error).toBe('User not found');
+      // No relationship check is needed when there is no candidate at all.
+      expect(callerCanViewUser).not.toHaveBeenCalled();
     });
 
-    it('should return user data when found', async () => {
+    it('should return user data when found AND caller already shares context', async () => {
       const userData = {
         id: 'user_456',
         name: 'Test User',
@@ -149,13 +165,72 @@ describe('GET /api/users/find', () => {
         image: 'https://example.com/avatar.png',
       };
       mockFindFirst.mockResolvedValue(userData);
+      vi.mocked(callerCanViewUser).mockResolvedValue(true);
 
       const request = new Request('https://example.com/api/users/find?email=test@example.com');
       const response = await GET(request);
       const body = await response.json();
 
+      expect(callerCanViewUser).toHaveBeenCalledWith(mockUserId, 'user_456');
       expect(response.status).toBe(200);
       expect(body).toEqual(userData);
+    });
+
+    it('should return a UNIFORM 404 when the account exists but the caller cannot see them (L1)', async () => {
+      // Indistinguishable from the "not found" case above — no existence leak,
+      // no name/avatar harvest.
+      mockFindFirst.mockResolvedValue({
+        id: 'stranger_1',
+        name: 'Stranger',
+        email: 'stranger@example.com',
+        image: 'https://example.com/s.png',
+      });
+      vi.mocked(callerCanViewUser).mockResolvedValue(false);
+
+      const request = new Request('https://example.com/api/users/find?email=stranger@example.com');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body).toEqual({ error: 'User not found' });
+      expect(body).not.toHaveProperty('name');
+      expect(body).not.toHaveProperty('image');
+    });
+
+    it('should always let a caller resolve their own account regardless of relationship', async () => {
+      const self = {
+        id: mockUserId,
+        name: 'Me',
+        email: 'me@example.com',
+        image: null,
+      };
+      mockFindFirst.mockResolvedValue(self);
+      vi.mocked(callerCanViewUser).mockResolvedValue(false);
+
+      const request = new Request('https://example.com/api/users/find?email=me@example.com');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual(self);
+    });
+  });
+
+  describe('rate limiting (L1)', () => {
+    it('should return 429 when the per-user rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+        allowed: false,
+        retryAfter: 30,
+      });
+
+      const request = new Request('https://example.com/api/users/find?email=test@example.com');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get('Retry-After')).toBe('30');
+      expect(body.error).toBe('Too many requests');
+      expect(mockFindFirst).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/users/find/route.ts
+++ b/apps/web/src/app/api/users/find/route.ts
@@ -5,6 +5,12 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { callerCanViewUser } from '@/lib/users/visibility';
+import { resolveFindUser } from '@/lib/users/enumeration-safe';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false } as const;
 
@@ -22,19 +28,42 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Email parameter is missing' }, { status: 400 });
   }
 
+  // Rate limit per caller — this is an exact-email existence probe (L1); cap how
+  // fast one account can test addresses.
+  const rateLimit = await checkDistributedRateLimit(
+    `users-find:${auth.userId}`,
+    DISTRIBUTED_RATE_LIMITS.API,
+  );
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfter ?? 60) } },
+    );
+  }
+
   try {
-    const user = await db.query.users.findFirst({
+    const candidate = await db.query.users.findFirst({
       where: eq(users.email, email),
       columns: { id: true, name: true, email: true, image: true },
     });
 
-    if (!user) {
+    // Relationship scoping (L1): only surface a user's identity to a caller who
+    // already shares context (a drive or accepted connection) — or to the user
+    // themselves. "No such account" and "exists but not visible to you" collapse
+    // into the SAME 404, so the endpoint can no longer be used to enumerate which
+    // emails have accounts or to harvest names/avatars.
+    const callerCanView = candidate
+      ? await callerCanViewUser(auth.userId, candidate.id)
+      : false;
+    const outcome = resolveFindUser(candidate ?? null, auth.userId, callerCanView);
+
+    if (!outcome.found) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    auditRequest(request, { eventType: 'data.read', userId: auth.userId, resourceType: 'user_search', resourceId: user.id, details: { queryLength: email.length, resultCount: 1 } });
+    auditRequest(request, { eventType: 'data.read', userId: auth.userId, resourceType: 'user_search', resourceId: outcome.user.id, details: { queryLength: email.length, resultCount: 1 } });
 
-    return NextResponse.json(user);
+    return NextResponse.json(outcome.user);
   } catch (error) {
     loggers.api.error('Error finding user:', error as Error);
     return NextResponse.json({ error: 'Failed to find user' }, { status: 500 });

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -27,6 +27,11 @@ vi.mock('@/lib/auth', () => ({
   verifyAuth: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: { API: { maxAttempts: 100, windowMs: 60000 } },
+}));
+
 // Track all chained query builder calls
 const mockLimit = vi.fn();
 const mockWhere = vi.fn();
@@ -104,6 +109,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { and, isNotNull } from '@pagespace/db/operators';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 // ============================================================================
 // Test Helpers
@@ -156,6 +162,7 @@ describe('GET /api/users/search', () => {
       // @ts-expect-error - test mock with extra properties
       hasSessionBearerToken: false,
     });
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
     setupDbChains();
   });
 
@@ -202,7 +209,9 @@ describe('GET /api/users/search', () => {
   });
 
   describe('profile search results', () => {
-    it('should return profile results when found', async () => {
+    it('should return profile results WITHOUT an email (M3 — email harvest)', async () => {
+      // The DB row deliberately still carries an email to prove the route drops
+      // it: a 2-char substring match must never surface a public profile's email.
       const profileResults = [
         {
           userId: 'user_456',
@@ -227,8 +236,31 @@ describe('GET /api/users/search', () => {
         displayName: 'Test User',
         bio: 'A bio',
         avatarUrl: 'https://example.com/avatar.png',
-        email: 'test@example.com',
       });
+      expect(body.users[0]).not.toHaveProperty('email');
+    });
+  });
+
+  describe('rate limiting (M3)', () => {
+    it('should return 429 when the per-user rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+        allowed: false,
+        retryAfter: 42,
+      });
+
+      const request = new Request('https://example.com/api/users/search?q=test');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get('Retry-After')).toBe('42');
+      expect(body.error).toBe('Too many requests');
+    });
+
+    it('should NOT count too-short queries against the rate limit', async () => {
+      const request = new Request('https://example.com/api/users/search?q=a');
+      await GET(request);
+      expect(checkDistributedRateLimit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -7,6 +7,14 @@ import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+import {
+  buildPublicProfileResult,
+  buildExactEmailMatchResult,
+} from '@/lib/users/enumeration-safe';
 
 export async function GET(request: Request) {
   try {
@@ -27,6 +35,20 @@ export async function GET(request: Request) {
       return NextResponse.json({ users: [] });
     }
 
+    // Rate limit real searches per user. An unanchored 2-char substring search
+    // iterated `aa..zz` is the email-harvest vector (M3); capping per-user
+    // request volume is defense in depth on top of dropping email below.
+    const rateLimit = await checkDistributedRateLimit(
+      `users-search:${user.id}`,
+      DISTRIBUTED_RATE_LIMITS.API,
+    );
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfter ?? 60) } },
+      );
+    }
+
     // Search for users by username, display name, or email
     // Only search public profiles or exact email matches
     const searchPattern = `%${query}%`;
@@ -35,13 +57,17 @@ export async function GET(request: Request) {
     // The inner join on users + isNotNull(emailVerified) excludes temp users
     // created by pending magic-link invites — those accounts have no human
     // behind them and must not surface as invite targets.
+    //
+    // Email is deliberately NOT selected here (M3): a public-profile substring
+    // match must never carry an email — that is not part of the public-profile
+    // model. Only the exact-email-match branch below (where the caller already
+    // supplied the full address) may surface an email.
     const profileResults = await db.select({
       userId: userProfiles.userId,
       username: userProfiles.username,
       displayName: userProfiles.displayName,
       bio: userProfiles.bio,
       avatarUrl: userProfiles.avatarUrl,
-      email: users.email,
     })
     .from(userProfiles)
     .leftJoin(users, eq(userProfiles.userId, users.id))
@@ -73,21 +99,15 @@ export async function GET(request: Request) {
     .limit(1);
 
     // Combine results, avoiding duplicates
-    const userMap = new Map();
-    
-    // Add profile results
+    const userMap = new Map<string, ReturnType<typeof buildPublicProfileResult>>();
+
+    // Add profile results — public-profile shape, no email (M3).
     for (const result of profileResults) {
-      userMap.set(result.userId, {
-        userId: result.userId,
-        username: result.username,
-        displayName: result.displayName,
-        bio: result.bio,
-        avatarUrl: result.avatarUrl,
-        email: result.email,
-      });
+      userMap.set(result.userId, buildPublicProfileResult(result));
     }
 
-    // Add email results if not already in map.
+    // Add email results if not already in map. These are exact-email matches,
+    // so the caller already knows the address and the result may carry it.
     // Defense in depth: even if the DB layer returns an unverified row,
     // drop it here so search can never surface a temp user.
     for (const result of emailResults) {
@@ -99,26 +119,23 @@ export async function GET(request: Request) {
           .where(eq(userProfiles.userId, result.userId))
           .limit(1);
 
-        if (profile.length > 0) {
-          userMap.set(result.userId, {
-            userId: result.userId,
-            username: profile[0].username,
-            displayName: profile[0].displayName,
-            bio: profile[0].bio,
-            avatarUrl: profile[0].avatarUrl,
-            email: result.email,
-          });
-        } else {
-          // User without profile
-          userMap.set(result.userId, {
-            userId: result.userId,
-            username: null,
-            displayName: result.name || 'Unknown User',
-            bio: null,
-            avatarUrl: null,
-            email: result.email,
-          });
-        }
+        const base = profile.length > 0
+          ? buildPublicProfileResult({
+              userId: result.userId,
+              username: profile[0].username,
+              displayName: profile[0].displayName,
+              bio: profile[0].bio,
+              avatarUrl: profile[0].avatarUrl,
+            })
+          : buildPublicProfileResult({
+              userId: result.userId,
+              username: null,
+              displayName: result.name || 'Unknown User',
+              bio: null,
+              avatarUrl: null,
+            });
+
+        userMap.set(result.userId, buildExactEmailMatchResult(base, result.email));
       }
     }
 

--- a/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
@@ -20,7 +20,9 @@ interface SelectedUser {
   userId: string;
   username?: string;
   displayName: string;
-  email: string;
+  // Optional: substring profile matches no longer carry an email (M3); invites
+  // use userId, so the email is display-only here.
+  email?: string;
   avatarUrl?: string;
 }
 

--- a/apps/web/src/app/dashboard/connections/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/connections/__tests__/page.test.tsx
@@ -4,7 +4,12 @@ import userEvent from '@testing-library/user-event';
 
 // ============================================================================
 // Smoke tests for the connections "Add Connection" tab invite branch.
-// Focuses on: user-not-found → invite CTA surface, and invite POST payload.
+//
+// L2 hardening: /api/connections/search returns a generic `{ user: null }` for
+// every non-actionable outcome (no account / self / existing relationship), so
+// the UI must treat them identically — surface the same neutral CTA and, after
+// the follow-up invite, the same uniform confirmation — rather than echoing the
+// distinguishing state and letting a user recover what the search concealed.
 // ============================================================================
 
 vi.mock('@/hooks/useAuth', () => ({
@@ -56,15 +61,20 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     return discoverTab;
   }
 
-  it('given user search returns "no user found", surfaces the invite-to-PageSpace CTA', async () => {
-    const user = userEvent.setup();
-
+  // Helper: the search endpoint now always returns a generic { user: null }
+  // for non-actionable outcomes.
+  function mockGenericNullSearch() {
     vi.mocked(fetchWithAuth).mockResolvedValueOnce(
-      new Response(JSON.stringify({ user: null, error: 'No user found with this email address' }), {
+      new Response(JSON.stringify({ user: null }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
     );
+  }
+
+  it('given a generic { user: null } search result, surfaces the neutral send-request CTA', async () => {
+    const user = userEvent.setup();
+    mockGenericNullSearch();
 
     const discoverTab = renderAndGetTab();
     await user.click(discoverTab);
@@ -74,21 +84,17 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     await user.click(screen.getByRole('button', { name: /Find User/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('User not found')).toBeInTheDocument();
-      expect(screen.getByText(/unknown@example.com is not on PageSpace yet/i)).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /Invite to PageSpace/i })).toBeInTheDocument();
+      expect(screen.getByText('Send a connection request')).toBeInTheDocument();
+      // Neutral copy: must NOT assert the account does/doesn't exist.
+      expect(screen.queryByText(/not on PageSpace yet/i)).not.toBeInTheDocument();
+      expect(screen.queryByText('User not found')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Send request/i })).toBeInTheDocument();
     });
   });
 
-  it('given user clicks the invite CTA, POSTs to /api/connections/invite with correct email', async () => {
+  it('given user clicks the CTA, POSTs to /api/connections/invite and shows the uniform confirmation', async () => {
     const user = userEvent.setup();
-
-    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
-      new Response(JSON.stringify({ user: null, error: 'No user found with this email address' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    );
+    mockGenericNullSearch();
     vi.mocked(post).mockResolvedValueOnce({
       kind: 'invited',
       inviteId: 'invite_abc',
@@ -104,30 +110,25 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     await user.click(screen.getByRole('button', { name: /Find User/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /Invite to PageSpace/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Send request/i })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole('button', { name: /Invite to PageSpace/i }));
+    await user.click(screen.getByRole('button', { name: /Send request/i }));
 
     await waitFor(() => {
       expect(post).toHaveBeenCalledWith('/api/connections/invite', {
         email: 'unknown@example.com',
       });
       expect(toast.success).toHaveBeenCalledWith(
-        expect.stringContaining('unknown@example.com')
+        expect.stringMatching(/connection request is on its way/i)
       );
     });
   });
 
-  it('given user search returns "already connected", shows error toast (not invite CTA)', async () => {
+  it('treats an existing-relationship result identically: same neutral CTA, no distinguishing error (L2)', async () => {
     const user = userEvent.setup();
-
-    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
-      new Response(JSON.stringify({ user: null, error: 'Already connected with this user' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    );
+    // Already-connected / pending / blocked all return the SAME generic shape.
+    mockGenericNullSearch();
 
     const discoverTab = renderAndGetTab();
     await user.click(discoverTab);
@@ -137,20 +138,16 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     await user.click(screen.getByRole('button', { name: /Find User/i }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Already connected with this user');
-      expect(screen.queryByRole('button', { name: /Invite to PageSpace/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Send request/i })).toBeInTheDocument();
     });
+    // No state-revealing error toast is shown.
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it('given invite returns 409 (already pending), shows appropriate error toast', async () => {
+  it('given the invite POST fails with a state-revealing error, still shows the uniform confirmation (does not leak)', async () => {
     const user = userEvent.setup();
-
-    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
-      new Response(JSON.stringify({ user: null, error: 'No user found with this email address' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    );
+    mockGenericNullSearch();
+    // The invite endpoint returns a distinguishing 409; the UI must NOT surface it.
     vi.mocked(post).mockRejectedValueOnce(
       new Error('An invitation is already pending for this email.')
     );
@@ -163,15 +160,17 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     await user.click(screen.getByRole('button', { name: /Find User/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /Invite to PageSpace/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Send request/i })).toBeInTheDocument()
     );
 
-    await user.click(screen.getByRole('button', { name: /Invite to PageSpace/i }));
+    await user.click(screen.getByRole('button', { name: /Send request/i }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        expect.stringContaining('already have a pending connection invite')
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringMatching(/connection request is on its way/i)
       );
     });
+    // The distinguishing "already pending" detail must never reach the user.
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -105,15 +105,12 @@ export default function ConnectionsPage() {
       const data = await response.json();
 
       if (!data.user) {
-        const errorMsg: string = data.error || '';
-        // Only surface the invite CTA for true "user not found" — not for
-        // self-search or existing PENDING/ACCEPTED/BLOCKED relationships,
-        // which also return user: null but with a specific reason.
-        if (errorMsg.toLowerCase().includes('no user found')) {
-          setInvitableEmail(trimmedEmail);
-        } else {
-          toast.error(errorMsg || 'No user found with this email address');
-        }
+        // The search endpoint now returns a single generic `{ user: null }` for
+        // every non-actionable case (no account, self-search, or an existing
+        // PENDING/ACCEPTED/BLOCKED relationship) so relationship state cannot be
+        // enumerated. Offer the invite path uniformly; /api/connections/invite
+        // enforces the real rules (dedupe, blocks, self) when a request is sent.
+        setInvitableEmail(trimmedEmail);
         return;
       }
 

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -134,24 +134,35 @@ export default function ConnectionsPage() {
     }
   };
 
-  const handleInviteToPageSpace = async () => {
+  const handleSendRequestOrInvite = async () => {
     if (!invitableEmail) return;
+    const targetEmail = invitableEmail;
 
     setIsInviting(true);
     try {
-      await post('/api/connections/invite', { email: invitableEmail });
-      toast.success(`Connection invite sent to ${invitableEmail}`);
+      try {
+        await post('/api/connections/invite', { email: targetEmail });
+      } catch (error) {
+        const errorMessage = (error as Error).message ?? '';
+        // Only caller-side conditions are safe to surface — they reveal nothing
+        // about the target's account or relationship state.
+        if (/verification|requiresEmailVerification/i.test(errorMessage)) {
+          setShowVerificationAlert(true);
+          return;
+        }
+        if (/too many/i.test(errorMessage)) {
+          toast.error('Too many requests right now. Please try again later.');
+          return;
+        }
+        // Everything else — already connected / pending / blocked / self / "invite
+        // already pending" / generic failure — falls through to the SAME uniform
+        // confirmation below. The connections/search response is intentionally
+        // generic (L2); surfacing these distinguishing outcomes here would let a
+        // user recover the existence/relationship state it conceals.
+      }
+      toast.success(`If ${targetEmail} can be reached, your connection request is on its way.`);
       setEmail('');
       setInvitableEmail(null);
-    } catch (error) {
-      const errorMessage = (error as Error).message;
-      if (errorMessage.includes('already pending')) {
-        toast.error(`You already have a pending connection invite for ${invitableEmail}`);
-      } else if (errorMessage.includes('requiresEmailVerification') || errorMessage.includes('verification')) {
-        setShowVerificationAlert(true);
-      } else {
-        toast.error(errorMessage || 'Failed to send invite');
-      }
     } finally {
       setIsInviting(false);
     }
@@ -425,18 +436,18 @@ export default function ConnectionsPage() {
                   <div className="flex items-start gap-3 rounded-lg border border-dashed p-4">
                     <Mail className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" />
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium">User not found</p>
+                      <p className="text-sm font-medium">Send a connection request</p>
                       <p className="text-sm text-muted-foreground truncate">
-                        {invitableEmail} is not on PageSpace yet.
+                        We&apos;ll reach {invitableEmail} — inviting them to PageSpace if they&apos;re not a member yet.
                       </p>
                     </div>
                     <Button
                       size="sm"
-                      onClick={handleInviteToPageSpace}
+                      onClick={handleSendRequestOrInvite}
                       disabled={isInviting}
                     >
                       <Mail className="h-4 w-4 mr-2" />
-                      {isInviting ? 'Sending...' : 'Invite to PageSpace'}
+                      {isInviting ? 'Sending...' : 'Send request'}
                     </Button>
                   </div>
                 )}

--- a/apps/web/src/components/members/UserSearch.tsx
+++ b/apps/web/src/components/members/UserSearch.tsx
@@ -12,7 +12,9 @@ interface SearchResult {
   userId: string;
   username?: string;
   displayName: string;
-  email: string;
+  // Public-profile substring matches no longer carry an email (M3 hardening);
+  // only exact-email matches do. Optional so the UI degrades gracefully.
+  email?: string;
   bio?: string;
   avatarUrl?: string;
 }

--- a/apps/web/src/lib/users/__tests__/enumeration-safe.test.ts
+++ b/apps/web/src/lib/users/__tests__/enumeration-safe.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPublicProfileResult,
+  buildExactEmailMatchResult,
+  resolveFindUser,
+  buildConnectionSearchResult,
+} from '../enumeration-safe';
+
+// ============================================================================
+// Pure response-shaping helpers for the user-enumeration / email-harvest
+// remediations (audit findings M3, L1, L2).
+//
+// These functions encode the security decisions as pure projections so the
+// "what data leaves the server" question is unit-testable in isolation.
+// ============================================================================
+
+describe('buildPublicProfileResult (M3 — email harvest)', () => {
+  const row = {
+    userId: 'user_1',
+    username: 'alice',
+    displayName: 'Alice',
+    bio: 'hello',
+    avatarUrl: 'https://cdn/avatar.png',
+  };
+
+  it('projects the public-profile fields', () => {
+    expect(buildPublicProfileResult(row)).toEqual({
+      userId: 'user_1',
+      username: 'alice',
+      displayName: 'Alice',
+      bio: 'hello',
+      avatarUrl: 'https://cdn/avatar.png',
+    });
+  });
+
+  it('NEVER includes an email field, even if the input row carries one', () => {
+    // The DB row is widened deliberately: a regression could re-add email to
+    // the SELECT. The projection must still drop it.
+    const result = buildPublicProfileResult({
+      ...row,
+      // @ts-expect-error — email is intentionally not part of the input type
+      email: 'alice@example.com',
+    });
+    expect(result).not.toHaveProperty('email');
+    expect(Object.values(result)).not.toContain('alice@example.com');
+  });
+
+  it('preserves null profile fields without inventing values', () => {
+    expect(
+      buildPublicProfileResult({
+        userId: 'u',
+        username: null,
+        displayName: null,
+        bio: null,
+        avatarUrl: null,
+      })
+    ).toEqual({
+      userId: 'u',
+      username: null,
+      displayName: null,
+      bio: null,
+      avatarUrl: null,
+    });
+  });
+});
+
+describe('buildExactEmailMatchResult (M3 — exact-match branch may surface email)', () => {
+  it('adds the email the caller already supplied to the public-profile base', () => {
+    const base = buildPublicProfileResult({
+      userId: 'user_2',
+      username: 'bob',
+      displayName: 'Bob',
+      bio: null,
+      avatarUrl: null,
+    });
+    expect(buildExactEmailMatchResult(base, 'bob@example.com')).toEqual({
+      userId: 'user_2',
+      username: 'bob',
+      displayName: 'Bob',
+      bio: null,
+      avatarUrl: null,
+      email: 'bob@example.com',
+    });
+  });
+});
+
+describe('resolveFindUser (L1 — /api/users/find existence + PII leak)', () => {
+  const candidate = {
+    id: 'target_1',
+    name: 'Target',
+    email: 'target@example.com',
+    image: null,
+  };
+
+  it('collapses "no such account" into a uniform not-found', () => {
+    expect(resolveFindUser(null, 'caller_1', false)).toEqual({ found: false });
+  });
+
+  it('collapses "account exists but caller cannot see them" into the SAME not-found', () => {
+    // Indistinguishable from the null case above — that is the whole point.
+    expect(resolveFindUser(candidate, 'caller_1', false)).toEqual({ found: false });
+  });
+
+  it('returns the user when the caller already shares context (visible)', () => {
+    expect(resolveFindUser(candidate, 'caller_1', true)).toEqual({
+      found: true,
+      user: candidate,
+    });
+  });
+
+  it('always lets a caller resolve their own account', () => {
+    const self = { id: 'caller_1', name: 'Me', email: 'me@example.com', image: null };
+    expect(resolveFindUser(self, 'caller_1', false)).toEqual({
+      found: true,
+      user: self,
+    });
+  });
+});
+
+describe('buildConnectionSearchResult (L2 — distinguishable relationship state)', () => {
+  const target = {
+    id: 'target_2',
+    name: 'Carol',
+    email: 'carol@example.com',
+    displayName: 'Carol',
+    bio: null,
+    avatarUrl: null,
+  };
+
+  it('returns the actionable user only when one can actually be invited', () => {
+    expect(
+      buildConnectionSearchResult({ isSelf: false, target, existingStatus: null })
+    ).toEqual({ user: target });
+  });
+
+  it('collapses self-search into the generic no-user response', () => {
+    expect(
+      buildConnectionSearchResult({ isSelf: true, target, existingStatus: null })
+    ).toEqual({ user: null });
+  });
+
+  it('collapses "no account" into the generic no-user response', () => {
+    expect(
+      buildConnectionSearchResult({ isSelf: false, target: null, existingStatus: null })
+    ).toEqual({ user: null });
+  });
+
+  it('collapses every existing-relationship state into the SAME generic response', () => {
+    for (const existingStatus of ['PENDING', 'ACCEPTED', 'BLOCKED'] as const) {
+      expect(
+        buildConnectionSearchResult({ isSelf: false, target, existingStatus })
+      ).toEqual({ user: null });
+    }
+  });
+
+  it('never leaks a distinguishing error string', () => {
+    const outcomes = [
+      buildConnectionSearchResult({ isSelf: true, target, existingStatus: null }),
+      buildConnectionSearchResult({ isSelf: false, target: null, existingStatus: null }),
+      buildConnectionSearchResult({ isSelf: false, target, existingStatus: 'BLOCKED' }),
+      buildConnectionSearchResult({ isSelf: false, target, existingStatus: 'PENDING' }),
+    ];
+    for (const outcome of outcomes) {
+      expect(outcome).not.toHaveProperty('error');
+      expect(outcome).toEqual({ user: null });
+    }
+  });
+});

--- a/apps/web/src/lib/users/__tests__/visibility.test.ts
+++ b/apps/web/src/lib/users/__tests__/visibility.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ============================================================================
+// callerCanViewUser — relationship scoping for /api/users/find (L1).
+//
+// Mocked at the DB seam: each db.select() consumes the next queued result set,
+// in the order the route issues them:
+//   1. accepted-connection check
+//   2. caller's owned drives          (getUserDriveIds)
+//   3. caller's member drives         (getUserDriveIds)
+//   4. target shared-membership check
+//   5. target shared-ownership check
+// ============================================================================
+
+vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn() } }));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  inArray: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'drives.id', ownerId: 'drives.ownerId' } }));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: { userId: 'driveMembers.userId', driveId: 'driveMembers.driveId' },
+}));
+vi.mock('@pagespace/db/schema/social', () => ({
+  connections: {
+    status: 'connections.status',
+    user1Id: 'connections.user1Id',
+    user2Id: 'connections.user2Id',
+  },
+}));
+
+import { callerCanViewUser } from '../visibility';
+import { db } from '@pagespace/db/db';
+
+function queueSelectResults(results: unknown[][]) {
+  let i = 0;
+  vi.mocked(db.select).mockImplementation((() => {
+    const result = results[i++] ?? [];
+    const terminal = Promise.resolve(result) as Promise<unknown[]> & {
+      limit: () => Promise<unknown[]>;
+    };
+    terminal.limit = () => Promise.resolve(result);
+    const chain = {
+      from: () => chain,
+      where: () => terminal,
+      limit: () => Promise.resolve(result),
+    };
+    return chain as never;
+  }) as never);
+}
+
+describe('callerCanViewUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true for the caller resolving themselves (no DB access)', async () => {
+    queueSelectResults([]);
+    expect(await callerCanViewUser('u1', 'u1')).toBe(true);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns true when an accepted connection exists', async () => {
+    queueSelectResults([[{ status: 'ACCEPTED' }]]);
+    expect(await callerCanViewUser('u1', 'u2')).toBe(true);
+  });
+
+  it('returns true when both share drive membership', async () => {
+    queueSelectResults([
+      [], // no connection
+      [{ id: 'drive_a' }], // caller owns drive_a
+      [], // caller member of none
+      [{ driveId: 'drive_a' }], // target is a member of drive_a
+    ]);
+    expect(await callerCanViewUser('u1', 'u2')).toBe(true);
+  });
+
+  it('returns true when the target owns a drive the caller belongs to', async () => {
+    queueSelectResults([
+      [], // no connection
+      [], // caller owns none
+      [{ driveId: 'drive_b' }], // caller is a member of drive_b
+      [], // target is a member of nothing shared
+      [{ id: 'drive_b' }], // target owns drive_b
+    ]);
+    expect(await callerCanViewUser('u1', 'u2')).toBe(true);
+  });
+
+  it('returns false when there is no connection and no shared drive', async () => {
+    queueSelectResults([
+      [], // no connection
+      [{ id: 'drive_a' }], // caller owns drive_a
+      [], // caller member of none
+      [], // target not a member of caller's drives
+      [], // target owns none of caller's drives
+    ]);
+    expect(await callerCanViewUser('u1', 'u2')).toBe(false);
+  });
+
+  it('returns false (short-circuits drive checks) when the caller has no drives', async () => {
+    queueSelectResults([
+      [], // no connection
+      [], // owns none
+      [], // member of none
+    ]);
+    expect(await callerCanViewUser('u1', 'u2')).toBe(false);
+    // 1 connection select + 2 drive-id selects; the shared-drive checks are skipped.
+    expect(db.select).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/src/lib/users/__tests__/visibility.test.ts
+++ b/apps/web/src/lib/users/__tests__/visibility.test.ts
@@ -18,10 +18,15 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn(),
   or: vi.fn(),
   inArray: vi.fn(),
+  isNotNull: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'drives.id', ownerId: 'drives.ownerId' } }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { userId: 'driveMembers.userId', driveId: 'driveMembers.driveId' },
+  driveMembers: {
+    userId: 'driveMembers.userId',
+    driveId: 'driveMembers.driveId',
+    acceptedAt: 'driveMembers.acceptedAt',
+  },
 }));
 vi.mock('@pagespace/db/schema/social', () => ({
   connections: {
@@ -33,6 +38,7 @@ vi.mock('@pagespace/db/schema/social', () => ({
 
 import { callerCanViewUser } from '../visibility';
 import { db } from '@pagespace/db/db';
+import { isNotNull } from '@pagespace/db/operators';
 
 function queueSelectResults(results: unknown[][]) {
   let i = 0;
@@ -108,5 +114,19 @@ describe('callerCanViewUser', () => {
     expect(await callerCanViewUser('u1', 'u2')).toBe(false);
     // 1 connection select + 2 drive-id selects; the shared-drive checks are skipped.
     expect(db.select).toHaveBeenCalledTimes(3);
+  });
+
+  it('gates driveMembers reads on isNotNull(acceptedAt) so pending invitations do not grant visibility (P1)', async () => {
+    queueSelectResults([
+      [], // no connection
+      [{ id: 'drive_a' }], // caller owns drive_a
+      [], // caller member of none (accepted)
+      [], // target not an accepted member of caller's drives
+      [], // target owns none of caller's drives
+    ]);
+    await callerCanViewUser('u1', 'u2');
+    // Both the caller's member-drive lookup and the target shared-membership
+    // lookup must compose the acceptedAt gate.
+    expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
   });
 });

--- a/apps/web/src/lib/users/enumeration-safe.ts
+++ b/apps/web/src/lib/users/enumeration-safe.ts
@@ -1,0 +1,154 @@
+/**
+ * Pure response-shaping helpers for the user-enumeration / email-harvest
+ * remediations (security audit findings M3, L1, L2).
+ *
+ * The shared theme across all three findings is that an attacker can probe a
+ * user-lookup endpoint and learn things they should not: a public profile's
+ * email (M3), whether an arbitrary email maps to an account plus that person's
+ * name/avatar (L1), or the exact relationship state between themselves and any
+ * email (L2).
+ *
+ * These functions isolate the "what data leaves the server" decision into pure
+ * projections so it can be unit-tested in isolation and cannot drift back to a
+ * leaky shape unnoticed. The route handlers do the I/O (auth, rate limiting, DB
+ * reads); these helpers decide the response body.
+ */
+
+// ============================================================================
+// M3 — Email harvest via public-profile substring search
+// ============================================================================
+
+/** A public-profile row as selected from `userProfiles` (NO email column). */
+export interface PublicProfileRow {
+  userId: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+}
+
+/** The public-profile shape returned to substring searchers. Never has email. */
+export interface PublicProfileResult {
+  userId: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+}
+
+export interface ExactEmailMatchResult extends PublicProfileResult {
+  email: string;
+}
+
+/**
+ * Project a public-profile row to the shape returned for unanchored substring
+ * matches. Critically, this NEVER carries an email: a 2-char substring search
+ * iterated `aa..zz` would otherwise harvest every public profile's email, and
+ * email is not part of the public-profile data model.
+ */
+export function buildPublicProfileResult(row: PublicProfileRow): PublicProfileResult {
+  return {
+    userId: row.userId,
+    username: row.username,
+    displayName: row.displayName,
+    bio: row.bio,
+    avatarUrl: row.avatarUrl,
+  };
+}
+
+/**
+ * The exact-email-match branch may surface the email because the caller already
+ * supplied the full address (they cannot learn an address they did not type).
+ * This composes the public-profile base with that already-known email.
+ */
+export function buildExactEmailMatchResult(
+  base: PublicProfileResult,
+  email: string,
+): ExactEmailMatchResult {
+  return { ...base, email };
+}
+
+// ============================================================================
+// L1 — /api/users/find leaks existence + name/avatar for any exact email
+// ============================================================================
+
+export interface FindUserCandidate {
+  id: string;
+  name: string | null;
+  email: string;
+  image: string | null;
+}
+
+export type FindUserOutcome =
+  | { found: true; user: FindUserCandidate }
+  | { found: false };
+
+/**
+ * Collapse the two distinguishable outcomes — "no account with this email" and
+ * "an account exists but the caller has no relationship to it" — into a single
+ * uniform not-found result, so an attacker cannot enumerate which emails have
+ * accounts (nor harvest the owner's name/avatar).
+ *
+ * Identity is only surfaced when the caller already shares context with the
+ * target (a shared drive or accepted connection — decided by the route via the
+ * DB) or when the caller is resolving their own account.
+ */
+export function resolveFindUser(
+  candidate: FindUserCandidate | null,
+  callerId: string,
+  callerCanView: boolean,
+): FindUserOutcome {
+  if (!candidate) return { found: false };
+  if (candidate.id === callerId || callerCanView) {
+    return { found: true, user: candidate };
+  }
+  return { found: false };
+}
+
+// ============================================================================
+// L2 — /api/connections/search distinguishable relationship state
+// ============================================================================
+
+export type ConnectionStatus = 'PENDING' | 'ACCEPTED' | 'BLOCKED';
+
+export interface ConnectionSearchProfile {
+  id: string;
+  name: string | null;
+  email: string;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+}
+
+export interface ConnectionSearchInput {
+  /** True when the searched email belongs to the caller themselves. */
+  isSelf: boolean;
+  /** The matched user, or null when no account has that email. */
+  target: ConnectionSearchProfile | null;
+  /** Existing connection status between caller and target, or null if none. */
+  existingStatus: ConnectionStatus | null;
+}
+
+export type ConnectionSearchResponse =
+  | { user: ConnectionSearchProfile }
+  | { user: null };
+
+/**
+ * Collapse every non-actionable outcome — self-search, no account, and any
+ * existing relationship state (PENDING / ACCEPTED / BLOCKED) — into a single
+ * generic `{ user: null }` response with no distinguishing error string. This
+ * prevents an attacker from telling "no such user" apart from "blocked you" /
+ * "already connected" / "request pending", any of which would otherwise leak
+ * both existence and relationship state.
+ *
+ * A profile is only returned when a connection request can actually be sent:
+ * the account exists, it is not the caller, and no connection row exists yet.
+ */
+export function buildConnectionSearchResult(
+  input: ConnectionSearchInput,
+): ConnectionSearchResponse {
+  if (input.isSelf || !input.target || input.existingStatus !== null) {
+    return { user: null };
+  }
+  return { user: input.target };
+}

--- a/apps/web/src/lib/users/visibility.ts
+++ b/apps/web/src/lib/users/visibility.ts
@@ -1,0 +1,74 @@
+/**
+ * Relationship-scoping for user lookups (security audit finding L1).
+ *
+ * Decides whether `callerId` is already allowed to see `targetId` — i.e. they
+ * share a drive (as owner or member) or have an accepted connection. The
+ * `/api/users/find` handler uses this so it can only surface a user's identity
+ * to callers who already have a relationship, collapsing every other outcome
+ * into a uniform not-found (see `resolveFindUser`).
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq, and, or, inArray } from '@pagespace/db/operators';
+import { drives } from '@pagespace/db/schema/core';
+import { driveMembers } from '@pagespace/db/schema/members';
+import { connections } from '@pagespace/db/schema/social';
+
+/** Drive ids the user owns or is a member of. */
+async function getUserDriveIds(userId: string): Promise<string[]> {
+  const [owned, member] = await Promise.all([
+    db.select({ id: drives.id }).from(drives).where(eq(drives.ownerId, userId)),
+    db
+      .select({ driveId: driveMembers.driveId })
+      .from(driveMembers)
+      .where(eq(driveMembers.userId, userId)),
+  ]);
+  return Array.from(
+    new Set<string>([...owned.map((d) => d.id), ...member.map((m) => m.driveId)]),
+  );
+}
+
+/**
+ * True when the caller already shares context with the target: themselves, an
+ * accepted connection (either direction), or co-membership of any drive.
+ */
+export async function callerCanViewUser(
+  callerId: string,
+  targetId: string,
+): Promise<boolean> {
+  if (callerId === targetId) return true;
+
+  const acceptedConnection = await db
+    .select({ status: connections.status })
+    .from(connections)
+    .where(
+      and(
+        eq(connections.status, 'ACCEPTED'),
+        or(
+          and(eq(connections.user1Id, callerId), eq(connections.user2Id, targetId)),
+          and(eq(connections.user1Id, targetId), eq(connections.user2Id, callerId)),
+        ),
+      ),
+    )
+    .limit(1);
+  if (acceptedConnection.length > 0) return true;
+
+  const callerDriveIds = await getUserDriveIds(callerId);
+  if (callerDriveIds.length === 0) return false;
+
+  const sharedMembership = await db
+    .select({ driveId: driveMembers.driveId })
+    .from(driveMembers)
+    .where(
+      and(eq(driveMembers.userId, targetId), inArray(driveMembers.driveId, callerDriveIds)),
+    )
+    .limit(1);
+  if (sharedMembership.length > 0) return true;
+
+  const sharedOwnership = await db
+    .select({ id: drives.id })
+    .from(drives)
+    .where(and(eq(drives.ownerId, targetId), inArray(drives.id, callerDriveIds)))
+    .limit(1);
+  return sharedOwnership.length > 0;
+}

--- a/apps/web/src/lib/users/visibility.ts
+++ b/apps/web/src/lib/users/visibility.ts
@@ -9,19 +9,26 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, or, inArray } from '@pagespace/db/operators';
+import { eq, and, or, inArray, isNotNull } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';
 import { driveMembers } from '@pagespace/db/schema/members';
 import { connections } from '@pagespace/db/schema/social';
 
-/** Drive ids the user owns or is a member of. */
+/**
+ * Drive ids the user owns or is an ACCEPTED member of.
+ *
+ * `driveMembers` reads used for an authorization decision must gate on
+ * `isNotNull(acceptedAt)` (repo convention — see drive-member-gate-coverage):
+ * a pending, unaccepted invitation is not an established shared context, so it
+ * must not let the invitee resolve other members' identities (nor vice versa).
+ */
 async function getUserDriveIds(userId: string): Promise<string[]> {
   const [owned, member] = await Promise.all([
     db.select({ id: drives.id }).from(drives).where(eq(drives.ownerId, userId)),
     db
       .select({ driveId: driveMembers.driveId })
       .from(driveMembers)
-      .where(eq(driveMembers.userId, userId)),
+      .where(and(eq(driveMembers.userId, userId), isNotNull(driveMembers.acceptedAt))),
   ]);
   return Array.from(
     new Set<string>([...owned.map((d) => d.id), ...member.map((m) => m.driveId)]),
@@ -60,7 +67,11 @@ export async function callerCanViewUser(
     .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
     .where(
-      and(eq(driveMembers.userId, targetId), inArray(driveMembers.driveId, callerDriveIds)),
+      and(
+        eq(driveMembers.userId, targetId),
+        inArray(driveMembers.driveId, callerDriveIds),
+        isNotNull(driveMembers.acceptedAt),
+      ),
     )
     .limit(1);
   if (sharedMembership.length > 0) return true;


### PR DESCRIPTION
## Summary
Remediates security-audit findings **M3, L1, L2** (user enumeration / email harvest). One PR; strict-TDD with response-shaping isolated into pure, unit-tested functions; reuses the existing `checkDistributedRateLimit` utility.

## Findings closed

**M3 — Email harvest via public-profile substring search** (`api/users/search`)
- Dropped `users.email` from the public-profile (`profileResults`) projection and from every returned object. A 2-char unanchored substring iterated `aa..zz` can no longer harvest public-profile emails — email is not part of the public-profile model.
- Only the exact-email-match branch (caller already supplied the full address) surfaces an email.
- Added per-user rate limiting on real searches.

**L1 — `/api/users/find` leaked existence + name/avatar for any exact email**
- Now relationship-scoped: identity is returned only to a caller who already shares context (shared drive ∪ accepted connection) or to the user themselves.
- "No such account" and "exists but not visible to you" collapse into the **same uniform 404**, so account existence and name/avatar can't be enumerated.
- Added per-user rate limiting.

**L2 — `/api/connections/search` distinguishable not-found vs blocked/pending + full profile on hit**
- Returns a single generic `{ user: null }` (no distinguishing error string) for every non-actionable outcome: self-search, no account, or any existing `PENDING`/`ACCEPTED`/`BLOCKED` relationship.
- A profile is surfaced only when a connection request can actually be sent.
- Added per-user rate limiting.

## Data closed off
- Public-profile substring matches no longer leak email.
- Existence of an account for an arbitrary email is no longer observable to unrelated callers (find) or at all (connections search).
- Relationship state (connected / pending / blocked) is no longer distinguishable.

## Pure functions + tests
- `apps/web/src/lib/users/enumeration-safe.ts` — `buildPublicProfileResult` (asserts **no** email), `buildExactEmailMatchResult`, `resolveFindUser`, `buildConnectionSearchResult`. Colocated unit tests (13).
- `apps/web/src/lib/users/visibility.ts` — `callerCanViewUser` relationship scoping for L1. Colocated unit tests (6).
- Route contract tests updated to the secure behavior (search 19, find 14, connections/search 7).
- Consumers updated for the new shapes: `UserSearch`, members invite page, connections dashboard (offers the invite path uniformly on `{ user: null }`).

## Verification
- `bun run --filter 'web' typecheck` — ✅ exit 0
- `bun run --filter 'web' lint` — ✅ exit 0 (only pre-existing warnings in untouched files)
- Affected unit suites — ✅ `api/users/*`, `api/connections/*`, `lib/users/*`, plus consumer tests `UserSearch` and `ShareDialog` (86 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review responses (Codex)

**P1 — visibility scoping must exclude pending memberships** (`visibility.ts`)
- `callerCanViewUser` now gates both `driveMembers` reads on `isNotNull(acceptedAt)` (the caller's member-drive lookup and the target shared-membership lookup), so an unaccepted invitation no longer counts as shared context. Matches the repo's `drive-member-gate-coverage` authz convention. Added a regression test. _(commit e15ab4eb6)_

**P2 — keep the generic outcome through the follow-up action** (`connections` dashboard)
- The UI no longer surfaces `/api/connections/invite`'s distinguishing outcomes: all target-state-dependent results (success / already-connected / pending / blocked / self / 409) collapse into one uniform confirmation; only caller-side conditions (email verification, rate limit) are shown. CTA copy neutralized (no existence assertions). Page tests updated to lock in the indistinguishable behavior. _(commit e15ab4eb6)_
- Scope note: `/api/connections/invite`'s own response distinguishability is **pre-existing** and intentionally untouched — the L2 finding scoped the GET `/api/connections/search` oracle. The invite endpoint is CSRF-protected, side-effecting, and separately rate-limited (3/(inviter,email)/15min + 3/email/15min) with a verified-inviter requirement; uniforming it would change a deliberate, separately-tested contract and is left for a follow-up.

### Validation (post-review)
- Full repo `typecheck` ✅ · web `lint` ✅ · affected unit suites ✅ (85 tests: `lib/users/*`, `api/users/*`, `api/connections/*`, connections dashboard page).


---

## Known scope boundaries (deliberate)

A proactive self-review surfaced three items intentionally left as-is, per the WO-13 spec and to avoid breaking adjacent features. Documented here for reviewer visibility:

1. **`/api/users/search` exact-email branch still returns `{ existence + display name + email }`.** This is required by WO-13 M3, which scoped the fix to *"drop email from the public-profile (substring) projection"* and explicitly allows the exact-email-match branch to surface data because *"the caller already knows the address."* It also backs member-invite-by-email (`UserSearch`) and connection invites — relationship-scoping it (like L1) would break inviting a brand-new collaborator. Mitigated with per-user rate limiting (defense-in-depth). Closing this oracle too (for consistency with L1) would be a deliberate product/scope expansion → follow-up.

2. **L1 relationship-scoping of `/api/users/find` degrades `ShareDialog` for existing-but-unrelated users.** When a sharer has no shared drive/accepted connection with an existing target, `find` now returns the uniform 404, so ShareDialog routes through the off-platform share-invite path: an extra click, the pre-existing "not yet on PageSpace" copy is shown though the account exists, and DELETE can't be granted via that path (share-invite caps at VIEW/EDIT/SHARE). Sharing still **functionally succeeds** (share-invite grants access). This is the intended security/UX tradeoff of the mandated L1 fix; neutralizing the ShareDialog copy / allowing DELETE on share-invite would be a follow-up (out of WO-13 scope; ShareDialog is unchanged by this PR).

3. **Pre-existing TOCTOU in `handleSendConnectionRequest`'s actionable path** (the `data.user` branch, unchanged by this PR) can surface a relationship-state error if the relationship changes between search and the immediate `POST /api/connections`. Narrow window, and the target was already disclosed by the (actionable) search result. Left as-is — not introduced or worsened by this PR.
