### PR TITLE
fix(sidebar): restore AI chat tab on settings and non-dashboard pages

### DIFF
--- a/apps/web/src/hooks/__tests__/useDashboardContext.test.ts
+++ b/apps/web/src/hooks/__tests__/useDashboardContext.test.ts
@@ -212,14 +212,13 @@ describe('useDashboardContext', () => {
       expect(result.current.isDashboardContext).toBe(true);
     });
 
-    it('should handle non-dashboard routes', () => {
+    it('should return false for non-dashboard routes like /account', () => {
       vi.mocked(useParams).mockReturnValue({});
       vi.mocked(usePathname).mockReturnValue('/account');
 
       const { result } = renderHook(() => useDashboardContext());
-      // No pageId and not settings, so technically "dashboard context" even though not on dashboard
-      // This is fine because the hook is only used within dashboard layout
-      expect(result.current.isDashboardContext).toBe(true);
+      // No driveId param → not a drive root → sidebar shows Chat tab
+      expect(result.current.isDashboardContext).toBe(false);
     });
   });
 });

--- a/apps/web/src/hooks/useDashboardContext.ts
+++ b/apps/web/src/hooks/useDashboardContext.ts
@@ -2,39 +2,24 @@
 
 import { useParams, usePathname } from 'next/navigation';
 
-// Full-page routes that render their own content in the center panel
-// (no GlobalAssistantView). The sidebar should show the chat tab for these.
-const FULL_PAGE_ROUTE_PATTERN = /\/(activity|calendar|channels|connections|dms|drives|files|members|storage|tasks|trash|workflows)(\/|$)/;
-
 /**
- * Hook to detect if we're on a "dashboard context" where GlobalAssistantView
- * is displayed in the middle panel.
+ * Hook to detect if we're on the dashboard or drive root where GlobalAssistantView
+ * is displayed in the center panel and its state is shared with the sidebar.
  *
- * Dashboard context includes:
+ * isDashboardContext = true ONLY at:
  * - /dashboard (main dashboard)
- * - /dashboard/[driveId] (drive root)
+ * - /dashboard/[driveId] (drive root, no sub-route)
  *
- * NOT dashboard context:
- * - /dashboard/[driveId]/[pageId] (viewing a specific page)
- * - /dashboard/[driveId]/settings (settings pages)
- * - /dashboard/activity, /dashboard/trash, /dashboard/storage, /dashboard/connections (full-page routes)
- * - /dashboard/calendar, /dashboard/tasks, /dashboard/dms, /dashboard/channels (full-page routes)
- * - /dashboard/[driveId]/activity, /dashboard/[driveId]/trash, /dashboard/[driveId]/workflows (drive-level full-page routes)
- * - /dashboard/[driveId]/files, /dashboard/[driveId]/members, /dashboard/[driveId]/calendar, etc.
+ * All other routes (pages, full-page routes, settings, notifications, etc.) use
+ * an independent sidebar chat and return isDashboardContext = false.
  */
 export function useDashboardContext() {
   const params = useParams();
   const pathname = usePathname();
 
-  // Full-page routes render their own content (no GlobalAssistantView),
-  // so the sidebar should show the chat tab independently
-  const isFullPageRoute = FULL_PAGE_ROUTE_PATTERN.test(pathname || '');
-
-  // Dashboard context = no pageId in params, not on special routes, not on full-page routes
-  const isDashboardContext = !params.pageId &&
-    !pathname.endsWith('/settings') &&
-    !pathname.endsWith('/settings/mcp') &&
-    !isFullPageRoute;
+  const isDashboardContext =
+    pathname === '/dashboard' ||
+    (!params.pageId && /^\/dashboard\/[^/]+$/.test(pathname || ''));
 
   return { isDashboardContext };
 }

--- a/apps/web/src/hooks/useDashboardContext.ts
+++ b/apps/web/src/hooks/useDashboardContext.ts
@@ -17,9 +17,13 @@ export function useDashboardContext() {
   const params = useParams();
   const pathname = usePathname();
 
+  // Normalize pathname to strip any trailing slash for consistent matching
+  const normalizedPath = pathname?.replace(/\/$/, '') || '';
+
+  // params.driveId distinguishes /dashboard/[driveId] from static routes like /dashboard/calendar
   const isDashboardContext =
-    pathname === '/dashboard' ||
-    (!params.pageId && /^\/dashboard\/[^/]+$/.test(pathname || ''));
+    normalizedPath === '/dashboard' ||
+    (!!params.driveId && !params.pageId && /^\/dashboard\/[^/]+$/.test(normalizedPath));
 
   return { isDashboardContext };
 }


### PR DESCRIPTION
## Summary

- All \`/settings/*\` sub-pages (at both app level and drive level), \`/notifications\`, and \`/account\` were missing the Chat tab in the right sidebar — only History and Activity showed
- Root cause: \`useDashboardContext\` used a \`FULL_PAGE_ROUTE_PATTERN\` blocklist that couldn't keep up with new pages; anything not in the list incorrectly got \`isDashboardContext = true\`
- Fix: replace the blocklist with a positive match — \`isDashboardContext\` is \`true\` only at \`/dashboard\` and \`/dashboard/[driveId]\` (the two routes where GlobalAssistantView is in the center and synced with the sidebar); every other route shows Chat independently

## Two bugs caught in review and fixed

1. **Static dashboard routes regressed** — \`/dashboard/calendar\`, \`/dashboard/tasks\`, etc. have no \`params.driveId\` but matched the \`/dashboard/<segment>\` regex, incorrectly hiding Chat. Fixed by gating the drive-root check on \`!!params.driveId\`.

2. **Trailing slashes** — \`/dashboard/\` and \`/dashboard/drive-123/\` failed the equality/regex checks. Fixed by normalizing with \`pathname?.replace(/\\/\$/, '')\` before all comparisons.

## Affected pages (now fixed)

**App-level settings:** \`/settings/account\`, \`/settings/ai\`, \`/settings/backups\`, \`/settings/billing\`, \`/settings/commands\`, \`/settings/display\`, \`/settings/hotkeys\`, \`/settings/integrations\`, \`/settings/local-mcp\`, \`/settings/notifications\`, \`/settings/personalization\`, \`/settings/plan\`, \`/settings/usage\`

**Drive-level settings:** \`/dashboard/[driveId]/settings/backups\`, \`/settings/commands\`, \`/settings/context\`, \`/settings/danger\`, \`/settings/general\`, \`/settings/integrations\`, \`/settings/roles\`

**Other:** \`/notifications\`, \`/account\`

## Test plan

- [ ] Navigate to \`/settings/billing\` — Chat tab appears in right sidebar
- [ ] Navigate to \`/dashboard/[driveId]/settings/general\` — Chat tab appears
- [ ] Navigate to \`/notifications\` — Chat tab appears
- [ ] Navigate to \`/dashboard\` — only History + Activity (no Chat tab, GlobalAssistantView is in center)
- [ ] Navigate to \`/dashboard/[driveId]\` (drive root) — only History + Activity
- [ ] Navigate to a specific page \`/dashboard/[driveId]/[pageId]\` — Chat tab appears
- [ ] Navigate to \`/dashboard/[driveId]/activity\` — Chat tab appears
- [ ] Navigate to \`/dashboard/calendar\` — Chat tab appears (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)