### PR TITLE
fix(realtime): broadcast drive:updated on command and workflow mutations

### DIFF
--- a/apps/web/src/app/api/commands/[commandId]/route.ts
+++ b/apps/web/src/app/api/commands/[commandId]/route.ts
@@ -197,7 +197,7 @@ export async function PATCH(request: Request, context: RouteContext) {
     if (command.driveId !== null) {
       try {
         const recipientUserIds = await getDriveRecipientUserIds(command.driveId);
-        await broadcastDriveEvent(createDriveEventPayload(command.driveId, 'updated'), recipientUserIds);
+        await broadcastDriveEvent(createDriveEventPayload(command.driveId, 'updated', { resourceType: 'command' }), recipientUserIds);
       } catch (broadcastError) {
         loggers.api.error('[COMMANDS_PATCH_BROADCAST]', broadcastError as Error);
       }
@@ -240,7 +240,7 @@ export async function DELETE(request: Request, context: RouteContext) {
     if (command.driveId !== null) {
       try {
         const recipientUserIds = await getDriveRecipientUserIds(command.driveId);
-        await broadcastDriveEvent(createDriveEventPayload(command.driveId, 'updated'), recipientUserIds);
+        await broadcastDriveEvent(createDriveEventPayload(command.driveId, 'updated', { resourceType: 'command' }), recipientUserIds);
       } catch (broadcastError) {
         loggers.api.error('[COMMANDS_DELETE_BROADCAST]', broadcastError as Error);
       }

--- a/apps/web/src/app/api/commands/[commandId]/route.ts
+++ b/apps/web/src/app/api/commands/[commandId]/route.ts
@@ -6,6 +6,8 @@ import type { SelectCommand } from '@pagespace/db/schema/commands';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
 import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import {
   validateCommandTrigger,
@@ -192,6 +194,15 @@ export async function PATCH(request: Request, context: RouteContext) {
       details: { action: 'update', fields: Object.keys(updateData) },
     });
 
+    if (command.driveId !== null) {
+      try {
+        const recipientUserIds = await getDriveRecipientUserIds(command.driveId);
+        await broadcastDriveEvent(createDriveEventPayload(command.driveId, 'updated'), recipientUserIds);
+      } catch (broadcastError) {
+        loggers.api.error('[COMMANDS_PATCH_BROADCAST]', broadcastError as Error);
+      }
+    }
+
     return NextResponse.json({ command: toCommandResponse(updated) });
   } catch (error) {
     loggers.api.error('[COMMANDS_PATCH]', error as Error);
@@ -225,6 +236,15 @@ export async function DELETE(request: Request, context: RouteContext) {
         driveId: command.driveId,
       },
     });
+
+    if (command.driveId !== null) {
+      try {
+        const recipientUserIds = await getDriveRecipientUserIds(command.driveId);
+        await broadcastDriveEvent(createDriveEventPayload(command.driveId, 'updated'), recipientUserIds);
+      } catch (broadcastError) {
+        loggers.api.error('[COMMANDS_DELETE_BROADCAST]', broadcastError as Error);
+      }
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/commands/route.ts
+++ b/apps/web/src/app/api/commands/route.ts
@@ -8,6 +8,8 @@ import { users } from '@pagespace/db/schema/auth';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
 import { canUserViewPage, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import {
   validateCommandTrigger,
@@ -253,6 +255,15 @@ export async function POST(request: Request) {
         driveId: created.driveId,
       },
     });
+
+    if (commandDriveId !== null) {
+      try {
+        const recipientUserIds = await getDriveRecipientUserIds(commandDriveId);
+        await broadcastDriveEvent(createDriveEventPayload(commandDriveId, 'updated'), recipientUserIds);
+      } catch (broadcastError) {
+        loggers.api.error('[COMMANDS_POST_BROADCAST]', broadcastError as Error);
+      }
+    }
 
     return NextResponse.json({ command: toCommandResponse(created) }, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/commands/route.ts
+++ b/apps/web/src/app/api/commands/route.ts
@@ -259,7 +259,7 @@ export async function POST(request: Request) {
     if (commandDriveId !== null) {
       try {
         const recipientUserIds = await getDriveRecipientUserIds(commandDriveId);
-        await broadcastDriveEvent(createDriveEventPayload(commandDriveId, 'updated'), recipientUserIds);
+        await broadcastDriveEvent(createDriveEventPayload(commandDriveId, 'updated', { resourceType: 'command' }), recipientUserIds);
       } catch (broadcastError) {
         loggers.api.error('[COMMANDS_POST_BROADCAST]', broadcastError as Error);
       }

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { checkDriveAccess, getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { db } from '@pagespace/db/db'
 import { eq, and } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
@@ -134,6 +136,13 @@ export async function PATCH(
 
   auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'workflow', resourceId: workflowId, details: { updatedFields: Object.keys(data) } });
 
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(workflow.driveId);
+    await broadcastDriveEvent(createDriveEventPayload(workflow.driveId, 'updated'), recipientUserIds);
+  } catch (broadcastError) {
+    loggers.api.error('[WORKFLOWS_PATCH_BROADCAST]', broadcastError as Error);
+  }
+
   return NextResponse.json(updated);
 }
 
@@ -152,6 +161,13 @@ export async function DELETE(
   await db.delete(workflows).where(eq(workflows.id, workflowId));
 
   auditRequest(request, { eventType: 'data.delete', userId: auth.userId, resourceType: 'workflow', resourceId: workflowId });
+
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(result.workflow.driveId);
+    await broadcastDriveEvent(createDriveEventPayload(result.workflow.driveId, 'updated'), recipientUserIds);
+  } catch (broadcastError) {
+    loggers.api.error('[WORKFLOWS_DELETE_BROADCAST]', broadcastError as Error);
+  }
 
   return NextResponse.json({ success: true });
 }

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -138,7 +138,7 @@ export async function PATCH(
 
   try {
     const recipientUserIds = await getDriveRecipientUserIds(workflow.driveId);
-    await broadcastDriveEvent(createDriveEventPayload(workflow.driveId, 'updated'), recipientUserIds);
+    await broadcastDriveEvent(createDriveEventPayload(workflow.driveId, 'updated', { resourceType: 'workflow' }), recipientUserIds);
   } catch (broadcastError) {
     loggers.api.error('[WORKFLOWS_PATCH_BROADCAST]', broadcastError as Error);
   }
@@ -164,7 +164,7 @@ export async function DELETE(
 
   try {
     const recipientUserIds = await getDriveRecipientUserIds(result.workflow.driveId);
-    await broadcastDriveEvent(createDriveEventPayload(result.workflow.driveId, 'updated'), recipientUserIds);
+    await broadcastDriveEvent(createDriveEventPayload(result.workflow.driveId, 'updated', { resourceType: 'workflow' }), recipientUserIds);
   } catch (broadcastError) {
     loggers.api.error('[WORKFLOWS_DELETE_BROADCAST]', broadcastError as Error);
   }

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { checkDriveAccess, getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { db } from '@pagespace/db/db'
 import { eq, and, isNotNull, sql } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
@@ -175,6 +177,13 @@ export async function POST(request: Request) {
   }).returning();
 
   auditRequest(request, { eventType: 'data.write', userId, resourceType: 'workflow', resourceId: workflow.id, details: { driveId: data.driveId, triggerType: MANAGEABLE_TRIGGER_TYPE } });
+
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(data.driveId);
+    await broadcastDriveEvent(createDriveEventPayload(data.driveId, 'updated'), recipientUserIds);
+  } catch (broadcastError) {
+    loggers.api.error('[WORKFLOWS_POST_BROADCAST]', broadcastError as Error);
+  }
 
   return NextResponse.json(workflow, { status: 201 });
 }

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -180,7 +180,7 @@ export async function POST(request: Request) {
 
   try {
     const recipientUserIds = await getDriveRecipientUserIds(data.driveId);
-    await broadcastDriveEvent(createDriveEventPayload(data.driveId, 'updated'), recipientUserIds);
+    await broadcastDriveEvent(createDriveEventPayload(data.driveId, 'updated', { resourceType: 'workflow' }), recipientUserIds);
   } catch (broadcastError) {
     loggers.api.error('[WORKFLOWS_POST_BROADCAST]', broadcastError as Error);
   }

--- a/apps/web/src/hooks/useCommands.ts
+++ b/apps/web/src/hooks/useCommands.ts
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import useSWR from 'swr';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
+import { useSocket } from './useSocket';
 import {
   toggleCommandInList,
   removeCommandFromList,
@@ -31,11 +33,19 @@ const EMPTY_COMMANDS: CommandItem[] = [];
  * page title/availability, author name) stay authoritative.
  */
 export function useCommands(active: boolean = true) {
+  const socket = useSocket();
   const { data, error, isLoading, mutate } = useSWR<CommandsResponse>(
     active ? '/api/commands' : null,
     fetcher,
     { revalidateOnFocus: false }
   );
+
+  useEffect(() => {
+    if (!socket || !active) return;
+    const handleDriveUpdated = () => { void mutate(); };
+    socket.on('drive:updated', handleDriveUpdated);
+    return () => { socket.off('drive:updated', handleDriveUpdated); };
+  }, [socket, active, mutate]);
 
   const commands = data?.commands ?? EMPTY_COMMANDS;
 

--- a/apps/web/src/hooks/useCommands.ts
+++ b/apps/web/src/hooks/useCommands.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import useSWR from 'swr';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
 import { useSocket } from './useSocket';
+import type { DriveEventPayload } from '@/lib/websocket';
 import {
   toggleCommandInList,
   removeCommandFromList,
@@ -42,7 +43,7 @@ export function useCommands(active: boolean = true) {
 
   useEffect(() => {
     if (!socket || !active) return;
-    const handleDriveUpdated = (payload: { resourceType?: string }) => {
+    const handleDriveUpdated = (payload: DriveEventPayload) => {
       if (payload.resourceType === 'command') void mutate();
     };
     socket.on('drive:updated', handleDriveUpdated);

--- a/apps/web/src/hooks/useCommands.ts
+++ b/apps/web/src/hooks/useCommands.ts
@@ -42,7 +42,9 @@ export function useCommands(active: boolean = true) {
 
   useEffect(() => {
     if (!socket || !active) return;
-    const handleDriveUpdated = () => { void mutate(); };
+    const handleDriveUpdated = (payload: { resourceType?: string }) => {
+      if (payload.resourceType === 'command') void mutate();
+    };
     socket.on('drive:updated', handleDriveUpdated);
     return () => { socket.off('drive:updated', handleDriveUpdated); };
   }, [socket, active, mutate]);

--- a/apps/web/src/hooks/useGlobalDriveSocket.ts
+++ b/apps/web/src/hooks/useGlobalDriveSocket.ts
@@ -40,6 +40,12 @@ export function useGlobalDriveSocket() {
 
     console.log(`🚀 GLOBAL DRIVE EVENT: ${operation}`, eventData);
 
+    // command/workflow events reuse the drive:updated channel but are handled by
+    // useCommands/useWorkflows — they don't affect the drives sidebar list.
+    if ('resourceType' in eventData && (eventData.resourceType === 'command' || eventData.resourceType === 'workflow')) {
+      return;
+    }
+
     switch (operation) {
       case 'created':
       case 'updated':

--- a/apps/web/src/hooks/useWorkflows.ts
+++ b/apps/web/src/hooks/useWorkflows.ts
@@ -1,8 +1,10 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useEffect } from 'react';
 import useSWR from 'swr';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
 import type { Workflow } from '@/components/workflows/types';
+import { useSocket } from './useSocket';
+import type { DriveEventPayload } from '@/lib/websocket';
 
 const fetcher = (url: string) => fetchWithAuth(url).then(res => {
   if (!res.ok) throw new Error('Failed to fetch workflows');
@@ -10,6 +12,7 @@ const fetcher = (url: string) => fetchWithAuth(url).then(res => {
 });
 
 export function useWorkflows(driveId: string) {
+  const socket = useSocket();
   const hasLoadedRef = useRef(false);
 
   const { data, error, isLoading, mutate } = useSWR<Workflow[]>(
@@ -22,6 +25,15 @@ export function useWorkflows(driveId: string) {
       revalidateOnFocus: false,
     }
   );
+
+  useEffect(() => {
+    if (!socket || !driveId) return;
+    const handleDriveUpdated = (payload: DriveEventPayload) => {
+      if (payload.driveId === driveId) void mutate();
+    };
+    socket.on('drive:updated', handleDriveUpdated);
+    return () => { socket.off('drive:updated', handleDriveUpdated); };
+  }, [socket, driveId, mutate]);
 
   const runWorkflow = useCallback(async (workflowId: string) => {
     const result = await post<{ success: boolean; error?: string; responseText?: string; toolCallCount?: number; durationMs?: number }>(

--- a/apps/web/src/hooks/useWorkflows.ts
+++ b/apps/web/src/hooks/useWorkflows.ts
@@ -29,7 +29,7 @@ export function useWorkflows(driveId: string) {
   useEffect(() => {
     if (!socket || !driveId) return;
     const handleDriveUpdated = (payload: DriveEventPayload) => {
-      if (payload.driveId === driveId) void mutate();
+      if (payload.driveId === driveId && payload.resourceType === 'workflow') void mutate();
     };
     socket.on('drive:updated', handleDriveUpdated);
     return () => { socket.off('drive:updated', handleDriveUpdated); };

--- a/apps/web/src/lib/ai/tools/command-tools.ts
+++ b/apps/web/src/lib/ai/tools/command-tools.ts
@@ -14,7 +14,18 @@ import {
 import { canUserViewPage, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
 import type { ToolExecutionContext } from '../core/types';
+
+async function broadcastCommandChange(driveId: string): Promise<void> {
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', { resourceType: 'command' }), recipientUserIds);
+  } catch {
+    // best-effort; never surface broadcast failures to the caller
+  }
+}
 
 const commandLogger = loggers.ai.child({ module: 'command-tools' });
 
@@ -150,6 +161,8 @@ export const commandTools = {
           })
           .returning();
 
+        if (commandDriveId !== null) void broadcastCommandChange(commandDriveId);
+
         return {
           success: true,
           commandId: created.id,
@@ -251,6 +264,8 @@ export const commandTools = {
           .where(eq(commands.id, command.id))
           .returning();
 
+        if (command.driveId !== null) void broadcastCommandChange(command.driveId);
+
         return {
           success: true,
           commandId: updated.id,
@@ -286,6 +301,7 @@ export const commandTools = {
       try {
         const command = await loadCommandForManage(userId, commandId);
         await db.delete(commands).where(eq(commands.id, command.id));
+        if (command.driveId !== null) void broadcastCommandChange(command.driveId);
 
         return {
           success: true,

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -7,15 +7,6 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
 import type { ToolExecutionContext } from '../core/types';
-
-async function broadcastWorkflowChange(driveId: string): Promise<void> {
-  try {
-    const recipientUserIds = await getDriveRecipientUserIds(driveId);
-    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', { resourceType: 'workflow' }), recipientUserIds);
-  } catch {
-    // best-effort; never surface broadcast failures to the caller
-  }
-}
 import { canActorManageDrive } from './actor-permissions';
 import { agentTriggerBaseSchema, validateAgentTrigger } from '@/lib/workflows/agent-trigger-shared';
 import {
@@ -28,6 +19,15 @@ import {
 const logger = loggers.api.child({ module: 'workflow-tools' });
 
 const DEFAULT_TRIGGER_PROMPT = 'Execute instructions from linked page.';
+
+async function broadcastWorkflowChange(driveId: string): Promise<void> {
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', { resourceType: 'workflow' }), recipientUserIds);
+  } catch {
+    // best-effort; never surface broadcast failures to the caller
+  }
+}
 
 /**
  * Tools for standalone, recurring (cron) agent workflows.

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -4,7 +4,18 @@ import { db } from '@pagespace/db/db';
 import { eq, and, isNotNull } from '@pagespace/db/operators';
 import { workflows } from '@pagespace/db/schema/workflows';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket/socket-utils';
 import type { ToolExecutionContext } from '../core/types';
+
+async function broadcastWorkflowChange(driveId: string): Promise<void> {
+  try {
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', { resourceType: 'workflow' }), recipientUserIds);
+  } catch {
+    // best-effort; never surface broadcast failures to the caller
+  }
+}
 import { canActorManageDrive } from './actor-permissions';
 import { agentTriggerBaseSchema, validateAgentTrigger } from '@/lib/workflows/agent-trigger-shared';
 import {
@@ -95,6 +106,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
         cronExpression,
         timezone: tz,
       });
+      void broadcastWorkflowChange(driveId);
 
       return {
         success: true,
@@ -235,6 +247,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
       await db.update(workflows).set(updates).where(eq(workflows.id, workflowId));
 
       logger.info('Updated cron workflow', { workflowId, fields: Object.keys(updates) });
+      void broadcastWorkflowChange(workflow.driveId);
 
       return {
         success: true,
@@ -269,6 +282,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
       await db.delete(workflows).where(eq(workflows.id, workflowId));
 
       logger.info('Deleted cron workflow', { workflowId, driveId: workflow.driveId });
+      void broadcastWorkflowChange(workflow.driveId);
 
       return { success: true, workflowId, summary: `Deleted workflow "${workflow.name}".` };
     },

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -48,6 +48,8 @@ export interface DriveEventPayload {
   operation: DriveOperation;
   name?: string;
   slug?: string;
+  /** Discriminates command/workflow broadcasts from drive-level changes. Absent = drive-level. */
+  resourceType?: 'command' | 'workflow';
 }
 
 export interface DriveMemberEventPayload {
@@ -445,6 +447,7 @@ export function createDriveEventPayload(
   options: {
     name?: string;
     slug?: string;
+    resourceType?: DriveEventPayload['resourceType'];
   } = {}
 ): DriveEventPayload {
   return {


### PR DESCRIPTION
## Summary

Audited all 21 new MCP tools added in #1623 and related PRs for socket event coverage. Found two gaps where agent-driven mutations were silent to other connected clients:

- **Drive commands** (\`create_command\`, \`update_command\`, \`delete_command\`) — no broadcast after DB write
- **Workflows** (\`create_workflow\`, \`update_workflow\`, \`delete_workflow\`) — no broadcast after DB write

All drive role tools and trigger tools were already correctly wired.

## Changes

**AI tool layer (primary fix)** — The MCP tools in \`command-tools.ts\` and \`workflow-tools.ts\` write to the DB directly, bypassing the REST routes. Added \`broadcastCommandChange\` and \`broadcastWorkflowChange\` helpers called fire-and-forget (\`void\`) after each successful DB mutation. Broadcast failures are swallowed so they never surface to callers.

**Backend REST routes** (secondary coverage for human-initiated mutations via the web UI) — 4 route files get \`broadcastDriveEvent\` after each successful DB write, using the same \`getDriveRecipientUserIds\` + \`createDriveEventPayload\` utilities already used by the roles routes.

- \`api/commands/route.ts\` POST — broadcasts when \`commandDriveId !== null\` (personal commands are single-user; no broadcast)
- \`api/commands/[commandId]/route.ts\` PATCH + DELETE — broadcasts when \`command.driveId !== null\`
- \`api/workflows/route.ts\` POST — always broadcasts (all workflows are drive-scoped)
- \`api/workflows/[workflowId]/route.ts\` PATCH + DELETE — always broadcasts

**\`resourceType\` discriminator** — Added optional \`resourceType?: 'command' | 'workflow'\` to \`DriveEventPayload\`. All command broadcasts set \`resourceType: 'command'\`, all workflow broadcasts set \`resourceType: 'workflow'\`. This prevents cross-resource cache invalidations:

- \`useCommands\` — only calls \`mutate()\` when \`payload.resourceType === 'command'\`
- \`useWorkflows\` — filters on both \`driveId\` and \`resourceType === 'workflow'\`
- \`useGlobalDriveSocket\` — short-circuits the drives-list refetch when \`resourceType\` is \`'command'\` or \`'workflow'\`

**Frontend** — 2 hooks add \`drive:updated\` listeners to revalidate their SWR data. The \`user:${userId}:drives\` channel is already joined globally by \`useGlobalDriveSocket\`, so no join/leave logic is needed.

## Test plan

- [ ] Create/update/delete a drive command via an agent tool; confirm the commands settings panel in a separate tab refreshes without a manual reload
- [ ] Create/update/delete a workflow via an agent tool; confirm the WorkflowsDashboard in a separate tab updates live
- [ ] Confirm personal command mutations do NOT trigger a broadcast (scope guard: \`commandDriveId !== null\`)
- [ ] Confirm no regression in the roles UI (untouched by this PR)
- [ ] Confirm renaming a drive (which fires \`drive:updated\`) does NOT cause commands or workflows to refetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)