### PR TITLE
fix(ai): require user address before finish tool — no silent turns

### DIFF
--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -28,8 +28,8 @@ const BEHAVIOR_PROMPT = `APPROACH:
 • When intent is clear (find, create, show me), use tools right away
 • Share interesting findings as you work
 • Complete what you start, don't overextend beyond what was asked
-• When you have finished all requested work, always address the user first — summarise what was done, then call the finish tool. Never end a turn silently after a string of tool calls.
-• If a sequence of tool calls produced no meaningful output to share, still close with a one-liner so the user knows the turn is done.
+• At the end of a turn — whenever finish is called or the last step completes — send one message to the user summarising what was done. A string of silent tool calls with no closing message is a broken UX, not an efficient one.
+• If the tool calls produced nothing worth reporting, still close with a one-liner so the user knows the turn is done.
 
 STYLE:
 • Skip preambles ("I'll help you...") and postambles ("Let me know if...")

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -28,7 +28,8 @@ const BEHAVIOR_PROMPT = `APPROACH:
 • When intent is clear (find, create, show me), use tools right away
 • Share interesting findings as you work
 • Complete what you start, don't overextend beyond what was asked
-• When you have finished all requested work, call the finish tool to signal completion
+• When you have finished all requested work, always address the user first — summarise what was done, then call the finish tool. Never end a turn silently after a string of tool calls.
+• If a sequence of tool calls produced no meaningful output to share, still close with a one-liner so the user knows the turn is done.
 
 STYLE:
 • Skip preambles ("I'll help you...") and postambles ("Let me know if...")

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -26,7 +26,6 @@ const CORE_PROMPT = `You are PageSpace AI. You can explore, read, and modify the
 const BEHAVIOR_PROMPT = `APPROACH:
 • When ideas are forming, engage in conversation before reaching for tools
 • When intent is clear (find, create, show me), use tools right away
-• Share interesting findings as you work
 • Complete what you start, don't overextend beyond what was asked
 • At the end of a turn — whenever finish is called or the last step completes — send one message to the user summarising what was done. A string of silent tool calls with no closing message is a broken UX, not an efficient one.
 • If the tool calls produced nothing worth reporting, still close with a one-liner so the user knows the turn is done.


### PR DESCRIPTION
## Summary

Tightens the turn-end messaging rule in the AI system prompt (`BEHAVIOR_PROMPT`) to eliminate silent turns.

**Key change:** framed as a state-transition, not a per-tool instruction — the rule fires once, at the end of the turn, not after each individual tool call.

- **Updated bullet:** *"At the end of a turn — whenever finish is called or the last step completes — send one message to the user summarising what was done. A string of silent tool calls with no closing message is a broken UX, not an efficient one."*
- **Fallback bullet:** *"If the tool calls produced nothing worth reporting, still close with a one-liner so the user knows the turn is done."*

One file changed: `apps/web/src/lib/ai/core/system-prompt.ts`

## Test plan

- [ ] Trigger a multi-tool action (e.g. "find all pages tagged X and rename them") — confirm a single closing summary appears after all tools complete, not after each one
- [ ] Trigger a silent action with no output (e.g. "move this page to folder Y") — confirm it still closes with a one-liner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLgRh1rgYLJAyXy7yJpPai