### PR TITLE
feat(ai): set_home_page tool — agents can set/clear a drive's landing page

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -48,6 +48,7 @@ const TOOL_NAME_MAP: Record<string, string> = {
   'create_drive': 'Create Workspace',
   'rename_drive': 'Rename Workspace',
   'update_drive_context': 'Update Context',
+  'set_home_page': 'Set Home Page',
   // Member tools
   'list_drive_members': 'Members',
   'list_collaborators': 'Collaborators',

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -230,6 +230,16 @@ export const toolRenderers: Record<string, ToolRenderer> = {
     />
   ),
 
+  set_home_page: ({ parsedOutput }) => (
+    <ActionResultRenderer
+      actionType="update"
+      success={parsedOutput.success !== false}
+      title="Home Page"
+      message={parsedOutput.message as string | undefined}
+      errorMessage={parsedOutput.error as string | undefined}
+    />
+  ),
+
   // === PAGE READ TOOLS ===
   list_pages: ({ parsedOutput }) => {
     if (parsedOutput.tree) {

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -138,6 +138,14 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(filtered).toHaveProperty('read_page');
   });
 
+  it('classifies set_home_page as a write tool and excludes it in read-only mode', () => {
+    expect(isWriteTool('set_home_page')).toBe(true);
+    const tools = { set_home_page: 'w', list_pages: 'r' };
+    const filtered = filterToolsForReadOnly(tools, true);
+    expect(filtered).not.toHaveProperty('set_home_page');
+    expect(filtered).toHaveProperty('list_pages');
+  });
+
   it('classifies workflow tools: writes are write tools, list is read', () => {
     expect(isWriteTool('create_workflow')).toBe(true);
     expect(isWriteTool('update_workflow')).toBe(true);

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -18,6 +18,7 @@ export const WRITE_TOOLS = new Set([
   'create_drive',
   'rename_drive',
   'update_drive_context',
+  'set_home_page',
   // Explicit per-entity trash/restore (pages and drives)
   'trash_page',
   'trash_drive',

--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -172,6 +172,23 @@ describe('drive-tools', () => {
   });
 });
 
+  describe('set_home_page', () => {
+    it('has correct tool definition', () => {
+      expect(typeof driveTools.set_home_page).toBe('object');
+      expect(typeof driveTools.set_home_page.description).toBe('string');
+      expect(driveTools.set_home_page.description).toContain('home');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        driveTools.set_home_page.execute!({ driveId: 'drive-1', pageId: 'page-1' }, context)
+      ).rejects.toThrow('User authentication required');
+    });
+  });
+});
+
 // ============================================================================
 // Home Drive Guards
 // ============================================================================

--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -170,7 +170,6 @@ describe('drive-tools', () => {
       ).rejects.toThrow('Drive not found or you do not have permission to rename it');
     });
   });
-});
 
   describe('set_home_page', () => {
     it('has correct tool definition', () => {

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -7,7 +7,7 @@ import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 import { slugify } from '@pagespace/lib/utils/utils';
 import { isReservedDriveName, isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { logDriveActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
-import { getDriveAccessWithDrive } from '@pagespace/lib/services/drive-service';
+import { getDriveAccessWithDrive, isValidDriveHomePage, updateDrive } from '@pagespace/lib/services/drive-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
@@ -487,6 +487,95 @@ This context persists across conversations and helps provide better assistance. 
       } catch (error) {
         console.error('Error updating drive context:', error);
         throw new Error(`Failed to update drive context for "${driveName}": ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Set a page as the home/landing page for a drive
+   */
+  set_home_page: tool({
+    description: 'Set a page as the home/landing page of a drive. When users navigate to the drive, they land on this page instead of the default page tree. Pass null for pageId to clear the home page. Only drive owners and admins can set the home page.',
+    inputSchema: z.object({
+      driveId: z.string().describe('The unique ID of the drive'),
+      pageId: z.string().nullable().describe('The ID of the page to set as the home page, or null to clear it'),
+    }),
+    execute: async ({ driveId, pageId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      if (await driveDeniedByAppToken(context as ToolExecutionContext, driveId, 'manage')) {
+        throw new Error('This token does not have access to this drive');
+      }
+
+      try {
+        const result = await getDriveAccessWithDrive(driveId, userId);
+        if (!result) {
+          throw new Error('Drive not found');
+        }
+
+        const { drive, access } = result;
+
+        if (!access.isOwner && !access.isAdmin) {
+          throw new Error('Only drive owners and admins can set the home page');
+        }
+
+        if (typeof pageId === 'string') {
+          const valid = await isValidDriveHomePage(driveId, pageId);
+          if (!valid) {
+            throw new Error('Home page must be a non-trashed page in this drive');
+          }
+        }
+
+        const previousHomePageId = drive.homePageId;
+
+        const updatedDrive = await updateDrive(driveId, { homePageId: pageId });
+
+        const recipientUserIds = await getDriveRecipientUserIds(driveId);
+        await broadcastDriveEvent(
+          createDriveEventPayload(drive.id, 'updated', {
+            name: updatedDrive?.name ?? drive.name,
+            slug: updatedDrive?.slug ?? drive.slug,
+          }),
+          recipientUserIds
+        );
+
+        const aiContext = await getAiContextWithActor(context as ToolExecutionContext);
+        logDriveActivity(userId, 'update', {
+          id: driveId,
+          name: updatedDrive?.name ?? drive.name,
+        }, {
+          ...aiContext,
+          previousValues: { homePageId: previousHomePageId },
+          newValues: { homePageId: pageId },
+          metadata: {
+            ...aiContext.metadata,
+            updateType: 'homePageId',
+          },
+        });
+
+        const message = pageId
+          ? `Successfully set home page for "${drive.name}"`
+          : `Successfully cleared home page for "${drive.name}"`;
+
+        return {
+          success: true,
+          drive: {
+            id: driveId,
+            name: drive.name,
+            homePageId: pageId,
+          },
+          message,
+          summary: message,
+          nextSteps: pageId
+            ? ['Navigating to this drive will now land on the specified page']
+            : ['Drive will now show the default page tree on navigation'],
+        };
+      } catch (error) {
+        console.error('Error setting home page:', error);
+        throw new Error(`Failed to set home page: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   }),

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -7,12 +7,12 @@ import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 import { slugify } from '@pagespace/lib/utils/utils';
 import { isReservedDriveName, isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { logDriveActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
-import { getDriveAccessWithDrive, isValidDriveHomePage, updateDrive } from '@pagespace/lib/services/drive-service';
+import { getDriveAccessWithDrive, getDriveById, isValidDriveHomePage, updateDrive } from '@pagespace/lib/services/drive-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
 import type { ToolExecutionContext } from '../core/types';
-import { getAgentPageId, filterDriveIdsByAppTokenScope, driveDeniedByAppToken, isMcpScoped } from './actor-permissions';
+import { getAgentPageId, filterDriveIdsByAppTokenScope, driveDeniedByAppToken, isMcpScoped, canActorManageDrive } from './actor-permissions';
 
 // Helper: Extract AI attribution context with actor info for activity logging
 async function getAiContextWithActor(context: ToolExecutionContext) {
@@ -506,19 +506,13 @@ This context persists across conversations and helps provide better assistance. 
         throw new Error('User authentication required');
       }
 
-      if (await driveDeniedByAppToken(context as ToolExecutionContext, driveId, 'manage')) {
-        throw new Error('This token does not have access to this drive');
-      }
-
       try {
-        const result = await getDriveAccessWithDrive(driveId, userId);
-        if (!result) {
+        const drive = await getDriveById(driveId);
+        if (!drive) {
           throw new Error('Drive not found');
         }
 
-        const { drive, access } = result;
-
-        if (!access.isOwner && !access.isAdmin) {
+        if (!(await canActorManageDrive(context as ToolExecutionContext, driveId))) {
           throw new Error('Only drive owners and admins can set the home page');
         }
 
@@ -532,29 +526,40 @@ This context persists across conversations and helps provide better assistance. 
         const previousHomePageId = drive.homePageId;
 
         const updatedDrive = await updateDrive(driveId, { homePageId: pageId });
+        if (!updatedDrive) {
+          throw new Error('Drive update failed');
+        }
 
-        const recipientUserIds = await getDriveRecipientUserIds(driveId);
-        await broadcastDriveEvent(
-          createDriveEventPayload(drive.id, 'updated', {
-            name: updatedDrive?.name ?? drive.name,
-            slug: updatedDrive?.slug ?? drive.slug,
-          }),
-          recipientUserIds
-        );
+        try {
+          const recipientUserIds = await getDriveRecipientUserIds(driveId);
+          await broadcastDriveEvent(
+            createDriveEventPayload(drive.id, 'updated', {
+              name: updatedDrive.name,
+              slug: updatedDrive.slug,
+            }),
+            recipientUserIds
+          );
+        } catch (sideEffectError) {
+          console.error('Home page updated, but drive broadcast failed:', sideEffectError);
+        }
 
-        const aiContext = await getAiContextWithActor(context as ToolExecutionContext);
-        logDriveActivity(userId, 'update', {
-          id: driveId,
-          name: updatedDrive?.name ?? drive.name,
-        }, {
-          ...aiContext,
-          previousValues: { homePageId: previousHomePageId },
-          newValues: { homePageId: pageId },
-          metadata: {
-            ...aiContext.metadata,
-            updateType: 'homePageId',
-          },
-        });
+        try {
+          const aiContext = await getAiContextWithActor(context as ToolExecutionContext);
+          logDriveActivity(userId, 'update', {
+            id: driveId,
+            name: updatedDrive.name,
+          }, {
+            ...aiContext,
+            previousValues: { homePageId: previousHomePageId },
+            newValues: { homePageId: pageId },
+            metadata: {
+              ...aiContext.metadata,
+              updateType: 'homePageId',
+            },
+          });
+        } catch (sideEffectError) {
+          console.error('Home page updated, but activity logging failed:', sideEffectError);
+        }
 
         const message = pageId
           ? `Successfully set home page for "${drive.name}"`


### PR DESCRIPTION
## Summary

- Adds `set_home_page` to `driveTools` in `apps/web/src/lib/ai/tools/drive-tools.ts`
- Registers it in `WRITE_TOOLS` in `apps/web/src/lib/ai/core/tool-filtering.ts`

## What the tool does

Agents can now call `set_home_page` to designate any non-trashed page within a drive as its landing page. Passing `null` for `pageId` clears the home page (restoring the default page tree view).

**Authorization:** owner or admin only (via `getDriveAccessWithDrive`); scoped MCP tokens gated via `driveDeniedByAppToken`.

**Validation:** `isValidDriveHomePage` confirms the target page exists, belongs to the drive, and is not trashed — same check used by `PATCH /api/drives/[driveId]`.

**Side effects:** broadcasts `drive:updated` to all drive members + logs activity with before/after `homePageId` values.

## Test plan

- [ ] Agent sets a page as home page — drive redirects to that page on navigation
- [ ] Agent clears home page (`pageId: null`) — drive reverts to default tree
- [ ] Rejects if page belongs to a different drive (400)
- [ ] Rejects if caller is not owner/admin (403)
- [ ] Rejects if scoped MCP token lacks manage access (403)
- [ ] Read-only mode excludes `set_home_page` (it's in `WRITE_TOOLS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to set or clear a drive's home/landing page with AI tools (requires owner or admin permissions)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->