### PR TITLE
fix(mentions): validate mention targets before sync so literal format examples cannot crash document saves

### DIFF
--- a/apps/web/src/services/api/__tests__/page-mention-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-mention-service.test.ts
@@ -294,6 +294,28 @@ describe('syncMentions — group mention expansion is fail-soft', () => {
     expect(result.newlyMentionedUserIds).toEqual([]);
   });
 
+  it('defers direct user mentions too when expansion fails — never syncs a partial recipient set', async () => {
+    // Direct and group-derived rows are indistinguishable in userMentions, so
+    // syncing only the direct set would delete the group-derived rows. The
+    // whole user-mention sync waits for the next successful save instead.
+    vi.mocked(getDriveRecipientUserIds).mockRejectedValueOnce(new Error('drive query failed'));
+    const { tx, userMentionInserts, deletes } = makeTx({
+      existingUserIds: ['user42', 'member-1'],
+      existingUserMentions: ['member-1'],
+    });
+
+    const result = await syncMentions(
+      'source-page',
+      'Hey @[Alice](user42:user) and @[everyone](everyone:everyone)',
+      tx as unknown as AnyTx,
+      { driveId: 'drive-1', mentionedByUserId: 'author-1' }
+    );
+
+    expect(userMentionInserts).toHaveLength(0);
+    expect(deletes.filter(d => d.table === userMentions)).toHaveLength(0);
+    expect(result.newlyMentionedUserIds).toEqual([]);
+  });
+
   it('still syncs page mentions when group expansion fails', async () => {
     vi.mocked(getDriveRecipientUserIds).mockRejectedValueOnce(new Error('drive query failed'));
     const { tx, mentionInserts } = makeTx({ existingPageIds: ['page123'] });

--- a/apps/web/src/services/api/__tests__/page-mention-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-mention-service.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Schema tables are opaque markers in these tests; the mock tx dispatches on
+// object identity to decide which "table" a query targets.
+vi.mock('@pagespace/db/schema/core', () => ({
+  mentions: {
+    sourcePageId: 'mentions.sourcePageId',
+    targetPageId: 'mentions.targetPageId',
+  },
+  userMentions: {
+    sourcePageId: 'userMentions.sourcePageId',
+    targetUserId: 'userMentions.targetUserId',
+  },
+  pages: { id: 'pages.id' },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'users.id' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a, b) => ['eq', a, b]),
+  and: vi.fn((...c) => ['and', ...c]),
+  inArray: vi.fn((c, v) => ['inArray', c, v]),
+}));
+// The service imports `db` only to derive types; provide a stub so the module loads.
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: vi.fn(async () => []),
+  getDriveMemberUserIdsByStandardRole: vi.fn(async () => []),
+  getDriveMemberUserIdsByCustomRole: vi.fn(async () => []),
+}));
+
+import { syncMentions } from '../page-mention-service';
+import { mentions, userMentions, pages } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import {
+  getDriveRecipientUserIds,
+  getDriveMemberUserIdsByCustomRole,
+} from '@pagespace/lib/services/drive-member-service';
+
+/**
+ * Build a mock transaction that behaves like Postgres with the real FK
+ * constraints: inserting a mention whose targetPageId is not an existing page
+ * (or a user mention whose targetUserId is not an existing user) rejects,
+ * mirroring `mentions_targetPageId_pages_id_fk` in production.
+ */
+function makeTx(state: {
+  existingPageIds?: string[];
+  existingUserIds?: string[];
+  existingMentions?: string[];      // current mentions.targetPageId rows for the source page
+  existingUserMentions?: string[];  // current userMentions.targetUserId rows
+} = {}) {
+  const {
+    existingPageIds = [],
+    existingUserIds = [],
+    existingMentions = [],
+    existingUserMentions = [],
+  } = state;
+
+  const mentionInserts: Array<Record<string, unknown>> = [];
+  const userMentionInserts: Array<Record<string, unknown>> = [];
+  const deletes: Array<{ table: unknown; cond: unknown }> = [];
+
+  const tx = {
+    select: vi.fn(() => ({
+      from: (table: unknown) => ({
+        where: (cond: unknown[]) => {
+          if (table === mentions) {
+            return Promise.resolve(existingMentions.map(targetPageId => ({ targetPageId })));
+          }
+          if (table === userMentions) {
+            return Promise.resolve(existingUserMentions.map(targetUserId => ({ targetUserId })));
+          }
+          if (table === pages) {
+            const ids = (cond?.[2] as string[]) ?? [];
+            return Promise.resolve(ids.filter(id => existingPageIds.includes(id)).map(id => ({ id })));
+          }
+          if (table === users) {
+            const ids = (cond?.[2] as string[]) ?? [];
+            return Promise.resolve(ids.filter(id => existingUserIds.includes(id)).map(id => ({ id })));
+          }
+          return Promise.resolve([]);
+        },
+      }),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: (vals: Array<Record<string, unknown>>) => {
+        if (table === mentions) {
+          for (const row of vals) {
+            if (!existingPageIds.includes(row.targetPageId as string)) {
+              return Promise.reject(new Error(
+                'insert or update on table "mentions" violates foreign key constraint "mentions_targetPageId_pages_id_fk"'
+              ));
+            }
+          }
+          mentionInserts.push(...vals);
+        }
+        if (table === userMentions) {
+          for (const row of vals) {
+            if (!existingUserIds.includes(row.targetUserId as string)) {
+              return Promise.reject(new Error(
+                'insert or update on table "user_mentions" violates foreign key constraint "userMentions_targetUserId_users_id_fk"'
+              ));
+            }
+          }
+          userMentionInserts.push(...vals);
+        }
+        return Promise.resolve();
+      },
+    })),
+    delete: vi.fn((table: unknown) => ({
+      where: (cond: unknown) => {
+        deletes.push({ table, cond });
+        return Promise.resolve();
+      },
+    })),
+  };
+
+  return { tx, mentionInserts, userMentionInserts, deletes };
+}
+
+type AnyTx = Parameters<typeof syncMentions>[2];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('syncMentions — literal mention-format examples must not crash saves', () => {
+  it('saves a document containing the literal text @[Label](id:type) as plain prose with zero mention rows', async () => {
+    const { tx, mentionInserts, userMentionInserts } = makeTx();
+    const content = '<p>Mentions use the format @[Label](id:type) in markdown.</p>';
+
+    const result = await syncMentions('source-page', content, tx as unknown as AnyTx);
+
+    expect(mentionInserts).toHaveLength(0);
+    expect(userMentionInserts).toHaveLength(0);
+    expect(result.newlyMentionedUserIds).toEqual([]);
+  });
+
+  it('saves a document containing @[Label](id:type) inside <code> with zero mention rows', async () => {
+    const { tx, mentionInserts } = makeTx();
+    const content = '<p>Example:</p><code>@[Label](id:type)</code>';
+
+    await expect(syncMentions('source-page', content, tx as unknown as AnyTx)).resolves.toBeDefined();
+    expect(mentionInserts).toHaveLength(0);
+  });
+
+  it('saves a document containing @[Label](id:type) inside <pre> with zero mention rows', async () => {
+    const { tx, mentionInserts } = makeTx();
+    const content = '<pre>@[Docs Page](id:page)\n@[Someone](id:user)</pre>';
+
+    await expect(syncMentions('source-page', content, tx as unknown as AnyTx)).resolves.toBeDefined();
+    expect(mentionInserts).toHaveLength(0);
+  });
+
+  it('does not parse literal user-mention examples into user mention rows', async () => {
+    const { tx, userMentionInserts } = makeTx();
+    const content = 'To mention a user write @[Their Name](id:user) anywhere.';
+
+    await expect(syncMentions('source-page', content, tx as unknown as AnyTx)).resolves.toBeDefined();
+    expect(userMentionInserts).toHaveLength(0);
+  });
+});
+
+describe('syncMentions — valid mentions still sync', () => {
+  it('inserts a page mention whose target page exists (markdown branch)', async () => {
+    const { tx, mentionInserts } = makeTx({ existingPageIds: ['page123'] });
+
+    await syncMentions('source-page', 'See @[My Page](page123:page)', tx as unknown as AnyTx);
+
+    expect(mentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetPageId: 'page123' },
+    ]);
+  });
+
+  it('inserts a page mention from the HTML branch (data-page-id anchor)', async () => {
+    const { tx, mentionInserts } = makeTx({ existingPageIds: ['page123'] });
+    const content = '<p><a data-page-id="page123">My Page</a></p>';
+
+    await syncMentions('source-page', content, tx as unknown as AnyTx);
+
+    expect(mentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetPageId: 'page123' },
+    ]);
+  });
+
+  it('deletes a previously synced mention when it is removed from content', async () => {
+    const { tx, mentionInserts, deletes } = makeTx({
+      existingPageIds: ['page123'],
+      existingMentions: ['page123'],
+    });
+
+    await syncMentions('source-page', '<p>no more mentions</p>', tx as unknown as AnyTx);
+
+    expect(mentionInserts).toHaveLength(0);
+    const mentionDeletes = deletes.filter(d => d.table === mentions);
+    expect(mentionDeletes).toHaveLength(1);
+  });
+
+  it('does not re-insert an already-synced mention', async () => {
+    const { tx, mentionInserts, deletes } = makeTx({
+      existingPageIds: ['page123'],
+      existingMentions: ['page123'],
+    });
+
+    await syncMentions('source-page', 'Still here: @[My Page](page123:page)', tx as unknown as AnyTx);
+
+    expect(mentionInserts).toHaveLength(0);
+    expect(deletes.filter(d => d.table === mentions)).toHaveLength(0);
+  });
+
+  it('inserts a user mention whose target user exists and reports it as newly mentioned', async () => {
+    const { tx, userMentionInserts } = makeTx({ existingUserIds: ['user42'] });
+
+    const result = await syncMentions(
+      'source-page',
+      'Hey @[Alice](user42:user)',
+      tx as unknown as AnyTx,
+      { mentionedByUserId: 'author-1' }
+    );
+
+    expect(userMentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetUserId: 'user42', mentionedByUserId: 'author-1' },
+    ]);
+    expect(result.newlyMentionedUserIds).toEqual(['user42']);
+  });
+});
+
+describe('syncMentions — nonexistent targets are dropped silently', () => {
+  it('drops a mention of a nonexistent page ID without throwing', async () => {
+    const { tx, mentionInserts } = makeTx({ existingPageIds: ['real-page'] });
+
+    const result = await syncMentions(
+      'source-page',
+      '@[Real](real-page:page) and @[Gone](deleted-page:page)',
+      tx as unknown as AnyTx
+    );
+
+    expect(mentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetPageId: 'real-page' },
+    ]);
+    expect(result).toBeDefined();
+  });
+
+  it('drops a mention of a nonexistent user ID without throwing', async () => {
+    const { tx, userMentionInserts } = makeTx({ existingUserIds: [] });
+
+    const result = await syncMentions(
+      'source-page',
+      '@[Ghost](no-such-user:user)',
+      tx as unknown as AnyTx,
+      { mentionedByUserId: 'author-1' }
+    );
+
+    expect(userMentionInserts).toHaveLength(0);
+    expect(result.newlyMentionedUserIds).toEqual([]);
+  });
+});
+
+describe('syncMentions — group mention expansion is fail-soft', () => {
+  it('does not destroy the save when @everyone expansion throws', async () => {
+    vi.mocked(getDriveRecipientUserIds).mockRejectedValueOnce(new Error('drive query failed'));
+    const { tx, userMentionInserts } = makeTx();
+
+    await expect(
+      syncMentions('source-page', 'Hi @[everyone](everyone:everyone)', tx as unknown as AnyTx, {
+        driveId: 'drive-1',
+      })
+    ).resolves.toBeDefined();
+    expect(userMentionInserts).toHaveLength(0);
+  });
+
+  it('still validates group-expanded user IDs before inserting', async () => {
+    // Expansion returns one real and one stale user; only the real one is inserted.
+    vi.mocked(getDriveMemberUserIdsByCustomRole).mockResolvedValueOnce(['real-user', 'stale-user']);
+    const { tx, userMentionInserts } = makeTx({ existingUserIds: ['real-user'] });
+
+    await syncMentions('source-page', '@[Designers](role-1:role)', tx as unknown as AnyTx, {
+      driveId: 'drive-1',
+    });
+
+    expect(userMentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetUserId: 'real-user', mentionedByUserId: null },
+    ]);
+  });
+});
+
+describe('syncMentions — HTML branch skips mention nodes inside code regions', () => {
+  it('ignores data-page-id anchors inside <pre> and <code> but keeps ones outside', async () => {
+    const { tx, mentionInserts } = makeTx({ existingPageIds: ['outside', 'inside-pre', 'inside-code'] });
+    const content =
+      '<p><a data-page-id="outside">Real</a></p>' +
+      '<pre><a data-page-id="inside-pre">Example</a></pre>' +
+      '<code><a data-page-id="inside-code">Example</a></code>';
+
+    await syncMentions('source-page', content, tx as unknown as AnyTx);
+
+    expect(mentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetPageId: 'outside' },
+    ]);
+  });
+});

--- a/apps/web/src/services/api/__tests__/page-mention-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-mention-service.test.ts
@@ -272,6 +272,44 @@ describe('syncMentions — group mention expansion is fail-soft', () => {
     expect(userMentionInserts).toHaveLength(0);
   });
 
+  it('preserves existing user-mention rows when expansion fails instead of treating the empty set as authoritative', async () => {
+    // The doc still contains the group mention; a transient drive-member
+    // lookup failure must not delete the group-derived rows (which a later
+    // successful save would recreate and re-notify).
+    vi.mocked(getDriveRecipientUserIds).mockRejectedValueOnce(new Error('drive query failed'));
+    const { tx, userMentionInserts, deletes } = makeTx({
+      existingUserIds: ['member-1', 'member-2'],
+      existingUserMentions: ['member-1', 'member-2'],
+    });
+
+    const result = await syncMentions(
+      'source-page',
+      'Hi @[everyone](everyone:everyone)',
+      tx as unknown as AnyTx,
+      { driveId: 'drive-1' }
+    );
+
+    expect(userMentionInserts).toHaveLength(0);
+    expect(deletes.filter(d => d.table === userMentions)).toHaveLength(0);
+    expect(result.newlyMentionedUserIds).toEqual([]);
+  });
+
+  it('still syncs page mentions when group expansion fails', async () => {
+    vi.mocked(getDriveRecipientUserIds).mockRejectedValueOnce(new Error('drive query failed'));
+    const { tx, mentionInserts } = makeTx({ existingPageIds: ['page123'] });
+
+    await syncMentions(
+      'source-page',
+      '@[My Page](page123:page) cc @[everyone](everyone:everyone)',
+      tx as unknown as AnyTx,
+      { driveId: 'drive-1' }
+    );
+
+    expect(mentionInserts).toEqual([
+      { sourcePageId: 'source-page', targetPageId: 'page123' },
+    ]);
+  });
+
   it('still validates group-expanded user IDs before inserting', async () => {
     // Expansion returns one real and one stale user; only the real one is inserted.
     vi.mocked(getDriveMemberUserIdsByCustomRole).mockResolvedValueOnce(['real-user', 'stale-user']);

--- a/apps/web/src/services/api/page-mention-service.ts
+++ b/apps/web/src/services/api/page-mention-service.ts
@@ -227,28 +227,36 @@ export async function syncMentions(
   const { pageIds: extractedPageIds, userIds: directUserIds, groupMentions } = extracted;
 
   // Expand group mentions (@everyone, @role) to individual user IDs. Role IDs
-  // also come from content, so expansion is fail-soft: on error the group
-  // mention is dropped and the save proceeds.
+  // also come from content, so expansion is fail-soft: on error the save
+  // proceeds, but user-mention sync is skipped for this save — substituting an
+  // empty recipient set would delete existing group-derived rows and a later
+  // successful save would recreate them and re-notify.
   let expandedUserIds: string[] = [];
+  let expansionFailed = false;
   if (groupMentions.length > 0 && options?.driveId) {
     try {
       expandedUserIds = await expandGroupMentions(groupMentions, options.driveId);
     } catch (error) {
-      loggers.api.error('Failed to expand group mentions; dropping group recipients:', error as Error);
+      loggers.api.error('Failed to expand group mentions; skipping user-mention sync for this save:', error as Error);
+      expansionFailed = true;
     }
   }
-
-  // Merge direct and group-expanded user IDs, preserving uniqueness
-  const allUserIdSet = new Set([...directUserIds, ...expandedUserIds]);
 
   // Validate every extracted ID against the database before any insert —
   // nonexistent targets (literal examples, deleted pages, stale users) are
   // dropped silently instead of violating an FK mid-transaction.
   const mentionedPageIds = await filterToExistingPageIds(extractedPageIds, tx);
-  const mentionedUserIds = await filterToExistingUserIds(Array.from(allUserIdSet), tx);
 
   // Sync page mentions
   await syncPageMentions(sourcePageId, mentionedPageIds, tx);
+
+  if (expansionFailed) {
+    return emptyResult;
+  }
+
+  // Merge direct and group-expanded user IDs, preserving uniqueness
+  const allUserIdSet = new Set([...directUserIds, ...expandedUserIds]);
+  const mentionedUserIds = await filterToExistingUserIds(Array.from(allUserIdSet), tx);
 
   // Sync user mentions and get newly created user IDs
   const newlyMentionedUserIds = await syncUserMentions(sourcePageId, mentionedUserIds, tx, options?.mentionedByUserId);

--- a/apps/web/src/services/api/page-mention-service.ts
+++ b/apps/web/src/services/api/page-mention-service.ts
@@ -1,7 +1,8 @@
 import * as cheerio from 'cheerio';
 import { db } from '@pagespace/db/db'
 import { eq, and, inArray } from '@pagespace/db/operators'
-import { mentions, userMentions } from '@pagespace/db/schema/core';
+import { mentions, userMentions, pages } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   getDriveRecipientUserIds,
@@ -26,6 +27,18 @@ interface MentionIds {
 
 const STANDARD_ROLES = new Set(['OWNER', 'ADMIN', 'MEMBER']);
 
+/**
+ * Remove <pre> and <code> regions so documentation that shows literal mention
+ * syntax (e.g. a doc explaining `@[Label](id:type)`) is never parsed as a real
+ * mention. Without this, the placeholder "id" reaches the mentions insert and
+ * fails the FK, aborting the caller's whole save transaction.
+ */
+function stripCodeRegions(content: string): string {
+  return content
+    .replace(/<pre\b[^>]*>[\s\S]*?<\/pre\s*>/gi, ' ')
+    .replace(/<code\b[^>]*>[\s\S]*?<\/code\s*>/gi, ' ');
+}
+
 function findMentionNodes(content: unknown): MentionIds {
   const pageIds: string[] = [];
   const userIds: string[] = [];
@@ -43,6 +56,8 @@ function findMentionNodes(content: unknown): MentionIds {
   if (shouldParseHtml) {
     try {
       const $ = cheerio.load(contentStr);
+      // Code regions hold literal examples, not real mentions.
+      $('pre, code').remove();
       $('a[data-page-id]').each((_, element) => {
         const pageId = $(element).attr('data-page-id');
         if (pageId) pageIds.push(pageId);
@@ -82,9 +97,10 @@ function findMentionNodes(content: unknown): MentionIds {
 
   if (!shouldParseHtml || parseFailed) {
     // Parse markdown-style mentions: @[Label](id:type)
+    const searchable = stripCodeRegions(contentStr);
     const regex = /@\[([^\]]{1,500})\]\(([^:)]{1,200}):?([^)]{0,200})\)/g;
     let match;
-    while ((match = regex.exec(contentStr)) !== null) {
+    while ((match = regex.exec(searchable)) !== null) {
       const id = match[2];
       const type = match[3] || 'page';
       if (type === 'user') {
@@ -152,23 +168,84 @@ export interface SyncMentionsResult {
   mentionedByUserId?: string;
 }
 
+/**
+ * Filter extracted page IDs down to pages that actually exist. Mention IDs
+ * come from user-authored content (and can be literal format examples like
+ * `@[Label](id:type)`), so an unvalidated insert can violate the
+ * mentions_targetPageId FK and abort the caller's save transaction.
+ * Nonexistent IDs are dropped silently — a bad mention must never fail a save.
+ */
+async function filterToExistingPageIds(
+  pageIds: string[],
+  tx: TransactionType | DatabaseType
+): Promise<string[]> {
+  if (pageIds.length === 0) return [];
+  const rows = await tx
+    .select({ id: pages.id })
+    .from(pages)
+    .where(inArray(pages.id, pageIds));
+  const existing = new Set(rows.map(r => r.id));
+  return pageIds.filter(id => existing.has(id));
+}
+
+/** Same FK hazard as page IDs: userMentions.targetUserId references users.id. */
+async function filterToExistingUserIds(
+  userIds: string[],
+  tx: TransactionType | DatabaseType
+): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  const rows = await tx
+    .select({ id: users.id })
+    .from(users)
+    .where(inArray(users.id, userIds));
+  const existing = new Set(rows.map(r => r.id));
+  return userIds.filter(id => existing.has(id));
+}
+
 export async function syncMentions(
   sourcePageId: string,
   content: unknown,
   tx: TransactionType | DatabaseType,
   options?: SyncMentionsOptions
 ): Promise<SyncMentionsResult> {
-  const { pageIds: mentionedPageIds, userIds: directUserIds, groupMentions } = findMentionNodes(content);
+  const emptyResult: SyncMentionsResult = {
+    newlyMentionedUserIds: [],
+    sourcePageId,
+    mentionedByUserId: options?.mentionedByUserId,
+  };
 
-  // Expand group mentions (@everyone, @role) to individual user IDs
+  // Mention sync runs inside the caller's save transaction, so a throw here on
+  // bad content poisons the whole save. Content parsing failures skip the sync
+  // (existing mention rows are left untouched) rather than failing the save.
+  let extracted: MentionIds;
+  try {
+    extracted = findMentionNodes(content);
+  } catch (error) {
+    loggers.api.error('Failed to parse content for mentions; skipping mention sync:', error as Error);
+    return emptyResult;
+  }
+  const { pageIds: extractedPageIds, userIds: directUserIds, groupMentions } = extracted;
+
+  // Expand group mentions (@everyone, @role) to individual user IDs. Role IDs
+  // also come from content, so expansion is fail-soft: on error the group
+  // mention is dropped and the save proceeds.
   let expandedUserIds: string[] = [];
   if (groupMentions.length > 0 && options?.driveId) {
-    expandedUserIds = await expandGroupMentions(groupMentions, options.driveId);
+    try {
+      expandedUserIds = await expandGroupMentions(groupMentions, options.driveId);
+    } catch (error) {
+      loggers.api.error('Failed to expand group mentions; dropping group recipients:', error as Error);
+    }
   }
 
   // Merge direct and group-expanded user IDs, preserving uniqueness
   const allUserIdSet = new Set([...directUserIds, ...expandedUserIds]);
-  const mentionedUserIds = Array.from(allUserIdSet);
+
+  // Validate every extracted ID against the database before any insert —
+  // nonexistent targets (literal examples, deleted pages, stale users) are
+  // dropped silently instead of violating an FK mid-transaction.
+  const mentionedPageIds = await filterToExistingPageIds(extractedPageIds, tx);
+  const mentionedUserIds = await filterToExistingUserIds(Array.from(allUserIdSet), tx);
 
   // Sync page mentions
   await syncPageMentions(sourcePageId, mentionedPageIds, tx);


### PR DESCRIPTION
## Problem

Production document saves (including the MCP `replace_lines` route) were returning 500 with:

```
insert or update on table "mentions" violates foreign key constraint "mentions_targetPageId_pages_id_fk"
```

Any document whose content contains a **literal mention-format example** like `@[Label](id:type)` — e.g. documentation *about* the mention system — became permanently un-editable: every save re-parses the content, the markdown-regex branch of `findMentionNodes` extracts the placeholder `id` as a `targetPageId`, the unvalidated insert hits the FK, and because `syncMentions` runs inside the caller's save transaction, the **whole save rolls back**.

## Fix (all in `apps/web/src/services/api/page-mention-service.ts`)

1. **Validate before insert** — extracted page IDs are filtered to rows that exist in `pages` (single `inArray` select), and user IDs (direct *and* group-expanded) to rows that exist in `users`, before any insert. Nonexistent IDs are dropped silently; a bad mention must never fail a save. This is the primary guarantee — once a statement fails inside a Postgres transaction, the tx is poisoned, so catching after the fact can't help.
2. **Fail-soft on bad content** — content parsing and group-mention expansion (`@everyone` / `@role`, whose role IDs also come from content) are wrapped: on error they log and skip mention sync instead of throwing into the caller's transaction. Per Codex review, an expansion failure skips user-mention sync entirely (existing `userMentions` rows are preserved — an empty recipient set is never treated as authoritative, so no delete/recreate/re-notify churn); page-mention sync still runs. Callers are untouched; sync stays inside the transaction.
3. **Code regions are documentation, not mentions** — `<pre>`/`<code>` contents are stripped before the markdown-regex branch, and the cheerio HTML branch removes `pre, code` subtrees before extracting mention nodes. This also sets the defensive-parsing pattern for the upcoming Universal Commands token format `/[Label](commandId:command)`.

## Survey of other `@[Label](id:type)` regex users

- `apps/web/src/lib/channels/extract-user-mentions.ts` / `expand-group-mentions.ts` → channel & DM message routes: extracted IDs only reach **broadcasts and notifications**, gated by `canUserViewPage` / participant intersection (false for nonexistent users), and the `createMentionNotification` call is `.catch`-wrapped. No user-facing save can fail. **No change.**
- `apps/web/src/lib/ai/core/mention-processor.ts` → read-only prompt building, no DB writes. **No change.**

## Tests (`page-mention-service.test.ts`, 17 new — mock tx simulates the real FK constraints)

- Regression: saving content with literal `@[Label](id:type)` as plain prose, inside `<code>`, and inside `<pre>` succeeds with **zero** mention rows
- Valid existing page ID still syncs (markdown + HTML branches); removal still deletes; no duplicate re-insert
- Nonexistent page ID dropped silently while valid ones in the same doc still sync
- User-mention path with nonexistent user ID does not throw; valid user still inserts and is reported in `newlyMentionedUserIds`
- Group expansion failure is fail-soft: the save succeeds, existing user-mention rows are preserved (zero deletes/inserts), direct user mentions defer to the next successful save (a partial recipient set is never treated as authoritative), and page mentions still sync; group-expanded user IDs are also existence-validated
- HTML branch skips `data-page-id` anchors inside `pre`/`code` but keeps ones outside

## Verification

- `bunx vitest run src/services/api` — 11 files, 159 tests passed
- `bun run typecheck` — 13/13 tasks green

Note: the repo's changelog tooling (`scripts/changelog/`) was removed in #1044 and recent fix PRs carry no changelog file, so there is no changelog entry to update — this PR body serves as the user-visible note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for mention synchronization functionality.

* **Bug Fixes**
  * Mentions appearing inside code blocks no longer create mention records.
  * Mention syncing is now more resilient and gracefully handles invalid or nonexistent targets.
  * Added database validation to prevent mention-related data integrity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
