### PR TITLE
feat(drives): backfill empty Home drive for existing users (epic PR 4/5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "pagespace-local",
       "devDependencies": {
         "@faker-js/faker": "^9.3.0",
+        "@pagespace/db": "workspace:*",
+        "@pagespace/lib": "workspace:*",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "setup:admin": "bun scripts/setup-onprem-admin.ts"
   },
   "devDependencies": {
+    "@pagespace/db": "workspace:*",
+    "@pagespace/lib": "workspace:*",
     "@faker-js/faker": "^9.3.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/scripts/__tests__/backfill-home-drives.test.ts
+++ b/scripts/__tests__/backfill-home-drives.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { computeHomeBackfillInserts, type UserBackfillData } from '../lib/home-drive-backfill';
+
+// ─── DB mock setup (hoisted before imports) ──────────────────────────────────
+
+const { selectMock, insertMock } = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  insertMock: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: selectMock, insert: insertMock },
+}));
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id' },
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  drives: {
+    id: 'id',
+    ownerId: 'ownerId',
+    kind: 'kind',
+    slug: 'slug',
+    name: 'name',
+    createdAt: 'createdAt',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: Object.assign(() => ({}), { raw: () => ({}) }),
+  eq: () => ({}),
+  and: () => ({}),
+  gt: () => ({}),
+  asc: () => ({}),
+  inArray: () => ({}),
+}));
+
+// @paralleldrive/cuid2 lives in the bun package cache, not in node_modules/
+// that Vite sees — mock it so the forked vitest process can import the script.
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: () => 'test-cuid-id',
+}));
+
+import { backfill } from '../backfill-home-drives';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * A chainable + directly-awaitable stub.
+ * - `.limit()` terminates the paginated user query.
+ * - Direct await (thenable) handles the slug query (no LIMIT).
+ * - All intermediate chain methods return the same stub.
+ */
+function makeChain(rows: unknown[]) {
+  const stub: Record<string, unknown> = {};
+  for (const m of ['from', 'leftJoin', 'where', 'orderBy']) stub[m] = () => stub;
+  stub['limit'] = () => Promise.resolve(rows);
+  stub['then'] = (resolve: (r: unknown) => void, reject: (e: unknown) => void) =>
+    Promise.resolve(rows).then(resolve, reject);
+  return stub;
+}
+
+/**
+ * Set up the select mock for one backfill loop iteration.
+ *
+ * - Call 1 (paginated users + home-drive LEFT JOIN) → batchRows
+ * - Call 2 (slug lookup for users needing Home) → slugRows (live mode only)
+ * - Subsequent calls → [] (empty batch terminates the cursor loop)
+ *
+ * mockReset() in beforeEach clears both the one-time queue and the default,
+ * so each test starts from a clean slate.
+ */
+function setupSelect(batchRows: unknown[], slugRows: unknown[] = []) {
+  // Fallback default: empty batch → loop terminates cleanly after one iteration
+  selectMock.mockReturnValue(makeChain([]));
+  selectMock.mockReturnValueOnce(makeChain(batchRows));
+  selectMock.mockReturnValueOnce(makeChain(slugRows));
+}
+
+/** Set up a chainable insert mock. Returns the inner spy for assertion. */
+function setupInsert() {
+  const onConflictSpy = vi.fn().mockResolvedValue(undefined);
+  const valuesSpy = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictSpy });
+  insertMock.mockReturnValue({ values: valuesSpy });
+  return { valuesSpy, onConflictSpy };
+}
+
+// ─── Pure-function tests (no DB, no mocks needed) ────────────────────────────
+
+describe('computeHomeBackfillInserts', () => {
+  it('returns [] for an empty batch', () => {
+    expect(computeHomeBackfillInserts([])).toEqual([]);
+  });
+
+  it('skips users who already have a Home drive', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'user-1', hasHome: true, existingSlugs: ['home'] },
+    ];
+    expect(computeHomeBackfillInserts(users)).toEqual([]);
+  });
+
+  it('returns a row for a user with no Home drive and no slug collision', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'user-1', hasHome: false, existingSlugs: [] },
+    ];
+    expect(computeHomeBackfillInserts(users)).toEqual([
+      { ownerId: 'user-1', slug: 'home', name: 'Home' },
+    ]);
+  });
+
+  it('applies -2 suffix when slug "home" is already taken', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'user-1', hasHome: false, existingSlugs: ['home'] },
+    ];
+    expect(computeHomeBackfillInserts(users)).toEqual([
+      { ownerId: 'user-1', slug: 'home-2', name: 'Home' },
+    ]);
+  });
+
+  it('increments suffix past consecutive taken slugs', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'user-1', hasHome: false, existingSlugs: ['home', 'home-2', 'home-3'] },
+    ];
+    expect(computeHomeBackfillInserts(users)).toEqual([
+      { ownerId: 'user-1', slug: 'home-4', name: 'Home' },
+    ]);
+  });
+
+  it('finds the lowest free suffix even when gaps exist', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'user-1', hasHome: false, existingSlugs: ['home', 'home-3'] },
+    ];
+    expect(computeHomeBackfillInserts(users)).toEqual([
+      { ownerId: 'user-1', slug: 'home-2', name: 'Home' },
+    ]);
+  });
+
+  it('processes a mixed batch, returning rows only for users lacking Home', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'already', hasHome: true, existingSlugs: ['home'] },
+      { userId: 'clean', hasHome: false, existingSlugs: [] },
+      { userId: 'collision', hasHome: false, existingSlugs: ['home', 'work'] },
+    ];
+    const result = computeHomeBackfillInserts(users);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ ownerId: 'clean', slug: 'home', name: 'Home' });
+    expect(result[1]).toEqual({ ownerId: 'collision', slug: 'home-2', name: 'Home' });
+  });
+
+  it('preserves order of users needing Home in the output', () => {
+    const users: UserBackfillData[] = [
+      { userId: 'a', hasHome: false, existingSlugs: [] },
+      { userId: 'b', hasHome: false, existingSlugs: [] },
+      { userId: 'c', hasHome: false, existingSlugs: [] },
+    ];
+    expect(computeHomeBackfillInserts(users).map((r) => r.ownerId)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+// ─── Script-level tests (mocked DB) ──────────────────────────────────────────
+
+describe('backfill (dry-run)', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    insertMock.mockReset();
+  });
+
+  it('reports users lacking Home and inserts nothing', async () => {
+    // batch: user-1 has no Home, user-2 already has one
+    setupSelect([
+      { userId: 'user-1', homeDriveId: null },
+      { userId: 'user-2', homeDriveId: 'drive-home-2' },
+    ]);
+
+    const { inserted, skipped } = await backfill(true);
+
+    expect(inserted).toBe(0);
+    expect(skipped).toBe(1); // user-2 already had Home
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it('returns zero counts for an empty database', async () => {
+    setupSelect([]);
+
+    const { inserted, skipped } = await backfill(true);
+
+    expect(inserted).toBe(0);
+    expect(skipped).toBe(0);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('backfill (live)', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    insertMock.mockReset();
+  });
+
+  it('is idempotent: skips users who already have a Home drive', async () => {
+    setupSelect([{ userId: 'user-1', homeDriveId: 'existing-home' }]);
+
+    const { inserted, skipped } = await backfill(false);
+
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(inserted).toBe(0);
+    expect(skipped).toBe(1);
+  });
+
+  it('inserts Home drives for users that are missing them', async () => {
+    setupSelect(
+      [{ userId: 'user-needs-home', homeDriveId: null }],
+      [], // no existing slugs for this user
+    );
+    const { onConflictSpy } = setupInsert();
+
+    const { inserted, skipped } = await backfill(false);
+
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(inserted).toBe(1);
+    expect(skipped).toBe(0);
+    // Verify conflict is swallowed via onConflictDoNothing (partial-unique-index guard)
+    expect(onConflictSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a conflict via onConflictDoNothing (race with lazy provisioning)', async () => {
+    setupSelect(
+      [{ userId: 'user-race', homeDriveId: null }],
+      [],
+    );
+    const { onConflictSpy } = setupInsert();
+
+    await backfill(false);
+
+    // onConflictDoNothing must be called — the partial unique index handles races silently
+    expect(onConflictSpy).toHaveBeenCalledTimes(1);
+    const callArg = onConflictSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg).toHaveProperty('target');
+    expect(callArg).toHaveProperty('targetWhere');
+  });
+
+  it('returns zero counts for an empty database (idempotent second run)', async () => {
+    setupSelect([]);
+
+    const { inserted, skipped } = await backfill(false);
+
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(inserted).toBe(0);
+    expect(skipped).toBe(0);
+  });
+});

--- a/scripts/__tests__/backfill-home-drives.test.ts
+++ b/scripts/__tests__/backfill-home-drives.test.ts
@@ -79,12 +79,17 @@ function setupSelect(batchRows: unknown[], slugRows: unknown[] = []) {
   selectMock.mockReturnValueOnce(makeChain(slugRows));
 }
 
-/** Set up a chainable insert mock. Returns the inner spy for assertion. */
-function setupInsert() {
-  const onConflictSpy = vi.fn().mockResolvedValue(undefined);
+/**
+ * Set up a chainable insert mock that supports .values().onConflictDoNothing().returning().
+ * writtenRows controls what .returning() resolves to — this is the count that
+ * `backfill` uses for `inserted` in live mode (only actually-written rows).
+ */
+function setupInsert(writtenRows: Array<{ id: string }> = [{ id: 'test-cuid-id' }]) {
+  const returningSpy = vi.fn().mockResolvedValue(writtenRows);
+  const onConflictSpy = vi.fn().mockReturnValue({ returning: returningSpy });
   const valuesSpy = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictSpy });
   insertMock.mockReturnValue({ values: valuesSpy });
-  return { valuesSpy, onConflictSpy };
+  return { valuesSpy, onConflictSpy, returningSpy };
 }
 
 // ─── Pure-function tests (no DB, no mocks needed) ────────────────────────────
@@ -167,8 +172,8 @@ describe('backfill (dry-run)', () => {
     insertMock.mockReset();
   });
 
-  it('reports users lacking Home and inserts nothing', async () => {
-    // batch: user-1 has no Home, user-2 already has one
+  it('reports the projected count of users lacking Home and inserts nothing', async () => {
+    // batch: user-1 has no Home (projected insert), user-2 already has one (skipped)
     setupSelect([
       { userId: 'user-1', homeDriveId: null },
       { userId: 'user-2', homeDriveId: 'drive-home-2' },
@@ -176,8 +181,9 @@ describe('backfill (dry-run)', () => {
 
     const { inserted, skipped } = await backfill(true);
 
-    expect(inserted).toBe(0);
-    expect(skipped).toBe(1); // user-2 already had Home
+    // inserted = projected count (1 user lacks Home); skipped = already-have-Home count
+    expect(inserted).toBe(1);
+    expect(skipped).toBe(1);
     expect(insertMock).not.toHaveBeenCalled();
   });
 
@@ -213,31 +219,39 @@ describe('backfill (live)', () => {
       [{ userId: 'user-needs-home', homeDriveId: null }],
       [], // no existing slugs for this user
     );
-    const { onConflictSpy } = setupInsert();
+    const { valuesSpy, onConflictSpy } = setupInsert([{ id: 'test-cuid-id' }]);
 
     const { inserted, skipped } = await backfill(false);
 
     expect(insertMock).toHaveBeenCalledTimes(1);
+    // inserted reflects .returning() count — only actually-written rows
     expect(inserted).toBe(1);
     expect(skipped).toBe(0);
+
+    // Verify kind: 'HOME' is included in the inserted rows
+    const insertedRows = valuesSpy.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(insertedRows[0]).toMatchObject({ kind: 'HOME', ownerId: 'user-needs-home', name: 'Home' });
+
     // Verify conflict is swallowed via onConflictDoNothing (partial-unique-index guard)
-    expect(onConflictSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('swallows a conflict via onConflictDoNothing (race with lazy provisioning)', async () => {
-    setupSelect(
-      [{ userId: 'user-race', homeDriveId: null }],
-      [],
-    );
-    const { onConflictSpy } = setupInsert();
-
-    await backfill(false);
-
-    // onConflictDoNothing must be called — the partial unique index handles races silently
     expect(onConflictSpy).toHaveBeenCalledTimes(1);
     const callArg = onConflictSpy.mock.calls[0][0] as Record<string, unknown>;
     expect(callArg).toHaveProperty('target');
     expect(callArg).toHaveProperty('targetWhere');
+  });
+
+  it('swallows a conflict via onConflictDoNothing: counts only actually-written rows', async () => {
+    // Lazy provisioning raced and created the Home drive — returning() returns [] (conflict)
+    setupSelect(
+      [{ userId: 'user-race', homeDriveId: null }],
+      [],
+    );
+    const { onConflictSpy } = setupInsert([]); // returning empty = conflict was skipped
+
+    const { inserted } = await backfill(false);
+
+    expect(onConflictSpy).toHaveBeenCalledTimes(1);
+    // inserted = 0 because the race was won by lazy provisioning (row not written)
+    expect(inserted).toBe(0);
   });
 
   it('returns zero counts for an empty database (idempotent second run)', async () => {

--- a/scripts/backfill-home-drives.ts
+++ b/scripts/backfill-home-drives.ts
@@ -75,6 +75,8 @@ export async function backfill(dryRun: boolean, dbInstance: DbLike = defaultDb):
 
     if (needsHome.length > 0) {
       if (dryRun) {
+        // In dry-run, count projected inserts so the summary is accurate.
+        inserted += needsHome.length;
         console.log(`  would insert ${needsHome.length} Home drives (cursor: ${cursor || '<start>'})`);
       } else {
         const userIds = needsHome.map((r) => r.userId);
@@ -104,19 +106,24 @@ export async function backfill(dryRun: boolean, dbInstance: DbLike = defaultDb):
         const rows = toInsert.map((r) => ({
           id: createId(),
           ...r,
+          // kind must be explicit — the DB default is STANDARD, not HOME.
+          kind: 'HOME' as const,
           createdAt: now,
           updatedAt: now,
         }));
 
-        await (dbInstance as typeof defaultDb)
+        // Use .returning() so the count reflects only rows actually written,
+        // not the attempted batch size (onConflictDoNothing skips races).
+        const written = await (dbInstance as typeof defaultDb)
           .insert(drives)
           .values(rows)
           .onConflictDoNothing({
             target: [drives.ownerId],
             targetWhere: sql`"kind" = 'HOME'`,
-          });
+          })
+          .returning({ id: drives.id });
 
-        inserted += toInsert.length;
+        inserted += written.length;
       }
     }
 

--- a/scripts/backfill-home-drives.ts
+++ b/scripts/backfill-home-drives.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+/**
+ * Backfill Script: Create an empty Home drive for every existing user
+ *
+ * PR 4 of 5 — Home Drive epic (branch: pu/starting-drive).
+ *
+ * New signups get their Home drive from provisioning (PR 3). Password/passkey
+ * sign-in routes never call provisioning, so a one-time backfill is MANDATORY
+ * for all users created before PR 3 lands.
+ *
+ * Each user receives a fresh, EMPTY Home drive (kind='HOME'). Their existing
+ * drives — including any "Getting Started" drive — are never touched.
+ *
+ * The insert uses onConflictDoNothing targeting the partial unique index
+ * drives_owner_home_unique (ownerId WHERE kind='HOME'), so a concurrent lazy
+ * provisioning race is a silent skip, not an error. Running the script twice
+ * is equally safe (the missing set is re-derived from the DB each run).
+ *
+ * Usage:
+ *   bun scripts/backfill-home-drives.ts [--dry-run]
+ *
+ * Options:
+ *   --dry-run   Report how many users lack a Home drive without inserting.
+ *
+ * ─── Production procedure (Fly) ────────────────────────────────────────────
+ * 1. Deploy the schema migration (adds kind column + partial unique index).
+ * 2. Deploy the new app image (provisioning + guards from PRs 1–3).
+ * 3. Run this script as a one-off machine on the migrate image:
+ *
+ *      fly machine run <migrate-image> \
+ *        --app pagespace \
+ *        --env DATABASE_URL="$DATABASE_URL" \
+ *        -- bun scripts/backfill-home-drives.ts
+ *
+ *    apps/web/Dockerfile.migrate already copies scripts/ into the image.
+ *    DO NOT run this script against production yourself — document only.
+ * ────────────────────────────────────────────────────────────────────────────
+ */
+
+import { createId } from '@paralleldrive/cuid2';
+import { db as defaultDb } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { drives } from '@pagespace/db/schema/core';
+import { eq, and, gt, asc, inArray, sql } from '@pagespace/db/operators';
+import { computeHomeBackfillInserts } from './lib/home-drive-backfill';
+
+const BATCH_SIZE = 500;
+
+export type BackfillResult = { inserted: number; skipped: number };
+
+type DbLike = Pick<typeof defaultDb, 'select' | 'insert'>;
+
+export async function backfill(dryRun: boolean, dbInstance: DbLike = defaultDb): Promise<BackfillResult> {
+  console.log(`🚀 Backfilling Home drives${dryRun ? ' (dry run)' : ''}...`);
+
+  let inserted = 0;
+  let skipped = 0;
+  let cursor = '';
+
+  for (;;) {
+    // One row per user: homeDriveId is null when the user lacks a Home drive.
+    const batch = await (dbInstance as typeof defaultDb)
+      .select({ userId: users.id, homeDriveId: drives.id })
+      .from(users)
+      .leftJoin(drives, and(eq(drives.ownerId, users.id), eq(drives.kind, 'HOME')))
+      .where(gt(users.id, cursor))
+      .orderBy(asc(users.id))
+      .limit(BATCH_SIZE);
+
+    if (batch.length === 0) break;
+
+    const needsHome = batch.filter((row) => row.homeDriveId === null);
+    const alreadyHasHome = batch.length - needsHome.length;
+    skipped += alreadyHasHome;
+
+    if (needsHome.length > 0) {
+      if (dryRun) {
+        console.log(`  would insert ${needsHome.length} Home drives (cursor: ${cursor || '<start>'})`);
+      } else {
+        const userIds = needsHome.map((r) => r.userId);
+
+        // Fetch all drive slugs for users lacking Home (for collision avoidance).
+        const slugRows = await (dbInstance as typeof defaultDb)
+          .select({ ownerId: drives.ownerId, slug: drives.slug })
+          .from(drives)
+          .where(inArray(drives.ownerId, userIds));
+
+        const slugsByOwner = new Map<string, string[]>();
+        for (const { ownerId, slug } of slugRows) {
+          const list = slugsByOwner.get(ownerId) ?? [];
+          list.push(slug);
+          slugsByOwner.set(ownerId, list);
+        }
+
+        const toInsert = computeHomeBackfillInserts(
+          needsHome.map((row) => ({
+            userId: row.userId,
+            hasHome: false,
+            existingSlugs: slugsByOwner.get(row.userId) ?? [],
+          })),
+        );
+
+        const now = new Date();
+        const rows = toInsert.map((r) => ({
+          id: createId(),
+          ...r,
+          createdAt: now,
+          updatedAt: now,
+        }));
+
+        await (dbInstance as typeof defaultDb)
+          .insert(drives)
+          .values(rows)
+          .onConflictDoNothing({
+            target: [drives.ownerId],
+            targetWhere: sql`"kind" = 'HOME'`,
+          });
+
+        inserted += toInsert.length;
+      }
+    }
+
+    cursor = batch[batch.length - 1].userId;
+    if (batch.length < BATCH_SIZE) break;
+  }
+
+  console.log(
+    `✅ Backfill ${dryRun ? 'dry run ' : ''}complete. ${
+      dryRun
+        ? `would insert: ${inserted}, already have Home: ${skipped}`
+        : `inserted: ${inserted}, already had Home: ${skipped}`
+    }`,
+  );
+
+  return { inserted, skipped };
+}
+
+if (import.meta.main) {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+  backfill(dryRun)
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('💥 Backfill failed:', error);
+      process.exit(1);
+    });
+}

--- a/scripts/lib/home-drive-backfill.ts
+++ b/scripts/lib/home-drive-backfill.ts
@@ -1,6 +1,5 @@
 /**
  * Pure decision functions for the Home drive backfill.
- *
  * Intentionally self-contained (no @pagespace/* imports) so that the
  * scripts/ vitest context — which runs in a forked Node process without
  * bun's workspace resolver — can load this file without aliases or stubs.
@@ -9,10 +8,8 @@
  * mirrored here.
  */
 
-// Mirrors HOME_DRIVE_NAME from @pagespace/lib/services/drive-guards
 const HOME_DRIVE_NAME = 'Home';
 
-// Mirrors resolveUniqueSlug from @pagespace/lib/services/drive-guards
 function resolveUniqueSlug(existingSlugs: string[], base: string): string {
   const taken = new Set(existingSlugs);
   if (!taken.has(base)) return base;
@@ -38,7 +35,7 @@ export type DriveInsertData = {
 /**
  * Given a batch of users (with their Home-drive status and existing slugs),
  * returns the drive rows to insert. Users who already have a Home drive are
- * skipped. The caller stamps `id` and timestamps before inserting.
+ * skipped. The caller stamps `id`, `kind`, and timestamps before inserting.
  */
 export function computeHomeBackfillInserts(users: UserBackfillData[]): DriveInsertData[] {
   const result: DriveInsertData[] = [];

--- a/scripts/lib/home-drive-backfill.ts
+++ b/scripts/lib/home-drive-backfill.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure decision functions for the Home drive backfill.
+ *
+ * Intentionally self-contained (no @pagespace/* imports) so that the
+ * scripts/ vitest context — which runs in a forked Node process without
+ * bun's workspace resolver — can load this file without aliases or stubs.
+ * The canonical definitions of HOME_DRIVE_NAME and resolveUniqueSlug live in
+ * packages/lib/src/services/drive-guards.ts; any changes there must be
+ * mirrored here.
+ */
+
+// Mirrors HOME_DRIVE_NAME from @pagespace/lib/services/drive-guards
+const HOME_DRIVE_NAME = 'Home';
+
+// Mirrors resolveUniqueSlug from @pagespace/lib/services/drive-guards
+function resolveUniqueSlug(existingSlugs: string[], base: string): string {
+  const taken = new Set(existingSlugs);
+  if (!taken.has(base)) return base;
+  let suffix = 2;
+  while (taken.has(`${base}-${suffix}`)) suffix++;
+  return `${base}-${suffix}`;
+}
+
+export type UserBackfillData = {
+  userId: string;
+  /** true when the LEFT JOIN produced a Home drive row for this user */
+  hasHome: boolean;
+  /** all drive slugs already owned by this user (for collision avoidance) */
+  existingSlugs: string[];
+};
+
+export type DriveInsertData = {
+  ownerId: string;
+  slug: string;
+  name: string;
+};
+
+/**
+ * Given a batch of users (with their Home-drive status and existing slugs),
+ * returns the drive rows to insert. Users who already have a Home drive are
+ * skipped. The caller stamps `id` and timestamps before inserting.
+ */
+export function computeHomeBackfillInserts(users: UserBackfillData[]): DriveInsertData[] {
+  const result: DriveInsertData[] = [];
+  for (const user of users) {
+    if (user.hasHome) continue;
+    result.push({
+      ownerId: user.userId,
+      slug: resolveUniqueSlug(user.existingSlugs, 'home'),
+      name: HOME_DRIVE_NAME,
+    });
+  }
+  return result;
+}

--- a/scripts/lib/home-drive-backfill.ts
+++ b/scripts/lib/home-drive-backfill.ts
@@ -1,22 +1,4 @@
-/**
- * Pure decision functions for the Home drive backfill.
- * Intentionally self-contained (no @pagespace/* imports) so that the
- * scripts/ vitest context — which runs in a forked Node process without
- * bun's workspace resolver — can load this file without aliases or stubs.
- * The canonical definitions of HOME_DRIVE_NAME and resolveUniqueSlug live in
- * packages/lib/src/services/drive-guards.ts; any changes there must be
- * mirrored here.
- */
-
-const HOME_DRIVE_NAME = 'Home';
-
-function resolveUniqueSlug(existingSlugs: string[], base: string): string {
-  const taken = new Set(existingSlugs);
-  if (!taken.has(base)) return base;
-  let suffix = 2;
-  while (taken.has(`${base}-${suffix}`)) suffix++;
-  return `${base}-${suffix}`;
-}
+import { HOME_DRIVE_NAME, resolveUniqueSlug } from '@pagespace/lib/services/drive-guards';
 
 export type UserBackfillData = {
   userId: string;


### PR DESCRIPTION
## Summary

Delivers the mandatory one-time backfill that creates an empty `kind='HOME'` drive for every existing user.

**Why this is non-optional:** New signups get their Home drive from provisioning (PR 3). Password/passkey sign-in routes **never** call provisioning — so every user created before PR 3 lands would be stuck without a Home drive until their next OAuth/magic-link login (lazy provisioning). This script closes that gap.

**Base branch:** `pu/starting-drive` (includes PR 1 schema + guards)

---

## Deliverables

### 1. `scripts/lib/home-drive-backfill.ts` — pure planning core
- `computeHomeBackfillInserts(users: UserBackfillData[]): DriveInsertData[]`
- No DB, no `Date.now()`, no `createId()` — pure input → output
- Imports `HOME_DRIVE_NAME` and `resolveUniqueSlug` from `@pagespace/lib/services/drive-guards` (the canonical single source of truth; `@pagespace/lib` is declared as a workspace devDependency in root `package.json` so `bun install` always creates the node_modules symlink Vite needs)

### 2. `scripts/backfill-home-drives.ts` — script shell
- `#!/usr/bin/env bun`, `--dry-run` flag, idempotent
- Cursor-paginates users (ORDER BY id, 500/batch)
- LEFT JOINs `drives` on `ownerId AND kind='HOME'` to identify who lacks a Home
- For users needing Home: fetches their existing slugs (second query) → `computeHomeBackfillInserts` → batch insert
- Insert via `.onConflictDoNothing({ target: [drives.ownerId], targetWhere: sql\`"kind" = 'HOME'\` })` — the partial unique index arbitrates concurrent lazy-provisioning races
- Documents the Fly production run procedure in the header

---

## Acceptance criteria

- [x] User who already has a Home → no row inserted
- [x] User whose slug `home` is taken → `home-2` suffix via `resolveUniqueSlug`
- [x] Empty batch → `[]`
- [x] `--dry-run` reports the count of users lacking Home, inserts nothing
- [x] Second run inserts nothing (missing set re-derived from DB)
- [x] Insert uses `onConflictDoNothing` targeting the partial unique index (conflict = skip, not error)
- [x] Fly production procedure documented in script header

---

## RED-first evidence

Tests were written and run against the missing implementation to confirm RED before implementing:

```
 FAIL  __tests__/backfill-home-drives.test.ts [ __tests__/backfill-home-drives.test.ts ]
Error: Failed to load url ../lib/home-drive-backfill (resolved id: ../lib/home-drive-backfill)
       in .../scripts/__tests__/backfill-home-drives.test.ts. Does the file exist?
```

Then after implementing `lib/home-drive-backfill.ts` but before the script existed:

```
 FAIL  __tests__/backfill-home-drives.test.ts [ __tests__/backfill-home-drives.test.ts ]
Error: Failed to load url ../backfill-home-drives (resolved id: ../backfill-home-drives)
       in .../scripts/__tests__/backfill-home-drives.test.ts. Does the file exist?
```

GREEN after full implementation (14/14):

```
 ✓ __tests__/backfill-home-drives.test.ts (14 tests) 8ms
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

---

## Local dry-run output

Docker Desktop encountered an I/O error during this session and could not start (`input/output error` on the overlay FS). The dev DB could not be spun up locally.

**Expected output format** (based on code path + unit test verification):

```
🚀 Backfilling Home drives (dry run)...
  would insert 3 Home drives (cursor: <start>)
✅ Backfill dry run complete. would insert: 0, already have Home: 247
```

*(3 users in first batch lacked Home; 247 already had one; `--dry-run` inserts nothing)*

To run against the real dev DB once Docker is healthy:

```bash
DATABASE_URL=postgresql://user:password@localhost:5432/pagespace \
  bun scripts/backfill-home-drives.ts --dry-run
```

---

## vitest quirks documented

The `scripts/` vitest context runs in a forked Node process via Vite and cannot resolve bun workspace packages (`@pagespace/lib`, `@pagespace/db`, `@paralleldrive/cuid2`) through the standard `node_modules` symlink path. All three solutions applied:

1. `lib/home-drive-backfill.ts` is self-contained (no `@pagespace/*` imports) — mirrors `resolveUniqueSlug`/`HOME_DRIVE_NAME` inline with a comment pointing back to the canonical source
2. Script-level tests use `vi.mock` to intercept all `@pagespace/db/*` and `@paralleldrive/cuid2` imports before Vite tries to load them
3. `mockReset()` (not `clearAllMocks()`) in `beforeEach` — `clearAllMocks` does NOT flush the `mockReturnValueOnce` queue

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)