### PR TITLE
feat(notifications): agent @mention notifications across channels, threads, and AI chat

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -454,6 +454,32 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
 
       expect(mockBroadcastChatUserMessage).not.toHaveBeenCalled();
     });
+
+    it('should omit mentionNotify from saveMessageToDatabase when isShared=false', async () => {
+      mockGetConversation.mockResolvedValueOnce({
+        id: 'conv-1', userId: 'user-1', isShared: false,
+      });
+
+      await POST(makeRequest({ conversationId: 'conv-1' }));
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      const saveCalls = mockSaveMessageToDatabase.mock.calls;
+      const assistantSave = saveCalls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
+      expect(assistantSave?.[0]?.mentionNotify).toBeUndefined();
+    });
+
+    it('should include mentionNotify in saveMessageToDatabase when isShared=true', async () => {
+      mockGetConversation.mockResolvedValueOnce({
+        id: 'conv-1', userId: 'user-1', isShared: true,
+      });
+
+      await POST(makeRequest({ conversationId: 'conv-1' }));
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      const saveCalls = mockSaveMessageToDatabase.mock.calls;
+      const assistantSave = saveCalls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
+      expect(assistantSave?.[0]?.mentionNotify).toBeDefined();
+    });
   });
 
   describe('chunk forwarding', () => {

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -94,6 +94,7 @@ export async function POST(request: Request) {
   let userId: string | undefined;
   let chatId: string | undefined;
   let conversationId: string | undefined;
+  let isConversationShared = false;
   let selectedProvider: string | undefined;
   let selectedModel: string | undefined;
   // Outcome of the retry shell, shared from execute() to onFinish(). Carries the
@@ -904,7 +905,8 @@ export async function POST(request: Request) {
       // Only broadcast to the page channel if the conversation is explicitly shared.
       // Fail closed: no broadcast if the row is missing or private.
       const convRow = await conversationRepository.getConversation(conversationId!).catch(() => null);
-      const shouldBroadcast = convRow?.isShared === true;
+      isConversationShared = convRow?.isShared === true;
+      const shouldBroadcast = isConversationShared;
       if (shouldBroadcast) {
         broadcastChatUserMessage({
           message: userMessage,
@@ -1096,7 +1098,7 @@ export async function POST(request: Request) {
                 toolCalls: extractedToolCalls.length > 0 ? extractedToolCalls : undefined,
                 toolResults: extractedToolResults.length > 0 ? extractedToolResults : undefined,
                 uiMessage: responseMessage, // Pass complete UIMessage to preserve part ordering
-                ...(page?.driveId && userId && {
+                ...(page?.driveId && userId && isConversationShared && {
                   mentionNotify: {
                     driveId: page.driveId,
                     triggeredByUserId: userId,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1096,6 +1096,13 @@ export async function POST(request: Request) {
                 toolCalls: extractedToolCalls.length > 0 ? extractedToolCalls : undefined,
                 toolResults: extractedToolResults.length > 0 ? extractedToolResults : undefined,
                 uiMessage: responseMessage, // Pass complete UIMessage to preserve part ordering
+                ...(page?.driveId && userId && {
+                  mentionNotify: {
+                    driveId: page.driveId,
+                    triggeredByUserId: userId,
+                    mentionerName: page.title ?? undefined,
+                  },
+                }),
               });
 
               loggers.ai.debug('AI Chat API: AI response message saved to database with tools');

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -119,6 +119,11 @@ vi.mock('@pagespace/lib/notifications/notifications', () => ({
   createMentionNotification: (...args: unknown[]) => mockCreateMentionNotification(...args),
 }));
 
+const mockNotifyMentionedUsers = vi.fn();
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: (...args: unknown[]) => mockNotifyMentionedUsers(...args),
+}));
+
 // --- Imports under test --------------------------------------------------------
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
@@ -696,6 +701,7 @@ describe('POST /api/channels/[pageId]/messages (top-level — mention notificati
       user: { id: USER_ID, name: 'Sender', image: null },
     });
     mockCreateMentionNotification.mockResolvedValue(undefined);
+    mockNotifyMentionedUsers.mockResolvedValue(undefined);
     mockBroadcastInboxEvent.mockResolvedValue(undefined);
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     vi.mocked(canUserViewPage).mockResolvedValue(true);
@@ -718,36 +724,34 @@ describe('POST /api/channels/[pageId]/messages (top-level — mention notificati
     }
   });
 
-  it('fires createMentionNotification for a @mentioned user who can view the channel', async () => {
+  it('fires notifyMentionedUsers for a @mentioned user', async () => {
     const res = await callPost({ content: 'hello @[Alice](user-alice:user)' });
 
     expect(res.status).toBe(201);
-    expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-alice', PAGE_ID, USER_ID);
+    expect(mockNotifyMentionedUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'hello @[Alice](user-alice:user)',
+        pageId: PAGE_ID,
+        driveId: 'drive-1',
+        triggeredByUserId: USER_ID,
+      })
+    );
   });
 
   it('does not notify the sender even if they @mention themselves', async () => {
     const res = await callPost({ content: `hello @[Me](${USER_ID}:user)` });
 
     expect(res.status).toBe(201);
-    expect(mockCreateMentionNotification).not.toHaveBeenCalledWith(
-      USER_ID,
-      expect.anything(),
-      expect.anything(),
+    // notifyMentionedUsers handles invoker exclusion internally;
+    // the route still fires it (the helper silently drops self-mentions).
+    // No regression: the test verifies the route does not pass an override name.
+    expect(mockNotifyMentionedUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ triggeredByUserId: USER_ID })
     );
   });
 
-  it('does not notify a @mentioned user who cannot view the channel', async () => {
-    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
-    vi.mocked(canUserViewPage).mockResolvedValue(false);
-
-    const res = await callPost({ content: 'hello @[Outsider](user-outsider:user)' });
-
-    expect(res.status).toBe(201);
-    expect(mockCreateMentionNotification).not.toHaveBeenCalled();
-  });
-
-  it('returns 201 even when createMentionNotification throws', async () => {
-    mockCreateMentionNotification.mockRejectedValue(new Error('notification service down'));
+  it('returns 201 even when notifyMentionedUsers rejects', async () => {
+    mockNotifyMentionedUsers.mockRejectedValue(new Error('notification service down'));
 
     const res = await callPost({ content: 'hello @[Alice](user-alice:user)' });
 

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -17,6 +17,7 @@ import { expandMentionsToUserIds } from '@/lib/channels/expand-group-mentions';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { attachQuotedMessages } from '@pagespace/lib/services/quote-enrichment';
 import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
+import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
 import type { AttachmentMeta } from '@pagespace/lib/types';
 
 interface ChannelInboxFanoutInput {
@@ -647,26 +648,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         lastMessageSender: newMessage?.aiMeta?.senderName || newMessage?.user?.name || undefined,
       });
 
-      try {
-        const mentionedIds = await expandMentionsToUserIds(messageContent, channel.driveId);
-        const candidates = mentionedIds.filter((id) => id !== userId);
-        if (candidates.length > 0) {
-          const viewChecks = await Promise.all(
-            candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
-          );
-          await Promise.all(
-            viewChecks
-              .filter((e) => e.canView)
-              .map((e) =>
-                createMentionNotification(e.id, pageId, userId).catch((err) =>
-                  loggers.realtime.error('Failed to send mention notification', err as Error)
-                )
-              )
-          );
-        }
-      } catch (mentionErr) {
-        loggers.realtime.error('Failed to resolve mention targets', mentionErr as Error);
-      }
+      await notifyMentionedUsers({
+        content: messageContent,
+        pageId,
+        driveId: channel.driveId,
+        triggeredByUserId: userId,
+      });
 
       // Broadcast read status change to sender to update their unread count
       await broadcastInboxEvent(userId, {

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -1072,4 +1072,56 @@ describe('POST /api/v1/chat/completions', () => {
       expected: { status: 500, released: true },
     });
   });
+
+  test('mention notifications: omits mentionNotify for private conversations (isShared=false)', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce({
+      id: 'conv-private',
+      userId: 'user-1',
+      isActive: true,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isShared: false,
+      type: 'page',
+      lastMessageAt: null,
+    });
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-private' }));
+    await response.text();
+
+    const saveCalls = vi.mocked(saveMessageToDatabase).mock.calls;
+    const assistantSave = saveCalls.find((c) => c[0].role === 'assistant');
+    assert({
+      given: 'an assistant message in a private conversation (isShared=false)',
+      should: 'not include mentionNotify in the saveMessageToDatabase call',
+      actual: assistantSave?.[0]?.mentionNotify,
+      expected: undefined,
+    });
+  });
+
+  test('mention notifications: includes mentionNotify for shared conversations (isShared=true)', async () => {
+    vi.mocked(conversationRepository.getConversation).mockResolvedValueOnce({
+      id: 'conv-shared',
+      userId: 'user-1',
+      isActive: true,
+      title: null,
+      contextId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      isShared: true,
+      type: 'page',
+      lastMessageAt: null,
+    });
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-shared' }));
+    await response.text();
+
+    const saveCalls = vi.mocked(saveMessageToDatabase).mock.calls;
+    const assistantSave = saveCalls.find((c) => c[0].role === 'assistant');
+    assert({
+      given: 'an assistant message in a shared conversation (isShared=true)',
+      should: 'include mentionNotify in the saveMessageToDatabase call',
+      actual: typeof assistantSave?.[0]?.mentionNotify,
+      expected: 'object',
+    });
+  });
 });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -125,6 +125,8 @@ export async function POST(request: Request): Promise<Response> {
   // supply a brand-new conversation_id. When the row doesn't exist yet we auto-create it
   // here (not deferred) so we can immediately re-read and catch a TOCTOU race where two
   // requests collide on the same new ID. We still 403 on wrong owner and 404 on inactive.
+  // Fail-closed: private by default. Only shared conversations get mention notifications.
+  let isConversationShared = false;
   if (incomingConversationId) {
     const conv = await conversationRepository.getConversation(incomingConversationId);
     if (clientManagesHistory) {
@@ -136,6 +138,7 @@ export async function POST(request: Request): Promise<Response> {
         if (conv.userId !== authResult.userId) {
           return NextResponse.json({ error: 'Access denied' }, { status: 403 });
         }
+        isConversationShared = conv.isShared === true;
       } else {
         // First use: create the row then re-read to verify ownership, guarding against
         // the unlikely TOCTOU case where two requests race on the same new UUID.
@@ -147,12 +150,14 @@ export async function POST(request: Request): Promise<Response> {
         if (owned.userId !== authResult.userId) {
           return NextResponse.json({ error: 'Access denied' }, { status: 403 });
         }
+        // newly created rows are always isShared: false — isConversationShared stays false
       }
     } else {
       const convAccess = validateConversationAccess(conv, authResult.userId);
       if (!convAccess.ok) {
         return NextResponse.json({ error: convAccess.message }, { status: convAccess.status });
       }
+      isConversationShared = conv?.isShared === true;
     }
   }
 
@@ -400,7 +405,7 @@ export async function POST(request: Request): Promise<Response> {
           content: text ?? '',
           toolCalls: extracted.toolCalls.length > 0 ? extracted.toolCalls : undefined,
           toolResults: extracted.toolResults.length > 0 ? extracted.toolResults : undefined,
-          ...(page?.driveId && {
+          ...(page?.driveId && isConversationShared && {
             mentionNotify: {
               driveId: page.driveId,
               triggeredByUserId: authResult.userId,

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -400,6 +400,13 @@ export async function POST(request: Request): Promise<Response> {
           content: text ?? '',
           toolCalls: extracted.toolCalls.length > 0 ? extracted.toolCalls : undefined,
           toolResults: extracted.toolResults.length > 0 ? extracted.toolResults : undefined,
+          ...(page?.driveId && {
+            mentionNotify: {
+              driveId: page.driveId,
+              triggeredByUserId: authResult.userId,
+              mentionerName: page.title ?? undefined,
+            },
+          }),
         }).catch((err: unknown) => {
           loggers.ai.error('OpenAI API: failed to save assistant message', err as Error);
         });

--- a/apps/web/src/lib/ai/core/__tests__/message-utils-mention-notify.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils-mention-notify.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// -------------------------------------------------------------------------
+// Mocks — hoisted before imports
+// -------------------------------------------------------------------------
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  chatMessages: { id: 'id' },
+}));
+
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  messages: { id: 'id' },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    ai: {
+      debug: vi.fn(),
+      trace: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}));
+
+const mockNotifyMentionedUsers = vi.fn();
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: (...args: unknown[]) => mockNotifyMentionedUsers(...args),
+}));
+
+// -------------------------------------------------------------------------
+// Import after mocks
+// -------------------------------------------------------------------------
+
+import { saveMessageToDatabase } from '../message-utils';
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+const baseArgs = {
+  messageId: 'msg-1',
+  pageId: 'page-1',
+  conversationId: 'conv-1',
+  userId: null as string | null,
+  role: 'assistant' as const,
+  content: 'Hello @[Alice](alice-id:user)',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNotifyMentionedUsers.mockResolvedValue(undefined);
+});
+
+describe('saveMessageToDatabase — mentionNotify', () => {
+  it('fires notifyMentionedUsers for assistant role when mentionNotify is provided', async () => {
+    await saveMessageToDatabase({
+      ...baseArgs,
+      mentionNotify: {
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-x',
+        mentionerName: 'MyAgent',
+      },
+    });
+
+    // Fire-and-forget — flush promise queue
+    await Promise.resolve();
+
+    expect(mockNotifyMentionedUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Hello @[Alice](alice-id:user)',
+        pageId: 'page-1',
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-x',
+        mentionerNameOverride: 'MyAgent',
+      })
+    );
+  });
+
+  it('does NOT fire notifyMentionedUsers for user role saves', async () => {
+    await saveMessageToDatabase({
+      ...baseArgs,
+      userId: 'human-user',
+      role: 'user',
+      mentionNotify: {
+        driveId: 'drive-1',
+        triggeredByUserId: 'human-user',
+      },
+    });
+
+    await Promise.resolve();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire notifyMentionedUsers when mentionNotify is absent', async () => {
+    await saveMessageToDatabase({ ...baseArgs });
+
+    await Promise.resolve();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('save succeeds even when notifyMentionedUsers rejects', async () => {
+    mockNotifyMentionedUsers.mockRejectedValue(new Error('notify boom'));
+
+    await expect(
+      saveMessageToDatabase({
+        ...baseArgs,
+        mentionNotify: { driveId: 'drive-1', triggeredByUserId: 'user-x' },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not fire when content is empty', async () => {
+    await saveMessageToDatabase({
+      ...baseArgs,
+      content: '',
+      mentionNotify: { driveId: 'drive-1', triggeredByUserId: 'user-x' },
+    });
+
+    await Promise.resolve();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -8,6 +8,7 @@ import { db } from '@pagespace/db/db'
 import { chatMessages } from '@pagespace/db/schema/core'
 import { messages } from '@pagespace/db/schema/conversations';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
 
 /** Narrow a UIMessage part to TextUIPart */
 function isTextPart(part: { type: string }): part is TextUIPart {
@@ -452,6 +453,7 @@ export async function saveMessageToDatabase({
   toolResults,
   uiMessage,
   sourceAgentId,
+  mentionNotify,
 }: {
   messageId: string;
   pageId: string;
@@ -463,6 +465,7 @@ export async function saveMessageToDatabase({
   toolResults?: ToolResult[];
   uiMessage?: UIMessage; // Pass the complete UIMessage to preserve part ordering
   sourceAgentId?: string | null; // ID of the AI agent that sent this message (for agent-to-agent communication)
+  mentionNotify?: { driveId: string; triggeredByUserId: string; mentionerName?: string };
 }) {
   try {
     let structuredContent = content;
@@ -502,6 +505,17 @@ export async function saveMessageToDatabase({
           sourceAgentId: sourceAgentId ?? null,
         }
       });
+
+    // Fire-and-forget mention notifications for assistant messages only
+    if (mentionNotify && role === 'assistant' && content.trim()) {
+      void notifyMentionedUsers({
+        content,
+        pageId,
+        driveId: mentionNotify.driveId,
+        triggeredByUserId: mentionNotify.triggeredByUserId,
+        mentionerNameOverride: mentionNotify.mentionerName,
+      });
+    }
 
   } catch (error) {
     loggers.ai.error('Failed to save message to database', error as Error);

--- a/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
@@ -101,6 +101,11 @@ vi.mock('@/lib/logging/mask', () => ({
   maskIdentifier: vi.fn((id) => `***${id?.slice(-4) || ''}`),
 }));
 
+const mockNotifyMentionedUsers = vi.fn();
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: (...args: unknown[]) => mockNotifyMentionedUsers(...args),
+}));
+
 import { channelTools } from '../channel-tools';
 import { canActorEditPage } from '../actor-permissions';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
@@ -472,6 +477,65 @@ describe('channel-tools', () => {
           context
         )
       ).rejects.toThrow('Message content cannot be empty');
+    });
+
+    it('fires notifyMentionedUsers with senderIdentity.senderName as override', async () => {
+      mockNotifyMentionedUsers.mockResolvedValue(undefined);
+      mockPagesFindFirst.mockResolvedValue({
+        id: 'ch-1',
+        title: 'General',
+        type: 'CHANNEL',
+        driveId: 'drive-1',
+        drive: { ownerId: 'user-456' },
+      });
+      mockCanActorEditPage.mockResolvedValue(true);
+      mockDriveMembersFindMany.mockResolvedValue([]);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: {
+          userId: 'user-123',
+          chatSource: { type: 'page', agentPageId: 'agent-1', agentTitle: 'ResearchBot' },
+        } as ToolExecutionContext,
+      };
+
+      await executeToolAs({ channelId: 'ch-1', content: 'hello @[Bob](bob-id:user)' }, context);
+
+      // Fire-and-forget — flush microtasks
+      await vi.runAllTimersAsync().catch(() => undefined);
+      await Promise.resolve();
+
+      expect(mockNotifyMentionedUsers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'hello @[Bob](bob-id:user)',
+          pageId: 'ch-1',
+          driveId: 'drive-1',
+          triggeredByUserId: 'user-123',
+          mentionerNameOverride: 'ResearchBot (Test User)',
+        })
+      );
+    });
+
+    it('send succeeds even when notifyMentionedUsers rejects', async () => {
+      mockNotifyMentionedUsers.mockRejectedValue(new Error('notify exploded'));
+      mockPagesFindFirst.mockResolvedValue({
+        id: 'ch-1',
+        title: 'General',
+        type: 'CHANNEL',
+        driveId: 'drive-1',
+        drive: { ownerId: 'user-456' },
+      });
+      mockCanActorEditPage.mockResolvedValue(true);
+      mockDriveMembersFindMany.mockResolvedValue([]);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        executeToolAs({ channelId: 'ch-1', content: 'hi' }, context)
+      ).resolves.toMatchObject({ success: true });
     });
   });
 

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -644,6 +644,11 @@ export const agentCommunicationTools = {
           role: 'assistant',
           content: agentResponse,
           sourceAgentId: null, // Assistant responses are native to this agent, not forwarded
+          mentionNotify: {
+            driveId: targetAgent.driveId,
+            triggeredByUserId: userId,
+            mentionerName: targetAgent.title,
+          },
         });
 
         loggers.ai.debug('Saved ask_agent conversation:', {

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -14,6 +14,7 @@ import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
 import type { ToolExecutionContext } from '../core/types';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
 
 const channelLogger = loggers.ai.child({ module: 'channel-tools' });
 
@@ -246,6 +247,17 @@ export const channelTools = {
           }
         } catch (error) {
           channelLogger.error('Failed to broadcast inbox update for AI message', error instanceof Error ? error : undefined);
+        }
+
+        // Fire-and-forget mention notifications — never fail the send
+        if (channel.driveId) {
+          void notifyMentionedUsers({
+            content: content.trim(),
+            pageId: channelId,
+            driveId: channel.driveId,
+            triggeredByUserId: userId,
+            mentionerNameOverride: senderIdentity.senderName,
+          });
         }
 
         return {

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
@@ -69,6 +69,11 @@ vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
   createSignedBroadcastHeaders: vi.fn(() => ({ 'x-signed': 'yes' })),
 }));
 
+const mockNotifyMentionedUsers = vi.fn();
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: (...args: unknown[]) => mockNotifyMentionedUsers(...args),
+}));
+
 const mockBroadcastInboxEvent = vi.fn();
 const mockBroadcastThreadReplyCountUpdated = vi.fn();
 vi.mock('@/lib/websocket/socket-utils', () => ({
@@ -425,6 +430,52 @@ describe('agent-mention-responder', () => {
     expect(mockInsertChannelThreadReply).not.toHaveBeenCalled();
     expect(mockSendChannelExecute).not.toHaveBeenCalled();
     expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+  });
+
+  it('fires notifyMentionedUsers with agent title after a successful thread reply', async () => {
+    mockNotifyMentionedUsers.mockResolvedValue(undefined);
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+    mockAskAgentExecute.mockResolvedValue(createAskAgentSuccess('Here is my analysis @[Alice](user-alice:user)'));
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      parentId: 'parent-thread',
+      content: 'Hey @[Budget Agent](agent-1:page) what do you think?',
+    });
+
+    // Flush microtasks for fire-and-forget
+    await Promise.resolve();
+
+    expect(mockNotifyMentionedUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Here is my analysis @[Alice](user-alice:user)',
+        pageId: 'channel-1',
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-1',
+        mentionerNameOverride: 'Budget Agent',
+      })
+    );
+  });
+
+  it('skips notifyMentionedUsers when driveId is absent', async () => {
+    mockNotifyMentionedUsers.mockResolvedValue(undefined);
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+    mockAskAgentExecute.mockResolvedValue(createAskAgentSuccess('Reply @[Alice](user-alice:user)'));
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      driveId: undefined,
+      parentId: 'parent-thread',
+      content: 'Hey @[Budget Agent](agent-1:page)',
+    });
+
+    await Promise.resolve();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/lib/channels/__tests__/notify-mentioned-users.test.ts
+++ b/apps/web/src/lib/channels/__tests__/notify-mentioned-users.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// -------------------------------------------------------------------------
+// Mocks — must be hoisted before imports
+// -------------------------------------------------------------------------
+
+const mockExpandMentions = vi.fn();
+vi.mock('../expand-group-mentions', () => ({
+  expandMentionsToUserIds: (...args: unknown[]) => mockExpandMentions(...args),
+}));
+
+const mockCanUserViewPage = vi.fn();
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: (...args: unknown[]) => mockCanUserViewPage(...args),
+}));
+
+const mockCreateMentionNotification = vi.fn();
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+  createMentionNotification: (...args: unknown[]) => mockCreateMentionNotification(...args),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    realtime: { error: vi.fn(), warn: vi.fn() },
+    ai: { error: vi.fn(), warn: vi.fn() },
+  },
+}));
+
+// -------------------------------------------------------------------------
+// Import after mocks
+// -------------------------------------------------------------------------
+
+import { notifyMentionedUsers } from '../notify-mentioned-users';
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExpandMentions.mockResolvedValue([]);
+  mockCanUserViewPage.mockResolvedValue(true);
+  mockCreateMentionNotification.mockResolvedValue({ id: 'notif-1' });
+});
+
+describe('notifyMentionedUsers', () => {
+  it('excludes triggeredByUserId from notification targets', async () => {
+    mockExpandMentions.mockResolvedValue(['invoker', 'other']);
+
+    await notifyMentionedUsers({
+      content: '@[Invoker](invoker:user) @[Other](other:user)',
+      pageId: 'page-1',
+      driveId: 'drive-1',
+      triggeredByUserId: 'invoker',
+    });
+
+    expect(mockCreateMentionNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateMentionNotification).toHaveBeenCalledWith(
+      'other',
+      'page-1',
+      'invoker',
+      undefined
+    );
+  });
+
+  it('filters out users who cannot view the page', async () => {
+    mockExpandMentions.mockResolvedValue(['alice', 'bob']);
+    mockCanUserViewPage.mockImplementation(async (userId: string) => userId === 'alice');
+
+    await notifyMentionedUsers({
+      content: 'hello',
+      pageId: 'page-1',
+      driveId: 'drive-1',
+      triggeredByUserId: 'someone-else',
+    });
+
+    expect(mockCreateMentionNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateMentionNotification).toHaveBeenCalledWith(
+      'alice',
+      'page-1',
+      'someone-else',
+      undefined
+    );
+  });
+
+  it('passes mentionerNameOverride through to createMentionNotification', async () => {
+    mockExpandMentions.mockResolvedValue(['target']);
+
+    await notifyMentionedUsers({
+      content: '@[Target](target:user)',
+      pageId: 'page-1',
+      driveId: 'drive-1',
+      triggeredByUserId: 'agent-user',
+      mentionerNameOverride: 'ResearchBot',
+    });
+
+    expect(mockCreateMentionNotification).toHaveBeenCalledWith(
+      'target',
+      'page-1',
+      'agent-user',
+      { mentionerNameOverride: 'ResearchBot' }
+    );
+  });
+
+  it('never throws even when createMentionNotification rejects', async () => {
+    mockExpandMentions.mockResolvedValue(['target']);
+    mockCreateMentionNotification.mockRejectedValue(new Error('DB failure'));
+
+    await expect(
+      notifyMentionedUsers({
+        content: '@[Target](target:user)',
+        pageId: 'page-1',
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-x',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws even when expandMentionsToUserIds rejects', async () => {
+    mockExpandMentions.mockRejectedValue(new Error('Expand failure'));
+
+    await expect(
+      notifyMentionedUsers({
+        content: '@[Target](target:user)',
+        pageId: 'page-1',
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-x',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('does nothing when no mentions are found', async () => {
+    mockExpandMentions.mockResolvedValue([]);
+
+    await notifyMentionedUsers({
+      content: 'no mentions here',
+      pageId: 'page-1',
+      driveId: 'drive-1',
+      triggeredByUserId: 'user-x',
+    });
+
+    expect(mockCreateMentionNotification).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -10,6 +10,7 @@ import {
   broadcastInboxEvent,
   broadcastThreadReplyCountUpdated,
 } from '@/lib/websocket/socket-utils';
+import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
 import { processMentionsInMessage } from '@/lib/ai/core/mention-processor';
 import {
   buildCommandPromptSection,
@@ -222,6 +223,7 @@ async function postAgentThreadReply(input: {
   parentId: string;
   agent: MentionedAgent;
   commandExecution?: CommandExecutionData;
+  driveId?: string | null;
 }): Promise<void> {
   const result = await channelMessageRepository.insertChannelThreadReply({
     parentId: input.parentId,
@@ -303,6 +305,17 @@ async function postAgentThreadReply(input: {
       error instanceof Error ? error : undefined,
       { channelId: input.channelId, parentId: input.parentId }
     );
+  }
+
+  // Fire-and-forget mention notifications for the agent's reply content
+  if (input.driveId) {
+    void notifyMentionedUsers({
+      content: input.content,
+      pageId: input.channelId,
+      driveId: input.driveId,
+      triggeredByUserId: input.userId,
+      mentionerNameOverride: input.agent.title,
+    });
   }
 }
 
@@ -457,6 +470,7 @@ export async function triggerMentionedAgentResponses(
             parentId: trimmedParent,
             agent,
             commandExecution,
+            driveId: params.driveId,
           });
         } else {
           await sendChannelExecute(

--- a/apps/web/src/lib/channels/notify-mentioned-users.ts
+++ b/apps/web/src/lib/channels/notify-mentioned-users.ts
@@ -1,0 +1,42 @@
+import { expandMentionsToUserIds } from './expand-group-mentions';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const logger = loggers.realtime;
+
+export async function notifyMentionedUsers(opts: {
+  content: string;
+  pageId: string;
+  driveId: string;
+  triggeredByUserId: string;
+  mentionerNameOverride?: string;
+}): Promise<void> {
+  try {
+    const { content, pageId, driveId, triggeredByUserId, mentionerNameOverride } = opts;
+    const mentionedIds = await expandMentionsToUserIds(content, driveId);
+    const candidates = mentionedIds.filter((id) => id !== triggeredByUserId);
+    if (candidates.length === 0) return;
+
+    const viewChecks = await Promise.all(
+      candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
+    );
+
+    await Promise.all(
+      viewChecks
+        .filter((e) => e.canView)
+        .map((e) =>
+          createMentionNotification(
+            e.id,
+            pageId,
+            triggeredByUserId,
+            mentionerNameOverride ? { mentionerNameOverride } : undefined
+          ).catch((err) =>
+            logger.error('Failed to send agent mention notification', err as Error)
+          )
+        )
+    );
+  } catch (err) {
+    logger.error('Failed to resolve agent mention targets', err as Error);
+  }
+}

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -371,6 +371,11 @@ async function runExecution(input: WorkflowExecutionInput, startTime: number): P
       userId: null,
       role: 'assistant',
       content: responseText,
+      mentionNotify: {
+        driveId: input.driveId,
+        triggeredByUserId: input.createdBy,
+        mentionerName: agent.title,
+      },
     });
 
     // 10. Track usage

--- a/packages/lib/src/notifications/__tests__/notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/notifications.test.ts
@@ -549,6 +549,31 @@ describe('createMentionNotification', () => {
     await createMentionNotification('user-1', 'page-1', 'user-2');
     expect(db.insert).toHaveBeenCalled();
   });
+
+  it('uses mentionerNameOverride in message and metadata when provided', async () => {
+    const { valuesFn } = setupInsertChain(mockNotification);
+
+    await createMentionNotification('user-1', 'page-1', 'user-2', { mentionerNameOverride: 'ResearchBot' });
+
+    const insertArg = valuesFn.mock.calls[0][0];
+    expect(insertArg.message).toContain('ResearchBot');
+    expect(insertArg.metadata?.mentionerName).toBe('ResearchBot');
+  });
+
+  it('falls back to DB user name when no override', async () => {
+    const { valuesFn } = setupInsertChain(mockNotification);
+
+    await createMentionNotification('user-1', 'page-1', 'user-2');
+
+    const insertArg = valuesFn.mock.calls[0][0];
+    expect(insertArg.message).toContain('Alice');
+    expect(insertArg.metadata?.mentionerName).toBe('Alice');
+  });
+
+  it('self-mention still returns null even with override', async () => {
+    const result = await createMentionNotification('user-1', 'page-1', 'user-1', { mentionerNameOverride: 'Bot' });
+    expect(result).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/lib/src/notifications/notifications.ts
+++ b/packages/lib/src/notifications/notifications.ts
@@ -436,7 +436,8 @@ export async function createOrUpdateMessageNotification(
 export async function createMentionNotification(
   targetUserId: string,
   pageId: string,
-  triggeredByUserId: string
+  triggeredByUserId: string,
+  options?: { mentionerNameOverride?: string }
 ) {
   // Don't notify users who mention themselves
   if (targetUserId === triggeredByUserId) return null;
@@ -450,11 +451,13 @@ export async function createMentionNotification(
 
   if (!page) return null;
 
-  const triggeredByUser = await db.query.users.findFirst({
-    where: eq(users.id, triggeredByUserId),
-  });
+  const triggeredByUser = options?.mentionerNameOverride
+    ? null
+    : await db.query.users.findFirst({
+        where: eq(users.id, triggeredByUserId),
+      });
 
-  const mentionerName = triggeredByUser?.name || 'Someone';
+  const mentionerName = options?.mentionerNameOverride || triggeredByUser?.name || 'Someone';
 
   return createNotification({
     userId: targetUserId,


### PR DESCRIPTION
## Summary

Closes the gap where agent @mentions didn't notify mentioned humans. Agents now trigger the same in-app + socket + email + push pipeline as human mentions everywhere they write.

- **AC1** — \`createMentionNotification\` gains optional \`mentionerNameOverride\` so agent names credit correctly
- **AC2** — New \`notifyMentionedUsers\` helper centralises expand → exclude-invoker → permission-check → notify; never throws
- **AC3** — \`send_channel_message\` tool fires the helper fire-and-forget with the agent's display name
- **AC4** — \`agent-mention-responder\` passes \`driveId\` into thread replies and fires the helper on success
- **AC5** — \`saveMessageToDatabase\` gains optional \`mentionNotify\` param; wired at all four assistant-persistence sites: \`ai/chat\` onFinish, \`v1/chat/completions\` settle, \`workflow-executor\`, \`agent-communication-tools\` ask_agent
- **AC6** — Human top-level channel POST path refactored to use the helper (thread-reply block left untouched to avoid unread-count regressions)
- **AC7** — Documents/tasks path already notifies via \`applyPageMutation\` — no change needed
- **Privacy fix** — AI chat (\`ai/chat\`, \`v1/completions\`) gates \`mentionNotify\` on \`isConversationShared === true\`; private conversations (default) never fire mention notifications

## AC Checklist

- [x] **AC1**: \`createMentionNotification\` accepts \`options?.mentionerNameOverride\`; override flows into message + \`metadata.mentionerName\`; backwards compatible
- [x] **AC2**: \`notify-mentioned-users.ts\` helper: expand → exclude invoker → filter by \`canUserViewPage\` → fire notifications; never throws
- [x] **AC3**: \`send_channel_message\` fires helper after insert+broadcast; guarded by \`channel.driveId\`; failure never fails the send
- [x] **AC4**: \`agent-mention-responder\` passes \`driveId\` to \`postAgentThreadReply\`; fires helper on success with \`mentionerNameOverride: agent.title\`; skipped without driveId
- [x] **AC5**: \`saveMessageToDatabase\` fires helper for \`role=assistant\` + non-empty content + \`mentionNotify\` present; all four callers wired; user-role saves never fire (no double-fire)
- [x] **AC6**: Top-level human channel POST now uses helper; thread-reply block untouched
- [x] **AC7**: Documents/tasks path unchanged
- [x] **Privacy**: \`isConversationShared\` guard on both AI chat callers (fail-closed: new conversations default \`isShared=false\`; no extra DB reads — row already fetched for broadcast gating)

## Test plan

- [x] \`bun run test:unit\` — no new failures introduced (pre-existing AbortSignal + admin-role-version + activity-tools failures unchanged)
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] TDD: every AC written as RED test first, then GREEN implementation
- [x] \`notify-mentioned-users.test.ts\` — 6 tests covering invoker exclusion, view-permission filter, override pass-through, never-throws × 2, no-op on empty
- [x] \`notifications.test.ts\` — 3 new tests for override in message/metadata, fallback, self-mention still null
- [x] \`channel-tools.test.ts\` — 2 new tests for helper called with senderName; send succeeds when helper rejects
- [x] \`agent-mention-responder.test.ts\` — 2 new tests for thread-reply fires helper with agent title; skipped without driveId
- [x] \`message-utils-mention-notify.test.ts\` — 5 new tests for assistant save fires; user-role save doesn't; absent param fires nothing; save succeeds when helper rejects; empty content skipped
- [x] \`route.test.ts\` — top-level mention tests re-pointed at helper module; thread-reply tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)