### PR TITLE
fix(onboarding): provision Home drive on every login path (PR 3/5 follow-up)

### DIFF
--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -407,7 +407,7 @@ describe('POST /api/auth/apple/native', () => {
 
       expect(response.status).toBe(200);
       expect(loggers.auth.error).toHaveBeenCalledWith(
-        'Failed to provision Getting Started drive',
+        'Failed to provision Home drive',
         new Error('DB error'),
         { userId: 'new-user-id', provider: 'apple-native' }
       );
@@ -466,14 +466,15 @@ describe('POST /api/auth/apple/native', () => {
       expect(authRepository.updateUser).not.toHaveBeenCalled();
     });
 
-    it('does not provision drive for existing users', async () => {
+    it('provisions Home drive for existing users (idempotent lazy provisioning)', async () => {
       const completeUser = { ...existingUser, appleId: 'apple-sub-123' };
       vi.mocked(authRepository.findUserByAppleId).mockResolvedValue(completeUser as never);
       vi.mocked(authRepository.findUserByEmail).mockResolvedValue(completeUser as never);
+      vi.mocked(provisionHomeDriveIfNeeded).mockResolvedValue({ driveId: 'new-drive-id', created: false });
 
       await POST(createNativeRequest(validPayload));
 
-      expect(provisionHomeDriveIfNeeded).not.toHaveBeenCalled();
+      expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith(completeUser.id);
     });
 
     it('handles re-fetch returning null after update', async () => {

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -175,15 +175,12 @@ export async function POST(req: Request) {
       loggers.auth.info('New user created via native Apple OAuth', { userId: user.id, platform });
     }
 
-    // Provision getting started drive for new users
-    if (isNewUser) {
-      await provisionHomeDriveIfNeeded(user.id).catch((error) => {
-        loggers.auth.error('Failed to provision Getting Started drive', error as Error, {
-          userId: user.id,
-          provider: 'apple-native',
-        });
+    await provisionHomeDriveIfNeeded(user.id).catch((error) => {
+      loggers.auth.error('Failed to provision Home drive', error as Error, {
+        userId: user.id,
+        provider: 'apple-native',
       });
-    }
+    });
 
     // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
     // new one. Admin-console sessions are scoped separately and left intact.

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -321,14 +321,15 @@ describe('POST /api/auth/google/native', () => {
       expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith(mockNewUser.id);
     });
 
-    it('given existing user, should not provision Getting Started drive', async () => {
+    it('given existing user, should provision Home drive (idempotent lazy provisioning)', async () => {
       vi.mocked(authRepository.findUserByGoogleId).mockResolvedValue(mockExistingUser as never);
       vi.mocked(authRepository.findUserByEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(provisionHomeDriveIfNeeded).mockResolvedValue({ driveId: 'drive-123', created: false });
 
       const request = createNativeRequest(validNativePayload);
       await POST(request);
 
-      expect(provisionHomeDriveIfNeeded).not.toHaveBeenCalled();
+      expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith(mockExistingUser.id);
     });
 
     it('should create session with correct parameters', async () => {

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -198,15 +198,12 @@ export async function POST(req: Request) {
       loggers.auth.info('New user created via native Google OAuth', { userId: user.id, platform });
     }
 
-    // Provision getting started drive for new users
-    if (isNewUser) {
-      await provisionHomeDriveIfNeeded(user.id).catch((error) => {
-        loggers.auth.error('Failed to provision Getting Started drive', error as Error, {
-          userId: user.id,
-          provider: 'google-native',
-        });
+    await provisionHomeDriveIfNeeded(user.id).catch((error) => {
+      loggers.auth.error('Failed to provision Home drive', error as Error, {
+        userId: user.id,
+        provider: 'google-native',
       });
-    }
+    });
 
     // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
     // new one. Admin-console sessions are scoped separately and left intact.

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -179,10 +179,10 @@ describe('GET /api/auth/magic-link/verify - desktop platform', () => {
     expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith('user-1');
   });
 
-  it('does not provision drive for existing desktop users', async () => {
+  it('provisions Home drive for existing desktop users (lazy idempotent)', async () => {
     await GET(createVerifyRequest());
 
-    expect(provisionHomeDriveIfNeeded).not.toHaveBeenCalled();
+    expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith('user-1');
   });
 
   it('falls through to web flow when no desktop metadata', async () => {

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -89,7 +89,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@/lib/onboarding/home-drive', () => ({
-  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue({ driveId: 'new-drive-id', created: true }),
+  provisionHomeDriveIfNeeded: vi.fn().mockResolvedValue({ driveId: 'new-drive-id', created: false }),
 }));
 
 vi.mock('@/lib/repositories/drive-invite-repository', () => ({
@@ -464,21 +464,25 @@ describe('GET /api/auth/magic-link/verify', () => {
       expect(location).toContain('/dashboard');
       expect(location).not.toContain('provisioned');
       expect(loggers.auth.error).toHaveBeenCalledWith(
-        'Failed to provision Getting Started drive',
+        'Failed to provision Home drive',
         new Error('DB error'),
         { userId: 'test-user-id' }
       );
     });
 
-    it('does not provision drive for existing users', async () => {
+    it('provisions Home drive for existing users (lazy idempotent); uses default redirect when created:false', async () => {
       vi.mocked(verifyMagicLinkToken).mockResolvedValue({
         ok: true,
         data: { userId: 'test-user-id', isNewUser: false },
       });
+      vi.mocked(provisionHomeDriveIfNeeded).mockResolvedValue({ driveId: 'existing-drive', created: false });
 
-      await GET(createVerifyRequest('valid-token'));
+      const response = await GET(createVerifyRequest('valid-token'));
+      const location = response.headers.get('Location')!;
 
-      expect(provisionHomeDriveIfNeeded).not.toHaveBeenCalled();
+      expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith('test-user-id');
+      expect(location).toContain('/dashboard');
+      expect(location).not.toContain('existing-drive');
     });
   });
 

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -237,7 +237,7 @@ export async function GET(req: Request) {
               : inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId
                 ? `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`
                 : await resolvePostLoginRedirectPath({
-                    isNewUser, userId, next: safeNext, invitedDriveId,
+                    userId, next: safeNext, invitedDriveId,
                   });
           const desktopRedirectUrl = new URL(desktopRedirectPath, baseUrl);
           desktopRedirectUrl.searchParams.set('auth', 'success');
@@ -304,7 +304,7 @@ export async function GET(req: Request) {
         : inviteResult?.kind === 'page' && invitedDriveId && inviteResult.invitedPageId
           ? `/dashboard/${invitedDriveId}/pages/${inviteResult.invitedPageId}`
           : await resolvePostLoginRedirectPath({
-              isNewUser, userId, next: safeNext, invitedDriveId,
+              userId, next: safeNext, invitedDriveId,
             });
 
     const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
@@ -364,12 +364,10 @@ function redirectWithError(error: string): NextResponse {
  * and swallowed — the user still lands on /dashboard.
  */
 async function resolvePostLoginRedirectPath({
-  isNewUser,
   userId,
   next,
   invitedDriveId,
 }: {
-  isNewUser: boolean;
   userId: string;
   next?: string;
   invitedDriveId?: string | null;
@@ -382,17 +380,13 @@ async function resolvePostLoginRedirectPath({
     return next;
   }
 
-  if (!isNewUser) {
-    return '/dashboard';
-  }
-
   try {
     const provisionedDrive = await provisionHomeDriveIfNeeded(userId);
-    if (provisionedDrive) {
+    if (provisionedDrive?.created) {
       return `/dashboard/${provisionedDrive.driveId}`;
     }
   } catch (error) {
-    loggers.auth.error('Failed to provision Getting Started drive', error as Error, { userId });
+    loggers.auth.error('Failed to provision Home drive', error as Error, { userId });
   }
 
   return '/dashboard';


### PR DESCRIPTION
## Summary

Follow-up to #1624 addressing a P1 gap found by Codex review.

- Drop `isNewUser` guard in `google/native` and `apple/native` — `provisionHomeDriveIfNeeded` is idempotent; gating on `isNewUser` prevented lazy provisioning for existing users
- Remove `!isNewUser` early-return in `magic-link/verify` `resolvePostLoginRedirectPath` — same reason; now keys the welcome redirect on `created: true` instead
- Update 5 test files to match: existing-user paths now assert provisioning IS called (not skipped), redirect to `/dashboard` when `created: false`

> **`passkey/authenticate`** is intentionally not covered here — PR 4/5 (#1625 backfill script) handles all existing users including those who authenticate via passkey and have never hit any of these routes.

## Test plan

- [ ] `bun run test:unit` passes (135 tests)
- [ ] `bun run --filter 'web' typecheck` passes
- [ ] All three login paths (magic-link, google/native, apple/native) call provisioner on every successful sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)