### PR TITLE
fix(scripts): backfill onConflictDoNothing used wrong option key (targetWhere → where)

### DIFF
--- a/scripts/__tests__/backfill-home-drives.test.ts
+++ b/scripts/__tests__/backfill-home-drives.test.ts
@@ -232,11 +232,14 @@ describe('backfill (live)', () => {
     const insertedRows = valuesSpy.mock.calls[0][0] as Array<Record<string, unknown>>;
     expect(insertedRows[0]).toMatchObject({ kind: 'HOME', ownerId: 'user-needs-home', name: 'Home' });
 
-    // Verify conflict is swallowed via onConflictDoNothing (partial-unique-index guard)
+    // Verify conflict is swallowed via onConflictDoNothing (partial-unique-index guard).
+    // The predicate key MUST be `where` — drizzle 0.32.x silently ignores
+    // `targetWhere` on onConflictDoNothing, which breaks index inference in prod.
     expect(onConflictSpy).toHaveBeenCalledTimes(1);
     const callArg = onConflictSpy.mock.calls[0][0] as Record<string, unknown>;
     expect(callArg).toHaveProperty('target');
-    expect(callArg).toHaveProperty('targetWhere');
+    expect(callArg).toHaveProperty('where');
+    expect(callArg).not.toHaveProperty('targetWhere');
   });
 
   it('swallows a conflict via onConflictDoNothing: counts only actually-written rows', async () => {

--- a/scripts/backfill-home-drives.ts
+++ b/scripts/backfill-home-drives.ts
@@ -114,12 +114,15 @@ export async function backfill(dryRun: boolean, dbInstance: DbLike = defaultDb):
 
         // Use .returning() so the count reflects only rows actually written,
         // not the attempted batch size (onConflictDoNothing skips races).
+        // NOTE: the option key is `where` in drizzle-orm 0.32.x — `targetWhere`
+        // (the onConflictDoUpdate key) is silently ignored here, which drops
+        // the predicate and breaks partial-unique-index inference at runtime.
         const written = await (dbInstance as typeof defaultDb)
           .insert(drives)
           .values(rows)
           .onConflictDoNothing({
             target: [drives.ownerId],
-            targetWhere: sql`"kind" = 'HOME'`,
+            where: sql`"kind" = 'HOME'`,
           })
           .returning({ id: drives.id });
 


### PR DESCRIPTION
## Summary

The Home-drive backfill's conflict-swallow was a no-op in production: drizzle-orm 0.32.x **silently ignores `targetWhere`** on `onConflictDoNothing` (that key belongs to `onConflictDoUpdate`), so the generated SQL was `ON CONFLICT ("ownerId") DO NOTHING` with no predicate. Postgres can't match that against the partial unique index `drives_owner_home_unique (ownerId) WHERE kind='HOME'`, and the live run failed with *"no unique or exclusion constraint matching the ON CONFLICT specification"*. The correct option key is `where`.

The mocked tests couldn't catch this (they assert the option object, which previously pinned the wrong key); the assertion now pins `where` and rejects `targetWhere`.

## Production status

Already run successfully with this fix via a one-off derived image on Fly (`registry.fly.io/pagespace-web:home-backfill-fix1`):

- dry-run: would insert 81, already have Home: 0
- live: **inserted: 81, already had Home: 0**
- verified in DB: 81 `kind='HOME'` drives, 0 users without a Home, 0 duplicates

This PR just lands the fix in the repo so future runs (and the documented re-run procedure) work from the standard migrate image.

## Diagnosis trail

- `psql` zero-row inference probe with the intended SQL → works
- `q.toSQL()` on the script's query → `on conflict ("ownerId") do nothing` (predicate dropped)
- drizzle-orm 0.32.2 source: `onConflictDoNothing(config)` reads `config.where` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conflict-handling logic in the home drives backfill process to correctly process records.

* **Tests**
  * Updated backfill tests to verify the corrected conflict-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->