### PR TITLE
feat(members): drive-wide permissions in role editor + UX fixes

### DIFF
--- a/apps/web/src/components/members/PermissionsGrid.tsx
+++ b/apps/web/src/components/members/PermissionsGrid.tsx
@@ -215,13 +215,13 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
     const perms = permissions.get(page.id) || { canView: false, canEdit: false, canShare: false };
     return (
       <div key={page.id} className="flex items-center p-2 bg-blue-50 dark:bg-blue-900/20 border-b-2 border-blue-200 dark:border-blue-700">
-        <div className="flex-1 flex items-center space-x-2">
+        <div className="flex-1 flex items-center space-x-2 min-w-0 overflow-hidden">
           <HardDrive className="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
-          <span className="font-semibold truncate">{page.title}</span>
-          <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">
+          <span className="font-semibold shrink-0">{page.title}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
             {readOnlyDriveRoot
-              ? '(drive root — access derived from membership role)'
-              : '(drive root — controls root-level page creation)'}
+              ? '(access derived from membership role)'
+              : '(controls root-level page creation)'}
           </span>
         </div>
         <div className="w-[100px] flex justify-center">

--- a/apps/web/src/components/settings/RoleEditor.tsx
+++ b/apps/web/src/components/settings/RoleEditor.tsx
@@ -251,7 +251,7 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
             </div>
             {driveWidePerms && (
               <p className="text-xs text-amber-600 dark:text-amber-400">
-                Drive-wide access is active — per-page settings below add extra permissions on top.
+                Drive-wide access is active — use per-page settings below to grant private pages or deny specific pages.
               </p>
             )}
           </div>

--- a/apps/web/src/components/settings/RoleEditor.tsx
+++ b/apps/web/src/components/settings/RoleEditor.tsx
@@ -99,10 +99,11 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
 
     setSaving(true);
     try {
-      // Convert Map to object for JSON - only include pages with at least one permission
       const permissionsObj: Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }> = {};
       permissions.forEach((perms, pageId) => {
-        if (perms.canView || perms.canEdit || perms.canShare) {
+        // When drive-wide access is active, retain all-false entries as explicit denials —
+        // the permission resolver uses canView:false entries to remove pages from the drive-wide grant.
+        if (perms.canView || perms.canEdit || perms.canShare || driveWidePerms) {
           permissionsObj[pageId] = perms;
         }
       });
@@ -234,7 +235,7 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
             <div>
               <p className="text-sm font-medium">Drive-Wide Access</p>
               <p className="text-xs text-muted-foreground mt-0.5">
-                Grant the same permission to every page in the drive. Leave unchecked to control access per page below.
+                Grant the same permission to every non-private page in the drive. Leave unchecked to control access per page below.
               </p>
             </div>
             <div className="flex gap-6">

--- a/apps/web/src/components/settings/RoleEditor.tsx
+++ b/apps/web/src/components/settings/RoleEditor.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
+import { Checkbox } from '@/components/ui/checkbox';
 import { ChevronLeft, Save } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { post, patch } from '@/lib/auth/auth-fetch';
@@ -20,6 +21,7 @@ interface Role {
   color?: string;
   isDefault: boolean;
   permissions: Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }>;
+  driveWidePermissions?: { canView: boolean; canEdit: boolean; canShare: boolean } | null;
   position: number;
 }
 
@@ -40,12 +42,14 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
   const [isDefault, setIsDefault] = useState(role?.isDefault || false);
   const [permissions, setPermissions] = useState<Map<string, { canView: boolean; canEdit: boolean; canShare: boolean }>>(
     () => {
-      // Initialize from role's permissions if editing
       if (role?.permissions) {
         return new Map(Object.entries(role.permissions));
       }
       return new Map();
     }
+  );
+  const [driveWidePerms, setDriveWidePerms] = useState<{ canView: boolean; canEdit: boolean; canShare: boolean } | null>(
+    role?.driveWidePermissions ?? null
   );
   const [saving, setSaving] = useState(false);
 
@@ -54,6 +58,22 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
       const newPerms = new Map(prev);
       newPerms.set(pageId, perms);
       return newPerms;
+    });
+  };
+
+  const handleDriveWideChange = (perm: 'canView' | 'canEdit' | 'canShare', value: boolean) => {
+    setDriveWidePerms(prev => {
+      const base = prev ?? { canView: false, canEdit: false, canShare: false };
+      const next = { ...base };
+      if (perm === 'canView' && !value) {
+        return null;
+      } else if ((perm === 'canEdit' || perm === 'canShare') && value) {
+        next.canView = true;
+        next[perm] = true;
+      } else {
+        next[perm] = value;
+      }
+      return (next.canView || next.canEdit || next.canShare) ? next : null;
     });
   };
 
@@ -93,6 +113,7 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
         color,
         isDefault,
         permissions: permissionsObj,
+        driveWidePermissions: driveWidePerms,
       };
 
       if (isEditing && role) {
@@ -199,20 +220,55 @@ export function RoleEditor({ driveId, role, onSave, onCancel }: RoleEditorProps)
         </CardContent>
       </Card>
 
-      {/* Page Permissions */}
+      {/* Access Level */}
       <Card>
         <CardHeader>
-          <CardTitle>Page Permissions</CardTitle>
+          <CardTitle>Access Level</CardTitle>
           <CardDescription>
-            Select which pages members with this role can access
+            Set what members with this role can access across the drive
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          <PermissionsGrid
-            driveId={driveId}
-            permissions={permissions}
-            onChange={handlePermissionChange}
-          />
+        <CardContent className="space-y-6">
+          {/* Drive-Wide Access */}
+          <div className="space-y-3">
+            <div>
+              <p className="text-sm font-medium">Drive-Wide Access</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Grant the same permission to every page in the drive. Leave unchecked to control access per page below.
+              </p>
+            </div>
+            <div className="flex gap-6">
+              {(['canView', 'canEdit', 'canShare'] as const).map((perm) => (
+                <label key={perm} className="flex items-center gap-2 cursor-pointer select-none">
+                  <Checkbox
+                    checked={driveWidePerms?.[perm] ?? false}
+                    onCheckedChange={(v) => handleDriveWideChange(perm, !!v)}
+                  />
+                  <span className="text-sm capitalize">{perm.replace('can', '')}</span>
+                </label>
+              ))}
+            </div>
+            {driveWidePerms && (
+              <p className="text-xs text-amber-600 dark:text-amber-400">
+                Drive-wide access is active — per-page settings below add extra permissions on top.
+              </p>
+            )}
+          </div>
+
+          {/* Per-Page Overrides */}
+          <div className="space-y-2">
+            <div>
+              <p className="text-sm font-medium">Per-Page Overrides</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Fine-tune access for individual pages.
+              </p>
+            </div>
+            <PermissionsGrid
+              driveId={driveId}
+              permissions={permissions}
+              onChange={handlePermissionChange}
+            />
+          </div>
         </CardContent>
       </Card>
 

--- a/apps/web/src/components/settings/RolesManager.tsx
+++ b/apps/web/src/components/settings/RolesManager.tsx
@@ -29,6 +29,7 @@ interface Role {
   color?: string;
   isDefault: boolean;
   permissions: Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }>;
+  driveWidePermissions?: { canView: boolean; canEdit: boolean; canShare: boolean } | null;
   position: number;
 }
 


### PR DESCRIPTION
## Summary

- **Drive-wide permissions**: The role editor now surfaces the `driveWidePermissions` field (a drive-wide override granting blanket View/Edit/Share to every page for that role). Previously the API and DB supported it but the UI never showed or edited it — only per-page permissions were visible.
- **Drive root row text overflow fix**: The description text in `PermissionsGrid`'s drive root row had `shrink-0`, causing it to bleed across the View/Edit/Share checkbox columns. Fixed with `min-w-0 overflow-hidden` on the container and `truncate` on the text span.
- **UX clarity**: "Page Permissions" card renamed to "Access Level" with a two-section layout — "Drive-Wide Access" (new, at top) and "Per-Page Overrides" (existing tree, below). Copy tightened throughout.

## Files changed

- `apps/web/src/components/settings/RoleEditor.tsx` — drive-wide state, handler, UI card, save payload
- `apps/web/src/components/settings/RolesManager.tsx` — `driveWidePermissions` added to `Role` interface
- `apps/web/src/components/members/PermissionsGrid.tsx` — overflow fix + shortened drive root copy

## Test plan

- [ ] Drive settings → Roles → Create Role: confirm "Access Level" card shows "Drive-Wide Access" checkboxes above the page tree
- [ ] Check View → Edit/Share become interactive; uncheck View → all clear
- [ ] Save role with drive-wide perms set, reopen — values persist
- [ ] Drive root row text no longer bleeds over View/Edit/Share columns
- [ ] Existing per-page permissions behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drive-wide permission controls to the role editor with toggles for managing view, edit, and share access levels across drives

* **UI/UX Updates**
  * Refined permission grid display with improved layout handling and updated informational labels
  * Introduced "Access Level" section to organize both drive-wide and page-level permission controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->