### PR TITLE
feat(billing): Usage/Billing page split + mobile buy-credits fix

### DIFF
--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -404,7 +404,7 @@ describe('AI settings route', () => {
       const body = await response.json();
 
       expect(response.status).toBe(403);
-      expect(body.upgradeUrl).toBe('/settings/billing');
+      expect(body.upgradeUrl).toBe('/settings/usage');
     });
 
     it('lets a free user select an allowlist model (default model)', async () => {

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -404,7 +404,7 @@ describe('AI settings route', () => {
       const body = await response.json();
 
       expect(response.status).toBe(403);
-      expect(body.upgradeUrl).toBe('/settings/usage');
+      expect(body.upgradeUrl).toBe('/settings/plan');
     });
 
     it('lets a free user select an allowlist model (default model)', async () => {

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -145,7 +145,7 @@ export async function PATCH(request: Request) {
         {
           error: 'Subscription required',
           message: 'This model is available on paid plans. Upgrade to access the full model catalog.',
-          upgradeUrl: '/settings/billing',
+          upgradeUrl: '/settings/usage',
         },
         { status: 403 }
       );

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -145,7 +145,7 @@ export async function PATCH(request: Request) {
         {
           error: 'Subscription required',
           message: 'This model is available on paid plans. Upgrade to access the full model catalog.',
-          upgradeUrl: '/settings/usage',
+          upgradeUrl: '/settings/plan',
         },
         { status: 403 }
       );

--- a/apps/web/src/app/api/credits/breakdown/route.ts
+++ b/apps/web/src/app/api/credits/breakdown/route.ts
@@ -7,7 +7,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 /**
  * GET /api/credits/breakdown — the authenticated user's prepaid-credit spend for the
  * current billing period, grouped by feature (chat, pulse, memory, voice, …) and by
- * model. Powers the usage-breakdown card on /settings/billing.
+ * model. Powers the usage-breakdown card on /settings/usage.
  */
 export async function GET(request: NextRequest) {
   try {

--- a/apps/web/src/app/api/stripe/create-credit-topup/route.ts
+++ b/apps/web/src/app/api/stripe/create-credit-topup/route.ts
@@ -114,8 +114,8 @@ export async function POST(request: NextRequest) {
       payment_intent_data: {
         metadata: { kind: 'credit_pack', packId: purchase.id, userId: user.id },
       },
-      success_url: `${baseUrl}/settings/billing?credits=success`,
-      cancel_url: `${baseUrl}/settings/billing?credits=canceled`,
+      success_url: `${baseUrl}/settings/usage?credits=success`,
+      cancel_url: `${baseUrl}/settings/usage?credits=canceled`,
     });
 
     if (!session.url) {

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request) {
           {
             error: 'Pro plan required',
             message: 'Voice mode requires a Pro or above subscription.',
-            upgradeUrl: '/settings/billing',
+            upgradeUrl: '/settings/usage',
           },
           { status: 403 }
         );

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request) {
           {
             error: 'Pro plan required',
             message: 'Voice mode requires a Pro or above subscription.',
-            upgradeUrl: '/settings/usage',
+            upgradeUrl: '/settings/plan',
           },
           { status: 403 }
         );

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: Request) {
           {
             error: 'Pro plan required',
             message: 'Voice mode requires a Pro or above subscription.',
-            upgradeUrl: '/settings/billing',
+            upgradeUrl: '/settings/usage',
           },
           { status: 403 }
         );

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: Request) {
           {
             error: 'Pro plan required',
             message: 'Voice mode requires a Pro or above subscription.',
-            upgradeUrl: '/settings/usage',
+            upgradeUrl: '/settings/plan',
           },
           { status: 403 }
         );

--- a/apps/web/src/app/dashboard/storage/page.tsx
+++ b/apps/web/src/app/dashboard/storage/page.tsx
@@ -6,5 +6,5 @@ import { redirect } from 'next/navigation';
  * is kept only to redirect existing links/bookmarks.
  */
 export default function StorageRedirectPage() {
-  redirect('/settings/billing');
+  redirect('/settings/usage');
 }

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -24,10 +24,6 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { InvoiceList, type Invoice } from '@/components/billing/InvoiceList';
 import { UpcomingInvoice } from '@/components/billing/UpcomingInvoice';
 import { BillingAddressForm, type BillingAddress } from '@/components/billing/BillingAddressForm';
-import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
-import { UsageBreakdownCard } from '@/components/billing/UsageBreakdownCard';
-import { AutomationsCard } from '@/components/billing/AutomationsCard';
-import { StorageUsageCard } from '@/components/billing/StorageUsageCard';
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { getPlan, getPlanFromPriceId, type SubscriptionTier } from '@/lib/subscription/plans';
 import { post } from '@/lib/auth/auth-fetch';
@@ -57,43 +53,29 @@ interface UpcomingInvoiceData {
 export default function BillingPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  // Stripe/payment sections (subscription, payment methods, invoices, address) are
-  // hidden on iOS (App Store compliance). Non-payment sections — AI credits balance,
-  // usage breakdown, automations, storage — stay visible on every platform (full
-  // mobile parity), so unlike the old BillingGuard we DON'T redirect the whole page.
   const { isReady, hideBilling } = useBillingVisibility();
   const showBillingSections = isReady && !hideBilling;
 
-  // State
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Subscription
   const [subscriptionData, setSubscriptionData] = useState<SubscriptionData | null>(null);
 
-  // Portal
   const [portalLoading, setPortalLoading] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
 
-  // Invoices
   const [invoices, setInvoices] = useState<Invoice[]>([]);
   const [invoicesHasMore, setInvoicesHasMore] = useState(false);
   const [invoicesLoading, setInvoicesLoading] = useState(false);
 
-  // Upcoming Invoice
   const [upcomingInvoice, setUpcomingInvoice] = useState<UpcomingInvoiceData['invoice']>(null);
 
-  // Billing Address
   const [billingAddress, setBillingAddress] = useState<BillingAddress | null>(null);
   const [billingName, setBillingName] = useState<string | null>(null);
 
-  // Schedule cancellation
   const [cancellingSchedule, setCancellingSchedule] = useState(false);
 
-  // URL params
   const success = searchParams.get('success');
-  // Set by the credit top-up checkout return (`?credits=success|canceled`).
-  const creditsParam = searchParams.get('credits');
 
   const fetchAllData = useCallback(async () => {
     setLoading(true);
@@ -117,15 +99,14 @@ export default function BillingPage() {
     fetchAllData();
   }, [fetchAllData]);
 
-  // Clear URL params after showing alerts
   useEffect(() => {
-    if (success || creditsParam) {
+    if (success) {
       const timer = setTimeout(() => {
         router.replace('/settings/billing');
       }, 5000);
       return () => clearTimeout(timer);
     }
-  }, [success, creditsParam, router]);
+  }, [success, router]);
 
   const fetchSubscription = async () => {
     const res = await fetchWithAuth('/api/subscriptions/status');
@@ -236,98 +217,8 @@ export default function BillingPage() {
   const scheduledPlan = scheduledPriceId ? getPlanFromPriceId(scheduledPriceId) : null;
   const scheduledChangeDate = subscriptionData?.subscription?.scheduledChangeDate;
 
-  // Current Subscription card — lifted into the headline row so the plan reads first,
-  // alongside AI Credits, instead of sitting below usage/automations/storage.
-  const subscriptionCard = (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Sparkles className="h-5 w-5" />
-          Current Subscription
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        {/* Wraps instead of a fixed row so the card stays readable in the half-width md grid column. */}
-        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
-          <div className="flex items-center gap-3">
-            <div className={`p-2 rounded-full ${plan.accentColor}`}>
-              <plan.icon className={`h-5 w-5 ${plan.iconColor}`} />
-            </div>
-            <div>
-              <div className="font-semibold flex items-center gap-2">
-                {plan.displayName}
-                {isPaid && (
-                  <Badge variant={isCanceling ? 'secondary' : 'default'}>
-                    {isCanceling ? 'Canceling' : subscriptionData?.subscription?.status}
-                  </Badge>
-                )}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {plan.price.formatted}{plan.price.monthly > 0 && '/month'}
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            {isPaid && subscriptionData?.subscription && (
-              <div className="text-sm text-muted-foreground flex items-center gap-1 mr-4">
-                <Clock className="h-4 w-4" />
-                {isCanceling ? 'Ends' : 'Renews'}{' '}
-                {new Date(subscriptionData.subscription.currentPeriodEnd).toLocaleDateString()}
-              </div>
-            )}
-            <Link href="/settings/plan">
-              <Button variant="outline">
-                {isPaid ? 'Change Plan' : 'Upgrade'}
-              </Button>
-            </Link>
-          </div>
-        </div>
-
-        {isCanceling && (
-          <Alert className="mt-4">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription>
-              Your subscription will end on{' '}
-              {new Date(subscriptionData!.subscription!.currentPeriodEnd).toLocaleDateString()}.
-              You can reactivate anytime before then.
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {scheduledPlan && !isCanceling && (
-          <Alert className="mt-4 border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20">
-            <Clock className="h-4 w-4 text-blue-600" />
-            <AlertDescription className="text-blue-800 dark:text-blue-200 flex items-center justify-between">
-              <span>
-                Changing to {scheduledPlan.displayName} on{' '}
-                {scheduledChangeDate ? new Date(scheduledChangeDate).toLocaleDateString() : 'next billing period'}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleCancelSchedule}
-                disabled={cancellingSchedule}
-                className="ml-4"
-              >
-                {cancellingSchedule ? (
-                  <>
-                    <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                    Cancelling...
-                  </>
-                ) : (
-                  'Keep Current Plan'
-                )}
-              </Button>
-            </AlertDescription>
-          </Alert>
-        )}
-      </CardContent>
-    </Card>
-  );
-
   return (
     <div className="container mx-auto p-6 space-y-8 max-w-4xl">
-      {/* Header */}
       <div>
         <Button
           variant="ghost"
@@ -339,14 +230,13 @@ export default function BillingPage() {
           Back to Settings
         </Button>
         <div className="text-center space-y-2">
-          <h1 className="text-4xl font-bold">Billing &amp; Usage</h1>
+          <h1 className="text-4xl font-bold">Billing</h1>
           <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
-            Your subscription, AI credits, usage, automations, and storage
+            Your subscription, payment methods, and invoices
           </p>
         </div>
       </div>
 
-      {/* Success Alert */}
       {success && (
         <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20">
           <CheckCircle className="h-4 w-4 text-green-600" />
@@ -356,25 +246,6 @@ export default function BillingPage() {
         </Alert>
       )}
 
-      {/* Credit top-up result alerts */}
-      {creditsParam === 'success' && (
-        <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20">
-          <CheckCircle className="h-4 w-4 text-green-600" />
-          <AlertDescription className="text-green-800 dark:text-green-200">
-            Credits added! Your top-up balance has been updated.
-          </AlertDescription>
-        </Alert>
-      )}
-      {creditsParam === 'canceled' && (
-        <Alert>
-          <AlertTriangle className="h-4 w-4" />
-          <AlertDescription>
-            Credit purchase canceled. You can buy credits anytime.
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* Error Alert */}
       {error && (
         <Alert variant="destructive">
           <XCircle className="h-4 w-4" />
@@ -382,117 +253,183 @@ export default function BillingPage() {
         </Alert>
       )}
 
-      {/* Headline row: Current Subscription + AI Credits side by side */}
-      <div className={showBillingSections ? 'grid gap-8 md:grid-cols-2' : undefined}>
-        {showBillingSections && subscriptionCard}
-        <CreditBalanceCard />
-      </div>
-
-      {/* AI usage breakdown */}
-      <UsageBreakdownCard />
-
-      {/* Automations — background AI that spends credits (Pulse, Memory) */}
-      <AutomationsCard />
-
-      {/* Storage usage (moved from the standalone /dashboard/storage page) */}
-      <StorageUsageCard />
-
-      {/* Payment & subscription sections — Stripe-backed, hidden on iOS (App Store). */}
       {showBillingSections && (
-      <>
-      {/* Payment Methods */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <CreditCard className="h-5 w-5" />
-            Payment Methods
-          </CardTitle>
-          <CardDescription>
-            Add, remove, or update your payment methods securely through Stripe.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {portalError && (
-            <Alert variant="destructive" className="mb-4">
-              <XCircle className="h-4 w-4" />
-              <AlertDescription>{portalError}</AlertDescription>
-            </Alert>
-          )}
-          <Button onClick={handleManagePaymentMethods} disabled={portalLoading}>
-            {portalLoading ? (
-              <>
-                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Opening...
-              </>
-            ) : (
-              <>
-                <ExternalLink className="h-4 w-4 mr-2" />
-                Manage Payment Methods
-              </>
-            )}
-          </Button>
-        </CardContent>
-      </Card>
-
-      {/* Upcoming Invoice */}
-      {isPaid && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Receipt className="h-5 w-5" />
-              Upcoming Invoice
+              <Sparkles className="h-5 w-5" />
+              Current Subscription
             </CardTitle>
-            <CardDescription>
-              Your next scheduled payment
-            </CardDescription>
           </CardHeader>
           <CardContent>
-            <UpcomingInvoice invoice={upcomingInvoice} />
+            <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
+              <div className="flex items-center gap-3">
+                <div className={`p-2 rounded-full ${plan.accentColor}`}>
+                  <plan.icon className={`h-5 w-5 ${plan.iconColor}`} />
+                </div>
+                <div>
+                  <div className="font-semibold flex items-center gap-2">
+                    {plan.displayName}
+                    {isPaid && (
+                      <Badge variant={isCanceling ? 'secondary' : 'default'}>
+                        {isCanceling ? 'Canceling' : subscriptionData?.subscription?.status}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {plan.price.formatted}{plan.price.monthly > 0 && '/month'}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {isPaid && subscriptionData?.subscription && (
+                  <div className="text-sm text-muted-foreground flex items-center gap-1 mr-4">
+                    <Clock className="h-4 w-4" />
+                    {isCanceling ? 'Ends' : 'Renews'}{' '}
+                    {new Date(subscriptionData.subscription.currentPeriodEnd).toLocaleDateString()}
+                  </div>
+                )}
+                <Link href="/settings/plan">
+                  <Button variant="outline">
+                    {isPaid ? 'Change Plan' : 'Upgrade'}
+                  </Button>
+                </Link>
+              </div>
+            </div>
+
+            {isCanceling && (
+              <Alert className="mt-4">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  Your subscription will end on{' '}
+                  {new Date(subscriptionData!.subscription!.currentPeriodEnd).toLocaleDateString()}.
+                  You can reactivate anytime before then.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {scheduledPlan && !isCanceling && (
+              <Alert className="mt-4 border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20">
+                <Clock className="h-4 w-4 text-blue-600" />
+                <AlertDescription className="text-blue-800 dark:text-blue-200 flex items-center justify-between">
+                  <span>
+                    Changing to {scheduledPlan.displayName} on{' '}
+                    {scheduledChangeDate ? new Date(scheduledChangeDate).toLocaleDateString() : 'next billing period'}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCancelSchedule}
+                    disabled={cancellingSchedule}
+                    className="ml-4"
+                  >
+                    {cancellingSchedule ? (
+                      <>
+                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                        Cancelling...
+                      </>
+                    ) : (
+                      'Keep Current Plan'
+                    )}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
           </CardContent>
         </Card>
       )}
 
-      {/* Invoice History */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Receipt className="h-5 w-5" />
-            Invoice History
-          </CardTitle>
-          <CardDescription>
-            View and download your past invoices
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <InvoiceList
-            invoices={invoices}
-            hasMore={invoicesHasMore}
-            onLoadMore={handleLoadMoreInvoices}
-            loading={invoicesLoading}
-          />
-        </CardContent>
-      </Card>
+      {showBillingSections && (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <CreditCard className="h-5 w-5" />
+                Payment Methods
+              </CardTitle>
+              <CardDescription>
+                Add, remove, or update your payment methods securely through Stripe.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {portalError && (
+                <Alert variant="destructive" className="mb-4">
+                  <XCircle className="h-4 w-4" />
+                  <AlertDescription>{portalError}</AlertDescription>
+                </Alert>
+              )}
+              <Button onClick={handleManagePaymentMethods} disabled={portalLoading}>
+                {portalLoading ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Opening...
+                  </>
+                ) : (
+                  <>
+                    <ExternalLink className="h-4 w-4 mr-2" />
+                    Manage Payment Methods
+                  </>
+                )}
+              </Button>
+            </CardContent>
+          </Card>
 
-      {/* Billing Address */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <MapPin className="h-5 w-5" />
-            Billing Address
-          </CardTitle>
-          <CardDescription>
-            Your billing address for invoices and receipts
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <BillingAddressForm
-            address={billingAddress}
-            name={billingName}
-            onUpdate={fetchBillingAddress}
-          />
-        </CardContent>
-      </Card>
-      </>
+          {isPaid && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Receipt className="h-5 w-5" />
+                  Upcoming Invoice
+                </CardTitle>
+                <CardDescription>
+                  Your next scheduled payment
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <UpcomingInvoice invoice={upcomingInvoice} />
+              </CardContent>
+            </Card>
+          )}
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Receipt className="h-5 w-5" />
+                Invoice History
+              </CardTitle>
+              <CardDescription>
+                View and download your past invoices
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <InvoiceList
+                invoices={invoices}
+                hasMore={invoicesHasMore}
+                onLoadMore={handleLoadMoreInvoices}
+                loading={invoicesLoading}
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <MapPin className="h-5 w-5" />
+                Billing Address
+              </CardTitle>
+              <CardDescription>
+                Your billing address for invoices and receipts
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <BillingAddressForm
+                address={billingAddress}
+                name={billingName}
+                onUpdate={fetchBillingAddress}
+              />
+            </CardContent>
+          </Card>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -126,7 +126,7 @@ export default function BillingPage() {
       if (res.ok) {
         const data = await res.json();
         if (startingAfter) {
-          setInvoices(prev => [...prev, ...(data.invoices || [])]);
+          setInvoices((prev: Invoice[]) => [...prev, ...(data.invoices || [])]);
         } else {
           setInvoices(data.invoices || []);
         }

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -6,7 +6,7 @@ import { useMCP } from "@/hooks/useMCP";
 import { useAuth } from "@/hooks/useAuth";
 import { useBillingVisibility } from "@/hooks/useBillingVisibility";
 import { Button } from "@/components/ui/button";
-import { User, Plug2, Key, ArrowLeft, CreditCard, Bell, Shield, Keyboard, Sparkles, Eye, Cable, Calendar, Scale, HardDrive, SlashSquare } from "lucide-react";
+import { User, Plug2, Key, ArrowLeft, CreditCard, Bell, Shield, Keyboard, Sparkles, Eye, Cable, Calendar, Scale, HardDrive, SlashSquare, Coins } from "lucide-react";
 import { SettingsRow, type SettingsItem } from "./SettingsRow";
 import { canUseCommands } from "@/lib/commands/command-gating";
 
@@ -71,8 +71,15 @@ export default function SettingsPage() {
           available: true,
         },
         {
-          title: "Billing & Subscription",
-          description: "Subscription, AI credits, usage & storage",
+          title: "Usage",
+          description: "AI credits, usage breakdown, automations & storage",
+          icon: Coins,
+          href: "/settings/usage",
+          available: true,
+        },
+        {
+          title: "Billing",
+          description: "Subscription, payment methods & invoices",
           icon: CreditCard,
           href: "/settings/billing",
           available: true,

--- a/apps/web/src/app/settings/usage/page.tsx
+++ b/apps/web/src/app/settings/usage/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ArrowLeft, CheckCircle, AlertTriangle } from 'lucide-react';
+import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
+import { UsageBreakdownCard } from '@/components/billing/UsageBreakdownCard';
+import { AutomationsCard } from '@/components/billing/AutomationsCard';
+import { StorageUsageCard } from '@/components/billing/StorageUsageCard';
+
+export default function UsagePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const creditsParam = searchParams.get('credits');
+
+  useEffect(() => {
+    if (creditsParam) {
+      const timer = setTimeout(() => {
+        router.replace('/settings/usage');
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [creditsParam, router]);
+
+  return (
+    <div className="container mx-auto p-6 space-y-8 max-w-4xl">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push('/settings')}
+          className="mb-4"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Settings
+        </Button>
+        <div className="text-center space-y-2">
+          <h1 className="text-4xl font-bold">Usage</h1>
+          <p className="text-muted-foreground text-lg max-w-2xl mx-auto">
+            AI credits, usage breakdown, automations, and storage
+          </p>
+        </div>
+      </div>
+
+      {creditsParam === 'success' && (
+        <Alert className="border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20">
+          <CheckCircle className="h-4 w-4 text-green-600" />
+          <AlertDescription className="text-green-800 dark:text-green-200">
+            Credits added! Your top-up balance has been updated.
+          </AlertDescription>
+        </Alert>
+      )}
+      {creditsParam === 'canceled' && (
+        <Alert>
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            Credit purchase canceled. You can buy credits anytime.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <CreditBalanceCard />
+      <UsageBreakdownCard />
+      <AutomationsCard />
+      <StorageUsageCard />
+    </div>
+  );
+}

--- a/apps/web/src/components/billing/BuyCreditsButton.tsx
+++ b/apps/web/src/components/billing/BuyCreditsButton.tsx
@@ -38,7 +38,7 @@ type TopupBody = { packId: string } | { amountCents: number };
  * via the in-app credits helper) PLUS a custom-amount field, and starts a one-time
  * Stripe Checkout session for the chosen amount, redirecting to the hosted page. On
  * success the webhook funds the user's top-up bucket (paying down any debt first);
- * Stripe returns the user to `/settings/billing?credits=success`.
+ * Stripe returns the user to `/settings/usage?credits=success`.
  */
 export function BuyCreditsButton({
   variant = 'default',

--- a/apps/web/src/components/billing/CreditBalance.tsx
+++ b/apps/web/src/components/billing/CreditBalance.tsx
@@ -66,7 +66,7 @@ export function CreditBalance() {
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={() => router.push('/settings/billing')}
+              onClick={() => router.push('/settings/usage')}
               className="hidden sm:flex items-center gap-1.5"
               aria-label="View AI credit balance"
             >
@@ -127,7 +127,11 @@ export function CreditBalance() {
         </Tooltip>
       </TooltipProvider>
 
-      {showBilling && <BuyCreditsButton variant={isLow ? 'default' : 'ghost'} size="sm" />}
+      {showBilling && (
+        <div className="hidden sm:flex">
+          <BuyCreditsButton variant={isLow ? 'default' : 'ghost'} size="sm" />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
@@ -492,7 +492,7 @@ const SidebarSettingsTab: React.FC<SidebarSettingsTabProps> = ({
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => router.push('/settings/usage')}
+                    onClick={() => router.push('/settings/plan')}
                     className="w-full border-primary/30 text-primary hover:bg-primary/10 dark:border-primary/30 dark:text-primary dark:hover:bg-primary/20"
                   >
                     View Upgrade Options

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
@@ -492,7 +492,7 @@ const SidebarSettingsTab: React.FC<SidebarSettingsTabProps> = ({
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => router.push('/settings/billing')}
+                    onClick={() => router.push('/settings/usage')}
                     className="w-full border-primary/30 text-primary hover:bg-primary/10 dark:border-primary/30 dark:text-primary dark:hover:bg-primary/20"
                   >
                     View Upgrade Options

--- a/apps/web/src/components/shared/UserDropdown.tsx
+++ b/apps/web/src/components/shared/UserDropdown.tsx
@@ -19,13 +19,16 @@ import {
   DropdownMenuPortal,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { LogOut, MessageSquareText, Settings, LayoutDashboard, Sun, Moon, Monitor, HardDrive, CreditCard, Sparkles } from 'lucide-react';
+import { LogOut, MessageSquareText, Settings, LayoutDashboard, Sun, Moon, Monitor, CreditCard, Sparkles, Coins } from 'lucide-react';
 import { useTheme } from "next-themes";
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
+import { useCreditBalance } from '@/hooks/useCreditBalance';
 import { isOnPrem } from '@/lib/deployment-mode';
 import useSWR from 'swr';
-import { Progress } from "@/components/ui/progress";
 import { FeedbackDialog } from './FeedbackDialog';
+import { formatCreditCount } from '@/lib/subscription/credits';
+
+const LOW_BALANCE_THRESHOLD_PCT = 15;
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -42,32 +45,35 @@ export default function UserDropdown() {
   const { showBilling } = useBillingVisibility();
   const [feedbackOpen, setFeedbackOpen] = useState(false);
 
-  // Fetch storage info
-  const { data: storageInfo } = useSWR(
-    isAuthenticated ? '/api/storage/info' : null,
-    fetcher,
-    {
-      refreshInterval: 300000, // 5 minutes (reduced from 30 seconds)
-      revalidateOnFocus: false, // Don't revalidate on tab focus (prevents interruptions)
-    }
-  );
+  const { balance } = useCreditBalance();
 
-  // Fetch subscription status
+  // Fetch subscription status (for tier label in Billing item)
   const { data: subscriptionInfo } = useSWR(
     isAuthenticated ? '/api/subscriptions/status' : null,
     fetcher,
     {
-      refreshInterval: 300000, // 5 minutes (reduced from 60 seconds)
-      revalidateOnFocus: false, // Don't revalidate on tab focus (prevents interruptions)
+      refreshInterval: 300000,
+      revalidateOnFocus: false,
     }
   );
+
+  // Derive credit balance display values
+  const spendable = balance?.spendable ?? 0;
+  const topupRemaining = balance?.topup?.remaining ?? 0;
+  const monthlyAllowance = balance?.monthly?.allowance ?? 0;
+  const netMonthly = spendable - topupRemaining;
+  const inDebt = spendable < 0;
+  const isLow = balance
+    ? inDebt || (monthlyAllowance > 0 && netMonthly / monthlyAllowance <= LOW_BALANCE_THRESHOLD_PCT / 100)
+    : false;
+  const netMonthlyStr = formatCreditCount(netMonthly);
+  const allowanceStr = formatCreditCount(monthlyAllowance);
 
   const handleSignOut = async () => {
     try {
       await actions.logout();
     } catch (error) {
       console.error('Logout failed:', error);
-      // Still redirect to signin even if logout fails
       router.push('/auth/signin');
     }
   };
@@ -108,23 +114,17 @@ export default function UserDropdown() {
             <Sparkles className="mr-2 h-4 w-4" />
             <span>Personalization</span>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => router.push('/settings/billing')}>
-            <HardDrive className="mr-2 h-4 w-4" />
+          <DropdownMenuItem onClick={() => router.push('/settings/usage')}>
+            <Coins className={`mr-2 h-4 w-4 ${isLow ? 'text-amber-500' : ''}`} />
             <div className="flex-1">
               <div className="flex items-center justify-between">
-                <span>Storage</span>
-                {storageInfo?.quota && (
-                  <span className="text-xs text-muted-foreground ml-2">
-                    {storageInfo.quota.formattedUsed} / {storageInfo.quota.formattedQuota}
+                <span>Usage</span>
+                {balance && balance.billingEnabled && (
+                  <span className={`text-xs ml-2 ${isLow ? 'text-amber-500' : 'text-muted-foreground'}`}>
+                    {netMonthlyStr} / {allowanceStr}
                   </span>
                 )}
               </div>
-              {storageInfo?.quota && (
-                <Progress
-                  value={storageInfo.quota.utilizationPercent}
-                  className="h-1 mt-1"
-                />
-              )}
             </div>
           </DropdownMenuItem>
           {showBilling && (

--- a/apps/web/src/lib/subscription/rate-limit-middleware.ts
+++ b/apps/web/src/lib/subscription/rate-limit-middleware.ts
@@ -28,7 +28,7 @@ export function createSubscriptionRequiredResponse(): NextResponse {
     {
       error: 'Subscription required',
       message: 'This model is available on paid plans. Upgrade to access the full model catalog.',
-      upgradeUrl: '/settings/billing',
+      upgradeUrl: '/settings/usage',
     },
     { status: 403 }
   );

--- a/apps/web/src/lib/subscription/rate-limit-middleware.ts
+++ b/apps/web/src/lib/subscription/rate-limit-middleware.ts
@@ -28,7 +28,7 @@ export function createSubscriptionRequiredResponse(): NextResponse {
     {
       error: 'Subscription required',
       message: 'This model is available on paid plans. Upgrade to access the full model catalog.',
-      upgradeUrl: '/settings/usage',
+      upgradeUrl: '/settings/plan',
     },
     { status: 403 }
   );


### PR DESCRIPTION
## Summary

- **New \`/settings/usage\` page** — AI credit balance + buy credits, usage breakdown by model/feature, automations (Pulse/Memory), and storage quota. Platform-neutral: works on iOS too.
- **Trimmed \`/settings/billing\` page** — subscription, payment methods, upcoming invoice, invoice history, billing address only. Still Stripe-gated (\`mobileHidden: true\`).
- **Mobile header fix** — \`BuyCreditsButton\` in the header is now hidden below \`sm\` (640px) via Tailwind responsive class, not native platform detection. Users on mobile rely on the auth dropdown instead.
- **Auth dropdown** — \"Storage\" + \"Billing\" items replaced with a single **\"Usage\"** item showing live credit balance (\`X / Y\`, amber when low). \"Billing\" item kept, still gated by \`showBilling\`.
- **Settings index** — \"Billing & Subscription\" split into \"Usage\" (always visible) + \"Billing\" (mobileHidden).

## Reference updates

- **Credit top-up flows** (Stripe checkout return, dashboard/storage redirect, sidebar usage link, credit balance click) → \`/settings/usage\`
- **Subscription upgrade flows** (locked-model gate, voice mode gate, \"View Upgrade Options\" button) → \`/settings/plan\`
- Stripe portal return URL stays at \`/settings/billing\`

## Test plan

- [ ] \`/settings/usage\` — shows CreditBalanceCard, UsageBreakdownCard, AutomationsCard, StorageUsageCard; no Stripe sections
- [ ] \`/settings/billing\` — shows subscription + Stripe sections only
- [ ] \`/settings\` index — shows both \"Usage\" and \"Billing\" rows; \"Billing\" hidden on iOS
- [ ] Auth dropdown: \"Usage\" item shows live balance and links to \`/settings/usage\`; \"Billing\" shows tier and links to \`/settings/billing\`
- [ ] Mobile (<640px): no \"Buy credits\" button in header; clicking the balance badge goes to \`/settings/usage\`
- [ ] Credit topup Stripe checkout returns to \`/settings/usage?credits=success\` with alert
- [ ] \`/dashboard/storage\` redirects to \`/settings/usage\`
- [ ] Locked-model or voice-gated 403: \"View Upgrade Options\" and \`upgradeUrl\` field → \`/settings/plan\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)