### PR TITLE
feat(share): surface page link and ID in the share dialog

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Copy } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface PageLinkSectionProps {
+  pageId: string;
+  driveId: string;
+}
+
+async function copyToClipboard(text: string, label: string) {
+  const copied = await navigator.clipboard.writeText(text).then(() => true).catch(() => false);
+  if (copied) toast.success(`${label} copied to clipboard`);
+  else toast.error(`Could not copy ${label.toLowerCase()} to clipboard`);
+}
+
+export function PageLinkSection({ pageId, driveId }: PageLinkSectionProps) {
+  // window is read in an effect so the dialog renders identically on server and client
+  const [origin, setOrigin] = useState('');
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  const pageUrl = origin ? `${origin}/dashboard/${driveId}/${pageId}` : '';
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="w-8 shrink-0 text-xs text-muted-foreground">Link</span>
+        <input
+          type="text"
+          readOnly
+          value={pageUrl}
+          aria-label="Page link"
+          className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
+          onClick={(e) => (e.target as HTMLInputElement).select()}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 shrink-0"
+          onClick={() => copyToClipboard(pageUrl, 'Page link')}
+          disabled={!pageUrl}
+          aria-label="Copy page link"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="w-8 shrink-0 text-xs text-muted-foreground">ID</span>
+        <input
+          type="text"
+          readOnly
+          value={pageId}
+          aria-label="Page ID"
+          className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
+          onClick={(e) => (e.target as HTMLInputElement).select()}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 shrink-0"
+          onClick={() => copyToClipboard(pageId, 'Page ID')}
+          aria-label="Copy page ID"
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        The link opens this page for people who already have access.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
@@ -15,7 +15,7 @@ async function copyToClipboard(text: string, label: string) {
     await navigator.clipboard.writeText(text);
     toast.success(`${label} copied to clipboard`);
   } catch {
-    toast.error(`Could not copy ${label.toLowerCase()} to clipboard`);
+    toast.error(`Could not copy ${label} to clipboard`);
   }
 }
 

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
@@ -19,6 +19,32 @@ async function copyToClipboard(text: string, label: string) {
   }
 }
 
+function CopyableRow({ label, value, ariaLabel }: { label: string; value: string; ariaLabel: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-8 shrink-0 text-xs text-muted-foreground">{label}</span>
+      <input
+        type="text"
+        readOnly
+        value={value}
+        aria-label={ariaLabel}
+        className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
+        onClick={(e) => (e.target as HTMLInputElement).select()}
+      />
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7 px-2 shrink-0"
+        onClick={() => copyToClipboard(value, label)}
+        disabled={!value}
+        aria-label={`Copy ${ariaLabel}`}
+      >
+        <Copy className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}
+
 export function PageLinkSection({ pageId, driveId }: PageLinkSectionProps) {
   // window is read in an effect so the dialog renders identically on server and client
   const [origin, setOrigin] = useState('');
@@ -30,47 +56,8 @@ export function PageLinkSection({ pageId, driveId }: PageLinkSectionProps) {
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <span className="w-8 shrink-0 text-xs text-muted-foreground">Link</span>
-        <input
-          type="text"
-          readOnly
-          value={pageUrl}
-          aria-label="Page link"
-          className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
-          onClick={(e) => (e.target as HTMLInputElement).select()}
-        />
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 shrink-0"
-          onClick={() => copyToClipboard(pageUrl, 'Page link')}
-          disabled={!pageUrl}
-          aria-label="Copy page link"
-        >
-          <Copy className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-      <div className="flex items-center gap-2">
-        <span className="w-8 shrink-0 text-xs text-muted-foreground">ID</span>
-        <input
-          type="text"
-          readOnly
-          value={pageId}
-          aria-label="Page ID"
-          className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
-          onClick={(e) => (e.target as HTMLInputElement).select()}
-        />
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 px-2 shrink-0"
-          onClick={() => copyToClipboard(pageId, 'Page ID')}
-          aria-label="Copy page ID"
-        >
-          <Copy className="h-3.5 w-3.5" />
-        </Button>
-      </div>
+      <CopyableRow label="Link" value={pageUrl} ariaLabel="Page link" />
+      <CopyableRow label="ID" value={pageId} ariaLabel="Page ID" />
       <p className="text-xs text-muted-foreground">
         The link opens this page for people who already have access.
       </p>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageLinkSection.tsx
@@ -11,9 +11,12 @@ interface PageLinkSectionProps {
 }
 
 async function copyToClipboard(text: string, label: string) {
-  const copied = await navigator.clipboard.writeText(text).then(() => true).catch(() => false);
-  if (copied) toast.success(`${label} copied to clipboard`);
-  else toast.error(`Could not copy ${label.toLowerCase()} to clipboard`);
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(`${label} copied to clipboard`);
+  } catch {
+    toast.error(`Could not copy ${label.toLowerCase()} to clipboard`);
+  }
 }
 
 export function PageLinkSection({ pageId, driveId }: PageLinkSectionProps) {

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -45,6 +45,7 @@ import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { post, put, fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
 import { PageShareLinkSection } from './PageShareLinkSection';
+import { PageLinkSection } from './PageLinkSection';
 import type { DriveRole } from '@pagespace/lib/services/drive-role-service';
 import type { RoleGrant } from '@/services/api';
 
@@ -281,31 +282,16 @@ export function ShareDialog({
 
   const ungrantedRoles = driveRoles.filter(r => !grantedRoles.some(g => g.roleId === r.id));
 
-  // Show disabled button when no share permission and not controlled (used as trigger)
-  if (!canShare && !isControlled) {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost" size={isMobile ? "icon" : "sm"} disabled className="opacity-50 cursor-not-allowed">
-              <Lock className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
-              {!isMobile && "Share"}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>{getPermissionErrorMessage('share')}</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
-
+  // Users without share permission can still open the dialog to copy the
+  // page link/ID — the dialog body locks out the sharing controls.
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       {!isControlled && (
         <DialogTrigger asChild>
           <Button variant="ghost" size={isMobile ? "icon" : "sm"}>
-            <Share2 className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
+            {canShare
+              ? <Share2 className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
+              : <Lock className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />}
             {!isMobile && "Share"}
           </Button>
         </DialogTrigger>
@@ -317,6 +303,9 @@ export function ShareDialog({
             Manage who has access to this page.
           </DialogDescription>
         </DialogHeader>
+        <div className="mt-2">
+          <PageLinkSection pageId={page.id} driveId={driveId} />
+        </div>
         {!canShare ? (
           <Alert className="mt-4">
             <Lock className="h-4 w-4" />

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -281,6 +281,7 @@ export function ShareDialog({
   };
 
   const ungrantedRoles = driveRoles.filter(r => !grantedRoles.some(g => g.roleId === r.id));
+  const triggerIconCn = isMobile ? "h-4 w-4" : "mr-2 h-4 w-4";
 
   // Users without share permission can still open the dialog to copy the
   // page link/ID — the dialog body locks out the sharing controls.
@@ -290,8 +291,8 @@ export function ShareDialog({
         <DialogTrigger asChild>
           <Button variant="ghost" size={isMobile ? "icon" : "sm"}>
             {canShare
-              ? <Share2 className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
-              : <Lock className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />}
+              ? <Share2 className={triggerIconCn} />
+              : <Lock className={triggerIconCn} />}
             {!isMobile && "Share"}
           </Button>
         </DialogTrigger>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/PageLinkSection.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/PageLinkSection.test.tsx
@@ -108,4 +108,29 @@ describe('PageLinkSection', () => {
       });
     });
   });
+
+  it('given navigator.clipboard is undefined (non-secure origin), shows an error toast instead of throwing', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    });
+    render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy page ID' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'navigator.clipboard is undefined',
+        should: 'show an error toast and not throw an unhandled rejection',
+        actual: vi.mocked(toast.error).mock.calls.length > 0,
+        expected: true,
+      });
+      assert({
+        given: 'navigator.clipboard is undefined',
+        should: 'not show a success toast',
+        actual: vi.mocked(toast.success).mock.calls.length,
+        expected: 0,
+      });
+    });
+  });
 });

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/PageLinkSection.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/PageLinkSection.test.tsx
@@ -60,7 +60,7 @@ describe('PageLinkSection', () => {
     render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
 
     await waitFor(() => screen.getByLabelText('Page link'));
-    fireEvent.click(screen.getByRole('button', { name: 'Copy page link' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Page link' }));
 
     await waitFor(() => {
       assert({
@@ -81,7 +81,7 @@ describe('PageLinkSection', () => {
   it('given a click on the copy-ID button, writes the page ID to the clipboard', async () => {
     render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy page ID' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Page ID' }));
 
     await waitFor(() => {
       assert({
@@ -97,7 +97,7 @@ describe('PageLinkSection', () => {
     writeText.mockRejectedValueOnce(new Error('denied'));
     render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy page ID' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Page ID' }));
 
     await waitFor(() => {
       assert({
@@ -116,7 +116,7 @@ describe('PageLinkSection', () => {
     });
     render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy page ID' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Page ID' }));
 
     await waitFor(() => {
       assert({

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/PageLinkSection.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/PageLinkSection.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { assert } from '@/stores/__tests__/riteway';
+
+// ============================================================================
+// Tests for PageLinkSection — surfaces the direct page link and page ID in
+// the share dialog so users (especially on desktop, which has no address
+// bar) can copy them.
+// ============================================================================
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+import { PageLinkSection } from '../PageLinkSection';
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+describe('PageLinkSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom's navigator.clipboard is getter-only; redefine it for the spy
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  it('given a pageId and driveId, renders the direct page link built from the current origin', async () => {
+    render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
+
+    await waitFor(() => {
+      const linkInput = screen.getByLabelText('Page link') as HTMLInputElement;
+      assert({
+        given: 'a pageId and driveId',
+        should: 'render the /dashboard/{driveId}/{pageId} link on the current origin',
+        actual: linkInput.value,
+        expected: `${window.location.origin}/dashboard/drive_xyz/page_abc`,
+      });
+    });
+  });
+
+  it('given the page ID field, shows the raw page ID', () => {
+    render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
+
+    const idInput = screen.getByLabelText('Page ID') as HTMLInputElement;
+    assert({
+      given: 'a pageId',
+      should: 'show the raw page ID in its own field',
+      actual: idInput.value,
+      expected: 'page_abc',
+    });
+  });
+
+  it('given a click on the copy-link button, writes the page link to the clipboard', async () => {
+    render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
+
+    await waitFor(() => screen.getByLabelText('Page link'));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy page link' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a click on the copy-link button',
+        should: 'write the page link to the clipboard',
+        actual: writeText.mock.calls[0]?.[0],
+        expected: `${window.location.origin}/dashboard/drive_xyz/page_abc`,
+      });
+      assert({
+        given: 'a successful copy',
+        should: 'show a success toast',
+        actual: vi.mocked(toast.success).mock.calls.length > 0,
+        expected: true,
+      });
+    });
+  });
+
+  it('given a click on the copy-ID button, writes the page ID to the clipboard', async () => {
+    render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy page ID' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a click on the copy-ID button',
+        should: 'write the page ID to the clipboard',
+        actual: writeText.mock.calls[0]?.[0],
+        expected: 'page_abc',
+      });
+    });
+  });
+
+  it('given the clipboard write fails, shows an error toast', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'));
+    render(<PageLinkSection pageId="page_abc" driveId="drive_xyz" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy page ID' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a clipboard write failure',
+        should: 'show an error toast instead of a success toast',
+        actual: vi.mocked(toast.error).mock.calls.length > 0,
+        expected: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Why

Desktop (Electron) users have no browser address bar, so there is currently **no way to get the URL of the page they're looking at**. The page ID is also useful on its own (MCP tools, API calls, support) and wasn't surfaced anywhere in the UI.

## What

- **New `PageLinkSection`** at the top of the share dialog showing:
  - the direct page link (`{origin}/dashboard/{driveId}/{pageId}`) with a copy button
  - the raw page ID with a copy button
  - both fields are click-to-select, with sonner toasts on copy success/failure
- Origin comes from `window.location.origin` (read in a `useEffect` for SSR safety), which on desktop is the configured app URL (pagespace.ai by default), so copied links work everywhere.
- **View-only users can now open the share dialog** to copy the link/ID. The trigger button was previously disabled without share permission; it now opens the dialog, which keeps the existing lock alert in place of the sharing controls (the trigger shows the lock icon to signal restricted access). The direct link only opens for people who already have access, so nothing is exposed.

## Changes

- `PageLinkSection.tsx` — new component with `CopyableRow` helper to avoid duplication across the two read-only fields; clipboard guarded with `try/catch` so `navigator.clipboard === undefined` (non-secure origin) shows an error toast instead of throwing
- `ShareDialog.tsx` — import + render `PageLinkSection` above the permission gate; remove early-return disabled button; simplify trigger icon ternary with a shared `triggerIconCn` variable

## Tests

- New `PageLinkSection.test.tsx` (6 tests): link construction from origin, raw ID display, copy-link button, copy-ID button, rejected `writeText`, and undefined `navigator.clipboard`
- Existing `ShareDialog.test.tsx` still green (10 total in page-settings)
- `tsc --noEmit` and eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)