### PR TITLE
fix(calendar): remove unused RecurrenceRule import

### DIFF
--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -15,7 +15,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkM
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { pushEventToGoogle } from '@/lib/integrations/google-calendar/push-service';
 import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
-import { expandRecurringEvents, RecurrenceRule } from '@/lib/workflows/recurrence-utils';
+import { expandRecurringEvents } from '@/lib/workflows/recurrence-utils';
 import { CronExpressionParser } from 'cron-parser';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };


### PR DESCRIPTION
## Summary
- Removes the unused `RecurrenceRule` type import from `apps/web/src/app/api/calendar/events/route.ts` (line 18)
- This import was left behind when `expandRecurringEvents` was moved to `recurrence-utils.ts` in 8df78e8ed but the type was no longer needed at the call site
- The unused import caused an ESLint `@typescript-eslint/no-unused-vars` error that broke the build and all CI checks on master

## Test plan
- [ ] CI lint passes
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized calendar events API by removing unused import references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->