### PR TITLE
fix(avatar): cap crop canvas to 512px, fix false-positive file-too-large error

### DIFF
--- a/apps/web/src/components/dialogs/ImageCropperDialog.tsx
+++ b/apps/web/src/components/dialogs/ImageCropperDialog.tsx
@@ -29,6 +29,8 @@ interface ImageCropperDialogProps {
 
 type CropShape = "circle" | "square";
 
+const MAX_AVATAR_SIZE = 512;
+
 function centerAspectCrop(
   mediaWidth: number,
   mediaHeight: number,
@@ -61,16 +63,13 @@ async function getCroppedImage(
     throw new Error("No 2d context");
   }
 
-  const MAX_AVATAR_SIZE = 512;
-
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
 
   const naturalWidth = crop.width * scaleX;
   const naturalHeight = crop.height * scaleY;
 
-  // Cap output to MAX_AVATAR_SIZE — devicePixelRatio is a display trick and doesn't belong in a file export;
-  // without this cap, large source images (e.g. phone photos) produce 6000×6000px PNGs that exceed the 5MB limit.
+  // Drop devicePixelRatio (display hint only) and cap to MAX_AVATAR_SIZE to prevent oversized PNG exports.
   const downScale = Math.min(1, MAX_AVATAR_SIZE / Math.max(naturalWidth, naturalHeight));
 
   canvas.width = Math.floor(naturalWidth * downScale);

--- a/apps/web/src/components/dialogs/ImageCropperDialog.tsx
+++ b/apps/web/src/components/dialogs/ImageCropperDialog.tsx
@@ -61,29 +61,34 @@ async function getCroppedImage(
     throw new Error("No 2d context");
   }
 
+  const MAX_AVATAR_SIZE = 512;
+
   const scaleX = image.naturalWidth / image.width;
   const scaleY = image.naturalHeight / image.height;
 
-  const pixelRatio = window.devicePixelRatio || 1;
+  const naturalWidth = crop.width * scaleX;
+  const naturalHeight = crop.height * scaleY;
 
-  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
-  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+  // Cap output to MAX_AVATAR_SIZE — devicePixelRatio is a display trick and doesn't belong in a file export;
+  // without this cap, large source images (e.g. phone photos) produce 6000×6000px PNGs that exceed the 5MB limit.
+  const downScale = Math.min(1, MAX_AVATAR_SIZE / Math.max(naturalWidth, naturalHeight));
 
-  ctx.scale(pixelRatio, pixelRatio);
+  canvas.width = Math.floor(naturalWidth * downScale);
+  canvas.height = Math.floor(naturalHeight * downScale);
+
+  ctx.scale(downScale, downScale);
   ctx.imageSmoothingQuality = "high";
 
   const cropX = crop.x * scaleX;
   const cropY = crop.y * scaleY;
-  const cropWidth = crop.width * scaleX;
-  const cropHeight = crop.height * scaleY;
 
   // Apply circular mask if shape is circle
   if (shape === "circle") {
     ctx.beginPath();
     ctx.arc(
-      (crop.width * scaleX) / 2,
-      (crop.height * scaleY) / 2,
-      Math.min(crop.width * scaleX, crop.height * scaleY) / 2,
+      naturalWidth / 2,
+      naturalHeight / 2,
+      Math.min(naturalWidth, naturalHeight) / 2,
       0,
       2 * Math.PI
     );
@@ -94,12 +99,12 @@ async function getCroppedImage(
     image,
     cropX,
     cropY,
-    cropWidth,
-    cropHeight,
+    naturalWidth,
+    naturalHeight,
     0,
     0,
-    crop.width * scaleX,
-    crop.height * scaleY
+    naturalWidth,
+    naturalHeight
   );
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- Avatars uploaded from large source images (phone photos ~4000px natural width) were hitting a false-positive \"File too large\" 400 error despite the input file being <1MB
- Root cause: `getCroppedImage` multiplied the natural crop dimensions by `window.devicePixelRatio` (2× on Retina), producing 6000×6000px PNG exports that exceeded the 5MB server limit
- Fix: drop `devicePixelRatio` from the file-output canvas (it's a display-sharpness hint, irrelevant for an uploaded file) and cap output to 512px on the longest side

## Test plan

- [ ] Upload a large phone photo (3–4 MB JPEG) as avatar → succeeds, produces ≤512px PNG
- [ ] Upload a small (<100 KB) image → still succeeds
- [ ] Upload a file >5MB without going through the crop dialog → server correctly rejects with 400
- [ ] Avatar renders crisply on Retina display (512px is sufficient for any avatar size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)