### PR TITLE
feat(sandbox): terminal session key, lifecycle planning, and acquireTerminalSandbox

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -317,6 +317,11 @@
       "import": "./dist/services/sandbox/session-manager.js",
       "require": "./dist/services/sandbox/session-manager.js"
     },
+    "./services/sandbox/terminal-session-manager": {
+      "types": "./dist/services/sandbox/terminal-session-manager.d.ts",
+      "import": "./dist/services/sandbox/terminal-session-manager.js",
+      "require": "./dist/services/sandbox/terminal-session-manager.js"
+    },
     "./services/sandbox/command-policy": {
       "types": "./dist/services/sandbox/command-policy.d.ts",
       "import": "./dist/services/sandbox/command-policy.js",
@@ -1114,6 +1119,9 @@
       ],
       "services/sandbox/session-manager": [
         "./dist/services/sandbox/session-manager.d.ts"
+      ],
+      "services/sandbox/terminal-session-manager": [
+        "./dist/services/sandbox/terminal-session-manager.d.ts"
       ],
       "services/sandbox/command-policy": [
         "./dist/services/sandbox/command-policy.d.ts"

--- a/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveTerminalSessionKey,
+  planTerminalLifecycle,
+  acquireTerminalSandbox,
+  type TerminalSessionStore,
+  type TerminalSessionRecord,
+} from '../terminal-session-manager';
+import type { SandboxClient } from '../session-manager';
+
+const SECRET = 'x'.repeat(32);
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+
+const namespacing = { tenantId: 't1', driveId: 'd1', pageId: 'p1' };
+const actor = { userId: 'u1', ...namespacing };
+
+function keyFor() {
+  return deriveTerminalSessionKey({ ...namespacing, secret: SECRET });
+}
+
+function makeStore(seed?: TerminalSessionRecord) {
+  const rows = new Map<string, TerminalSessionRecord>();
+  if (seed) rows.set(seed.sessionKey, seed);
+  const calls = { save: 0, touch: 0, remove: 0 };
+  const store: TerminalSessionStore = {
+    findBySessionKey: async (sessionKey) => rows.get(sessionKey) ?? null,
+    save: async (input) => {
+      calls.save += 1;
+      rows.set(input.sessionKey, {
+        sessionKey: input.sessionKey,
+        pageId: input.pageId,
+        userId: input.userId,
+        sandboxId: input.sandboxId,
+        lastActiveAt: input.now,
+      });
+    },
+    touch: async ({ sessionKey, now }) => {
+      calls.touch += 1;
+      const row = rows.get(sessionKey);
+      if (row) rows.set(sessionKey, { ...row, lastActiveAt: now });
+    },
+    remove: async (sessionKey) => {
+      calls.remove += 1;
+      rows.delete(sessionKey);
+    },
+  };
+  return { store, rows, calls };
+}
+
+function makeClient(overrides: Partial<SandboxClient> = {}) {
+  const calls = {
+    getOrCreate: [] as Array<{ name: string }>,
+    get: [] as string[],
+    stop: [] as string[],
+  };
+  const client: SandboxClient = {
+    getOrCreate: async ({ name }) => {
+      calls.getOrCreate.push({ name });
+      return { sandboxId: 'sbx-new' };
+    },
+    get: async ({ sandboxId }) => {
+      calls.get.push(sandboxId);
+      return { sandboxId };
+    },
+    stop: async ({ sandboxId }) => {
+      calls.stop.push(sandboxId);
+    },
+    ...overrides,
+  };
+  return { client, calls };
+}
+
+function seedRecord(over: Partial<TerminalSessionRecord> = {}): TerminalSessionRecord {
+  return {
+    sessionKey: keyFor(),
+    pageId: 'p1',
+    userId: 'u1',
+    sandboxId: 'sbx-existing',
+    lastActiveAt: new Date('2026-06-01T11:59:00.000Z'),
+    ...over,
+  };
+}
+
+describe('deriveTerminalSessionKey', () => {
+  it('given the same inputs, returns the same key every time', () => {
+    const a = deriveTerminalSessionKey({ ...namespacing, secret: SECRET });
+    const b = deriveTerminalSessionKey({ ...namespacing, secret: SECRET });
+    expect(a).toBe(b);
+  });
+
+  it('given different pageIds (same tenantId+driveId), returns different keys', () => {
+    const a = deriveTerminalSessionKey({ ...namespacing, pageId: 'p1', secret: SECRET });
+    const b = deriveTerminalSessionKey({ ...namespacing, pageId: 'p2', secret: SECRET });
+    expect(a).not.toBe(b);
+  });
+
+  it('given an empty string secret, throws', () => {
+    expect(() => deriveTerminalSessionKey({ ...namespacing, secret: '' })).toThrow(
+      'deriveTerminalSessionKey requires a non-empty secret',
+    );
+  });
+});
+
+describe('planTerminalLifecycle', () => {
+  it('given canRun=false and no session, returns { action: deny }', () => {
+    const result = planTerminalLifecycle({ canRun: false, now: NOW });
+    expect(result).toEqual({ action: 'deny' });
+  });
+
+  it('given canRun=false and an existing session, returns { action: deny } (re-authz enforced)', () => {
+    const result = planTerminalLifecycle({
+      canRun: false,
+      existingSession: { sandboxId: 'sbx-x', lastActiveAt: NOW },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'deny' });
+  });
+
+  it('given canRun=true and no session, returns { action: create }', () => {
+    const result = planTerminalLifecycle({ canRun: true, now: NOW });
+    expect(result).toEqual({ action: 'create' });
+  });
+
+  it('given canRun=true and a fresh session, returns { action: resume, sandboxId }', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      existingSession: { sandboxId: 'sbx-warm', lastActiveAt: new Date(NOW.getTime() - 1000) },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'resume', sandboxId: 'sbx-warm' });
+  });
+
+  it('given canRun=true and an idle session (lastActiveAt older than idleTimeoutMs), returns { action: teardown, reason: idle }', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      existingSession: { sandboxId: 'sbx-idle', lastActiveAt: new Date(NOW.getTime() - 20 * 60 * 1000) },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'teardown', sandboxId: 'sbx-idle', reason: 'idle' });
+  });
+
+  it('given intent=end and an existing session, returns { action: teardown, reason: session_end }', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      existingSession: { sandboxId: 'sbx-end', lastActiveAt: NOW },
+      now: NOW,
+      intent: 'end',
+    });
+    expect(result).toEqual({ action: 'teardown', sandboxId: 'sbx-end', reason: 'session_end' });
+  });
+
+  it('given intent=end and no session, returns { action: noop }', () => {
+    const result = planTerminalLifecycle({ canRun: true, now: NOW, intent: 'end' });
+    expect(result).toEqual({ action: 'noop' });
+  });
+});
+
+describe('acquireTerminalSandbox', () => {
+  it('given empty pageId, returns { ok: false, reason: error }', async () => {
+    const { store } = makeStore();
+    const { client } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      pageId: '',
+      deps: { store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: false, reason: 'error' });
+  });
+
+  it('given empty secret, returns { ok: false, reason: error }', async () => {
+    const { store } = makeStore();
+    const { client } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      deps: { store, client, now: () => NOW, secret: '' },
+    });
+    expect(result).toEqual({ ok: false, reason: 'error' });
+  });
+
+  it('given no existing session, calls client.getOrCreate and store.save; returns { ok: true, resumed: false }', async () => {
+    const { store, calls: storeCalls } = makeStore();
+    const { client, calls } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      deps: { store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
+    expect(calls.getOrCreate).toEqual([{ name: keyFor() }]);
+    expect(storeCalls.save).toBe(1);
+  });
+
+  it('given fresh existing session and client.get returns a handle, returns { ok: true, resumed: true } without calling getOrCreate', async () => {
+    const { store, calls: storeCalls } = makeStore(seedRecord());
+    const { client, calls } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      deps: { store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-existing', resumed: true });
+    expect(calls.get).toEqual(['sbx-existing']);
+    expect(calls.getOrCreate).toEqual([]);
+    expect(storeCalls.touch).toBe(1);
+  });
+
+  it('given existing session but client.get returns null (VM gone), provisions fresh (calls getOrCreate)', async () => {
+    const { store, calls: storeCalls } = makeStore(seedRecord());
+    const { client, calls } = makeClient({ get: async () => null });
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      deps: { store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
+    expect(storeCalls.remove).toBe(1);
+    expect(calls.getOrCreate).toEqual([{ name: keyFor() }]);
+  });
+
+  it('given store.save throws after getOrCreate, calls client.stop and returns { ok: false, reason: provision_failed }', async () => {
+    const failingStore = makeStore();
+    failingStore.store.save = async () => {
+      throw new Error('db down');
+    };
+    const { client, calls } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      deps: { store: failingStore.store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: false, reason: 'provision_failed' });
+    expect(calls.stop).toEqual(['sbx-new']);
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
@@ -161,6 +161,7 @@ describe('acquireTerminalSandbox', () => {
     const { client } = makeClient();
     const result = await acquireTerminalSandbox({
       ...actor,
+      canRun: true,
       pageId: '',
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
@@ -172,6 +173,7 @@ describe('acquireTerminalSandbox', () => {
     const { client } = makeClient();
     const result = await acquireTerminalSandbox({
       ...actor,
+      canRun: true,
       deps: { store, client, now: () => NOW, secret: '' },
     });
     expect(result).toEqual({ ok: false, reason: 'error' });
@@ -182,6 +184,7 @@ describe('acquireTerminalSandbox', () => {
     const { client, calls } = makeClient();
     const result = await acquireTerminalSandbox({
       ...actor,
+      canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
     expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
@@ -194,6 +197,7 @@ describe('acquireTerminalSandbox', () => {
     const { client, calls } = makeClient();
     const result = await acquireTerminalSandbox({
       ...actor,
+      canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
     expect(result).toEqual({ ok: true, sandboxId: 'sbx-existing', resumed: true });
@@ -207,6 +211,7 @@ describe('acquireTerminalSandbox', () => {
     const { client, calls } = makeClient({ get: async () => null });
     const result = await acquireTerminalSandbox({
       ...actor,
+      canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
     expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
@@ -222,9 +227,42 @@ describe('acquireTerminalSandbox', () => {
     const { client, calls } = makeClient();
     const result = await acquireTerminalSandbox({
       ...actor,
+      canRun: true,
       deps: { store: failingStore.store, client, now: () => NOW, secret: SECRET },
     });
     expect(result).toEqual({ ok: false, reason: 'provision_failed' });
     expect(calls.stop).toEqual(['sbx-new']);
+  });
+
+  it('given canRun=false, returns { ok: false, reason: deny } without calling client', async () => {
+    const { store } = makeStore(seedRecord());
+    const { client, calls } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      canRun: false,
+      deps: { store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: false, reason: 'deny' });
+    expect(calls.get).toEqual([]);
+    expect(calls.getOrCreate).toEqual([]);
+    expect(calls.stop).toEqual([]);
+  });
+
+  it('given teardown plan and safeStop fails, keeps the session link and returns { ok: false, reason: error }', async () => {
+    // lastActiveAt 20 min ago triggers idle teardown (default timeout = 15 min)
+    const stale = seedRecord({ lastActiveAt: new Date(NOW.getTime() - 20 * 60 * 1000) });
+    const { store, calls: storeCalls } = makeStore(stale);
+    const { client } = makeClient({
+      stop: async () => {
+        throw new Error('stop failed');
+      },
+    });
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      canRun: true,
+      deps: { store, client, now: () => NOW, secret: SECRET },
+    });
+    expect(result).toEqual({ ok: false, reason: 'error' });
+    expect(storeCalls.remove).toBe(0);
   });
 });

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -1,0 +1,226 @@
+import { createHmac } from 'crypto';
+import { mapPolicyToSandboxOptions } from './sandbox-options';
+import type { SandboxClient } from './session-manager';
+
+export interface TerminalSessionKeyInput {
+  tenantId: string;
+  driveId: string;
+  pageId: string;
+  secret: string;
+}
+
+const NAMESPACE_VERSION = 'terminal-session:v1';
+
+export function deriveTerminalSessionKey({
+  tenantId,
+  driveId,
+  pageId,
+  secret,
+}: TerminalSessionKeyInput): string {
+  if (secret.length === 0) {
+    throw new Error('deriveTerminalSessionKey requires a non-empty secret');
+  }
+  const payload = [NAMESPACE_VERSION, tenantId, driveId, pageId].join('\0');
+  const digest = createHmac('sha3-256', secret).update(payload).digest('hex');
+  return `pgs-sbx-${digest}`;
+}
+
+export type TerminalTeardownReason = 'idle' | 'session_end';
+export type TerminalLifecycleIntent = 'run' | 'end';
+
+export interface TerminalSessionRef {
+  sandboxId: string;
+  lastActiveAt: Date;
+}
+
+export type TerminalLifecyclePlan =
+  | { action: 'create' }
+  | { action: 'resume'; sandboxId: string }
+  | { action: 'teardown'; sandboxId: string; reason: TerminalTeardownReason }
+  | { action: 'noop' }
+  | { action: 'deny' };
+
+export interface PlanTerminalLifecycleInput {
+  canRun: boolean;
+  existingSession?: TerminalSessionRef | null;
+  now: Date;
+  idleTimeoutMs?: number;
+  intent?: TerminalLifecycleIntent;
+}
+
+const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
+
+export function planTerminalLifecycle({
+  canRun,
+  existingSession = null,
+  now,
+  idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
+  intent = 'run',
+}: PlanTerminalLifecycleInput): TerminalLifecyclePlan {
+  // Cleanup is unconditional on 'end' intent — authorization never gates cleanup.
+  if (intent === 'end') {
+    return existingSession
+      ? { action: 'teardown', sandboxId: existingSession.sandboxId, reason: 'session_end' }
+      : { action: 'noop' };
+  }
+
+  // Resume re-authz: deny before considering any warm session so an unauthorized
+  // actor is never handed back another session's state.
+  if (!canRun) {
+    return { action: 'deny' };
+  }
+
+  if (!existingSession) {
+    return { action: 'create' };
+  }
+
+  const idleFor = now.getTime() - existingSession.lastActiveAt.getTime();
+  if (idleFor >= idleTimeoutMs) {
+    return { action: 'teardown', sandboxId: existingSession.sandboxId, reason: 'idle' };
+  }
+
+  return { action: 'resume', sandboxId: existingSession.sandboxId };
+}
+
+export interface TerminalSessionRecord {
+  sessionKey: string;
+  pageId: string;
+  sandboxId: string;
+  userId: string;
+  lastActiveAt: Date;
+}
+
+export interface TerminalSessionStore {
+  findBySessionKey(sessionKey: string): Promise<TerminalSessionRecord | null>;
+  save(input: { sessionKey: string; pageId: string; sandboxId: string; userId: string; now: Date }): Promise<void>;
+  touch(args: { sessionKey: string; now: Date }): Promise<void>;
+  remove(sessionKey: string): Promise<void>;
+}
+
+export interface AcquireTerminalSandboxInput {
+  pageId: string;
+  driveId: string;
+  tenantId: string;
+  userId: string;
+  deps: {
+    store: TerminalSessionStore;
+    client: SandboxClient;
+    now: () => Date;
+    secret: string;
+  };
+}
+
+export type AcquireTerminalSandboxResult =
+  | { ok: true; sandboxId: string; resumed: boolean }
+  | { ok: false; reason: 'deny' | 'provision_failed' | 'error' };
+
+async function safeStop(client: SandboxClient, sandboxId: string): Promise<boolean> {
+  try {
+    await client.stop({ sandboxId });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeRemove(store: TerminalSessionStore, sessionKey: string): Promise<void> {
+  try {
+    await store.remove(sessionKey);
+  } catch {
+    // best-effort
+  }
+}
+
+async function safeTouch(store: TerminalSessionStore, sessionKey: string, now: Date): Promise<void> {
+  try {
+    await store.touch({ sessionKey, now });
+  } catch {
+    // best-effort
+  }
+}
+
+async function provisionFreshTerminal({
+  key,
+  input,
+}: {
+  key: string;
+  input: AcquireTerminalSandboxInput;
+}): Promise<AcquireTerminalSandboxResult> {
+  const { deps, pageId, userId } = input;
+  const options = mapPolicyToSandboxOptions({});
+
+  let sandboxId: string;
+  try {
+    const handle = await deps.client.getOrCreate({ name: key, options });
+    sandboxId = handle.sandboxId;
+  } catch {
+    return { ok: false, reason: 'provision_failed' };
+  }
+
+  try {
+    await deps.store.save({ sessionKey: key, pageId, userId, sandboxId, now: deps.now() });
+  } catch {
+    // The sandbox exists but we could not record the link — tear it down to
+    // prevent an unreachable, unaudited orphan.
+    await safeStop(deps.client, sandboxId);
+    return { ok: false, reason: 'provision_failed' };
+  }
+
+  return { ok: true, sandboxId, resumed: false };
+}
+
+export async function acquireTerminalSandbox(
+  input: AcquireTerminalSandboxInput,
+): Promise<AcquireTerminalSandboxResult> {
+  const { deps, pageId, driveId, tenantId, userId } = input;
+
+  // Fail closed if any namespacing component or the secret is missing.
+  if (!deps.secret || !pageId || !driveId || !tenantId || !userId) {
+    return { ok: false, reason: 'error' };
+  }
+
+  const key = deriveTerminalSessionKey({ tenantId, driveId, pageId, secret: deps.secret });
+
+  try {
+    const existing = await deps.store.findBySessionKey(key);
+
+    const plan = planTerminalLifecycle({
+      canRun: true,
+      existingSession: existing
+        ? { sandboxId: existing.sandboxId, lastActiveAt: existing.lastActiveAt }
+        : null,
+      now: deps.now(),
+      intent: 'run',
+    });
+
+    switch (plan.action) {
+      case 'deny':
+        return { ok: false, reason: 'deny' };
+
+      case 'create':
+        return await provisionFreshTerminal({ key, input });
+
+      case 'resume': {
+        const handle = await deps.client.get({ sandboxId: plan.sandboxId });
+        if (!handle) {
+          // Recorded sandbox is gone — drop the stale link and provision fresh.
+          await deps.store.remove(key);
+          return await provisionFreshTerminal({ key, input });
+        }
+        await safeTouch(deps.store, key, deps.now());
+        return { ok: true, sandboxId: handle.sandboxId, resumed: true };
+      }
+
+      case 'teardown': {
+        await safeStop(deps.client, plan.sandboxId);
+        await safeRemove(deps.store, key);
+        return await provisionFreshTerminal({ key, input });
+      }
+
+      default:
+        return { ok: false, reason: 'error' };
+    }
+  } catch {
+    return { ok: false, reason: 'error' };
+  }
+}

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -102,6 +102,8 @@ export interface AcquireTerminalSandboxInput {
   driveId: string;
   tenantId: string;
   userId: string;
+  /** Caller re-checks authz every request and passes the result through to the planner. */
+  canRun: boolean;
   deps: {
     store: TerminalSessionStore;
     client: SandboxClient;
@@ -172,7 +174,7 @@ async function provisionFreshTerminal({
 export async function acquireTerminalSandbox(
   input: AcquireTerminalSandboxInput,
 ): Promise<AcquireTerminalSandboxResult> {
-  const { deps, pageId, driveId, tenantId, userId } = input;
+  const { deps, pageId, driveId, tenantId, userId, canRun } = input;
 
   // Fail closed if any namespacing component or the secret is missing.
   if (!deps.secret || !pageId || !driveId || !tenantId || !userId) {
@@ -185,7 +187,7 @@ export async function acquireTerminalSandbox(
     const existing = await deps.store.findBySessionKey(key);
 
     const plan = planTerminalLifecycle({
-      canRun: true,
+      canRun,
       existingSession: existing
         ? { sandboxId: existing.sandboxId, lastActiveAt: existing.lastActiveAt }
         : null,
@@ -212,7 +214,11 @@ export async function acquireTerminalSandbox(
       }
 
       case 'teardown': {
-        await safeStop(deps.client, plan.sandboxId);
+        const stopped = await safeStop(deps.client, plan.sandboxId);
+        if (!stopped) {
+          // VM may still be running — keep the link so the idle reaper can reclaim it.
+          return { ok: false, reason: 'error' };
+        }
         await safeRemove(deps.store, key);
         return await provisionFreshTerminal({ key, input });
       }


### PR DESCRIPTION
## Summary

PR1 of the Terminal Page → Sprites epic. Pure functions + IO interface only — no DB implementation, no migration.

- **`deriveTerminalSessionKey`** — HMAC-SHA3-256, namespace `terminal-session:v1`, page-scoped (`tenantId + driveId + pageId`). Fail-closed on empty secret.
- **`planTerminalLifecycle`** — pure lifecycle planner that takes `canRun: boolean` (caller does authz). Resume re-authz enforced: deny even when a warm session exists. Cleanup unconditional on `end` intent.
- **`TerminalSessionStore`** — IO boundary interface with `TerminalSessionRecord`. No implementation, no real DB.
- **`acquireTerminalSandbox`** — dependency-injected, fully testable. No-orphan guarantee: if `store.save` fails after `getOrCreate`, calls `safeStop`. Fail-closed on missing inputs.

## Files changed

- `packages/lib/src/services/sandbox/terminal-session-manager.ts` — new implementation
- `packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts` — 16 tests (TDD: RED then GREEN)
- `packages/lib/package.json` — exports entry for `./services/sandbox/terminal-session-manager`

## Test plan

- [x] 16 tests all pass: `bun vitest run src/services/sandbox/__tests__/terminal-session-manager.test.ts`
- [x] `bun run --filter '@pagespace/lib' build` — clean
- [x] `bun run --filter '@pagespace/lib' typecheck` — clean
- [x] Full monorepo typecheck — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C5UawKVMC5FHZ9Abx6BNm2