### PR TITLE
feat(drives): pin Home drive in sidebar, hide destructive/sharing affordances (epic PR 5/5)

### DIFF
--- a/apps/web/src/app/dashboard/[driveId]/members/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/page.tsx
@@ -61,7 +61,7 @@ export default function MembersPage() {
           </Button>
         </div>
         
-        <DriveMembers driveId={driveId} />
+        <DriveMembers driveId={driveId} driveKind={drive.kind} />
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/left-sidebar/DriveList.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DriveList.tsx
@@ -8,7 +8,7 @@ import { useGlobalDriveSocket } from '@/hooks/useGlobalDriveSocket';
 import { useTouchDevice } from '@/hooks/useTouchDevice';
 import { Skeleton } from "@/components/ui/skeleton";
 import { Drive } from "@/hooks/useDrive";
-import { Folder, Trash2, MoreHorizontal, Pencil, Undo2 } from "lucide-react";
+import { Folder, House, Trash2, MoreHorizontal, Pencil, Undo2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useFileDrop } from '@/hooks/useFileDrop';
 import {
@@ -24,6 +24,18 @@ import { toast } from "sonner";
 import { patch, del, post } from '@/lib/auth/auth-fetch';
 import { PullToRefresh } from "@/components/ui/pull-to-refresh";
 import { CustomScrollArea } from "@/components/ui/custom-scroll-area";
+import { isHomeDrive } from '@pagespace/lib/services/drive-guards';
+
+/** Puts the single Home drive (kind='HOME') first; all others follow in their
+ *  original order. Treats undefined kind as STANDARD (stale cache safety). */
+export function pinHomeFirst(drives: Drive[]): Drive[] {
+  const homeIdx = drives.findIndex(d => isHomeDrive(d));
+  if (homeIdx <= 0) return [...drives];
+  const result = [...drives];
+  const [home] = result.splice(homeIdx, 1);
+  result.unshift(home);
+  return result;
+}
 
 const DriveListItem = ({
   drive,
@@ -81,7 +93,7 @@ const DriveListItem = ({
         )}
       >
         <Link href={`/dashboard/${drive.id}`} className="flex items-center gap-2 flex-1 min-w-0">
-          <Folder className="h-4 w-4" />
+          {isHomeDrive(drive) ? <House className="h-4 w-4" /> : <Folder className="h-4 w-4" />}
           <span className="truncate">{drive.name}</span>
         </Link>
         {canManage && (
@@ -265,7 +277,7 @@ export default function DriveList() {
         shared.push(d);
       }
     });
-    return { ownedDrives: owned, sharedDrives: shared, trashedDrives: trashed };
+    return { ownedDrives: pinHomeFirst(owned), sharedDrives: shared, trashedDrives: trashed };
   }, [drives]);
 
   const handleRefresh = useCallback(async () => {
@@ -298,7 +310,7 @@ export default function DriveList() {
                     key={drive.id}
                     drive={drive}
                     isActive={!isTrashView && drive.id === urlDriveId}
-                    canManage={true}
+                    canManage={!isHomeDrive(drive)}
                     isTouchDevice={isTouchDevice}
                     onRename={() => setRenameDialogState({ isOpen: true, drive })}
                     onDelete={() => setDeleteDialogState({ isOpen: true, drive })}

--- a/apps/web/src/components/layout/left-sidebar/__tests__/pinHomeFirst.test.ts
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/pinHomeFirst.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { pinHomeFirst } from '../DriveList';
+import type { Drive } from '@/hooks/useDrive';
+
+function makeDrive(overrides: Partial<Drive>): Drive {
+  return {
+    id: 'id',
+    name: 'Drive',
+    slug: 'drive',
+    role: 'OWNER',
+    isOwned: true,
+    isTrashed: false,
+    memberCount: 1,
+    ...overrides,
+  } as Drive;
+}
+
+describe('pinHomeFirst', () => {
+  it('puts the Home drive first when it exists in the list', () => {
+    const a = makeDrive({ id: 'a', name: 'Alpha', kind: 'STANDARD' });
+    const h = makeDrive({ id: 'h', name: 'Home', kind: 'HOME' });
+    const b = makeDrive({ id: 'b', name: 'Beta', kind: 'STANDARD' });
+
+    const result = pinHomeFirst([a, h, b]);
+    expect(result[0].id).toBe('h');
+    expect(result.map(d => d.id)).toEqual(['h', 'a', 'b']);
+  });
+
+  it('preserves original order when no Home drive is present', () => {
+    const a = makeDrive({ id: 'a', kind: 'STANDARD' });
+    const b = makeDrive({ id: 'b', kind: 'STANDARD' });
+    const result = pinHomeFirst([a, b]);
+    expect(result.map(d => d.id)).toEqual(['a', 'b']);
+  });
+
+  it('treats undefined kind as STANDARD (stale cache)', () => {
+    const a = makeDrive({ id: 'a', kind: undefined });
+    const b = makeDrive({ id: 'b', kind: undefined });
+    const result = pinHomeFirst([a, b]);
+    expect(result.map(d => d.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(pinHomeFirst([])).toEqual([]);
+  });
+
+  it('returns a new array (does not mutate input)', () => {
+    const a = makeDrive({ id: 'a', kind: 'STANDARD' });
+    const h = makeDrive({ id: 'h', kind: 'HOME' });
+    const original = [a, h];
+    const result = pinHomeFirst(original);
+    expect(result).not.toBe(original);
+    expect(original[0].id).toBe('a');
+  });
+});

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -14,6 +14,7 @@ import type { PendingInvite } from './PendingInviteRow';
 import { useToast } from '@/hooks/useToast';
 import { useSocket } from '@/hooks/useSocket';
 import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { isHomeDrive } from '@pagespace/lib/services/drive-guards';
 
 interface DriveMember {
   id: string;
@@ -45,6 +46,7 @@ interface DriveMember {
 
 interface DriveMembersProps {
   driveId: string;
+  driveKind?: string | null;
 }
 
 interface DriveMemberSocketEvent {
@@ -65,7 +67,8 @@ const DRIVE_MEMBER_EVENTS = [
   'drive:member_role_changed',
 ] as const;
 
-export function DriveMembers({ driveId }: DriveMembersProps) {
+export function DriveMembers({ driveId, driveKind }: DriveMembersProps) {
+  const isHome = isHomeDrive({ kind: driveKind });
   const [members, setMembers] = useState<DriveMember[]>([]);
   const [agentMembers, setAgentMembers] = useState<AgentMember[]>([]);
   const [appMembers, setAppMembers] = useState<AppMember[]>([]);
@@ -225,7 +228,7 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
             People with access to this drive
           </p>
         </div>
-        {(currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && (
+        {!isHome && (currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && (
           <Button onClick={() => router.push(`/dashboard/${driveId}/members/invite`)}>
             <UserPlus className="w-4 h-4 mr-2" />
             Invite Member
@@ -233,7 +236,13 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
         )}
       </div>
 
-      {(currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && (
+      {isHome && (
+        <p className="text-sm text-muted-foreground">
+          Home is your private drive and can&apos;t be shared.
+        </p>
+      )}
+
+      {!isHome && (currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && (
         <DriveShareLinkSection driveId={driveId} />
       )}
 


### PR DESCRIPTION
## Summary

This is the **final PR (5/5)** of the Home Drive epic. It removes user-facing affordances for the protected `kind='HOME'` drive so users never reach the server 403s introduced in PR 2.

## Deliverables

### 1. DriveList: pin Home first, House icon, no manage menu

- **`pinHomeFirst(drives: Drive[]): Drive[]`** — exported pure helper. Finds the single `kind='HOME'` drive in the list and moves it to index 0; all other drives follow in their original order. Treats `undefined` kind as STANDARD (stale Zustand cache safety — the `drive-storage` persist key survives without `kind`).
- **`useMemo` partition** applies `pinHomeFirst` to the owned-drives array so Home always appears at the top of "My Drives".
- **`DriveListItem`** renders `<House>` (lucide-react) instead of `<Folder>` when `isHomeDrive(drive)`.
- **Owned-drives map** passes `canManage={!isHomeDrive(drive)}` → the `MoreHorizontal` dropdown (Rename / Move to Trash) is never rendered for Home.
- Home cannot appear in the trashed-drives branch (server blocks trash); no guard there.

### 2. DriveMembers: hide invite and share-link controls for Home

- Added `driveKind?: string | null` to `DriveMembersProps`.
- `members/page.tsx` passes `driveKind={drive.kind}` from the Zustand store.
- When `isHomeDrive({ kind: driveKind })`:
  - "Invite Member" button is hidden.
  - `DriveShareLinkSection` is hidden.
  - One-line note renders: *"Home is your private drive and can't be shared."*
- Standard/undefined kind: renders unchanged.
- Uses `isHomeDrive` from `@pagespace/lib/services/drive-guards` directly — no duplicated inline logic.

### 3. Publish UI `available` flag

**No change needed.** `CanvasPublishControls` already returns `null` when `state.available === false` (line 130). When PR 2 ships and the GET `/publish` route returns `available: false` for pages in Home drives, the control will automatically hide — zero additional work required here.

## Acceptance checkboxes

- [x] `pinHomeFirst` pure helper exported and tested
- [x] Home appears first in owned-drives sidebar partition
- [x] `House` icon renders for Home; `Folder` for all others
- [x] No Rename / Move-to-Trash dropdown for Home
- [x] Invite Member button hidden for Home drives
- [x] DriveShareLinkSection hidden for Home drives
- [x] "Home is your private drive and can't be shared." note shown
- [x] Standard/undefined kind: no behaviour change
- [x] Publish UI already honors `available` — verified, no change
- [x] `bun run typecheck` ✅
- [x] `bun run lint` ✅ (no new warnings)
- [x] `pinHomeFirst.test.ts` 5/5 GREEN (RED-first confirmed)
- [x] `DriveMembers.test.tsx` 8/8 GREEN (existing tests unbroken)
- [x] `@pagespace/lib` 5114/5114 tests GREEN

## RED-first TDD evidence

Tests written before implementation; confirmed failing with `TypeError: pinHomeFirst is not a function`. Five cases covered:
1. Home drive placed first
2. Stable order preserved when no Home drive present
3. `undefined` kind treated as STANDARD (stale cache)
4. Empty array input
5. Input array not mutated

## Constraints respected

- No server changes (PR 2 owns all 403 guards)
- No provisioning/backfill changes (PRs 3/4)
- `isHomeDrive` from `@pagespace/lib/services/drive-guards` used everywhere — no inline `drive.kind === 'HOME'`
- No React render tests (worktree dual-React constraint); components validated via typecheck

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>