### PR TITLE
fix(security): require verified email before OAuth account linking

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -35,7 +35,8 @@ vi.mock('google-auth-library', () => ({
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn(),
+    findUserByGoogleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -160,7 +161,8 @@ describe('/api/auth/google/callback redirect', () => {
       created: true,
     });
 
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue({
       id: 'user-123',
@@ -193,7 +195,15 @@ describe('/api/auth/google/callback redirect', () => {
       driveId: 'existing-drive',
       created: false,
     });
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue({
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue({
+      id: 'user-123',
+      name: 'Existing User',
+      email: 'test@example.com',
+      googleId: 'google-id',
+      tokenVersion: 0,
+      role: 'user',
+    } as never);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue({
       id: 'user-123',
       name: 'Existing User',
       email: 'test@example.com',

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -155,7 +155,7 @@ describe('/api/auth/mobile/oauth/google/exchange', () => {
       success: true,
       userInfo: mockUserInfo,
     } as never);
-    vi.mocked(createOrLinkOAuthUser).mockResolvedValue(mockUser as never);
+    vi.mocked(createOrLinkOAuthUser).mockResolvedValue({ status: 'linked', user: mockUser } as never);
     vi.mocked(validateOrCreateDeviceToken).mockResolvedValue({
       deviceToken: 'mock-device-token',
     } as never);

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -25,7 +25,8 @@ import crypto from 'crypto';
 // Mock dependencies BEFORE imports
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByAppleIdOrEmail: vi.fn(),
+    findUserByAppleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -209,7 +210,8 @@ describe('POST /api/auth/apple/callback', () => {
     };
     vi.mocked(getClientIP).mockReturnValue('127.0.0.1');
     vi.mocked(isSafeReturnUrl).mockReturnValue(true);
-    vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
@@ -593,7 +595,8 @@ describe('POST /api/auth/apple/callback', () => {
               appleId: null,
       };
 
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, appleId: 'apple-sub-123' } as never);
 
       const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
@@ -610,6 +613,44 @@ describe('POST /api/auth/apple/callback', () => {
       expect(authRepository.createUser).not.toHaveBeenCalled();
     });
 
+    // SECURITY (M5): an unverified Apple email must never link to / authenticate
+    // an existing account; only a subject-id (appleId) match may.
+    it('redirects to oauth_error and never links when email matches an existing account but is unverified', async () => {
+      vi.mocked(verifyAppleIdToken).mockResolvedValue({
+        success: true,
+        // @ts-expect-error - partial mock data
+        userInfo: {
+          providerId: 'attacker-apple-sub',
+          email: 'victim@example.com',
+          emailVerified: false,
+        },
+      });
+      // No appleId subject match; only the email collides with an existing account.
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue({
+        id: 'victim-id',
+        name: 'Victim',
+        email: 'victim@example.com',
+        image: null,
+        emailVerified: new Date(),
+        tokenVersion: 0,
+        appleId: null,
+      } as never);
+
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/auth/signin?error=oauth_error');
+      // No account was linked, created, or signed in.
+      expect(authRepository.updateUser).not.toHaveBeenCalled();
+      expect(authRepository.createUser).not.toHaveBeenCalled();
+      expect(sessionService.createSession).not.toHaveBeenCalled();
+    });
+
     it('updates existing user missing name', async () => {
       const existingUser = {
         id: 'existing-id',
@@ -621,7 +662,8 @@ describe('POST /api/auth/apple/callback', () => {
               appleId: 'apple-sub-123',
       };
 
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'test' } as never);
 
       const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
@@ -648,7 +690,8 @@ describe('POST /api/auth/apple/callback', () => {
               appleId: 'apple-sub-123',
       };
 
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(existingUser as never);
 
       const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
       const request = createCallbackRequest({
@@ -673,7 +716,8 @@ describe('POST /api/auth/apple/callback', () => {
               appleId: null,
       };
 
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(null);
 
       const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
@@ -1129,7 +1173,8 @@ describe('POST /api/auth/apple/callback', () => {
         tokenVersion: 0,
         appleId: null,
       };
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'test', appleId: 'apple-sub-123' } as never);
 
       const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
@@ -1152,7 +1197,8 @@ describe('POST /api/auth/apple/callback', () => {
         tokenVersion: 0,
         appleId: null,
       };
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'test', appleId: 'apple-sub-123' } as never);
 
       const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
@@ -1235,7 +1281,8 @@ describe('POST /api/auth/apple/callback', () => {
     });
 
     it('calls consumeAnyInviteIfPresent with isNewUser=false for existing users when inviteToken is in state', async () => {
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValue(mockExistingUser as never);
 
       vi.mocked(consumeAnyInviteIfPresent).mockResolvedValueOnce({

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -22,6 +22,7 @@ import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/cookie-config';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
 import {
   consumeAllInvitesForEmail,
@@ -139,8 +140,41 @@ export async function POST(req: Request) {
     const name = [givenName, familyName].filter(Boolean).join(' ') || undefined;
     const userName = name || email.split('@')[0] || 'User';
 
+    // Resolve the account match through the shared, security-critical decision.
+    // SECURITY (M5): match an EXISTING account by raw email only when Apple
+    // asserts the email is verified; the subject id (appleId) may always match.
+    const subMatch = await authRepository.findUserByAppleId(appleId);
+    const emailMatch = await authRepository.findUserByEmail(email);
+    const matchDecision = resolveOAuthMatch({
+      providerSubMatch: !!subMatch,
+      emailMatch: !!emailMatch,
+      emailVerified: emailVerified === true,
+    });
+
+    if (matchDecision === 'reject') {
+      loggers.auth.warn('Blocked OAuth account link: unverified email matches existing account', {
+        email: maskEmail(email),
+        provider: 'apple',
+      });
+      auditRequest(req, {
+        eventType: 'auth.login.failure',
+        riskScore: 0.8,
+        userId: emailMatch?.id,
+        details: { reason: 'apple_oauth_unverified_email_link_blocked' },
+      });
+      if (platform === 'desktop') {
+        return NextResponse.redirect('pagespace://auth-error?error=oauth_error');
+      }
+      return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', baseUrl));
+    }
+
     // Find or create user
-    let user = await authRepository.findUserByAppleIdOrEmail(appleId, email);
+    let user =
+      matchDecision === 'use-sub'
+        ? subMatch
+        : matchDecision === 'use-email'
+          ? emailMatch
+          : null;
     const wasNewUser = !user;
 
     if (user) {

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -22,7 +22,7 @@ import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/cookie-config';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
+import { resolveOAuthAccount } from '@/lib/auth/oauth-account-resolver';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
 import {
   consumeAllInvitesForEmail,
@@ -143,11 +143,10 @@ export async function POST(req: Request) {
     // Resolve the account match through the shared, security-critical decision.
     // SECURITY (M5): match an EXISTING account by raw email only when Apple
     // asserts the email is verified; the subject id (appleId) may always match.
-    const subMatch = await authRepository.findUserByAppleId(appleId);
-    const emailMatch = await authRepository.findUserByEmail(email);
-    const matchDecision = resolveOAuthMatch({
-      providerSubMatch: !!subMatch,
-      emailMatch: !!emailMatch,
+    const { decision: matchDecision, user: matchedUser, emailMatch } = await resolveOAuthAccount({
+      provider: 'apple',
+      providerId: appleId,
+      email,
       emailVerified: emailVerified === true,
     });
 
@@ -169,12 +168,7 @@ export async function POST(req: Request) {
     }
 
     // Find or create user
-    let user =
-      matchDecision === 'use-sub'
-        ? subMatch
-        : matchDecision === 'use-email'
-          ? emailMatch
-          : null;
+    let user = matchedUser;
     const wasNewUser = !user;
 
     if (user) {

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -23,7 +23,8 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 // Mock dependencies BEFORE imports
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByAppleIdOrEmail: vi.fn(),
+    findUserByAppleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -184,7 +185,8 @@ describe('POST /api/auth/apple/native', () => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, APPLE_CLIENT_ID: 'com.example.app' };
     vi.mocked(getClientIP).mockReturnValue('127.0.0.1');
-    vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
@@ -424,7 +426,8 @@ describe('POST /api/auth/apple/native', () => {
     };
 
     it('updates existing user when appleId is missing', async () => {
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, appleId: 'apple-sub-123' } as never);
 
       const response = await POST(createNativeRequest(validPayload));
@@ -439,7 +442,8 @@ describe('POST /api/auth/apple/native', () => {
 
     it('updates existing user when name is missing', async () => {
       const userWithoutName = { ...existingUser, appleId: null, name: null };
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(userWithoutName as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(userWithoutName as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutName as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userWithoutName, appleId: 'apple-sub-123', name: 'John Doe' } as never);
 
       const response = await POST(createNativeRequest(validPayload));
@@ -453,7 +457,8 @@ describe('POST /api/auth/apple/native', () => {
 
     it('does not update user when no update is needed', async () => {
       const completeUser = { ...existingUser, appleId: 'apple-sub-123' };
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(completeUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(completeUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(completeUser as never);
 
       const response = await POST(createNativeRequest(validPayload));
 
@@ -463,7 +468,8 @@ describe('POST /api/auth/apple/native', () => {
 
     it('does not provision drive for existing users', async () => {
       const completeUser = { ...existingUser, appleId: 'apple-sub-123' };
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(completeUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(completeUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(completeUser as never);
 
       await POST(createNativeRequest(validPayload));
 
@@ -471,7 +477,8 @@ describe('POST /api/auth/apple/native', () => {
     });
 
     it('handles re-fetch returning null after update', async () => {
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(null);
 
       const response = await POST(createNativeRequest(validPayload));
@@ -702,7 +709,8 @@ describe('POST /api/auth/apple/native', () => {
       vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
 
     it('masks email in "Creating new user via native Apple OAuth" log', async () => {
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
       vi.mocked(authRepository.createUser).mockResolvedValue({
         id: 'new-user-id',
         name: 'Test',
@@ -733,7 +741,8 @@ describe('POST /api/auth/apple/native', () => {
         image: null,
         emailVerified: new Date(),
       };
-      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByAppleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'Joe', appleId: 'apple-sub-123' } as never);
 
       await POST(createNativeRequest({ ...validPayload, givenName: 'Joe' }));

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -18,7 +18,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
+import { resolveOAuthAccount } from '@/lib/auth/oauth-account-resolver';
 import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import {
   consumeAllInvitesForEmail,
@@ -113,11 +113,10 @@ export async function POST(req: Request) {
     // Resolve the account match through the shared, security-critical decision.
     // SECURITY (M5): match an EXISTING account by raw email only when Apple
     // asserts the email is verified; the subject id (appleId) may always match.
-    const subMatch = await authRepository.findUserByAppleId(appleId);
-    const emailMatch = await authRepository.findUserByEmail(email);
-    const matchDecision = resolveOAuthMatch({
-      providerSubMatch: !!subMatch,
-      emailMatch: !!emailMatch,
+    const { decision: matchDecision, user: matchedUser, emailMatch } = await resolveOAuthAccount({
+      provider: 'apple',
+      providerId: appleId,
+      email,
       emailVerified: emailVerified === true,
     });
 
@@ -140,12 +139,7 @@ export async function POST(req: Request) {
     }
 
     // Find or create user
-    let user =
-      matchDecision === 'use-sub'
-        ? subMatch
-        : matchDecision === 'use-email'
-          ? emailMatch
-          : null;
+    let user = matchedUser;
 
     let isNewUser = false;
     if (user) {

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -18,6 +18,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
 import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import {
   consumeAllInvitesForEmail,
@@ -109,8 +110,42 @@ export async function POST(req: Request) {
     // Apple only sends the name on first authorization
     const name = [givenName, familyName].filter(Boolean).join(' ') || undefined;
 
+    // Resolve the account match through the shared, security-critical decision.
+    // SECURITY (M5): match an EXISTING account by raw email only when Apple
+    // asserts the email is verified; the subject id (appleId) may always match.
+    const subMatch = await authRepository.findUserByAppleId(appleId);
+    const emailMatch = await authRepository.findUserByEmail(email);
+    const matchDecision = resolveOAuthMatch({
+      providerSubMatch: !!subMatch,
+      emailMatch: !!emailMatch,
+      emailVerified: emailVerified === true,
+    });
+
+    if (matchDecision === 'reject') {
+      loggers.auth.warn('Blocked OAuth account link: unverified email matches existing account', {
+        email: maskEmail(email),
+        provider: 'apple-native',
+        platform,
+      });
+      auditRequest(req, {
+        eventType: 'auth.login.failure',
+        riskScore: 0.8,
+        userId: emailMatch?.id,
+        details: { reason: 'apple_native_unverified_email_link_blocked' },
+      });
+      return Response.json(
+        { error: 'Unable to sign in with this account. Please use your original sign-in method.' },
+        { status: 403 }
+      );
+    }
+
     // Find or create user
-    let user = await authRepository.findUserByAppleIdOrEmail(appleId, email);
+    let user =
+      matchDecision === 'use-sub'
+        ? subMatch
+        : matchDecision === 'use-email'
+          ? emailMatch
+          : null;
 
     let isNewUser = false;
     if (user) {

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -30,7 +30,8 @@ vi.mock('google-auth-library', () => ({
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn(),
+    findUserByGoogleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -209,7 +210,8 @@ describe('GET /api/auth/google/callback', () => {
     vi.mocked(provisionGettingStartedDriveIfNeeded).mockResolvedValue({ driveId: 'existing-drive', created: false });
 
     // Default to existing user
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
     vi.mocked(authRepository.findUserById).mockResolvedValue(mockExistingUser as never);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockExistingUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -31,7 +31,8 @@ vi.mock('google-auth-library', () => ({
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn(),
+    findUserByGoogleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -187,7 +188,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     // Default to new user flow
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
@@ -210,7 +212,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     it('given valid credential for existing user, should return success with user data', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
       vi.mocked(provisionGettingStartedDriveIfNeeded).mockResolvedValue({ driveId: 'existing-drive', created: false });
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -230,7 +233,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     it('given existing user, should check for drive provisioning', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
       vi.mocked(provisionGettingStartedDriveIfNeeded).mockResolvedValue({ driveId: 'existing-drive', created: false });
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -342,7 +346,8 @@ describe('POST /api/auth/google/one-tap', () => {
 
   describe('desktop platform handling (unified path)', () => {
     it('given desktop platform without deviceId, should succeed without device token', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
       vi.mocked(provisionGettingStartedDriveIfNeeded).mockResolvedValue({ driveId: 'existing-drive', created: false });
 
       const request = createOneTapRequest({
@@ -360,7 +365,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     it('given desktop platform with deviceId, should return top-level tokens', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
       vi.mocked(provisionGettingStartedDriveIfNeeded).mockResolvedValue({ driveId: 'existing-drive', created: false });
 
       const request = createOneTapRequest({

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -74,7 +74,16 @@ vi.mock('google-auth-library', () => ({
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn().mockResolvedValue({
+    findUserByGoogleId: vi.fn().mockResolvedValue({
+      id: 'user-123',
+      name: 'Test User',
+      email: 'test@example.com',
+      googleId: 'google-id-123',
+      tokenVersion: 1,
+      role: 'user',
+      provider: 'google',
+    }),
+    findUserByEmail: vi.fn().mockResolvedValue({
       id: 'user-123',
       name: 'Test User',
       email: 'test@example.com',

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -53,7 +53,8 @@ vi.mock('google-auth-library', () => ({
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn(),
+    findUserByGoogleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -334,7 +335,8 @@ describe('GET /api/auth/google/callback', () => {
     vi.mocked(resolveGoogleAvatarImage).mockResolvedValue(null);
 
     // Default to new user flow
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
@@ -625,7 +627,8 @@ describe('GET /api/auth/google/callback', () => {
   describe('user update scenarios', () => {
     it('updates existing user without googleId', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -636,7 +639,8 @@ describe('GET /api/auth/google/callback', () => {
 
     it('updates existing user without name', async () => {
       const userWithoutName = { ...mockExistingUser, name: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutName as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutName as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutName as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userWithoutName, name: 'Test User' } as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -648,7 +652,8 @@ describe('GET /api/auth/google/callback', () => {
     it('updates existing user with different avatar', async () => {
       const userWithOldAvatar = { ...mockExistingUser, image: '/old-avatar.jpg' };
       vi.mocked(resolveGoogleAvatarImage).mockResolvedValue('/new-avatar.jpg');
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithOldAvatar as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithOldAvatar as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithOldAvatar as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userWithOldAvatar, image: '/new-avatar.jpg' } as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -667,7 +672,8 @@ describe('GET /api/auth/google/callback', () => {
 
     it('updates existing user with unverified email when email_verified', async () => {
       const userUnverified = { ...mockExistingUser, emailVerified: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userUnverified as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userUnverified as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userUnverified as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userUnverified, emailVerified: new Date() } as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -687,7 +693,8 @@ describe('GET /api/auth/google/callback', () => {
         image: null,
         emailVerified: new Date(),
       };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(fullyUpdatedUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(fullyUpdatedUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(fullyUpdatedUser as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
       await GET(request);
@@ -697,7 +704,8 @@ describe('GET /api/auth/google/callback', () => {
 
     it('handles re-fetch returning null after update (falls back to original user)', async () => {
       const existingUser = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(existingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(null);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -1256,7 +1264,8 @@ describe('GET /api/auth/google/callback', () => {
 
     it('masks email in "Updating existing user" log', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -1270,7 +1279,8 @@ describe('GET /api/auth/google/callback', () => {
 
     it('does not include name in "User updated" log', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createCallbackRequest({ code: 'valid-code' });
@@ -1363,7 +1373,8 @@ describe('GET /api/auth/google/callback', () => {
     });
 
     it('calls consumeAnyInviteIfPresent with isNewUser=false for existing users when inviteToken is in state', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
       vi.mocked(authRepository.findUserById).mockResolvedValue(mockExistingUser as never);
 
       vi.mocked(consumeAnyInviteIfPresent).mockResolvedValueOnce({

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -23,6 +23,7 @@ import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { consumePKCEVerifier } from '@pagespace/lib/auth/pkce';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
 import {
   consumeAllInvitesForEmail,
@@ -133,7 +134,40 @@ export async function GET(req: Request) {
 
     const userName = name || email.split('@')[0] || 'User';
 
-    let user = await authRepository.findUserByGoogleIdOrEmail(googleId!, email);
+    // Resolve the account match through the shared, security-critical decision.
+    // SECURITY (M5): match an EXISTING account by raw email only when Google
+    // asserts `email_verified === true`; the subject id may always match.
+    const subMatch = await authRepository.findUserByGoogleId(googleId!);
+    const emailMatch = await authRepository.findUserByEmail(email);
+    const matchDecision = resolveOAuthMatch({
+      providerSubMatch: !!subMatch,
+      emailMatch: !!emailMatch,
+      emailVerified: email_verified === true,
+    });
+
+    if (matchDecision === 'reject') {
+      loggers.auth.warn('Blocked OAuth account link: unverified email matches existing account', {
+        email: maskEmail(email),
+        provider: 'google',
+      });
+      auditRequest(req, {
+        eventType: 'auth.login.failure',
+        riskScore: 0.8,
+        userId: emailMatch?.id,
+        details: { reason: 'google_oauth_unverified_email_link_blocked' },
+      });
+      if (verifiedState.platform === 'desktop') {
+        return NextResponse.redirect('pagespace://auth-error?error=oauth_error');
+      }
+      return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', baseUrl));
+    }
+
+    let user =
+      matchDecision === 'use-sub'
+        ? subMatch
+        : matchDecision === 'use-email'
+          ? emailMatch
+          : null;
     const wasNewUser = !user;
 
     if (user) {

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -23,7 +23,7 @@ import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { consumePKCEVerifier } from '@pagespace/lib/auth/pkce';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
+import { resolveOAuthAccount } from '@/lib/auth/oauth-account-resolver';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
 import {
   consumeAllInvitesForEmail,
@@ -137,11 +137,10 @@ export async function GET(req: Request) {
     // Resolve the account match through the shared, security-critical decision.
     // SECURITY (M5): match an EXISTING account by raw email only when Google
     // asserts `email_verified === true`; the subject id may always match.
-    const subMatch = await authRepository.findUserByGoogleId(googleId!);
-    const emailMatch = await authRepository.findUserByEmail(email);
-    const matchDecision = resolveOAuthMatch({
-      providerSubMatch: !!subMatch,
-      emailMatch: !!emailMatch,
+    const { decision: matchDecision, user: matchedUser, emailMatch } = await resolveOAuthAccount({
+      provider: 'google',
+      providerId: googleId!,
+      email,
       emailVerified: email_verified === true,
     });
 
@@ -162,12 +161,7 @@ export async function GET(req: Request) {
       return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', baseUrl));
     }
 
-    let user =
-      matchDecision === 'use-sub'
-        ? subMatch
-        : matchDecision === 'use-email'
-          ? emailMatch
-          : null;
+    let user = matchedUser;
     const wasNewUser = !user;
 
     if (user) {

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -56,7 +56,8 @@ import {
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn(),
+    findUserByGoogleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -272,7 +273,8 @@ describe('POST /api/auth/google/native', () => {
     vi.mocked(resolveGoogleAvatarImage).mockResolvedValue(null);
 
     // Default to new user flow
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
@@ -298,7 +300,8 @@ describe('POST /api/auth/google/native', () => {
     });
 
     it('given valid idToken for existing user, should return tokens without creating user', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
 
       const request = createNativeRequest(validNativePayload);
       const response = await POST(request);
@@ -319,7 +322,8 @@ describe('POST /api/auth/google/native', () => {
     });
 
     it('given existing user, should not provision Getting Started drive', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
 
       const request = createNativeRequest(validNativePayload);
       await POST(request);
@@ -641,7 +645,8 @@ describe('POST /api/auth/google/native', () => {
 
   describe('error handling', () => {
     it('given unexpected error, should return 500', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockRejectedValueOnce(new Error('Database error'));
+      vi.mocked(authRepository.findUserByGoogleId).mockRejectedValueOnce(new Error('Database error'));
+      vi.mocked(authRepository.findUserByEmail).mockRejectedValueOnce(new Error('Database error'));
 
       const request = createNativeRequest(validNativePayload);
       const response = await POST(request);
@@ -679,7 +684,8 @@ describe('POST /api/auth/google/native', () => {
   describe('user update scenarios', () => {
     it('given existing user without googleId, should update with googleId', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createNativeRequest(validNativePayload);
@@ -692,7 +698,8 @@ describe('POST /api/auth/google/native', () => {
 
     it('given existing user without name, should set name from Google payload', async () => {
       const userWithoutName = { ...mockExistingUser, googleId: null, name: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutName as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutName as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutName as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userWithoutName, name: 'Test User', googleId: 'google-id-123' } as never);
 
       const request = createNativeRequest(validNativePayload);
@@ -706,7 +713,8 @@ describe('POST /api/auth/google/native', () => {
     it('given existing user with different avatar, should update image', async () => {
       const userWithOldAvatar = { ...mockExistingUser, image: '/old-avatar.jpg' };
       vi.mocked(resolveGoogleAvatarImage).mockResolvedValue('/new-avatar.jpg');
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithOldAvatar as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithOldAvatar as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithOldAvatar as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userWithOldAvatar, image: '/new-avatar.jpg' } as never);
 
       const request = createNativeRequest(validNativePayload);
@@ -719,7 +727,8 @@ describe('POST /api/auth/google/native', () => {
 
     it('given existing user with unverified email and email_verified token, should update emailVerified', async () => {
       const userUnverified = { ...mockExistingUser, emailVerified: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userUnverified as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userUnverified as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userUnverified as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userUnverified, emailVerified: new Date() } as never);
 
       const request = createNativeRequest(validNativePayload);
@@ -741,7 +750,8 @@ describe('POST /api/auth/google/native', () => {
         image: null, // resolveGoogleAvatarImage returns null by default
         emailVerified: new Date(),
       };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(fullyUpdatedUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(fullyUpdatedUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(fullyUpdatedUser as never);
 
       const request = createNativeRequest(validNativePayload);
       await POST(request);
@@ -769,7 +779,8 @@ describe('POST /api/auth/google/native', () => {
       vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
 
     it('masks email in "Creating new user via native Google OAuth" log', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
       vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
 
       const request = createNativeRequest(validNativePayload);
@@ -783,7 +794,8 @@ describe('POST /api/auth/google/native', () => {
 
     it('masks email in "Updating existing user via native Google OAuth" log', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createNativeRequest(validNativePayload);

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -19,7 +19,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
+import { resolveOAuthAccount } from '@/lib/auth/oauth-account-resolver';
 import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import {
   consumeAllInvitesForEmail,
@@ -113,11 +113,10 @@ export async function POST(req: Request) {
     // Resolve the account match through the shared, security-critical decision.
     // SECURITY (M5): match an EXISTING account by raw email only when Google
     // asserts `email_verified === true`; the subject id may always match.
-    const subMatch = await authRepository.findUserByGoogleId(googleId!);
-    const emailMatch = await authRepository.findUserByEmail(email);
-    const matchDecision = resolveOAuthMatch({
-      providerSubMatch: !!subMatch,
-      emailMatch: !!emailMatch,
+    const { decision: matchDecision, user: matchedUser, emailMatch } = await resolveOAuthAccount({
+      provider: 'google',
+      providerId: googleId!,
+      email,
       emailVerified: email_verified === true,
     });
 
@@ -140,12 +139,7 @@ export async function POST(req: Request) {
     }
 
     // Find or create user
-    let user =
-      matchDecision === 'use-sub'
-        ? subMatch
-        : matchDecision === 'use-email'
-          ? emailMatch
-          : null;
+    let user = matchedUser;
 
     let isNewUser = false;
     if (user) {

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -19,6 +19,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
 import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import {
   consumeAllInvitesForEmail,
@@ -109,8 +110,42 @@ export async function POST(req: Request) {
 
     const { sub: googleId, email, name, picture, email_verified } = payload;
 
+    // Resolve the account match through the shared, security-critical decision.
+    // SECURITY (M5): match an EXISTING account by raw email only when Google
+    // asserts `email_verified === true`; the subject id may always match.
+    const subMatch = await authRepository.findUserByGoogleId(googleId!);
+    const emailMatch = await authRepository.findUserByEmail(email);
+    const matchDecision = resolveOAuthMatch({
+      providerSubMatch: !!subMatch,
+      emailMatch: !!emailMatch,
+      emailVerified: email_verified === true,
+    });
+
+    if (matchDecision === 'reject') {
+      loggers.auth.warn('Blocked OAuth account link: unverified email matches existing account', {
+        email: maskEmail(email),
+        provider: 'google-native',
+        platform,
+      });
+      auditRequest(req, {
+        eventType: 'auth.login.failure',
+        riskScore: 0.8,
+        userId: emailMatch?.id,
+        details: { reason: 'google_native_unverified_email_link_blocked' },
+      });
+      return Response.json(
+        { error: 'Unable to sign in with this account. Please use your original sign-in method.' },
+        { status: 403 }
+      );
+    }
+
     // Find or create user
-    let user = await authRepository.findUserByGoogleIdOrEmail(googleId!, email);
+    let user =
+      matchDecision === 'use-sub'
+        ? subMatch
+        : matchDecision === 'use-email'
+          ? emailMatch
+          : null;
 
     let isNewUser = false;
     if (user) {

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -41,7 +41,8 @@ vi.mock('google-auth-library', () => ({
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
-    findUserByGoogleIdOrEmail: vi.fn(),
+    findUserByGoogleId: vi.fn(),
+    findUserByEmail: vi.fn(),
     findUserById: vi.fn(),
     createUser: vi.fn(),
     updateUser: vi.fn(),
@@ -256,7 +257,8 @@ describe('POST /api/auth/google/one-tap', () => {
     vi.mocked(resolveGoogleAvatarImage).mockResolvedValue(null);
 
     // Default to new user flow
-    vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
@@ -401,7 +403,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     it('returns success for existing user', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
       const response = await POST(request);
@@ -410,6 +413,85 @@ describe('POST /api/auth/google/one-tap', () => {
       expect(response.status).toBe(200);
       expect(body.isNewUser).toBe(false);
       expect(authRepository.createUser).not.toHaveBeenCalled();
+    });
+
+    // SECURITY (M5): an unverified Google email must never link to / authenticate
+    // an existing magic-link / passkey account. Subject-id matches stay allowed.
+    describe('email_verified takeover guard (M5)', () => {
+      it('refuses to authenticate an existing account when email matches but email_verified is false', async () => {
+        // Token: unverified email, and NO googleId subject match — only the email
+        // collides with a pre-existing (e.g. magic-link) account.
+        mockVerifyIdToken.mockResolvedValue({
+          getPayload: () => ({
+            sub: 'attacker-google-sub',
+            email: 'victim@example.com',
+            name: 'Attacker',
+            email_verified: false,
+          }),
+        });
+        vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+        vi.mocked(authRepository.findUserByEmail).mockResolvedValue({
+          ...mockExistingUser,
+          email: 'victim@example.com',
+          googleId: null,
+        } as never);
+
+        const request = createOneTapRequest(validOneTapPayload);
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.success).toBeUndefined();
+        // No account was linked, created, or signed in.
+        expect(authRepository.updateUser).not.toHaveBeenCalled();
+        expect(authRepository.createUser).not.toHaveBeenCalled();
+        expect(sessionService.createSession).not.toHaveBeenCalled();
+      });
+
+      it('still authenticates when the subject id matches even if email_verified is false', async () => {
+        // A returning Google user whose token happens to carry email_verified:false
+        // is identified by the strong subject id — sign-in proceeds.
+        mockVerifyIdToken.mockResolvedValue({
+          getPayload: () => ({
+            sub: 'google-id-123',
+            email: 'test@example.com',
+            name: 'Test User',
+            email_verified: false,
+          }),
+        });
+        vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+        vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
+
+        const request = createOneTapRequest(validOneTapPayload);
+        const response = await POST(request);
+
+        expect(response.status).toBe(200);
+        expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+        expect(authRepository.createUser).not.toHaveBeenCalled();
+      });
+
+      it('creates a fresh account for an unverified email with no existing match', async () => {
+        // No subject match and no email collision → normal new-user signup, even
+        // though the email is unverified (nothing to take over).
+        mockVerifyIdToken.mockResolvedValue({
+          getPayload: () => ({
+            sub: 'brand-new-sub',
+            email: 'brand-new@example.com',
+            name: 'New Person',
+            email_verified: false,
+          }),
+        });
+        vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+        vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
+
+        const request = createOneTapRequest(validOneTapPayload);
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.isNewUser).toBe(true);
+        expect(authRepository.createUser).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('sets session cookie for web platform', async () => {
@@ -550,7 +632,8 @@ describe('POST /api/auth/google/one-tap', () => {
   describe('user update scenarios', () => {
     it('updates existing user without googleId', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -562,7 +645,8 @@ describe('POST /api/auth/google/one-tap', () => {
     it('updates existing user with different avatar', async () => {
       const userWithOldAvatar = { ...mockExistingUser, image: '/old-avatar.jpg' };
       vi.mocked(resolveGoogleAvatarImage).mockResolvedValue('/new-avatar.jpg');
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithOldAvatar as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithOldAvatar as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithOldAvatar as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...userWithOldAvatar, image: '/new-avatar.jpg' } as never);
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -587,7 +671,8 @@ describe('POST /api/auth/google/one-tap', () => {
         image: null,
         emailVerified: new Date(),
       };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(fullyUpdatedUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(fullyUpdatedUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(fullyUpdatedUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
       await POST(request);
@@ -687,7 +772,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     it('tracks login event for existing users', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
       await POST(request);
@@ -704,7 +790,8 @@ describe('POST /api/auth/google/one-tap', () => {
 
   describe('error handling', () => {
     it('returns 500 on unexpected exception', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockRejectedValueOnce(new Error('Database error'));
+      vi.mocked(authRepository.findUserByGoogleId).mockRejectedValueOnce(new Error('Database error'));
+      vi.mocked(authRepository.findUserByEmail).mockRejectedValueOnce(new Error('Database error'));
 
       const request = createOneTapRequest(validOneTapPayload);
       const response = await POST(request);
@@ -724,7 +811,8 @@ describe('POST /api/auth/google/one-tap', () => {
       vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
 
     it('masks email in "Creating new user via Google One Tap" log', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
       vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -737,7 +825,8 @@ describe('POST /api/auth/google/one-tap', () => {
     });
 
     it('does not include name in "New user created via Google One Tap" log', async () => {
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
       vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -752,7 +841,8 @@ describe('POST /api/auth/google/one-tap', () => {
 
     it('masks email in "Updating existing user via Google One Tap" log', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);
@@ -766,7 +856,8 @@ describe('POST /api/auth/google/one-tap', () => {
 
     it('does not include name in "User updated via Google One Tap" log', async () => {
       const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
-      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByGoogleId).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserByEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
       vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
 
       const request = createOneTapRequest(validOneTapPayload);

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -20,6 +20,7 @@ import { getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
 import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import {
   consumeAllInvitesForEmail,
@@ -128,8 +129,42 @@ export async function POST(req: Request) {
     // Create fallback name if Google doesn't provide one
     const userName = name || email.split('@')[0] || 'User';
 
-    // Check if user exists by Google ID or email
-    let user = await authRepository.findUserByGoogleIdOrEmail(googleId!, email);
+    // Resolve the account match through the shared, security-critical decision.
+    // SECURITY (M5): the Google subject id (`googleId`) is the strong identity and
+    // may always match; an EXISTING account may only be matched by raw email when
+    // Google asserts `email_verified === true`. An unverified email that collides
+    // with a magic-link / passkey account is refused — never linked.
+    const subMatch = await authRepository.findUserByGoogleId(googleId!);
+    const emailMatch = await authRepository.findUserByEmail(email);
+    const matchDecision = resolveOAuthMatch({
+      providerSubMatch: !!subMatch,
+      emailMatch: !!emailMatch,
+      emailVerified: email_verified === true,
+    });
+
+    if (matchDecision === 'reject') {
+      loggers.auth.warn('Blocked OAuth account link: unverified email matches existing account', {
+        email: maskEmail(email),
+        provider: 'google-one-tap',
+      });
+      auditRequest(req, {
+        eventType: 'auth.login.failure',
+        riskScore: 0.8,
+        userId: emailMatch?.id,
+        details: { reason: 'google_one_tap_unverified_email_link_blocked' },
+      });
+      return NextResponse.json(
+        { error: 'Unable to sign in with this account. Please use your original sign-in method.' },
+        { status: 403 }
+      );
+    }
+
+    let user =
+      matchDecision === 'use-sub'
+        ? subMatch
+        : matchDecision === 'use-email'
+          ? emailMatch
+          : null;
 
     let isNewUser = false;
 

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -20,7 +20,7 @@ import { getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { resolveOAuthMatch } from '@pagespace/lib/auth/oauth-account-match';
+import { resolveOAuthAccount } from '@/lib/auth/oauth-account-resolver';
 import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import {
   consumeAllInvitesForEmail,
@@ -134,11 +134,10 @@ export async function POST(req: Request) {
     // may always match; an EXISTING account may only be matched by raw email when
     // Google asserts `email_verified === true`. An unverified email that collides
     // with a magic-link / passkey account is refused — never linked.
-    const subMatch = await authRepository.findUserByGoogleId(googleId!);
-    const emailMatch = await authRepository.findUserByEmail(email);
-    const matchDecision = resolveOAuthMatch({
-      providerSubMatch: !!subMatch,
-      emailMatch: !!emailMatch,
+    const { decision: matchDecision, user: matchedUser, emailMatch } = await resolveOAuthAccount({
+      provider: 'google',
+      providerId: googleId!,
+      email,
       emailVerified: email_verified === true,
     });
 
@@ -159,12 +158,7 @@ export async function POST(req: Request) {
       );
     }
 
-    let user =
-      matchDecision === 'use-sub'
-        ? subMatch
-        : matchDecision === 'use-email'
-          ? emailMatch
-          : null;
+    let user = matchedUser;
 
     let isNewUser = false;
 

--- a/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
+++ b/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
@@ -223,10 +223,30 @@ export async function POST(req: Request) {
     });
 
     const googlePictureUrl = userInfo.picture;
-    let user = await createOrLinkOAuthUser({
+    const linkResult = await createOrLinkOAuthUser({
       ...userInfo,
       picture: undefined,
     });
+
+    // SECURITY (M5): refuse sign-in when an unverified provider email collides
+    // with an existing account (the helper never links it).
+    if (linkResult.status === 'rejected') {
+      loggers.auth.warn('Blocked OAuth account link via mobile exchange: unverified email conflict', {
+        email: maskEmail(userInfo.email),
+        provider: userInfo.provider,
+      });
+      auditRequest(req, {
+        eventType: 'auth.login.failure',
+        riskScore: 0.8,
+        details: { reason: 'mobile_oauth_unverified_email_link_blocked' },
+      });
+      return Response.json(
+        { error: 'Unable to sign in with this account. Please use your original sign-in method.' },
+        { status: 403 }
+      );
+    }
+
+    let user = linkResult.user;
 
     const resolvedImage = await resolveGoogleAvatarImage({
       userId: user.id,

--- a/apps/web/src/lib/auth/__tests__/oauth-account-resolver.test.ts
+++ b/apps/web/src/lib/auth/__tests__/oauth-account-resolver.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/repositories/auth-repository', () => ({
+  authRepository: {
+    findUserByGoogleId: vi.fn(),
+    findUserByAppleId: vi.fn(),
+    findUserByEmail: vi.fn(),
+  },
+}));
+
+import { resolveOAuthAccount } from '../oauth-account-resolver';
+import { authRepository } from '@/lib/repositories/auth-repository';
+
+const subUser = { id: 'sub-user', email: 'a@example.com', googleId: 'g-1', appleId: null } as never;
+const emailUser = { id: 'email-user', email: 'a@example.com', googleId: null, appleId: null } as never;
+
+describe('resolveOAuthAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(null);
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(null);
+  });
+
+  it('returns use-sub and the subject account when the provider id matches (Google)', async () => {
+    vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(subUser);
+    const res = await resolveOAuthAccount({ provider: 'google', providerId: 'g-1', email: 'a@example.com', emailVerified: false });
+    expect(res.decision).toBe('use-sub');
+    expect(res.user).toBe(subUser);
+    expect(authRepository.findUserByGoogleId).toHaveBeenCalledWith('g-1');
+    expect(authRepository.findUserByAppleId).not.toHaveBeenCalled();
+  });
+
+  it('returns use-email when only a verified email matches', async () => {
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(emailUser);
+    const res = await resolveOAuthAccount({ provider: 'google', providerId: 'g-x', email: 'a@example.com', emailVerified: true });
+    expect(res.decision).toBe('use-email');
+    expect(res.user).toBe(emailUser);
+  });
+
+  it('returns reject (and exposes the email match for auditing) when an unverified email collides', async () => {
+    vi.mocked(authRepository.findUserByEmail).mockResolvedValue(emailUser);
+    const res = await resolveOAuthAccount({ provider: 'google', providerId: 'g-x', email: 'a@example.com', emailVerified: false });
+    expect(res.decision).toBe('reject');
+    expect(res.user).toBeNull();
+    expect(res.emailMatch).toBe(emailUser);
+  });
+
+  it('returns create-new when nothing matches', async () => {
+    const res = await resolveOAuthAccount({ provider: 'google', providerId: 'g-x', email: 'new@example.com', emailVerified: false });
+    expect(res.decision).toBe('create-new');
+    expect(res.user).toBeNull();
+  });
+
+  it('uses the Apple subject lookup for the apple provider', async () => {
+    vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(subUser);
+    const res = await resolveOAuthAccount({ provider: 'apple', providerId: 'ap-1', email: 'a@example.com', emailVerified: false });
+    expect(res.decision).toBe('use-sub');
+    expect(authRepository.findUserByAppleId).toHaveBeenCalledWith('ap-1');
+    expect(authRepository.findUserByGoogleId).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/auth/oauth-account-resolver.ts
+++ b/apps/web/src/lib/auth/oauth-account-resolver.ts
@@ -1,0 +1,52 @@
+import { authRepository, type User } from '@/lib/repositories/auth-repository';
+import { resolveOAuthMatch, type OAuthMatchDecision } from '@pagespace/lib/auth/oauth-account-match';
+
+export interface OAuthAccountResolution {
+  /** The shared account-match decision (see {@link resolveOAuthMatch}). */
+  decision: OAuthMatchDecision;
+  /**
+   * The account to authenticate for `use-sub` / `use-email`; `null` for
+   * `create-new` and `reject`.
+   */
+  user: User | null;
+  /**
+   * The account matched by raw email, if any. Exposed so the `reject` path can
+   * audit the targeted victim account; never authenticate this directly.
+   */
+  emailMatch: User | null;
+}
+
+/**
+ * Resolve an OAuth identity against existing accounts (audit finding M5).
+ *
+ * The single security-critical choke point shared by every OAuth route: it
+ * looks up the provider-subject and the email separately and reconciles them
+ * through {@link resolveOAuthMatch}, so an unverified provider email can never
+ * link to an existing account. The route shell maps the returned `decision` to
+ * a provider-appropriate response — and a `reject` decision MUST deny sign-in.
+ */
+export async function resolveOAuthAccount(params: {
+  provider: 'google' | 'apple';
+  providerId: string;
+  email: string;
+  emailVerified: boolean;
+}): Promise<OAuthAccountResolution> {
+  const { provider, providerId, email, emailVerified } = params;
+
+  const subMatch =
+    provider === 'google'
+      ? await authRepository.findUserByGoogleId(providerId)
+      : await authRepository.findUserByAppleId(providerId);
+  const emailMatch = await authRepository.findUserByEmail(email);
+
+  const decision = resolveOAuthMatch({
+    providerSubMatch: !!subMatch,
+    emailMatch: !!emailMatch,
+    emailVerified,
+  });
+
+  const user =
+    decision === 'use-sub' ? subMatch : decision === 'use-email' ? emailMatch : null;
+
+  return { decision, user, emailMatch };
+}

--- a/apps/web/src/lib/repositories/auth-repository.ts
+++ b/apps/web/src/lib/repositories/auth-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { eq, and, or, isNull, sql, type InferSelectModel, type InferInsertModel } from '@pagespace/db/operators'
+import { eq, and, isNull, sql, type InferSelectModel, type InferInsertModel } from '@pagespace/db/operators'
 import { users, deviceTokens } from '@pagespace/db/schema/auth';
 
 // Types derived from Drizzle schema - ensures type safety without manual definitions
@@ -69,21 +69,28 @@ export const authRepository = {
   },
 
   /**
-   * Find a user by Google ID or email (for OAuth login/signup)
+   * Find a user by Google subject id (OAuth provider identity).
+   *
+   * SECURITY: provider-subject and email lookups are kept SEPARATE so the
+   * account-match decision (`resolveOAuthMatch`) can require a verified email
+   * before ever linking by email. See audit finding M5.
    */
-  async findUserByGoogleIdOrEmail(googleId: string, email: string): Promise<User | null> {
+  async findUserByGoogleId(googleId: string): Promise<User | null> {
     const user = await db.query.users.findFirst({
-      where: or(eq(users.googleId, googleId), eq(users.email, email)),
+      where: eq(users.googleId, googleId),
     });
     return user ?? null;
   },
 
   /**
-   * Find a user by Apple ID or email (for OAuth login/signup)
+   * Find a user by Apple subject id (OAuth provider identity).
+   *
+   * SECURITY: see {@link findUserByGoogleId} — subject and email lookups are
+   * intentionally separate to enforce the verified-email link rule (M5).
    */
-  async findUserByAppleIdOrEmail(appleId: string, email: string): Promise<User | null> {
+  async findUserByAppleId(appleId: string): Promise<User | null> {
     const user = await db.query.users.findFirst({
-      where: or(eq(users.appleId, appleId), eq(users.email, email)),
+      where: eq(users.appleId, appleId),
     });
     return user ?? null;
   },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -487,6 +487,11 @@
       "import": "./dist/auth/secure-compare.js",
       "require": "./dist/auth/secure-compare.js"
     },
+    "./auth/oauth-account-match": {
+      "types": "./dist/auth/oauth-account-match.d.ts",
+      "import": "./dist/auth/oauth-account-match.js",
+      "require": "./dist/auth/oauth-account-match.js"
+    },
     "./auth/magic-link-service": {
       "types": "./dist/auth/magic-link-service.d.ts",
       "import": "./dist/auth/magic-link-service.js",
@@ -1168,6 +1173,9 @@
       ],
       "auth/secure-compare": [
         "./dist/auth/secure-compare.d.ts"
+      ],
+      "auth/oauth-account-match": [
+        "./dist/auth/oauth-account-match.d.ts"
       ],
       "auth/magic-link-service": [
         "./dist/auth/magic-link-service.d.ts"

--- a/packages/lib/src/auth/__tests__/oauth-account-match.test.ts
+++ b/packages/lib/src/auth/__tests__/oauth-account-match.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { resolveOAuthMatch, type OAuthMatchDecision } from '../oauth-account-match';
+
+/**
+ * Decision matrix for the OAuth account-match rule that closes audit finding M5
+ * (pre-account takeover via an unverified provider email). The provider subject
+ * id (googleId/appleId) is the strong identity and may always match; matching an
+ * EXISTING account by raw email is only allowed when the provider asserts the
+ * email is verified.
+ */
+describe('resolveOAuthMatch', () => {
+  // Every combination of (providerSubMatch, emailMatch, emailVerified) is pinned
+  // so the security rule cannot silently drift.
+  const cases: Array<{
+    providerSubMatch: boolean;
+    emailMatch: boolean;
+    emailVerified: boolean;
+    expected: OAuthMatchDecision;
+    why: string;
+  }> = [
+    // Subject-id match is authoritative — it wins regardless of email/verification.
+    { providerSubMatch: true, emailMatch: true, emailVerified: true, expected: 'use-sub', why: 'returning user, verified' },
+    { providerSubMatch: true, emailMatch: true, emailVerified: false, expected: 'use-sub', why: 'returning user, unverified email still ok via sub' },
+    { providerSubMatch: true, emailMatch: false, emailVerified: true, expected: 'use-sub', why: 'sub match, email changed/absent' },
+    { providerSubMatch: true, emailMatch: false, emailVerified: false, expected: 'use-sub', why: 'sub match dominates even unverified' },
+
+    // No subject match: link by email ONLY when verified.
+    { providerSubMatch: false, emailMatch: true, emailVerified: true, expected: 'use-email', why: 'verified email links to existing account' },
+    // THE FIX: unverified email that collides with an existing account => takeover guard.
+    { providerSubMatch: false, emailMatch: true, emailVerified: false, expected: 'reject', why: 'unverified email must NOT link to existing account' },
+
+    // No subject match, no email collision => fresh signup.
+    { providerSubMatch: false, emailMatch: false, emailVerified: true, expected: 'create-new', why: 'brand new verified user' },
+    { providerSubMatch: false, emailMatch: false, emailVerified: false, expected: 'create-new', why: 'brand new unverified user (no collision)' },
+  ];
+
+  it.each(cases)(
+    'sub=$providerSubMatch email=$emailMatch verified=$emailVerified -> $expected ($why)',
+    ({ providerSubMatch, emailMatch, emailVerified, expected }) => {
+      expect(resolveOAuthMatch({ providerSubMatch, emailMatch, emailVerified })).toBe(expected);
+    },
+  );
+
+  it('never links by email when the email is unverified and there is no sub match', () => {
+    // Property: the only takeover path (unverified email-only) is always refused.
+    expect(resolveOAuthMatch({ providerSubMatch: false, emailMatch: true, emailVerified: false })).not.toBe('use-email');
+  });
+});

--- a/packages/lib/src/auth/__tests__/oauth-utils-unit.test.ts
+++ b/packages/lib/src/auth/__tests__/oauth-utils-unit.test.ts
@@ -252,6 +252,47 @@ describe('oauth-utils', () => {
       expect(db.update).toHaveBeenCalledWith(users);
     });
 
+    // SECURITY (M5): an unverified provider email that collides with an existing
+    // account must be rejected — never linked, never authenticated.
+    it('rejects when an unverified email matches an existing account and there is no subject match', async () => {
+      vi.mocked(db.query.users.findFirst)
+        .mockResolvedValueOnce(undefined as never) // subject-id lookup: no match
+        .mockResolvedValueOnce({ id: 'victim', email: 'victim@test.com', googleId: 'other' } as never); // email lookup: existing account
+
+      const result = await createOrLinkOAuthUser({
+        providerId: 'attacker-sub',
+        email: 'victim@test.com',
+        emailVerified: false,
+        name: 'Attacker',
+        picture: undefined,
+        provider: OAuthProvider.GOOGLE,
+      });
+
+      expect(result).toEqual({ status: 'rejected', reason: 'unverified_email_conflict' });
+      // No write side effects.
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
+    it('links by email when an unverified email has no existing match (fresh signup)', async () => {
+      vi.mocked(db.query.users.findFirst).mockResolvedValue(undefined as never);
+      const mockReturning = vi.fn().mockResolvedValue([{ id: 'new-user', name: 'New', email: 'new@test.com' }]);
+      vi.mocked(db.insert).mockReturnValue({ values: vi.fn(() => ({ returning: mockReturning })) } as never);
+      const mockCountWhere = vi.fn().mockResolvedValue([{ count: 1 }]);
+      vi.mocked(db.select).mockReturnValue({ from: vi.fn(() => ({ where: mockCountWhere })) } as never);
+
+      const result = await createOrLinkOAuthUser({
+        providerId: 'fresh-sub',
+        email: 'new@test.com',
+        emailVerified: false,
+        name: 'New',
+        picture: undefined,
+        provider: OAuthProvider.GOOGLE,
+      });
+
+      expect(result.status).toBe('linked');
+    });
+
     it('should create new user when not found', async () => {
       vi.mocked(db.query.users.findFirst).mockResolvedValue(undefined as never);
       const mockReturning = vi.fn().mockResolvedValue([{

--- a/packages/lib/src/auth/oauth-account-match.ts
+++ b/packages/lib/src/auth/oauth-account-match.ts
@@ -1,0 +1,63 @@
+/**
+ * OAuth account-match decision (security-critical, pure).
+ *
+ * Closes audit finding M5 (pre-account takeover via an unverified OAuth email):
+ * an OAuth token whose email matches an existing magic-link / passkey account
+ * must NOT authenticate as that account unless the provider asserts the email is
+ * verified. The provider subject id (googleId / appleId) is the strong,
+ * cryptographically-bound identity carried in the signed token, so a subject
+ * match may always authenticate that account.
+ *
+ * This single decision is shared by every OAuth account-matching surface
+ * (Google one-tap / native / callback, Apple callback / native, mobile exchange)
+ * so the rule cannot drift between flows.
+ */
+
+export type OAuthMatchDecision = 'use-sub' | 'use-email' | 'create-new' | 'reject';
+
+export interface ResolveOAuthMatchInput {
+  /** An existing account matches the provider subject id (googleId / appleId). */
+  providerSubMatch: boolean;
+  /** An existing account matches the token's raw email address. */
+  emailMatch: boolean;
+  /**
+   * The provider's verification claim for the email
+   * (Google `email_verified` / Apple `email_verified`).
+   */
+  emailVerified: boolean;
+}
+
+/**
+ * Resolve how an OAuth sign-in should be reconciled against existing accounts.
+ *
+ * - `use-sub`     authenticate the account matched by provider subject id.
+ * - `use-email`   link to / authenticate the account matched by (verified) email.
+ * - `create-new`  no account matches the subject id or the email — fresh signup.
+ * - `reject`      an unverified email collides with an existing account — refuse
+ *                 to authenticate (the takeover guard). `email` is unique in the
+ *                 schema, so this collision cannot be resolved by creating a new
+ *                 account; the caller must deny the sign-in.
+ */
+export function resolveOAuthMatch({
+  providerSubMatch,
+  emailMatch,
+  emailVerified,
+}: ResolveOAuthMatchInput): OAuthMatchDecision {
+  // Strong identity: a provider-subject match authenticates that account
+  // regardless of the email_verified claim. The subject id is bound to the
+  // signed token and cannot be spoofed onto a victim's account.
+  if (providerSubMatch) {
+    return 'use-sub';
+  }
+
+  // No subject match. Linking to an EXISTING account by raw email is only safe
+  // when the provider asserts the email is verified. An unverified email that
+  // happens to match a victim's account is exactly the takeover vector — refuse.
+  if (emailMatch) {
+    return emailVerified ? 'use-email' : 'reject';
+  }
+
+  // No account matches the subject id or the email → fresh signup. Because email
+  // is unique in the schema, create-new only occurs when there is no collision.
+  return 'create-new';
+}

--- a/packages/lib/src/auth/oauth-utils.ts
+++ b/packages/lib/src/auth/oauth-utils.ts
@@ -10,11 +10,25 @@ import appleSignIn from 'apple-signin-auth';
 import { users } from '@pagespace/db/schema/auth';
 import { drives } from '@pagespace/db/schema/core';
 import { db } from '@pagespace/db/db';
-import { eq, or, count } from '@pagespace/db/operators';
+import { eq, count } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
 import { slugify } from '../utils/utils';
 import { loggers } from '../logging/logger-config';
 import { OAuthProvider, type OAuthUserInfo, type OAuthVerificationResult } from './oauth-types';
+import { resolveOAuthMatch } from './oauth-account-match';
+
+type UserRecord = typeof users.$inferSelect;
+
+/**
+ * Result of reconciling an OAuth identity against existing accounts.
+ *
+ * `rejected` is the M5 takeover guard: an unverified provider email collided
+ * with an existing account, so the caller MUST deny the sign-in rather than
+ * authenticate as (or create) that account.
+ */
+export type OAuthLinkResult =
+  | { status: 'linked'; user: UserRecord }
+  | { status: 'rejected'; reason: 'unverified_email_conflict' };
 
 /**
  * Verify Google ID token and extract user information
@@ -159,10 +173,18 @@ export async function verifyOAuthIdToken(
 }
 
 /**
- * Create new user or link OAuth provider to existing user
- * Returns the user record with updated OAuth information
+ * Create new user or link OAuth provider to existing user.
+ *
+ * SECURITY (M5): provider-subject and email lookups are performed SEPARATELY and
+ * reconciled through {@link resolveOAuthMatch}. An EXISTING account is matched by
+ * raw email only when the provider asserts the email is verified — an unverified
+ * email that collides with an existing account is rejected, never linked.
+ *
+ * Returns `{ status: 'linked', user }` on success, or
+ * `{ status: 'rejected', reason: 'unverified_email_conflict' }` when the caller
+ * must deny the sign-in.
  */
-export async function createOrLinkOAuthUser(userInfo: OAuthUserInfo) {
+export async function createOrLinkOAuthUser(userInfo: OAuthUserInfo): Promise<OAuthLinkResult> {
   const { providerId, email, emailVerified, name, picture, provider } = userInfo;
 
   // Create fallback name if provider doesn't provide one
@@ -173,17 +195,31 @@ export async function createOrLinkOAuthUser(userInfo: OAuthUserInfo) {
     : provider === OAuthProvider.APPLE ? 'apple'
     : 'email';
 
-  // Check if user exists by provider ID or email
-  let user = await db.query.users.findFirst({
-    where: or(
-      // For Google: check googleId
-      provider === OAuthProvider.GOOGLE ? eq(users.googleId, providerId) : undefined,
-      // For Apple: check appleId
-      provider === OAuthProvider.APPLE ? eq(users.appleId, providerId) : undefined,
-      // For all providers: check email
-      eq(users.email, email)
-    ),
+  // Look up the provider-subject match and the email match independently so the
+  // verified-email link rule can be enforced (never collapse them into one OR).
+  const subMatch = provider === OAuthProvider.GOOGLE
+    ? await db.query.users.findFirst({ where: eq(users.googleId, providerId) })
+    : provider === OAuthProvider.APPLE
+      ? await db.query.users.findFirst({ where: eq(users.appleId, providerId) })
+      : undefined;
+  const emailMatch = await db.query.users.findFirst({ where: eq(users.email, email) });
+
+  const decision = resolveOAuthMatch({
+    providerSubMatch: !!subMatch,
+    emailMatch: !!emailMatch,
+    emailVerified: emailVerified === true,
   });
+
+  if (decision === 'reject') {
+    loggers.auth.warn('Blocked OAuth account link: unverified email matches existing account', {
+      provider: providerDbValue,
+    });
+    return { status: 'rejected', reason: 'unverified_email_conflict' };
+  }
+
+  let user = decision === 'use-sub' ? subMatch
+    : decision === 'use-email' ? emailMatch
+    : undefined;
 
   if (user) {
     // Update existing user with OAuth provider ID if not set
@@ -278,5 +314,5 @@ export async function createOrLinkOAuthUser(userInfo: OAuthUserInfo) {
     });
   }
 
-  return user;
+  return { status: 'linked', user };
 }


### PR DESCRIPTION
## Finding
**M5 — OAuth sign-in/linking ignores `email_verified` → pre-account takeover** (audit 2026-06-09).

Every Google/Apple flow resolved the account via `findUserBy{Google,Apple}IdOrEmail(providerId, email)` and minted a session for **any** match — including a match by **raw email alone** — regardless of the provider's `email_verified` / `emailVerified` claim (which was only used afterward to stamp `users.emailVerified`). An unverified-email OAuth token whose email matched an existing magic-link / passkey account therefore **linked to and authenticated as that victim account**.

## Attack closed
Attacker mints a provider token carrying a victim's email with `email_verified === false` and no matching subject id → previously authenticated as the victim. Now refused.

## Fix — one pure decision, shared by every surface
```
resolveOAuthMatch({ providerSubMatch, emailMatch, emailVerified })
  -> 'use-sub' | 'use-email' | 'create-new' | 'reject'
```
- The provider **subject id** (`googleId`/`appleId`) is the strong, signed identity — it may always match (`use-sub`), even with an unverified email.
- An **existing** account may be matched by raw email **only** when the provider asserts the email is verified (`use-email`).
- An **unverified** email colliding with an existing account → `reject` (email is unique, so it can't be a fresh account either) — never linked, never authenticated.
- No match → `create-new`.

New pure module: `packages/lib/src/auth/oauth-account-match.ts`.

### Wiring (thin shells)
- Repo seam split: `findUserByGoogleId` / `findUserByAppleId` (subject lookups) alongside the existing `findUserByEmail`; removed the unsafe combined `findUserBy{Google,Apple}IdOrEmail`.
- Routed through `resolveOAuthMatch`:
  - `google/one-tap`, `google/native`, `google/callback`, `apple/callback` — the four audited routes.
  - `apple/native` — **identical vector the audit missed**; left unfixed it would have kept M5 open for Apple native sign-in.
  - `createOrLinkOAuthUser` (powers `mobile/oauth/google/exchange`) — same vector via the shared lib helper; now returns `{ status: 'linked' | 'rejected' }`.
- `reject` ⇒ `403` on JSON routes / `/auth/signin?error=oauth_error` on redirect routes; an audit event + warn is logged and **no session is created**.

## Pure function + tests (strict TDD)
- RED-first **full 8-row decision matrix** for `resolveOAuthMatch`.
- End-to-end M5 regression tests: JSON `403` (one-tap), redirect-error (apple/callback), helper rejection (`createOrLinkOAuthUser`), plus *subject-match-still-authenticates* and *unverified-no-collision-creates-new*.
- Migrated all existing OAuth route tests to the split repo seam (no existing test asserted the vulnerable path).

## Verification
- `bun run typecheck` — `@pagespace/lib` ✅ and `web` ✅
- `bun run lint` — `@pagespace/lib` ✅ and `web` ✅ (only pre-existing unrelated warnings)
- Unit: lib-auth **361** ✅, web-auth **941** ✅, pure-fn matrix **9** ✅, oauth-utils helper **20** ✅
- Security-suite entries touched (Google One Tap, Open Redirect Protection) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
### Update — centralized wiring
The per-route lookup+decision wiring is now a single auditable choke point: `apps/web/src/lib/auth/oauth-account-resolver.ts` (`resolveOAuthAccount`) does the provider-subject + email lookups and the `resolveOAuthMatch` call; each route shell only maps the returned `decision` to its provider-appropriate response (JSON `403` / redirect / deep-link). Behavior unchanged; added a focused resolver unit test.
