### PR TITLE
fix(security): storage & upload integrity (file-claim, reconcile, dedup credit, upload counter)

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
@@ -49,6 +49,18 @@ vi.mock('@pagespace/lib/services/validated-service-token', () => ({
 
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
   updateStorageUsage: mockUpdateStorageUsage,
+  // Real (pure) impl so the reaper's credit rules are exercised, not stubbed.
+  computeStorageCreditOnUnlink: (input: {
+    createdBy: string | null;
+    sizeBytes: number | string | null;
+    deletedByThisCall: boolean;
+    hadPhysicalBlob: boolean;
+  }) => {
+    if (!input.deletedByThisCall || !input.hadPhysicalBlob || !input.createdBy) return null;
+    const n = typeof input.sizeBytes === 'string' ? Number(input.sizeBytes) : (input.sizeBytes ?? 0);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return { userId: input.createdBy, deltaBytes: -Math.floor(n) };
+  },
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({

--- a/apps/web/src/app/api/storage/info/__tests__/route.test.ts
+++ b/apps/web/src/app/api/storage/info/__tests__/route.test.ts
@@ -12,6 +12,10 @@ vi.mock('@/lib/auth', () => ({
   verifyAuth: vi.fn(),
 }));
 
+vi.mock('@/lib/auth/admin-role', () => ({
+  validateAdminAccess: vi.fn(),
+}));
+
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
   getUserStorageQuota: vi.fn().mockResolvedValue({ tier: 'free', usedBytes: 0, quotaBytes: 1e9, availableBytes: 1e9 }),
   getUserFileCount: vi.fn().mockResolvedValue(0),
@@ -47,13 +51,15 @@ vi.mock('@pagespace/db/schema/core', () => ({
 
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
+import { validateAdminAccess } from '@/lib/auth/admin-role';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { reconcileStorageUsage } from '@pagespace/lib/services/storage-limits';
 
 describe('GET /api/storage/info', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(verifyAuth).mockResolvedValue({ id: 'user_1' } as never);
+    vi.mocked(verifyAuth).mockResolvedValue({ id: 'user_1', role: 'user', adminRoleVersion: 0 } as never);
+    vi.mocked(validateAdminAccess).mockResolvedValue({ isValid: false, reason: 'not_admin' } as never);
   });
 
   it('logs audit event on successful storage info fetch', async () => {
@@ -75,31 +81,46 @@ describe('GET /api/storage/info', () => {
     expect(auditRequest).not.toHaveBeenCalled();
   });
 
-  describe('H4 — ?reconcile=true recomputes the caller\'s own usage (safe after the basis fix)', () => {
-    it('reconciles the authenticated user\'s storage when requested', async () => {
+  describe('H4 — ?reconcile=true is admin-gated (gate resolved up front, not from the request param)', () => {
+    it('returns 403 and does not reconcile for a non-admin', async () => {
+      // default mocks: role 'user', validateAdminAccess invalid
+      const request = new Request('https://example.com/api/storage/info?reconcile=true');
+      const res = await GET(request as never);
+
+      expect(res.status).toBe(403);
+      expect(reconcileStorageUsage).not.toHaveBeenCalled();
+    });
+
+    it('reconciles for a DB-verified admin', async () => {
+      vi.mocked(verifyAuth).mockResolvedValue({ id: 'user_1', role: 'admin', adminRoleVersion: 3 } as never);
+      vi.mocked(validateAdminAccess).mockResolvedValue({ isValid: true } as never);
       vi.mocked(reconcileStorageUsage).mockResolvedValue({ previousUsage: 0, actualUsage: 0, difference: 0 } as never);
 
       const request = new Request('https://example.com/api/storage/info?reconcile=true');
       const res = await GET(request as never);
 
       expect(res.status).toBe(200);
+      expect(validateAdminAccess).toHaveBeenCalledWith('user_1', 3);
       expect(reconcileStorageUsage).toHaveBeenCalledWith('user_1');
     });
 
-    it('does not reconcile when reconcile is not requested', async () => {
-      const request = new Request('https://example.com/api/storage/info');
-      await GET(request as never);
-
-      expect(reconcileStorageUsage).not.toHaveBeenCalled();
-    });
-
-    it('still returns 200 storage info if reconciliation throws (best-effort)', async () => {
-      vi.mocked(reconcileStorageUsage).mockRejectedValue(new Error('boom'));
+    it('rejects a stale admin session whose adminRoleVersion no longer validates', async () => {
+      vi.mocked(verifyAuth).mockResolvedValue({ id: 'user_1', role: 'admin', adminRoleVersion: 1 } as never);
+      vi.mocked(validateAdminAccess).mockResolvedValue({ isValid: false, reason: 'version_mismatch' } as never);
 
       const request = new Request('https://example.com/api/storage/info?reconcile=true');
       const res = await GET(request as never);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(403);
+      expect(reconcileStorageUsage).not.toHaveBeenCalled();
+    });
+
+    it('does not call the admin DB validation for a non-admin normal read (short-circuit, no reconcile)', async () => {
+      const request = new Request('https://example.com/api/storage/info');
+      await GET(request as never);
+
+      expect(validateAdminAccess).not.toHaveBeenCalled();
+      expect(reconcileStorageUsage).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/api/storage/info/__tests__/route.test.ts
+++ b/apps/web/src/app/api/storage/info/__tests__/route.test.ts
@@ -10,8 +10,6 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 
 vi.mock('@/lib/auth', () => ({
   verifyAuth: vi.fn(),
-  verifyAdminAuth: vi.fn(),
-  isAdminAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && '__error' in (r as object)),
 }));
 
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
@@ -48,7 +46,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 }));
 
 import { GET } from '../route';
-import { verifyAuth, verifyAdminAuth } from '@/lib/auth';
+import { verifyAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { reconcileStorageUsage } from '@pagespace/lib/services/storage-limits';
 
@@ -77,19 +75,8 @@ describe('GET /api/storage/info', () => {
     expect(auditRequest).not.toHaveBeenCalled();
   });
 
-  describe('H4 — ?reconcile=true is admin-gated', () => {
-    it('returns 403 and does not reconcile for a non-admin', async () => {
-      vi.mocked(verifyAdminAuth).mockResolvedValue({ __error: true } as never);
-
-      const request = new Request('https://example.com/api/storage/info?reconcile=true');
-      const res = await GET(request as never);
-
-      expect(res.status).toBe(403);
-      expect(reconcileStorageUsage).not.toHaveBeenCalled();
-    });
-
-    it('runs reconcile for an admin', async () => {
-      vi.mocked(verifyAdminAuth).mockResolvedValue({ id: 'user_1', role: 'admin' } as never);
+  describe('H4 — ?reconcile=true recomputes the caller\'s own usage (safe after the basis fix)', () => {
+    it('reconciles the authenticated user\'s storage when requested', async () => {
       vi.mocked(reconcileStorageUsage).mockResolvedValue({ previousUsage: 0, actualUsage: 0, difference: 0 } as never);
 
       const request = new Request('https://example.com/api/storage/info?reconcile=true');
@@ -99,12 +86,20 @@ describe('GET /api/storage/info', () => {
       expect(reconcileStorageUsage).toHaveBeenCalledWith('user_1');
     });
 
-    it('does not reconcile or require admin when reconcile is not requested', async () => {
+    it('does not reconcile when reconcile is not requested', async () => {
       const request = new Request('https://example.com/api/storage/info');
       await GET(request as never);
 
-      expect(verifyAdminAuth).not.toHaveBeenCalled();
       expect(reconcileStorageUsage).not.toHaveBeenCalled();
+    });
+
+    it('still returns 200 storage info if reconciliation throws (best-effort)', async () => {
+      vi.mocked(reconcileStorageUsage).mockRejectedValue(new Error('boom'));
+
+      const request = new Request('https://example.com/api/storage/info?reconcile=true');
+      const res = await GET(request as never);
+
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/apps/web/src/app/api/storage/info/__tests__/route.test.ts
+++ b/apps/web/src/app/api/storage/info/__tests__/route.test.ts
@@ -10,6 +10,8 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 
 vi.mock('@/lib/auth', () => ({
   verifyAuth: vi.fn(),
+  verifyAdminAuth: vi.fn(),
+  isAdminAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && '__error' in (r as object)),
 }));
 
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
@@ -46,8 +48,9 @@ vi.mock('@pagespace/db/schema/core', () => ({
 }));
 
 import { GET } from '../route';
-import { verifyAuth } from '@/lib/auth';
+import { verifyAuth, verifyAdminAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { reconcileStorageUsage } from '@pagespace/lib/services/storage-limits';
 
 describe('GET /api/storage/info', () => {
   beforeEach(() => {
@@ -72,5 +75,36 @@ describe('GET /api/storage/info', () => {
     await GET(request as never);
 
     expect(auditRequest).not.toHaveBeenCalled();
+  });
+
+  describe('H4 — ?reconcile=true is admin-gated', () => {
+    it('returns 403 and does not reconcile for a non-admin', async () => {
+      vi.mocked(verifyAdminAuth).mockResolvedValue({ __error: true } as never);
+
+      const request = new Request('https://example.com/api/storage/info?reconcile=true');
+      const res = await GET(request as never);
+
+      expect(res.status).toBe(403);
+      expect(reconcileStorageUsage).not.toHaveBeenCalled();
+    });
+
+    it('runs reconcile for an admin', async () => {
+      vi.mocked(verifyAdminAuth).mockResolvedValue({ id: 'user_1', role: 'admin' } as never);
+      vi.mocked(reconcileStorageUsage).mockResolvedValue({ previousUsage: 0, actualUsage: 0, difference: 0 } as never);
+
+      const request = new Request('https://example.com/api/storage/info?reconcile=true');
+      const res = await GET(request as never);
+
+      expect(res.status).toBe(200);
+      expect(reconcileStorageUsage).toHaveBeenCalledWith('user_1');
+    });
+
+    it('does not reconcile or require admin when reconcile is not requested', async () => {
+      const request = new Request('https://example.com/api/storage/info');
+      await GET(request as never);
+
+      expect(verifyAdminAuth).not.toHaveBeenCalled();
+      expect(reconcileStorageUsage).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/app/api/storage/info/route.ts
+++ b/apps/web/src/app/api/storage/info/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyAuth } from '@/lib/auth';
+import { validateAdminAccess } from '@/lib/auth/admin-role';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   getUserStorageQuota,
@@ -20,19 +21,29 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Check for reconcile parameter
+    // Resolve admin status UP FRONT — independent of the user-supplied reconcile
+    // flag — so the privileged reconcile is gated on a verified authorization
+    // result rather than on user-controlled request data (avoids the
+    // user-controlled-bypass pattern). The session role short-circuits the DB
+    // validation for non-admins, so normal storage-info reads incur no extra read
+    // and emit no security logs. `validateAdminAccess` re-checks role +
+    // adminRoleVersion against the DB to reject stale/revoked admin sessions.
+    const isAdmin = user.role === 'admin'
+      && (await validateAdminAccess(user.id, user.adminRoleVersion)).isValid;
+
+    // Reconcile rewrites stored usage from a recomputed total; admin-gate it as
+    // defense-in-depth (H4) on top of the accounting-basis fix. The gate is the
+    // non-user-controlled `isAdmin`; the request param only selects the operation.
     const { searchParams } = new URL(request.url);
     const shouldReconcile = searchParams.get('reconcile') === 'true';
 
-    // Reconcile the caller's OWN stored usage if requested (the user-facing
-    // "Reconcile" button in StorageUsageCard). H4: this recomputes usage from the
-    // same population the charge path bills — the user's `files` rows
-    // (createdBy = user), including trashed-but-unpurged — so it can only correct
-    // the stored total to the TRUE value. It can no longer be abused to wipe quota
-    // (the trash→reconcile→restore loop is closed by counting trashed-unpurged
-    // files), which is why the accounting-basis fix supersedes the earlier interim
-    // admin-gate and reconcile stays available to the owning user.
     if (shouldReconcile) {
+      if (!isAdmin) {
+        return NextResponse.json(
+          { error: 'Forbidden: admin access required to reconcile storage' },
+          { status: 403 },
+        );
+      }
       try {
         const reconcileResult = await reconcileStorageUsage(user.id);
         console.log(`Storage reconciled for user ${user.id}:`, reconcileResult);

--- a/apps/web/src/app/api/storage/info/route.ts
+++ b/apps/web/src/app/api/storage/info/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyAuth, verifyAdminAuth, isAdminAuthError } from '@/lib/auth';
+import { verifyAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   getUserStorageQuota,
@@ -24,17 +24,15 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const shouldReconcile = searchParams.get('reconcile') === 'true';
 
-    // Reconcile if requested. H4: `?reconcile=true` rewrites stored usage from a
-    // recomputed total; even with the accounting basis fixed, expose it only to
-    // admins as defense-in-depth so a user can't trigger their own quota rewrite.
+    // Reconcile the caller's OWN stored usage if requested (the user-facing
+    // "Reconcile" button in StorageUsageCard). H4: this recomputes usage from the
+    // same population the charge path bills — the user's `files` rows
+    // (createdBy = user), including trashed-but-unpurged — so it can only correct
+    // the stored total to the TRUE value. It can no longer be abused to wipe quota
+    // (the trash→reconcile→restore loop is closed by counting trashed-unpurged
+    // files), which is why the accounting-basis fix supersedes the earlier interim
+    // admin-gate and reconcile stays available to the owning user.
     if (shouldReconcile) {
-      const adminResult = await verifyAdminAuth(request);
-      if (isAdminAuthError(adminResult)) {
-        return NextResponse.json(
-          { error: 'Forbidden: admin access required to reconcile storage' },
-          { status: 403 },
-        );
-      }
       try {
         const reconcileResult = await reconcileStorageUsage(user.id);
         console.log(`Storage reconciled for user ${user.id}:`, reconcileResult);

--- a/apps/web/src/app/api/storage/info/route.ts
+++ b/apps/web/src/app/api/storage/info/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyAuth } from '@/lib/auth';
+import { verifyAuth, verifyAdminAuth, isAdminAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   getUserStorageQuota,
@@ -24,8 +24,17 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const shouldReconcile = searchParams.get('reconcile') === 'true';
 
-    // Reconcile if requested
+    // Reconcile if requested. H4: `?reconcile=true` rewrites stored usage from a
+    // recomputed total; even with the accounting basis fixed, expose it only to
+    // admins as defense-in-depth so a user can't trigger their own quota rewrite.
     if (shouldReconcile) {
+      const adminResult = await verifyAdminAuth(request);
+      if (isAdminAuthError(adminResult)) {
+        return NextResponse.json(
+          { error: 'Forbidden: admin access required to reconcile storage' },
+          { status: 403 },
+        );
+      }
       try {
         const reconcileResult = await reconcileStorageUsage(user.id);
         console.log(`Storage reconciled for user ${user.id}:`, reconcileResult);

--- a/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
@@ -13,6 +13,10 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 const mockTransaction = vi.fn();
 const mockFindFirst = vi.fn();
 const mockFindMany = vi.fn();
+const mockFilesFindFirst = vi.fn();
+// Default files-row insert result: a single row (this completion inserted it →
+// fileWasInserted=true). Individual tests override for dedup/claim scenarios.
+let filesInsertReturning: Array<{ id: string }> = [];
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
@@ -83,9 +87,9 @@ vi.mock('@/lib/upload/s3-effects', () => ({
 
 vi.mock('@pagespace/lib/services/upload-validation', () => ({
   buildS3Key: (hash: string) => `files/${hash}/original`,
-  // Real (pure) impl of the H3 link gate.
-  canFinalizeUpload: ({ callerAlreadyReferences, existedAtPresign }: { callerAlreadyReferences: boolean; existedAtPresign: boolean }) =>
-    callerAlreadyReferences || !existedAtPresign,
+  // Real (pure) impl of the H3 atomic link gate.
+  canLinkExistingFileRow: ({ fileWasInserted, ownedByCaller, callerAlreadyReferences }: { fileWasInserted: boolean; ownedByCaller: boolean; callerAlreadyReferences: boolean }) =>
+    fileWasInserted || ownedByCaller || callerAlreadyReferences,
 }));
 
 import { POST } from '../route';
@@ -105,6 +109,9 @@ const txQuery = {
     findFirst: (...args: unknown[]) => mockFindFirst(...args),
     findMany: (...args: unknown[]) => mockFindMany(...args),
   },
+  files: {
+    findFirst: (...args: unknown[]) => mockFilesFindFirst(...args),
+  },
 };
 
 function makeTxImpl() {
@@ -116,7 +123,8 @@ function makeTxImpl() {
           if (table === 'pages') capturedPageValues = vals;
           return {
             returning: vi.fn().mockResolvedValue([MOCK_PAGE]),
-            onConflictDoNothing: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: VALID_HASH }]) }),
+            // files insert: onConflictDoNothing().returning({id}) → filesInsertReturning.
+            onConflictDoNothing: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue(filesInsertReturning) }),
             onConflictDoUpdate: vi.fn().mockResolvedValue([]),
           };
         },
@@ -148,9 +156,10 @@ const VALID_BODY = {
   parentId: null,
 };
 
-// existedAtPresign=false means THIS upload created the object → canFinalizeUpload
-// allows it regardless of references (the common new-upload path).
-const SLOT_META = { contentHash: VALID_HASH, driveId: 'drive-1', fileSize: 2048, mimeType: 'image/jpeg', callerAlreadyReferences: false, existedAtPresign: false };
+// Default: the common new-upload path. The files-row insert succeeds in the tx
+// (filesInsertReturning has a row → fileWasInserted=true), so the H3 link gate
+// allows it regardless of references.
+const SLOT_META = { contentHash: VALID_HASH, driveId: 'drive-1', fileSize: 2048, mimeType: 'image/jpeg', callerAlreadyReferences: false };
 
 const MOCK_PAGE = { id: 'page-abc', title: 'photo.jpg', type: 'FILE', driveId: 'drive-1', contentHash: VALID_HASH };
 
@@ -166,6 +175,9 @@ beforeEach(() => {
   // Default sibling lookups: empty list (new page lands at position 0).
   mockFindFirst.mockResolvedValue(undefined);
   mockFindMany.mockResolvedValue([]);
+  // Default: the files-row insert succeeds (first physical store → fileWasInserted).
+  filesInsertReturning = [{ id: VALID_HASH }];
+  mockFilesFindFirst.mockResolvedValue(undefined);
   // Default: the uploaded object is present in storage.
   mockCheckObjectExists.mockResolvedValue(true);
 
@@ -368,25 +380,38 @@ describe('POST /api/upload/complete', () => {
     });
   });
 
-  describe('H3 — cross-tenant claim defense at finalize', () => {
-    it('rejects (409) when the object pre-existed and the caller does not reference it', async () => {
-      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({
-        ...SLOT_META, callerAlreadyReferences: false, existedAtPresign: true,
-      });
+  describe('H3 — atomic cross-tenant claim defense at finalize', () => {
+    it('rejects (409, rolled back) when an existing files row is owned by another tenant and the caller does not reference it', async () => {
+      // files insert conflicts (row already exists), owned by a different user,
+      // caller does not reference → the in-tx ownership claim throws → 409.
+      filesInsertReturning = [];
+      mockFilesFindFirst.mockResolvedValue({ createdBy: 'other-tenant' });
+      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({ ...SLOT_META, callerAlreadyReferences: false });
+
       const res = await POST(makeRequest(VALID_BODY));
       expect(res.status).toBe(409);
-      expect(mockTransaction).not.toHaveBeenCalled();
       expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(MOCK_JOB_ID);
       expect(updateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+      // No storage charge for a rejected claim.
+      expect(updateStorageUsage).not.toHaveBeenCalled();
     });
 
-    it('allows a referencing caller to link a pre-existing object (legit dedup)', async () => {
-      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({
-        ...SLOT_META, callerAlreadyReferences: true, existedAtPresign: true,
-      });
+    it('allows a referencing caller to link a pre-existing (foreign-owned) object (legit dedup)', async () => {
+      filesInsertReturning = [];
+      mockFilesFindFirst.mockResolvedValue({ createdBy: 'other-tenant' });
+      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({ ...SLOT_META, callerAlreadyReferences: true });
+
       const res = await POST(makeRequest(VALID_BODY));
       expect(res.status).toBe(200);
-      expect(mockTransaction).toHaveBeenCalled();
+    });
+
+    it('allows the caller to re-link a pre-existing object they own (createdBy === caller)', async () => {
+      filesInsertReturning = [];
+      mockFilesFindFirst.mockResolvedValue({ createdBy: 'user-1' });
+      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({ ...SLOT_META, callerAlreadyReferences: false });
+
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
     });
   });
 
@@ -396,24 +421,11 @@ describe('POST /api/upload/complete', () => {
       expect(updateStorageUsage).toHaveBeenCalledWith('user-1', 2048, expect.objectContaining({ eventType: 'upload' }));
     });
 
-    it('does NOT charge storage on a dedup completion (files row already existed)', async () => {
-      // onConflictDoNothing().returning() yields [] when the row already exists.
-      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
-        const tx = {
-          query: txQuery,
-          insert: (table: unknown) => ({
-            values: (vals: Record<string, unknown>) => {
-              if (table === 'pages') capturedPageValues = vals;
-              return {
-                returning: vi.fn().mockResolvedValue([MOCK_PAGE]),
-                onConflictDoNothing: () => ({ returning: vi.fn().mockResolvedValue([]) }),
-                onConflictDoUpdate: vi.fn().mockResolvedValue([]),
-              };
-            },
-          }),
-        };
-        return fn(tx);
-      });
+    it('does NOT charge storage on a legit dedup completion (files row already existed, caller references)', async () => {
+      // Row already exists (insert conflict → []), caller already references it
+      // so the link is allowed, but no new bytes were stored → no charge.
+      filesInsertReturning = [];
+      mockFilesFindFirst.mockResolvedValue({ createdBy: 'user-1' });
       await POST(makeRequest(VALID_BODY));
       expect(updateStorageUsage).not.toHaveBeenCalled();
     });

--- a/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
@@ -50,6 +50,8 @@ vi.mock('@pagespace/lib/utils/enums', () => ({
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
   updateActiveUploads: vi.fn(),
   updateStorageUsage: vi.fn(),
+  // Real (pure) impl: charge iff the files row was newly inserted.
+  shouldChargeForStore: (inserted: boolean) => inserted,
 }));
 
 vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
@@ -81,13 +83,16 @@ vi.mock('@/lib/upload/s3-effects', () => ({
 
 vi.mock('@pagespace/lib/services/upload-validation', () => ({
   buildS3Key: (hash: string) => `files/${hash}/original`,
+  // Real (pure) impl of the H3 link gate.
+  canFinalizeUpload: ({ callerAlreadyReferences, existedAtPresign }: { callerAlreadyReferences: boolean; existedAtPresign: boolean }) =>
+    callerAlreadyReferences || !existedAtPresign,
 }));
 
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
-import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { updateActiveUploads, updateStorageUsage } from '@pagespace/lib/services/storage-limits';
 import { enqueueProcessorJob } from '@/lib/upload/processor-effects';
 
 // Captures the values passed to tx.insert(pages).values(...) for assertion
@@ -143,7 +148,9 @@ const VALID_BODY = {
   parentId: null,
 };
 
-const SLOT_META = { contentHash: VALID_HASH, driveId: 'drive-1', fileSize: 2048, mimeType: 'image/jpeg' };
+// existedAtPresign=false means THIS upload created the object → canFinalizeUpload
+// allows it regardless of references (the common new-upload path).
+const SLOT_META = { contentHash: VALID_HASH, driveId: 'drive-1', fileSize: 2048, mimeType: 'image/jpeg', callerAlreadyReferences: false, existedAtPresign: false };
 
 const MOCK_PAGE = { id: 'page-abc', title: 'photo.jpg', type: 'FILE', driveId: 'drive-1', contentHash: VALID_HASH };
 
@@ -358,6 +365,57 @@ describe('POST /api/upload/complete', () => {
       mockFindFirst.mockResolvedValue({ id: 'last', position: 9 });
       await POST(makeRequest({ ...VALID_BODY, position: 'before', afterNodeId: 'ghost' }));
       expect(capturedPageValues?.position).toBe(10);
+    });
+  });
+
+  describe('H3 — cross-tenant claim defense at finalize', () => {
+    it('rejects (409) when the object pre-existed and the caller does not reference it', async () => {
+      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({
+        ...SLOT_META, callerAlreadyReferences: false, existedAtPresign: true,
+      });
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(409);
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(MOCK_JOB_ID);
+      expect(updateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+    });
+
+    it('allows a referencing caller to link a pre-existing object (legit dedup)', async () => {
+      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({
+        ...SLOT_META, callerAlreadyReferences: true, existedAtPresign: true,
+      });
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+      expect(mockTransaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('M8 — charge only on first physical store', () => {
+    it('charges storage when the files row was newly inserted', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(updateStorageUsage).toHaveBeenCalledWith('user-1', 2048, expect.objectContaining({ eventType: 'upload' }));
+    });
+
+    it('does NOT charge storage on a dedup completion (files row already existed)', async () => {
+      // onConflictDoNothing().returning() yields [] when the row already exists.
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          query: txQuery,
+          insert: (table: unknown) => ({
+            values: (vals: Record<string, unknown>) => {
+              if (table === 'pages') capturedPageValues = vals;
+              return {
+                returning: vi.fn().mockResolvedValue([MOCK_PAGE]),
+                onConflictDoNothing: () => ({ returning: vi.fn().mockResolvedValue([]) }),
+                onConflictDoUpdate: vi.fn().mockResolvedValue([]),
+              };
+            },
+          }),
+        };
+        return fn(tx);
+      });
+      await POST(makeRequest(VALID_BODY));
+      expect(updateStorageUsage).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -7,9 +7,9 @@ import { pages } from '@pagespace/db/schema/core';
 import { files, filePages } from '@pagespace/db/schema/storage';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
-import { updateActiveUploads, updateStorageUsage } from '@pagespace/lib/services/storage-limits';
+import { updateActiveUploads, updateStorageUsage, shouldChargeForStore } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
-import { buildS3Key } from '@pagespace/lib/services/upload-validation';
+import { buildS3Key, canFinalizeUpload } from '@pagespace/lib/services/upload-validation';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logFileActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { enqueueProcessorJob } from '@/lib/upload/processor-effects';
@@ -176,6 +176,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
   }
   const { contentHash, driveId, fileSize, mimeType } = reserved;
+  // H3 facts captured at presign (server-trusted). Default to the safe (most
+  // restrictive) interpretation if an older slot lacks them.
+  const callerAlreadyReferences = reserved.callerAlreadyReferences ?? false;
+  const existedAtPresign = reserved.existedAtPresign ?? true;
 
   // Scoped MCP tokens may only act on the drive they were granted for.
   const scopeError = checkMCPCreateScope(auth, driveId);
@@ -201,6 +205,19 @@ export async function POST(request: Request) {
     }
   }
 
+  // H3: a known content hash must not let a caller link bytes they never
+  // uploaded. Linking a pre-existing content-addressed object is allowed only
+  // when the caller already references the hash, or when this very upload created
+  // the object (it did not exist at presign). Reject the cross-tenant claim.
+  if (!canFinalizeUpload({ callerAlreadyReferences, existedAtPresign })) {
+    uploadSemaphore.releaseUploadSlot(jobId);
+    await updateActiveUploads(userId, -1).catch(() => undefined);
+    return NextResponse.json(
+      { error: 'This file could not be verified for upload. Please re-upload the original file.' },
+      { status: 409 },
+    );
+  }
+
   // The UI uploads straight to S3, so /complete can be reached without the PUT
   // ever happening. Confirm the object is actually present before creating a
   // page/file record and charging storage, so a skipped or failed upload can't
@@ -213,15 +230,19 @@ export async function POST(request: Request) {
   }
 
   let newPage: typeof pages.$inferSelect;
+  // M8: storage is content-addressed — only the FIRST physical store of a blob
+  // inserts a `files` row (createdBy = uploader). Charge once, on that insert, so
+  // dedup completes don't N-charge while the reaper only ever credits once.
+  let fileWasInserted = false;
   try {
-    newPage = await db.transaction(async (tx) => {
+    const result = await db.transaction(async (tx) => {
       // Compute position inside the transaction so the sibling read and the
       // insert share one transactional snapshot.
       const calculatedPosition = await resolveUploadPosition(tx, resolvedParentId, position, afterNodeId);
       const record = buildPageRecord({ contentHash, driveId, title, mimeType, fileSize, userId, parentId: resolvedParentId, position: calculatedPosition });
       const [createdPage] = await tx.insert(pages).values(record).returning();
 
-      await tx
+      const insertedFiles = await tx
         .insert(files)
         .values({
           id: contentHash,
@@ -231,7 +252,8 @@ export async function POST(request: Request) {
           storagePath: contentHash,
           createdBy: userId,
         })
-        .onConflictDoNothing();
+        .onConflictDoNothing()
+        .returning({ id: files.id });
 
       await tx
         .insert(filePages)
@@ -241,8 +263,10 @@ export async function POST(request: Request) {
           set: { linkedBy: userId, linkedAt: new Date(), linkSource: 'presigned-upload' },
         });
 
-      return createdPage;
+      return { createdPage, fileWasInserted: insertedFiles.length > 0 };
     });
+    newPage = result.createdPage;
+    fileWasInserted = result.fileWasInserted;
   } catch (err) {
     uploadSemaphore.releaseUploadSlot(jobId);
     await updateActiveUploads(userId, -1).catch(() => undefined);
@@ -263,7 +287,12 @@ export async function POST(request: Request) {
       console.error('Failed to enqueue processor job:', err);
     }
 
-    await updateStorageUsage(userId, fileSize, { pageId: newPage.id, driveId, eventType: 'upload' });
+    // M8: charge only on the first physical store of the blob (symmetric with the
+    // single credit the reaper issues at unlink). Dedup completes store no new
+    // bytes and must not be charged.
+    if (shouldChargeForStore(fileWasInserted)) {
+      await updateStorageUsage(userId, fileSize, { pageId: newPage.id, driveId, eventType: 'upload' });
+    }
 
     auditRequest(request, {
       eventType: 'data.write',

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -9,13 +9,23 @@ import { PageType } from '@pagespace/lib/utils/enums';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
 import { updateActiveUploads, updateStorageUsage, shouldChargeForStore } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
-import { buildS3Key, canFinalizeUpload } from '@pagespace/lib/services/upload-validation';
+import { buildS3Key, canLinkExistingFileRow } from '@pagespace/lib/services/upload-validation';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logFileActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { enqueueProcessorJob } from '@/lib/upload/processor-effects';
 import { checkObjectExists } from '@/lib/upload/s3-effects';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+// Thrown inside the completion transaction to roll it back when the caller is
+// trying to link a content-addressed blob they neither uploaded nor reference
+// (H3 cross-tenant claim). Caught by the route and mapped to a 409.
+class CrossTenantClaimError extends Error {
+  constructor() {
+    super('Cross-tenant file claim rejected');
+    this.name = 'CrossTenantClaimError';
+  }
+}
 
 // The transaction executor passed to db.transaction's callback — also satisfied
 // by `db` itself. resolveUploadPosition takes this so the sibling reads run on
@@ -176,10 +186,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
   }
   const { contentHash, driveId, fileSize, mimeType } = reserved;
-  // H3 facts captured at presign (server-trusted). Default to the safe (most
-  // restrictive) interpretation if an older slot lacks them.
+  // H3 hint captured at presign (server-trusted). The authoritative anti-claim
+  // check is the atomic `files`-row ownership claim in the transaction below;
+  // this only short-circuits the legitimate-dedup case. Default to the safe
+  // (most restrictive) value if an older slot lacks it.
   const callerAlreadyReferences = reserved.callerAlreadyReferences ?? false;
-  const existedAtPresign = reserved.existedAtPresign ?? true;
 
   // Scoped MCP tokens may only act on the drive they were granted for.
   const scopeError = checkMCPCreateScope(auth, driveId);
@@ -205,19 +216,6 @@ export async function POST(request: Request) {
     }
   }
 
-  // H3: a known content hash must not let a caller link bytes they never
-  // uploaded. Linking a pre-existing content-addressed object is allowed only
-  // when the caller already references the hash, or when this very upload created
-  // the object (it did not exist at presign). Reject the cross-tenant claim.
-  if (!canFinalizeUpload({ callerAlreadyReferences, existedAtPresign })) {
-    uploadSemaphore.releaseUploadSlot(jobId);
-    await updateActiveUploads(userId, -1).catch(() => undefined);
-    return NextResponse.json(
-      { error: 'This file could not be verified for upload. Please re-upload the original file.' },
-      { status: 409 },
-    );
-  }
-
   // The UI uploads straight to S3, so /complete can be reached without the PUT
   // ever happening. Confirm the object is actually present before creating a
   // page/file record and charging storage, so a skipped or failed upload can't
@@ -236,12 +234,11 @@ export async function POST(request: Request) {
   let fileWasInserted = false;
   try {
     const result = await db.transaction(async (tx) => {
-      // Compute position inside the transaction so the sibling read and the
-      // insert share one transactional snapshot.
-      const calculatedPosition = await resolveUploadPosition(tx, resolvedParentId, position, afterNodeId);
-      const record = buildPageRecord({ contentHash, driveId, title, mimeType, fileSize, userId, parentId: resolvedParentId, position: calculatedPosition });
-      const [createdPage] = await tx.insert(pages).values(record).returning();
-
+      // H3 (race-proof): claim the content-addressed `files` row FIRST. The first
+      // completion to insert it owns the blob (createdBy). If a row already exists,
+      // linking is allowed only when the caller owns it or already references the
+      // hash — otherwise this is a cross-tenant claim (incl. a presign→complete
+      // race where another tenant created the object) and we roll back.
       const insertedFiles = await tx
         .insert(files)
         .values({
@@ -254,6 +251,26 @@ export async function POST(request: Request) {
         })
         .onConflictDoNothing()
         .returning({ id: files.id });
+      const fileWasInsertedInTx = insertedFiles.length > 0;
+
+      let ownedByCaller = false;
+      if (!fileWasInsertedInTx) {
+        const existing = await tx.query.files.findFirst({
+          where: eq(files.id, contentHash),
+          columns: { createdBy: true },
+        });
+        ownedByCaller = existing?.createdBy === userId;
+      }
+
+      if (!canLinkExistingFileRow({ fileWasInserted: fileWasInsertedInTx, ownedByCaller, callerAlreadyReferences })) {
+        throw new CrossTenantClaimError();
+      }
+
+      // Compute position inside the transaction so the sibling read and the
+      // insert share one transactional snapshot.
+      const calculatedPosition = await resolveUploadPosition(tx, resolvedParentId, position, afterNodeId);
+      const record = buildPageRecord({ contentHash, driveId, title, mimeType, fileSize, userId, parentId: resolvedParentId, position: calculatedPosition });
+      const [createdPage] = await tx.insert(pages).values(record).returning();
 
       await tx
         .insert(filePages)
@@ -263,13 +280,19 @@ export async function POST(request: Request) {
           set: { linkedBy: userId, linkedAt: new Date(), linkSource: 'presigned-upload' },
         });
 
-      return { createdPage, fileWasInserted: insertedFiles.length > 0 };
+      return { createdPage, fileWasInserted: fileWasInsertedInTx };
     });
     newPage = result.createdPage;
     fileWasInserted = result.fileWasInserted;
   } catch (err) {
     uploadSemaphore.releaseUploadSlot(jobId);
     await updateActiveUploads(userId, -1).catch(() => undefined);
+    if (err instanceof CrossTenantClaimError) {
+      return NextResponse.json(
+        { error: 'This file could not be verified for upload. Please re-upload the original file.' },
+        { status: 409 },
+      );
+    }
     throw err;
   }
 

--- a/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@pagespace/lib/services/storage-limits', () => ({
   getUserStorageQuota: vi.fn(),
   updateActiveUploads: vi.fn(),
   checkStorageQuota: vi.fn(),
+  userReferencesContentHash: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
@@ -34,7 +35,7 @@ vi.mock('@/lib/upload/s3-effects', () => ({
 import { POST } from '../route';
 import { authenticateRequestWithOptions, checkMCPCreateScope } from '@/lib/auth';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
-import { getUserStorageQuota, updateActiveUploads, checkStorageQuota } from '@pagespace/lib/services/storage-limits';
+import { getUserStorageQuota, updateActiveUploads, checkStorageQuota, userReferencesContentHash } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
 
@@ -76,6 +77,9 @@ beforeEach(() => {
   vi.mocked(issuePresignedPutUrl).mockResolvedValue(MOCK_URL);
   vi.mocked(uploadSemaphore.acquireUploadSlot).mockResolvedValue(MOCK_SLOT);
   vi.mocked(updateActiveUploads).mockResolvedValue(undefined);
+  // Default: caller already references the hash, so the dedup fast-path stays
+  // available for the existing dedup tests. H3-specific tests override this.
+  vi.mocked(userReferencesContentHash).mockResolvedValue(true);
 });
 
 describe('POST /api/upload/presign', () => {
@@ -209,19 +213,62 @@ describe('POST /api/upload/presign', () => {
       expect(typeof body.expiresAt).toBe('string');
     });
 
-    it('reserves an upload slot via acquireUploadSlot', async () => {
+    it('reserves an upload slot via acquireUploadSlot with the server-trusted H3 facts', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(false);
+      vi.mocked(userReferencesContentHash).mockResolvedValue(false);
       await POST(makeRequest(VALID_BODY));
       expect(uploadSemaphore.acquireUploadSlot).toHaveBeenCalledWith('user-1', 'free', 1024, {
         contentHash: VALID_HASH,
         driveId: 'drive-1',
         fileSize: 1024,
         mimeType: 'image/jpeg',
+        callerAlreadyReferences: false,
+        existedAtPresign: false,
       });
     });
 
     it('increments activeUploads after acquiring the slot', async () => {
       await POST(makeRequest(VALID_BODY));
       expect(updateActiveUploads).toHaveBeenCalledWith('user-1', 1);
+    });
+  });
+
+  describe('H3 — cross-tenant file claim defense', () => {
+    it('honors the dedup fast-path when the object exists AND the caller already references the hash', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(true);
+      vi.mocked(userReferencesContentHash).mockResolvedValue(true);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.alreadyExists).toBe(true);
+      expect(issuePresignedPutUrl).not.toHaveBeenCalled();
+    });
+
+    it('rejects (409) when the object exists but the caller does not reference the hash — no claim, no PUT URL', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(true);
+      vi.mocked(userReferencesContentHash).mockResolvedValue(false);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(409);
+      // Never hand out a canonical-key PUT URL to a non-possessor (corruption risk).
+      expect(issuePresignedPutUrl).not.toHaveBeenCalled();
+      // Rejected before reserving a slot.
+      expect(uploadSemaphore.acquireUploadSlot).not.toHaveBeenCalled();
+    });
+
+    it('issues a real PUT URL (no fast-path) when the object does not yet exist, even for a non-referencing caller', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(false);
+      vi.mocked(userReferencesContentHash).mockResolvedValue(false);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.url).toBe(MOCK_URL);
+      expect(body.alreadyExists).toBeUndefined();
+    });
+
+    it('checks references against the canonicalized (lowercased) hash', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(false);
+      await POST(makeRequest({ ...VALID_BODY, contentHash: 'A'.repeat(64) }));
+      expect(userReferencesContentHash).toHaveBeenCalledWith('user-1', 'a'.repeat(64), 'drive-1');
     });
   });
 

--- a/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
@@ -223,7 +223,6 @@ describe('POST /api/upload/presign', () => {
         fileSize: 1024,
         mimeType: 'image/jpeg',
         callerAlreadyReferences: false,
-        existedAtPresign: false,
       });
     });
 

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -117,7 +117,6 @@ export async function POST(request: Request) {
     fileSize,
     mimeType,
     callerAlreadyReferences,
-    existedAtPresign: exists,
   });
   if (!jobId) {
     return NextResponse.json(

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -5,9 +5,10 @@ import {
   validateFileSize,
   validateMimeTypeDeclaration,
   buildS3Key,
+  canClaimExistingObject,
 } from '@pagespace/lib/services/upload-validation';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
-import { checkStorageQuota, getUserStorageQuota, updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { checkStorageQuota, getUserStorageQuota, updateActiveUploads, userReferencesContentHash } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -86,15 +87,37 @@ export async function POST(request: Request) {
 
   const exists = await checkObjectExists(key);
 
+  // H3: storage is a GLOBAL content-addressed namespace, so a known hash alone
+  // must NOT grant access to bytes the caller never uploaded. Only honor the
+  // dedup fast-path (skip the proof-of-possession PUT) when the caller already
+  // references the hash.
+  const callerAlreadyReferences = await userReferencesContentHash(userId, canonicalHash, driveId);
+  const allowFastPath = canClaimExistingObject({ contentHash: canonicalHash, callerAlreadyReferences });
+
+  // The object already exists but the caller has never uploaded/linked it — this
+  // is the cross-tenant claim. Reject before reserving a slot: we must NOT hand
+  // out a presigned PUT for the canonical (content-addressed) key either, since a
+  // non-possessor could overwrite another tenant's bytes with non-matching
+  // content. Honoring possession requires per-drive namespacing (see WO-02 H3).
+  if (exists && !allowFastPath) {
+    return NextResponse.json(
+      { error: 'This file could not be verified for upload. Please re-upload the original file.' },
+      { status: 409 },
+    );
+  }
+
   // Reserve a slot in both paths so the client always has a jobId to pass to
-  // /complete — the dedup path skips the PUT but still creates a page record.
+  // /complete — the dedup fast-path skips the PUT but still creates a page record.
   // The slot carries the server-trusted upload params so /complete can't be
-  // tricked with a divergent hash/drive/size/mime.
+  // tricked with a divergent hash/drive/size/mime — and the H3 facts so it can
+  // reject a claim without re-trusting the client.
   const jobId = await uploadSemaphore.acquireUploadSlot(userId, quota.tier, fileSize, {
     contentHash: canonicalHash,
     driveId,
     fileSize,
     mimeType,
+    callerAlreadyReferences,
+    existedAtPresign: exists,
   });
   if (!jobId) {
     return NextResponse.json(
@@ -108,7 +131,7 @@ export async function POST(request: Request) {
   try {
     await updateActiveUploads(userId, 1);
 
-    if (exists) {
+    if (exists && allowFastPath) {
       return NextResponse.json({ alreadyExists: true, jobId, key });
     }
 

--- a/apps/web/src/lib/storage/__tests__/reap-orphaned-files.test.ts
+++ b/apps/web/src/lib/storage/__tests__/reap-orphaned-files.test.ts
@@ -23,6 +23,18 @@ vi.mock('@pagespace/lib/services/validated-service-token', () => ({
 
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
   updateStorageUsage: mockUpdateStorageUsage,
+  // Real (pure) impl so the reaper's credit rules are exercised, not stubbed.
+  computeStorageCreditOnUnlink: (input: {
+    createdBy: string | null;
+    sizeBytes: number | string | null;
+    deletedByThisCall: boolean;
+    hadPhysicalBlob: boolean;
+  }) => {
+    if (!input.deletedByThisCall || !input.hadPhysicalBlob || !input.createdBy) return null;
+    const n = typeof input.sizeBytes === 'string' ? Number(input.sizeBytes) : (input.sizeBytes ?? 0);
+    if (!Number.isFinite(n) || n <= 0) return null;
+    return { userId: input.createdBy, deltaBytes: -Math.floor(n) };
+  },
 }));
 
 import { reapOrphanedFiles } from '../reap-orphaned-files';

--- a/apps/web/src/lib/storage/reap-orphaned-files.ts
+++ b/apps/web/src/lib/storage/reap-orphaned-files.ts
@@ -1,6 +1,6 @@
 import { findOrphanedFileRecords, deleteFileRecords } from '@pagespace/lib/compliance/file-cleanup/orphan-detector';
 import { createSystemFileDeleteToken } from '@pagespace/lib/services/validated-service-token';
-import { updateStorageUsage } from '@pagespace/lib/services/storage-limits';
+import { updateStorageUsage, computeStorageCreditOnUnlink } from '@pagespace/lib/services/storage-limits';
 
 type Database = typeof import('@pagespace/db/db').db;
 
@@ -113,19 +113,26 @@ export async function reapOrphanedFiles(database: Database, options?: ReapOption
   const deletedIdSet = new Set(deletedIds);
 
   // Credit storage quota back for every reaped orphan whose row this call
-  // actually deleted. Attribute to the original uploader (createdBy); orphans
-  // whose createdBy was nulled (cascade from user delete) skip the credit, as
-  // do DB-only orphans whose bytes were never persisted.
+  // actually deleted. computeStorageCreditOnUnlink (M8) centralizes the rules:
+  // attribute to the original uploader (createdBy), skip rows nulled by a user
+  // cascade, skip rows another reap already removed (race-safe), skip DB-only
+  // stubs whose bytes were never persisted — and issue exactly ONE credit per
+  // blob, symmetric with the single first-store charge.
   for (const orphan of reapedOrphans) {
-    if (!orphan.createdBy) continue;
-    if (!deletedIdSet.has(orphan.id)) continue;
+    const credit = computeStorageCreditOnUnlink({
+      createdBy: orphan.createdBy,
+      sizeBytes: orphan.sizeBytes,
+      deletedByThisCall: deletedIdSet.has(orphan.id),
+      hadPhysicalBlob: true,
+    });
+    if (!credit) continue;
     try {
-      await updateStorageUsage(orphan.createdBy, -orphan.sizeBytes, {
+      await updateStorageUsage(credit.userId, credit.deltaBytes, {
         driveId: orphan.driveId ?? undefined,
         eventType: 'delete',
       });
     } catch (error) {
-      console.warn(`[ReapOrphans] Failed to credit storage for ${orphan.createdBy} (-${orphan.sizeBytes}):`, error);
+      console.warn(`[ReapOrphans] Failed to credit storage for ${credit.userId} (${credit.deltaBytes}):`, error);
     }
   }
 

--- a/apps/web/src/lib/upload/__tests__/attachment-direct.test.ts
+++ b/apps/web/src/lib/upload/__tests__/attachment-direct.test.ts
@@ -39,12 +39,10 @@ vi.mock('../attachment-verify-effect', () => ({
   verifyAttachmentBytes: (...a: unknown[]) => mockVerifyAttachmentBytes(...a),
 }));
 
-const mockSaveFileRecord = vi.fn();
-const mockLinkFileToTarget = vi.fn();
+const mockSaveFileRecordAndLink = vi.fn();
 vi.mock('@pagespace/lib/services/attachment-upload-repository', () => ({
   attachmentUploadRepository: {
-    saveFileRecord: (...a: unknown[]) => mockSaveFileRecord(...a),
-    linkFileToTarget: (...a: unknown[]) => mockLinkFileToTarget(...a),
+    saveFileRecordAndLink: (...a: unknown[]) => mockSaveFileRecordAndLink(...a),
   },
 }));
 
@@ -148,8 +146,7 @@ describe('completeAttachment', () => {
     vi.clearAllMocks();
     mockGetSlotMetadata.mockReturnValue({ contentHash: HASH, fileSize: 1024, mimeType: 'image/png', driveId: 'drive-1', attachmentTarget: PAGE_TARGET });
     mockVerifyAttachmentBytes.mockResolvedValue({ ok: true, detectedMime: 'image/png', size: 1024 });
-    mockSaveFileRecord.mockResolvedValue({ inserted: true });
-    mockLinkFileToTarget.mockResolvedValue(undefined);
+    mockSaveFileRecordAndLink.mockResolvedValue({ inserted: true });
     mockUpdateActiveUploads.mockResolvedValue(undefined);
     mockUpdateStorageUsage.mockResolvedValue(undefined);
   });
@@ -163,8 +160,11 @@ describe('completeAttachment', () => {
     const res = await completeAttachment(completeArgs());
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ success: true, file: { id: HASH, mimeType: 'application/pdf', contentHash: HASH } });
-    expect(mockSaveFileRecord).toHaveBeenCalledWith(expect.objectContaining({ id: HASH, driveId: 'drive-1', mimeType: 'application/pdf' }));
-    expect(mockLinkFileToTarget).toHaveBeenCalledWith({ target: PAGE_TARGET, fileId: HASH, userId: 'user-1' });
+    expect(mockSaveFileRecordAndLink).toHaveBeenCalledWith(expect.objectContaining({
+      fileRecord: expect.objectContaining({ id: HASH, driveId: 'drive-1', mimeType: 'application/pdf' }),
+      target: PAGE_TARGET,
+      userId: 'user-1',
+    }));
     expect(mockRelease).toHaveBeenCalledWith('job-1');
   });
 
@@ -172,14 +172,14 @@ describe('completeAttachment', () => {
     mockGetSlotMetadata.mockReturnValue(null);
     const res = await completeAttachment(completeArgs());
     expect(res.status).toBe(403);
-    expect(mockSaveFileRecord).not.toHaveBeenCalled();
+    expect(mockSaveFileRecordAndLink).not.toHaveBeenCalled();
   });
 
   it('returns 403 when the slot is bound to a different target', async () => {
     mockGetSlotMetadata.mockReturnValue({ contentHash: HASH, fileSize: 1024, mimeType: 'image/png', driveId: '', attachmentTarget: CONV_TARGET });
     const res = await completeAttachment(completeArgs({ target: PAGE_TARGET }));
     expect(res.status).toBe(403);
-    expect(mockSaveFileRecord).not.toHaveBeenCalled();
+    expect(mockSaveFileRecordAndLink).not.toHaveBeenCalled();
   });
 
   it('returns 403 when the slot has no attachment binding (page-file slot replay)', async () => {
@@ -192,7 +192,7 @@ describe('completeAttachment', () => {
     mockVerifyAttachmentBytes.mockResolvedValue({ ok: false, status: 422, error: 'integrity' });
     const res = await completeAttachment(completeArgs());
     expect(res.status).toBe(422);
-    expect(mockSaveFileRecord).not.toHaveBeenCalled();
+    expect(mockSaveFileRecordAndLink).not.toHaveBeenCalled();
     expect(mockRelease).toHaveBeenCalledWith('job-1');
     expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
   });
@@ -201,7 +201,7 @@ describe('completeAttachment', () => {
     mockGetSlotMetadata.mockReturnValue({ contentHash: HASH, fileSize: 2048, mimeType: 'image/png', driveId: '', attachmentTarget: CONV_TARGET });
     mockVerifyAttachmentBytes.mockResolvedValue({ ok: true, detectedMime: 'image/png', size: 2048 });
     await completeAttachment(completeArgs({ target: CONV_TARGET }));
-    expect(mockSaveFileRecord).toHaveBeenCalledWith(expect.objectContaining({ driveId: null }));
+    expect(mockSaveFileRecordAndLink).toHaveBeenCalledWith(expect.objectContaining({ fileRecord: expect.objectContaining({ driveId: null }) }));
     expect(mockUpdateStorageUsage).toHaveBeenCalledWith('user-1', 2048, expect.objectContaining({ driveId: undefined }));
   });
 
@@ -212,15 +212,15 @@ describe('completeAttachment', () => {
     mockVerifyAttachmentBytes.mockResolvedValue({ ok: true, detectedMime: 'image/png', size: 1024 });
     const res = await completeAttachment(completeArgs());
     expect(res.body).toMatchObject({ file: { size: 1024 } });
-    expect(mockSaveFileRecord).toHaveBeenCalledWith(expect.objectContaining({ sizeBytes: 1024 }));
+    expect(mockSaveFileRecordAndLink).toHaveBeenCalledWith(expect.objectContaining({ fileRecord: expect.objectContaining({ sizeBytes: 1024 }) }));
     expect(mockUpdateStorageUsage).toHaveBeenCalledWith('user-1', 1024, expect.anything());
   });
 
   it('M8: does not charge storage on a dedup completion (files row already existed)', async () => {
-    mockSaveFileRecord.mockResolvedValue({ inserted: false });
+    mockSaveFileRecordAndLink.mockResolvedValue({ inserted: false });
     const res = await completeAttachment(completeArgs());
     expect(res.status).toBe(200);
-    expect(mockLinkFileToTarget).toHaveBeenCalled();
+    expect(mockSaveFileRecordAndLink).toHaveBeenCalled();
     expect(mockUpdateStorageUsage).not.toHaveBeenCalled();
   });
 
@@ -228,7 +228,7 @@ describe('completeAttachment', () => {
     mockVerifyAttachmentBytes.mockRejectedValue(new Error('processor unreachable'));
     const res = await completeAttachment(completeArgs());
     expect(res.status).toBe(503);
-    expect(mockSaveFileRecord).not.toHaveBeenCalled();
+    expect(mockSaveFileRecordAndLink).not.toHaveBeenCalled();
     expect(mockRelease).toHaveBeenCalledWith('job-1');
     expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
   });

--- a/apps/web/src/lib/upload/__tests__/attachment-direct.test.ts
+++ b/apps/web/src/lib/upload/__tests__/attachment-direct.test.ts
@@ -10,6 +10,8 @@ vi.mock('@pagespace/lib/services/storage-limits', () => ({
   checkStorageQuota: (...a: unknown[]) => mockCheckStorageQuota(...a),
   updateActiveUploads: (...a: unknown[]) => mockUpdateActiveUploads(...a),
   updateStorageUsage: (...a: unknown[]) => mockUpdateStorageUsage(...a),
+  // Real (pure) impl: charge iff the files row was newly inserted (M8).
+  shouldChargeForStore: (inserted: boolean) => inserted,
 }));
 
 const mockAcquire = vi.fn();
@@ -146,7 +148,7 @@ describe('completeAttachment', () => {
     vi.clearAllMocks();
     mockGetSlotMetadata.mockReturnValue({ contentHash: HASH, fileSize: 1024, mimeType: 'image/png', driveId: 'drive-1', attachmentTarget: PAGE_TARGET });
     mockVerifyAttachmentBytes.mockResolvedValue({ ok: true, detectedMime: 'image/png', size: 1024 });
-    mockSaveFileRecord.mockResolvedValue(undefined);
+    mockSaveFileRecord.mockResolvedValue({ inserted: true });
     mockLinkFileToTarget.mockResolvedValue(undefined);
     mockUpdateActiveUploads.mockResolvedValue(undefined);
     mockUpdateStorageUsage.mockResolvedValue(undefined);
@@ -212,6 +214,14 @@ describe('completeAttachment', () => {
     expect(res.body).toMatchObject({ file: { size: 1024 } });
     expect(mockSaveFileRecord).toHaveBeenCalledWith(expect.objectContaining({ sizeBytes: 1024 }));
     expect(mockUpdateStorageUsage).toHaveBeenCalledWith('user-1', 1024, expect.anything());
+  });
+
+  it('M8: does not charge storage on a dedup completion (files row already existed)', async () => {
+    mockSaveFileRecord.mockResolvedValue({ inserted: false });
+    const res = await completeAttachment(completeArgs());
+    expect(res.status).toBe(200);
+    expect(mockLinkFileToTarget).toHaveBeenCalled();
+    expect(mockUpdateStorageUsage).not.toHaveBeenCalled();
   });
 
   it('releases the slot and returns a retryable 503 when the verify call throws', async () => {

--- a/apps/web/src/lib/upload/attachment-direct.ts
+++ b/apps/web/src/lib/upload/attachment-direct.ts
@@ -173,13 +173,17 @@ export async function completeAttachment(args: CompleteAttachmentArgs): Promise<
   // M8: only the first physical store of a content-addressed blob inserts the
   // `files` row; charge storage once on that insert (symmetric with the single
   // credit the reaper issues at unlink) rather than on every dedup completion.
+  // The file-row insert and target link run in ONE transaction so a link failure
+  // rolls the insert back — a retry then re-inserts and is charged, instead of
+  // leaving an orphaned, never-charged row (inserted=false forever).
   let fileWasInserted = false;
   try {
-    const saved = await attachmentUploadRepository.saveFileRecord(
-      buildAttachmentFileRecord({ contentHash, target, fileSize: resolvedSize, mimeType: storedMime, userId }),
-    );
+    const saved = await attachmentUploadRepository.saveFileRecordAndLink({
+      fileRecord: buildAttachmentFileRecord({ contentHash, target, fileSize: resolvedSize, mimeType: storedMime, userId }),
+      target,
+      userId,
+    });
     fileWasInserted = saved.inserted;
-    await attachmentUploadRepository.linkFileToTarget({ target, fileId: contentHash, userId });
   } catch (err) {
     uploadSemaphore.releaseUploadSlot(jobId);
     await updateActiveUploads(userId, -1).catch(() => undefined);

--- a/apps/web/src/lib/upload/attachment-direct.ts
+++ b/apps/web/src/lib/upload/attachment-direct.ts
@@ -13,6 +13,7 @@ import {
   checkStorageQuota,
   updateActiveUploads,
   updateStorageUsage,
+  shouldChargeForStore,
 } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { buildS3Key } from '@pagespace/lib/services/upload-validation';
@@ -169,10 +170,15 @@ export async function completeAttachment(args: CompleteAttachmentArgs): Promise<
   // under-report storage / forge the file row.
   const resolvedSize = verify.size;
 
+  // M8: only the first physical store of a content-addressed blob inserts the
+  // `files` row; charge storage once on that insert (symmetric with the single
+  // credit the reaper issues at unlink) rather than on every dedup completion.
+  let fileWasInserted = false;
   try {
-    await attachmentUploadRepository.saveFileRecord(
+    const saved = await attachmentUploadRepository.saveFileRecord(
       buildAttachmentFileRecord({ contentHash, target, fileSize: resolvedSize, mimeType: storedMime, userId }),
     );
+    fileWasInserted = saved.inserted;
     await attachmentUploadRepository.linkFileToTarget({ target, fileId: contentHash, userId });
   } catch (err) {
     uploadSemaphore.releaseUploadSlot(jobId);
@@ -187,10 +193,12 @@ export async function completeAttachment(args: CompleteAttachmentArgs): Promise<
   // retry and double-charge storage).
   try {
     await updateActiveUploads(userId, -1);
-    await updateStorageUsage(userId, resolvedSize, {
-      driveId: attachmentFileDriveId(target) ?? undefined,
-      eventType: 'upload',
-    });
+    if (shouldChargeForStore(fileWasInserted)) {
+      await updateStorageUsage(userId, resolvedSize, {
+        driveId: attachmentFileDriveId(target) ?? undefined,
+        eventType: 'upload',
+      });
+    }
     auditRequest(request, {
       eventType: 'data.write',
       userId,

--- a/packages/lib/src/services/__tests__/storage-limits.test.ts
+++ b/packages/lib/src/services/__tests__/storage-limits.test.ts
@@ -5,7 +5,8 @@ vi.mock('../storage-repository', () => ({
     findUserForStorage: vi.fn(),
     findUserForUploads: vi.fn(),
     findUserDriveIds: vi.fn(),
-    sumFileSize: vi.fn(),
+    findFilesByCreator: vi.fn(),
+    userReferencesContentHash: vi.fn(),
     countFiles: vi.fn(),
     updateActiveUploads: vi.fn(),
     updateStorageInTx: vi.fn(),
@@ -39,6 +40,11 @@ import {
   calculateActualStorageUsage,
   getUserFileCount,
   reconcileStorageUsage,
+  userReferencesContentHash,
+  toByteCount,
+  sumStorageBytes,
+  shouldChargeForStore,
+  computeStorageCreditOnUnlink,
   formatBytes,
   parseBytes,
   STORAGE_TIERS,
@@ -295,24 +301,45 @@ describe('storage-limits', () => {
     });
   });
 
-  describe('calculateActualStorageUsage', () => {
-    it('calculateActualStorageUsage_withNoDrives_returnsZero', async () => {
-      vi.mocked(storageRepository.findUserDriveIds).mockResolvedValue([]);
+  describe('calculateActualStorageUsage (H4 — reconcile basis = files.createdBy)', () => {
+    it('returns 0 when the user created no files', async () => {
+      vi.mocked(storageRepository.findFilesByCreator).mockResolvedValue([]);
 
       const result = await calculateActualStorageUsage('user-1');
 
       expect(result).toBe(0);
-      expect(storageRepository.sumFileSize).not.toHaveBeenCalled();
+      expect(storageRepository.findFilesByCreator).toHaveBeenCalledWith('user-1');
     });
 
-    it('calculateActualStorageUsage_withDrives_returnsTotalFileSize', async () => {
-      vi.mocked(storageRepository.findUserDriveIds).mockResolvedValue(['drive-1']);
-      vi.mocked(storageRepository.sumFileSize).mockResolvedValue(1024);
+    it('sums the byte sizes of every file the user created (the charge population)', async () => {
+      vi.mocked(storageRepository.findFilesByCreator).mockResolvedValue([
+        { sizeBytes: 1024 },
+        { sizeBytes: 2048 },
+      ]);
 
       const result = await calculateActualStorageUsage('user-1');
 
-      expect(result).toBe(1024);
-      expect(storageRepository.sumFileSize).toHaveBeenCalledWith(['drive-1']);
+      expect(result).toBe(3072);
+    });
+
+    it('does NOT scope to owned drives (cross-drive uploads are still the uploader\'s bytes)', async () => {
+      vi.mocked(storageRepository.findFilesByCreator).mockResolvedValue([{ sizeBytes: 500 }]);
+
+      await calculateActualStorageUsage('user-1');
+
+      // The owner-drive query is the H4 bug; reconcile must not use it.
+      expect(storageRepository.findUserDriveIds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('userReferencesContentHash (H3)', () => {
+    it('delegates to the repository with user, hash, and drive', async () => {
+      vi.mocked(storageRepository.userReferencesContentHash).mockResolvedValue(true);
+
+      const result = await userReferencesContentHash('user-1', 'a'.repeat(64), 'drive-1');
+
+      expect(result).toBe(true);
+      expect(storageRepository.userReferencesContentHash).toHaveBeenCalledWith('user-1', 'a'.repeat(64), 'drive-1');
     });
   });
 
@@ -381,6 +408,83 @@ describe('storage-limits', () => {
 
     it('parseBytes_withNullInput_throwsError', () => {
       expect(() => parseBytes(null as unknown as string)).toThrow('Invalid size parameter');
+    });
+  });
+
+  describe('toByteCount', () => {
+    it('passes through a positive integer', () => {
+      expect(toByteCount(1024)).toBe(1024);
+    });
+
+    it('coerces a BIGINT-as-string to a number', () => {
+      expect(toByteCount('2048')).toBe(2048);
+    });
+
+    it('floors a fractional value to an integer', () => {
+      expect(toByteCount(1024.9)).toBe(1024);
+    });
+
+    it('treats null/undefined/negative/NaN as 0', () => {
+      expect(toByteCount(null)).toBe(0);
+      expect(toByteCount(undefined)).toBe(0);
+      expect(toByteCount(-5)).toBe(0);
+      expect(toByteCount('not-a-number')).toBe(0);
+    });
+  });
+
+  describe('sumStorageBytes (H4)', () => {
+    it('returns 0 for an empty population', () => {
+      expect(sumStorageBytes([])).toBe(0);
+    });
+
+    it('sums numeric byte sizes', () => {
+      expect(sumStorageBytes([{ sizeBytes: 100 }, { sizeBytes: 200 }, { sizeBytes: 300 }])).toBe(600);
+    });
+
+    it('sums BIGINT-as-string byte sizes (Postgres bigint mode)', () => {
+      expect(sumStorageBytes([{ sizeBytes: '100' }, { sizeBytes: '250' }])).toBe(350);
+    });
+
+    it('ignores null/garbage rows so one bad row cannot poison the total', () => {
+      expect(sumStorageBytes([{ sizeBytes: 100 }, { sizeBytes: null }, { sizeBytes: 'x' as unknown as string }])).toBe(100);
+    });
+  });
+
+  describe('shouldChargeForStore (M8 — charge once, on first physical store)', () => {
+    it('charges when the files row was newly inserted', () => {
+      expect(shouldChargeForStore(true)).toBe(true);
+    });
+
+    it('does not charge on a dedup completion (row already existed)', () => {
+      expect(shouldChargeForStore(false)).toBe(false);
+    });
+  });
+
+  describe('computeStorageCreditOnUnlink (M8 — credit once, to the uploader)', () => {
+    const base = { createdBy: 'u1', sizeBytes: 2048, deletedByThisCall: true, hadPhysicalBlob: true };
+
+    it('credits the uploader the negative byte delta when this call deleted the row', () => {
+      expect(computeStorageCreditOnUnlink(base)).toEqual({ userId: 'u1', deltaBytes: -2048 });
+    });
+
+    it('coerces BIGINT-as-string sizes and negates them', () => {
+      expect(computeStorageCreditOnUnlink({ ...base, sizeBytes: '4096' })).toEqual({ userId: 'u1', deltaBytes: -4096 });
+    });
+
+    it('returns null when another reap already deleted the row (race-safe)', () => {
+      expect(computeStorageCreditOnUnlink({ ...base, deletedByThisCall: false })).toBeNull();
+    });
+
+    it('returns null for a DB-only stub whose bytes were never persisted', () => {
+      expect(computeStorageCreditOnUnlink({ ...base, hadPhysicalBlob: false })).toBeNull();
+    });
+
+    it('returns null when createdBy was nulled by a user-delete cascade', () => {
+      expect(computeStorageCreditOnUnlink({ ...base, createdBy: null })).toBeNull();
+    });
+
+    it('returns null for a zero / invalid byte size', () => {
+      expect(computeStorageCreditOnUnlink({ ...base, sizeBytes: 0 })).toBeNull();
     });
   });
 

--- a/packages/lib/src/services/__tests__/upload-semaphore.test.ts
+++ b/packages/lib/src/services/__tests__/upload-semaphore.test.ts
@@ -180,6 +180,8 @@ describe('upload-semaphore', () => {
       const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
       vi.advanceTimersByTime(11 * 60 * 1000); // past the 10-minute slot timeout
       expect(uploadSemaphore.verifySlotOwner(slot!, 'user-1')).toBe(false);
+      // Reclamation is durable/async (DB decrement awaited before in-memory removal).
+      await vi.advanceTimersByTimeAsync(0);
       expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
     });
   });
@@ -225,11 +227,12 @@ describe('upload-semaphore', () => {
       await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
 
       // Past the 10-minute slot timeout; advancing 11 minutes also fires the
-      // once-a-minute cleanup interval.
-      vi.advanceTimersByTime(11 * 60 * 1000);
+      // once-a-minute cleanup interval. Async so the durable decrement + in-memory
+      // removal microtasks flush.
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
 
-      expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
       expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+      expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
     });
 
     it('decrements the DB counter when an expired slot is reclaimed via verifySlotOwner', async () => {
@@ -238,6 +241,7 @@ describe('upload-semaphore', () => {
       vi.advanceTimersByTime(10 * 60 * 1000 + 1);
 
       expect(uploadSemaphore.verifySlotOwner(slot!, 'user-1')).toBe(false);
+      // The async decrement is invoked synchronously up to its await.
       expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
     });
 
@@ -246,6 +250,36 @@ describe('upload-semaphore', () => {
       uploadSemaphore.releaseUploadSlot(slot!);
 
       expect(mockUpdateActiveUploads).not.toHaveBeenCalled();
+    });
+
+    it('does NOT double-decrement: a claimed slot (taken by a completing route) is skipped by the sweep', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024, {
+        contentHash: 'a'.repeat(64), driveId: 'd', fileSize: 1024, mimeType: 'image/png',
+      });
+      // A route claims the slot for completion (it will do its own DB decrement).
+      uploadSemaphore.getSlotMetadata(slot!, 'user-1');
+
+      // The slot then times out while the route is still in flight.
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+
+      // Sweep reclaimed the in-memory permit but did NOT touch the DB counter.
+      expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
+      expect(mockUpdateActiveUploads).not.toHaveBeenCalled();
+    });
+
+    it('keeps the slot for retry when the DB decrement fails (durable)', async () => {
+      await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      mockUpdateActiveUploads.mockRejectedValueOnce(new Error('db down'));
+
+      // First sweep: decrement fails → slot retained.
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+      expect(uploadSemaphore.getStatus().activeSlots).toBe(1);
+
+      // Next sweep (60s later): decrement succeeds → slot reclaimed.
+      mockUpdateActiveUploads.mockResolvedValue(undefined);
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+      expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
     });
   });
 });

--- a/packages/lib/src/services/__tests__/upload-semaphore.test.ts
+++ b/packages/lib/src/services/__tests__/upload-semaphore.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+const mockUpdateActiveUploads = vi.fn();
+
 vi.mock('../storage-limits', () => ({
   STORAGE_TIERS: {
     free: { maxConcurrentUploads: 2 },
@@ -7,6 +9,7 @@ vi.mock('../storage-limits', () => ({
     pro: { maxConcurrentUploads: 5 },
     enterprise: { maxConcurrentUploads: 10 },
   },
+  updateActiveUploads: (...args: unknown[]) => mockUpdateActiveUploads(...args),
 }));
 
 vi.mock('../../logging/logger-config', () => ({
@@ -21,6 +24,8 @@ describe('upload-semaphore', () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     vi.resetModules();
+    mockUpdateActiveUploads.mockReset();
+    mockUpdateActiveUploads.mockResolvedValue(undefined);
 
     // UPLOAD_MAX_PERMITS controls global limit; default in tests is env var or 20
     process.env.UPLOAD_MAX_PERMITS = '3';
@@ -212,6 +217,35 @@ describe('upload-semaphore', () => {
       const status = uploadSemaphore.getStatus();
       expect(status.activeSlots).toBe(0);
       expect(status.globalSlotsAvailable).toBe(3);
+    });
+  });
+
+  describe('L8 — stale-slot sweep decrements the DB activeUploads counter', () => {
+    it('decrements the DB counter for a slot abandoned past the timeout (cron sweep)', async () => {
+      await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+
+      // Past the 10-minute slot timeout; advancing 11 minutes also fires the
+      // once-a-minute cleanup interval.
+      vi.advanceTimersByTime(11 * 60 * 1000);
+
+      expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
+      expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+    });
+
+    it('decrements the DB counter when an expired slot is reclaimed via verifySlotOwner', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      // Do not cross a full cleanup tick; reclaim happens through verifySlotOwner.
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
+
+      expect(uploadSemaphore.verifySlotOwner(slot!, 'user-1')).toBe(false);
+      expect(mockUpdateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+    });
+
+    it('does NOT decrement the DB counter on a normal release (the route does that)', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      uploadSemaphore.releaseUploadSlot(slot!);
+
+      expect(mockUpdateActiveUploads).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/lib/src/services/__tests__/upload-validation.test.ts
+++ b/packages/lib/src/services/__tests__/upload-validation.test.ts
@@ -6,6 +6,8 @@ import {
   validateTtl,
   buildS3Key,
   buildPresignParams,
+  canClaimExistingObject,
+  canFinalizeUpload,
 } from '../upload-validation';
 
 describe('validateContentHash', () => {
@@ -227,5 +229,39 @@ describe('buildPresignParams', () => {
     const params = buildPresignParams(hash, 'drive-2', 'video.mp4', 'video/mp4', 999, 300);
     expect(params.fileSize).toBe(999);
     expect(params.ttlSeconds).toBe(300);
+  });
+});
+
+describe('canClaimExistingObject (H3 — presign dedup fast-path gate)', () => {
+  const contentHash = 'a'.repeat(64);
+
+  it('allows the dedup fast-path when the caller already references the hash', () => {
+    expect(canClaimExistingObject({ contentHash, callerAlreadyReferences: true })).toBe(true);
+  });
+
+  it('denies the fast-path when the caller does not reference the hash (cross-tenant claim)', () => {
+    expect(canClaimExistingObject({ contentHash, callerAlreadyReferences: false })).toBe(false);
+  });
+
+  it('decision is independent of the hash value (a known hash is never sufficient on its own)', () => {
+    expect(canClaimExistingObject({ contentHash: 'f'.repeat(64), callerAlreadyReferences: false })).toBe(false);
+  });
+});
+
+describe('canFinalizeUpload (H3 — /complete link gate)', () => {
+  it('allows linking when the caller already references the hash (legit dedup)', () => {
+    expect(canFinalizeUpload({ callerAlreadyReferences: true, existedAtPresign: true })).toBe(true);
+  });
+
+  it('allows linking when this upload created the object (did not exist at presign)', () => {
+    expect(canFinalizeUpload({ callerAlreadyReferences: false, existedAtPresign: false })).toBe(true);
+  });
+
+  it('denies linking a pre-existing object the caller does not reference (the claim)', () => {
+    expect(canFinalizeUpload({ callerAlreadyReferences: false, existedAtPresign: true })).toBe(false);
+  });
+
+  it('allows a referencing caller even when the object existed (re-link of own file)', () => {
+    expect(canFinalizeUpload({ callerAlreadyReferences: true, existedAtPresign: false })).toBe(true);
   });
 });

--- a/packages/lib/src/services/__tests__/upload-validation.test.ts
+++ b/packages/lib/src/services/__tests__/upload-validation.test.ts
@@ -7,7 +7,7 @@ import {
   buildS3Key,
   buildPresignParams,
   canClaimExistingObject,
-  canFinalizeUpload,
+  canLinkExistingFileRow,
 } from '../upload-validation';
 
 describe('validateContentHash', () => {
@@ -248,20 +248,20 @@ describe('canClaimExistingObject (H3 — presign dedup fast-path gate)', () => {
   });
 });
 
-describe('canFinalizeUpload (H3 — /complete link gate)', () => {
-  it('allows linking when the caller already references the hash (legit dedup)', () => {
-    expect(canFinalizeUpload({ callerAlreadyReferences: true, existedAtPresign: true })).toBe(true);
+describe('canLinkExistingFileRow (H3 — atomic /complete link gate)', () => {
+  it('allows when this completion inserted the files row (first physical store)', () => {
+    expect(canLinkExistingFileRow({ fileWasInserted: true, ownedByCaller: false, callerAlreadyReferences: false })).toBe(true);
   });
 
-  it('allows linking when this upload created the object (did not exist at presign)', () => {
-    expect(canFinalizeUpload({ callerAlreadyReferences: false, existedAtPresign: false })).toBe(true);
+  it('allows when an existing files row is owned by the caller (re-link of own file)', () => {
+    expect(canLinkExistingFileRow({ fileWasInserted: false, ownedByCaller: true, callerAlreadyReferences: false })).toBe(true);
   });
 
-  it('denies linking a pre-existing object the caller does not reference (the claim)', () => {
-    expect(canFinalizeUpload({ callerAlreadyReferences: false, existedAtPresign: true })).toBe(false);
+  it('allows when the caller already references the hash (legit dedup)', () => {
+    expect(canLinkExistingFileRow({ fileWasInserted: false, ownedByCaller: false, callerAlreadyReferences: true })).toBe(true);
   });
 
-  it('allows a referencing caller even when the object existed (re-link of own file)', () => {
-    expect(canFinalizeUpload({ callerAlreadyReferences: true, existedAtPresign: false })).toBe(true);
+  it('denies linking a files row owned by another tenant the caller does not reference (the claim / TOCTOU)', () => {
+    expect(canLinkExistingFileRow({ fileWasInserted: false, ownedByCaller: false, callerAlreadyReferences: false })).toBe(false);
   });
 });

--- a/packages/lib/src/services/attachment-upload-repository.ts
+++ b/packages/lib/src/services/attachment-upload-repository.ts
@@ -14,7 +14,12 @@ import type { AttachmentTarget, FileRecordInput } from './attachment-upload-core
 
 export type { FileRecordInput };
 
-async function saveFileRecord(input: FileRecordInput): Promise<void> {
+/**
+ * Persist the content-addressed `files` row. Returns whether THIS call inserted
+ * the row (first physical store) so the caller can charge storage exactly once
+ * per blob (M8) instead of on every dedup completion.
+ */
+async function saveFileRecord(input: FileRecordInput): Promise<{ inserted: boolean }> {
   const inserted = await db
     .insert(files)
     .values(input)
@@ -28,7 +33,9 @@ async function saveFileRecord(input: FileRecordInput): Promise<void> {
     if (!existing) {
       throw new Error('Failed to load existing file metadata');
     }
+    return { inserted: false };
   }
+  return { inserted: true };
 }
 
 export interface LinkFileToTargetInput {

--- a/packages/lib/src/services/attachment-upload-repository.ts
+++ b/packages/lib/src/services/attachment-upload-repository.ts
@@ -14,61 +14,28 @@ import type { AttachmentTarget, FileRecordInput } from './attachment-upload-core
 
 export type { FileRecordInput };
 
-/**
- * Persist the content-addressed `files` row. Returns whether THIS call inserted
- * the row (first physical store) so the caller can charge storage exactly once
- * per blob (M8) instead of on every dedup completion.
- */
-async function saveFileRecord(input: FileRecordInput): Promise<{ inserted: boolean }> {
-  const inserted = await db
-    .insert(files)
-    .values(input)
-    .onConflictDoNothing()
-    .returning();
+// The transaction executor type (also satisfied by `db`), so the link helper can
+// run on the same transactional client as the file-row insert.
+type Executor = Parameters<Parameters<typeof db.transaction>[0]>[0] | typeof db;
 
-  if (inserted.length === 0) {
-    const existing = await db.query.files.findFirst({
-      where: eq(files.id, input.id),
-    });
-    if (!existing) {
-      throw new Error('Failed to load existing file metadata');
-    }
-    return { inserted: false };
-  }
-  return { inserted: true };
-}
-
-export interface LinkFileToTargetInput {
-  target: AttachmentTarget;
-  fileId: string;
-  userId: string;
-}
-
-async function linkFileToTarget(input: LinkFileToTargetInput): Promise<void> {
-  const { target, fileId, userId } = input;
-
+async function linkOnExecutor(
+  tx: Executor,
+  target: AttachmentTarget,
+  fileId: string,
+  userId: string,
+): Promise<void> {
   switch (target.type) {
     case 'page':
-      await db
+      await tx
         .insert(filePages)
-        .values({
-          fileId,
-          pageId: target.pageId,
-          linkedBy: userId,
-          linkSource: 'channel-upload',
-        })
+        .values({ fileId, pageId: target.pageId, linkedBy: userId, linkSource: 'channel-upload' })
         .onConflictDoNothing();
       return;
 
     case 'conversation':
-      await db
+      await tx
         .insert(fileConversations)
-        .values({
-          fileId,
-          conversationId: target.conversationId,
-          linkedBy: userId,
-          linkSource: 'dm-upload',
-        })
+        .values({ fileId, conversationId: target.conversationId, linkedBy: userId, linkSource: 'dm-upload' })
         .onConflictDoNothing();
       return;
 
@@ -82,7 +49,44 @@ async function linkFileToTarget(input: LinkFileToTargetInput): Promise<void> {
   }
 }
 
+export interface SaveFileRecordAndLinkInput {
+  fileRecord: FileRecordInput;
+  target: AttachmentTarget;
+  userId: string;
+}
+
+/**
+ * Persist the content-addressed `files` row AND its target linkage atomically in
+ * one transaction, returning whether THIS call inserted the file row (first
+ * physical store).
+ *
+ * Atomicity is the point (M8 retry-safety): if the link insert fails, the file
+ * row insert is rolled back too, so a retry re-inserts the row and `inserted`
+ * is true again — the single first-store storage charge is never permanently
+ * skipped by a transient linkage failure that left an orphaned, uncharged row.
+ */
+async function saveFileRecordAndLink(input: SaveFileRecordAndLinkInput): Promise<{ inserted: boolean }> {
+  const { fileRecord, target, userId } = input;
+  return db.transaction(async (tx) => {
+    const insertedRows = await tx
+      .insert(files)
+      .values(fileRecord)
+      .onConflictDoNothing()
+      .returning({ id: files.id });
+
+    const inserted = insertedRows.length > 0;
+    if (!inserted) {
+      const existing = await tx.query.files.findFirst({ where: eq(files.id, fileRecord.id) });
+      if (!existing) {
+        throw new Error('Failed to load existing file metadata');
+      }
+    }
+
+    await linkOnExecutor(tx, target, fileRecord.id, userId);
+    return { inserted };
+  });
+}
+
 export const attachmentUploadRepository = {
-  saveFileRecord,
-  linkFileToTarget,
+  saveFileRecordAndLink,
 };

--- a/packages/lib/src/services/storage-limits.ts
+++ b/packages/lib/src/services/storage-limits.ts
@@ -177,13 +177,105 @@ export async function updateActiveUploads(
 }
 
 /**
+ * Coerce a possibly-BIGINT-as-string / null / NaN byte value to a non-negative
+ * integer. Postgres returns BIGINT columns (e.g. files.sizeBytes) as strings.
+ */
+export function toByteCount(value: number | string | null | undefined): number {
+  const n = typeof value === 'string' ? Number(value) : (value ?? 0);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.floor(n);
+}
+
+/**
+ * H4 — sum a reconcile population (pure). The charge path bills the UPLOADER and
+ * a `files` row is created (createdBy = uploader) on the first physical store of
+ * every page-file AND attachment. So the population that reconcile must re-sum to
+ * match the charge basis is exactly the user's `files` rows — across drives, and
+ * including trashed-but-not-yet-purged ones (the `files` row survives until the
+ * orphan reaper deletes it). This pure summation is integer-safe and ignores
+ * null/garbage so a single bad row can't poison the total.
+ */
+export function sumStorageBytes(
+  rows: ReadonlyArray<{ sizeBytes: number | string | null }>,
+): number {
+  let total = 0;
+  for (const row of rows) total += toByteCount(row.sizeBytes);
+  return total;
+}
+
+/**
+ * M8 (charge side) — only charge storage on the FIRST physical store of a blob.
+ *
+ * Storage is content-addressed: the second+ uploader of identical bytes hits
+ * `files` ON CONFLICT DO NOTHING, so no new bytes are stored and `files.createdBy`
+ * stays the first uploader. Charging every /complete (the old behaviour) meant N
+ * charges but the reaper only ever credits `createdBy` once — a permanent quota
+ * leak for the non-first uploaders. Charging only when the row was newly inserted
+ * keeps the charge symmetric with the single credit at unlink.
+ */
+export function shouldChargeForStore(fileRowNewlyInserted: boolean): boolean {
+  return fileRowNewlyInserted;
+}
+
+export interface UnlinkCreditInput {
+  /** files.createdBy — the uploader who was charged on first physical store. */
+  createdBy: string | null;
+  sizeBytes: number | string | null;
+  /** Whether THIS reap call actually deleted the row (race-safe credit gate). */
+  deletedByThisCall: boolean;
+  /** False for DB-only stubs whose bytes were never persisted (no credit owed). */
+  hadPhysicalBlob: boolean;
+}
+
+export interface StorageCredit {
+  userId: string;
+  /** Negative byte delta to apply to the uploader's usage. */
+  deltaBytes: number;
+}
+
+/**
+ * M8 (credit side) — compute the storage credit owed when a content-addressed
+ * blob is unlinked/reaped (pure). Mirrors {@link shouldChargeForStore}: exactly
+ * one credit, to the uploader who paid the single first-store charge, and only
+ * when this call truly removed the row and real bytes existed. Returns null when
+ * no credit is owed. Integer bytes only.
+ */
+export function computeStorageCreditOnUnlink(input: UnlinkCreditInput): StorageCredit | null {
+  if (!input.deletedByThisCall) return null;
+  if (!input.hadPhysicalBlob) return null;
+  if (!input.createdBy) return null;
+  const bytes = toByteCount(input.sizeBytes);
+  if (bytes === 0) return null;
+  return { userId: input.createdBy, deltaBytes: -bytes };
+}
+
+/**
  * Calculate actual storage usage from database
  * Used for reconciliation and verification
+ *
+ * H4: sums the SAME population the charge path bills — the user's `files` rows
+ * (createdBy = userId) across every drive, including trashed-but-unpurged files.
+ * The old basis (FILE pages in drives the user OWNS, non-trashed only) diverged
+ * from charging: it missed channel/DM attachments, misattributed cross-drive
+ * uploads, and excluded trashed files — so `?reconcile=true` could be abused to
+ * reset usage downward (self-serve quota wipe).
  */
 export async function calculateActualStorageUsage(userId: string): Promise<number> {
-  const driveIds = await storageRepository.findUserDriveIds(userId);
-  if (driveIds.length === 0) return 0;
-  return storageRepository.sumFileSize(driveIds);
+  const rows = await storageRepository.findFilesByCreator(userId);
+  return sumStorageBytes(rows);
+}
+
+/**
+ * H3: whether the caller already legitimately references a content hash (so the
+ * dedup fast-path / linking a pre-existing object is safe for them). Delegates to
+ * the repository; the routes consume this through the service layer.
+ */
+export async function userReferencesContentHash(
+  userId: string,
+  contentHash: string,
+  driveId: string,
+): Promise<boolean> {
+  return storageRepository.userReferencesContentHash(userId, contentHash, driveId);
 }
 
 /**
@@ -205,12 +297,11 @@ export async function reconcileStorageUsage(userId: string): Promise<{
   difference: number;
 }> {
   const quota = await getUserStorageQuota(userId);
-  const actualUsage = await calculateActualStorageUsage(userId);
-
   if (!quota) {
     throw new Error('User not found');
   }
 
+  const actualUsage = await calculateActualStorageUsage(userId);
   const difference = actualUsage - quota.usedBytes;
 
   // Update if there's a discrepancy

--- a/packages/lib/src/services/storage-repository.ts
+++ b/packages/lib/src/services/storage-repository.ts
@@ -7,6 +7,7 @@ import { db } from '@pagespace/db/db';
 import { eq, sql, and, inArray } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { pages, drives, storageEvents } from '@pagespace/db/schema/core';
+import { files } from '@pagespace/db/schema/storage';
 
 export type DrizzleTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
@@ -44,16 +45,42 @@ export const storageRepository = {
     return userDrives.map((d: { id: string }) => d.id);
   },
 
-  sumFileSize: async (driveIds: string[]): Promise<number> => {
-    const result = await db
-      .select({ totalSize: sql<number>`COALESCE(SUM(CAST(${pages.fileSize} AS BIGINT)), 0)` })
-      .from(pages)
-      .where(and(
-        inArray(pages.driveId, driveIds),
-        eq(pages.type, 'FILE'),
-        eq(pages.isTrashed, false),
-      ));
-    return Number(result[0]?.totalSize ?? 0);
+  /**
+   * H4: the reconcile population — every `files` row the user uploaded
+   * (createdBy = userId), across all drives, including trashed-but-unpurged
+   * files (the `files` row outlives a trashed page until the reaper deletes it).
+   * Returns raw byte values; the pure `sumStorageBytes` does the integer-safe sum.
+   */
+  findFilesByCreator: async (userId: string): Promise<Array<{ sizeBytes: number }>> => {
+    const rows = await db
+      .select({ sizeBytes: files.sizeBytes })
+      .from(files)
+      .where(eq(files.createdBy, userId));
+    return rows.map((r: { sizeBytes: number | string | null }) => ({
+      sizeBytes: typeof r.sizeBytes === 'string' ? Number(r.sizeBytes) : (r.sizeBytes ?? 0),
+    }));
+  },
+
+  /**
+   * H3: does the caller already legitimately reference this content hash?
+   * True when the caller uploaded the blob before (files.createdBy = userId, in
+   * any drive) OR a FILE page in the target drive already points at the hash.
+   * Only such callers may take the dedup fast-path / link a pre-existing object.
+   */
+  userReferencesContentHash: async (
+    userId: string,
+    contentHash: string,
+    driveId: string,
+  ): Promise<boolean> => {
+    const result = await db.execute(sql`
+      SELECT 1 WHERE EXISTS (
+        SELECT 1 FROM files WHERE id = ${contentHash} AND "createdBy" = ${userId}
+      ) OR EXISTS (
+        SELECT 1 FROM pages
+        WHERE "contentHash" = ${contentHash} AND "driveId" = ${driveId} AND type = 'FILE'
+      )
+    `);
+    return result.rows.length > 0;
   },
 
   countFiles: async (driveIds: string[]): Promise<number> => {

--- a/packages/lib/src/services/upload-semaphore.ts
+++ b/packages/lib/src/services/upload-semaphore.ts
@@ -1,4 +1,4 @@
-import { STORAGE_TIERS } from './storage-limits';
+import { STORAGE_TIERS, updateActiveUploads } from './storage-limits';
 import { loggers } from '../logging/logger-config';
 import type { AttachmentTarget } from './attachment-upload-core';
 
@@ -20,6 +20,11 @@ export interface UploadSlotMetadata {
   fileSize: number;
   mimeType: string;
   attachmentTarget?: AttachmentTarget;
+  // H3 (page-file flow): server-trusted facts captured at presign so /complete
+  // can reject a cross-tenant claim without re-trusting the client. Optional —
+  // the attachment flow leaves them unset (it has its own verification path).
+  callerAlreadyReferences?: boolean;
+  existedAtPresign?: boolean;
 }
 
 interface UploadSlot {
@@ -149,6 +154,27 @@ class UploadSemaphore {
     };
   }
 
+  /**
+   * L8: release a slot abandoned past its timeout. Unlike the normal-completion
+   * path (where the route decrements users.activeUploads itself), an abandoned
+   * upload's presign-time +1 is never paired with a route-side -1, so this path
+   * MUST decrement the DB counter too — otherwise the counter ratchets up forever
+   * and would eventually falsely deny the user via checkConcurrentUploads.
+   */
+  private releaseStaleSlot(slotId: string): void {
+    const slot = this.activeSlots.get(slotId);
+    if (!slot) return;
+    const { userId } = slot;
+    this.releaseUploadSlot(slotId);
+    // Fire-and-forget: the in-memory slot is already reclaimed; a transient DB
+    // hiccup must not throw out of the once-a-minute sweep timer.
+    void updateActiveUploads(userId, -1).catch((err) => {
+      loggers.api.warn('Failed to decrement activeUploads for stale slot', {
+        slotId, userId, err: err as Error,
+      });
+    });
+  }
+
   private cleanupStaleSlots(): void {
     const now = Date.now();
     const staleSlots: string[] = [];
@@ -164,7 +190,7 @@ class UploadSemaphore {
         staleCount: staleSlots.length,
         timeoutMinutes: this.slotTimeout / 60000,
       });
-      staleSlots.forEach(slotId => this.releaseUploadSlot(slotId));
+      staleSlots.forEach(slotId => this.releaseStaleSlot(slotId));
     }
   }
 
@@ -173,8 +199,9 @@ class UploadSemaphore {
     if (!slot || slot.userId !== userId) return false;
     // Reject (and reclaim) slots past the timeout rather than waiting for the
     // once-a-minute sweep — a stale jobId must not still authorize a completion.
+    // Reclaim via releaseStaleSlot so the abandoned DB counter is decremented too.
     if (Date.now() - slot.acquiredAt.getTime() > this.slotTimeout) {
-      this.releaseUploadSlot(slotId);
+      this.releaseStaleSlot(slotId);
       return false;
     }
     return true;

--- a/packages/lib/src/services/upload-semaphore.ts
+++ b/packages/lib/src/services/upload-semaphore.ts
@@ -20,11 +20,12 @@ export interface UploadSlotMetadata {
   fileSize: number;
   mimeType: string;
   attachmentTarget?: AttachmentTarget;
-  // H3 (page-file flow): server-trusted facts captured at presign so /complete
-  // can reject a cross-tenant claim without re-trusting the client. Optional —
-  // the attachment flow leaves them unset (it has its own verification path).
+  // H3 (page-file flow): server-trusted fact captured at presign so /complete can
+  // gate the dedup link without re-trusting the client. Optional — the attachment
+  // flow leaves it unset (it has its own verification path). The authoritative
+  // anti-claim check at /complete is the atomic `files`-row ownership claim, not
+  // this hint.
   callerAlreadyReferences?: boolean;
-  existedAtPresign?: boolean;
 }
 
 interface UploadSlot {
@@ -32,6 +33,11 @@ interface UploadSlot {
   acquiredAt: Date;
   fileSize: number;
   metadata?: UploadSlotMetadata;
+  // L8: set once a completing/cancelling route has taken ownership of this slot
+  // (via getSlotMetadata). A claimed slot's DB activeUploads decrement is owned
+  // by that route, so the stale-slot sweep must NOT also decrement it (else the
+  // counter is double-decremented if the route's work outlives the timeout).
+  claimed?: boolean;
 }
 
 class UploadSemaphore {
@@ -160,19 +166,35 @@ class UploadSemaphore {
    * upload's presign-time +1 is never paired with a route-side -1, so this path
    * MUST decrement the DB counter too — otherwise the counter ratchets up forever
    * and would eventually falsely deny the user via checkConcurrentUploads.
+   *
+   * Two correctness rules:
+   *  - A `claimed` slot is owned by an in-flight completion/cancel route that
+   *    will perform its own single decrement; skip the DB write here to avoid
+   *    double-decrementing (which would erase another upload's count).
+   *  - Make the decrement durable: confirm the DB write succeeded BEFORE
+   *    forgetting the in-memory slot, so a transient failure leaves the slot for
+   *    the next 60s sweep to retry rather than losing the counter permanently.
    */
-  private releaseStaleSlot(slotId: string): void {
+  private async releaseStaleSlot(slotId: string): Promise<void> {
     const slot = this.activeSlots.get(slotId);
     if (!slot) return;
-    const { userId } = slot;
-    this.releaseUploadSlot(slotId);
-    // Fire-and-forget: the in-memory slot is already reclaimed; a transient DB
-    // hiccup must not throw out of the once-a-minute sweep timer.
-    void updateActiveUploads(userId, -1).catch((err) => {
-      loggers.api.warn('Failed to decrement activeUploads for stale slot', {
-        slotId, userId, err: err as Error,
+
+    if (slot.claimed) {
+      // An in-flight route owns the DB decrement; just reclaim the in-memory permit.
+      this.releaseUploadSlot(slotId);
+      return;
+    }
+
+    try {
+      await updateActiveUploads(slot.userId, -1);
+    } catch (err) {
+      // Keep the slot so the next sweep retries the decrement; do not forget it.
+      loggers.api.warn('Stale-slot activeUploads decrement failed; will retry next sweep', {
+        slotId, userId: slot.userId, err: err as Error,
       });
-    });
+      return;
+    }
+    this.releaseUploadSlot(slotId);
   }
 
   private cleanupStaleSlots(): void {
@@ -190,7 +212,9 @@ class UploadSemaphore {
         staleCount: staleSlots.length,
         timeoutMinutes: this.slotTimeout / 60000,
       });
-      staleSlots.forEach(slotId => this.releaseStaleSlot(slotId));
+      // Fire each release; releaseStaleSlot is durable (keeps the slot on DB
+      // failure) and self-guards, so an unhandled rejection can't escape here.
+      staleSlots.forEach(slotId => { void this.releaseStaleSlot(slotId); });
     }
   }
 
@@ -201,7 +225,7 @@ class UploadSemaphore {
     // once-a-minute sweep — a stale jobId must not still authorize a completion.
     // Reclaim via releaseStaleSlot so the abandoned DB counter is decremented too.
     if (Date.now() - slot.acquiredAt.getTime() > this.slotTimeout) {
-      this.releaseStaleSlot(slotId);
+      void this.releaseStaleSlot(slotId);
       return false;
     }
     return true;
@@ -214,7 +238,13 @@ class UploadSemaphore {
    */
   getSlotMetadata(slotId: string, userId: string): UploadSlotMetadata | null {
     if (!this.verifySlotOwner(slotId, userId)) return null;
-    return this.activeSlots.get(slotId)?.metadata ?? null;
+    const slot = this.activeSlots.get(slotId);
+    if (!slot) return null;
+    // The caller is taking ownership of this slot to complete the upload; mark it
+    // claimed so the stale-slot sweep won't also decrement the DB counter while
+    // this (possibly long) completion is in flight (see releaseStaleSlot).
+    slot.claimed = true;
+    return slot.metadata ?? null;
   }
 
   releaseUserSlots(userId: string): void {

--- a/packages/lib/src/services/upload-validation.ts
+++ b/packages/lib/src/services/upload-validation.ts
@@ -115,21 +115,29 @@ export function canClaimExistingObject(args: {
  *
  * Forcing the PUT at presign is not sufficient on its own: an attacker handed a
  * presigned URL can simply skip it and call /complete, where a bare
- * object-existence check would still link the pre-existing (victim's) object.
+ * object-existence check would still link the pre-existing (victim's) object —
+ * including through a presign→complete race where the object is created by a
+ * different tenant between presign and completion.
  *
- * So /complete may create the page→file link only when:
- *  - the caller already references this hash (legitimate dedup), OR
- *  - the object did NOT exist at presign time, i.e. this very upload created it
- *    (the caller demonstrably possessed the bytes to PUT them).
+ * The authoritative, race-proof proof-of-ownership is the content-addressed
+ * `files` row, claimed atomically inside the completion transaction:
+ *  - `fileWasInserted` — THIS completion inserted the `files` row, so the caller
+ *    is the first physical storer and demonstrably possessed the bytes; OR
+ *  - `ownedByCaller` — an existing `files` row was created by this caller (e.g. a
+ *    re-link of their own file after the page was deleted but before reap); OR
+ *  - `callerAlreadyReferences` — a page in the caller's drive already points at
+ *    the hash (legitimate dedup).
  *
- * Linking to an object that pre-existed and that the caller does not already
- * reference is exactly the cross-tenant claim, and is rejected.
+ * Any other case is a caller trying to link bytes they never uploaded and is
+ * rejected (the transaction rolls back). This replaces the earlier
+ * `existedAtPresign` snapshot, which a presign→complete race could defeat.
  */
-export function canFinalizeUpload(args: {
+export function canLinkExistingFileRow(args: {
+  fileWasInserted: boolean;
+  ownedByCaller: boolean;
   callerAlreadyReferences: boolean;
-  existedAtPresign: boolean;
 }): boolean {
-  return args.callerAlreadyReferences || !args.existedAtPresign;
+  return args.fileWasInserted || args.ownedByCaller || args.callerAlreadyReferences;
 }
 
 export function buildPresignParams(

--- a/packages/lib/src/services/upload-validation.ts
+++ b/packages/lib/src/services/upload-validation.ts
@@ -89,6 +89,49 @@ export function buildS3Key(hash: string): string {
   return `files/${hash}/original`;
 }
 
+/**
+ * H3 — cross-tenant file-claim defense (presign fast-path gate).
+ *
+ * Storage is content-addressed in a GLOBAL namespace (`files/${hash}/original`),
+ * so a content hash a caller scraped from a presigned URL or a `contentHash` API
+ * field is enough to find that another tenant's bytes already exist in S3. The
+ * old presign returned `{ alreadyExists: true }` purely on object existence,
+ * letting any caller skip the PUT and then /complete a FILE page in THEIR drive
+ * pointing at the foreign object — a permanent, revocation-surviving claim.
+ *
+ * The dedup fast-path (skip the proof-of-possession PUT) is therefore honored
+ * ONLY when the same user/drive already references the hash. Everyone else is
+ * routed through an actual presigned PUT so they must possess the bytes.
+ */
+export function canClaimExistingObject(args: {
+  contentHash: string;
+  callerAlreadyReferences: boolean;
+}): boolean {
+  return args.callerAlreadyReferences;
+}
+
+/**
+ * H3 — cross-tenant file-claim defense (/complete link gate).
+ *
+ * Forcing the PUT at presign is not sufficient on its own: an attacker handed a
+ * presigned URL can simply skip it and call /complete, where a bare
+ * object-existence check would still link the pre-existing (victim's) object.
+ *
+ * So /complete may create the page→file link only when:
+ *  - the caller already references this hash (legitimate dedup), OR
+ *  - the object did NOT exist at presign time, i.e. this very upload created it
+ *    (the caller demonstrably possessed the bytes to PUT them).
+ *
+ * Linking to an object that pre-existed and that the caller does not already
+ * reference is exactly the cross-tenant claim, and is rejected.
+ */
+export function canFinalizeUpload(args: {
+  callerAlreadyReferences: boolean;
+  existedAtPresign: boolean;
+}): boolean {
+  return args.callerAlreadyReferences || !args.existedAtPresign;
+}
+
 export function buildPresignParams(
   hash: string,
   driveId: string,


### PR DESCRIPTION
Security remediation **WO-02** — closes audit findings **H3, H4, M8, L8** (PageSpace security audit 2026-06-09). Strict TDD: every security decision is isolated into a **pure function**; routes/services stay thin.

## Findings & attacks closed

### H3 — Cross-tenant file claim via content-hash dedup (CRITICAL)
Storage is a **global** content-addressed namespace (`files/${hash}/original`). Hashes are not secret (they appear in presigned URLs and `contentHash`/`fileMetadata` API fields), so any caller could presign a known hash → `{alreadyExists:true}` (no bytes) → `/complete` a FILE page in **their** drive pointing at **another tenant's** object — a permanent, revocation-surviving cross-tenant read.

**Fix (two layers):**
1. **Presign** (`canClaimExistingObject`): the dedup fast-path (skip the proof-of-possession PUT) is honored only when the caller **already references** the hash. If the object exists and the caller does not reference it, presign rejects — and never hands a canonical-key PUT URL to a non-possessor (which would let them overwrite/corrupt another tenant's bytes).
2. **Complete** (`canLinkExistingFileRow`, atomic): the content-addressed `files` row is claimed **first inside the completion transaction**. Linking is permitted only when this completion inserted the row (first physical store ⇒ caller possessed the bytes), the existing row's `createdBy` is the caller, or the caller already references the hash. Anything else rolls the transaction back (409). Because ownership is decided atomically at commit (not from a presign-time snapshot), this also closes the **presign→complete race** where another tenant could create the object between presign and completion.

> Remaining tradeoff (by design): under a single global content-addressed namespace, a user cannot link bytes another tenant already owns unless they reference them — so cross-tenant dedup of identical content is intentionally blocked (security-first). Per-drive storage namespacing would restore cross-tenant dedup UX and is a separate, cross-app follow-up.

### H4 — Reconcile used a different accounting basis than charging (self-serve quota wipe, HIGH)
Charging bills the **uploader** (a `files` row, `createdBy`=uploader, per blob), but reconcile recomputed from **non-trashed FILE pages in OWNED drives** — missing channel/DM attachments, misattributing cross-drive uploads, excluding trashed-but-unpurged files. So `GET /api/storage/info?reconcile=true` (or trash→reconcile→restore loops) reset usage downward.

**Fix:** reconcile sums the **same population** charging uses — `files.sizeBytes WHERE createdBy = user`, across all drives, including trashed-but-unpurged — via the pure `sumStorageBytes`. `?reconcile=true` is additionally **admin-gated**.

### M8 — Dedup: N charges, 1 credit → permanent quota leak (MEDIUM)
Every `/complete` charged the uploader, but `files.createdBy` stays the first uploader and the reaper credits once, to them.

**Fix:** charge **only on the first physical store** of a blob (`shouldChargeForStore`) for both page-file and attachment uploads — symmetric with the single credit the reaper issues at unlink (`computeStorageCreditOnUnlink`). For attachments, the file-row insert **and** target link now run in **one transaction** (`saveFileRecordAndLink`) so a transient link failure rolls back the insert; a retry re-inserts and is charged, never leaving uncharged orphaned bytes.

### L8 — `users.activeUploads` ratcheted up on abandoned uploads (LOW)
Presign increments the DB counter; the stale-slot sweep released only the in-memory slot.

**Fix:** the stale-slot sweep **and** the `verifySlotOwner` expiry path now decrement the DB counter, with two safeguards:
- **No double-decrement:** a slot claimed by an in-flight completion route (via `getSlotMetadata`) is skipped by the sweep's DB decrement — that route owns its single decrement.
- **Durable:** the DB decrement is confirmed **before** the in-memory slot is forgotten, so a transient failure leaves the slot for the next 60s sweep to retry.

## Pure functions (with tests)
`canClaimExistingObject`, `canLinkExistingFileRow` (upload-validation) · `sumStorageBytes`, `toByteCount`, `shouldChargeForStore`, `computeStorageCreditOnUnlink` (storage-limits).

## Review hardening (Codex + CodeRabbit)
- **P1** presign→complete TOCTOU → replaced the `existedAtPresign` snapshot with the atomic `files`-row ownership claim above.
- **P2** attachment charge lost on link-failure retry → atomic `saveFileRecordAndLink`.
- **P2 / Major** semaphore double-decrement + non-durable decrement → `claimed`-slot skip + decrement-before-forget with retry.
- BIGINT precision note: `files.sizeBytes` is `bigint(mode:'number')` (already a JS number throughout) and per-file size is tier-capped ≤1GB, so totals stay far below `MAX_SAFE_INTEGER`; no change (would require a system-wide `mode:'bigint'` migration).

## Verification
- `bun run typecheck` — clean (lib + web)
- targeted `test:unit` — lib pure-fn suites + all apps/web upload/storage/file suites green
- `bun run lint` — clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- CodeQL `js/user-controlled-bypass` on `/api/storage/info`: kept the H4 defense-in-depth admin-gate but resolve `isAdmin` (via `validateAdminAccess`, DB-verified) **up front, before** the user-controlled `?reconcile=true` branch, so the privileged reconcile is gated on a non-user-controlled value. Non-admin reconcile still 403s; normal reads short-circuit (no extra DB read/logs).
