### PR TITLE
fix(onboarding): provision Home drive before redirect selection (PR 3/5 fix-2)

### DIFF
--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -598,6 +598,8 @@ describe('GET /api/auth/magic-link/verify', () => {
       const location = response.headers.get('Location')!;
       expect(location).toContain('/dashboard/drive_abc');
       expect(location).toContain('auth=success');
+      // Provisioning must run even when `next` is present
+      expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith('test-user-id');
     });
 
     it('falls back to /dashboard when next is /invite/<token> (invite acceptance no longer travels via next; the inviteToken metadata path consumes invites server-side)', async () => {
@@ -640,6 +642,8 @@ describe('GET /api/auth/magic-link/verify', () => {
       const location = response.headers.get('Location')!;
       expect(location).toContain('/dashboard/drive_abc');
       expect(location).not.toContain('provisioned-drive-id');
+      // Provisioning still fires even though `next` wins the redirect
+      expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith('test-user-id');
     });
   });
 
@@ -725,6 +729,28 @@ describe('GET /api/auth/magic-link/verify', () => {
       const location = response.headers.get('Location')!;
       expect(location).toContain('/dashboard/drive_invited_42');
       expect(location).not.toContain('some_other_drive');
+    });
+
+    it('provisions Home drive even when invite redirect wins (invitedDriveId takes priority over provisioned drive)', async () => {
+      vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+        ok: true,
+        data: {
+          userId: 'test-user-id',
+          isNewUser: false,
+          metadata: JSON.stringify({ inviteToken: 'ps_invite_abc' }),
+        },
+      });
+      vi.mocked(consumeAnyInviteIfPresent).mockResolvedValueOnce({
+        kind: 'drive', invitedDriveId: 'drive_invited_42', invitedPageId: null, connectionId: null,
+      });
+
+      const response = await GET(new Request('http://localhost/api/auth/magic-link/verify?token=valid', { method: 'GET' }));
+
+      // Redirect goes to the invited drive
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard/drive_invited_42');
+      // But provisioning still ran unconditionally
+      expect(provisionHomeDriveIfNeeded).toHaveBeenCalledWith('test-user-id');
     });
 
     it('given consumeAnyInviteIfPresent throws (DB blip), still completes login and lands on /dashboard (session is already committed)', async () => {

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -372,6 +372,19 @@ async function resolvePostLoginRedirectPath({
   next?: string;
   invitedDriveId?: string | null;
 }): Promise<string> {
+  // Provision unconditionally — idempotent, so safe regardless of which redirect wins.
+  // Must run before the early-return branches so users with an invite or a `next` param
+  // still get a Home drive provisioned on their first login.
+  let provisionedDriveId: string | null = null;
+  try {
+    const result = await provisionHomeDriveIfNeeded(userId);
+    if (result.created) {
+      provisionedDriveId = result.driveId;
+    }
+  } catch (error) {
+    loggers.auth.error('Failed to provision Home drive', error as Error, { userId });
+  }
+
   if (invitedDriveId) {
     return `/dashboard/${invitedDriveId}`;
   }
@@ -380,13 +393,8 @@ async function resolvePostLoginRedirectPath({
     return next;
   }
 
-  try {
-    const provisionedDrive = await provisionHomeDriveIfNeeded(userId);
-    if (provisionedDrive?.created) {
-      return `/dashboard/${provisionedDrive.driveId}`;
-    }
-  } catch (error) {
-    loggers.auth.error('Failed to provision Home drive', error as Error, { userId });
+  if (provisionedDriveId) {
+    return `/dashboard/${provisionedDriveId}`;
   }
 
   return '/dashboard';


### PR DESCRIPTION
## Summary

Addresses Codex P2 on #1628: provisioning was still skipped when `invitedDriveId` or a safe `next` caused an early-return in `resolvePostLoginRedirectPath`.

**Root cause:** `provisionHomeDriveIfNeeded` sat at the bottom of the function, after two branches that returned early. Users signing in via an invite link or a bookmarked `next=` URL never reached provisioning.

**Fix:** Move `provisionHomeDriveIfNeeded` above both early-return branches. It fires unconditionally on every magic-link login. The `created` result is only used for the default-destination case (no invite, no `next`); it doesn't affect the invite or `next` redirects.

**Tests:**
- Added assertion: provisioning fires even when `next` wins the redirect
- Added assertion: provisioning fires even when `invitedDriveId` wins the redirect
- New test: provisioning runs on invite-bound magic-link login
- 61 tests pass (route.test.ts: 42, desktop-verify.test.ts: 9, onboarding: 10)

## Test plan
- [ ] `bun run vitest --run apps/web/src/app/api/auth/magic-link/verify/__tests__/` — all pass
- [ ] `bun run --filter 'web' typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)