### PR TITLE
feat(ai): page AI inherits inline instructions by default (tool-aware)

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -49,6 +49,7 @@ import {
 import { planCommandExecution } from '@/lib/ai/core/command-resolver';
 import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import { buildSystemPrompt, buildPersonalizationPrompt } from '@/lib/ai/core/system-prompt';
+import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
 import { filterToolsForReadOnly } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
 import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
@@ -832,6 +833,19 @@ export async function POST(request: Request) {
         } : undefined,
         readOnlyMode,
         personalization ?? undefined
+      );
+
+      // Append workspace knowledge (tool-aware). Custom systemPrompt = opt-out (blank slate).
+      systemPrompt += buildInlineInstructions(
+        {
+          pageTitle: pageContext?.pageTitle,
+          pageType: pageContext?.pageType,
+          driveName: pageContext?.driveName,
+          pagePath: pageContext?.pagePath,
+          driveSlug: pageContext?.driveSlug,
+          driveId: pageContext?.driveId,
+        },
+        Object.keys(filteredTools)
       );
     }
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -641,6 +641,10 @@ export async function POST(request: Request) {
     // search mode too — routing it through execute_tool would hit that tool's
     // allowlist check and be rejected whenever the agent's saved enabledTools omit it.
     const toolExposureMode = (page.toolExposureMode as 'upfront' | 'search' | null) ?? 'upfront';
+    // Capture BEFORE exposure so capability sections (TASK_MANAGEMENT, AGENTS, etc.) are
+    // correctly included in search mode where non-core tools become callable via execute_tool
+    // and disappear from filteredTools.
+    const allowedToolNames = Object.keys(filteredTools);
     const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
     filteredTools = exposure.tools;
     const toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
@@ -845,7 +849,7 @@ export async function POST(request: Request) {
           driveSlug: pageContext?.driveSlug,
           driveId: pageContext?.driveId,
         },
-        Object.keys(filteredTools)
+        allowedToolNames
       );
     }
 

--- a/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for apps/web/src/lib/ai/core/inline-instructions.ts
+ *
+ * Covers:
+ * - buildInlineInstructions: always-on sections, tool-gated sections, context interpolation
+ * - Tool-gating: TASK_MANAGEMENT, AGENTS, AUTOMATION, SEARCH presence/absence
+ * - availableTools=undefined sentinel (include all — backward compat for admin viewer)
+ * - availableTools=[] (no tools — only always-on sections)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildInlineInstructions } from '../inline-instructions';
+
+const BASE_CONTEXT = {
+  pageTitle: 'My Page',
+  pageType: 'DOCUMENT',
+  driveName: 'My Drive',
+  pagePath: '/my-drive/my-page',
+  driveSlug: 'my-drive',
+  driveId: 'cuid_drive_123',
+};
+
+describe('buildInlineInstructions — always-on sections', () => {
+  it('includes WORKSPACE RULES regardless of tool list', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('WORKSPACE RULES');
+  });
+
+  it('includes PAGE TYPES regardless of tool list', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('PAGE TYPES');
+  });
+
+  it('includes AFTER TOOLS regardless of tool list', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('AFTER TOOLS');
+  });
+
+  it('includes MENTIONS regardless of tool list', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('MENTIONS');
+  });
+
+  it('includes CONTEXT section regardless of tool list', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('CONTEXT');
+  });
+});
+
+describe('buildInlineInstructions — context interpolation', () => {
+  it('includes pageTitle in CONTEXT', () => {
+    const result = buildInlineInstructions({ ...BASE_CONTEXT, pageTitle: 'Sprint Board' }, []);
+    expect(result).toContain('Sprint Board');
+  });
+
+  it('includes driveName in CONTEXT', () => {
+    const result = buildInlineInstructions({ ...BASE_CONTEXT, driveName: 'Engineering Hub' }, []);
+    expect(result).toContain('Engineering Hub');
+  });
+
+  it('includes driveId in CONTEXT', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('cuid_drive_123');
+  });
+
+  it('includes driveSlug in CONTEXT', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('my-drive');
+  });
+
+  it('appends task-linked annotation when isTaskLinked=true', () => {
+    const result = buildInlineInstructions({ ...BASE_CONTEXT, isTaskLinked: true }, []);
+    expect(result).toContain('Task-linked page');
+  });
+
+  it('does not append task-linked annotation when isTaskLinked=false', () => {
+    const result = buildInlineInstructions({ ...BASE_CONTEXT, isTaskLinked: false }, []);
+    expect(result).not.toContain('Task-linked page');
+  });
+});
+
+describe('buildInlineInstructions — TASK_MANAGEMENT gating', () => {
+  it('includes TASK MANAGEMENT when create_task is available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['create_task']);
+    expect(result).toContain('TASK MANAGEMENT');
+  });
+
+  it('includes TASK MANAGEMENT when update_task is available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['update_task']);
+    expect(result).toContain('TASK MANAGEMENT');
+  });
+
+  it('includes TASK MANAGEMENT when any task tool is available', () => {
+    for (const tool of ['delete_task', 'create_task_status', 'reorder_task', 'get_assigned_tasks']) {
+      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      expect(result).toContain('TASK MANAGEMENT');
+    }
+  });
+
+  it('excludes TASK MANAGEMENT when no task tools are available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['read_page', 'list_pages']);
+    expect(result).not.toContain('TASK MANAGEMENT');
+  });
+});
+
+describe('buildInlineInstructions — AGENTS gating', () => {
+  it('includes AGENTS when ask_agent is available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['ask_agent']);
+    expect(result).toContain('AGENTS');
+  });
+
+  it('includes AGENTS when list_agents is available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['list_agents']);
+    expect(result).toContain('AGENTS');
+  });
+
+  it('includes AGENTS when any agent tool is available', () => {
+    for (const tool of ['multi_drive_list_agents', 'update_agent_config', 'list_models']) {
+      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      expect(result).toContain('AGENTS');
+    }
+  });
+
+  it('excludes AGENTS when no agent tools are available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['read_page', 'create_task']);
+    expect(result).not.toContain('AGENTS');
+  });
+});
+
+describe('buildInlineInstructions — AUTOMATION gating', () => {
+  it('includes AUTOMATION when set_task_trigger is available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['set_task_trigger']);
+    expect(result).toContain('AUTOMATION');
+  });
+
+  it('includes AUTOMATION when any trigger/workflow tool is available', () => {
+    for (const tool of ['delete_task_trigger', 'set_calendar_trigger', 'delete_calendar_trigger', 'create_workflow', 'list_workflows']) {
+      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      expect(result).toContain('AUTOMATION');
+    }
+  });
+
+  it('excludes AUTOMATION when no trigger or workflow tools are available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['create_task', 'ask_agent']);
+    expect(result).not.toContain('AUTOMATION');
+  });
+});
+
+describe('buildInlineInstructions — SEARCH gating', () => {
+  it('includes SEARCH when glob_search is available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['glob_search']);
+    expect(result).toContain('SEARCH');
+  });
+
+  it('includes SEARCH when any search tool is available', () => {
+    for (const tool of ['regex_search', 'multi_drive_search', 'web_search', 'web_fetch']) {
+      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      expect(result).toContain('SEARCH');
+    }
+  });
+
+  it('excludes SEARCH when no search tools are available', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, ['read_page', 'create_task']);
+    expect(result).not.toContain('SEARCH');
+  });
+});
+
+describe('buildInlineInstructions — availableTools=undefined sentinel', () => {
+  it('includes all sections when availableTools is omitted', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT);
+    expect(result).toContain('TASK MANAGEMENT');
+    expect(result).toContain('AGENTS');
+    expect(result).toContain('AUTOMATION');
+    expect(result).toContain('SEARCH');
+  });
+
+  it('includes all sections when availableTools is explicitly undefined', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, undefined);
+    expect(result).toContain('TASK MANAGEMENT');
+    expect(result).toContain('AGENTS');
+    expect(result).toContain('AUTOMATION');
+    expect(result).toContain('SEARCH');
+  });
+});
+
+describe('buildInlineInstructions — full tool set', () => {
+  it('includes all gated sections when all relevant tools are provided', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, [
+      'create_task', 'ask_agent', 'set_task_trigger', 'glob_search',
+    ]);
+    expect(result).toContain('TASK MANAGEMENT');
+    expect(result).toContain('AGENTS');
+    expect(result).toContain('AUTOMATION');
+    expect(result).toContain('SEARCH');
+  });
+
+  it('returns a non-empty string', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -89,6 +89,7 @@ ${everyoneLine}`;
 // Exported builders
 // ---------------------------------------------------------------------------
 
+/** Returns true if any of `toolNames` appears in `availableTools`, or if `availableTools` is undefined (include-all sentinel). */
 function hasAny(availableTools: string[] | undefined, toolNames: string[]): boolean {
   if (!availableTools) return true;
   return toolNames.some(t => availableTools.includes(t));

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -89,10 +89,22 @@ ${everyoneLine}`;
 // Exported builders
 // ---------------------------------------------------------------------------
 
+function hasAny(availableTools: string[] | undefined, toolNames: string[]): boolean {
+  if (!availableTools) return true;
+  return toolNames.some(t => availableTools.includes(t));
+}
+
 /**
  * Build the inline instructions block for page context.
+ *
+ * Pass `availableTools` (the filtered tool name list) to omit sections for
+ * capabilities the agent doesn't have. Omitting `availableTools` includes
+ * all sections — used by the admin prompt viewer for a complete preview.
  */
-export function buildInlineInstructions(context: InlineInstructionsContext): string {
+export function buildInlineInstructions(
+  context: InlineInstructionsContext,
+  availableTools?: string[]
+): string {
   const {
     pageTitle = 'current',
     pageType = 'DOCUMENT',
@@ -105,29 +117,29 @@ export function buildInlineInstructions(context: InlineInstructionsContext): str
 
   const taskSuffix = isTaskLinked ? ' (Task-linked page)' : '';
 
-  return `
-${WORKSPACE_RULES}
+  const includeTaskManagement = hasAny(availableTools, ['create_task', 'update_task', 'delete_task', 'create_task_status', 'reorder_task', 'get_assigned_tasks']);
+  const includeAgents = hasAny(availableTools, ['ask_agent', 'list_agents', 'multi_drive_list_agents', 'update_agent_config', 'list_models']);
+  const includeAutomation = hasAny(availableTools, ['set_task_trigger', 'delete_task_trigger', 'set_calendar_trigger', 'delete_calendar_trigger', 'create_workflow', 'list_workflows']);
+  const includeSearch = hasAny(availableTools, ['glob_search', 'regex_search', 'multi_drive_search', 'web_search', 'web_fetch']);
 
-CONTEXT:
+  const sections = [
+    WORKSPACE_RULES,
+    `CONTEXT:
 • Current location: "${pageTitle}" [${pageType}]${taskSuffix} at ${pagePath} in "${driveName}"
 • DriveSlug: ${driveSlug}, DriveId: ${driveId}
 • When user says "here" or "this", they mean this location
 • Explore current drive first (list_pages) before other drives${isTaskLinked ? `
-• This page is linked to a task - use task management tools to update task status` : ''}
+• This page is linked to a task - use task management tools to update task status` : ''}`,
+    PAGE_TYPES,
+    includeTaskManagement ? TASK_MANAGEMENT : null,
+    includeAgents ? AGENTS : null,
+    includeAutomation ? AUTOMATION : null,
+    includeSearch ? SEARCH : null,
+    AFTER_TOOLS,
+    buildMentions(true),
+  ].filter(Boolean);
 
-${PAGE_TYPES}
-
-${TASK_MANAGEMENT}
-
-${AGENTS}
-
-${AUTOMATION}
-
-${SEARCH}
-
-${AFTER_TOOLS}
-
-${buildMentions(true)}`;
+  return '\n' + sections.join('\n\n');
 }
 
 /**


### PR DESCRIPTION
## Summary

- Page AI now appends the same workspace knowledge the global assistant has — WORKSPACE_RULES, PAGE_TYPES, TASK_MANAGEMENT, AGENTS, AUTOMATION, SEARCH, MENTIONS — via \`buildInlineInstructions()\` on every request
- Sections are **tool-aware**: an agent with a restricted \`enabledTools\` list won't see instructions for tools it can't call (e.g. no TASK_MANAGEMENT if no task tools, no SEARCH section if no search tools)
- Custom \`page.systemPrompt\` remains the implicit **blank-slate opt-out** — when a user has explicitly configured a raw system prompt, no additions are made
- Tool availability is evaluated on the **pre-exposure tool set** — so in \`search\` mode where non-core tools are deferred behind \`execute_tool\`, capability sections (TASK_MANAGEMENT, AGENTS, etc.) are still correctly included

## Changes

- \`apps/web/src/lib/ai/core/inline-instructions.ts\` — \`buildInlineInstructions()\` gains an optional \`availableTools?: string[]\` param; a private \`hasAny()\` helper gates TASK_MANAGEMENT, AGENTS, AUTOMATION, SEARCH on tool presence; always-on sections (WORKSPACE_RULES, CONTEXT, PAGE_TYPES, AFTER_TOOLS, MENTIONS) are unaffected; omitting \`availableTools\` includes everything (admin viewer compat)
- \`apps/web/src/app/api/ai/chat/route.ts\` — captures \`allowedToolNames\` **before** \`applyToolExposureMode\` (so search-mode agents aren't incorrectly stripped of capability sections), then passes those names to \`buildInlineInstructions\` on the default path
- \`apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts\` — 29 unit tests covering tool-gating (each of the 4 sections, presence + absence), the \`undefined\` backward-compat sentinel, context interpolation, and task-linked annotation

## Test plan

- [ ] Open a Page AI chat with no custom system prompt — workspace knowledge (WORKSPACE_RULES, PAGE_TYPES etc.) appears in the effective prompt
- [ ] Open a Page AI configured with a custom \`systemPrompt\` — inline instructions are NOT appended (blank slate preserved)
- [ ] Open a Page AI agent with a restricted \`enabledTools\` list (e.g. only read tools) — TASK_MANAGEMENT / AGENTS / AUTOMATION absent; WORKSPACE_RULES / PAGE_TYPES still present
- [ ] Open a Page AI agent with \`toolExposureMode=search\` and task tools in the allowlist — TASK_MANAGEMENT still present (pre-exposure gating is correct)
- [ ] Admin global-prompt viewer unaffected (calls \`buildInlineInstructions\` without \`availableTools\` → all sections)
- [ ] \`bun run vitest run inline-instructions\` → 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcA91X9fYxUcJnGVZnmkcq