### PR TITLE
feat(avatar): raise avatar upload size limit from 5MB to 25MB

### DIFF
--- a/apps/processor/src/api/avatar.ts
+++ b/apps/processor/src/api/avatar.ts
@@ -25,7 +25,7 @@ const storage = multer.memoryStorage();
 const upload = multer({
   storage,
   limits: {
-    fileSize: 5 * 1024 * 1024, // 5MB limit
+    fileSize: 25 * 1024 * 1024, // 25MB limit
   },
   /* c8 ignore next 8 -- callback invoked by multer internals, not reachable in unit tests */
   fileFilter: (req, file, cb) => {

--- a/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
@@ -146,13 +146,27 @@ describe('POST /api/account/avatar', () => {
       expect(body.error).toContain('Invalid file type');
     });
 
-    it('returns 400 when file exceeds 5MB', async () => {
-      const file = createMockFile('image/png', 6 * 1024 * 1024, 'huge.png');
+    it('returns 400 when file exceeds 25MB', async () => {
+      const file = createMockFile('image/png', 26 * 1024 * 1024, 'huge.png');
       const response = await POST(createUploadRequest(file));
       const body = await response.json();
 
       expect(response.status).toBe(400);
       expect(body.error).toContain('File too large');
+    });
+
+    it('accepts a file between 5MB and 25MB', async () => {
+      mockSelectChain([{ image: null }]);
+      mockUpdateChain();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ filename: 'avatar.png' }),
+      });
+
+      const file = createMockFile('image/png', 6 * 1024 * 1024, 'big.png');
+      const response = await POST(createUploadRequest(file));
+
+      expect(response.status).toBe(200);
     });
 
     it('accepts image/jpeg', async () => {

--- a/apps/web/src/app/api/account/avatar/route.ts
+++ b/apps/web/src/app/api/account/avatar/route.ts
@@ -8,8 +8,8 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token';
 
-// Maximum file size: 5MB
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
+// Maximum file size: 25MB
+const MAX_FILE_SIZE = 25 * 1024 * 1024;
 
 // Allowed image types
 const ALLOWED_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
     // Validate file size
     if (file.size > MAX_FILE_SIZE) {
       return NextResponse.json(
-        { error: 'File too large. Maximum size is 5MB' },
+        { error: 'File too large. Maximum size is 25MB' },
         { status: 400 }
       );
     }

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -169,9 +169,9 @@ export default function AccountPage() {
       return;
     }
 
-    // Validate file size (5MB)
-    if (file.size > 5 * 1024 * 1024) {
-      toast.error('Image must be less than 5MB');
+    // Validate file size (25MB)
+    if (file.size > 25 * 1024 * 1024) {
+      toast.error('Image must be less than 25MB');
       return;
     }
 

--- a/apps/web/src/lib/auth/google-avatar.ts
+++ b/apps/web/src/lib/auth/google-avatar.ts
@@ -2,7 +2,7 @@ import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/servic
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
-const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+const MAX_AVATAR_BYTES = 25 * 1024 * 1024;
 const FETCH_TIMEOUT_MS = 5000;
 const REQUIRED_AVATAR_SCOPES: ServiceScope[] = ['avatars:write'];
 


### PR DESCRIPTION
## Summary
Raises the avatar upload limit from 5MB to 25MB at every gate on the upload path. Users with modern phone photos were hitting "Image must be less than 5MB".

## Changes
- `apps/web/src/app/settings/account/page.tsx` — client-side size check + toast message
- `apps/web/src/app/api/account/avatar/route.ts` — `MAX_FILE_SIZE` + "Maximum size is 25MB" error string
- `apps/processor/src/api/avatar.ts` — multer `limits.fileSize`
- `apps/web/src/lib/auth/google-avatar.ts` — `MAX_AVATAR_BYTES` for the Google sign-in avatar fetch (consistency)
- `apps/web/src/app/api/account/avatar/__tests__/route.test.ts` — RED→GREEN: oversize rejection moved to 26MB, new test asserts a 6MB file (previously rejected) now returns 200

## Infra-level body cap audit (per the prior 20MB build-time-cap prod bug)
Checked every layer in this repo that could silently reject a 25MB multipart POST:

- **Next.js route handler**: `/api/account/avatar` is an App Router route handler using `request.formData()` — route handlers have no default body-size limit on self-hosted Node. No `serverActions.bodySizeLimit` or custom body config exists in `apps/web/next.config.*` (that limit only applies to Server Actions anyway).
- **Processor (Express)**: `express.json({ limit: '50mb' })` applies only to JSON bodies; the multipart avatar upload is parsed by multer, whose `fileSize` limit is what this PR raises. No other Express body cap.
- **`NEXT_PUBLIC_*` build-time vars**: the only build-time upload limit (`useFileDrop.ts`) is on the channel/DM attachment path, not avatars. The avatar path uses no `NEXT_PUBLIC` size constant, so the docker-images.yml build-time-baking issue does not apply here.
- **Outside this repo (NOT verified)**: the Fly/Caddy proxy config lives in PageSpace-Deploy. Caddy has no default request-body limit, but if a `request_body max_size` directive was added there it would gate this before the app sees it — worth a quick grep in PageSpace-Deploy before calling this done in prod.

## Changelog
CLAUDE.md says to update the changelog, but the repo currently has no changelog file — `scripts/changelog/` (referenced by the `changelog:generate` script) no longer exists and no CHANGELOG.md is tracked. Nothing to update; flagging so it can land in whatever the current changelog surface is.

## Testing
- `bun run typecheck` — 13/13 tasks green (includes full web build)
- `apps/web` avatar route tests: 31 passed (RED verified first: 6MB file rejected with old limit)
- `apps/web` google-avatar tests: 6 passed
- `apps/processor` avatar tests: 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)