### PR TITLE
feat(ai-tools): role CRUD and permission-setter tools

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -51,6 +51,15 @@ const TOOL_NAME_MAP: Record<string, string> = {
   // Member tools
   'list_drive_members': 'Members',
   'list_collaborators': 'Collaborators',
+  // Role management tools
+  'list_drive_roles': 'Roles',
+  'get_drive_role': 'Role',
+  'create_drive_role': 'Create Role',
+  'update_drive_role': 'Update Role',
+  'delete_drive_role': 'Delete Role',
+  'set_role_page_permissions': 'Set Role Page Access',
+  'set_role_drive_wide_permissions': 'Set Role Drive Access',
+  'remove_role_page_permissions': 'Remove Role Page Access',
   // Page read tools
   'list_pages': 'Pages',
   'read_page': 'Read Page',

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -547,6 +547,93 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     return <MemberListRenderer members={parsedOutput.collaborators as MemberInfo[]} title="Collaborators" />;
   },
 
+  // === ROLE MANAGEMENT TOOLS ===
+  list_drive_roles: ({ parsedOutput }) => {
+    if (!Array.isArray(parsedOutput.roles)) return null;
+    const roles = parsedOutput.roles as Array<{ name: string; description?: string | null; driveWidePermissions?: { canView: boolean; canEdit: boolean; canShare: boolean } | null }>;
+    const driveName = (parsedOutput.stats as { driveName?: string } | undefined)?.driveName;
+    const content = roles.length
+      ? roles.map((r) => {
+          const dwp = r.driveWidePermissions;
+          const scope = dwp ? ` (drive-wide: ${[dwp.canView && 'view', dwp.canEdit && 'edit', dwp.canShare && 'share'].filter(Boolean).join('/') || 'none'})` : '';
+          return `• ${r.name}${scope}${r.description ? ` — ${r.description}` : ''}`;
+        }).join('\n')
+      : 'No custom roles yet';
+    return <RichContentRenderer title={driveName ? `Roles · ${driveName}` : 'Roles'} content={content} />;
+  },
+
+  get_drive_role: ({ parsedOutput }) => {
+    const role = parsedOutput.role as { name: string; description?: string | null; driveWidePermissions?: { canView: boolean; canEdit: boolean; canShare: boolean } | null; permissions?: Record<string, unknown> } | undefined;
+    if (!role) return null;
+    const dwp = role.driveWidePermissions;
+    const lines = [
+      role.description ? `${role.description}` : null,
+      dwp ? `Drive-wide: ${[dwp.canView && 'view', dwp.canEdit && 'edit', dwp.canShare && 'share'].filter(Boolean).join('/') || 'none'}` : 'Drive-wide: not set',
+      `Per-page grants: ${Object.keys(role.permissions ?? {}).length}`,
+    ].filter(Boolean).join('\n');
+    return <RichContentRenderer title={`Role · ${role.name}`} content={lines} />;
+  },
+
+  create_drive_role: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="create"
+      success={parsedOutput.success !== false}
+      title={(parsedOutput.role as { name?: string } | undefined)?.name ?? 'Role'}
+      message={parsedOutput.summary as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  update_drive_role: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="update"
+      success={parsedOutput.success !== false}
+      title={(parsedOutput.role as { name?: string } | undefined)?.name ?? 'Role'}
+      message={parsedOutput.summary as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  delete_drive_role: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="delete"
+      success={parsedOutput.success !== false}
+      title="Role"
+      message={parsedOutput.summary as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  set_role_page_permissions: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="update"
+      success={parsedOutput.success !== false}
+      title="Role Page Permissions"
+      message={parsedOutput.summary as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  set_role_drive_wide_permissions: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="update"
+      success={parsedOutput.success !== false}
+      title="Role Drive-Wide Permissions"
+      message={parsedOutput.summary as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
+  remove_role_page_permissions: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="remove"
+      success={parsedOutput.success !== false}
+      title="Role Page Permissions"
+      message={parsedOutput.summary as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
   // === AGENT TOOLS ===
   list_agents: ({ parsedOutput }) => {
     if (!parsedOutput.agents) return null;

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -119,6 +119,19 @@ vi.mock('../../tools/member-tools', () => ({
   },
 }));
 
+vi.mock('../../tools/role-management-tools', () => ({
+  roleManagementTools: {
+    list_drive_roles: { name: 'list_drive_roles', description: 'List drive roles' },
+    get_drive_role: { name: 'get_drive_role', description: 'Get drive role' },
+    create_drive_role: { name: 'create_drive_role', description: 'Create drive role' },
+    update_drive_role: { name: 'update_drive_role', description: 'Update drive role' },
+    delete_drive_role: { name: 'delete_drive_role', description: 'Delete drive role' },
+    set_role_page_permissions: { name: 'set_role_page_permissions', description: 'Set role page permissions' },
+    set_role_drive_wide_permissions: { name: 'set_role_drive_wide_permissions', description: 'Set role drive-wide permissions' },
+    remove_role_page_permissions: { name: 'remove_role_page_permissions', description: 'Remove role page permissions' },
+  },
+}));
+
 // Stub the sandbox tools so the builder can be exercised without loading the DB
 // module graph or the real Fly Sprites driver.
 vi.mock('../../tools/sandbox-tools-runtime', () => ({
@@ -132,6 +145,7 @@ vi.mock('../../tools/sandbox-tools-runtime', () => ({
 import { pageSpaceTools, corePageSpaceTools, buildPageSpaceTools } from '../ai-tools';
 import { CORE_TOOL_NAMES } from '../stub-tools';
 import { memberTools } from '../../tools/member-tools';
+import { roleManagementTools } from '../../tools/role-management-tools';
 import { driveTools } from '../../tools/drive-tools';
 import { pageReadTools } from '../../tools/page-read-tools';
 import { pageWriteTools } from '../../tools/page-write-tools';
@@ -156,6 +170,7 @@ describe('ai-tools', () => {
     it('equals the merged object of all tool modules', () => {
       expect(pageSpaceTools).toEqual({
         ...memberTools,
+        ...roleManagementTools,
         ...driveTools,
         ...pageReadTools,
         ...pageWriteTools,
@@ -176,6 +191,7 @@ describe('ai-tools', () => {
     it('has no key collisions between tool modules', () => {
       const moduleKeysets = [
         Object.keys(memberTools),
+        Object.keys(roleManagementTools),
         Object.keys(driveTools),
         Object.keys(pageReadTools),
         Object.keys(pageWriteTools),

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -1,6 +1,7 @@
 import type { Tool } from 'ai';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { memberTools } from '../tools/member-tools';
+import { roleManagementTools } from '../tools/role-management-tools';
 import { driveTools } from '../tools/drive-tools';
 import { pageReadTools } from '../tools/page-read-tools';
 import { pageWriteTools } from '../tools/page-write-tools';
@@ -20,6 +21,7 @@ import { CORE_TOOL_NAMES } from './stub-tools';
 
 const baseTools = {
   ...memberTools,
+  ...roleManagementTools,
   ...driveTools,
   ...pageReadTools,
   ...pageWriteTools,

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -43,6 +43,13 @@ const WRITE_TOOLS = new Set([
   'create_workflow',
   'update_workflow',
   'delete_workflow',
+  // Role management operations
+  'create_drive_role',
+  'update_drive_role',
+  'delete_drive_role',
+  'set_role_page_permissions',
+  'set_role_drive_wide_permissions',
+  'remove_role_page_permissions',
 ]);
 
 // Web search tools (excluded when web search is disabled)
@@ -139,6 +146,8 @@ export function getToolsSummary(isReadOnly: boolean, webSearchEnabled = true): {
     // Read tools
     'list_drive_members',
     'list_collaborators',
+    'list_drive_roles',
+    'get_drive_role',
     'list_drives',
     'list_pages',
     'read_page',

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -55,6 +55,7 @@ import {
   deleteDriveRole,
 } from '@pagespace/lib/services/drive-role-service';
 import { driveDeniedByAppToken } from '../actor-permissions';
+import { db } from '@pagespace/db/db';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockCheckAccess = vi.mocked(checkDriveAccessForRoles);
@@ -64,6 +65,7 @@ const mockCreateRole = vi.mocked(createDriveRole);
 const mockUpdateRole = vi.mocked(updateDriveRole);
 const mockDeleteRole = vi.mocked(deleteDriveRole);
 const mockDenied = vi.mocked(driveDeniedByAppToken);
+const mockFindPage = vi.mocked(db.query.pages.findFirst);
 
 const makeContext = (userId?: string) => ({
   toolCallId: '1',
@@ -343,6 +345,162 @@ describe('role-management-tools', () => {
 
       const result = await roleManagementTools.delete_drive_role.execute!(
         { driveId: 'drive1', roleId: 'role1' },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('set_role_page_permissions', () => {
+    const input = { driveId: 'drive1', roleId: 'role1', pageId: 'page1', canView: true, canEdit: true, canShare: false };
+
+    it('rejects a plain member', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+
+      const result = await roleManagementTools.set_role_page_permissions.execute!(
+        input,
+        makeContext('user1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(false);
+    });
+
+    it('merges the page grant into role.permissions for an admin', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(
+        makeRole({ permissions: { existing: { canView: true, canEdit: false, canShare: false } } })
+      );
+      mockFindPage.mockResolvedValueOnce({ id: 'page1', driveId: 'drive1' } as never);
+      mockUpdateRole.mockImplementationOnce(async (_d, _r, patch) => ({
+        role: makeRole({ permissions: patch.permissions }),
+        wasDefault: false,
+      }));
+
+      const result = await roleManagementTools.set_role_page_permissions.execute!(
+        input,
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateRole).toHaveBeenCalledWith('drive1', 'role1', {
+        permissions: {
+          existing: { canView: true, canEdit: false, canShare: false },
+          page1: { canView: true, canEdit: true, canShare: false },
+        },
+      });
+    });
+
+    it('returns error when pageId is not in this drive', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(makeRole());
+      mockFindPage.mockResolvedValueOnce(undefined as never);
+
+      const result = await roleManagementTools.set_role_page_permissions.execute!(
+        input,
+        makeContext('admin1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+
+    it('returns error when roleId is not in this drive', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(null);
+
+      const result = await roleManagementTools.set_role_page_permissions.execute!(
+        input,
+        makeContext('admin1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('set_role_drive_wide_permissions', () => {
+    it('rejects a plain member', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+
+      const result = await roleManagementTools.set_role_drive_wide_permissions.execute!(
+        { driveId: 'drive1', roleId: 'role1', canView: true, canEdit: false, canShare: false },
+        makeContext('user1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(false);
+    });
+
+    it('sets driveWidePermissions for an admin', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockUpdateRole.mockResolvedValueOnce({
+        role: makeRole({ driveWidePermissions: { canView: true, canEdit: false, canShare: false } }),
+        wasDefault: false,
+      });
+
+      const result = await roleManagementTools.set_role_drive_wide_permissions.execute!(
+        { driveId: 'drive1', roleId: 'role1', canView: true, canEdit: false, canShare: false },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateRole).toHaveBeenCalledWith('drive1', 'role1', {
+        driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+      });
+    });
+
+    it('accepts an all-false grant (clears effective drive-wide access)', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockUpdateRole.mockResolvedValueOnce({
+        role: makeRole({ driveWidePermissions: { canView: false, canEdit: false, canShare: false } }),
+        wasDefault: false,
+      });
+
+      const result = await roleManagementTools.set_role_drive_wide_permissions.execute!(
+        { driveId: 'drive1', roleId: 'role1', canView: false, canEdit: false, canShare: false },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateRole).toHaveBeenCalledWith('drive1', 'role1', {
+        driveWidePermissions: { canView: false, canEdit: false, canShare: false },
+      });
+    });
+  });
+
+  describe('remove_role_page_permissions', () => {
+    it('removes an existing page grant for an admin', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(
+        makeRole({
+          permissions: {
+            page1: { canView: true, canEdit: true, canShare: false },
+            page2: { canView: true, canEdit: false, canShare: false },
+          },
+        })
+      );
+      mockUpdateRole.mockImplementationOnce(async (_d, _r, patch) => ({
+        role: makeRole({ permissions: patch.permissions }),
+        wasDefault: false,
+      }));
+
+      const result = await roleManagementTools.remove_role_page_permissions.execute!(
+        { driveId: 'drive1', roleId: 'role1', pageId: 'page1' },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockUpdateRole).toHaveBeenCalledWith('drive1', 'role1', {
+        permissions: { page2: { canView: true, canEdit: false, canShare: false } },
+      });
+    });
+
+    it('is idempotent when the pageId has no grant on the role', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(makeRole({ permissions: {} }));
+
+      const result = await roleManagementTools.remove_role_page_permissions.execute!(
+        { driveId: 'drive1', roleId: 'role1', pageId: 'ghost' },
         makeContext('admin1')
       ) as { success: boolean };
 

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -24,6 +24,10 @@ vi.mock('@pagespace/lib/services/drive-role-service', () => ({
   deleteDriveRole: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: vi.fn().mockResolvedValue(['owner1', 'user1']),
+}));
+
 vi.mock('../actor-permissions', () => ({
   driveDeniedByAppToken: vi.fn(),
 }));

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -46,6 +46,9 @@ import {
   checkDriveAccessForRoles,
   listDriveRoles,
   getRoleById,
+  createDriveRole,
+  updateDriveRole,
+  deleteDriveRole,
 } from '@pagespace/lib/services/drive-role-service';
 import { driveDeniedByAppToken } from '../actor-permissions';
 import type { ToolExecutionContext } from '../../core/types';
@@ -53,6 +56,9 @@ import type { ToolExecutionContext } from '../../core/types';
 const mockCheckAccess = vi.mocked(checkDriveAccessForRoles);
 const mockListRoles = vi.mocked(listDriveRoles);
 const mockGetRole = vi.mocked(getRoleById);
+const mockCreateRole = vi.mocked(createDriveRole);
+const mockUpdateRole = vi.mocked(updateDriveRole);
+const mockDeleteRole = vi.mocked(deleteDriveRole);
 const mockDenied = vi.mocked(driveDeniedByAppToken);
 
 const makeContext = (userId?: string) => ({
@@ -64,6 +70,7 @@ const makeContext = (userId?: string) => ({
 const drive = { id: 'drive1', name: 'Test Drive', slug: 'test-drive', ownerId: 'owner1' };
 
 const memberAccess = { isOwner: false, isAdmin: false, isMember: true, drive };
+const adminAccess = { isOwner: false, isAdmin: true, isMember: true, drive };
 
 const makeRole = (overrides: Record<string, unknown> = {}) => ({
   id: 'role1',
@@ -184,6 +191,158 @@ describe('role-management-tools', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('create_drive_role', () => {
+    it('rejects a plain member (not admin)', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Editors' },
+        makeContext('user1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('admin');
+    });
+
+    it('creates a role for an admin with a valid name', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockCreateRole.mockResolvedValueOnce(makeRole({ id: 'newrole', name: 'Editors' }));
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Editors' },
+        makeContext('admin1')
+      ) as { success: boolean; role: Record<string, unknown> };
+
+      expect(result.success).toBe(true);
+      expect(result.role).toMatchObject({ id: 'newrole', name: 'Editors' });
+    });
+
+    it('returns error when the name already exists in the drive', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockCreateRole.mockRejectedValueOnce(new Error('A role named "Editors" already exists'));
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Editors' },
+        makeContext('admin1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('already exists');
+    });
+
+    it('passes provided driveWidePermissions through to the created role', async () => {
+      const dwp = { canView: true, canEdit: true, canShare: false };
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockCreateRole.mockImplementationOnce(async (_driveId, input) =>
+        makeRole({ id: 'r9', name: input.name, driveWidePermissions: input.driveWidePermissions ?? null })
+      );
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Viewers', driveWidePermissions: dwp },
+        makeContext('admin1')
+      ) as { success: boolean; role: { driveWidePermissions: unknown } };
+
+      expect(result.success).toBe(true);
+      expect(result.role.driveWidePermissions).toEqual(dwp);
+    });
+
+    it('defaults driveWidePermissions to null when omitted', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockCreateRole.mockImplementationOnce(async (_driveId, input) =>
+        makeRole({ id: 'r10', name: input.name, driveWidePermissions: input.driveWidePermissions ?? null })
+      );
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Plain' },
+        makeContext('admin1')
+      ) as { success: boolean; role: { driveWidePermissions: unknown } };
+
+      expect(result.success).toBe(true);
+      expect(result.role.driveWidePermissions).toBeNull();
+    });
+  });
+
+  describe('update_drive_role', () => {
+    it('rejects a plain member', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+
+      const result = await roleManagementTools.update_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'role1', name: 'Renamed' },
+        makeContext('user1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(false);
+    });
+
+    it('updates a role for an admin with a valid roleId', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockUpdateRole.mockResolvedValueOnce({
+        role: makeRole({ name: 'Renamed' }),
+        wasDefault: false,
+      });
+
+      const result = await roleManagementTools.update_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'role1', name: 'Renamed' },
+        makeContext('admin1')
+      ) as { success: boolean; role: Record<string, unknown> };
+
+      expect(result.success).toBe(true);
+      expect(result.role).toMatchObject({ name: 'Renamed' });
+    });
+
+    it('returns error when roleId is not in this drive', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockUpdateRole.mockRejectedValueOnce(new Error('Role not found'));
+
+      const result = await roleManagementTools.update_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'ghost', name: 'X' },
+        makeContext('admin1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+
+  describe('delete_drive_role', () => {
+    it('rejects a plain member', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+
+      const result = await roleManagementTools.delete_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'role1' },
+        makeContext('user1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(false);
+    });
+
+    it('deletes a role for an admin', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(makeRole());
+      mockDeleteRole.mockResolvedValueOnce(undefined);
+
+      const result = await roleManagementTools.delete_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'role1' },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+    });
+
+    it('succeeds when the role has members assigned (service cascades)', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockGetRole.mockResolvedValueOnce(makeRole());
+      mockDeleteRole.mockResolvedValueOnce(undefined);
+
+      const result = await roleManagementTools.delete_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'role1' },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -55,6 +55,9 @@ import {
   deleteDriveRole,
 } from '@pagespace/lib/services/drive-role-service';
 import { driveDeniedByAppToken } from '../actor-permissions';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { broadcastDriveEvent } from '@/lib/websocket';
 import { db } from '@pagespace/db/db';
 import type { ToolExecutionContext } from '../../core/types';
 
@@ -253,6 +256,34 @@ describe('role-management-tools', () => {
 
       expect(result.success).toBe(true);
       expect(result.role.driveWidePermissions).toEqual(dwp);
+    });
+
+    it('still succeeds and logs activity when the broadcast fails after the role is created', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockCreateRole.mockResolvedValueOnce(makeRole({ id: 'r11', name: 'Survivors' }));
+      vi.mocked(getDriveRecipientUserIds).mockRejectedValueOnce(new Error('socket down'));
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Survivors' },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(vi.mocked(logDriveActivity)).toHaveBeenCalled();
+    });
+
+    it('still succeeds when broadcastDriveEvent itself rejects', async () => {
+      mockCheckAccess.mockResolvedValueOnce(adminAccess);
+      mockCreateRole.mockResolvedValueOnce(makeRole({ id: 'r12', name: 'Resilient' }));
+      vi.mocked(broadcastDriveEvent).mockRejectedValueOnce(new Error('emit failed'));
+
+      const result = await roleManagementTools.create_drive_role.execute!(
+        { driveId: 'drive1', name: 'Resilient' },
+        makeContext('admin1')
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(vi.mocked(logDriveActivity)).toHaveBeenCalled();
     });
 
     it('defaults driveWidePermissions to null when omitted', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: vi.fn() },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId' },
+}));
+
+vi.mock('@pagespace/lib/services/drive-role-service', () => ({
+  checkDriveAccessForRoles: vi.fn(),
+  listDriveRoles: vi.fn(),
+  getRoleById: vi.fn(),
+  createDriveRole: vi.fn(),
+  updateDriveRole: vi.fn(),
+  deleteDriveRole: vi.fn(),
+}));
+
+vi.mock('../actor-permissions', () => ({
+  driveDeniedByAppToken: vi.fn(),
+}));
+
+vi.mock('../task-helpers', () => ({
+  getAiContextWithActor: vi.fn().mockResolvedValue({ source: 'ai' }),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  logDriveActivity: vi.fn(),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastDriveEvent: vi.fn(),
+  createDriveEventPayload: vi.fn(),
+}));
+
+import { roleManagementTools } from '../role-management-tools';
+import {
+  checkDriveAccessForRoles,
+  listDriveRoles,
+  getRoleById,
+} from '@pagespace/lib/services/drive-role-service';
+import { driveDeniedByAppToken } from '../actor-permissions';
+import type { ToolExecutionContext } from '../../core/types';
+
+const mockCheckAccess = vi.mocked(checkDriveAccessForRoles);
+const mockListRoles = vi.mocked(listDriveRoles);
+const mockGetRole = vi.mocked(getRoleById);
+const mockDenied = vi.mocked(driveDeniedByAppToken);
+
+const makeContext = (userId?: string) => ({
+  toolCallId: '1',
+  messages: [],
+  experimental_context: (userId ? { userId } : {}) as ToolExecutionContext,
+});
+
+const drive = { id: 'drive1', name: 'Test Drive', slug: 'test-drive', ownerId: 'owner1' };
+
+const memberAccess = { isOwner: false, isAdmin: false, isMember: true, drive };
+
+const makeRole = (overrides: Record<string, unknown> = {}) => ({
+  id: 'role1',
+  driveId: 'drive1',
+  name: 'Editors',
+  description: null,
+  color: null,
+  isDefault: false,
+  permissions: {},
+  driveWidePermissions: null,
+  position: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('role-management-tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDenied.mockResolvedValue(false);
+  });
+
+  describe('list_drive_roles', () => {
+    it('throws when userId is missing', async () => {
+      await expect(
+        roleManagementTools.list_drive_roles.execute!({ driveId: 'drive1' }, makeContext())
+      ).rejects.toThrow('User authentication required');
+    });
+
+    it('returns error when drive not found', async () => {
+      mockCheckAccess.mockResolvedValueOnce({ isOwner: false, isAdmin: false, isMember: false, drive: null });
+
+      const result = await roleManagementTools.list_drive_roles.execute!(
+        { driveId: 'missing' },
+        makeContext('user1')
+      );
+
+      expect(result).toMatchObject({ success: false, error: 'Drive not found' });
+    });
+
+    it('returns error when user is not a drive member', async () => {
+      mockCheckAccess.mockResolvedValueOnce({ isOwner: false, isAdmin: false, isMember: false, drive });
+
+      const result = await roleManagementTools.list_drive_roles.execute!(
+        { driveId: 'drive1' },
+        makeContext('outsider')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('member');
+    });
+
+    it('returns roles for a member when drive has 3 roles', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+      mockListRoles.mockResolvedValueOnce([
+        makeRole({ id: 'r1', name: 'A' }),
+        makeRole({ id: 'r2', name: 'B' }),
+        makeRole({ id: 'r3', name: 'C' }),
+      ]);
+
+      const result = await roleManagementTools.list_drive_roles.execute!(
+        { driveId: 'drive1' },
+        makeContext('user1')
+      ) as { success: boolean; roles: unknown[]; summary: string };
+
+      expect(result.success).toBe(true);
+      expect(result.roles).toHaveLength(3);
+      expect(result.summary).toContain('3');
+    });
+
+    it('returns empty list when drive has 0 roles', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+      mockListRoles.mockResolvedValueOnce([]);
+
+      const result = await roleManagementTools.list_drive_roles.execute!(
+        { driveId: 'drive1' },
+        makeContext('user1')
+      ) as { success: boolean; roles: unknown[]; summary: string };
+
+      expect(result.success).toBe(true);
+      expect(result.roles).toEqual([]);
+      expect(result.summary).toContain('0');
+    });
+  });
+
+  describe('get_drive_role', () => {
+    it('returns the full role for a valid member and roleId', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+      mockGetRole.mockResolvedValueOnce(
+        makeRole({
+          permissions: { page1: { canView: true, canEdit: false, canShare: false } },
+          driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+        })
+      );
+
+      const result = await roleManagementTools.get_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'role1' },
+        makeContext('user1')
+      ) as { success: boolean; role: Record<string, unknown> };
+
+      expect(result.success).toBe(true);
+      expect(result.role).toMatchObject({
+        id: 'role1',
+        name: 'Editors',
+        permissions: { page1: { canView: true, canEdit: false, canShare: false } },
+        driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+      });
+    });
+
+    it('returns error when roleId is not found in this drive', async () => {
+      mockCheckAccess.mockResolvedValueOnce(memberAccess);
+      mockGetRole.mockResolvedValueOnce(null);
+
+      const result = await roleManagementTools.get_drive_role.execute!(
+        { driveId: 'drive1', roleId: 'nope' },
+        makeContext('user1')
+      ) as { success: boolean; error: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+});

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -1,0 +1,100 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import {
+  checkDriveAccessForRoles,
+  listDriveRoles,
+  getRoleById,
+} from '@pagespace/lib/services/drive-role-service';
+import type { ToolExecutionContext } from '../core/types';
+import { driveDeniedByAppToken } from './actor-permissions';
+
+const driveIdSchema = z.string().regex(/^[a-z][a-z0-9]{1,31}$/, 'Invalid drive ID format');
+
+export const roleManagementTools = {
+  list_drive_roles: tool({
+    description: 'List all custom roles in a drive with their names, colors, and positions. Use this to discover existing roles before creating new ones or assigning roles to members.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive to list roles for'),
+    }),
+    execute: async ({ driveId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      if (await driveDeniedByAppToken(context as ToolExecutionContext, driveId, 'view')) {
+        return { success: false, error: 'This token does not have access to this drive' };
+      }
+
+      const access = await checkDriveAccessForRoles(driveId, userId);
+      if (!access.drive) return { success: false, error: 'Drive not found' };
+      if (!access.isOwner && !access.isMember) {
+        return { success: false, error: 'You must be a drive member to view roles' };
+      }
+
+      const roles = await listDriveRoles(driveId);
+
+      return {
+        success: true,
+        roles: roles.map((r) => ({
+          id: r.id,
+          name: r.name,
+          description: r.description,
+          color: r.color,
+          isDefault: r.isDefault,
+          driveWidePermissions: r.driveWidePermissions,
+          position: r.position,
+        })),
+        summary: `${roles.length} role${roles.length === 1 ? '' : 's'} in "${access.drive.name}"`,
+        stats: { total: roles.length, driveName: access.drive.name },
+        nextSteps: [
+          'Use get_drive_role to inspect a role\'s full permissions',
+          'Use create_drive_role to add a new role',
+        ],
+      };
+    },
+  }),
+
+  get_drive_role: tool({
+    description: 'Get a single drive role with its full per-page permissions map and drive-wide permissions. Use after list_drive_roles to inspect what a role can access.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
+      roleId: z.string().describe('The ID of the role to fetch'),
+    }),
+    execute: async ({ driveId, roleId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      if (await driveDeniedByAppToken(context as ToolExecutionContext, driveId, 'view')) {
+        return { success: false, error: 'This token does not have access to this drive' };
+      }
+
+      const access = await checkDriveAccessForRoles(driveId, userId);
+      if (!access.drive) return { success: false, error: 'Drive not found' };
+      if (!access.isOwner && !access.isMember) {
+        return { success: false, error: 'You must be a drive member to view roles' };
+      }
+
+      const role = await getRoleById(driveId, roleId);
+      if (!role) return { success: false, error: `Role "${roleId}" not found in this drive` };
+
+      return {
+        success: true,
+        role: {
+          id: role.id,
+          name: role.name,
+          description: role.description,
+          color: role.color,
+          isDefault: role.isDefault,
+          permissions: role.permissions,
+          driveWidePermissions: role.driveWidePermissions,
+          position: role.position,
+        },
+        summary: `Role "${role.name}" in "${access.drive.name}"`,
+        stats: { driveName: access.drive.name, pagePermissionCount: Object.keys(role.permissions).length },
+        nextSteps: [
+          'Use set_role_page_permissions to grant this role access to a page',
+          'Use set_role_drive_wide_permissions to apply drive-wide access',
+        ],
+      };
+    },
+  }),
+};

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -201,7 +201,7 @@ export const roleManagementTools = {
           stats: { driveName: gate.access.drive.name },
           nextSteps: [
             'Use set_role_page_permissions to grant page access',
-            'Use assign_custom_role_to_member to give this role to a member',
+            'Use set_role_drive_wide_permissions to apply drive-wide access',
           ],
         };
       } catch (error) {

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -1,5 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
 import {
   checkDriveAccessForRoles,
   listDriveRoles,
@@ -8,6 +11,7 @@ import {
   updateDriveRole,
   deleteDriveRole,
   type DriveRoleAccessInfo,
+  type RolePermissions,
 } from '@pagespace/lib/services/drive-role-service';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
@@ -44,6 +48,15 @@ async function requireDriveAdmin(
 
   return { ok: true, access: { ...access, drive: access.drive } };
 }
+
+const mergePagePermission = (
+  permissions: RolePermissions,
+  pageId: string,
+  perm: { canView: boolean; canEdit: boolean; canShare: boolean }
+): RolePermissions => ({ ...permissions, [pageId]: perm });
+
+const prunePagePermission = (permissions: RolePermissions, pageId: string): RolePermissions =>
+  Object.fromEntries(Object.entries(permissions).filter(([key]) => key !== pageId));
 
 async function logAndBroadcastRoleChange(
   context: ToolExecutionContext,
@@ -273,6 +286,128 @@ export const roleManagementTools = {
         };
       } catch (error) {
         return { success: false, error: error instanceof Error ? error.message : 'Failed to delete role' };
+      }
+    },
+  }),
+
+  set_role_page_permissions: tool({
+    description: 'Grant or change a role\'s permissions (view/edit/share) on a specific page. Merges into the role\'s per-page permission map. Requires drive admin or owner.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
+      roleId: z.string().describe('The ID of the role to modify'),
+      pageId: z.string().describe('The ID of the page to set permissions for (must be in the same drive)'),
+      canView: z.boolean().describe('Whether the role can view the page'),
+      canEdit: z.boolean().describe('Whether the role can edit the page'),
+      canShare: z.boolean().describe('Whether the role can share the page'),
+    }),
+    execute: async ({ driveId, roleId, pageId, canView, canEdit, canShare }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const gate = await requireDriveAdmin(context as ToolExecutionContext, driveId);
+      if (!gate.ok) return gate.error;
+
+      try {
+        const role = await getRoleById(driveId, roleId);
+        if (!role) return { success: false, error: `Role "${roleId}" not found in this drive` };
+
+        const page = await db.query.pages.findFirst({
+          where: and(eq(pages.id, pageId), eq(pages.driveId, driveId)),
+        });
+        if (!page) return { success: false, error: `Page "${pageId}" not found in this drive` };
+
+        const merged = mergePagePermission(role.permissions, pageId, { canView, canEdit, canShare });
+        await updateDriveRole(driveId, roleId, { permissions: merged });
+
+        await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'update', role.name);
+
+        return {
+          success: true,
+          summary: `Set ${role.name}'s permissions on page ${pageId}: view=${canView}, edit=${canEdit}, share=${canShare}`,
+          stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(merged).length },
+          nextSteps: ['Use get_drive_role to see the full permission map'],
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to set page permissions' };
+      }
+    },
+  }),
+
+  set_role_drive_wide_permissions: tool({
+    description: 'Set a role\'s drive-wide permissions (view/edit/share applying to ALL pages in the drive, including future ones). Per-page permissions still override. Requires drive admin or owner.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
+      roleId: z.string().describe('The ID of the role to modify'),
+      canView: z.boolean().describe('Whether the role can view all pages'),
+      canEdit: z.boolean().describe('Whether the role can edit all pages'),
+      canShare: z.boolean().describe('Whether the role can share all pages'),
+    }),
+    execute: async ({ driveId, roleId, canView, canEdit, canShare }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const gate = await requireDriveAdmin(context as ToolExecutionContext, driveId);
+      if (!gate.ok) return gate.error;
+
+      try {
+        const { role } = await updateDriveRole(driveId, roleId, {
+          driveWidePermissions: { canView, canEdit, canShare },
+        });
+
+        await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'update', role.name);
+
+        return {
+          success: true,
+          summary: `Set ${role.name}'s drive-wide permissions: view=${canView}, edit=${canEdit}, share=${canShare}`,
+          stats: { driveName: gate.access.drive.name },
+          nextSteps: ['Use get_drive_role to verify', 'Per-page grants override drive-wide settings'],
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to set drive-wide permissions' };
+      }
+    },
+  }),
+
+  remove_role_page_permissions: tool({
+    description: 'Remove a role\'s per-page permission entry for a specific page, so the role falls back to its drive-wide permissions (if any). Idempotent. Requires drive admin or owner.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
+      roleId: z.string().describe('The ID of the role to modify'),
+      pageId: z.string().describe('The ID of the page whose permission entry should be removed'),
+    }),
+    execute: async ({ driveId, roleId, pageId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const gate = await requireDriveAdmin(context as ToolExecutionContext, driveId);
+      if (!gate.ok) return gate.error;
+
+      try {
+        const role = await getRoleById(driveId, roleId);
+        if (!role) return { success: false, error: `Role "${roleId}" not found in this drive` };
+
+        if (!(pageId in role.permissions)) {
+          return {
+            success: true,
+            summary: `Role "${role.name}" had no permission entry for page ${pageId} — nothing to remove`,
+            stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(role.permissions).length },
+            nextSteps: ['Use get_drive_role to see the current permission map'],
+          };
+        }
+
+        const pruned = prunePagePermission(role.permissions, pageId);
+        await updateDriveRole(driveId, roleId, { permissions: pruned });
+
+        await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'update', role.name);
+
+        return {
+          success: true,
+          summary: `Removed ${role.name}'s permission entry for page ${pageId}`,
+          stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(pruned).length },
+          nextSteps: ['Use get_drive_role to see the remaining permission map'],
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to remove page permissions' };
       }
     },
   }),

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -4,11 +4,59 @@ import {
   checkDriveAccessForRoles,
   listDriveRoles,
   getRoleById,
+  createDriveRole,
+  updateDriveRole,
+  deleteDriveRole,
+  type DriveRoleAccessInfo,
 } from '@pagespace/lib/services/drive-role-service';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import type { ToolExecutionContext } from '../core/types';
 import { driveDeniedByAppToken } from './actor-permissions';
+import { getAiContextWithActor } from './task-helpers';
 
 const driveIdSchema = z.string().regex(/^[a-z][a-z0-9]{1,31}$/, 'Invalid drive ID format');
+
+const driveWidePermissionsSchema = z.object({
+  canView: z.boolean(),
+  canEdit: z.boolean(),
+  canShare: z.boolean(),
+});
+
+type AdminGate =
+  | { ok: true; access: DriveRoleAccessInfo & { drive: NonNullable<DriveRoleAccessInfo['drive']> } }
+  | { ok: false; error: { success: false; error: string } };
+
+async function requireDriveAdmin(
+  context: ToolExecutionContext,
+  driveId: string
+): Promise<AdminGate> {
+  if (await driveDeniedByAppToken(context, driveId, 'manage')) {
+    return { ok: false, error: { success: false, error: 'This token does not have access to this drive' } };
+  }
+
+  const access = await checkDriveAccessForRoles(driveId, context.userId);
+  if (!access.drive) return { ok: false, error: { success: false, error: 'Drive not found' } };
+  if (!access.isOwner && !access.isAdmin) {
+    return { ok: false, error: { success: false, error: 'You must be a drive admin or owner to manage roles' } };
+  }
+
+  return { ok: true, access: { ...access, drive: access.drive } };
+}
+
+async function logAndBroadcastRoleChange(
+  context: ToolExecutionContext,
+  driveId: string,
+  driveName: string,
+  action: 'create' | 'update' | 'delete',
+  roleName: string
+): Promise<void> {
+  const recipientUserIds = await getDriveRecipientUserIds(driveId);
+  await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+  logDriveActivity(context.userId, action, { id: driveId, name: `${driveName} — role "${roleName}"` },
+    await getAiContextWithActor(context));
+}
 
 export const roleManagementTools = {
   list_drive_roles: tool({
@@ -95,6 +143,137 @@ export const roleManagementTools = {
           'Use set_role_drive_wide_permissions to apply drive-wide access',
         ],
       };
+    },
+  }),
+
+  create_drive_role: tool({
+    description: 'Create a new custom role in a drive. Optionally set drive-wide permissions (canView/canEdit/canShare applying to all pages including future ones). Requires drive admin or owner.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive to create the role in'),
+      name: z.string().min(1).describe('Role name, unique within the drive'),
+      description: z.string().optional().describe('What this role is for'),
+      color: z.string().optional().describe('Display color (hex)'),
+      driveWidePermissions: driveWidePermissionsSchema.nullable().optional()
+        .describe('Permissions applying to ALL pages in the drive, including future ones. Omit or null for per-page-only.'),
+    }),
+    execute: async ({ driveId, name, description, color, driveWidePermissions }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const gate = await requireDriveAdmin(context as ToolExecutionContext, driveId);
+      if (!gate.ok) return gate.error;
+
+      try {
+        const role = await createDriveRole(driveId, {
+          name,
+          description: description ?? null,
+          color: color ?? null,
+          permissions: {},
+          driveWidePermissions: driveWidePermissions ?? null,
+        });
+
+        await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'create', role.name);
+
+        return {
+          success: true,
+          role: {
+            id: role.id,
+            name: role.name,
+            description: role.description,
+            color: role.color,
+            driveWidePermissions: role.driveWidePermissions,
+            position: role.position,
+          },
+          summary: `Created role "${role.name}" in "${gate.access.drive.name}"`,
+          stats: { driveName: gate.access.drive.name },
+          nextSteps: [
+            'Use set_role_page_permissions to grant page access',
+            'Use assign_custom_role_to_member to give this role to a member',
+          ],
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to create role' };
+      }
+    },
+  }),
+
+  update_drive_role: tool({
+    description: 'Update a custom role\'s name, description, color, or drive-wide permissions. Requires drive admin or owner.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
+      roleId: z.string().describe('The ID of the role to update'),
+      name: z.string().min(1).optional().describe('New role name'),
+      description: z.string().nullable().optional().describe('New description'),
+      color: z.string().nullable().optional().describe('New display color'),
+      driveWidePermissions: driveWidePermissionsSchema.nullable().optional()
+        .describe('New drive-wide permissions; null clears them'),
+    }),
+    execute: async ({ driveId, roleId, name, description, color, driveWidePermissions }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const gate = await requireDriveAdmin(context as ToolExecutionContext, driveId);
+      if (!gate.ok) return gate.error;
+
+      try {
+        const { role } = await updateDriveRole(driveId, roleId, {
+          ...(name !== undefined && { name }),
+          ...(description !== undefined && { description }),
+          ...(color !== undefined && { color }),
+          ...(driveWidePermissions !== undefined && { driveWidePermissions }),
+        });
+
+        await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'update', role.name);
+
+        return {
+          success: true,
+          role: {
+            id: role.id,
+            name: role.name,
+            description: role.description,
+            color: role.color,
+            driveWidePermissions: role.driveWidePermissions,
+            position: role.position,
+          },
+          summary: `Updated role "${role.name}" in "${gate.access.drive.name}"`,
+          stats: { driveName: gate.access.drive.name },
+          nextSteps: ['Use get_drive_role to verify the changes'],
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to update role' };
+      }
+    },
+  }),
+
+  delete_drive_role: tool({
+    description: 'Delete a custom role from a drive. Members holding this role revert to plain members. Requires drive admin or owner.',
+    inputSchema: z.object({
+      driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
+      roleId: z.string().describe('The ID of the role to delete'),
+    }),
+    execute: async ({ driveId, roleId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const gate = await requireDriveAdmin(context as ToolExecutionContext, driveId);
+      if (!gate.ok) return gate.error;
+
+      try {
+        const role = await getRoleById(driveId, roleId);
+        const roleName = role?.name ?? roleId;
+        await deleteDriveRole(driveId, roleId);
+
+        await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'delete', roleName);
+
+        return {
+          success: true,
+          summary: `Deleted role "${roleName}" from "${gate.access.drive.name}" — members with this role revert to plain members`,
+          stats: { driveName: gate.access.drive.name },
+          nextSteps: ['Use list_drive_roles to see remaining roles'],
+        };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : 'Failed to delete role' };
+      }
     },
   }),
 };

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -65,8 +65,14 @@ async function logAndBroadcastRoleChange(
   action: 'create' | 'update' | 'delete',
   roleName: string
 ): Promise<void> {
-  const recipientUserIds = await getDriveRecipientUserIds(driveId);
-  await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+  // Broadcast is best-effort: the mutation has already committed, so a socket
+  // failure must not surface as a tool error (mirrors the role API routes).
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+  } catch (broadcastError) {
+    console.error('Failed to broadcast role change event for drive', driveId, broadcastError);
+  }
   logDriveActivity(context.userId, action, { id: driveId, name: `${driveName} — role "${roleName}"` },
     await getAiContextWithActor(context));
 }
@@ -160,14 +166,14 @@ export const roleManagementTools = {
   }),
 
   create_drive_role: tool({
-    description: 'Create a new custom role in a drive. Optionally set drive-wide permissions (canView/canEdit/canShare applying to all pages including future ones). Requires drive admin or owner.',
+    description: 'Create a new custom role in a drive. Optionally set drive-wide permissions (canView/canEdit/canShare applying to all non-private pages, including future ones; private pages always need per-page grants). Requires drive admin or owner.',
     inputSchema: z.object({
       driveId: driveIdSchema.describe('The ID of the drive to create the role in'),
       name: z.string().min(1).describe('Role name, unique within the drive'),
       description: z.string().optional().describe('What this role is for'),
       color: z.string().optional().describe('Display color (hex)'),
       driveWidePermissions: driveWidePermissionsSchema.nullable().optional()
-        .describe('Permissions applying to ALL pages in the drive, including future ones. Omit or null for per-page-only.'),
+        .describe('Permissions applying to all non-private pages in the drive, including future ones. Private pages always require per-page grants (set_role_page_permissions). Omit or null for per-page-only.'),
     }),
     execute: async ({ driveId, name, description, color, driveWidePermissions }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
@@ -334,13 +340,13 @@ export const roleManagementTools = {
   }),
 
   set_role_drive_wide_permissions: tool({
-    description: 'Set a role\'s drive-wide permissions (view/edit/share applying to ALL pages in the drive, including future ones). Per-page permissions still override. Requires drive admin or owner.',
+    description: 'Set a role\'s drive-wide permissions (view/edit/share applying to all non-private pages in the drive, including future ones). Private pages are excluded — they always require per-page grants via set_role_page_permissions. Per-page permissions still override. Requires drive admin or owner.',
     inputSchema: z.object({
       driveId: driveIdSchema.describe('The ID of the drive the role belongs to'),
       roleId: z.string().describe('The ID of the role to modify'),
-      canView: z.boolean().describe('Whether the role can view all pages'),
-      canEdit: z.boolean().describe('Whether the role can edit all pages'),
-      canShare: z.boolean().describe('Whether the role can share all pages'),
+      canView: z.boolean().describe('Whether the role can view all non-private pages'),
+      canEdit: z.boolean().describe('Whether the role can edit all non-private pages'),
+      canShare: z.boolean().describe('Whether the role can share all non-private pages'),
     }),
     execute: async ({ driveId, roleId, canView, canEdit, canShare }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
@@ -360,7 +366,11 @@ export const roleManagementTools = {
           success: true,
           summary: `Set ${role.name}'s drive-wide permissions: view=${canView}, edit=${canEdit}, share=${canShare}`,
           stats: { driveName: gate.access.drive.name },
-          nextSteps: ['Use get_drive_role to verify', 'Per-page grants override drive-wide settings'],
+          nextSteps: [
+            'Use get_drive_role to verify',
+            'Per-page grants override drive-wide settings',
+            'Private pages are not covered — use set_role_page_permissions for those',
+          ],
         };
       } catch (error) {
         return { success: false, error: error instanceof Error ? error.message : 'Failed to set drive-wide permissions' };


### PR DESCRIPTION
## PR2 of the Role Management Tools epic (PR1: drive-wide custom role permissions — merged)

Exposes the existing drive-role service layer to AI agents as 8 individually-named tools, so agents can be granted some role capabilities but not others via the `enabledTools` whitelist.

### New tools (`apps/web/src/lib/ai/tools/role-management-tools.ts`)

**Read (any drive member):**
- `list_drive_roles` — names, colors, drive-wide permission summary
- `get_drive_role` — full per-page permission map + driveWidePermissions

**Write (drive admin/owner only, app-token `manage` scope required):**
- `create_drive_role` / `update_drive_role` / `delete_drive_role`
- `set_role_page_permissions` — merges a page grant into the role's permission map (verifies the page belongs to the drive)
- `set_role_drive_wide_permissions` — sets canView/canEdit/canShare for all pages incl. future ones
- `remove_role_page_permissions` — idempotent removal (skips the write when no entry exists)

All writes go through `logDriveActivity` + `broadcastDriveEvent` for audit + real-time sync, mirroring the API routes. Auth is the established tool pattern: `driveDeniedByAppToken` ceiling → `checkDriveAccessForRoles` gate.

### Registration & exposure
- spread into `baseTools` (`ai-tools.ts`)
- 6 write tools added to `WRITE_TOOLS` so read-only mode excludes them (scope addition vs. task spec — omitting it would let read-only agents mutate roles)
- read tools added to `getToolsSummary`; display labels + rich renderers for all 8 (registry coverage test enforces this)

### TDD
Strict RED→GREEN per the PageSpace task list (PR2 tasks 2.1–2.8): 29 unit tests, service layer mocked, no DB. Each RED commit precedes its GREEN commit in history.

### Review responses (Codex)
- Broadcasts are now best-effort: a socket failure after the mutation committed no longer flips the result to `success:false` (which invited duplicate-create retries) and the activity log always lands — parity with the role API routes. Covered by 2 regression tests.
- Drive-wide permission copy corrected: applies to **non-private pages only** (resolver rule in `permissions.ts:238-240`); private pages need per-page grants, and the tool says so.

### Verification
- `bun run typecheck` ✅ (forced fresh) · `bun run lint` ✅
- role-management-tools: 29/29 ✅ · registry/filtering/exposure/stub/MCP-name tests ✅
- full web unit suite: 9529 passed; the 19 failures in 5 files (admin-role-version, message grouping, activity-tools, v1 completions abort, +1) reproduce on clean master locally — environmental, not from this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
