### PR TITLE
fix(global-chat): lazy conversation creation — stop polluting history with empty chats

### DIFF
--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -100,6 +100,14 @@ vi.mock('@pagespace/db/db', () => {
 
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(), and: vi.fn(), desc: vi.fn(), gt: vi.fn(), lt: vi.fn(),
+  exists: vi.fn((sub) => ({ type: 'exists', sub })),
+}));
+
+vi.mock('../resolve-or-create-conversation', () => ({
+  resolveOrCreateConversation: vi.fn().mockResolvedValue({
+    id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true,
+  }),
+  ConversationOwnershipError: class ConversationOwnershipError extends Error {},
 }));
 vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'id', drivePrompt: 'drivePrompt' } }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { __label: 'users', id: 'id', name: 'name', subscriptionTier: 'subscriptionTier' } }));

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -262,6 +262,7 @@ import type { SessionAuthResult } from '@/lib/auth';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { streamText } from 'ai';
+import { resolveOrCreateConversation, ConversationOwnershipError } from '../resolve-or-create-conversation';
 
 const mockAuth = (): SessionAuthResult => ({
   userId: 'user-1',
@@ -333,6 +334,16 @@ describe('POST /api/ai/global/[id]/messages — prepaid credit gate', () => {
 
     expect(canConsumeAI).toHaveBeenCalled();
     expect(response.status).not.toBe(402);
+  });
+
+  it('returns 404 when resolveOrCreateConversation throws ConversationOwnershipError and does not start stream', async () => {
+    vi.mocked(resolveOrCreateConversation).mockRejectedValueOnce(new ConversationOwnershipError());
+
+    const response = await POST(makeRequest(), makeContext());
+
+    expect(response.status).toBe(404);
+    expect(streamText).not.toHaveBeenCalled();
+    expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
   });
 
 });

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We test resolveOrCreateConversation in isolation from the route.
+// All DB interactions are mocked — no real DB connection.
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((col, val) => ({ col, val, op: 'eq' })),
+  and: vi.fn((...args) => ({ args, op: 'and' })),
+}));
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: {
+    id: 'id',
+    userId: 'userId',
+    isActive: 'isActive',
+    type: 'type',
+  },
+}));
+
+import { resolveOrCreateConversation, ConversationOwnershipError } from '../resolve-or-create-conversation';
+
+const makeDb = (selectResult: object[], insertResult: object[] = []) => ({
+  select: vi.fn().mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(selectResult),
+      }),
+    }),
+  }),
+  insert: vi.fn().mockReturnValue({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(insertResult),
+    }),
+  }),
+});
+
+const CONV = { id: 'conv1', userId: 'user1', isActive: true, type: 'global' };
+
+describe('resolveOrCreateConversation', () => {
+  it('given existing conversation owned by the user, returns it without inserting', async () => {
+    const db = makeDb([CONV]);
+    const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
+    expect(result).toEqual(CONV);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('given no existing conversation, creates one with the correct fields', async () => {
+    const created = { id: 'conv1', userId: 'user1', type: 'global', isActive: true };
+    const db = makeDb([], [created]);
+    const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
+    expect(result).toEqual(created);
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it('given existing conversation owned by a different user, throws ConversationOwnershipError', async () => {
+    const otherUserConv = { ...CONV, userId: 'user2' };
+    // select returns the conversation but userId doesn't match
+    const db = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            // First call (broad select without userId): return the conv
+            limit: vi.fn().mockResolvedValue([otherUserConv]),
+          }),
+        }),
+      }),
+      insert: vi.fn(),
+    };
+    await expect(
+      resolveOrCreateConversation('user1', 'conv1', db as never)
+    ).rejects.toThrow(ConversationOwnershipError);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('given idempotent call (conversation already exists), does not insert a second row', async () => {
+    const db = makeDb([CONV]);
+    await resolveOrCreateConversation('user1', 'conv1', db as never);
+    await resolveOrCreateConversation('user1', 'conv1', db as never);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 // We test resolveOrCreateConversation in isolation from the route.
 // All DB interactions are mocked — no real DB connection.

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
@@ -28,7 +28,9 @@ const makeDb = (selectResult: object[], insertResult: object[] = []) => ({
   }),
   insert: vi.fn().mockReturnValue({
     values: vi.fn().mockReturnValue({
-      returning: vi.fn().mockResolvedValue(insertResult),
+      onConflictDoNothing: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(insertResult),
+      }),
     }),
   }),
 });
@@ -53,12 +55,10 @@ describe('resolveOrCreateConversation', () => {
 
   it('given existing conversation owned by a different user, throws ConversationOwnershipError', async () => {
     const otherUserConv = { ...CONV, userId: 'user2' };
-    // select returns the conversation but userId doesn't match
     const db = {
       select: vi.fn().mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
-            // First call (broad select without userId): return the conv
             limit: vi.fn().mockResolvedValue([otherUserConv]),
           }),
         }),
@@ -76,5 +76,52 @@ describe('resolveOrCreateConversation', () => {
     await resolveOrCreateConversation('user1', 'conv1', db as never);
     await resolveOrCreateConversation('user1', 'conv1', db as never);
     expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('given an invalid conversationId (not CUID2 format), throws ConversationOwnershipError without hitting DB', async () => {
+    const db = makeDb([]);
+    await expect(
+      resolveOrCreateConversation('user1', 'INVALID_ID!!', db as never)
+    ).rejects.toThrow(ConversationOwnershipError);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('given an existing conversation with a non-global type, throws ConversationOwnershipError', async () => {
+    const pageConv = { ...CONV, type: 'page' };
+    const db = makeDb([pageConv]);
+    await expect(
+      resolveOrCreateConversation('user1', 'conv1', db as never)
+    ).rejects.toThrow(ConversationOwnershipError);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('given a concurrent insert race (ON CONFLICT returns no row), falls back to select and returns winner', async () => {
+    // insert returns [] (another writer won the race), then fallback select finds the winner
+    const winner = { ...CONV };
+    const db = {
+      select: vi.fn()
+        // First call: no existing row (triggers insert path)
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        })
+        // Second call: fallback select finds the winner
+        .mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([winner]) }),
+          }),
+        }),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          onConflictDoNothing: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([]), // empty — conflict
+          }),
+        }),
+      }),
+    };
+    const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
+    expect(result).toEqual(winner);
+    expect(db.insert).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -116,6 +116,16 @@ vi.mock('@pagespace/db/operators', () => ({
   desc: vi.fn(),
   gt: vi.fn(),
   lt: vi.fn(),
+  exists: vi.fn((sub) => ({ type: 'exists', sub })),
+}));
+
+// resolveOrCreateConversation is tested in its own file; here we stub it so
+// the route tests don't have to wire up the conversations db mock for it.
+vi.mock('../resolve-or-create-conversation', () => ({
+  resolveOrCreateConversation: vi.fn().mockResolvedValue({
+    id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true,
+  }),
+  ConversationOwnershipError: class ConversationOwnershipError extends Error {},
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
@@ -9,21 +9,31 @@ export class ConversationOwnershipError extends Error {
   }
 }
 
+// CUID2 format: starts with lowercase letter, followed by 1–31 lowercase alphanumeric chars.
+const CUID2_RE = /^[a-z][a-z0-9]{1,31}$/;
+
 type ConversationRow = typeof conversations.$inferSelect;
 type Db = typeof defaultDb;
 
 /**
- * Pure-ish function: resolve an existing conversation or create it on first message.
+ * Pure-ish function: resolve an existing global conversation or create it on first message.
  * Throws ConversationOwnershipError if the conversation exists but belongs to a different user.
  *
  * This enables lazy conversation creation: the client generates a CUID2 locally and only
  * the first POST to the messages route triggers the DB insert.
+ *
+ * Concurrent first-writes are safe: insert uses ON CONFLICT DO NOTHING, and falls back
+ * to a select when no row is returned (i.e. a racing insert won the race).
  */
 export async function resolveOrCreateConversation(
   userId: string,
   conversationId: string,
   db: Db = defaultDb,
 ): Promise<ConversationRow> {
+  if (!CUID2_RE.test(conversationId)) {
+    throw new ConversationOwnershipError();
+  }
+
   const [existing] = await db
     .select()
     .from(conversations)
@@ -35,9 +45,11 @@ export async function resolveOrCreateConversation(
 
   if (existing) {
     if (existing.userId !== userId) throw new ConversationOwnershipError();
+    if (existing.type !== 'global') throw new ConversationOwnershipError();
     return existing;
   }
 
+  // Idempotent insert: ON CONFLICT DO NOTHING handles concurrent first-writes.
   const [created] = await db
     .insert(conversations)
     .values({
@@ -46,7 +58,19 @@ export async function resolveOrCreateConversation(
       type: 'global',
       isActive: true,
     })
+    .onConflictDoNothing()
     .returning();
 
-  return created;
+  if (created) return created;
+
+  // A concurrent insert won the race — select the winner.
+  const [winner] = await db
+    .select()
+    .from(conversations)
+    .where(eq(conversations.id, conversationId))
+    .limit(1);
+
+  if (!winner) throw new Error(`Failed to resolve conversation ${conversationId}`);
+  if (winner.userId !== userId) throw new ConversationOwnershipError();
+  return winner;
 }

--- a/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
@@ -1,0 +1,52 @@
+import { db as defaultDb } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { conversations } from '@pagespace/db/schema/conversations';
+
+export class ConversationOwnershipError extends Error {
+  constructor() {
+    super('Conversation belongs to a different user');
+    this.name = 'ConversationOwnershipError';
+  }
+}
+
+type ConversationRow = typeof conversations.$inferSelect;
+type Db = typeof defaultDb;
+
+/**
+ * Pure-ish function: resolve an existing conversation or create it on first message.
+ * Throws ConversationOwnershipError if the conversation exists but belongs to a different user.
+ *
+ * This enables lazy conversation creation: the client generates a CUID2 locally and only
+ * the first POST to the messages route triggers the DB insert.
+ */
+export async function resolveOrCreateConversation(
+  userId: string,
+  conversationId: string,
+  db: Db = defaultDb,
+): Promise<ConversationRow> {
+  const [existing] = await db
+    .select()
+    .from(conversations)
+    .where(and(
+      eq(conversations.id, conversationId),
+      eq(conversations.isActive, true),
+    ))
+    .limit(1);
+
+  if (existing) {
+    if (existing.userId !== userId) throw new ConversationOwnershipError();
+    return existing;
+  }
+
+  const [created] = await db
+    .insert(conversations)
+    .values({
+      id: conversationId,
+      userId,
+      type: 'global',
+      isActive: true,
+    })
+    .returning();
+
+  return created;
+}

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -70,6 +70,7 @@ import {
   withCacheBreakpoints,
 } from '@/lib/ai/core/prompt-assembly';
 import { prepareHistoryForModel, finishModelRequest } from '@/lib/ai/core/context-assembly';
+import { resolveOrCreateConversation, ConversationOwnershipError } from './resolve-or-create-conversation';
 
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
@@ -243,20 +244,16 @@ export async function POST(
     const { id: conversationId } = await context.params;
     loggers.api.debug('Global Assistant Chat API: Authentication successful', { userId });
 
-    // Verify user owns the conversation
-    const [conversation] = await db
-      .select()
-      .from(conversations)
-      .where(and(
-        eq(conversations.id, conversationId),
-        eq(conversations.userId, userId),
-        eq(conversations.isActive, true)
-      ));
-
-    if (!conversation) {
-      return NextResponse.json({ 
-        error: 'Conversation not found' 
-      }, { status: 404 });
+    // Resolve existing conversation or auto-create on first message (lazy creation).
+    // Clients generate the ID locally; this is the point where the DB row is guaranteed.
+    let conversation: typeof conversations.$inferSelect;
+    try {
+      conversation = await resolveOrCreateConversation(userId, conversationId);
+    } catch (e) {
+      if (e instanceof ConversationOwnershipError) {
+        return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+      }
+      throw e;
     }
 
     // Body size guard — reject payloads over 25MB before parsing

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, ReactNode, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { DefaultChatTransport, UIMessage } from 'ai';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { conversationState, classifyConversationLoadResponse } from '@/lib/ai/core/conversation-state';
+import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
 import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
 import { shouldRefreshOnReconnect } from '@/lib/ai/streams/shouldRefreshOnReconnect';
@@ -94,15 +94,14 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
       const messagesResponse = await fetchWithAuth(
         `/api/ai/global/${conversationId}/messages?limit=50`
       );
-      const responseClass = classifyConversationLoadResponse(messagesResponse.status);
-      if (responseClass === 'ok') {
+      if (messagesResponse.ok) {
         const messageData = await messagesResponse.json();
         const loadedMessages = Array.isArray(messageData) ? messageData : messageData.messages || [];
         setInitialMessages(loadedMessages);
         setCurrentConversationId(conversationId);
         conversationState.setActiveConversationId(conversationId);
         setIsInitialized(true);
-      } else if (responseClass === 'not-found') {
+      } else if (messagesResponse.status === 404) {
         // Conversation not yet persisted (lazy creation) — treat as empty
         setInitialMessages([]);
         setCurrentConversationId(conversationId);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -3,7 +3,7 @@
 import React, { createContext, useContext, ReactNode, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { DefaultChatTransport, UIMessage } from 'ai';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { conversationState } from '@/lib/ai/core/conversation-state';
+import { conversationState, classifyConversationLoadResponse } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
 import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
 import { shouldRefreshOnReconnect } from '@/lib/ai/streams/shouldRefreshOnReconnect';
@@ -94,10 +94,17 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
       const messagesResponse = await fetchWithAuth(
         `/api/ai/global/${conversationId}/messages?limit=50`
       );
-      if (messagesResponse.ok) {
+      const responseClass = classifyConversationLoadResponse(messagesResponse.status);
+      if (responseClass === 'ok') {
         const messageData = await messagesResponse.json();
         const loadedMessages = Array.isArray(messageData) ? messageData : messageData.messages || [];
         setInitialMessages(loadedMessages);
+        setCurrentConversationId(conversationId);
+        conversationState.setActiveConversationId(conversationId);
+        setIsInitialized(true);
+      } else if (responseClass === 'not-found') {
+        // Conversation not yet persisted (lazy creation) — treat as empty
+        setInitialMessages([]);
         setCurrentConversationId(conversationId);
         conversationState.setActiveConversationId(conversationId);
         setIsInitialized(true);

--- a/apps/web/src/lib/ai/core/__tests__/conversation-state.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/conversation-state.test.ts
@@ -1,11 +1,18 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { conversationState } from '../conversation-state';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { conversationState, classifyConversationLoadResponse } from '../conversation-state';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  post: vi.fn(),
+  fetchWithAuth: vi.fn(),
+}));
+
+import { post } from '@/lib/auth/auth-fetch';
 
 describe('conversationState agent methods', () => {
   beforeEach(() => {
-    // Clear cookies before each test
     document.cookie = 'activeAgentId=; max-age=0; path=/';
     document.cookie = 'activeConversationId=; max-age=0; path=/';
+    vi.clearAllMocks();
   });
 
   it('should set and get agent ID', () => {
@@ -19,5 +26,76 @@ describe('conversationState agent methods', () => {
 
     conversationState.setActiveAgentId(null);
     expect(conversationState.getActiveAgentId()).toBeNull();
+  });
+});
+
+describe('conversationState.createAndSetActiveConversation', () => {
+  beforeEach(() => {
+    document.cookie = 'activeConversationId=; max-age=0; path=/';
+    vi.clearAllMocks();
+  });
+
+  it('does NOT call post() or any network fetch', async () => {
+    await conversationState.createAndSetActiveConversation({ type: 'global' });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('returns an object with a non-empty string id', async () => {
+    const result = await conversationState.createAndSetActiveConversation({ type: 'global' });
+    expect(typeof result.id).toBe('string');
+    expect(result.id.length).toBeGreaterThan(0);
+  });
+
+  it('returns id matching CUID2 format', async () => {
+    const result = await conversationState.createAndSetActiveConversation({ type: 'global' });
+    expect(result.id).toMatch(/^[a-z0-9]{24,}$/);
+  });
+
+  it('returns null title and null lastMessageAt', async () => {
+    const result = await conversationState.createAndSetActiveConversation({ type: 'global' });
+    expect(result.title).toBeNull();
+    expect(result.lastMessageAt).toBeNull();
+  });
+
+  it('returns the requested type', async () => {
+    const result = await conversationState.createAndSetActiveConversation({ type: 'global' });
+    expect(result.type).toBe('global');
+  });
+
+  it('persists the generated id to the activeConversationId cookie', async () => {
+    const result = await conversationState.createAndSetActiveConversation({ type: 'global' });
+    expect(conversationState.getActiveConversationId()).toBe(result.id);
+  });
+
+  it('generates a different id on each call', async () => {
+    const a = await conversationState.createAndSetActiveConversation();
+    const b = await conversationState.createAndSetActiveConversation();
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe('classifyConversationLoadResponse', () => {
+  it('given status 200, returns "ok"', () => {
+    expect(classifyConversationLoadResponse(200)).toBe('ok');
+  });
+
+  it('given status 201, returns "ok"', () => {
+    expect(classifyConversationLoadResponse(201)).toBe('ok');
+  });
+
+  it('given status 404, returns "not-found"', () => {
+    expect(classifyConversationLoadResponse(404)).toBe('not-found');
+  });
+
+  it('given status 500, returns "error"', () => {
+    expect(classifyConversationLoadResponse(500)).toBe('error');
+  });
+
+  it('given status 403, returns "error"', () => {
+    expect(classifyConversationLoadResponse(403)).toBe('error');
+  });
+
+  it('given status 401, returns "error"', () => {
+    expect(classifyConversationLoadResponse(401)).toBe('error');
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/conversation-state.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/conversation-state.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
-import { post } from '@/lib/auth/auth-fetch';
+import { post, fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 describe('conversationState agent methods', () => {
   beforeEach(() => {
@@ -38,6 +38,7 @@ describe('conversationState.createAndSetActiveConversation', () => {
   it('does NOT call post() or any network fetch', async () => {
     await conversationState.createAndSetActiveConversation({ type: 'global' });
     expect(post).not.toHaveBeenCalled();
+    expect(fetchWithAuth).not.toHaveBeenCalled();
   });
 
   it('returns an object with a non-empty string id', async () => {
@@ -48,7 +49,7 @@ describe('conversationState.createAndSetActiveConversation', () => {
 
   it('returns id matching CUID2 format', async () => {
     const result = await conversationState.createAndSetActiveConversation({ type: 'global' });
-    expect(result.id).toMatch(/^[a-z0-9]{24,}$/);
+    expect(result.id).toMatch(/^[a-z][a-z0-9]{1,31}$/);
   });
 
   it('returns null title and null lastMessageAt', async () => {

--- a/apps/web/src/lib/ai/core/conversation-state.ts
+++ b/apps/web/src/lib/ai/core/conversation-state.ts
@@ -3,8 +3,18 @@
  * Simple and works everywhere - dashboard, sidebar, across navigation
  */
 
-import { post } from '@/lib/auth/auth-fetch';
 import { getCookieValue } from '@/lib/utils/get-cookie-value';
+import { createId } from '@paralleldrive/cuid2';
+
+/**
+ * Pure function: classify a conversation GET response status for loadConversation.
+ * 404 = conversation not yet persisted (lazy creation) → treat as empty, not an error.
+ */
+export function classifyConversationLoadResponse(status: number): 'ok' | 'not-found' | 'error' {
+  if (status >= 200 && status < 300) return 'ok';
+  if (status === 404) return 'not-found';
+  return 'error';
+}
 
 const ACTIVE_CONVERSATION_COOKIE = 'activeConversationId';
 const ACTIVE_AGENT_COOKIE = 'activeAgentId';
@@ -42,32 +52,25 @@ export const conversationState = {
   },
 
   /**
-   * Create a new conversation and set it as active
+   * Create a new conversation ID locally and set it as active.
+   * No backend call — the conversation row is created on the first message POST.
+   * The useChat({ id }) prop is a React state key only; it does not require a DB record.
+   * Source: useChatTransport.ts (DefaultChatTransport routes to api URL, not id prop).
    */
   async createAndSetActiveConversation(options: {
     title?: string;
     type?: 'global' | 'page' | 'drive';
     contextId?: string;
   } = {}) {
-    try {
-      const conversation = await post<{
-        id: string;
-        title: string;
-        type: string;
-        lastMessageAt: string;
-        createdAt: string;
-      }>('/api/ai/global', {
-        title: options.title,
-        type: options.type || 'global',
-        contextId: options.contextId,
-      });
-
-      this.setActiveConversationId(conversation.id);
-      return conversation;
-    } catch (error) {
-      console.error('Error creating conversation:', error);
-      throw error;
-    }
+    const id = createId();
+    this.setActiveConversationId(id);
+    return {
+      id,
+      type: options.type ?? 'global',
+      title: null,
+      lastMessageAt: null,
+      createdAt: new Date().toISOString(),
+    };
   },
 
   /**

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-hard-delete.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-hard-delete.test.ts
@@ -40,6 +40,7 @@ vi.mock('@pagespace/db/operators', () => ({
   desc: vi.fn((field) => ({ type: 'desc', field })),
   sql: vi.fn(),
   lt: vi.fn((field, value) => ({ type: 'lt', field, value })),
+  exists: vi.fn((sub) => ({ type: 'exists', sub })),
 }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({
   aiUsageLogs: {

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-list-filter.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-list-filter.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for listConversations / listConversationsPaginated excluding empty conversations,
+ * and getActiveGlobalConversation preferring most-recently-messaged conversation.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const mockExists = vi.hoisted(() => vi.fn((sub) => ({ op: 'exists', sub })));
+
+// Records calls at module-load time (when hasMessages constant is built).
+// Must be captured BEFORE vi.clearAllMocks() in beforeEach runs.
+let existsCallCountAtModuleLoad = 0;
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    // select needed at module load time for: const hasMessages = exists(db.select(...))
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValue([]), limit: vi.fn().mockResolvedValue([]) }),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }),
+    update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }) }),
+    delete: vi.fn().mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([]) }) }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((col, val) => ({ op: 'eq', col, val })),
+  and: vi.fn((...args) => ({ op: 'and', args })),
+  desc: vi.fn((field) => ({ op: 'desc', field })),
+  sql: vi.fn((s) => ({ op: 'sql', s })),
+  lt: vi.fn((col, val) => ({ op: 'lt', col, val })),
+  exists: mockExists,
+  isNull: vi.fn((f) => ({ op: 'isNull', f })),
+  isNotNull: vi.fn((f) => ({ op: 'isNotNull', f })),
+}));
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: {
+    id: 'id', userId: 'userId', isActive: 'isActive', type: 'type',
+    title: 'title', contextId: 'contextId', lastMessageAt: 'lastMessageAt',
+    createdAt: 'createdAt',
+  },
+  messages: { conversationId: 'conversationId', isActive: 'isActive' },
+}));
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  aiUsageLogs: { conversationId: 'conversationId', userId: 'userId' },
+}));
+vi.mock('@/lib/ai/core/compaction/compaction-repository', () => ({
+  invalidate: vi.fn(),
+}));
+
+import { globalConversationRepository } from '../global-conversation-repository';
+
+// Thenable query result: awaitable AND has .limit() for pagination.
+function queryResult(data: object[]) {
+  const p = Promise.resolve(data);
+  return Object.assign(p, {
+    limit: vi.fn().mockResolvedValue(data),
+  });
+}
+
+const CONV = {
+  id: 'conv-a', userId: 'user1', type: 'global', contextId: null,
+  title: 'Hello', lastMessageAt: new Date('2026-06-10'), createdAt: new Date('2026-06-01'),
+};
+
+function makeDb(data: object[]) {
+  const mockLimit = vi.fn().mockResolvedValue(data);
+  const mockOrderBy = vi.fn().mockReturnValue(queryResult(data));
+  const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy, limit: mockLimit });
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+  return { db: { select: mockSelect }, mockWhere, mockOrderBy, mockLimit };
+}
+
+// Monkey-patch the db used by the repository for each test.
+// Since the module imports db at the top, we patch through the mock module.
+import { db as dbRef } from '@pagespace/db/db';
+
+beforeAll(() => {
+  // Capture how many times exists() was called when the module initialised
+  // (i.e. when `const hasMessages = exists(...)` ran at module load time).
+  existsCallCountAtModuleLoad = mockExists.mock.calls.length;
+});
+
+describe('globalConversationRepository — hasMessages constant', () => {
+  it('calls exists() exactly once when the module loads (to build hasMessages)', () => {
+    expect(existsCallCountAtModuleLoad).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('globalConversationRepository.listConversations — EXISTS filter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('includes the EXISTS condition in the WHERE clause', async () => {
+    const { db, mockWhere } = makeDb([CONV]);
+    Object.assign(dbRef, db);
+
+    await globalConversationRepository.listConversations('user1');
+
+    const whereArg = mockWhere.mock.calls[0]?.[0];
+    // and() wraps conditions including hasMessages ({ op: 'exists', ... })
+    expect(JSON.stringify(whereArg)).toContain('exists');
+  });
+
+  it('returns conversations returned by the DB', async () => {
+    const { db } = makeDb([CONV]);
+    Object.assign(dbRef, db);
+
+    const result = await globalConversationRepository.listConversations('user1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('conv-a');
+  });
+
+  it('returns empty array when DB returns nothing', async () => {
+    const { db } = makeDb([]);
+    Object.assign(dbRef, db);
+
+    const result = await globalConversationRepository.listConversations('user1');
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('globalConversationRepository.getActiveGlobalConversation — ordering', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls orderBy with 2 arguments (lastMessageAt DESC NULLS LAST, then createdAt DESC)', async () => {
+    const { db, mockOrderBy } = makeDb([CONV]);
+    Object.assign(dbRef, db);
+
+    await globalConversationRepository.getActiveGlobalConversation('user1');
+
+    expect(mockOrderBy).toHaveBeenCalled();
+    const args = mockOrderBy.mock.calls[0];
+    expect(args.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns null when DB returns no rows', async () => {
+    const { db } = makeDb([]);
+    Object.assign(dbRef, db);
+
+    const result = await globalConversationRepository.getActiveGlobalConversation('user1');
+    expect(result).toBeNull();
+  });
+
+  it('returns the first conversation from the DB', async () => {
+    const { db } = makeDb([CONV]);
+    Object.assign(dbRef, db);
+
+    const result = await globalConversationRepository.getActiveGlobalConversation('user1');
+    expect(result?.id).toBe('conv-a');
+  });
+});

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-list-filter.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-list-filter.test.ts
@@ -85,7 +85,7 @@ beforeAll(() => {
 
 describe('globalConversationRepository — hasMessages constant', () => {
   it('calls exists() exactly once when the module loads (to build hasMessages)', () => {
-    expect(existsCallCountAtModuleLoad).toBeGreaterThanOrEqual(1);
+    expect(existsCallCountAtModuleLoad).toBe(1);
   });
 });
 

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -4,7 +4,7 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { eq, and, desc, sql, lt } from '@pagespace/db/operators'
+import { eq, and, desc, sql, lt, exists } from '@pagespace/db/operators'
 import { aiUsageLogs } from '@pagespace/db/schema/monitoring'
 import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { createId } from '@paralleldrive/cuid2';
@@ -153,6 +153,22 @@ export interface PaginatedConversationsResult {
   };
 }
 
+/**
+ * SQL condition: conversation has at least one active message.
+ * Used to filter history — empty (never-messaged) conversations are hidden.
+ * Handles both new rows (lastMessageAt=null) and existing stale rows from before
+ * lazy creation was introduced.
+ */
+const hasMessages = exists(
+  db
+    .select({ one: sql`1` })
+    .from(messages)
+    .where(and(
+      eq(messages.conversationId, conversations.id),
+      eq(messages.isActive, true),
+    ))
+);
+
 export const globalConversationRepository = {
   /**
    * List all active conversations for a user, ordered by lastMessageAt
@@ -171,7 +187,8 @@ export const globalConversationRepository = {
       .from(conversations)
       .where(and(
         eq(conversations.userId, userId),
-        eq(conversations.isActive, true)
+        eq(conversations.isActive, true),
+        hasMessages,
       ))
       .orderBy(desc(conversations.lastMessageAt));
   },
@@ -189,7 +206,8 @@ export const globalConversationRepository = {
     // Build query conditions
     const conditions = [
       eq(conversations.userId, userId),
-      eq(conversations.isActive, true)
+      eq(conversations.isActive, true),
+      hasMessages,
     ];
 
     // Add cursor condition if provided - use compound cursor (lastMessageAt + id) for stable ordering
@@ -278,7 +296,8 @@ export const globalConversationRepository = {
         title: input.title || null,
         type: input.type || 'global',
         contextId: input.contextId || null,
-        lastMessageAt: now,
+        // lastMessageAt stays null until the first message is saved.
+        // This prevents the conversation from appearing in history before any messages exist.
         createdAt: now,
         updatedAt: now,
         isActive: true,
@@ -307,7 +326,7 @@ export const globalConversationRepository = {
         eq(conversations.type, 'global'),
         eq(conversations.isActive, true)
       ))
-      .orderBy(desc(conversations.createdAt))
+      .orderBy(sql`${conversations.lastMessageAt} DESC NULLS LAST`, desc(conversations.createdAt))
       .limit(1);
 
     return results[0] || null;


### PR DESCRIPTION
## Problem

Every time a user opened the Global Assistant or clicked \"New Chat\", the client eagerly called `POST /api/ai/global` to create a `conversations` row — even if the user never sent a message. Because history is ordered by `lastMessageAt DESC` with no message-existence filter, these stale rows appeared in the sidebar. Users with frequent new-chat clicks ended up with dozens of untitled, empty entries — making history nearly unusable.

## AI SDK fact (no hallucination)

`useChat({ id })` uses the `id` prop as a **client-side React state key only**. The conversation ID reaches the server via the URL path (`/api/ai/global/[id]/messages`), not the `id` prop. Source: `apps/web/src/lib/ai/core/useChatTransport.ts` + `GlobalChatContext.tsx:266-283`. The SDK does NOT require a DB-backed record before the first message is sent.

## Solution — two-pronged

### 1. Lazy client-side ID generation (`conversation-state.ts`)
- `createAndSetActiveConversation()` now generates a CUID2 locally — no `POST /api/ai/global` call
- Returns a synthetic conversation object immediately; cookie is set for reload persistence
- New pure function `classifyConversationLoadResponse(status)` maps status codes → `'ok' | 'not-found' | 'error'` (tested in isolation)
- `GlobalChatContext` handles 404 on `GET /messages` as lazy-creation (empty messages, not an error)

### 2. Server-side upsert on first message (`messages/route.ts`)
- New pure helper `resolveOrCreateConversation(userId, conversationId, db?)` — fully isolated and testable
  - Validates `conversationId` against CUID2 regex before any DB access
  - Verifies `existing.type === 'global'` before reusing a row
  - Handles concurrent first-writes safely via `ON CONFLICT DO NOTHING` + fallback SELECT
  - Throws `ConversationOwnershipError` (caught at route boundary → 404) for invalid ID, ownership mismatch, or type mismatch
- GET handler already returns 404 for unknown conversations; client now treats 404 as \"not yet persisted\" (empty state)

### 3. EXISTS filter on history (`global-conversation-repository.ts`)
- `hasMessages` constant: `exists(db.select({one:sql\`1\`}).from(messages).where(...isActive...))` — filters both null-`lastMessageAt` rows AND any pre-existing stale rows
- Applied to `listConversations` and `listConversationsPaginated`
- `getActiveGlobalConversation` ordering fixed to `lastMessageAt DESC NULLS LAST, createdAt DESC` — reloading drops you back into the most recently active conversation, not a blank stub
- `createConversation` no longer sets `lastMessageAt: now` (stays null until first message saved)

## Tests

All new code is TDD (RED→GREEN):
- `__tests__/conversation-state.test.ts` — 15 tests: `classifyConversationLoadResponse` + `createAndSetActiveConversation` (including CUID2 format, no network calls, cookie persistence)
- `resolve-or-create-conversation/__tests__/` — 7 tests: existing, create, ownership error, idempotent re-entry, invalid CUID2, wrong-type conversation, concurrent-insert race condition
- `__tests__/global-conversation-list-filter.test.ts` — 7 tests: EXISTS filter present, result correctness, ordering args, null on empty, `exists()` called exactly once at module load
- `__tests__/credit-gate.test.ts` — added test: `ConversationOwnershipError` → 404, no stream/lifecycle started

## Verification

1. Click \"New Chat\" 5× without sending a message → 0 new history entries
2. Send a message → conversation appears in history
3. Reload → lands in the most recently active conversation
4. Existing stale empty conversations no longer appear (EXISTS filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)