### PR TITLE
fix(calendar): attached-doc picker — unfreeze search and restore scroll

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -96,20 +96,12 @@ export function TriggerPagePicker(props: Props) {
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query, 200);
 
-  // Same pause-while-editing contract as PageLabel — see comment there for rationale.
-  const isAnyActive = useEditingStore((s) => s.isAnyActive());
-  const searchLoadedRef = useRef(false);
-
   const searchKey = open && driveId
     ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${driveId}&types=page`
     : null;
   const { data: results = [], isLoading } = useSWR(searchKey, searchFetcher, {
     revalidateOnFocus: false,
     keepPreviousData: true,
-    isPaused: () => searchLoadedRef.current && isAnyActive,
-    onSuccess: () => {
-      searchLoadedRef.current = true;
-    },
   });
   const searching = isLoading || query !== debouncedQuery;
 
@@ -183,7 +175,7 @@ export function TriggerPagePicker(props: Props) {
               value={query}
               onValueChange={setQuery}
             />
-            <CommandList>
+            <CommandList onWheel={(e) => e.stopPropagation()}>
               <CommandEmpty>
                 {searching ? 'Searching…' : 'No pages found.'}
               </CommandEmpty>

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -67,9 +67,10 @@ type Props = SingleProps | MultiProps;
 // the props.value / onChange contract — this picker has no internal selection state
 // that a remote refetch could clobber. The two SWRs below (searchFetcher, pageFetcher)
 // are read-only display: they fetch search results and chip titles, but neither writes
-// back to selection. The hasLoadedRef + isPaused gates still apply so the chip label
-// and the search list don't flicker mid-edit when an editing session is active, mirroring
-// the contract the dialog uses for its own triggers/agents SWRs (see useEditingSession).
+// back to selection. PageLabel retains the hasLoadedRef + isPaused guard so the chip
+// label doesn't flicker mid-edit. The search SWR intentionally omits it: revalidateOnFocus:
+// false already blocks background refetch, and pausing on isAnyActive() froze results
+// whenever EventModal's long-lived 'form' session was open.
 // No dedicated "remote refetch must not clobber selection" test is added because the
 // data flow makes that property structural rather than behavioural.
 


### PR DESCRIPTION
## Summary

- **Search frozen**: `TriggerPagePicker`'s search SWR had an `isPaused` guard that fired whenever `isAnyActive()` was true. `EventModal` registers a `'form'` editing session for its entire open lifetime, so after the first empty-query fetch loaded `searchLoadedRef.current = true`, every subsequent key change (keystroke) was silently skipped — results stayed stuck at the initial 20 most-recent pages.
- **Scroll blocked**: The portaled `CommandList` inside a Radix `Dialog` had its wheel events captured by the Dialog's `react-remove-scroll` barrier, preventing scroll through the suggestion list.

## Changes

`apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx`

- Remove `isPaused` + `searchLoadedRef` from the search SWR — `revalidateOnFocus: false` already prevents the background refetch the guard was protecting against; `keepPreviousData: true` is retained for smooth loading UX
- Add `onWheel={e => e.stopPropagation()}` to `CommandList` to keep scroll events inside the portaled popover

The `PageLabel` sub-component's pause-while-editing guard (chip-label flicker prevention) is unchanged.

## Test plan

- [ ] Open a Drive calendar → click a date slot → expand **Advanced**
- [ ] Click **Pick a doc, sheet, or other page…**
- [ ] Type a search term — list should filter live (200 ms debounce)
- [ ] Clear input — recent pages reappear
- [ ] With 7+ results, scroll the list within the 300 px container

🤖 Generated with [Claude Code](https://claude.com/claude-code)