### PR TITLE
feat(agents): dedicated trigger tools for calendar and task scheduling

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -843,6 +843,47 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     />
   ),
 
+  // === TRIGGER TOOLS ===
+  set_calendar_trigger: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="update"
+      success={parsedOutput.success !== false}
+      title="Calendar Trigger"
+      message={(parsedOutput.summary || parsedOutput.message) as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  delete_calendar_trigger: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="delete"
+      success={parsedOutput.success !== false}
+      title="Calendar Trigger"
+      message={(parsedOutput.summary || parsedOutput.message) as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  set_task_trigger: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="update"
+      success={parsedOutput.success !== false}
+      title="Task Trigger"
+      message={(parsedOutput.summary || parsedOutput.message) as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  delete_task_trigger: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="delete"
+      success={parsedOutput.success !== false}
+      title="Task Trigger"
+      message={(parsedOutput.summary || parsedOutput.message) as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
   // === CLI TOOLS (pi / pagespace-cli) ===
   // pi tool names are lowercase (read, write, edit, bash, find, grep, ls).
   // These tools return plain strings so `output` carries the content and `parsedOutput` is {}.

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -119,6 +119,15 @@ vi.mock('../../tools/member-tools', () => ({
   },
 }));
 
+vi.mock('../../tools/trigger-tools', () => ({
+  triggerTools: {
+    set_calendar_trigger: { name: 'set_calendar_trigger', description: 'Set calendar trigger' },
+    delete_calendar_trigger: { name: 'delete_calendar_trigger', description: 'Delete calendar trigger' },
+    set_task_trigger: { name: 'set_task_trigger', description: 'Set task trigger' },
+    delete_task_trigger: { name: 'delete_task_trigger', description: 'Delete task trigger' },
+  },
+}));
+
 // Stub the sandbox tools so the builder can be exercised without loading the DB
 // module graph or the real Fly Sprites driver.
 vi.mock('../../tools/sandbox-tools-runtime', () => ({
@@ -145,6 +154,7 @@ import { calendarReadTools } from '../../tools/calendar-read-tools';
 import { calendarWriteTools } from '../../tools/calendar-write-tools';
 import { channelTools } from '../../tools/channel-tools';
 import { workflowTools } from '../../tools/workflow-tools';
+import { triggerTools } from '../../tools/trigger-tools';
 import { modelTools } from '../../tools/model-tools';
 
 describe('ai-tools', () => {
@@ -169,6 +179,7 @@ describe('ai-tools', () => {
         ...calendarWriteTools,
         ...channelTools,
         ...workflowTools,
+        ...triggerTools,
         ...modelTools,
       });
     });
@@ -189,6 +200,7 @@ describe('ai-tools', () => {
         Object.keys(calendarWriteTools),
         Object.keys(channelTools),
         Object.keys(workflowTools),
+        Object.keys(triggerTools),
         Object.keys(modelTools),
       ];
 

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -129,6 +129,10 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(isWriteTool('update_workflow')).toBe(true);
     expect(isWriteTool('delete_workflow')).toBe(true);
     expect(isWriteTool('list_workflows')).toBe(false);
+    expect(isWriteTool('set_calendar_trigger')).toBe(true);
+    expect(isWriteTool('delete_calendar_trigger')).toBe(true);
+    expect(isWriteTool('set_task_trigger')).toBe(true);
+    expect(isWriteTool('delete_task_trigger')).toBe(true);
   });
 
   it('excludes workflow write tools in read-only mode but keeps list_workflows', () => {
@@ -143,5 +147,21 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(filtered).not.toHaveProperty('create_workflow');
     expect(filtered).not.toHaveProperty('update_workflow');
     expect(filtered).not.toHaveProperty('delete_workflow');
+  });
+
+  it('excludes trigger write tools in read-only mode', () => {
+    const tools = {
+      set_calendar_trigger: 'w',
+      delete_calendar_trigger: 'w',
+      set_task_trigger: 'w',
+      delete_task_trigger: 'w',
+      list_calendar_events: 'r',
+    };
+    const filtered = filterToolsForReadOnly(tools, true);
+    expect(filtered).not.toHaveProperty('set_calendar_trigger');
+    expect(filtered).not.toHaveProperty('delete_calendar_trigger');
+    expect(filtered).not.toHaveProperty('set_task_trigger');
+    expect(filtered).not.toHaveProperty('delete_task_trigger');
+    expect(filtered).toHaveProperty('list_calendar_events');
   });
 });

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -14,6 +14,7 @@ import { calendarReadTools } from '../tools/calendar-read-tools';
 import { calendarWriteTools } from '../tools/calendar-write-tools';
 import { channelTools } from '../tools/channel-tools';
 import { workflowTools } from '../tools/workflow-tools';
+import { triggerTools } from '../tools/trigger-tools';
 import { modelTools } from '../tools/model-tools';
 import { buildSandboxTools } from '../tools/sandbox-tools-runtime';
 import { CORE_TOOL_NAMES } from './stub-tools';
@@ -33,6 +34,7 @@ const baseTools = {
   ...calendarWriteTools,
   ...channelTools,
   ...workflowTools,
+  ...triggerTools,
   ...modelTools,
 };
 

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -43,6 +43,11 @@ const WRITE_TOOLS = new Set([
   'create_workflow',
   'update_workflow',
   'delete_workflow',
+  // Trigger operations
+  'set_calendar_trigger',
+  'delete_calendar_trigger',
+  'set_task_trigger',
+  'delete_task_trigger',
 ]);
 
 // Web search tools (excluded when web search is disabled)

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -14,7 +14,7 @@ const {
   mockCreateTaskTriggerWorkflow,
   mockRecomputeTaskTriggerMetadata,
   mockIsUserDriveMember,
-  mockCanUserEditPage,
+  mockCanActorEditPage,
   mockCanActorManageDrive,
   mockDriveDeniedByAppToken,
   mockBroadcastCalendarEvent,
@@ -42,7 +42,7 @@ const {
     mockCreateTaskTriggerWorkflow: vi.fn(),
     mockRecomputeTaskTriggerMetadata: vi.fn(),
     mockIsUserDriveMember: vi.fn(),
-    mockCanUserEditPage: vi.fn(),
+    mockCanActorEditPage: vi.fn(),
     mockCanActorManageDrive: vi.fn(),
     mockDriveDeniedByAppToken: vi.fn().mockResolvedValue(false),
     mockBroadcastCalendarEvent: vi.fn(),
@@ -90,9 +90,9 @@ vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
 }));
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   isUserDriveMember: mockIsUserDriveMember,
-  canUserEditPage: mockCanUserEditPage,
 }));
 vi.mock('../actor-permissions', () => ({
+  canActorEditPage: mockCanActorEditPage,
   canActorManageDrive: mockCanActorManageDrive,
   driveDeniedByAppToken: mockDriveDeniedByAppToken,
 }));
@@ -290,7 +290,7 @@ describe('triggerTools.set_task_trigger', () => {
   });
 
   it('creates a due_date trigger on a task with due date', async () => {
-    mockCanUserEditPage.mockResolvedValue(true);
+    mockCanActorEditPage.mockResolvedValue(true);
     const result = await triggerTools.set_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Review task' },
       ctx(),
@@ -303,7 +303,7 @@ describe('triggerTools.set_task_trigger', () => {
   });
 
   it('creates a completion trigger', async () => {
-    mockCanUserEditPage.mockResolvedValue(true);
+    mockCanActorEditPage.mockResolvedValue(true);
     const result = await triggerTools.set_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'completion', agentPageId: 'agent-1', prompt: 'Post-completion work' },
       ctx(),
@@ -323,7 +323,7 @@ describe('triggerTools.set_task_trigger', () => {
       if (callCount === 2) return Promise.resolve(SAMPLE_TASKLIST_PAGE);
       return Promise.resolve(SAMPLE_TASKLIST);
     });
-    mockCanUserEditPage.mockResolvedValue(true);
+    mockCanActorEditPage.mockResolvedValue(true);
     const result = await triggerTools.set_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Run' },
       ctx(),
@@ -333,7 +333,7 @@ describe('triggerTools.set_task_trigger', () => {
   });
 
   it('rejects when user lacks edit access', async () => {
-    mockCanUserEditPage.mockResolvedValue(false);
+    mockCanActorEditPage.mockResolvedValue(false);
     const result = await triggerTools.set_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Run' },
       ctx(),
@@ -351,7 +351,7 @@ describe('triggerTools.set_task_trigger', () => {
       if (callCount === 2) return Promise.resolve({ ...SAMPLE_TASKLIST_PAGE, driveId: null });
       return Promise.resolve(SAMPLE_TASKLIST);
     });
-    mockCanUserEditPage.mockResolvedValue(true);
+    mockCanActorEditPage.mockResolvedValue(true);
     const result = await triggerTools.set_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'completion', agentPageId: 'agent-1', prompt: 'Run' },
       ctx(),
@@ -384,7 +384,7 @@ describe('triggerTools.delete_task_trigger', () => {
   });
 
   it('disables the trigger and recomputes metadata', async () => {
-    mockCanUserEditPage.mockResolvedValue(true);
+    mockCanActorEditPage.mockResolvedValue(true);
     const result = (await triggerTools.delete_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'due_date' },
       ctx(),
@@ -396,7 +396,7 @@ describe('triggerTools.delete_task_trigger', () => {
   });
 
   it('rejects when user lacks edit access', async () => {
-    mockCanUserEditPage.mockResolvedValue(false);
+    mockCanActorEditPage.mockResolvedValue(false);
     const result = (await triggerTools.delete_task_trigger.execute!(
       { taskId: 'task-1', triggerType: 'completion' },
       ctx(),

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -89,7 +89,7 @@ vi.mock('../actor-permissions', () => ({
 }));
 vi.mock('@/lib/websocket/calendar-events', () => ({ broadcastCalendarEvent: mockBroadcastCalendarEvent }));
 vi.mock('@/lib/websocket', () => ({ broadcastTaskEvent: mockBroadcastTaskEvent }));
-vi.mock('../core/timestamp-utils', () => ({
+vi.mock('../../core/timestamp-utils', () => ({
   parseDateTime: vi.fn((s: string) => new Date(s)),
   normalizeTimezone: vi.fn((tz: string) => tz ?? 'UTC'),
 }));
@@ -377,6 +377,9 @@ describe('triggerTools.delete_task_trigger', () => {
     vi.clearAllMocks();
     mockDriveDeniedByAppToken.mockResolvedValue(false);
     mockBroadcastTaskEvent.mockResolvedValue(undefined);
+    mockDbTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      return fn({ update: mockUpdate });
+    });
     let callCount = 0;
     mockDbQuery.mockImplementation(() => {
       callCount++;

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { z } from 'zod';
 
 const {
   mockDbQuery,
@@ -69,14 +68,6 @@ vi.mock('@pagespace/db/schema/tasks', () => ({ taskItems: {}, taskLists: {} }));
 vi.mock('@pagespace/db/schema/task-triggers', () => ({ taskTriggers: {} }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { ai: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) } },
-}));
-vi.mock('@/lib/workflows/agent-trigger-shared', () => ({
-  agentTriggerBaseSchema: z.object({
-    agentPageId: z.string(),
-    prompt: z.string().optional(),
-    instructionPageId: z.string().nullable().optional(),
-    contextPageIds: z.array(z.string()).optional(),
-  }),
 }));
 vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
   upsertCalendarTriggerWorkflow: mockUpsertCalendarTriggerWorkflow,
@@ -368,6 +359,16 @@ describe('triggerTools.set_task_trigger', () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/prompt or instructionPageId/);
   });
+
+  it('rejects when app token is denied access to the drive', async () => {
+    mockDriveDeniedByAppToken.mockResolvedValue(true);
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/token/);
+  });
 });
 
 describe('triggerTools.delete_task_trigger', () => {
@@ -403,5 +404,15 @@ describe('triggerTools.delete_task_trigger', () => {
     )) as { success: boolean; error?: string };
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/edit access/);
+  });
+
+  it('rejects when app token is denied access to the drive', async () => {
+    mockDriveDeniedByAppToken.mockResolvedValue(true);
+    const result = (await triggerTools.delete_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date' },
+      ctx(),
+    )) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/token/);
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -269,6 +269,7 @@ describe('triggerTools.delete_calendar_trigger', () => {
 describe('triggerTools.set_task_trigger', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDriveDeniedByAppToken.mockResolvedValue(false);
     mockBroadcastTaskEvent.mockResolvedValue(undefined);
     // Default multi-query mock: task → tasklist page → tasklist
     let callCount = 0;
@@ -374,6 +375,7 @@ describe('triggerTools.set_task_trigger', () => {
 describe('triggerTools.delete_task_trigger', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDriveDeniedByAppToken.mockResolvedValue(false);
     mockBroadcastTaskEvent.mockResolvedValue(undefined);
     let callCount = 0;
     mockDbQuery.mockImplementation(() => {

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+const {
+  mockDbQuery,
+  mockInsert, mockInsertValues, mockInsertReturning,
+  mockUpdate, mockUpdateSet, mockUpdateWhere,
+  mockSelect, mockSelectFrom, mockSelectWhere,
+  mockDbTransaction,
+  mockUpsertCalendarTriggerWorkflow,
+  mockUpsertCalendarTriggerWorkflowInTx,
+  mockRemoveCalendarTrigger,
+  mockValidateCalendarAgentTrigger,
+  mockCreateTaskTriggerWorkflow,
+  mockRecomputeTaskTriggerMetadata,
+  mockIsUserDriveMember,
+  mockCanUserEditPage,
+  mockCanActorManageDrive,
+  mockDriveDeniedByAppToken,
+  mockBroadcastCalendarEvent,
+  mockBroadcastTaskEvent,
+} = vi.hoisted(() => {
+  const mockInsertReturning = vi.fn().mockResolvedValue([{ id: 'event-1' }]);
+  const mockInsertValues = vi.fn(() => ({ returning: mockInsertReturning }));
+  const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+  const mockUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+  const mockSelectWhere = vi.fn().mockResolvedValue([]);
+  const mockSelectFrom = vi.fn(() => ({ where: mockSelectWhere }));
+  const mockSelect = vi.fn(() => ({ from: mockSelectFrom }));
+  return {
+    mockDbQuery: vi.fn(),
+    mockInsert, mockInsertValues, mockInsertReturning,
+    mockUpdate, mockUpdateSet, mockUpdateWhere,
+    mockSelect, mockSelectFrom, mockSelectWhere,
+    mockDbTransaction: vi.fn(),
+    mockUpsertCalendarTriggerWorkflow: vi.fn(),
+    mockUpsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'ct-1' }),
+    mockRemoveCalendarTrigger: vi.fn(),
+    mockValidateCalendarAgentTrigger: vi.fn(),
+    mockCreateTaskTriggerWorkflow: vi.fn(),
+    mockRecomputeTaskTriggerMetadata: vi.fn(),
+    mockIsUserDriveMember: vi.fn(),
+    mockCanUserEditPage: vi.fn(),
+    mockCanActorManageDrive: vi.fn(),
+    mockDriveDeniedByAppToken: vi.fn().mockResolvedValue(false),
+    mockBroadcastCalendarEvent: vi.fn(),
+    mockBroadcastTaskEvent: vi.fn(),
+  };
+});
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { calendarEvents: { findFirst: mockDbQuery }, taskItems: { findFirst: mockDbQuery }, pages: { findFirst: mockDbQuery }, taskLists: { findFirst: mockDbQuery } },
+    insert: mockInsert,
+    update: mockUpdate,
+    select: mockSelect,
+    transaction: mockDbTransaction,
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a, b) => ({ op: 'eq', a, b })),
+  and: vi.fn((...args) => ({ op: 'and', args })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
+vi.mock('@pagespace/db/schema/calendar', () => ({ calendarEvents: {}, eventAttendees: {} }));
+vi.mock('@pagespace/db/schema/tasks', () => ({ taskItems: {}, taskLists: {} }));
+vi.mock('@pagespace/db/schema/task-triggers', () => ({ taskTriggers: {} }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) } },
+}));
+vi.mock('@/lib/workflows/agent-trigger-shared', () => ({
+  agentTriggerBaseSchema: z.object({
+    agentPageId: z.string(),
+    prompt: z.string().optional(),
+    instructionPageId: z.string().nullable().optional(),
+    contextPageIds: z.array(z.string()).optional(),
+  }),
+}));
+vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
+  upsertCalendarTriggerWorkflow: mockUpsertCalendarTriggerWorkflow,
+  upsertCalendarTriggerWorkflowInTx: mockUpsertCalendarTriggerWorkflowInTx,
+  removeCalendarTrigger: mockRemoveCalendarTrigger,
+  validateCalendarAgentTrigger: mockValidateCalendarAgentTrigger,
+}));
+vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
+  createTaskTriggerWorkflow: mockCreateTaskTriggerWorkflow,
+  recomputeTaskTriggerMetadata: mockRecomputeTaskTriggerMetadata,
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: mockIsUserDriveMember,
+  canUserEditPage: mockCanUserEditPage,
+}));
+vi.mock('../actor-permissions', () => ({
+  canActorManageDrive: mockCanActorManageDrive,
+  driveDeniedByAppToken: mockDriveDeniedByAppToken,
+}));
+vi.mock('@/lib/websocket/calendar-events', () => ({ broadcastCalendarEvent: mockBroadcastCalendarEvent }));
+vi.mock('@/lib/websocket', () => ({ broadcastTaskEvent: mockBroadcastTaskEvent }));
+vi.mock('../core/timestamp-utils', () => ({
+  parseDateTime: vi.fn((s: string) => new Date(s)),
+  normalizeTimezone: vi.fn((tz: string) => tz ?? 'UTC'),
+}));
+
+import { triggerTools } from '../trigger-tools';
+
+type TR = { success: boolean; error?: string; [key: string]: unknown };
+
+function ctx(overrides: Record<string, unknown> = {}) {
+  return { toolCallId: '1', messages: [], experimental_context: { userId: 'user-1', timezone: 'UTC', ...overrides } };
+}
+
+const TRIGGER_AT = '2026-07-01T09:00:00Z';
+const SAMPLE_EVENT = {
+  id: 'ev-1', title: 'Stand-up', startAt: new Date(TRIGGER_AT), endAt: new Date('2026-07-01T10:00:00Z'),
+  timezone: 'UTC', driveId: 'drive-1', createdById: 'user-1', isTrashed: false, recurrenceRule: null, recurrenceExceptions: [],
+  allDay: false, visibility: 'DRIVE', color: 'default', metadata: null, pageId: null, description: null, location: null, updatedAt: new Date(),
+};
+
+const SAMPLE_TASK = {
+  id: 'task-1', dueDate: new Date('2026-07-15T00:00:00Z'), metadata: null,
+  page: { parentId: 'tasklist-page-1' },
+};
+const SAMPLE_TASKLIST_PAGE = { id: 'tasklist-page-1', driveId: 'drive-1', isTrashed: false };
+const SAMPLE_TASKLIST = { id: 'tl-1' };
+
+describe('triggerTools.set_calendar_trigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDriveDeniedByAppToken.mockResolvedValue(false);
+    mockBroadcastCalendarEvent.mockResolvedValue(undefined);
+    mockBroadcastTaskEvent.mockResolvedValue(undefined);
+    mockUpsertCalendarTriggerWorkflow.mockResolvedValue({ workflowId: 'wf-1', triggerId: 'ct-1' });
+  });
+
+  it('attaches trigger to existing event when calendarEventId is given', async () => {
+    mockDbQuery.mockResolvedValue(SAMPLE_EVENT);
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1', agentPageId: 'agent-1', prompt: 'Run daily summary' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(true);
+    expect(result.calendarEventId).toBe('ev-1');
+    expect(mockUpsertCalendarTriggerWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ calendarEventId: 'ev-1', agentTrigger: expect.objectContaining({ agentPageId: 'agent-1' }) }),
+    );
+  });
+
+  it('rejects trigger on personal event (no driveId)', async () => {
+    mockDbQuery.mockResolvedValue({ ...SAMPLE_EVENT, driveId: null });
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/drive event/);
+  });
+
+  it('rejects when user is not creator or admin', async () => {
+    mockDbQuery.mockResolvedValue({ ...SAMPLE_EVENT, createdById: 'other-user' });
+    mockCanActorManageDrive.mockResolvedValue(false);
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/creator or a drive admin/);
+  });
+
+  it('allows drive admin to attach trigger on another user\'s event', async () => {
+    mockDbQuery.mockResolvedValue({ ...SAMPLE_EVENT, createdById: 'other-user' });
+    mockCanActorManageDrive.mockResolvedValue(true);
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(true);
+  });
+
+  it('creates new event and trigger when triggerAt + driveId are provided', async () => {
+    mockIsUserDriveMember.mockResolvedValue(true);
+    mockValidateCalendarAgentTrigger.mockResolvedValue(undefined);
+    mockDbTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const mockTx = {
+        insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'new-ev-1' }]) })) })),
+        update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+      };
+      return fn(mockTx);
+    });
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { triggerAt: TRIGGER_AT, driveId: 'drive-1', agentPageId: 'agent-1', prompt: 'Run at time' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(true);
+    expect(mockIsUserDriveMember).toHaveBeenCalledWith('user-1', 'drive-1');
+    expect(mockValidateCalendarAgentTrigger).toHaveBeenCalled();
+  });
+
+  it('rejects when no calendarEventId and no triggerAt/driveId', async () => {
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/calendarEventId.*triggerAt/);
+  });
+
+  it('rejects when neither prompt nor instructionPageId given', async () => {
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1', agentPageId: 'agent-1' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/prompt or instructionPageId/);
+  });
+
+  it('returns error when event not found', async () => {
+    mockDbQuery.mockResolvedValue(undefined);
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { calendarEventId: 'missing-id', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/);
+  });
+
+  it('rejects when unauthenticated', async () => {
+    await expect(
+      triggerTools.set_calendar_trigger.execute!(
+        { calendarEventId: 'ev-1', agentPageId: 'agent-1', prompt: 'Run' },
+        { toolCallId: '1', messages: [], experimental_context: {} },
+      ),
+    ).rejects.toThrow('User authentication required');
+  });
+});
+
+describe('triggerTools.delete_calendar_trigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDriveDeniedByAppToken.mockResolvedValue(false);
+    mockBroadcastCalendarEvent.mockResolvedValue(undefined);
+  });
+
+  it('removes trigger and broadcasts', async () => {
+    mockDbQuery.mockResolvedValue(SAMPLE_EVENT);
+    const result = await triggerTools.delete_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(true);
+    expect(mockRemoveCalendarTrigger).toHaveBeenCalledWith(expect.anything(), 'ev-1');
+    expect(mockBroadcastCalendarEvent).toHaveBeenCalled();
+  });
+
+  it('rejects when user is not creator or admin', async () => {
+    mockDbQuery.mockResolvedValue({ ...SAMPLE_EVENT, createdById: 'other-user' });
+    mockCanActorManageDrive.mockResolvedValue(false);
+    const result = await triggerTools.delete_calendar_trigger.execute!(
+      { calendarEventId: 'ev-1' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error when event not found', async () => {
+    mockDbQuery.mockResolvedValue(undefined);
+    const result = await triggerTools.delete_calendar_trigger.execute!(
+      { calendarEventId: 'missing' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/);
+  });
+});
+
+describe('triggerTools.set_task_trigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBroadcastTaskEvent.mockResolvedValue(undefined);
+    // Default multi-query mock: task → tasklist page → tasklist
+    let callCount = 0;
+    mockDbQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(SAMPLE_TASK);
+      if (callCount === 2) return Promise.resolve(SAMPLE_TASKLIST_PAGE);
+      return Promise.resolve(SAMPLE_TASKLIST);
+    });
+  });
+
+  it('creates a due_date trigger on a task with due date', async () => {
+    mockCanUserEditPage.mockResolvedValue(true);
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Review task' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(true);
+    expect(mockCreateTaskTriggerWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-1', driveId: 'drive-1', agentTrigger: expect.objectContaining({ triggerType: 'due_date' }) }),
+    );
+    expect(mockBroadcastTaskEvent).toHaveBeenCalled();
+  });
+
+  it('creates a completion trigger', async () => {
+    mockCanUserEditPage.mockResolvedValue(true);
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'completion', agentPageId: 'agent-1', prompt: 'Post-completion work' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(true);
+    expect(mockCreateTaskTriggerWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ agentTrigger: expect.objectContaining({ triggerType: 'completion' }) }),
+    );
+  });
+
+  it('rejects due_date trigger when task has no due date', async () => {
+    mockDbQuery.mockReset();
+    let callCount = 0;
+    mockDbQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ ...SAMPLE_TASK, dueDate: null });
+      if (callCount === 2) return Promise.resolve(SAMPLE_TASKLIST_PAGE);
+      return Promise.resolve(SAMPLE_TASKLIST);
+    });
+    mockCanUserEditPage.mockResolvedValue(true);
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/due date/);
+  });
+
+  it('rejects when user lacks edit access', async () => {
+    mockCanUserEditPage.mockResolvedValue(false);
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/edit access/);
+  });
+
+  it('rejects when task list has no driveId (personal task list)', async () => {
+    mockDbQuery.mockReset();
+    let callCount = 0;
+    mockDbQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(SAMPLE_TASK);
+      if (callCount === 2) return Promise.resolve({ ...SAMPLE_TASKLIST_PAGE, driveId: null });
+      return Promise.resolve(SAMPLE_TASKLIST);
+    });
+    mockCanUserEditPage.mockResolvedValue(true);
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'completion', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/drive-based/);
+  });
+
+  it('rejects when neither prompt nor instructionPageId given', async () => {
+    const result = await triggerTools.set_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date', agentPageId: 'agent-1' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/prompt or instructionPageId/);
+  });
+});
+
+describe('triggerTools.delete_task_trigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBroadcastTaskEvent.mockResolvedValue(undefined);
+    let callCount = 0;
+    mockDbQuery.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(SAMPLE_TASK);
+      if (callCount === 2) return Promise.resolve(SAMPLE_TASKLIST_PAGE);
+      return Promise.resolve(SAMPLE_TASKLIST);
+    });
+  });
+
+  it('disables the trigger and recomputes metadata', async () => {
+    mockCanUserEditPage.mockResolvedValue(true);
+    const result = (await triggerTools.delete_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'due_date' },
+      ctx(),
+    )) as { success: boolean };
+    expect(result.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockRecomputeTaskTriggerMetadata).toHaveBeenCalledWith(expect.anything(), 'task-1', null);
+    expect(mockBroadcastTaskEvent).toHaveBeenCalled();
+  });
+
+  it('rejects when user lacks edit access', async () => {
+    mockCanUserEditPage.mockResolvedValue(false);
+    const result = (await triggerTools.delete_task_trigger.execute!(
+      { taskId: 'task-1', triggerType: 'completion' },
+      ctx(),
+    )) as { success: boolean; error?: string };
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/edit access/);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -217,6 +217,18 @@ describe('triggerTools.set_calendar_trigger', () => {
     expect(result.error).toMatch(/not found/);
   });
 
+  it('returns error when triggerAt is unparseable', async () => {
+    mockIsUserDriveMember.mockResolvedValue(true);
+    const { parseDateTime } = await import('../../core/timestamp-utils');
+    (parseDateTime as ReturnType<typeof vi.fn>).mockImplementationOnce(() => { throw new Error('Invalid date: garbage'); });
+    const result = await triggerTools.set_calendar_trigger.execute!(
+      { triggerAt: 'garbage', driveId: 'drive-1', agentPageId: 'agent-1', prompt: 'Run' },
+      ctx(),
+    ) as unknown as TR;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Invalid date/);
+  });
+
   it('rejects when unauthenticated', async () => {
     await expect(
       triggerTools.set_calendar_trigger.execute!(

--- a/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/trigger-tools.test.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 
 const {
   mockDbQuery,
-  mockInsert, mockInsertValues, mockInsertReturning,
-  mockUpdate, mockUpdateSet, mockUpdateWhere,
-  mockSelect, mockSelectFrom, mockSelectWhere,
+  mockInsert, _mockInsertValues, _mockInsertReturning,
+  mockUpdate, _mockUpdateSet, _mockUpdateWhere,
+  mockSelect, _mockSelectFrom, _mockSelectWhere,
   mockDbTransaction,
   mockUpsertCalendarTriggerWorkflow,
   mockUpsertCalendarTriggerWorkflowInTx,
@@ -31,9 +31,9 @@ const {
   const mockSelect = vi.fn(() => ({ from: mockSelectFrom }));
   return {
     mockDbQuery: vi.fn(),
-    mockInsert, mockInsertValues, mockInsertReturning,
-    mockUpdate, mockUpdateSet, mockUpdateWhere,
-    mockSelect, mockSelectFrom, mockSelectWhere,
+    mockInsert, _mockInsertValues: mockInsertValues, _mockInsertReturning: mockInsertReturning,
+    mockUpdate, _mockUpdateSet: mockUpdateSet, _mockUpdateWhere: mockUpdateWhere,
+    mockSelect, _mockSelectFrom: mockSelectFrom, _mockSelectWhere: mockSelectWhere,
     mockDbTransaction: vi.fn(),
     mockUpsertCalendarTriggerWorkflow: vi.fn(),
     mockUpsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'ct-1' }),

--- a/apps/web/src/lib/ai/tools/agent-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-tools.ts
@@ -18,7 +18,7 @@ export const agentTools = {
    * Update an existing AI agent's configuration
    */
   update_agent_config: tool({
-    description: 'Update the configuration of an existing AI agent, including system prompt, enabled tools, AI provider, and model settings.',
+    description: 'Update the configuration of an existing AI agent, including system prompt, enabled tools, AI provider, and model settings. Does not manage triggers — use set_calendar_trigger, set_task_trigger, or create_workflow for scheduling.',
     inputSchema: z.object({
       agentPath: z.string().describe('The agent path using titles like "/driveSlug/Agent Name" for semantic context'),
       agentId: z.string().describe('The unique ID of the AI agent to update'),

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -74,7 +74,7 @@ export const calendarWriteTools = {
    */
   create_calendar_event: tool({
     description:
-      'Create a new calendar event. Supports natural language dates like "tomorrow at 3pm" or "next Monday 10am" as well as ISO 8601 format. For recurring events, specify the recurrence rule. Optionally schedule an AI agent to execute when the event time arrives by providing agentTrigger.',
+      'Create a new calendar event. Supports natural language dates like "tomorrow at 3pm" or "next Monday 10am" as well as ISO 8601 format. For recurring events, specify the recurrence rule. To schedule an AI agent at a specific time, prefer set_calendar_trigger (dedicated tool with simpler schema). The agentTrigger param here works as a shortcut when creating the event and trigger together.',
     inputSchema: z.object({
       title: z.string().min(1).max(500).describe('Event title'),
       startAt: z
@@ -423,7 +423,7 @@ export const calendarWriteTools = {
    */
   update_calendar_event: tool({
     description:
-      'Update an existing calendar event. Only the event creator can update events. Supports partial updates - only specify the fields you want to change.',
+      'Update an existing calendar event. Only the event creator can update events. Supports partial updates - only specify the fields you want to change. To add or change an agent trigger on an existing event, prefer set_calendar_trigger instead.',
     inputSchema: z.object({
       eventId: z.string().describe('The unique ID of the event to update'),
       title: z.string().min(1).max(500).optional().describe('New event title'),

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -63,7 +63,8 @@ Assignment:
 - Agents can assign tasks to themselves or other agents
 
 Agent Triggers:
-- Schedule an AI agent to run at task due date or on task completion
+- Prefer set_task_trigger for attaching triggers to existing tasks (dedicated tool, simpler schema)
+- The agentTrigger param here works as a shortcut when updating the task and setting the trigger together
 - Provide agentTrigger with agentPageId and either prompt or instructionPageId
 - triggerType 'due_date' fires when the due date arrives (requires dueDate)
 - triggerType 'completion' fires when the task is marked done`,

--- a/apps/web/src/lib/ai/tools/trigger-tools.ts
+++ b/apps/web/src/lib/ai/tools/trigger-tools.ts
@@ -16,12 +16,12 @@ import {
   createTaskTriggerWorkflow,
   recomputeTaskTriggerMetadata,
 } from '@/lib/workflows/task-trigger-helpers';
-import { isUserDriveMember, canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import type { ToolExecutionContext } from '../core/types';
-import { canActorManageDrive, driveDeniedByAppToken } from './actor-permissions';
+import { canActorManageDrive, driveDeniedByAppToken, canActorEditPage } from './actor-permissions';
 import { parseDateTime, normalizeTimezone } from '../core/timestamp-utils';
 import type { CalendarTriggerMetadata } from '@pagespace/db/schema/calendar-triggers';
 
@@ -281,7 +281,7 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
       if (!taskListPage || taskListPage.isTrashed) return { success: false, error: 'Task list not found.' };
       if (!taskListPage.driveId) return { success: false, error: 'Task triggers require a drive-based task list.' };
 
-      if (!(await canUserEditPage(userId, taskListPageId))) {
+      if (!(await canActorEditPage(ctx, taskListPageId))) {
         return { success: false, error: 'You do not have edit access to this task list.' };
       }
 
@@ -348,7 +348,7 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
       ]);
 
       if (!taskListPage || taskListPage.isTrashed) return { success: false, error: 'Task list not found.' };
-      if (!(await canUserEditPage(userId, taskListPageId))) {
+      if (!(await canActorEditPage(ctx, taskListPageId))) {
         return { success: false, error: 'You do not have edit access to this task list.' };
       }
 

--- a/apps/web/src/lib/ai/tools/trigger-tools.ts
+++ b/apps/web/src/lib/ai/tools/trigger-tools.ts
@@ -1,0 +1,369 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
+import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
+import { taskTriggers } from '@pagespace/db/schema/task-triggers';
+import { agentTriggerBaseSchema } from '@/lib/workflows/agent-trigger-shared';
+import {
+  upsertCalendarTriggerWorkflow,
+  upsertCalendarTriggerWorkflowInTx,
+  removeCalendarTrigger,
+  validateCalendarAgentTrigger,
+} from '@/lib/workflows/calendar-trigger-helpers';
+import {
+  createTaskTriggerWorkflow,
+  recomputeTaskTriggerMetadata,
+} from '@/lib/workflows/task-trigger-helpers';
+import { isUserDriveMember, canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
+import { broadcastTaskEvent } from '@/lib/websocket';
+import type { ToolExecutionContext } from '../core/types';
+import { canActorManageDrive, driveDeniedByAppToken } from './actor-permissions';
+import { parseDateTime, normalizeTimezone } from '../core/timestamp-utils';
+import type { CalendarTriggerMetadata } from '@pagespace/db/schema/calendar-triggers';
+
+const logger = loggers.ai.child({ module: 'trigger-tools' });
+
+async function loadEventAttendeeIds(eventId: string): Promise<string[]> {
+  const rows = await db
+    .select({ userId: eventAttendees.userId })
+    .from(eventAttendees)
+    .where(eq(eventAttendees.eventId, eventId));
+  return rows.map((r) => r.userId);
+}
+
+async function canManageEvent(
+  ctx: ToolExecutionContext,
+  userId: string,
+  event: typeof calendarEvents.$inferSelect,
+): Promise<boolean> {
+  if (event.createdById === userId) return true;
+  if (event.driveId) return canActorManageDrive(ctx, event.driveId);
+  return false;
+}
+
+/**
+ * Dedicated tools for attaching and removing agent triggers on calendar events
+ * and task items.
+ *
+ * These are the primary surface for trigger management. The agentTrigger
+ * parameters that exist on create_calendar_event / update_calendar_event /
+ * create_task / update_task remain as convenience shortcuts but agents should
+ * prefer these tools when working with existing entities or scheduling new
+ * agent runs, because the intent is explicit and the schema is flat (no nested
+ * agentTrigger wrapper to navigate).
+ */
+export const triggerTools = {
+  set_calendar_trigger: tool({
+    description: `Attach or update an agent trigger on a calendar event — the agent runs when the event time arrives.
+
+Works in two modes:
+- **Attach to an existing event**: provide calendarEventId. The trigger is set on the event as-is; you must be the event creator or a drive owner/admin.
+- **Create a new scheduling event**: provide triggerAt (ISO 8601 datetime), driveId, and timezone. A calendar event is created solely as the scheduling anchor, and the agent trigger is set on it. Use this when there is no existing event to attach to.
+
+Either way, returns the calendarEventId so you can pass it to delete_calendar_trigger later. Calling again on the same calendarEventId replaces the existing trigger (upsert).`,
+    inputSchema: z.object({
+      calendarEventId: z.string().optional().describe('Existing calendar event ID to attach the trigger to. Provide this OR (triggerAt + driveId).'),
+      triggerAt: z.string().optional().describe('ISO 8601 datetime for the new scheduling event, e.g. "2025-06-15T09:00:00". Provide this with driveId when there is no existing event.'),
+      driveId: z.string().optional().describe('Drive the new scheduling event belongs to. Required when using triggerAt.'),
+      timezone: z.string().optional().describe('IANA timezone for interpreting triggerAt (e.g. "America/New_York"). Defaults to the user\'s timezone, then UTC.'),
+      name: z.string().max(200).optional().describe('Name for the new scheduling event (only used when triggerAt is provided). Defaults to "Agent trigger".'),
+      agentPageId: z.string().describe('ID of the AI agent (AI_CHAT page) to execute when the trigger fires.'),
+      prompt: z.string().max(10000).optional().describe('Instructions passed to the agent when it runs. Required if instructionPageId is omitted.'),
+      instructionPageId: z.string().nullable().optional().describe('ID of a page containing the agent\'s instructions. Required if prompt is omitted.'),
+      contextPageIds: z.array(z.string()).max(10).optional().describe('Up to 10 page IDs to include as reference context for the agent.'),
+    }),
+    execute: async (params, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const { calendarEventId, triggerAt, driveId, timezone: tzInput, name, agentPageId, prompt, instructionPageId, contextPageIds } = params;
+
+      const agentTrigger = { agentPageId, prompt, instructionPageId, contextPageIds };
+
+      if (!prompt && !instructionPageId) {
+        return { success: false, error: 'Provide either a prompt or instructionPageId for the agent trigger.' };
+      }
+
+      // --- Attach to existing event ---
+      if (calendarEventId) {
+        const event = await db.query.calendarEvents.findFirst({
+          where: and(eq(calendarEvents.id, calendarEventId), eq(calendarEvents.isTrashed, false)),
+        });
+        if (!event) return { success: false, error: 'Calendar event not found.' };
+
+        if (!event.driveId) {
+          return { success: false, error: 'Agent triggers require a drive event. This event has no drive.' };
+        }
+
+        if (await driveDeniedByAppToken(ctx, event.driveId, 'edit')) {
+          return { success: false, error: 'This token does not have access to this event\'s drive.' };
+        }
+
+        if (!(await canManageEvent(ctx, userId, event))) {
+          return { success: false, error: 'You must be the event creator or a drive admin to manage triggers on this event.' };
+        }
+
+        try {
+          await upsertCalendarTriggerWorkflow(db, {
+            driveId: event.driveId,
+            scheduledById: userId,
+            calendarEventId,
+            triggerAt: event.startAt,
+            timezone: event.timezone ?? 'UTC',
+            agentTrigger,
+            recurrenceRule: event.recurrenceRule,
+            recurrenceExceptions: event.recurrenceExceptions ?? [],
+          });
+        } catch (err) {
+          return { success: false, error: err instanceof Error ? err.message : 'Failed to save trigger' };
+        }
+
+        const attendeeIds = await loadEventAttendeeIds(calendarEventId);
+        void broadcastCalendarEvent({ eventId: calendarEventId, driveId: event.driveId, operation: 'updated', userId, attendeeIds });
+
+        logger.info('Calendar trigger set on existing event', { calendarEventId, agentPageId });
+        return { success: true, calendarEventId, summary: `Agent trigger set on event "${event.title}". The agent will run at ${event.startAt.toISOString()}.` };
+      }
+
+      // --- Create new scheduling event ---
+      if (!triggerAt || !driveId) {
+        return { success: false, error: 'Provide either calendarEventId (to attach to an existing event) or both triggerAt and driveId (to create a new scheduling event).' };
+      }
+
+      if (await driveDeniedByAppToken(ctx, driveId, 'edit')) {
+        return { success: false, error: 'This token does not have access to the specified drive.' };
+      }
+      if (!(await isUserDriveMember(userId, driveId))) {
+        return { success: false, error: 'You do not have access to this drive.' };
+      }
+
+      const tz = normalizeTimezone(tzInput ?? ctx.timezone);
+      const parsedAt = parseDateTime(triggerAt, undefined, tz);
+      const endAt = new Date(parsedAt.getTime() + 60 * 60 * 1000);
+
+      try {
+        await validateCalendarAgentTrigger(db, { driveId, agentTrigger });
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : 'Invalid agent trigger' };
+      }
+
+      const scheduledByAgentPageId = ctx?.chatSource?.agentPageId;
+
+      const { eventId: createdEventId } = await db.transaction(async (tx) => {
+        const [created] = await tx
+          .insert(calendarEvents)
+          .values({
+            driveId,
+            createdById: userId,
+            title: name ?? 'Agent trigger',
+            startAt: parsedAt,
+            endAt,
+            allDay: false,
+            timezone: tz,
+            visibility: 'DRIVE',
+            color: 'default',
+            updatedAt: new Date(),
+          })
+          .returning({ id: calendarEvents.id });
+
+        await tx.insert(eventAttendees).values({ eventId: created.id, userId, status: 'ACCEPTED', isOrganizer: true, respondedAt: new Date() });
+
+        const { triggerId } = await upsertCalendarTriggerWorkflowInTx(tx, {
+          driveId,
+          scheduledById: userId,
+          calendarEventId: created.id,
+          triggerAt: parsedAt,
+          timezone: tz,
+          agentTrigger,
+          recurrenceRule: null,
+          recurrenceExceptions: [],
+        });
+
+        await tx.update(calendarEvents).set({
+          metadata: {
+            isTrigger: true,
+            triggerType: 'agent_execution',
+            triggerId,
+            scheduledByAgentPageId,
+          } satisfies CalendarTriggerMetadata,
+        }).where(eq(calendarEvents.id, created.id));
+
+        return { eventId: created.id };
+      });
+
+      void broadcastCalendarEvent({ eventId: createdEventId, driveId, operation: 'created', userId, attendeeIds: [userId] });
+
+      logger.info('Calendar trigger created with new event', { calendarEventId: createdEventId, agentPageId, triggerAt: parsedAt.toISOString() });
+      return { success: true, calendarEventId: createdEventId, summary: `Agent trigger scheduled at ${parsedAt.toISOString()} (${tz}). The agent will run at that time.` };
+    },
+  }),
+
+  delete_calendar_trigger: tool({
+    description: 'Remove the agent trigger from a calendar event. Does not delete the event itself — only the scheduled agent execution is cancelled. Idempotent: safe to call even if no trigger exists.',
+    inputSchema: z.object({
+      calendarEventId: z.string().describe('ID of the calendar event whose agent trigger should be removed.'),
+    }),
+    execute: async ({ calendarEventId }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const event = await db.query.calendarEvents.findFirst({
+        where: and(eq(calendarEvents.id, calendarEventId), eq(calendarEvents.isTrashed, false)),
+      });
+      if (!event) return { success: false, error: 'Calendar event not found.' };
+
+      if (event.driveId && await driveDeniedByAppToken(ctx, event.driveId, 'edit')) {
+        return { success: false, error: 'This token does not have access to this event\'s drive.' };
+      }
+
+      if (!(await canManageEvent(ctx, userId, event))) {
+        return { success: false, error: 'You must be the event creator or a drive admin to manage triggers on this event.' };
+      }
+
+      await removeCalendarTrigger(db, calendarEventId);
+
+      const attendeeIds = await loadEventAttendeeIds(calendarEventId);
+      void broadcastCalendarEvent({ eventId: calendarEventId, driveId: event.driveId, operation: 'updated', userId, attendeeIds });
+
+      logger.info('Calendar trigger removed', { calendarEventId });
+      return { success: true, calendarEventId, summary: `Agent trigger removed from event "${event.title}".` };
+    },
+  }),
+
+  set_task_trigger: tool({
+    description: `Attach or update an agent trigger on an existing task item.
+
+- triggerType 'due_date': the agent runs when the task's due date arrives. The task must already have a due date set.
+- triggerType 'completion': the agent runs when the task is marked done.
+
+Calling again with the same taskId + triggerType replaces the existing trigger (upsert). The task must belong to a drive-based task list.`,
+    inputSchema: z.object({
+      taskId: z.string().describe('ID of the task item to attach the trigger to.'),
+      triggerType: z.enum(['due_date', 'completion']).describe('When the agent fires: at the task\'s due date, or when it is marked complete.'),
+      agentPageId: z.string().describe('ID of the AI agent (AI_CHAT page) to execute.'),
+      prompt: z.string().max(10000).optional().describe('Instructions passed to the agent. Required if instructionPageId is omitted.'),
+      instructionPageId: z.string().nullable().optional().describe('ID of a page containing the agent\'s instructions. Required if prompt is omitted.'),
+      contextPageIds: z.array(z.string()).max(10).optional().describe('Up to 10 page IDs to include as reference context for the agent.'),
+    }),
+    execute: async ({ taskId, triggerType, agentPageId, prompt, instructionPageId, contextPageIds }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      if (!prompt && !instructionPageId) {
+        return { success: false, error: 'Provide either a prompt or instructionPageId for the agent trigger.' };
+      }
+
+      const task = await db.query.taskItems.findFirst({
+        where: eq(taskItems.id, taskId),
+        with: { page: { columns: { parentId: true } } },
+      });
+      if (!task?.page?.parentId) return { success: false, error: 'Task not found.' };
+
+      const taskListPageId = task.page.parentId;
+      const [taskListPage, taskList] = await Promise.all([
+        db.query.pages.findFirst({
+          where: eq(pages.id, taskListPageId),
+          columns: { id: true, driveId: true, isTrashed: true },
+        }),
+        db.query.taskLists.findFirst({
+          where: eq(taskLists.pageId, taskListPageId),
+          columns: { id: true },
+        }),
+      ]);
+
+      if (!taskListPage || taskListPage.isTrashed) return { success: false, error: 'Task list not found.' };
+      if (!taskListPage.driveId) return { success: false, error: 'Task triggers require a drive-based task list.' };
+
+      if (!(await canUserEditPage(userId, taskListPageId))) {
+        return { success: false, error: 'You do not have edit access to this task list.' };
+      }
+
+      if (triggerType === 'due_date' && !task.dueDate) {
+        return { success: false, error: 'The task must have a due date set before a due_date trigger can be attached. Set the task\'s due date first via update_task.' };
+      }
+
+      try {
+        await createTaskTriggerWorkflow({
+          database: db,
+          driveId: taskListPage.driveId,
+          userId,
+          taskId,
+          taskMetadata: task.metadata as Record<string, unknown> | null,
+          agentTrigger: { agentPageId, prompt, instructionPageId: instructionPageId ?? undefined, contextPageIds: contextPageIds ?? [], triggerType },
+          dueDate: task.dueDate,
+          timezone: ctx.timezone ?? 'UTC',
+        });
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : 'Failed to save trigger' };
+      }
+
+      void broadcastTaskEvent({ type: 'task_updated', taskId, taskListId: taskList?.id, userId, pageId: taskListPageId, data: { id: taskId, triggerType } });
+
+      logger.info('Task trigger set', { taskId, triggerType, agentPageId });
+      return {
+        success: true,
+        taskId,
+        triggerType,
+        summary: triggerType === 'due_date'
+          ? `Agent trigger set on task. The agent will run at the task's due date (${task.dueDate!.toISOString()}).`
+          : 'Agent trigger set on task. The agent will run when the task is marked complete.',
+      };
+    },
+  }),
+
+  delete_task_trigger: tool({
+    description: 'Remove an agent trigger from a task. Disables the trigger so it will not fire. Idempotent: safe to call even if the trigger does not exist.',
+    inputSchema: z.object({
+      taskId: z.string().describe('ID of the task item.'),
+      triggerType: z.enum(['due_date', 'completion']).describe('Which trigger to remove.'),
+    }),
+    execute: async ({ taskId, triggerType }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const task = await db.query.taskItems.findFirst({
+        where: eq(taskItems.id, taskId),
+        with: { page: { columns: { parentId: true } } },
+      });
+      if (!task?.page?.parentId) return { success: false, error: 'Task not found.' };
+
+      const taskListPageId = task.page.parentId;
+      const [taskListPage, taskList] = await Promise.all([
+        db.query.pages.findFirst({
+          where: eq(pages.id, taskListPageId),
+          columns: { id: true, isTrashed: true },
+        }),
+        db.query.taskLists.findFirst({
+          where: eq(taskLists.pageId, taskListPageId),
+          columns: { id: true },
+        }),
+      ]);
+
+      if (!taskListPage || taskListPage.isTrashed) return { success: false, error: 'Task list not found.' };
+      if (!(await canUserEditPage(userId, taskListPageId))) {
+        return { success: false, error: 'You do not have edit access to this task list.' };
+      }
+
+      await db
+        .update(taskTriggers)
+        .set({ isEnabled: false, lastFireError: 'Disabled by agent', nextRunAt: null })
+        .where(and(eq(taskTriggers.taskItemId, taskId), eq(taskTriggers.triggerType, triggerType)));
+
+      await recomputeTaskTriggerMetadata(db, taskId, task.metadata as Record<string, unknown> | null);
+
+      void broadcastTaskEvent({ type: 'task_updated', taskId, taskListId: taskList?.id, userId, pageId: taskListPageId, data: { id: taskId, removedTriggerType: triggerType } });
+
+      logger.info('Task trigger removed', { taskId, triggerType });
+      return { success: true, taskId, triggerType, summary: `${triggerType === 'due_date' ? 'Due-date' : 'Completion'} trigger removed from task.` };
+    },
+  }),
+};

--- a/apps/web/src/lib/ai/tools/trigger-tools.ts
+++ b/apps/web/src/lib/ai/tools/trigger-tools.ts
@@ -142,8 +142,14 @@ Either way, returns the calendarEventId so you can pass it to delete_calendar_tr
         return { success: false, error: 'You do not have access to this drive.' };
       }
 
-      const tz = normalizeTimezone(tzInput ?? ctx.timezone);
-      const parsedAt = parseDateTime(triggerAt, undefined, tz);
+      let tz: string;
+      let parsedAt: Date;
+      try {
+        tz = normalizeTimezone(tzInput ?? ctx.timezone);
+        parsedAt = parseDateTime(triggerAt, undefined, tz);
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : 'Invalid triggerAt or timezone.' };
+      }
       const endAt = new Date(parsedAt.getTime() + 60 * 60 * 1000);
 
       try {
@@ -361,12 +367,14 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
         return { success: false, error: 'You do not have edit access to this task list.' };
       }
 
-      await db
-        .update(taskTriggers)
-        .set({ isEnabled: false, lastFireError: 'Disabled by agent', nextRunAt: null })
-        .where(and(eq(taskTriggers.taskItemId, taskId), eq(taskTriggers.triggerType, triggerType)));
+      await db.transaction(async (tx) => {
+        await tx
+          .update(taskTriggers)
+          .set({ isEnabled: false, lastFireError: 'Disabled by agent', nextRunAt: null })
+          .where(and(eq(taskTriggers.taskItemId, taskId), eq(taskTriggers.triggerType, triggerType)));
 
-      await recomputeTaskTriggerMetadata(db, taskId, task.metadata as Record<string, unknown> | null);
+        await recomputeTaskTriggerMetadata(tx, taskId, task.metadata as Record<string, unknown> | null);
+      });
 
       void broadcastTaskEvent({ type: 'task_updated', taskId, taskListId: taskList?.id, userId, pageId: taskListPageId, data: { id: taskId, removedTriggerType: triggerType } });
 

--- a/apps/web/src/lib/ai/tools/trigger-tools.ts
+++ b/apps/web/src/lib/ai/tools/trigger-tools.ts
@@ -6,7 +6,6 @@ import { pages } from '@pagespace/db/schema/core';
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
 import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
 import { taskTriggers } from '@pagespace/db/schema/task-triggers';
-import { agentTriggerBaseSchema } from '@/lib/workflows/agent-trigger-shared';
 import {
   upsertCalendarTriggerWorkflow,
   upsertCalendarTriggerWorkflowInTx,

--- a/apps/web/src/lib/ai/tools/trigger-tools.ts
+++ b/apps/web/src/lib/ai/tools/trigger-tools.ts
@@ -281,6 +281,10 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
       if (!taskListPage || taskListPage.isTrashed) return { success: false, error: 'Task list not found.' };
       if (!taskListPage.driveId) return { success: false, error: 'Task triggers require a drive-based task list.' };
 
+      if (await driveDeniedByAppToken(ctx, taskListPage.driveId, 'edit')) {
+        return { success: false, error: 'This token does not have access to this task list\'s drive.' };
+      }
+
       if (!(await canActorEditPage(ctx, taskListPageId))) {
         return { success: false, error: 'You do not have edit access to this task list.' };
       }
@@ -339,7 +343,7 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
       const [taskListPage, taskList] = await Promise.all([
         db.query.pages.findFirst({
           where: eq(pages.id, taskListPageId),
-          columns: { id: true, isTrashed: true },
+          columns: { id: true, driveId: true, isTrashed: true },
         }),
         db.query.taskLists.findFirst({
           where: eq(taskLists.pageId, taskListPageId),
@@ -348,6 +352,11 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
       ]);
 
       if (!taskListPage || taskListPage.isTrashed) return { success: false, error: 'Task list not found.' };
+
+      if (taskListPage.driveId && await driveDeniedByAppToken(ctx, taskListPage.driveId, 'edit')) {
+        return { success: false, error: 'This token does not have access to this task list\'s drive.' };
+      }
+
       if (!(await canActorEditPage(ctx, taskListPageId))) {
         return { success: false, error: 'You do not have edit access to this task list.' };
       }

--- a/apps/web/src/lib/ai/tools/trigger-tools.ts
+++ b/apps/web/src/lib/ai/tools/trigger-tools.ts
@@ -316,7 +316,7 @@ Calling again with the same taskId + triggerType replaces the existing trigger (
         taskId,
         triggerType,
         summary: triggerType === 'due_date'
-          ? `Agent trigger set on task. The agent will run at the task's due date (${task.dueDate!.toISOString()}).`
+          ? `Agent trigger set on task. The agent will run at the task's due date (${task.dueDate?.toISOString() ?? 'unknown'}).`
           : 'Agent trigger set on task. The agent will run when the task is marked complete.',
       };
     },

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -33,7 +33,7 @@ export const workflowTools = {
   create_workflow: tool({
     description: `Create a standalone recurring workflow that runs an AI agent on a cron schedule.
 
-Use this for scheduled, repeating agent work that isn't tied to a task due date or a calendar event — e.g. "every weekday at 9am, summarize new activity". For one-off or entity-bound scheduling, attach an agentTrigger to a task (update_task) or calendar event (create_calendar_event) instead.
+Use this for scheduled, repeating agent work that isn't tied to a task due date or a calendar event — e.g. "every weekday at 9am, summarize new activity". For one-off or event-bound scheduling use set_calendar_trigger. For task-bound scheduling (fire at due date or on completion) use set_task_trigger.
 
 The cron expression must not fire more often than every 5 minutes (the polling cadence). Times are interpreted in the workflow timezone.`,
     inputSchema: z.object({


### PR DESCRIPTION
## Summary

Agents were consistently failing to schedule triggers because the tool surfaces were named and structured for implementation intent, not agent intent:

- Calendar triggers: buried inside \`create_calendar_event\` as a nested \`agentTrigger\` param — nothing in the name indicated it was a scheduling primitive
- Task triggers: REST-only (\`PUT /api/tasks/[taskId]/triggers\`) — no AI tool path at all
- Agents were attempting trigger config via \`update_agent_config\` and failing silently

**Root cause:** Three surfaces, three discovery anti-patterns. Only cron (\`create_workflow\`) was correctly named for its purpose.

## Changes

**New file: \`trigger-tools.ts\`** — 4 intention-named, flat-schema tools:

| Tool | What it does |
|------|-------------|
| \`set_calendar_trigger\` | Attach/upsert trigger on an existing event, or create a new scheduling event. Two modes. |
| \`delete_calendar_trigger\` | Remove trigger from event (idempotent, doesn't delete the event). |
| \`set_task_trigger\` | Expose REST-only task trigger path to agents. Upserts on existing tasks. |
| \`delete_task_trigger\` | Disable task trigger and recompute task metadata atomically (db.transaction). |

All tools reuse existing service layer helpers — no new DB logic.

**Permissions** — full actor-scoped permission model throughout:
- Calendar tools: event creator OR drive admin (via \`canManageEvent\` + \`canActorManageDrive\`), plus \`driveDeniedByAppToken\` for MCP token scoping
- Task tools: \`canActorEditPage(ctx, taskListPageId)\` respects agent ACL, MCP drive scope, and app-role ceiling; \`driveDeniedByAppToken\` blocks MCP tokens lacking drive access

**Description redirects** — 4 existing tools now steer agents to the dedicated trigger tools:
- \`create_calendar_event\` / \`update_calendar_event\` → \`set_calendar_trigger\`
- \`update_task\` (Agent Triggers section) → \`set_task_trigger\`
- \`create_workflow\` → new dedicated tools instead of entity-creation tools
- \`update_agent_config\` → explicitly states it does not manage triggers

**Registry coverage** — 4 new \`ActionResultRenderer\` entries in \`registry.tsx\` and corresponding mock/import/spread entries in \`ai-tools.test.ts\`.

## Test plan

- [x] 23 unit tests in \`trigger-tools.test.ts\` — all green (covers token denial, actor permissions, parseDateTime error path)
- [x] \`bun run --filter web typecheck\` — clean
- [x] \`bun run --filter web lint\` — clean
- [x] CI Unit Tests green (runs 27385798729, 27386095883)
- [ ] CI green on latest push
- [ ] Manual: "schedule yourself to run at 9am tomorrow" → should call \`set_calendar_trigger\`, not \`create_calendar_event\`
- [ ] Manual: "run when this task completes" → should call \`set_task_trigger\`, not modify \`update_agent_config\`