### PR TITLE
fix(monaco): disable column selection mode by default

### DIFF
--- a/apps/web/src/components/editors/MonacoEditor.tsx
+++ b/apps/web/src/components/editors/MonacoEditor.tsx
@@ -36,7 +36,6 @@ const MonacoEditor = ({ value, onChange, readOnly, language = 'html', options: o
     domReadOnly: readOnly,
     cursorWidth: readOnly ? 0 : undefined,
     contextmenu: true,
-    columnSelection: true,
     dragAndDrop: !readOnly,
     hover: readOnly ? { enabled: true } : undefined,
     readOnlyMessage: readOnly ? { value: "" } : undefined,


### PR DESCRIPTION
## Summary

- Removes `columnSelection: true` from Monaco editor default options
- This option was causing all drag-selects to produce rectangular/block selections instead of normal flowing text selections, making code pages and code editors very hard to use
- Monaco defaults to `columnSelection: false`, which matches standard VS Code behavior

## Test plan

- [ ] Open a Code page and drag-select text — should produce a normal flowing selection
- [ ] Alt+Click (Opt+Click on Mac) should add a second cursor
- [ ] Ctrl+D / Cmd+D should select next occurrence of current word

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled column selection mode in the Monaco editor to improve editing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->