### PR TITLE
fix(uploads): grant files:ingest on upload tokens; fix CORS-blocked file downloads

### DIFF
--- a/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
@@ -363,6 +363,19 @@ describe('POST /api/account/avatar', () => {
       expect(response.status).toBe(500);
       expect(body.error).toBe('Failed to upload avatar');
     });
+
+    it('returns 504 when the processor upload times out', async () => {
+      mockSelectChain([{ image: null }]);
+      // fetch with AbortSignal.timeout rejects with DOMException TimeoutError
+      mockFetch.mockRejectedValue(new DOMException('The operation timed out', 'TimeoutError'));
+
+      const file = createMockFile('image/png', 1024);
+      const response = await POST(createUploadRequest(file));
+      const body = await response.json();
+
+      expect(response.status).toBe(504);
+      expect(body.error).toBe('Avatar upload timed out, please try again');
+    });
   });
 
   describe('successful upload', () => {

--- a/apps/web/src/app/api/account/avatar/route.ts
+++ b/apps/web/src/app/api/account/avatar/route.ts
@@ -78,7 +78,10 @@ export async function POST(request: NextRequest) {
             method: 'DELETE',
             headers: {
               'Authorization': `Bearer ${serviceToken}`
-            }
+            },
+            // Best-effort cleanup; bounded so a stalled processor can't pin
+            // the request slot before the upload fetch below is reached.
+            signal: AbortSignal.timeout(10_000),
           });
         } catch (error) {
           console.log('Could not delete old avatar:', error);

--- a/apps/web/src/app/api/account/avatar/route.ts
+++ b/apps/web/src/app/api/account/avatar/route.ts
@@ -100,13 +100,28 @@ export async function POST(request: NextRequest) {
       userId: userId,
     });
 
-    const processorResponse = await fetch(uploadUrl, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${serviceToken}`
-      },
-      body: processorFormData,
-    });
+    // Bounded so a stalled processor can't pin this request slot open —
+    // the web instance has a hard cap on concurrent requests.
+    let processorResponse: Response;
+    try {
+      processorResponse = await fetch(uploadUrl, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${serviceToken}`
+        },
+        body: processorFormData,
+        signal: AbortSignal.timeout(60_000),
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        console.error('Processor avatar upload timed out', { userId });
+        return NextResponse.json(
+          { error: 'Avatar upload timed out, please try again' },
+          { status: 504 }
+        );
+      }
+      throw err;
+    }
 
     if (!processorResponse.ok) {
       const errorData = await processorResponse.json().catch(() => ({}));

--- a/apps/web/src/app/api/files/[id]/download/__tests__/route.test.ts
+++ b/apps/web/src/app/api/files/[id]/download/__tests__/route.test.ts
@@ -132,6 +132,38 @@ describe('GET /api/files/[id]/download', () => {
     );
   });
 
+  it('returns JSON url when Accept: application/json for file page', async () => {
+    const request = new Request('http://localhost/api/files/file-1/download', {
+      headers: { Accept: 'application/json' },
+    });
+    const response = await GET(request as never, { params: Promise.resolve({ id: mockFileId }) });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { url: string };
+    expect(body.url).toBe('https://fly.storage.tigris.dev/presigned-download');
+  });
+
+  it('returns JSON url when Accept: application/json for attachment file', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(null as never);
+    vi.mocked(db.query.files.findFirst).mockResolvedValue({
+      id: mockFileId,
+      driveId: null,
+      storagePath: VALID_HASH,
+      mimeType: 'image/png',
+      sizeBytes: 10,
+    } as never);
+    vi.mocked(canUserAccessFile).mockResolvedValue(true);
+
+    const request = new Request('http://localhost/api/files/file-1/download?filename=dm.png', {
+      headers: { Accept: 'application/json' },
+    });
+    const response = await GET(request as never, { params: Promise.resolve({ id: mockFileId }) });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as { url: string };
+    expect(body.url).toBe('https://fly.storage.tigris.dev/presigned-download');
+  });
+
   it('normalizes legacy storagePath files/{hash}/original before presigning', async () => {
     const LEGACY_PATH = `files/${VALID_HASH}/original`;
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(null as never);

--- a/apps/web/src/app/api/files/[id]/download/route.ts
+++ b/apps/web/src/app/api/files/[id]/download/route.ts
@@ -32,6 +32,10 @@ export async function GET(
     const { id } = await context.params;
     const { searchParams } = new URL(request.url);
     const filenameParam = searchParams.get('filename');
+    // JSON mode lets the client fetch the presigned URL without credentials.
+    // A credentialed fetch following the 307 into Tigris fails CORS (the
+    // bucket never sends Access-Control-Allow-Credentials).
+    const wantsJson = request.headers.get('Accept')?.includes('application/json') ?? false;
 
     const user = await verifyAuth(request);
     if (!user) {
@@ -65,6 +69,7 @@ export async function GET(
 
       auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'file', resourceId: page.id, details: { source: 'download', mimeType } });
 
+      if (wantsJson) return NextResponse.json({ url: presignedUrl });
       return NextResponse.redirect(presignedUrl, 307);
     }
 
@@ -92,6 +97,7 @@ export async function GET(
 
     auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'file', resourceId: file.id, details: { source: 'download', mimeType } });
 
+    if (wantsJson) return NextResponse.json({ url: presignedUrl });
     return NextResponse.redirect(presignedUrl, 307);
 
   } catch (error) {

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -310,7 +310,7 @@ export async function POST(request: Request) {
     } catch (err) {
       // Best-effort by design, but the page now has no derived content
       // (thumbnails/OCR/extraction) until reprocessed — keep this loud.
-      loggers.api.error('Failed to enqueue processor job', err as Error, {
+      loggers.api.error('Failed to enqueue processor job', err instanceof Error ? err : new Error(String(err)), {
         userId,
         driveId,
         pageId: newPage.id,

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -12,6 +12,7 @@ import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { buildS3Key, canLinkExistingFileRow } from '@pagespace/lib/services/upload-validation';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logFileActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { enqueueProcessorJob } from '@/lib/upload/processor-effects';
 import { checkObjectExists } from '@/lib/upload/s3-effects';
 
@@ -307,7 +308,13 @@ export async function POST(request: Request) {
     try {
       await enqueueProcessorJob(userId, driveId, newPage.id);
     } catch (err) {
-      console.error('Failed to enqueue processor job:', err);
+      // Best-effort by design, but the page now has no derived content
+      // (thumbnails/OCR/extraction) until reprocessed — keep this loud.
+      loggers.api.error('Failed to enqueue processor job', err as Error, {
+        userId,
+        driveId,
+        pageId: newPage.id,
+      });
     }
 
     // M8: charge only on the first physical store of the blob (symmetric with the

--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -85,12 +85,23 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
 
     setIsDownloading(true);
     try {
-      const response = await fetchWithAuth(`/api/files/${page.id}/download`);
+      // Two-step fetch: get the presigned URL as JSON, then fetch it without
+      // credentials. Letting fetchWithAuth follow the 307 into Tigris fails
+      // CORS — its credentialed mode needs Access-Control-Allow-Credentials,
+      // which the bucket never sends.
+      const response = await fetchWithAuth(`/api/files/${page.id}/download`, {
+        headers: { Accept: 'application/json' },
+      });
       if (!response.ok) {
         throw new Error('Failed to download file');
       }
+      const { url: presignedUrl } = await response.json() as { url: string };
 
-      const blob = await response.blob();
+      const fileRes = await fetch(presignedUrl);
+      if (!fileRes.ok) {
+        throw new Error(`Failed to download file bytes: ${fileRes.status}`);
+      }
+      const blob = await fileRes.blob();
       const url = window.URL.createObjectURL(blob);
       const a = window.document.createElement('a');
       a.href = url;

--- a/packages/lib/src/services/__tests__/attachment-upload.test.ts
+++ b/packages/lib/src/services/__tests__/attachment-upload.test.ts
@@ -103,6 +103,9 @@ describe('createAttachmentUploadServiceToken', () => {
         driveId: 'drive-1',
         pageId: 'page-1',
         parentId: 'page-1',
+        // Attachments verify via /api/verify and never enqueue ingestion, so
+        // they must NOT inherit files:ingest from the page-upload default.
+        scopes: ['files:write'],
       });
       expect(result.token).toBe('ps_svc_page-token');
       // Conversation path must not run

--- a/packages/lib/src/services/__tests__/validated-service-token.test.ts
+++ b/packages/lib/src/services/__tests__/validated-service-token.test.ts
@@ -736,6 +736,32 @@ describe('createValidatedServiceToken', () => {
       );
     });
 
+    it('narrows granted scopes when an explicit scopes option is passed', async () => {
+      // Arrange - user has drive edit permission
+      (getUserDrivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue({
+        hasAccess: true,
+        isOwner: false,
+        isAdmin: false,
+        isMember: true,
+        canEdit: true,
+      });
+
+      // Act — attachment flows pass ['files:write'] so they don't inherit
+      // files:ingest from the page-upload default
+      const result = await createUploadServiceToken({
+        userId: 'user-1',
+        driveId: 'drive-1',
+        pageId: 'new-page-1',
+        scopes: ['files:write'],
+      });
+
+      // Assert
+      expect(result.grantedScopes).toEqual(['files:write']);
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ scopes: ['files:write'] })
+      );
+    });
+
     it('throws PermissionDeniedError when user lacks page edit permission', async () => {
       // Arrange - parent page exists in correct drive
       mockFindFirst.mockResolvedValue({ driveId: 'drive-1' });

--- a/packages/lib/src/services/__tests__/validated-service-token.test.ts
+++ b/packages/lib/src/services/__tests__/validated-service-token.test.ts
@@ -685,8 +685,9 @@ describe('createValidatedServiceToken', () => {
         parentId: 'parent-page-1',
       });
 
-      // Assert
-      expect(result.grantedScopes).toEqual(['files:write']);
+      // Assert — files:ingest must be granted so the post-upload enqueue can
+      // pass the processor's requireScope('files:ingest') on /api/ingest
+      expect(result.grantedScopes).toEqual(['files:write', 'files:ingest']);
       expect(result.token).toBe('ps_svc_mock-session-token');
       expect(mockFindFirst).toHaveBeenCalledWith(expect.objectContaining({
         columns: { driveId: true },
@@ -698,7 +699,7 @@ describe('createValidatedServiceToken', () => {
           resourceId: 'new-page-1',
           resourceType: 'page',
           driveId: 'drive-1',
-          scopes: ['files:write'],
+          scopes: ['files:write', 'files:ingest'],
         })
       );
     });
@@ -721,7 +722,7 @@ describe('createValidatedServiceToken', () => {
       });
 
       // Assert
-      expect(result.grantedScopes).toEqual(['files:write']);
+      expect(result.grantedScopes).toEqual(['files:write', 'files:ingest']);
       expect(result.token).toBe('ps_svc_mock-session-token');
       expect(getUserDrivePermissions).toHaveBeenCalledWith('user-1', 'drive-1');
       expect(getUserAccessLevel).not.toHaveBeenCalled();
@@ -730,7 +731,7 @@ describe('createValidatedServiceToken', () => {
           resourceId: 'new-page-1',
           resourceType: 'page',
           driveId: 'drive-1',
-          scopes: ['files:write'],
+          scopes: ['files:write', 'files:ingest'],
         })
       );
     });
@@ -885,7 +886,7 @@ describe('createValidatedServiceToken', () => {
           driveId: 'drive-1',
           pageId: 'new-page-1',
           permissionSource: 'drive',
-          scopes: ['files:write'],
+          scopes: ['files:write', 'files:ingest'],
         })
       );
     });

--- a/packages/lib/src/services/attachment-upload.ts
+++ b/packages/lib/src/services/attachment-upload.ts
@@ -55,18 +55,22 @@ export async function createAttachmentUploadServiceToken(
 
   switch (target.type) {
     case 'page': {
+      // Attachments are verified via /api/verify (files:write) and never
+      // enqueue processor ingestion, so don't inherit files:ingest from the
+      // page-upload default scopes.
       const result = await createUploadServiceToken({
         userId,
         driveId: target.driveId,
         pageId: target.pageId,
         parentId: target.pageId,
+        scopes: UPLOAD_SCOPES,
       });
       loggers.api.info('Attachment upload token grant', {
         userId,
         targetType: 'page',
         pageId: target.pageId,
         driveId: target.driveId,
-        scopes: UPLOAD_SCOPES,
+        scopes: result.grantedScopes,
       });
       return { token: result.token };
     }

--- a/packages/lib/src/services/validated-service-token.ts
+++ b/packages/lib/src/services/validated-service-token.ts
@@ -468,8 +468,14 @@ export async function createFileServiceToken(
   };
 }
 
-/** Scopes granted for file upload operations */
-const UPLOAD_SCOPES: ServiceScope[] = ['files:write'];
+/**
+ * Scopes granted for file upload operations.
+ *
+ * `files:ingest` is required by the processor's `/api/ingest` mount — the
+ * post-upload enqueue (`/api/upload/complete` → `/api/ingest/pull/{pageId}`)
+ * is rejected 403 without it, silently skipping thumbnails/OCR/extraction.
+ */
+const UPLOAD_SCOPES: ServiceScope[] = ['files:write', 'files:ingest'];
 
 /**
  * Options for creating an upload service token

--- a/packages/lib/src/services/validated-service-token.ts
+++ b/packages/lib/src/services/validated-service-token.ts
@@ -491,6 +491,12 @@ export interface UploadTokenOptions {
   parentId?: string;
   /** Token expiration (default '10m') */
   expiresIn?: string;
+  /**
+   * Scopes to grant (default {@link UPLOAD_SCOPES}). All requested scopes are
+   * gated behind the same canEdit check; callers that never enqueue ingestion
+   * (e.g. channel attachments) should narrow to ['files:write'].
+   */
+  scopes?: ServiceScope[];
 }
 
 /**
@@ -506,7 +512,7 @@ export interface UploadTokenOptions {
 export async function createUploadServiceToken(
   options: UploadTokenOptions
 ): Promise<ValidatedTokenResult> {
-  const { userId, driveId, pageId, parentId, expiresIn = '10m' } = options;
+  const { userId, driveId, pageId, parentId, expiresIn = '10m', scopes = UPLOAD_SCOPES } = options;
 
   let hasPermission = false;
   let permissionSource: 'parent_page' | 'drive';
@@ -567,13 +573,13 @@ export async function createUploadServiceToken(
     pageId,
     parentId,
     permissionSource,
-    scopes: UPLOAD_SCOPES,
+    scopes,
   });
 
   const token = await sessionService.createSession({
     userId,
     type: 'service',
-    scopes: UPLOAD_SCOPES as string[],
+    scopes: scopes as string[],
     resourceType: 'page',
     resourceId: pageId,
     driveId,
@@ -583,7 +589,7 @@ export async function createUploadServiceToken(
 
   return {
     token,
-    grantedScopes: UPLOAD_SCOPES,
+    grantedScopes: scopes,
   };
 }
 

--- a/scripts/reenqueue-unprocessed-uploads.ts
+++ b/scripts/reenqueue-unprocessed-uploads.ts
@@ -1,8 +1,11 @@
 import 'dotenv/config';
 import { db } from '@pagespace/db/db';
-import { pages } from '@pagespace/db/schema/core';
+import { drives, pages } from '@pagespace/db/schema/core';
 import { and, eq, sql } from '@pagespace/db/operators';
-import { createUploadServiceToken } from '@pagespace/lib/services/validated-service-token';
+import {
+  createUploadServiceToken,
+  isPermissionDeniedError,
+} from '@pagespace/lib/services/validated-service-token';
 
 /**
  * Re-enqueue processor ingestion for FILE pages whose post-upload enqueue was
@@ -33,8 +36,34 @@ if (Number.isNaN(SINCE.getTime())) {
   process.exit(1);
 }
 
-async function enqueue(userId: string, driveId: string, pageId: string): Promise<void> {
-  const { token } = await createUploadServiceToken({ userId, driveId, pageId });
+/**
+ * Mint an enqueue token as the original uploader, falling back to the drive
+ * owner. The uploader may have been removed or downgraded since the upload;
+ * the page and blob still belong to the drive, and the owner always has edit.
+ */
+async function mintToken(createdBy: string | null, driveId: string, pageId: string): Promise<string> {
+  if (createdBy) {
+    try {
+      const { token } = await createUploadServiceToken({ userId: createdBy, driveId, pageId });
+      return token;
+    } catch (err) {
+      if (!isPermissionDeniedError(err)) throw err;
+    }
+  }
+
+  const [drive] = await db
+    .select({ ownerId: drives.ownerId })
+    .from(drives)
+    .where(eq(drives.id, driveId))
+    .limit(1);
+  if (!drive) throw new Error(`Drive ${driveId} not found`);
+
+  const { token } = await createUploadServiceToken({ userId: drive.ownerId, driveId, pageId });
+  return token;
+}
+
+async function enqueue(createdBy: string | null, driveId: string, pageId: string): Promise<void> {
+  const token = await mintToken(createdBy, driveId, pageId);
   const res = await fetch(`${PROCESSOR_URL}/api/ingest/pull/${pageId}`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
@@ -61,7 +90,11 @@ async function main(): Promise<void> {
       and(
         eq(pages.type, 'FILE'),
         eq(pages.isTrashed, false),
-        sql`${pages.processingStatus} IN ('pending', 'failed')`,
+        // Only 'pending' — that's the state the missing-scope bug leaves
+        // behind. 'failed' means the processor actually ran and rejected the
+        // file (hash mismatch, disallowed type — rejectAndFail deletes the
+        // object), so re-enqueueing those can never succeed.
+        eq(pages.processingStatus, 'pending'),
         sql`${pages.createdAt} >= ${SINCE.toISOString()}`,
         sql`${pages.filePath} IS NOT NULL`,
       ),
@@ -71,17 +104,8 @@ async function main(): Promise<void> {
 
   let ok = 0;
   let failed = 0;
-  let skipped = 0;
 
   for (const row of rows) {
-    if (!row.createdBy) {
-      // Token minting validates the user's edit permission; without a creator
-      // there is no principal to mint for. Surface these for manual handling.
-      console.warn(`SKIP ${row.id} "${row.title}" — no createdBy user`);
-      skipped += 1;
-      continue;
-    }
-
     if (DRY_RUN) {
       console.log(`WOULD ENQUEUE ${row.id} "${row.title}" (status=${row.processingStatus}, created=${row.createdAt?.toISOString()})`);
       ok += 1;
@@ -98,7 +122,7 @@ async function main(): Promise<void> {
     }
   }
 
-  console.log(`Done: ${ok} enqueued, ${failed} failed, ${skipped} skipped`);
+  console.log(`Done: ${ok} enqueued, ${failed} failed`);
   process.exit(failed > 0 ? 1 : 0);
 }
 

--- a/scripts/reenqueue-unprocessed-uploads.ts
+++ b/scripts/reenqueue-unprocessed-uploads.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 import { db } from '@pagespace/db/db';
 import { drives, pages } from '@pagespace/db/schema/core';
-import { and, eq, sql } from '@pagespace/db/operators';
+import { and, eq, isNotNull, sql } from '@pagespace/db/operators';
 import {
   createUploadServiceToken,
   isPermissionDeniedError,
@@ -24,6 +24,11 @@ import {
  *   fly proxy 3003:3003 -a pagespace-processor   # in another terminal
  *   DATABASE_URL=<prod> PROCESSOR_URL=http://localhost:3003 \
  *     bun scripts/reenqueue-unprocessed-uploads.ts [--dry-run] [--since 2026-05-29]
+ *
+ * Idempotency: pages leave 'pending' only after the pull pipeline completes,
+ * so rerunning while the processor queue is still draining enqueues duplicate
+ * jobs (harmless — the pipeline re-hashes and rewrites statuses — but wasted
+ * work). Rerun after the queue drains and already-processed pages drop out.
  */
 
 const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
@@ -96,7 +101,7 @@ async function main(): Promise<void> {
         // object), so re-enqueueing those can never succeed.
         eq(pages.processingStatus, 'pending'),
         sql`${pages.createdAt} >= ${SINCE.toISOString()}`,
-        sql`${pages.filePath} IS NOT NULL`,
+        isNotNull(pages.filePath),
       ),
     );
 

--- a/scripts/reenqueue-unprocessed-uploads.ts
+++ b/scripts/reenqueue-unprocessed-uploads.ts
@@ -1,0 +1,108 @@
+import 'dotenv/config';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { and, eq, sql } from '@pagespace/db/operators';
+import { createUploadServiceToken } from '@pagespace/lib/services/validated-service-token';
+
+/**
+ * Re-enqueue processor ingestion for FILE pages whose post-upload enqueue was
+ * silently dropped.
+ *
+ * Between the direct-to-S3 cutover (#1456, 2026-05-29) and the UPLOAD_SCOPES
+ * fix, `/api/upload/complete` minted enqueue tokens without `files:ingest`,
+ * so the processor rejected every `/api/ingest/pull` with 403 and the pages
+ * stayed `processingStatus = 'pending'` with no derived content (thumbnails,
+ * OCR, text extraction).
+ *
+ * Tokens are minted here directly (with the fixed scopes), so this can run
+ * before the web deploy — it only needs DB access and a route to the
+ * processor:
+ *
+ *   fly proxy 3003:3003 -a pagespace-processor   # in another terminal
+ *   DATABASE_URL=<prod> PROCESSOR_URL=http://localhost:3003 \
+ *     bun scripts/reenqueue-unprocessed-uploads.ts [--dry-run] [--since 2026-05-29]
+ */
+
+const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
+const DRY_RUN = process.argv.includes('--dry-run');
+const sinceArgIdx = process.argv.indexOf('--since');
+const SINCE = new Date(sinceArgIdx === -1 ? '2026-05-29T00:00:00Z' : process.argv[sinceArgIdx + 1]);
+
+if (Number.isNaN(SINCE.getTime())) {
+  console.error('Invalid --since date');
+  process.exit(1);
+}
+
+async function enqueue(userId: string, driveId: string, pageId: string): Promise<void> {
+  const { token } = await createUploadServiceToken({ userId, driveId, pageId });
+  const res = await fetch(`${PROCESSOR_URL}/api/ingest/pull/${pageId}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error || `Processor ingest failed with status ${res.status}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const rows = await db
+    .select({
+      id: pages.id,
+      driveId: pages.driveId,
+      createdBy: pages.createdBy,
+      title: pages.title,
+      createdAt: pages.createdAt,
+      processingStatus: pages.processingStatus,
+    })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.type, 'FILE'),
+        eq(pages.isTrashed, false),
+        sql`${pages.processingStatus} IN ('pending', 'failed')`,
+        sql`${pages.createdAt} >= ${SINCE.toISOString()}`,
+        sql`${pages.filePath} IS NOT NULL`,
+      ),
+    );
+
+  console.log(`Found ${rows.length} unprocessed FILE pages since ${SINCE.toISOString()}${DRY_RUN ? ' (dry run)' : ''}`);
+
+  let ok = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    if (!row.createdBy) {
+      // Token minting validates the user's edit permission; without a creator
+      // there is no principal to mint for. Surface these for manual handling.
+      console.warn(`SKIP ${row.id} "${row.title}" — no createdBy user`);
+      skipped += 1;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(`WOULD ENQUEUE ${row.id} "${row.title}" (status=${row.processingStatus}, created=${row.createdAt?.toISOString()})`);
+      ok += 1;
+      continue;
+    }
+
+    try {
+      await enqueue(row.createdBy, row.driveId, row.id);
+      console.log(`ENQUEUED ${row.id} "${row.title}"`);
+      ok += 1;
+    } catch (err) {
+      console.error(`FAILED ${row.id} "${row.title}":`, (err as Error).message);
+      failed += 1;
+    }
+  }
+
+  console.log(`Done: ${ok} enqueued, ${failed} failed, ${skipped} skipped`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Production bugs

Both are fallout from the direct-to-S3 cutover (#1456 → #1463 era) surfaced by today's Fly logs and a user report of `Error: Failed to fetch (wispy-wood-9053.fly.storage.tigris.dev)`.

### 1. Page-file uploads never get processed (`Missing required scope: files:ingest`)

`/api/upload/complete` → `enqueueProcessorJob()` mints its service token from `UPLOAD_SCOPES = ['files:write']`, but the processor mounts `/api/ingest` behind `requireScope('files:ingest')` (`apps/processor/src/server.ts:170`). Every post-upload enqueue 403'd, and the route swallows the error by design — uploads "succeeded" but thumbnails/OCR/text-extraction never ran.

- Add `files:ingest` to `UPLOAD_SCOPES` (permission gating unchanged — the token already requires `canEdit`, and `files:ingest` is a `canEdit`-class scope in `filterScopesByPermissions`)
- Upgrade the swallowed failure to `loggers.api.error` with user/drive/page metadata
- `scripts/reenqueue-unprocessed-uploads.ts` backfills ingestion for FILE pages uploaded while this was broken (dry-run support; mints its own correctly-scoped tokens so it can run pre-deploy). Per Codex review: targets `processingStatus = 'pending'` only (`failed` means the processor ran and rejected the file — re-enqueueing can't succeed), and token minting falls back to the drive owner when the original uploader was removed or downgraded

### 2. File downloads CORS-blocked (the user-visible "Failed to fetch")

The download button used `fetchWithAuth('/api/files/{id}/download')`, which follows the route's 307 redirect into Tigris **with `credentials: 'include'`**. Tigris never sends `Access-Control-Allow-Credentials` (verified empirically against the prod bucket), so the browser blocks the response even now that bucket CORS allows GET.

- Add `Accept: application/json` mode to the download route (exact mirror of `/view`)
- Switch `handleDownload` to the same two-step pattern the PDF/DOCX/code viewers use: credentialed same-origin fetch for the presigned URL, then **uncredentialed** `fetch(url)` for the bytes

The viewers themselves needed no code change — they were fixed by adding `GET` to the bucket CORS rules (PageSpace-Deploy#7, **already applied to the prod bucket and verified**: presigned GET with `Origin: https://pagespace.ai` returns 200 + `access-control-allow-origin`; disallowed origins still 403).

### 3. Avatar upload timeout (hardening)

The web→processor avatar fetch had no timeout; an 80s call was logged while the instance hit its 200-concurrent-request hard limit. Bounded at 60s with a clean 504.

## Tests

- `validated-service-token.test.ts`: upload-token assertions now require `['files:write', 'files:ingest']` (45 passing)
- `download/__tests__/route.test.ts`: new JSON-mode tests for both the page and attachment branches (10 passing)
- `upload/complete` route tests: 30 passing
- typecheck + lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
