### PR TITLE
fix: remove localhost fallback from all email URL construction

### DIFF
--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -32,7 +32,10 @@ const loadUserAccountByEmailMock = vi.hoisted(() =>
 
 vi.mock('@pagespace/db/db', () => ({ db: { insert: dbInsertMock } }));
 vi.mock('@pagespace/db/schema/auth', () => ({ verificationTokens: {} }));
-vi.mock('@pagespace/lib/services/email-service', () => ({ sendEmail: sendEmailMock }));
+vi.mock('@pagespace/lib/services/email-service', async () => {
+  const actual = await vi.importActual<typeof import('@pagespace/lib/services/email-service')>('@pagespace/lib/services/email-service');
+  return { ...actual, sendEmail: sendEmailMock };
+});
 vi.mock('@pagespace/lib/email-templates/MagicLinkEmail', () => ({
   MagicLinkEmail: () => null,
 }));

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -545,14 +545,16 @@ describe('GET /api/auth/magic-link/verify', () => {
       expect(location).toContain('https://public.example.com');
     });
 
-    it('uses localhost as final fallback', async () => {
+    it('derives base URL from request origin when no env vars are set', async () => {
       delete process.env.WEB_APP_URL;
       delete process.env.NEXT_PUBLIC_APP_URL;
 
+      // Request origin is http://localhost; route falls back to new URL(req.url).origin
       const response = await GET(createVerifyRequest('valid-token'));
       const location = response.headers.get('Location')!;
 
-      expect(location).toContain('http://localhost:3000');
+      expect(location).toContain('http://localhost');
+      expect(location).not.toContain('localhost:3000');
     });
 
     it('logs successful magic link login', async () => {

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -18,6 +18,7 @@ import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';
 import { isSafeNextPath, SIGNIN_NEXT_ALLOWED_PREFIXES } from '@/lib/auth/auth-helpers';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
+import { resolveAppUrl } from '@pagespace/lib/services/email-service';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
@@ -366,7 +367,7 @@ function redirectWithError(error: string, requestUrl?: string): NextResponse {
   const baseUrl =
     process.env.WEB_APP_URL ||
     process.env.NEXT_PUBLIC_APP_URL ||
-    (requestUrl ? new URL(requestUrl).origin : undefined);
+    (requestUrl ? new URL(requestUrl).origin : resolveAppUrl());
   const redirectUrl = new URL('/auth/signin', baseUrl);
   redirectUrl.searchParams.set('error', error);
 

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -47,7 +47,7 @@ export async function GET(req: Request) {
     // Validate token format
     const validation = verifyTokenSchema.safeParse({ token });
     if (!validation.success) {
-      return redirectWithError('invalid_token');
+      return redirectWithError('invalid_token', req.url);
     }
 
     // Verify the magic link token
@@ -73,7 +73,7 @@ export async function GET(req: Request) {
         details: { reason: `magic_link_${result.error.code.toLowerCase()}` },
       });
 
-      return redirectWithError(errorCode);
+      return redirectWithError(errorCode, req.url);
     }
 
     const { userId, isNewUser, metadata } = result.data;
@@ -143,7 +143,7 @@ export async function GET(req: Request) {
     const sessionClaims = await sessionService.validateSession(sessionToken);
     if (!sessionClaims) {
       loggers.auth.error('Failed to validate newly created session', { userId });
-      return redirectWithError('session_error');
+      return redirectWithError('session_error', req.url);
     }
 
     // Generate CSRF token bound to session ID
@@ -245,7 +245,7 @@ export async function GET(req: Request) {
           // will detect this and trigger pagespace://auth-exchange client-side.
           // If the link was opened on a different device, the exchange code is
           // ignored and the user still has a valid cookie session.
-          const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+          const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
           const desktopRedirectPath =
             inviteResult?.kind === 'connection'
               ? '/dashboard/connections'
@@ -322,7 +322,7 @@ export async function GET(req: Request) {
               provisionedDriveId, next: safeNext, invitedDriveId,
             });
 
-    const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
     const redirectUrl = new URL(redirectPath, baseUrl);
     redirectUrl.searchParams.set('auth', 'success');
     if (inviteResult?.kind === 'connection') {
@@ -358,12 +358,15 @@ export async function GET(req: Request) {
 
   } catch (error) {
     loggers.auth.error('Magic link verify error', error as Error);
-    return redirectWithError('server_error');
+    return redirectWithError('server_error', req.url);
   }
 }
 
-function redirectWithError(error: string): NextResponse {
-  const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+function redirectWithError(error: string, requestUrl?: string): NextResponse {
+  const baseUrl =
+    process.env.WEB_APP_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    (requestUrl ? new URL(requestUrl).origin : undefined);
   const redirectUrl = new URL('/auth/signin', baseUrl);
   redirectUrl.searchParams.set('error', error);
 

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: NextRequest) {
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'email_verification', resourceId: userId });
 
     // Redirect to dashboard - triggers auth refresh via ?auth=success
-    const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(request.url).origin;
     return NextResponse.redirect(new URL('/dashboard?auth=success', baseUrl), {
       status: 303, // See Other - forces GET on redirect
     });

--- a/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
+++ b/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
@@ -107,7 +107,7 @@ export async function GET(
     }
 
     // Redirect to a confirmation page
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const appUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(request.url).origin;
 
     audit({ eventType: 'data.write', userId, resourceType: 'notification_prefs', resourceId: 'self' });
 

--- a/apps/web/src/lib/auth/__tests__/magic-link-adapters.test.ts
+++ b/apps/web/src/lib/auth/__tests__/magic-link-adapters.test.ts
@@ -33,9 +33,10 @@ const { sendEmailMock, dbInsertMock, dbSelectMock, returningMock, selectWhereMoc
     };
   });
 
-vi.mock('@pagespace/lib/services/email-service', () => ({
-  sendEmail: sendEmailMock,
-}));
+vi.mock('@pagespace/lib/services/email-service', async () => {
+  const actual = await vi.importActual<typeof import('@pagespace/lib/services/email-service')>('@pagespace/lib/services/email-service');
+  return { ...actual, sendEmail: sendEmailMock };
+});
 
 vi.mock('@pagespace/lib/email-templates/MagicLinkEmail', () => ({
   MagicLinkEmail: () => null,

--- a/apps/web/src/lib/auth/__tests__/send-verification-email.test.ts
+++ b/apps/web/src/lib/auth/__tests__/send-verification-email.test.ts
@@ -5,6 +5,7 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
 }));
 vi.mock('@pagespace/lib/services/email-service', () => ({
   sendEmail: vi.fn().mockResolvedValue(undefined),
+  resolveAppUrl: vi.fn().mockReturnValue('https://app.example.com'),
 }));
 vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
   VerificationEmail: () => null,
@@ -41,11 +42,8 @@ describe('sendVerificationEmail', () => {
     expect(args.subject).toBe('Verify your PageSpace email');
   });
 
-  it('falls back through WEB_APP_URL -> NEXT_PUBLIC_APP_URL -> localhost', async () => {
-    delete process.env.WEB_APP_URL;
-    delete process.env.NEXT_PUBLIC_APP_URL;
-
-    // Should not throw with no env configured (localhost fallback).
+  it('delegates URL resolution to resolveAppUrl and always calls sendEmail', async () => {
+    // resolveAppUrl is mocked; URL env-var behavior is tested in email-service.test.ts
     await expect(
       sendVerificationEmail({ userId: 'u1', email: 'a@example.com', userName: 'Ann' }),
     ).resolves.toBeUndefined();

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -4,7 +4,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { users, verificationTokens } from '@pagespace/db/schema/auth';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
+import { sendEmail, resolveAppUrl } from '@pagespace/lib/services/email-service';
 import { MagicLinkEmail } from '@pagespace/lib/email-templates/MagicLinkEmail';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { MagicLinkPorts } from '@pagespace/lib/services/invites';
@@ -88,10 +88,8 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
 
   sendMagicLinkEmail: async ({ email, token, next }) => {
     try {
-      const baseUrl =
-        process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
       const nextSuffix = next ? `&next=${encodeURIComponent(next)}` : '';
-      const magicLinkUrl = `${baseUrl}/api/auth/magic-link/verify?token=${encodeURIComponent(token)}${nextSuffix}`;
+      const magicLinkUrl = `${resolveAppUrl()}/api/auth/magic-link/verify?token=${encodeURIComponent(token)}${nextSuffix}`;
       await sendEmail({
         to: email,
         subject: 'Sign in to PageSpace',

--- a/apps/web/src/lib/auth/send-verification-email.ts
+++ b/apps/web/src/lib/auth/send-verification-email.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
+import { sendEmail, resolveAppUrl } from '@pagespace/lib/services/email-service';
 import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
 
 /**
@@ -27,9 +27,7 @@ export async function sendVerificationEmail(params: {
     email,
   });
 
-  const baseUrl =
-    process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
+  const verificationUrl = `${resolveAppUrl()}/api/auth/verify-email?token=${verificationToken}`;
 
   await sendEmail({
     to: email,

--- a/packages/lib/src/services/__tests__/email-service.test.ts
+++ b/packages/lib/src/services/__tests__/email-service.test.ts
@@ -130,4 +130,14 @@ describe('resolveAppUrl', () => {
     delete process.env.NEXT_PUBLIC_APP_URL;
     expect(() => resolveAppUrl()).toThrow('App base URL is not configured');
   });
+
+  it('throws on a relative path value', () => {
+    process.env.WEB_APP_URL = 'relative/path';
+    expect(() => resolveAppUrl()).toThrow('not a valid absolute URL');
+  });
+
+  it('throws on a non-http protocol', () => {
+    process.env.WEB_APP_URL = 'ftp://example.com';
+    expect(() => resolveAppUrl()).toThrow('must use http or https protocol');
+  });
 });

--- a/packages/lib/src/services/__tests__/email-service.test.ts
+++ b/packages/lib/src/services/__tests__/email-service.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../deployment-mode', () => ({
   isOnPrem: mockIsOnPrem,
 }));
 
-import { sendEmail } from '../email-service';
+import { sendEmail, resolveAppUrl } from '../email-service';
 import { checkRateLimit } from '../../auth/rate-limit-utils';
 
 describe('email-service', () => {
@@ -90,5 +90,44 @@ describe('email-service', () => {
     await expect(
       sendEmail({ to: 'user@test.com', subject: 'Test', react: null })
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('resolveAppUrl', () => {
+  const origWeb = process.env.WEB_APP_URL;
+  const origNext = process.env.NEXT_PUBLIC_APP_URL;
+
+  afterEach(() => {
+    process.env.WEB_APP_URL = origWeb;
+    process.env.NEXT_PUBLIC_APP_URL = origNext;
+  });
+
+  it('returns WEB_APP_URL when set', () => {
+    process.env.WEB_APP_URL = 'https://pagespace.ai';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(resolveAppUrl()).toBe('https://pagespace.ai');
+  });
+
+  it('falls back to NEXT_PUBLIC_APP_URL when WEB_APP_URL is absent', () => {
+    delete process.env.WEB_APP_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.pagespace.ai';
+    expect(resolveAppUrl()).toBe('https://app.pagespace.ai');
+  });
+
+  it('strips trailing slash from the URL', () => {
+    process.env.WEB_APP_URL = 'https://pagespace.ai/';
+    expect(resolveAppUrl()).toBe('https://pagespace.ai');
+  });
+
+  it('prefers WEB_APP_URL over NEXT_PUBLIC_APP_URL', () => {
+    process.env.WEB_APP_URL = 'https://web.example.com';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://next.example.com';
+    expect(resolveAppUrl()).toBe('https://web.example.com');
+  });
+
+  it('throws when neither env var is set', () => {
+    delete process.env.WEB_APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(() => resolveAppUrl()).toThrow('App base URL is not configured');
   });
 });

--- a/packages/lib/src/services/__tests__/notification-email-service.test.ts
+++ b/packages/lib/src/services/__tests__/notification-email-service.test.ts
@@ -30,6 +30,7 @@ vi.mock('@pagespace/db/operators', () => ({
 
 vi.mock('../email-service', () => ({
   sendEmail: vi.fn().mockResolvedValue(undefined),
+  resolveAppUrl: vi.fn().mockReturnValue('https://pagespace.ai'),
 }));
 
 // Mock all email templates

--- a/packages/lib/src/services/email-service.ts
+++ b/packages/lib/src/services/email-service.ts
@@ -24,6 +24,16 @@ function getResend(): Resend {
   return resendInstance;
 }
 
+export function resolveAppUrl(): string {
+  const url = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (!url) {
+    throw new Error(
+      'App base URL is not configured. Set WEB_APP_URL or NEXT_PUBLIC_APP_URL environment variable.'
+    );
+  }
+  return url.replace(/\/+$/, '');
+}
+
 export interface SendEmailOptions {
   to: string;
   subject: string;

--- a/packages/lib/src/services/email-service.ts
+++ b/packages/lib/src/services/email-service.ts
@@ -31,7 +31,19 @@ export function resolveAppUrl(): string {
       'App base URL is not configured. Set WEB_APP_URL or NEXT_PUBLIC_APP_URL environment variable.'
     );
   }
-  return url.replace(/\/+$/, '');
+  const normalized = url.replace(/\/+$/, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new Error(
+      `App base URL is not a valid absolute URL: ${normalized}. Set WEB_APP_URL or NEXT_PUBLIC_APP_URL to a valid URL.`
+    );
+  }
+  if (!parsed.protocol.startsWith('http')) {
+    throw new Error(`App base URL must use http or https protocol, got: ${parsed.protocol}`);
+  }
+  return normalized;
 }
 
 export interface SendEmailOptions {

--- a/packages/lib/src/services/notification-email-service.ts
+++ b/packages/lib/src/services/notification-email-service.ts
@@ -2,7 +2,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { users, emailUnsubscribeTokens } from '@pagespace/db/schema/auth';
 import { emailNotificationPreferences, emailNotificationLog } from '@pagespace/db/schema/email-notifications';
-import { sendEmail } from './email-service';
+import { sendEmail, resolveAppUrl } from './email-service';
 import { DriveInvitationEmail } from '../email-templates/DriveInvitationEmail';
 import { ConnectionInvitationEmail } from '../email-templates/ConnectionInvitationEmail';
 import { PageShareInvitationEmail } from '../email-templates/PageShareInvitationEmail';
@@ -113,7 +113,7 @@ interface TemplateData {
 }
 
 function getEmailTemplate(data: NotificationEmailData, user: { name: string; email: string }, unsubscribeUrl: string): TemplateData | null {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const appUrl = resolveAppUrl();
 
   switch (data.type) {
     case 'DRIVE_INVITED':
@@ -388,8 +388,7 @@ export async function sendNotificationEmail(data: NotificationEmailData): Promis
 
     // Generate unsubscribe URL
     const unsubscribeToken = await generateUnsubscribeToken(data.userId, data.type);
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-    const unsubscribeUrl = `${appUrl}/api/notifications/unsubscribe/${unsubscribeToken}`;
+    const unsubscribeUrl = `${resolveAppUrl()}/api/notifications/unsubscribe/${unsubscribeToken}`;
 
     // Get email template
     const templateData = getEmailTemplate(data, user, unsubscribeUrl);


### PR DESCRIPTION
Email notifications were embedding localhost:3000 links when WEB_APP_URL
and NEXT_PUBLIC_APP_URL env vars were not set in the deployment.

- Add resolveAppUrl() to email-service.ts that throws if neither env var
  is set, making misconfiguration loud instead of silently wrong
- Fix notification-email-service.ts to check WEB_APP_URL first (it only
  checked NEXT_PUBLIC_APP_URL before) and use resolveAppUrl()
- Update send-verification-email.ts and magic-link-adapters.ts to use
  resolveAppUrl() instead of the localhost fallback
- Fix verify-email, magic-link/verify, and unsubscribe redirect routes
  to derive base URL from the incoming request when env vars are absent,
  which is always correct since the user navigated to the correct domain
- Fix redirectWithError in magic-link/verify to use resolveAppUrl() as
  the final fallback (was silently producing undefined, risking TypeError)
- Add 5 unit tests for resolveAppUrl covering priority, fallback, trailing-
  slash strip, and throws-when-unconfigured
- Fix test mocks for email-service across 5 test files (notification-email-
  service, send-verification-email, magic-link-adapters, round-trip, route)
  that only stubbed sendEmail and not resolveAppUrl

**Out of scope / follow-up**: 14 remaining localhost:3000 fallbacks in OAuth
redirect routes (Apple, Google, integrations, feedback) — those use
NEXTAUTH_URL as a secondary fallback and are a separate concern.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jm8764Tr8hKmZy8dFVPVgU