### PR TITLE
fix(admin): exclude gifted subscriptions from paying users count

### DIFF
--- a/apps/admin/src/lib/monitoring-queries.ts
+++ b/apps/admin/src/lib/monitoring-queries.ts
@@ -1258,7 +1258,6 @@ export async function getGrowthMetrics(): Promise<GrowthMetrics> {
     .from(users)
     .innerJoin(subscriptions, eq(subscriptions.userId, users.id))
     .where(and(
-      sql`${users.subscriptionTier} != 'free'`,
       inArray(subscriptions.status, ['active', 'trialing']),
       eq(subscriptions.gifted, false)
     ));

--- a/apps/admin/src/lib/monitoring-queries.ts
+++ b/apps/admin/src/lib/monitoring-queries.ts
@@ -1254,9 +1254,14 @@ export async function getGrowthMetrics(): Promise<GrowthMetrics> {
     : null;
 
   const [payingResult] = await db
-    .select({ count: count() })
+    .select({ count: sql<number>`COUNT(DISTINCT ${users.id})::int` })
     .from(users)
-    .where(sql`${users.subscriptionTier} != 'free'`);
+    .innerJoin(subscriptions, eq(subscriptions.userId, users.id))
+    .where(and(
+      sql`${users.subscriptionTier} != 'free'`,
+      inArray(subscriptions.status, ['active', 'trialing']),
+      eq(subscriptions.gifted, false)
+    ));
   const payingUsers = payingResult?.count ?? 0;
 
   // MAU trend (12 months) from activity_logs — comprehensive audit trail

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -40,6 +40,7 @@ const mockSelectLimit = vi.fn();
 const mockInsertValues = vi.fn();
 const mockInsertOnConflictDoNothing = vi.fn();
 const mockInsertReturning = vi.fn();
+const mockTxInsertValues = vi.fn();
 const mockUpdateSet = vi.fn();
 const mockUpdateWhere = vi.fn();
 const mockUpdateReturning = vi.fn();
@@ -49,9 +50,9 @@ vi.mock('@pagespace/db/db', () => {
   // Create a mock transaction function
   const mockTx = {
     insert: vi.fn(() => ({
-      values: vi.fn(() => ({
+      values: mockTxInsertValues.mockReturnValue({
         onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
-      })),
+      }),
     })),
     update: vi.fn(() => ({
       set: mockUpdateSet.mockReturnValue({
@@ -277,6 +278,9 @@ describe('POST /api/stripe/webhook', () => {
     });
     // Default: the idempotency insert wins the race (fresh row) → event is processed.
     mockInsertReturning.mockResolvedValue([{ id: 'evt_test' }]);
+    mockTxInsertValues.mockReturnValue({
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
     // update().set().where() is awaited directly (completion/error marks) and also
     // chains .returning() on the reclaim takeover path.
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
@@ -494,6 +498,45 @@ describe('POST /api/stripe/webhook', () => {
         expect.objectContaining({
           subscriptionTier: 'founder',
         })
+      );
+    });
+
+    it('should set gifted=true when subscription has gift_subscription metadata', async () => {
+      const subscription = {
+        ...mockSubscription({ priceAmount: 1500 }),
+        metadata: { type: 'gift_subscription', giftedBy: 'admin_123', reason: 'Test gift' },
+      };
+      const event = mockStripeEvent('customer.subscription.created', subscription);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      await POST(request);
+
+      expect(mockTxInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ gifted: true })
+      );
+    });
+
+    it('should set gifted=false for regular (non-gift) subscriptions', async () => {
+      const subscription = mockSubscription({ priceAmount: 1500 });
+      const event = mockStripeEvent('customer.subscription.created', subscription);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      await POST(request);
+
+      expect(mockTxInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({ gifted: false })
       );
     });
 

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -361,6 +361,7 @@ async function handleSubscriptionChange(subscription: Stripe.Subscription) {
   // Use transaction to ensure subscription and user updates are atomic
   await db.transaction(async (tx) => {
     // Upsert subscription record
+    const isGifted = subscription.metadata?.type === 'gift_subscription';
     await tx.insert(subscriptions).values({
       userId,
       stripeSubscriptionId: subscription.id,
@@ -369,6 +370,7 @@ async function handleSubscriptionChange(subscription: Stripe.Subscription) {
       currentPeriodStart,
       currentPeriodEnd,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      gifted: isGifted,
       // Clear schedule fields on insert (schedule details set by update-subscription route)
       stripeScheduleId: subscription.schedule ? String(subscription.schedule) : null,
       scheduledPriceId: null,
@@ -380,6 +382,7 @@ async function handleSubscriptionChange(subscription: Stripe.Subscription) {
         currentPeriodStart,
         currentPeriodEnd,
         cancelAtPeriodEnd: subscription.cancel_at_period_end,
+        gifted: isGifted,
         // Clear schedule fields if schedule was released/completed
         ...(subscription.schedule === null && {
           stripeScheduleId: null,

--- a/packages/db/drizzle/0165_fantastic_silver_fox.sql
+++ b/packages/db/drizzle/0165_fantastic_silver_fox.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "subscriptions" ADD COLUMN "gifted" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0164_snapshot.json
+++ b/packages/db/drizzle/meta/0164_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "31a03145-1e5d-468a-9146-048b72216fc4",
+  "id": "53cb3ece-9b56-4801-b734-a15031c52be8",
   "prevId": "5549e4cb-b0b8-4246-b78e-395f689b47a2",
   "version": "7",
   "dialect": "postgresql",
@@ -9471,6 +9471,13 @@
           "notNull": true,
           "default": false
         },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
         "stripeScheduleId": {
           "name": "stripeScheduleId",
           "type": "text",
@@ -16623,7 +16630,7 @@
         "conversation_id": {
           "name": "conversation_id",
           "type": "text",
-          "primaryKey": false,
+          "primaryKey": true,
           "notNull": true
         },
         "source": {
@@ -16716,15 +16723,7 @@
         }
       },
       "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "conversation_compactions_conversation_id_source_pk": {
-          "name": "conversation_compactions_conversation_id_source_pk",
-          "columns": [
-            "conversation_id",
-            "source"
-          ]
-        }
-      },
+      "compositePrimaryKeys": {},
       "uniqueConstraints": {}
     }
   },

--- a/packages/db/drizzle/meta/0165_snapshot.json
+++ b/packages/db/drizzle/meta/0165_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "31a03145-1e5d-468a-9146-048b72216fc4",
-  "prevId": "5549e4cb-b0b8-4246-b78e-395f689b47a2",
+  "id": "c57b6db7-05fa-4edf-849d-1e0c782f453f",
+  "prevId": "31a03145-1e5d-468a-9146-048b72216fc4",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -9466,6 +9466,13 @@
         },
         "cancelAtPeriodEnd": {
           "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
           "type": "boolean",
           "primaryKey": false,
           "notNull": true,

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1153,8 +1153,8 @@
     {
       "idx": 164,
       "version": "7",
-      "when": 1781287501864,
-      "tag": "0164_cuddly_blue_marvel",
+      "when": 1781302193279,
+      "tag": "0164_outstanding_sumo",
       "breakpoints": true
     }
   ]

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1153,8 +1153,15 @@
     {
       "idx": 164,
       "version": "7",
-      "when": 1781302193279,
-      "tag": "0164_outstanding_sumo",
+      "when": 1781287501864,
+      "tag": "0164_cuddly_blue_marvel",
+      "breakpoints": true
+    },
+    {
+      "idx": 165,
+      "version": "7",
+      "when": 1781307863870,
+      "tag": "0165_fantastic_silver_fox",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/schema/subscriptions.ts
+++ b/packages/db/src/schema/subscriptions.ts
@@ -12,6 +12,7 @@ export const subscriptions = pgTable('subscriptions', {
   currentPeriodStart: timestamp('currentPeriodStart', { mode: 'date' }).notNull(),
   currentPeriodEnd: timestamp('currentPeriodEnd', { mode: 'date' }).notNull(),
   cancelAtPeriodEnd: boolean('cancelAtPeriodEnd').default(false).notNull(),
+  gifted: boolean('gifted').default(false).notNull(),
   // Schedule tracking for pending plan changes (downgrades)
   stripeScheduleId: text('stripeScheduleId'),
   scheduledPriceId: text('scheduledPriceId'),

--- a/scripts/backfill-gifted-subscriptions.ts
+++ b/scripts/backfill-gifted-subscriptions.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+/**
+ * Backfill Script: Mark existing gifted subscriptions in the DB
+ *
+ * The `gifted` column was added to the `subscriptions` table with DEFAULT false.
+ * All existing rows start as false. This script queries Stripe for each subscription,
+ * checks subscription.metadata.type === 'gift_subscription', and sets gifted = true
+ * for matches.
+ *
+ * Run once after deploying the migration:
+ *   bun scripts/backfill-gifted-subscriptions.ts [--dry-run]
+ *
+ * Options:
+ *   --dry-run   Report which subscriptions would be updated without writing.
+ */
+
+import Stripe from 'stripe';
+import { db as defaultDb } from '@pagespace/db/db';
+import { subscriptions } from '@pagespace/db/schema/subscriptions';
+import { eq, asc } from '@pagespace/db/operators';
+
+const isDryRun = process.argv.includes('--dry-run');
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2026-02-25.clover',
+});
+
+async function run(db = defaultDb) {
+  const rows = await db
+    .select({ id: subscriptions.id, stripeSubscriptionId: subscriptions.stripeSubscriptionId })
+    .from(subscriptions)
+    .orderBy(asc(subscriptions.createdAt));
+
+  console.log(`Found ${rows.length} subscription(s) to check.`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    let stripeSub: Stripe.Subscription;
+    try {
+      stripeSub = await stripe.subscriptions.retrieve(row.stripeSubscriptionId);
+    } catch (err) {
+      console.warn(`  SKIP ${row.stripeSubscriptionId}: Stripe retrieve failed — ${(err as Error).message}`);
+      skipped++;
+      continue;
+    }
+
+    const isGifted = stripeSub.metadata?.type === 'gift_subscription';
+    if (!isGifted) continue;
+
+    if (isDryRun) {
+      console.log(`  DRY-RUN would mark gifted: ${row.stripeSubscriptionId} (db id: ${row.id})`);
+    } else {
+      await db
+        .update(subscriptions)
+        .set({ gifted: true })
+        .where(eq(subscriptions.id, row.id));
+      console.log(`  Marked gifted: ${row.stripeSubscriptionId}`);
+    }
+    updated++;
+  }
+
+  console.log(`\nDone. ${updated} marked as gifted, ${skipped} skipped.`);
+  if (isDryRun) console.log('(dry-run — no writes performed)');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-gifted-subscriptions.ts
+++ b/scripts/backfill-gifted-subscriptions.ts
@@ -3,9 +3,9 @@
  * Backfill Script: Mark existing gifted subscriptions in the DB
  *
  * The `gifted` column was added to the `subscriptions` table with DEFAULT false.
- * All existing rows start as false. This script queries Stripe for each subscription,
- * checks subscription.metadata.type === 'gift_subscription', and sets gifted = true
- * for matches.
+ * All existing rows start as false. This script queries Stripe for each
+ * subscription not yet marked gifted, checks metadata.type === 'gift_subscription',
+ * and sets gifted = true for matches.
  *
  * Run once after deploying the migration:
  *   bun scripts/backfill-gifted-subscriptions.ts [--dry-run]
@@ -20,15 +20,18 @@ import { subscriptions } from '@pagespace/db/schema/subscriptions';
 import { eq, asc } from '@pagespace/db/operators';
 
 const isDryRun = process.argv.includes('--dry-run');
+const BATCH_SIZE = 10;
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2026-02-25.clover',
 });
 
 async function run(db = defaultDb) {
+  // Only fetch rows not yet marked gifted — safe to re-run, won't re-process
   const rows = await db
     .select({ id: subscriptions.id, stripeSubscriptionId: subscriptions.stripeSubscriptionId })
     .from(subscriptions)
+    .where(eq(subscriptions.gifted, false))
     .orderBy(asc(subscriptions.createdAt));
 
   console.log(`Found ${rows.length} subscription(s) to check.`);
@@ -36,29 +39,37 @@ async function run(db = defaultDb) {
   let updated = 0;
   let skipped = 0;
 
-  for (const row of rows) {
-    let stripeSub: Stripe.Subscription;
-    try {
-      stripeSub = await stripe.subscriptions.retrieve(row.stripeSubscriptionId);
-    } catch (err) {
-      console.warn(`  SKIP ${row.stripeSubscriptionId}: Stripe retrieve failed — ${(err as Error).message}`);
-      skipped++;
-      continue;
-    }
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE);
 
-    const isGifted = stripeSub.metadata?.type === 'gift_subscription';
-    if (!isGifted) continue;
+    await Promise.all(batch.map(async (row) => {
+      let stripeSub: Stripe.Subscription;
+      try {
+        stripeSub = await stripe.subscriptions.retrieve(row.stripeSubscriptionId);
+      } catch (err) {
+        console.warn(`  SKIP ${row.stripeSubscriptionId}: Stripe retrieve failed — ${(err as Error).message}`);
+        skipped++;
+        return;
+      }
 
-    if (isDryRun) {
-      console.log(`  DRY-RUN would mark gifted: ${row.stripeSubscriptionId} (db id: ${row.id})`);
-    } else {
-      await db
-        .update(subscriptions)
-        .set({ gifted: true })
-        .where(eq(subscriptions.id, row.id));
-      console.log(`  Marked gifted: ${row.stripeSubscriptionId}`);
+      const isGifted = stripeSub.metadata?.type === 'gift_subscription';
+      if (!isGifted) return;
+
+      if (isDryRun) {
+        console.log(`  DRY-RUN would mark gifted: ${row.stripeSubscriptionId} (db id: ${row.id})`);
+      } else {
+        await db
+          .update(subscriptions)
+          .set({ gifted: true })
+          .where(eq(subscriptions.id, row.id));
+        console.log(`  Marked gifted: ${row.stripeSubscriptionId}`);
+      }
+      updated++;
+    }));
+
+    if (i + BATCH_SIZE < rows.length) {
+      console.log(`  Progress: ${Math.min(i + BATCH_SIZE, rows.length)}/${rows.length}`);
     }
-    updated++;
   }
 
   console.log(`\nDone. ${updated} marked as gifted, ${skipped} skipped.`);


### PR DESCRIPTION
## Summary

- Adds a \`gifted\` boolean column to the \`subscriptions\` table (migration 0165, default \`false\`)
- Stripe webhook handler sets \`gifted = true\` when \`subscription.metadata.type === 'gift_subscription'\` on both insert and conflict-update paths
- Admin paying users query (growth dashboard) now joins \`subscriptions\`, filters to \`status IN ('active', 'trialing') AND gifted = false\` — gifted/comped users no longer inflate the count
- Backfill script \`scripts/backfill-gifted-subscriptions.ts\` retrieves each subscription from Stripe and marks existing gifted rows retroactively

## Deploy steps

1. \`bun run db:migrate\` — apply migration 0165
2. \`bun scripts/backfill-gifted-subscriptions.ts --dry-run\` — confirm the expected gifted subscriptions are detected
3. \`bun scripts/backfill-gifted-subscriptions.ts\` — mark existing gifted subscriptions

## Test plan

- [ ] Migration applies cleanly (\`bun run db:migrate\`)
- [ ] Dry-run backfill lists the expected gifted subscriptions
- [ ] After backfill, admin growth dashboard shows 0 paying users
- [ ] New gift subscriptions created via the admin gift route are marked \`gifted = true\` after the next webhook fires
- [ ] Real paid subscriptions (non-gifted) still appear in the paying users count
- [ ] \`bun run typecheck\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)