### PR TITLE
fix(billing): never show a past renewal date in credit balance

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -244,7 +244,7 @@ describe('getCreditBalance', () => {
       expect(b.monthly.periodEnd).toBeNull();
     });
 
-    it('returns null when no periodEnd has been stamped yet (null in DB)', async () => {
+    it('projects addOneMonth(now) for a free user when no periodEnd has been stamped yet (null in DB)', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 500,
@@ -257,6 +257,19 @@ describe('getCreditBalance', () => {
       const b = await getCreditBalance('u1', 'free');
       expect(b.monthly.periodEnd).not.toBeNull();
       expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns null for a paid user when no periodEnd has been stamped yet (null in DB)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 1500,
+          monthlyAllowanceCents: 1500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: null,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'pro');
+      expect(b.monthly.periodEnd).toBeNull();
     });
   });
 });

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -201,6 +201,64 @@ describe('getCreditBalance', () => {
     expect(b.reserved).toBe(50);
     expect(b.spendable).toBe(10);
   });
+
+  describe('monthly.periodEnd display projection', () => {
+    it('returns an active periodEnd as-is (ISO string)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 400,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: future,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'free');
+      expect(b.monthly.periodEnd).toBe(future.toISOString());
+    });
+
+    it('projects addOneMonth(now) for a free user with an expired period — never shows a past date', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 0,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: past,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'free');
+      // periodEnd must be in the future (not the stale past date from the DB)
+      expect(b.monthly.periodEnd).not.toBeNull();
+      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns null for a paid user with an expired period — hides the line rather than showing stale Stripe date', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 900,
+          monthlyAllowanceCents: 1500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: past,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'pro');
+      expect(b.monthly.periodEnd).toBeNull();
+    });
+
+    it('returns null when no periodEnd has been stamped yet (null in DB)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 500,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: null,
+        },
+      ];
+      // null DB periodEnd counts as expired; free tier projects addOneMonth
+      const b = await getCreditBalance('u1', 'free');
+      expect(b.monthly.periodEnd).not.toBeNull();
+      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+    });
+  });
 });
 
 describe('resolveTier', () => {

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -32,6 +32,7 @@ import { users } from '@pagespace/db/schema/auth';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import { TIER_MONTHLY_ALLOWANCE_CENTS } from './credit-pricing';
+import { addOneMonth } from './credit-gate';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
 export interface CreditBalanceSummary {
@@ -134,6 +135,12 @@ export async function getCreditBalance(
   const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
   const periodEnd = row.monthlyPeriodEnd;
   const expired = periodEnd === null || periodEnd < now;
+  // For display: never show a past renewal date. Free users will get addOneMonth(now)
+  // stamped by the gate on their next AI call; project that for display. Paid users
+  // wait for invoice.paid — we don't know the date, so show nothing.
+  const displayPeriodEnd: Date | null = expired
+    ? (tier === 'free' ? addOneMonth(now) : null)
+    : periodEnd;
 
   // Rollover: credits never expire. The carry balance is always spendable (both
   // in the gate and here) — the renewal adds the allowance and nets outstanding debt.
@@ -166,7 +173,7 @@ export async function getCreditBalance(
     monthly: {
       remaining: monthlyRemaining,
       allowance,
-      periodEnd: periodEnd ? periodEnd.toISOString() : null,
+      periodEnd: displayPeriodEnd ? displayPeriodEnd.toISOString() : null,
     },
     topup: { remaining: topupRemaining },
     debt,

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -32,8 +32,19 @@ import { users } from '@pagespace/db/schema/auth';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import { TIER_MONTHLY_ALLOWANCE_CENTS } from './credit-pricing';
-import { addOneMonth } from './credit-gate';
 import type { SubscriptionTier } from '../services/subscription-utils';
+
+// Mirror of addOneMonth in credit-gate (same logic, kept local to avoid pulling
+// credit-gate's DB imports into this display-only module and its unit-test mocks).
+function addOneMonth(from: Date): Date {
+  const d = new Date(from.getTime());
+  const day = d.getUTCDate();
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() + 1);
+  const lastDay = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+  d.setUTCDate(Math.min(day, lastDay));
+  return d;
+}
 
 export interface CreditBalanceSummary {
   /** false on billing-disabled deployments (tenant/onprem); the widget then hides. */


### PR DESCRIPTION
## Summary

- `getCreditBalance` was returning `monthlyPeriodEnd` verbatim from the DB even when expired, causing the UI to show e.g. \"Renews June 1\" when today is June 19
- For **free users** with a lapsed period: now projects `addOneMonth(now)` — the same date the gate stamps on their next AI call, so the display matches what will actually happen
- For **paid users** with a lapsed period: now returns `null`, hiding the \"Renews\" line rather than showing a stale Stripe `period_end` (the actual renewal date is unknown until `invoice.paid` fires)

Both the initial `GET /api/credits` load and every `emitCreditsUpdated` socket push call `getCreditBalance`, so this fixes the stale date in both paths — including the case where a paid user sends a message and the displayed date still didn't update.

## Test plan

- [ ] Free user with expired period: initial load shows a future renewal date ~1 month out
- [ ] Paid user with expired period: \"Renews\" line is hidden entirely
- [ ] Active period (not expired): renewal date unchanged
- [ ] `bun run test:unit` (billing tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01313yfGFVDsKMc8ctBUrg3S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing period end date display for credit balance summaries.
  * Free tier users with a missing or expired stored period end now see a calculated future period end date for presentation.
  * Other tiers now avoid showing stale/expired stored dates and instead return `null` when appropriate.
* **Tests**
  * Added coverage to verify `monthly.periodEnd` behavior across active, missing/expired free-tier, and expired paid-tier scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->