### PR TITLE
feat(ai-tools): find_and_replace and insert_content page editing tools

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -89,6 +89,8 @@ const TOOL_NAME_MAP: Record<string, string> = {
   'list_pages': 'List Pages',
   'read_page': 'Read',
   'replace_lines': 'Replace',
+  'find_and_replace': 'Find & Replace',
+  'insert_content': 'Insert',
   'create_page': 'Create',
   'rename_page': 'Rename',
   'send_channel_message': 'Send Message',
@@ -130,6 +132,8 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
       case 'send_channel_message':
         return <MessageSquare className={iconClass} />;
       case 'replace_lines':
+      case 'find_and_replace':
+      case 'insert_content':
         return <Edit className={iconClass} />;
       case 'create_page':
         return <Plus className={iconClass} />;
@@ -191,7 +195,7 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
     const params = parsedInput;
 
     // File-based tools
-    if (['read_page', 'replace_lines', 'list_pages'].includes(toolName)) {
+    if (['read_page', 'replace_lines', 'find_and_replace', 'insert_content', 'list_pages'].includes(toolName)) {
       if (params.title) return `${formattedToolName}: "${params.title}"`;
       if (params.dir) return `${formattedToolName}: ${params.dir}`;
     }

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -70,6 +70,8 @@ const TOOL_NAME_MAP: Record<string, string> = {
   'delete_channel_message': 'Delete Message',
   // Page write tools
   'replace_lines': 'Edit Document',
+  'find_and_replace': 'Find & Replace',
+  'insert_content': 'Insert Content',
   'create_page': 'Create Page',
   'rename_page': 'Rename Page',
   'trash_page': 'Move to Trash',

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -316,6 +316,52 @@ export const toolRenderers: Record<string, ToolRenderer> = {
   },
 
   // === PAGE WRITE TOOLS ===
+  find_and_replace: ({ parsedOutput }) => {
+    if (parsedOutput.success && parsedOutput.oldContent && parsedOutput.newContent) {
+      return (
+        <RichDiffRenderer
+          title={(parsedOutput.title as string | undefined) || 'Document'}
+          oldContent={parsedOutput.oldContent as string}
+          newContent={parsedOutput.newContent as string}
+          pageId={parsedOutput.pageId as string | undefined}
+          changeSummary={parsedOutput.message as string | undefined}
+        />
+      );
+    }
+    return (
+      <ActionResultRenderer
+        actionType="update"
+        success={parsedOutput.success !== false}
+        title={parsedOutput.title as string | undefined}
+        pageId={parsedOutput.pageId as string | undefined}
+        errorMessage={parsedOutput.error as string | undefined}
+      />
+    );
+  },
+
+  insert_content: ({ parsedOutput }) => {
+    if (parsedOutput.success && parsedOutput.oldContent && parsedOutput.newContent) {
+      return (
+        <RichDiffRenderer
+          title={(parsedOutput.title as string | undefined) || 'Document'}
+          oldContent={parsedOutput.oldContent as string}
+          newContent={parsedOutput.newContent as string}
+          pageId={parsedOutput.pageId as string | undefined}
+          changeSummary={parsedOutput.message as string | undefined}
+        />
+      );
+    }
+    return (
+      <ActionResultRenderer
+        actionType="update"
+        success={parsedOutput.success !== false}
+        title={parsedOutput.title as string | undefined}
+        pageId={parsedOutput.pageId as string | undefined}
+        errorMessage={parsedOutput.error as string | undefined}
+      />
+    );
+  },
+
   replace_lines: ({ parsedOutput }) => {
     if (parsedOutput.success && parsedOutput.oldContent && parsedOutput.newContent) {
       return (

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -317,12 +317,12 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 
   // === PAGE WRITE TOOLS ===
   find_and_replace: ({ parsedOutput }) => {
-    if (parsedOutput.success && parsedOutput.oldContent && parsedOutput.newContent) {
+    if (parsedOutput.success && typeof parsedOutput.oldContent === 'string' && typeof parsedOutput.newContent === 'string') {
       return (
         <RichDiffRenderer
           title={(parsedOutput.title as string | undefined) || 'Document'}
-          oldContent={parsedOutput.oldContent as string}
-          newContent={parsedOutput.newContent as string}
+          oldContent={parsedOutput.oldContent}
+          newContent={parsedOutput.newContent}
           pageId={parsedOutput.pageId as string | undefined}
           changeSummary={parsedOutput.message as string | undefined}
         />
@@ -334,18 +334,19 @@ export const toolRenderers: Record<string, ToolRenderer> = {
         success={parsedOutput.success !== false}
         title={parsedOutput.title as string | undefined}
         pageId={parsedOutput.pageId as string | undefined}
+        message={parsedOutput.message as string | undefined}
         errorMessage={parsedOutput.error as string | undefined}
       />
     );
   },
 
   insert_content: ({ parsedOutput }) => {
-    if (parsedOutput.success && parsedOutput.oldContent && parsedOutput.newContent) {
+    if (parsedOutput.success && typeof parsedOutput.oldContent === 'string' && typeof parsedOutput.newContent === 'string') {
       return (
         <RichDiffRenderer
           title={(parsedOutput.title as string | undefined) || 'Document'}
-          oldContent={parsedOutput.oldContent as string}
-          newContent={parsedOutput.newContent as string}
+          oldContent={parsedOutput.oldContent}
+          newContent={parsedOutput.newContent}
           pageId={parsedOutput.pageId as string | undefined}
           changeSummary={parsedOutput.message as string | undefined}
         />
@@ -357,6 +358,7 @@ export const toolRenderers: Record<string, ToolRenderer> = {
         success={parsedOutput.success !== false}
         title={parsedOutput.title as string | undefined}
         pageId={parsedOutput.pageId as string | undefined}
+        message={parsedOutput.message as string | undefined}
         errorMessage={parsedOutput.error as string | undefined}
       />
     );

--- a/apps/web/src/lib/ai/core/__tests__/stub-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stub-tools.test.ts
@@ -3,14 +3,16 @@ import { assert } from './riteway';
 import { CORE_TOOL_NAMES } from '../stub-tools';
 
 describe('CORE_TOOL_NAMES', () => {
-  it('contains exactly the 8 designated core tools', () => {
+  it('contains exactly the 10 designated core tools', () => {
     assert({
       given: 'the CORE_TOOL_NAMES set',
-      should: 'list exactly the 8 core tools',
+      should: 'list exactly the 10 core tools',
       actual: [...CORE_TOOL_NAMES].sort(),
       expected: [
         'create_page',
+        'find_and_replace',
         'get_page_details',
+        'insert_content',
         'list_drives',
         'list_pages',
         'multi_drive_search',

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -124,6 +124,23 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(isWebSearchTool('create_page')).toBe(false);
   });
 
+  it('classifies find_and_replace and insert_content as write tools', () => {
+    expect(isWriteTool('find_and_replace')).toBe(true);
+    expect(isWriteTool('insert_content')).toBe(true);
+  });
+
+  it('excludes find_and_replace and insert_content in read-only mode', () => {
+    const tools = {
+      find_and_replace: 'w',
+      insert_content: 'w',
+      read_page: 'r',
+    };
+    const filtered = filterToolsForReadOnly(tools, true);
+    expect(filtered).not.toHaveProperty('find_and_replace');
+    expect(filtered).not.toHaveProperty('insert_content');
+    expect(filtered).toHaveProperty('read_page');
+  });
+
   it('classifies workflow tools: writes are write tools, list is read', () => {
     expect(isWriteTool('create_workflow')).toBe(true);
     expect(isWriteTool('update_workflow')).toBe(true);

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -46,7 +46,7 @@ CONTEXT:
 
 PAGE TYPES:
 • FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.
-• DOCUMENT: Rich text stored as HTML. Use replace_lines for content changes.
+• DOCUMENT: Rich text stored as HTML. Use find_and_replace to swap specific text, insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits.
 • CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
 • CANVAS: Raw HTML/CSS rendered in an isolated sandbox. body/html/:root styles auto-remap to the sandbox root. Edit as HTML.
@@ -97,7 +97,7 @@ CONTEXT:
 `}
 PAGE TYPES:
 • FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.
-• DOCUMENT: Rich text stored as HTML. Use replace_lines for content changes.
+• DOCUMENT: Rich text stored as HTML. Use find_and_replace to swap specific text, insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits.
 • CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
 • CANVAS: Raw HTML/CSS rendered in an isolated sandbox. body/html/:root styles auto-remap to the sandbox root. Edit as HTML.

--- a/apps/web/src/lib/ai/core/stub-tools.ts
+++ b/apps/web/src/lib/ai/core/stub-tools.ts
@@ -5,6 +5,8 @@ export const CORE_TOOL_NAMES = new Set([
   'get_page_details',
   'create_page',
   'replace_lines',
+  'find_and_replace',
+  'insert_content',
   'regex_search',
   'multi_drive_search',
 ]);

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -11,6 +11,8 @@ const WRITE_TOOLS = new Set([
   'create_page',
   'rename_page',
   'replace_lines',
+  'find_and_replace',
+  'insert_content',
   'move_page',
   'edit_sheet_cells',
   // Drive operations

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -1008,6 +1008,259 @@ describe('page-write-tools', () => {
     });
   });
 
+  describe('find_and_replace', () => {
+    it('has correct tool definition', () => {
+      expect(pageWriteTools.find_and_replace).toBeDefined();
+      expect(pageWriteTools.find_and_replace.description).toContain('replace');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        pageWriteTools.find_and_replace.execute!(
+          { title: 'Doc', pageId: 'page-1', search: 'foo', replacement: 'bar' },
+          context
+        )
+      ).rejects.toThrow('User authentication required');
+    });
+
+    it('throws when page not found', async () => {
+      mockPageRepo.findById.mockResolvedValue(null);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.find_and_replace.execute!(
+          { title: 'Doc', pageId: 'missing', search: 'foo', replacement: 'bar' },
+          context
+        )
+      ).rejects.toThrow('Page with ID "missing" not found');
+    });
+
+    it('returns error for FILE pages', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'file.pdf', type: 'FILE', content: '',
+        mimeType: 'application/pdf', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.find_and_replace.execute!(
+        { title: 'file.pdf', pageId: 'page-1', search: 'foo', replacement: 'bar' },
+        context
+      );
+
+      if (!('error' in result)) throw new Error('Expected error result');
+      expect((result as { success: boolean }).success).toBe(false);
+    });
+
+    it('returns not-found result when search string is absent', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Doc', type: 'DOCUMENT',
+        content: 'hello world', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.find_and_replace.execute!(
+        { title: 'Doc', pageId: 'page-1', search: 'missing', replacement: 'x' },
+        context
+      ) as { success: boolean; found: boolean; matchCount: number };
+
+      expect(result.success).toBe(true);
+      expect(result.found).toBe(false);
+      expect(result.matchCount).toBe(0);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('replaces first occurrence and calls applyPageMutation', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Doc', type: 'DOCUMENT',
+        content: 'foo bar foo', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.find_and_replace.execute!(
+        { title: 'Doc', pageId: 'page-1', search: 'foo', replacement: 'baz' },
+        context
+      ) as { success: boolean; found: boolean; matchCount: number };
+
+      expect(result.success).toBe(true);
+      expect(result.found).toBe(true);
+      expect(result.matchCount).toBe(1);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: 'page-1',
+          operation: 'update',
+          updatedFields: ['content'],
+        })
+      );
+    });
+
+    it('replaces all occurrences when replaceAll is true', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Doc', type: 'DOCUMENT',
+        content: 'foo bar foo baz foo', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.find_and_replace.execute!(
+        { title: 'Doc', pageId: 'page-1', search: 'foo', replacement: 'qux', replaceAll: true },
+        context
+      ) as { success: boolean; matchCount: number };
+
+      expect(result.success).toBe(true);
+      expect(result.matchCount).toBe(3);
+    });
+  });
+
+  describe('insert_content', () => {
+    it('has correct tool definition', () => {
+      expect(pageWriteTools.insert_content).toBeDefined();
+      expect(pageWriteTools.insert_content.description).toContain('insert');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        pageWriteTools.insert_content.execute!(
+          { title: 'Doc', pageId: 'page-1', anchor: 'Heading', content: 'new line', position: 'after' },
+          context
+        )
+      ).rejects.toThrow('User authentication required');
+    });
+
+    it('throws when page not found', async () => {
+      mockPageRepo.findById.mockResolvedValue(null);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.insert_content.execute!(
+          { title: 'Doc', pageId: 'missing', anchor: 'Heading', content: 'new', position: 'after' },
+          context
+        )
+      ).rejects.toThrow('not found');
+    });
+
+    it('returns not-found result when anchor is absent', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Doc', type: 'DOCUMENT',
+        content: 'line one\nline two', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.insert_content.execute!(
+        { title: 'Doc', pageId: 'page-1', anchor: 'missing anchor', content: 'new', position: 'after' },
+        context
+      ) as { success: boolean; inserted: boolean };
+
+      expect(result.success).toBe(true);
+      expect(result.inserted).toBe(false);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('inserts after anchor and calls applyPageMutation', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Doc', type: 'DOCUMENT',
+        content: 'line one\nline two\nline three', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.insert_content.execute!(
+        { title: 'Doc', pageId: 'page-1', anchor: 'line two', content: 'inserted', position: 'after' },
+        context
+      ) as { success: boolean; inserted: boolean; anchorLine: number };
+
+      expect(result.success).toBe(true);
+      expect(result.inserted).toBe(true);
+      expect(result.anchorLine).toBe(2);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: 'page-1',
+          operation: 'update',
+          updates: { content: 'line one\nline two\ninserted\nline three' },
+          updatedFields: ['content'],
+        })
+      );
+    });
+
+    it('inserts before anchor', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Doc', type: 'DOCUMENT',
+        content: 'line one\nline two', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.insert_content.execute!(
+        { title: 'Doc', pageId: 'page-1', anchor: 'line two', content: 'prepended', position: 'before' },
+        context
+      ) as { success: boolean; inserted: boolean };
+
+      expect(result.success).toBe(true);
+      expect(result.inserted).toBe(true);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updates: { content: 'line one\nprepended\nline two' },
+        })
+      );
+    });
+  });
+
   describe('edit_sheet_cells', () => {
     it('has correct tool definition', () => {
       expect(pageWriteTools.edit_sheet_cells).toBeDefined();

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -20,6 +20,7 @@ import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-s
 import type { ToolExecutionContext } from '../core/types';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { replaceLines } from '@/lib/editor/line-edit';
+import { findAndReplace, insertAtAnchor } from '@/lib/editor/text-edit';
 
 const pageWriteLogger = loggers.ai.child({ module: 'page-write-tools' });
 
@@ -1043,6 +1044,216 @@ export const pageWriteTools = {
           newParentId: maskIdentifier(newParentId || undefined),
         });
         throw new Error(`Failed to move page "${title}": ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Find and replace text in a document or code page
+   */
+  find_and_replace: tool({
+    description: 'Find and replace a text string in a document or code page. More resilient than replace_lines because it anchors to content rather than line numbers. Replaces the first occurrence by default; set replaceAll: true to replace every occurrence.',
+    inputSchema: z.object({
+      title: z.string().describe('The document title for display context'),
+      pageId: z.string().describe('The unique ID of the page to edit'),
+      search: z.string().min(1).describe('The text to find'),
+      replacement: z.string().describe('The text to replace it with (empty string to delete the match)'),
+      replaceAll: z.boolean().optional().describe('Replace every occurrence instead of just the first (default false)'),
+    }),
+    execute: async ({ title, pageId, search, replacement, replaceAll = false }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      try {
+        const page = await pageRepository.findById(pageId);
+        if (!page) {
+          throw new Error(`Page with ID "${pageId}" not found`);
+        }
+
+        if (page.type === 'FILE') {
+          return {
+            success: false,
+            error: 'Cannot edit FILE pages',
+            message: 'This is an uploaded file. File content is read-only.',
+            pageInfo: { pageId: page.id, title: page.title, type: page.type, mimeType: page.mimeType },
+          };
+        }
+
+        if (isSheetType(page.type as PageType)) {
+          return {
+            success: false,
+            error: 'Cannot use text editing on sheets',
+            message: 'Use edit_sheet_cells for sheet pages.',
+            pageInfo: { pageId: page.id, title: page.title, type: page.type },
+          };
+        }
+
+        const canEdit = await canActorEditPage(context as ToolExecutionContext, page.id);
+        if (!canEdit) {
+          throw new Error('Insufficient permissions to edit this document');
+        }
+
+        const isRawText = page.contentMode === 'markdown' || isCodePage(page.type as PageType);
+        const { oldContent, newContent, matchCount, found } = findAndReplace({
+          content: page.content,
+          search,
+          replacement,
+          replaceAll,
+          isRawText,
+        });
+
+        if (!found) {
+          return {
+            success: true,
+            pageId: page.id,
+            title: page.title,
+            found: false,
+            matchCount: 0,
+            message: `Search string not found in "${page.title}"`,
+          };
+        }
+
+        const mutationContext = await buildAiMutationContext(context as ToolExecutionContext, {
+          metadata: { matchCount, replaceAll },
+        });
+
+        await applyPageMutation({
+          pageId: page.id,
+          operation: 'update',
+          updates: { content: newContent },
+          updatedFields: ['content'],
+          expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
+          context: mutationContext,
+        });
+
+        await broadcastPageEvent(
+          createPageEventPayload(page.driveId, page.id, 'content-updated', { title: page.title })
+        );
+
+        return {
+          success: true,
+          pageId: page.id,
+          title: page.title,
+          found: true,
+          matchCount,
+          oldContent,
+          newContent,
+          message: `Replaced ${matchCount} occurrence${matchCount === 1 ? '' : 's'} in "${page.title}"`,
+        };
+      } catch (error) {
+        pageWriteLogger.error('Failed to find and replace', error instanceof Error ? error : undefined, {
+          userId: maskIdentifier(userId),
+          pageId: maskIdentifier(pageId),
+          title,
+        });
+        throw new Error(`Failed to find and replace in "${title}": ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Insert content before or after an anchor line in a document or code page
+   */
+  insert_content: tool({
+    description: 'Anchored line insert — adds a new line of content immediately before or after the first line containing a given anchor string. Useful for agents that need to insert content relative to headings or landmarks without knowing exact line numbers.',
+    inputSchema: z.object({
+      title: z.string().describe('The document title for display context'),
+      pageId: z.string().describe('The unique ID of the page to edit'),
+      anchor: z.string().min(1).describe('Text to search for within a line — the first line containing this substring is used'),
+      content: z.string().describe('Content to insert as a new line'),
+      position: z.enum(['before', 'after']).describe('Insert the new line before or after the anchor line'),
+    }),
+    execute: async ({ title, pageId, anchor, content, position }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      try {
+        const page = await pageRepository.findById(pageId);
+        if (!page) {
+          throw new Error(`Page with ID "${pageId}" not found`);
+        }
+
+        if (page.type === 'FILE') {
+          return {
+            success: false,
+            error: 'Cannot edit FILE pages',
+            message: 'This is an uploaded file. File content is read-only.',
+            pageInfo: { pageId: page.id, title: page.title, type: page.type, mimeType: page.mimeType },
+          };
+        }
+
+        if (isSheetType(page.type as PageType)) {
+          return {
+            success: false,
+            error: 'Cannot use line insertion on sheets',
+            message: 'Use edit_sheet_cells for sheet pages.',
+            pageInfo: { pageId: page.id, title: page.title, type: page.type },
+          };
+        }
+
+        const canEdit = await canActorEditPage(context as ToolExecutionContext, page.id);
+        if (!canEdit) {
+          throw new Error('Insufficient permissions to edit this document');
+        }
+
+        const isRawText = page.contentMode === 'markdown' || isCodePage(page.type as PageType);
+        const { oldContent, newContent, inserted, anchorLine } = insertAtAnchor({
+          content: page.content,
+          anchor,
+          insertion: content,
+          position,
+          isRawText,
+        });
+
+        if (!inserted) {
+          return {
+            success: true,
+            pageId: page.id,
+            title: page.title,
+            inserted: false,
+            anchorLine: null,
+            message: `Anchor text not found in "${page.title}"`,
+          };
+        }
+
+        const mutationContext = await buildAiMutationContext(context as ToolExecutionContext, {
+          metadata: { anchorLine, position },
+        });
+
+        await applyPageMutation({
+          pageId: page.id,
+          operation: 'update',
+          updates: { content: newContent },
+          updatedFields: ['content'],
+          expectedRevision: typeof page.revision === 'number' ? page.revision : undefined,
+          context: mutationContext,
+        });
+
+        await broadcastPageEvent(
+          createPageEventPayload(page.driveId, page.id, 'content-updated', { title: page.title })
+        );
+
+        return {
+          success: true,
+          pageId: page.id,
+          title: page.title,
+          inserted: true,
+          anchorLine,
+          oldContent,
+          newContent,
+          message: `Inserted content ${position} line ${anchorLine} in "${page.title}"`,
+        };
+      } catch (error) {
+        pageWriteLogger.error('Failed to insert content', error instanceof Error ? error : undefined, {
+          userId: maskIdentifier(userId),
+          pageId: maskIdentifier(pageId),
+          title,
+        });
+        throw new Error(`Failed to insert content in "${title}": ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   }),

--- a/apps/web/src/lib/editor/__tests__/text-edit.test.ts
+++ b/apps/web/src/lib/editor/__tests__/text-edit.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import { findAndReplace, insertAtAnchor } from '../text-edit';
+import { addLineBreaksForAI } from '../line-breaks';
+
+describe('findAndReplace', () => {
+  describe('search not found', () => {
+    it('returns unchanged content with found: false when search is absent', () => {
+      const result = findAndReplace({
+        content: 'hello world',
+        search: 'missing',
+        replacement: 'x',
+        isRawText: true,
+      });
+
+      expect(result.found).toBe(false);
+      expect(result.matchCount).toBe(0);
+      expect(result.newContent).toBe(result.oldContent);
+    });
+
+    it('treats null content as empty string', () => {
+      const result = findAndReplace({
+        content: null,
+        search: 'anything',
+        replacement: 'x',
+        isRawText: true,
+      });
+
+      expect(result.found).toBe(false);
+      expect(result.oldContent).toBe('');
+      expect(result.newContent).toBe('');
+    });
+  });
+
+  describe('throws on bad input', () => {
+    it('throws when search is empty', () => {
+      expect(() =>
+        findAndReplace({ content: 'hello', search: '', replacement: 'x', isRawText: true })
+      ).toThrow('Search string cannot be empty');
+    });
+  });
+
+  describe('first-match replacement (replaceAll: false, the default)', () => {
+    it('replaces only the first occurrence', () => {
+      const result = findAndReplace({
+        content: 'foo bar foo',
+        search: 'foo',
+        replacement: 'baz',
+        isRawText: true,
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.matchCount).toBe(1);
+      expect(result.newContent).toBe('baz bar foo');
+    });
+
+    it('returns matchCount of 1 even when multiple occurrences exist', () => {
+      const result = findAndReplace({
+        content: 'a a a',
+        search: 'a',
+        replacement: 'b',
+        isRawText: true,
+      });
+
+      expect(result.matchCount).toBe(1);
+    });
+  });
+
+  describe('replaceAll: true', () => {
+    it('replaces every occurrence', () => {
+      const result = findAndReplace({
+        content: 'foo bar foo baz foo',
+        search: 'foo',
+        replacement: 'qux',
+        replaceAll: true,
+        isRawText: true,
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.matchCount).toBe(3);
+      expect(result.newContent).toBe('qux bar qux baz qux');
+    });
+
+    it('replaces across lines', () => {
+      const result = findAndReplace({
+        content: 'foo\nfoo',
+        search: 'foo',
+        replacement: 'bar',
+        replaceAll: true,
+        isRawText: true,
+      });
+
+      expect(result.newContent).toBe('bar\nbar');
+      expect(result.matchCount).toBe(2);
+    });
+  });
+
+  describe('replacement that deletes the match (empty replacement)', () => {
+    it('removes the matched text', () => {
+      const result = findAndReplace({
+        content: 'hello world',
+        search: ' world',
+        replacement: '',
+        isRawText: true,
+      });
+
+      expect(result.found).toBe(true);
+      expect(result.newContent).toBe('hello');
+    });
+  });
+
+  describe('HTML normalization', () => {
+    it('normalizes HTML before searching so agents can match readable text', () => {
+      const htmlContent = '<p>Hello</p><p>World</p>';
+      const normalized = addLineBreaksForAI(htmlContent);
+
+      const result = findAndReplace({
+        content: htmlContent,
+        search: 'Hello',
+        replacement: 'Hi',
+        isRawText: false,
+      });
+
+      expect(result.oldContent).toBe(normalized);
+      expect(result.found).toBe(true);
+      expect(result.newContent).toContain('Hi');
+      expect(result.newContent).not.toContain('Hello');
+    });
+
+    it('does not normalize raw text (markdown/code)', () => {
+      const content = 'line one\nline two';
+
+      const result = findAndReplace({
+        content,
+        search: 'line one',
+        replacement: 'line ONE',
+        isRawText: true,
+      });
+
+      expect(result.oldContent).toBe(content);
+    });
+  });
+});
+
+describe('insertAtAnchor', () => {
+  describe('anchor not found', () => {
+    it('returns unchanged content with inserted: false', () => {
+      const result = insertAtAnchor({
+        content: 'line one\nline two',
+        anchor: 'missing',
+        insertion: 'new line',
+        position: 'after',
+        isRawText: true,
+      });
+
+      expect(result.inserted).toBe(false);
+      expect(result.anchorLine).toBeNull();
+      expect(result.newContent).toBe(result.oldContent);
+    });
+
+    it('treats null content as empty string', () => {
+      const result = insertAtAnchor({
+        content: null,
+        anchor: 'something',
+        insertion: 'new',
+        position: 'after',
+        isRawText: true,
+      });
+
+      expect(result.inserted).toBe(false);
+      expect(result.oldContent).toBe('');
+    });
+  });
+
+  describe('throws on bad input', () => {
+    it('throws when anchor is empty', () => {
+      expect(() =>
+        insertAtAnchor({ content: 'hello', anchor: '', insertion: 'x', position: 'after', isRawText: true })
+      ).toThrow('Anchor string cannot be empty');
+    });
+  });
+
+  describe('insert after', () => {
+    it('inserts a new line immediately after the anchor line', () => {
+      const result = insertAtAnchor({
+        content: 'line one\nline two\nline three',
+        anchor: 'line two',
+        insertion: 'inserted line',
+        position: 'after',
+        isRawText: true,
+      });
+
+      expect(result.inserted).toBe(true);
+      expect(result.anchorLine).toBe(2);
+      expect(result.newContent).toBe('line one\nline two\ninserted line\nline three');
+    });
+
+    it('inserts after the last line without trailing newline issues', () => {
+      const result = insertAtAnchor({
+        content: 'line one\nline two',
+        anchor: 'line two',
+        insertion: 'appended',
+        position: 'after',
+        isRawText: true,
+      });
+
+      expect(result.newContent).toBe('line one\nline two\nappended');
+    });
+
+    it('inserts after the first line', () => {
+      const result = insertAtAnchor({
+        content: 'first\nsecond\nthird',
+        anchor: 'first',
+        insertion: 'inserted',
+        position: 'after',
+        isRawText: true,
+      });
+
+      expect(result.newContent).toBe('first\ninserted\nsecond\nthird');
+      expect(result.anchorLine).toBe(1);
+    });
+  });
+
+  describe('insert before', () => {
+    it('inserts a new line immediately before the anchor line', () => {
+      const result = insertAtAnchor({
+        content: 'line one\nline two\nline three',
+        anchor: 'line two',
+        insertion: 'inserted line',
+        position: 'before',
+        isRawText: true,
+      });
+
+      expect(result.inserted).toBe(true);
+      expect(result.anchorLine).toBe(2);
+      expect(result.newContent).toBe('line one\ninserted line\nline two\nline three');
+    });
+
+    it('inserts before the first line', () => {
+      const result = insertAtAnchor({
+        content: 'first\nsecond',
+        anchor: 'first',
+        insertion: 'prepended',
+        position: 'before',
+        isRawText: true,
+      });
+
+      expect(result.newContent).toBe('prepended\nfirst\nsecond');
+      expect(result.anchorLine).toBe(1);
+    });
+  });
+
+  describe('anchor matching', () => {
+    it('matches the first line containing the anchor substring', () => {
+      const result = insertAtAnchor({
+        content: 'prefix anchor suffix\nother anchor line',
+        anchor: 'anchor',
+        insertion: 'new',
+        position: 'after',
+        isRawText: true,
+      });
+
+      // First line matched; second is untouched
+      expect(result.anchorLine).toBe(1);
+      expect(result.newContent).toBe('prefix anchor suffix\nnew\nother anchor line');
+    });
+  });
+
+  describe('HTML normalization', () => {
+    it('normalizes HTML before inserting so agents can anchor to readable text', () => {
+      const htmlContent = '<h2>Summary</h2><p>Details here</p>';
+      const normalized = addLineBreaksForAI(htmlContent);
+      const summaryLine = normalized.split('\n').find(l => l.includes('Summary'))!;
+      expect(summaryLine).toBeTruthy();
+
+      const result = insertAtAnchor({
+        content: htmlContent,
+        anchor: 'Summary',
+        insertion: 'New paragraph',
+        position: 'after',
+        isRawText: false,
+      });
+
+      expect(result.inserted).toBe(true);
+      expect(result.oldContent).toBe(normalized);
+      expect(result.newContent).toContain('New paragraph');
+    });
+  });
+});

--- a/apps/web/src/lib/editor/__tests__/text-edit.test.ts
+++ b/apps/web/src/lib/editor/__tests__/text-edit.test.ts
@@ -285,4 +285,81 @@ describe('insertAtAnchor', () => {
       expect(result.newContent).toContain('New paragraph');
     });
   });
+
+  describe('HTML block boundary snapping', () => {
+    it('inserts AFTER the closing </h2> tag, not inside it', () => {
+      // Without boundary snapping the anchor "Summary" would match the text
+      // line inside <h2>, and the insertion would land between "Summary" and
+      // "</h2>", producing invalid markup.
+      const htmlContent = '<h2>Summary</h2><p>Details</p>';
+
+      const result = insertAtAnchor({
+        content: htmlContent,
+        anchor: 'Summary',
+        insertion: 'New section',
+        position: 'after',
+        isRawText: false,
+      });
+
+      expect(result.inserted).toBe(true);
+      const newLines = result.newContent.split('\n');
+      const h2CloseIdx = newLines.findIndex(l => l.includes('</h2>'));
+      const insertionIdx = newLines.findIndex(l => l === 'New section');
+      // Insertion must be AFTER the </h2> closing tag
+      expect(insertionIdx).toBeGreaterThan(h2CloseIdx);
+    });
+
+    it('inserts BEFORE the opening <h2> tag, not inside it', () => {
+      const htmlContent = '<p>Before</p><h2>Summary</h2>';
+
+      const result = insertAtAnchor({
+        content: htmlContent,
+        anchor: 'Summary',
+        insertion: 'New section',
+        position: 'before',
+        isRawText: false,
+      });
+
+      expect(result.inserted).toBe(true);
+      const newLines = result.newContent.split('\n');
+      const h2OpenIdx = newLines.findIndex(l => l.includes('<h2>'));
+      const insertionIdx = newLines.findIndex(l => l === 'New section');
+      // Insertion must be BEFORE the <h2> opening tag
+      expect(insertionIdx).toBeLessThan(h2OpenIdx);
+    });
+
+    it('advances past multiple closing tags for nested blocks', () => {
+      // <blockquote><p>Quote text</p></blockquote>
+      const htmlContent = '<blockquote><p>Quote text</p></blockquote>';
+
+      const result = insertAtAnchor({
+        content: htmlContent,
+        anchor: 'Quote text',
+        insertion: 'After blockquote',
+        position: 'after',
+        isRawText: false,
+      });
+
+      expect(result.inserted).toBe(true);
+      // Insertion should be after the entire </blockquote>, not between </p> and </blockquote>
+      const newLines = result.newContent.split('\n');
+      const blockquoteCloseIdx = newLines.findIndex(l => l.includes('</blockquote>'));
+      const insertionIdx = newLines.findIndex(l => l === 'After blockquote');
+      expect(insertionIdx).toBeGreaterThan(blockquoteCloseIdx);
+    });
+
+    it('does not snap boundaries for raw text (markdown/code)', () => {
+      // Raw text has no HTML tags — the current line-based behavior is correct
+      const result = insertAtAnchor({
+        content: 'line one\nline two\nline three',
+        anchor: 'line two',
+        insertion: 'inserted',
+        position: 'after',
+        isRawText: true,
+      });
+
+      // Standard after-line insertion, no HTML snapping
+      expect(result.newContent).toBe('line one\nline two\ninserted\nline three');
+    });
+  });
 });

--- a/apps/web/src/lib/editor/__tests__/text-edit.test.ts
+++ b/apps/web/src/lib/editor/__tests__/text-edit.test.ts
@@ -348,6 +348,26 @@ describe('insertAtAnchor', () => {
       expect(insertionIdx).toBeGreaterThan(blockquoteCloseIdx);
     });
 
+    it('backs up past multiple opening tags for nested before-blocks', () => {
+      // <blockquote><p>Quote text</p></blockquote>
+      const htmlContent = '<blockquote><p>Quote text</p></blockquote>';
+
+      const result = insertAtAnchor({
+        content: htmlContent,
+        anchor: 'Quote text',
+        insertion: 'Before blockquote',
+        position: 'before',
+        isRawText: false,
+      });
+
+      expect(result.inserted).toBe(true);
+      // Insertion should be before the entire <blockquote>, not between <blockquote> and <p>
+      const newLines = result.newContent.split('\n');
+      const blockquoteOpenIdx = newLines.findIndex(l => l.includes('<blockquote>'));
+      const insertionIdx = newLines.findIndex(l => l === 'Before blockquote');
+      expect(insertionIdx).toBeLessThan(blockquoteOpenIdx);
+    });
+
     it('does not snap boundaries for raw text (markdown/code)', () => {
       // Raw text has no HTML tags — the current line-based behavior is correct
       const result = insertAtAnchor({

--- a/apps/web/src/lib/editor/text-edit.ts
+++ b/apps/web/src/lib/editor/text-edit.ts
@@ -105,14 +105,16 @@ export function insertAtAnchor(params: InsertAtAnchorParams): InsertAtAnchorResu
   // For HTML pages, snap to the block boundary so insertion lands outside the
   // containing element rather than inside it.
   // after:  advance past all immediately following closing tags (</tag>)
-  // before: back up past the one opening tag immediately preceding the anchor
+  // before: back up past all immediately preceding opening tags (<tag>)
   if (!isRawText) {
     if (position === 'after') {
       while (insertAt < lines.length && lines[insertAt].trimStart().startsWith('</')) {
         insertAt++;
       }
-    } else if (insertAt > 0 && /^\s*<[^/!]/.test(lines[insertAt - 1])) {
-      insertAt--;
+    } else {
+      while (insertAt > 0 && /^\s*<[^/!]/.test(lines[insertAt - 1])) {
+        insertAt--;
+      }
     }
   }
 

--- a/apps/web/src/lib/editor/text-edit.ts
+++ b/apps/web/src/lib/editor/text-edit.ts
@@ -100,7 +100,22 @@ export function insertAtAnchor(params: InsertAtAnchorParams): InsertAtAnchorResu
     return { oldContent, newContent: oldContent, inserted: false, anchorLine: null };
   }
 
-  const insertAt = position === 'before' ? anchorIndex : anchorIndex + 1;
+  let insertAt = position === 'before' ? anchorIndex : anchorIndex + 1;
+
+  // For HTML pages, snap to the block boundary so insertion lands outside the
+  // containing element rather than inside it.
+  // after:  advance past all immediately following closing tags (</tag>)
+  // before: back up past the one opening tag immediately preceding the anchor
+  if (!isRawText) {
+    if (position === 'after') {
+      while (insertAt < lines.length && lines[insertAt].trimStart().startsWith('</')) {
+        insertAt++;
+      }
+    } else if (insertAt > 0 && /^\s*<[^/!]/.test(lines[insertAt - 1])) {
+      insertAt--;
+    }
+  }
+
   const newLines = [...lines.slice(0, insertAt), insertion, ...lines.slice(insertAt)];
 
   return {

--- a/apps/web/src/lib/editor/text-edit.ts
+++ b/apps/web/src/lib/editor/text-edit.ts
@@ -1,0 +1,112 @@
+/**
+ * Text-based document editing (pure)
+ *
+ * find_and_replace: string-match replacement, more resilient than line-based
+ * editing because it doesn't depend on stable line numbers.
+ *
+ * insertAtAnchor: insert a block before or after the first line that contains
+ * a given anchor string — natural for agents that think in terms of headings
+ * and landmarks rather than line offsets.
+ *
+ * Both functions normalize HTML content via addLineBreaksForAI before
+ * operating, matching the same invariant as replaceLines so that the returned
+ * oldContent/newContent pair can be diffed cleanly.
+ */
+
+import { addLineBreaksForAI } from './line-breaks';
+
+// ─── findAndReplace ──────────────────────────────────────────────────────────
+
+export interface FindAndReplaceParams {
+  content: string | null | undefined;
+  search: string;
+  replacement: string;
+  /** Replace every occurrence. Defaults to false (first match only). */
+  replaceAll?: boolean;
+  isRawText: boolean;
+}
+
+export interface FindAndReplaceResult {
+  /** Diff baseline, normalized identically to newContent. */
+  oldContent: string;
+  /** Content after replacement. */
+  newContent: string;
+  /** Number of replacements made (0 when not found). */
+  matchCount: number;
+  /** Whether the search string was present. */
+  found: boolean;
+}
+
+export function findAndReplace(params: FindAndReplaceParams): FindAndReplaceResult {
+  const { content, search, replacement, replaceAll = false, isRawText } = params;
+
+  if (!search) {
+    throw new Error('Search string cannot be empty');
+  }
+
+  const oldContent = isRawText ? (content ?? '') : addLineBreaksForAI(content ?? '');
+
+  if (!oldContent.includes(search)) {
+    return { oldContent, newContent: oldContent, matchCount: 0, found: false };
+  }
+
+  if (replaceAll) {
+    const parts = oldContent.split(search);
+    const matchCount = parts.length - 1;
+    return { oldContent, newContent: parts.join(replacement), matchCount, found: true };
+  }
+
+  const idx = oldContent.indexOf(search);
+  const newContent = oldContent.slice(0, idx) + replacement + oldContent.slice(idx + search.length);
+  return { oldContent, newContent, matchCount: 1, found: true };
+}
+
+// ─── insertAtAnchor ──────────────────────────────────────────────────────────
+
+export interface InsertAtAnchorParams {
+  content: string | null | undefined;
+  /** Substring to search for within a line. First matching line wins. */
+  anchor: string;
+  /** Text to insert as a new line. */
+  insertion: string;
+  position: 'before' | 'after';
+  isRawText: boolean;
+}
+
+export interface InsertAtAnchorResult {
+  /** Diff baseline, normalized identically to newContent. */
+  oldContent: string;
+  /** Content with the insertion applied. */
+  newContent: string;
+  /** Whether the anchor was found and the insertion was made. */
+  inserted: boolean;
+  /** 1-based line number of the anchor (null when not found). */
+  anchorLine: number | null;
+}
+
+export function insertAtAnchor(params: InsertAtAnchorParams): InsertAtAnchorResult {
+  const { content, anchor, insertion, position, isRawText } = params;
+
+  if (!anchor) {
+    throw new Error('Anchor string cannot be empty');
+  }
+
+  const oldContent = isRawText ? (content ?? '') : addLineBreaksForAI(content ?? '');
+  const lines = oldContent.split('\n');
+
+  const anchorIndex = lines.findIndex(line => line.includes(anchor));
+
+  if (anchorIndex === -1) {
+    return { oldContent, newContent: oldContent, inserted: false, anchorLine: null };
+  }
+
+  const insertAt = position === 'before' ? anchorIndex : anchorIndex + 1;
+  const newLines = [...lines.slice(0, insertAt), insertion, ...lines.slice(insertAt)];
+
+  return {
+    oldContent,
+    newContent: newLines.join('\n'),
+    inserted: true,
+    anchorLine: anchorIndex + 1,
+  };
+}


### PR DESCRIPTION
## Summary

- Adds \`find_and_replace\` tool — replaces a string (first match or all) without needing line numbers, returning \`found: false\` cleanly when absent so agents don't mutate on a miss
- Adds \`insert_content\` tool — inserts a line before or after the first line containing an anchor substring, letting agents say "add this after the \`## Summary\` heading" rather than computing a line offset
- Both built pure-function-first (\`text-edit.ts\`) with TDD, then wired into \`pageWriteTools\`, \`CORE_TOOL_NAMES\`, and inline instructions

## Changes

**New files:**
- \`apps/web/src/lib/editor/text-edit.ts\` — pure \`findAndReplace\` + \`insertAtAnchor\` functions
- \`apps/web/src/lib/editor/__tests__/text-edit.test.ts\` — 25 unit tests

**Modified files:**
- \`page-write-tools.ts\` — \`find_and_replace\` and \`insert_content\` tools
- \`stub-tools.ts\` — both tools added to \`CORE_TOOL_NAMES\` (8 → 10)
- \`tool-filtering.ts\` — both tools registered in \`WRITE_TOOLS\` (excluded in read-only mode)
- \`inline-instructions.ts\` — agents told to use new tools for DOCUMENT pages
- \`registry.tsx\` + \`CompactToolCallRenderer.tsx\` + \`ToolCallRenderer.tsx\` — UI renderers and display names
- \`tool-filtering.test.ts\` + \`page-write-tools.test.ts\` — coverage for new tools and read-only filtering

## Key design decisions

- **HTML block boundary snapping**: \`insertAtAnchor\` for HTML pages advances past all consecutive closing tags on \`after\` and backs up past all consecutive opening tags on \`before\` (both use \`while\` loops), so insertion always lands between block elements rather than inside them.
- **No mutation on miss**: both tools return \`found: false\` / \`inserted: false\` without calling \`applyPageMutation\` when the search/anchor isn't present.
- **Read-only safe**: both tools are in \`WRITE_TOOLS\` and are stripped in read-only mode.
- **Empty-string diffs handled**: registry uses \`typeof === 'string'\` checks (not truthiness) so empty-replacement diffs still render correctly.

## Test plan

- [ ] \`bunx vitest run src/lib/editor/__tests__/text-edit.test.ts\` — 25 pure fn tests pass
- [ ] \`bunx vitest run src/lib/ai/tools/__tests__/page-write-tools.test.ts\` — 57 tool tests pass
- [ ] \`bunx vitest run src/lib/ai/core/__tests__/tool-filtering.test.ts\` — read-only filtering tests pass
- [ ] \`bunx tsc --noEmit --project apps/web/tsconfig.json\` — no type errors
- [ ] In a live agent chat: ask agent to replace a specific phrase in a document — confirm \`find_and_replace\` is used and page updates
- [ ] Ask agent to add a paragraph after a heading — confirm \`insert_content\` inserts after the \`</h2>\` tag, not inside it
- [ ] Enable read-only mode for an agent, confirm neither new tool appears in the tool list

🤖 Generated with [Claude Code](https://claude.com/claude-code)