### PR TITLE
fix(ai): register `zai` in ALL_PROVIDER_NAMES so the public Z.ai provider is usable

### DIFF
--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -183,6 +183,20 @@ describe('AI settings route', () => {
       expect((await response.json()).providers.glm.isAvailable).toBe(true);
     });
 
+    it('reports the public zai provider available when the OpenRouter key is set', async () => {
+      // zai is OpenRouter-backed; without it in ALL_PROVIDER_NAMES the availability
+      // map omits it and the picker/agent-config show "Setup Required".
+      process.env.OPENROUTER_DEFAULT_API_KEY = 'or-key';
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).providers.zai.isAvailable).toBe(true);
+    });
+
+    it('reports the public zai provider unavailable when the OpenRouter key is unset', async () => {
+      delete process.env.OPENROUTER_DEFAULT_API_KEY;
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).providers.zai.isAvailable).toBe(false);
+    });
+
     it('does not expose a paid `openrouter` or `pagespace` provider key', async () => {
       process.env.OPENROUTER_DEFAULT_API_KEY = 'or-key';
 

--- a/apps/web/src/lib/ai/core/ai-utils.ts
+++ b/apps/web/src/lib/ai/core/ai-utils.ts
@@ -75,6 +75,7 @@ export const ALL_PROVIDER_NAMES = [
   'ai21',
   'inception',
   'writer',
+  'zai', // public OpenRouter-backed GLM family (z-ai/glm-*); distinct from admin-only `glm`
   // Local / on-prem
   'ollama',
   'lmstudio',


### PR DESCRIPTION
## Problem

After #1584 merged & deployed, the public **Z.ai** (`zai`) provider showed **"Setup Required"** in the AI agent config and chat picker (and couldn't be saved or used) even though the OpenRouter key is set.

## Root cause

`zai` was added to `AI_PROVIDERS` and `CLOUD_VENDOR_PROVIDERS` but **not** to `ALL_PROVIDER_NAMES` in `apps/web/src/lib/ai/core/ai-utils.ts`. That constant is the authoritative provider allowlist used in three places, all of which silently excluded `zai`:

1. **`buildProviderAvailabilityMap()`** iterates `ALL_PROVIDER_NAMES` to build the `{ provider: { isAvailable } }` map both AI GET routes return → no `zai` entry → picker (`ProviderModelSelector`) and agent config (`PageAgentSettingsTab` via `isProviderConfigured`) read `providers['zai']` as `undefined → isAvailable=false` → **"Setup Required"**.
2. **`/api/ai/settings` PATCH** rejects any provider not in the list → saving an agent/user config on `zai` returned **400 "Invalid provider"**.
3. **`/api/ai/chat`** rejects requests whose provider isn't in the list → a `zai` chat call was refused at runtime.

## Fix

Add `'zai'` to the cloud-vendor section of `ALL_PROVIDER_NAMES`. `getManagedProviderKey('zai')` already resolves to `OPENROUTER_DEFAULT_API_KEY` (since `getBackendProvider('zai') === 'openrouter'`), so it now reports available and both validators accept it. The derived `ProviderName` union auto-extends; billing already handles `z-ai/*` (real OpenRouter cost). One-line change + test.

## Tests
- Added: `providers.zai.isAvailable === true` when the OpenRouter key is set, `false` when unset (mirrors the existing `glm` assertions).
- `bun run --filter 'web' typecheck` + lint clean; settings route test (29) green.

## Note on GLM (admin)
`glm` is already in `ALL_PROVIDER_NAMES`, so it's unaffected by this bug. If **Z.ai (Admin)** still shows "Setup Required" after this fix, verify `GLM_CODER_DEFAULT_API_KEY` is set on the deployed web app and the account's role is `admin` — no code change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)