### PR TITLE
fix(admin): audit log stats show true DB totals, not page-local counts

### DIFF
--- a/apps/admin/src/app/(admin)/audit-logs/page.tsx
+++ b/apps/admin/src/app/(admin)/audit-logs/page.tsx
@@ -83,6 +83,8 @@ interface Pagination {
   totalPages: number;
   hasNextPage: boolean;
   hasPreviousPage: boolean;
+  aiGeneratedTotal: number;
+  hashChainTotal: number;
 }
 
 interface FiltersState {
@@ -358,8 +360,8 @@ export default function AdminAuditLogsPage() {
 
   // Calculate stats from pagination
   const totalLogs = pagination?.totalCount || 0;
-  const aiGeneratedCount = logs.filter(log => log.isAiGenerated).length;
-  const hasHashChain = logs.filter(log => log.logHash).length;
+  const aiGeneratedCount = pagination?.aiGeneratedTotal || 0;
+  const hasHashChain = pagination?.hashChainTotal || 0;
 
   return (
     <div className="space-y-6">
@@ -395,14 +397,14 @@ export default function AdminAuditLogsPage() {
               <div className="text-2xl font-bold text-purple-600">{aiGeneratedCount}</div>
               <div className="text-muted-foreground flex items-center justify-center">
                 <Bot className="h-4 w-4 mr-1" />
-                AI Generated (page)
+                AI Generated
               </div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-green-600">{hasHashChain}</div>
               <div className="text-muted-foreground flex items-center justify-center">
                 <Hash className="h-4 w-4 mr-1" />
-                Hash Chain (page)
+                Hash Chain
               </div>
             </div>
           </div>

--- a/apps/admin/src/app/(admin)/support/page.tsx
+++ b/apps/admin/src/app/(admin)/support/page.tsx
@@ -25,9 +25,16 @@ interface PaginationData {
   hasPrevPage: boolean;
 }
 
+interface StatsData {
+  todayCount: number;
+  weekCount: number;
+  uniqueEmailCount: number;
+}
+
 interface ApiResponse {
   submissions: ContactSubmission[];
   pagination: PaginationData;
+  stats: StatsData;
   meta: {
     searchTerm: string;
     sortBy: string;
@@ -37,6 +44,7 @@ interface ApiResponse {
 
 export default function AdminSupportPage() {
   const [submissions, setSubmissions] = useState<ContactSubmission[]>([]);
+  const [stats, setStats] = useState<StatsData>({ todayCount: 0, weekCount: 0, uniqueEmailCount: 0 });
   const [pagination, setPagination] = useState<PaginationData>({
     page: 1,
     pageSize: 25,
@@ -73,6 +81,7 @@ export default function AdminSupportPage() {
       const data: ApiResponse = await response.json();
       setSubmissions(data.submissions);
       setPagination(data.pagination);
+      setStats(data.stats);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
@@ -99,21 +108,7 @@ export default function AdminSupportPage() {
     setPagination(prev => ({ ...prev, page: 1 })); // Reset to first page on sort
   };
 
-  // Calculate statistics
-  const todaySubmissions = submissions.filter(submission => {
-    const today = new Date();
-    const submissionDate = new Date(submission.createdAt);
-    return submissionDate.toDateString() === today.toDateString();
-  }).length;
-
-  const weekSubmissions = submissions.filter(submission => {
-    const weekAgo = new Date();
-    weekAgo.setDate(weekAgo.getDate() - 7);
-    const submissionDate = new Date(submission.createdAt);
-    return submissionDate >= weekAgo;
-  }).length;
-
-  const uniqueEmails = new Set(submissions.map(s => s.email)).size;
+  const { todayCount: todaySubmissions, weekCount: weekSubmissions, uniqueEmailCount: uniqueEmails } = stats;
 
   if (error) {
     return (

--- a/apps/admin/src/app/api/admin/audit-logs/route.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/route.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, or, desc, count, gte, lte, ilike } from '@pagespace/db/operators'
+import { eq, and, or, desc, count, gte, lte, ilike, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { activityLogs } from '@pagespace/db/schema/monitoring';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -86,13 +86,20 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
 
     const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
-    // Get total count for pagination
-    const [countResult] = await db
-      .select({ count: count() })
-      .from(activityLogs)
-      .where(whereClause);
+    // Get total count + per-field totals in parallel
+    const [countResult, aiGenResult, hashChainResult] = await Promise.all([
+      db.select({ count: count() }).from(activityLogs).where(whereClause),
+      db.select({ count: count() }).from(activityLogs).where(
+        whereClause ? and(whereClause, eq(activityLogs.isAiGenerated, true)) : eq(activityLogs.isAiGenerated, true)
+      ),
+      db.select({ count: count() }).from(activityLogs).where(
+        whereClause ? and(whereClause, isNotNull(activityLogs.logHash)) : isNotNull(activityLogs.logHash)
+      ),
+    ]);
 
-    const totalCount = countResult?.count || 0;
+    const totalCount = countResult?.[0]?.count || 0;
+    const aiGeneratedTotal = aiGenResult?.[0]?.count || 0;
+    const hashChainTotal = hashChainResult?.[0]?.count || 0;
     const totalPages = Math.ceil(totalCount / limit);
 
     // Fetch paginated activity logs with user info
@@ -149,6 +156,8 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
         totalPages,
         hasNextPage: page < totalPages,
         hasPreviousPage: page > 1,
+        aiGeneratedTotal,
+        hashChainTotal,
       },
       filters: {
         userId,

--- a/apps/admin/src/app/api/admin/contact/route.ts
+++ b/apps/admin/src/app/api/admin/contact/route.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { asc, desc, ilike, or, count } from '@pagespace/db/operators'
+import { asc, desc, ilike, or, and, count, gte, sql } from '@pagespace/db/operators'
 import { contactSubmissions } from '@pagespace/db/schema/contact';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { withAdminAuth } from '@/lib/auth';
@@ -35,11 +35,27 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
         )
       : undefined;
 
-    // Get total count for pagination
-    const totalCount = await db
-      .select({ count: count() })
-      .from(contactSubmissions)
-      .where(searchConditions);
+    // Date boundaries for stats
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const weekAgo = new Date();
+    weekAgo.setDate(weekAgo.getDate() - 7);
+    weekAgo.setHours(0, 0, 0, 0);
+
+    const todayCondition = searchConditions
+      ? and(searchConditions, gte(contactSubmissions.createdAt, todayStart))
+      : gte(contactSubmissions.createdAt, todayStart);
+    const weekCondition = searchConditions
+      ? and(searchConditions, gte(contactSubmissions.createdAt, weekAgo))
+      : gte(contactSubmissions.createdAt, weekAgo);
+
+    // Get total + stats counts in parallel
+    const [totalCountResult, todayCountResult, weekCountResult, uniqueEmailResult] = await Promise.all([
+      db.select({ count: count() }).from(contactSubmissions).where(searchConditions),
+      db.select({ count: count() }).from(contactSubmissions).where(todayCondition),
+      db.select({ count: count() }).from(contactSubmissions).where(weekCondition),
+      db.select({ count: sql<number>`COUNT(DISTINCT ${contactSubmissions.email})` }).from(contactSubmissions).where(searchConditions),
+    ]);
 
     // Build sort condition
     const validSortColumns = {
@@ -71,7 +87,10 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
       .offset(offset);
 
     // Calculate pagination info
-    const total = totalCount[0]?.count || 0;
+    const total = totalCountResult[0]?.count || 0;
+    const todayCount = todayCountResult[0]?.count || 0;
+    const weekCount = weekCountResult[0]?.count || 0;
+    const uniqueEmailCount = Number(uniqueEmailResult[0]?.count ?? 0);
     const totalPages = Math.ceil(total / pageSize);
     const hasNextPage = page < totalPages;
     const hasPrevPage = page > 1;
@@ -85,6 +104,11 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
         totalPages,
         hasNextPage,
         hasPrevPage
+      },
+      stats: {
+        todayCount,
+        weekCount,
+        uniqueEmailCount,
       },
       meta: {
         searchTerm,


### PR DESCRIPTION
## Summary

Three admin panel fixes — all in the same area (admin stats + admin global prompt viewer).

**Audit Logs page** — "AI Generated" and "Hash Chain" cards showed counts from the current 50-row page slice instead of the full database total. Now three parallel `COUNT(*)` queries on the API; `aiGeneratedTotal` + `hashChainTotal` returned in the pagination payload. Removed the misleading `(page)` label suffix.

**Support page** — "Today", "This Week", and "Unique Contacts" filtered a 25-row page slice. Now four parallel COUNT queries (total, today, week, `COUNT(DISTINCT email)`); returned as a `stats` object alongside pagination.

**Global Prompt Viewer** — Page was showing "Forbidden" because `SERVICE_API_SECRET` was documented as required for the admin app but was **entirely absent** from `apps/web/.env.example` and `fly.web.toml`. The web app's service-auth check fails closed when the secret is missing (since `ca56e42dd`). Also fixed the catch block in `handleGlobalPrompt` which returned plain-text `new Response('Internal Server Error')` — this caused the proxy's `upstream.json()` to throw and masked the real error as "Failed to reach web app."

**To fix the prompt viewer in prod**: `fly secrets set --app pagespace-web SERVICE_API_SECRET=<same-value-as-admin-app>`

## Test plan

- [ ] Audit Logs: AI Generated and Hash Chain show true DB totals; applying a filter updates both counts correctly
- [ ] Support: Today / This Week / Unique Contacts show correct totals regardless of page or search term
- [ ] Global Prompt: page loads with Full Access / Read Only tabs after setting `SERVICE_API_SECRET` on both apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)