### PR TITLE
feat(canvas): CDN asset pipeline for published pages

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -43,11 +43,18 @@ const buildPublishedKey = vi.fn();
 const putPublishedArtifact = vi.fn();
 const deletePublishedArtifact = vi.fn();
 const isPublishConfigured = vi.fn();
+const getPublishAssetBaseUrl = vi.fn();
 vi.mock('@/lib/canvas/published-storage', () => ({
   buildPublishedKey: (...args: unknown[]) => buildPublishedKey(...args),
   putPublishedArtifact: (...args: unknown[]) => putPublishedArtifact(...args),
   deletePublishedArtifact: (...args: unknown[]) => deletePublishedArtifact(...args),
   isPublishConfigured: (...args: unknown[]) => isPublishConfigured(...args),
+  getPublishAssetBaseUrl: (...args: unknown[]) => getPublishAssetBaseUrl(...args),
+}));
+
+const rewriteCanvasAssets = vi.fn();
+vi.mock('@/lib/canvas/asset-pipeline', () => ({
+  rewriteCanvasAssets: (...args: unknown[]) => rewriteCanvasAssets(...args),
 }));
 
 const renderPublishedPage = vi.fn();
@@ -110,6 +117,8 @@ beforeEach(() => {
   canUserEditPage.mockResolvedValue(true);
   validatePublishSubdomain.mockReturnValue({ valid: true });
   isPublishConfigured.mockReturnValue(true);
+  getPublishAssetBaseUrl.mockReturnValue('https://test-publish.t3.tigrisfiles.io');
+  rewriteCanvasAssets.mockImplementation(async ({ html }: { html: string }) => ({ html }));
   buildPublishedKey.mockImplementation((subdomain: string, path: string) => `published/${subdomain}/${path}/index.html`);
   putPublishedArtifact.mockResolvedValue({ key: 'published/acme/welcome/index.html' });
   renderPublishedPage.mockReturnValue('<html>rendered</html>');
@@ -185,7 +194,7 @@ describe('POST /api/pages/[pageId]/publish', () => {
     // 2 updates: subdomain allocation + post-upload updatedAt advancement
     expect(updateWhere).toHaveBeenCalledTimes(2);
 
-    expect(renderPublishedPage).toHaveBeenCalledWith({ html: '<p>hi</p>', title: 'Welcome' });
+    expect(renderPublishedPage).toHaveBeenCalledWith({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io' });
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'acme', path: 'welcome', html: '<html>rendered</html>' });
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
 

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -194,6 +194,7 @@ describe('POST /api/pages/[pageId]/publish', () => {
     // 2 updates: subdomain allocation + post-upload updatedAt advancement
     expect(updateWhere).toHaveBeenCalledTimes(2);
 
+    expect(rewriteCanvasAssets).toHaveBeenCalledWith({ html: '<p>hi</p>', userId: 'user-1', db: expect.any(Object) });
     expect(renderPublishedPage).toHaveBeenCalledWith({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io' });
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'acme', path: 'welcome', html: '<html>rendered</html>' });
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -11,7 +11,8 @@ import { pages, drives } from '@pagespace/db/schema/core';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
 import { isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { renderPublishedPage } from '@/lib/canvas/render-published';
-import { buildPublishedKey, putPublishedArtifact, deletePublishedArtifact, isPublishConfigured } from '@/lib/canvas/published-storage';
+import { buildPublishedKey, putPublishedArtifact, deletePublishedArtifact, isPublishConfigured, getPublishAssetBaseUrl } from '@/lib/canvas/published-storage';
+import { rewriteCanvasAssets } from '@/lib/canvas/asset-pipeline';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -196,7 +197,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     const rawPath = parsedBody?.path ?? page.title ?? '';
     const path = slugify(rawPath) || pageId;
 
-    const html = renderPublishedPage({ html: page.content ?? '', title: page.title ?? undefined });
+    const { html: rewrittenHtml } = await rewriteCanvasAssets({ html: page.content ?? '', db });
+    const assetBaseUrl = getPublishAssetBaseUrl();
+    const html = renderPublishedPage({ html: rewrittenHtml, title: page.title ?? undefined, assetBaseUrl });
     const key = buildPublishedKey(subdomain, path);
 
     // Capture the artifact this page currently points at, so we can clean it up

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -197,7 +197,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     const rawPath = parsedBody?.path ?? page.title ?? '';
     const path = slugify(rawPath) || pageId;
 
-    const { html: rewrittenHtml } = await rewriteCanvasAssets({ html: page.content ?? '', db });
+    const { html: rewrittenHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId, db });
     const assetBaseUrl = getPublishAssetBaseUrl();
     const html = renderPublishedPage({ html: rewrittenHtml, title: page.title ?? undefined, assetBaseUrl });
     const key = buildPublishedKey(subdomain, path);

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { extractFileIds, rewriteCanvasAssets } from '../asset-pipeline';
+
+vi.mock('server-only', () => ({}));
+
+// ---------------------------------------------------------------------------
+// extractFileIds — pure, no I/O
+// ---------------------------------------------------------------------------
+
+describe('extractFileIds', () => {
+  it('given a relative /api/files/{id}/view src attribute, should extract the id', () => {
+    const html = '<img src="/api/files/abc123/view">';
+    expect(extractFileIds(html)).toEqual(['abc123']);
+  });
+
+  it('given an absolute https://pagespace.ai/api/files/{id}/view src, should extract the id', () => {
+    const html = '<img src="https://pagespace.ai/api/files/def456/view">';
+    expect(extractFileIds(html)).toEqual(['def456']);
+  });
+
+  it('given a /api/files/{id}/thumbnail src, should extract the id', () => {
+    const html = '<img src="/api/files/thumb789/thumbnail">';
+    expect(extractFileIds(html)).toEqual(['thumb789']);
+  });
+
+  it('given a CSS url() with /api/files/{id}/view, should extract the id', () => {
+    const html = '<style>body { background: url("/api/files/cssId001/view"); }</style>';
+    expect(extractFileIds(html)).toEqual(['cssId001']);
+  });
+
+  it('given an href attribute pointing to /api/files/{id}/view, should extract the id', () => {
+    const html = '<a href="/api/files/href002/view">Download</a>';
+    expect(extractFileIds(html)).toEqual(['href002']);
+  });
+
+  it('given multiple references to the same id, should deduplicate', () => {
+    const html =
+      '<img src="/api/files/dup1/view"><img src="/api/files/dup1/view"><img src="/api/files/dup2/view">';
+    const ids = extractFileIds(html);
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain('dup1');
+    expect(ids).toContain('dup2');
+  });
+
+  it('given an external URL with no /api/files/ path, should NOT extract it', () => {
+    const html = '<img src="https://example.com/photo.jpg">';
+    expect(extractFileIds(html)).toEqual([]);
+  });
+
+  it('given a data:image URI, should NOT extract it', () => {
+    const html = '<img src="data:image/png;base64,iVBORw0KGgo=">';
+    expect(extractFileIds(html)).toEqual([]);
+  });
+
+  it('given no file references, should return an empty array', () => {
+    expect(extractFileIds('<p>Hello world</p>')).toEqual([]);
+  });
+
+  it('given an empty string, should return an empty array', () => {
+    expect(extractFileIds('')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteCanvasAssets — async, DB + S3 mocked
+// ---------------------------------------------------------------------------
+
+const mockDb = {
+  query: {
+    pages: {
+      findMany: vi.fn(),
+    },
+  },
+};
+
+vi.mock('../published-storage', () => ({
+  buildAssetUrl: vi.fn((hash: string) => `https://cdn.example.com/assets/${hash}`),
+  copyAssetToPublishBucket: vi.fn().mockResolvedValue(undefined),
+  getPublishAssetBaseUrl: vi.fn().mockReturnValue('https://cdn.example.com'),
+}));
+
+describe('rewriteCanvasAssets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.query.pages.findMany.mockResolvedValue([]);
+  });
+
+  it('given no file IDs in the HTML, should return the HTML unchanged', async () => {
+    const html = '<p>No files here</p>';
+    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+    expect(result.html).toBe(html);
+    expect(mockDb.query.pages.findMany).not.toHaveBeenCalled();
+  });
+
+  it('given a file ID that resolves to a page with contentHash, should rewrite the URL to CDN and copy the asset', async () => {
+    const html = '<img src="/api/files/fileId1/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'fileId1', contentHash: 'hash001', mimeType: 'image/png' },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+
+    expect(result.html).toContain('https://cdn.example.com/assets/hash001');
+    expect(result.html).not.toContain('/api/files/fileId1/view');
+  });
+
+  it('given a file ID that cannot be resolved in the DB, should leave the URL as-is (graceful degradation)', async () => {
+    const html = '<img src="/api/files/missingId/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([]); // not found
+
+    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+
+    expect(result.html).toContain('/api/files/missingId/view');
+  });
+
+  it('given a page with no contentHash, should leave that file URL as-is', async () => {
+    const html = '<img src="/api/files/noHashId/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'noHashId', contentHash: null, mimeType: 'image/jpeg' },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+
+    expect(result.html).toContain('/api/files/noHashId/view');
+  });
+
+  it('given multiple distinct file IDs, should batch-query the DB once and rewrite all resolved URLs', async () => {
+    const html =
+      '<img src="/api/files/f1/view"><img src="/api/files/f2/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'f1', contentHash: 'h1', mimeType: 'image/png' },
+      { id: 'f2', contentHash: 'h2', mimeType: 'image/jpeg' },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+
+    expect(mockDb.query.pages.findMany).toHaveBeenCalledTimes(1);
+    expect(result.html).toContain('https://cdn.example.com/assets/h1');
+    expect(result.html).toContain('https://cdn.example.com/assets/h2');
+  });
+});

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { extractFileIds, rewriteCanvasAssets } from '../asset-pipeline';
 
 vi.mock('server-only', () => ({}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { warn: vi.fn() } },
+}));
+
+const canUserViewPage = vi.fn();
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: (...args: unknown[]) => canUserViewPage(...args),
+}));
 
 // ---------------------------------------------------------------------------
 // extractFileIds — pure, no I/O
@@ -74,8 +82,9 @@ const mockDb = {
 };
 
 vi.mock('../published-storage', () => ({
-  buildAssetUrl: vi.fn((hash: string) => `https://cdn.example.com/assets/${hash}`),
-  copyAssetToPublishBucket: vi.fn().mockResolvedValue(undefined),
+  buildAssetKey: vi.fn((hash: string) => `assets/${hash}`),
+  buildAssetUrlFromKey: vi.fn((key: string) => `https://cdn.example.com/${key}`),
+  copyObjectToPublishBucket: vi.fn().mockResolvedValue(undefined),
   getPublishAssetBaseUrl: vi.fn().mockReturnValue('https://cdn.example.com'),
 }));
 
@@ -83,11 +92,12 @@ describe('rewriteCanvasAssets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDb.query.pages.findMany.mockResolvedValue([]);
+    canUserViewPage.mockResolvedValue(true);
   });
 
   it('given no file IDs in the HTML, should return the HTML unchanged', async () => {
     const html = '<p>No files here</p>';
-    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
     expect(result.html).toBe(html);
     expect(mockDb.query.pages.findMany).not.toHaveBeenCalled();
   });
@@ -95,20 +105,28 @@ describe('rewriteCanvasAssets', () => {
   it('given a file ID that resolves to a page with contentHash, should rewrite the URL to CDN and copy the asset', async () => {
     const html = '<img src="/api/files/fileId1/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'fileId1', contentHash: 'hash001', mimeType: 'image/png' },
+      { id: 'fileId1', contentHash: 'hash001', mimeType: 'image/png', extractionMetadata: null },
     ]);
 
-    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
     expect(result.html).toContain('https://cdn.example.com/assets/hash001');
     expect(result.html).not.toContain('/api/files/fileId1/view');
+    const { copyObjectToPublishBucket } = await import('../published-storage');
+    expect(copyObjectToPublishBucket).toHaveBeenCalledWith({
+      id: 'fileId1',
+      kind: 'view',
+      sourceKey: 'files/hash001/original',
+      assetKey: 'assets/hash001',
+      contentType: 'image/png',
+    });
   });
 
   it('given a file ID that cannot be resolved in the DB, should leave the URL as-is (graceful degradation)', async () => {
     const html = '<img src="/api/files/missingId/view">';
     mockDb.query.pages.findMany.mockResolvedValue([]); // not found
 
-    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
     expect(result.html).toContain('/api/files/missingId/view');
   });
@@ -116,10 +134,10 @@ describe('rewriteCanvasAssets', () => {
   it('given a page with no contentHash, should leave that file URL as-is', async () => {
     const html = '<img src="/api/files/noHashId/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'noHashId', contentHash: null, mimeType: 'image/jpeg' },
+      { id: 'noHashId', contentHash: null, mimeType: 'image/jpeg', extractionMetadata: null },
     ]);
 
-    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
     expect(result.html).toContain('/api/files/noHashId/view');
   });
@@ -128,14 +146,78 @@ describe('rewriteCanvasAssets', () => {
     const html =
       '<img src="/api/files/f1/view"><img src="/api/files/f2/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'f1', contentHash: 'h1', mimeType: 'image/png' },
-      { id: 'f2', contentHash: 'h2', mimeType: 'image/jpeg' },
+      { id: 'f1', contentHash: 'h1', mimeType: 'image/png', extractionMetadata: null },
+      { id: 'f2', contentHash: 'h2', mimeType: 'image/jpeg', extractionMetadata: null },
     ]);
 
-    const result = await rewriteCanvasAssets({ html, db: mockDb as never });
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
     expect(mockDb.query.pages.findMany).toHaveBeenCalledTimes(1);
     expect(result.html).toContain('https://cdn.example.com/assets/h1');
     expect(result.html).toContain('https://cdn.example.com/assets/h2');
+  });
+
+  it('given the publisher cannot view a referenced file, should not copy or rewrite it', async () => {
+    const html = '<img src="/api/files/privateFile/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'privateFile', contentHash: 'privateHash', mimeType: 'image/png', extractionMetadata: null },
+    ]);
+    canUserViewPage.mockResolvedValue(false);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    const { copyObjectToPublishBucket } = await import('../published-storage');
+    expect(canUserViewPage).toHaveBeenCalledWith('user-1', 'privateFile');
+    expect(copyObjectToPublishBucket).not.toHaveBeenCalled();
+    expect(result.html).toContain('/api/files/privateFile/view');
+  });
+
+  it('given a thumbnail reference with metadata, should copy and rewrite the thumbnail cache object', async () => {
+    const html = '<video poster="/api/files/videoId/thumbnail"></video>';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      {
+        id: 'videoId',
+        contentHash: 'videoHash',
+        mimeType: 'video/mp4',
+        extractionMetadata: { thumbnailKey: 'cache/abcd1234/thumbnail.webp' },
+      },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    const { copyObjectToPublishBucket } = await import('../published-storage');
+    expect(copyObjectToPublishBucket).toHaveBeenCalledWith({
+      id: 'videoId',
+      kind: 'thumbnail',
+      sourceKey: 'cache/abcd1234/thumbnail.webp',
+      assetKey: 'assets/cache/abcd1234/thumbnail.webp',
+      contentType: 'image/webp',
+    });
+    expect(result.html).toContain('https://cdn.example.com/assets/cache/abcd1234/thumbnail.webp');
+    expect(result.html).not.toContain('/api/files/videoId/thumbnail');
+  });
+
+  it('given a thumbnail reference without valid thumbnail metadata, should leave the URL as-is', async () => {
+    const html = '<video poster="/api/files/videoId/thumbnail"></video>';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'videoId', contentHash: 'videoHash', mimeType: 'video/mp4', extractionMetadata: null },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    expect(result.html).toContain('/api/files/videoId/thumbnail');
+  });
+
+  it('given an asset copy fails, should leave that file URL as-is', async () => {
+    const html = '<img src="/api/files/fileId1/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'fileId1', contentHash: 'hash001', mimeType: 'image/png', extractionMetadata: null },
+    ]);
+    const { copyObjectToPublishBucket } = await import('../published-storage');
+    vi.mocked(copyObjectToPublishBucket).mockRejectedValueOnce(new Error('copy failed'));
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    expect(result.html).toContain('/api/files/fileId1/view');
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -41,6 +41,11 @@ describe('extractFileIds', () => {
     expect(extractFileIds(html)).toEqual(['href002']);
   });
 
+  it('given a longer endpoint that starts with /view, should not extract a partial file reference', () => {
+    const html = '<img src="/api/files/notARealFile/viewer">';
+    expect(extractFileIds(html)).toEqual([]);
+  });
+
   it('given multiple references to the same id, should deduplicate', () => {
     const html =
       '<img src="/api/files/dup1/view"><img src="/api/files/dup1/view"><img src="/api/files/dup2/view">';
@@ -98,6 +103,14 @@ describe('rewriteCanvasAssets', () => {
   it('given no file IDs in the HTML, should return the HTML unchanged', async () => {
     const html = '<p>No files here</p>';
     const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+    expect(result.html).toBe(html);
+    expect(mockDb.query.pages.findMany).not.toHaveBeenCalled();
+  });
+
+  it('given a longer endpoint that starts with /view, should leave it unchanged without querying files', async () => {
+    const html = '<img src="/api/files/notARealFile/viewer">';
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
     expect(result.html).toBe(html);
     expect(mockDb.query.pages.findMany).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import {
   buildPublishedKey,
   putPublishedArtifact,
   deletePublishedArtifact,
   isPublishConfigured,
+  buildAssetKey,
+  buildAssetUrl,
+  getPublishAssetBaseUrl,
+  copyAssetToPublishBucket,
 } from '../published-storage';
 
 const send = vi.fn();
@@ -129,5 +133,143 @@ describe('publish bucket configuration', () => {
       if (prev === undefined) delete process.env.PUBLISH_BUCKET;
       else process.env.PUBLISH_BUCKET = prev;
     }
+  });
+});
+
+describe('buildAssetKey', () => {
+  it('given a contentHash, should return assets/{contentHash}', () => {
+    expect(buildAssetKey('abc123def456')).toBe('assets/abc123def456');
+  });
+
+  it('given a 64-char SHA-256 hex hash, should return the correctly prefixed key', () => {
+    const hash = 'a'.repeat(64);
+    expect(buildAssetKey(hash)).toBe(`assets/${hash}`);
+  });
+});
+
+describe('getPublishAssetBaseUrl', () => {
+  let origAssetUrl: string | undefined;
+  let origBucket: string | undefined;
+
+  beforeEach(() => {
+    origAssetUrl = process.env.PUBLISH_ASSET_BASE_URL;
+    origBucket = process.env.PUBLISH_BUCKET;
+  });
+
+  afterEach(() => {
+    if (origAssetUrl === undefined) delete process.env.PUBLISH_ASSET_BASE_URL;
+    else process.env.PUBLISH_ASSET_BASE_URL = origAssetUrl;
+    if (origBucket === undefined) delete process.env.PUBLISH_BUCKET;
+    else process.env.PUBLISH_BUCKET = origBucket;
+  });
+
+  it('given PUBLISH_ASSET_BASE_URL is set, should return it', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'https://cdn.example.com';
+    expect(getPublishAssetBaseUrl()).toBe('https://cdn.example.com');
+  });
+
+  it('given PUBLISH_ASSET_BASE_URL unset but PUBLISH_BUCKET set, should derive Tigris public URL', () => {
+    delete process.env.PUBLISH_ASSET_BASE_URL;
+    process.env.PUBLISH_BUCKET = 'pagespace-published';
+    expect(getPublishAssetBaseUrl()).toBe('https://pagespace-published.t3.tigrisfiles.io');
+  });
+
+  it('given both PUBLISH_ASSET_BASE_URL and PUBLISH_BUCKET set, should prefer PUBLISH_ASSET_BASE_URL', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'https://cdn.example.com';
+    process.env.PUBLISH_BUCKET = 'pagespace-published';
+    expect(getPublishAssetBaseUrl()).toBe('https://cdn.example.com');
+  });
+
+  it('given both unset, should throw a descriptive error', () => {
+    delete process.env.PUBLISH_ASSET_BASE_URL;
+    delete process.env.PUBLISH_BUCKET;
+    expect(() => getPublishAssetBaseUrl()).toThrow(/PUBLISH_BUCKET/);
+  });
+});
+
+describe('buildAssetUrl', () => {
+  let origAssetUrl: string | undefined;
+  let origBucket: string | undefined;
+
+  beforeEach(() => {
+    origAssetUrl = process.env.PUBLISH_ASSET_BASE_URL;
+    origBucket = process.env.PUBLISH_BUCKET;
+    process.env.PUBLISH_BUCKET = 'pagespace-published';
+    delete process.env.PUBLISH_ASSET_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (origAssetUrl === undefined) delete process.env.PUBLISH_ASSET_BASE_URL;
+    else process.env.PUBLISH_ASSET_BASE_URL = origAssetUrl;
+    if (origBucket === undefined) delete process.env.PUBLISH_BUCKET;
+    else process.env.PUBLISH_BUCKET = origBucket;
+  });
+
+  it('given a contentHash, should return the full public asset URL', () => {
+    expect(buildAssetUrl('abc123')).toBe('https://pagespace-published.t3.tigrisfiles.io/assets/abc123');
+  });
+
+  it('given PUBLISH_ASSET_BASE_URL with trailing slash, should produce a clean URL without double slash', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'https://cdn.example.com/';
+    expect(buildAssetUrl('abc123')).toBe('https://cdn.example.com/assets/abc123');
+  });
+});
+
+describe('copyAssetToPublishBucket', () => {
+  beforeEach(() => {
+    send.mockReset();
+    process.env.PUBLISH_BUCKET = 'test-publish';
+    process.env.BUCKET_NAME = 'test-files';
+  });
+
+  it('given the asset already exists in the publish bucket (HeadObject 200), should skip GetObject and PutObject', async () => {
+    // HeadObject resolves → asset exists
+    send.mockResolvedValueOnce({});
+
+    await copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const cmd = send.mock.calls[0][0];
+    expect(cmd).toBeInstanceOf(HeadObjectCommand);
+    expect(cmd.input).toMatchObject({ Bucket: 'test-publish', Key: 'assets/abc123' });
+  });
+
+  it('given the asset does not exist in the publish bucket (HeadObject 404), should GetObject from private bucket then PutObject to publish bucket', async () => {
+    const notFound = Object.assign(new Error('Not Found'), { name: 'NotFound' });
+    const fakeBody = { transformToByteArray: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])) };
+
+    // HeadObject throws NotFound → GetObject succeeds → PutObject succeeds
+    send
+      .mockRejectedValueOnce(notFound)
+      .mockResolvedValueOnce({ Body: fakeBody })
+      .mockResolvedValueOnce({});
+
+    await copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' });
+
+    expect(send).toHaveBeenCalledTimes(3);
+
+    const [headCmd, getCmd, putCmd] = send.mock.calls.map((c) => c[0]);
+
+    expect(headCmd).toBeInstanceOf(HeadObjectCommand);
+    expect(headCmd.input).toMatchObject({ Bucket: 'test-publish', Key: 'assets/abc123' });
+
+    expect(getCmd).toBeInstanceOf(GetObjectCommand);
+    expect(getCmd.input).toMatchObject({ Bucket: 'test-files', Key: 'files/abc123/original' });
+
+    expect(putCmd).toBeInstanceOf(PutObjectCommand);
+    expect(putCmd.input).toMatchObject({
+      Bucket: 'test-publish',
+      Key: 'assets/abc123',
+      ContentType: 'image/png',
+    });
+    expect(putCmd.input.Body).toBeInstanceOf(Uint8Array);
+  });
+
+  it('given HeadObject throws a non-404 error, should propagate the error without copying', async () => {
+    const serverError = Object.assign(new Error('Server Error'), { name: 'ServiceUnavailable' });
+    send.mockRejectedValueOnce(serverError);
+
+    await expect(copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' })).rejects.toThrow('Server Error');
+    expect(send).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -7,8 +7,10 @@ import {
   isPublishConfigured,
   buildAssetKey,
   buildAssetUrl,
+  buildAssetUrlFromKey,
   getPublishAssetBaseUrl,
   copyAssetToPublishBucket,
+  copyObjectToPublishBucket,
 } from '../published-storage';
 
 const send = vi.fn();
@@ -215,6 +217,31 @@ describe('buildAssetUrl', () => {
   });
 });
 
+describe('buildAssetUrlFromKey', () => {
+  let origAssetUrl: string | undefined;
+  let origBucket: string | undefined;
+
+  beforeEach(() => {
+    origAssetUrl = process.env.PUBLISH_ASSET_BASE_URL;
+    origBucket = process.env.PUBLISH_BUCKET;
+    process.env.PUBLISH_BUCKET = 'pagespace-published';
+    delete process.env.PUBLISH_ASSET_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (origAssetUrl === undefined) delete process.env.PUBLISH_ASSET_BASE_URL;
+    else process.env.PUBLISH_ASSET_BASE_URL = origAssetUrl;
+    if (origBucket === undefined) delete process.env.PUBLISH_BUCKET;
+    else process.env.PUBLISH_BUCKET = origBucket;
+  });
+
+  it('given a resolved asset key, should return the full public asset URL', () => {
+    expect(buildAssetUrlFromKey('assets/cache/abc123/thumbnail.webp')).toBe(
+      'https://pagespace-published.t3.tigrisfiles.io/assets/cache/abc123/thumbnail.webp',
+    );
+  });
+});
+
 describe('copyAssetToPublishBucket', () => {
   beforeEach(() => {
     send.mockReset();
@@ -271,5 +298,52 @@ describe('copyAssetToPublishBucket', () => {
 
     await expect(copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' })).rejects.toThrow('Server Error');
     expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('copyObjectToPublishBucket', () => {
+  beforeEach(() => {
+    send.mockReset();
+    process.env.PUBLISH_BUCKET = 'test-publish';
+    process.env.BUCKET_NAME = 'test-files';
+  });
+
+  it('given a thumbnail cache object, should copy it to the requested public asset key', async () => {
+    const notFound = Object.assign(new Error('Not Found'), { name: 'NotFound' });
+    const fakeBody = { transformToByteArray: vi.fn().mockResolvedValue(new Uint8Array([4, 5, 6])) };
+
+    send
+      .mockRejectedValueOnce(notFound)
+      .mockResolvedValueOnce({ Body: fakeBody })
+      .mockResolvedValueOnce({});
+
+    await copyObjectToPublishBucket({
+      sourceKey: 'cache/abc123/thumbnail.webp',
+      assetKey: 'assets/cache/abc123/thumbnail.webp',
+      contentType: 'image/webp',
+    });
+
+    expect(send).toHaveBeenCalledTimes(3);
+
+    const [headCmd, getCmd, putCmd] = send.mock.calls.map((c) => c[0]);
+
+    expect(headCmd).toBeInstanceOf(HeadObjectCommand);
+    expect(headCmd.input).toMatchObject({
+      Bucket: 'test-publish',
+      Key: 'assets/cache/abc123/thumbnail.webp',
+    });
+
+    expect(getCmd).toBeInstanceOf(GetObjectCommand);
+    expect(getCmd.input).toMatchObject({
+      Bucket: 'test-files',
+      Key: 'cache/abc123/thumbnail.webp',
+    });
+
+    expect(putCmd).toBeInstanceOf(PutObjectCommand);
+    expect(putCmd.input).toMatchObject({
+      Bucket: 'test-publish',
+      Key: 'assets/cache/abc123/thumbnail.webp',
+      ContentType: 'image/webp',
+    });
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/render-published.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/render-published.test.ts
@@ -66,3 +66,39 @@ describe('renderPublishedPage', () => {
     expect(out).toContain('<title>Untitled</title>');
   });
 });
+
+describe('renderPublishedPage — assetBaseUrl', () => {
+  it('given assetBaseUrl, should allow that host in CSS url() values', () => {
+    const out = renderPublishedPage({
+      html: '<style>body { background: url("https://pagespace-published.t3.tigrisfiles.io/assets/abc123"); }</style>',
+      assetBaseUrl: 'https://pagespace-published.t3.tigrisfiles.io',
+    });
+    expect(out).toContain('https://pagespace-published.t3.tigrisfiles.io/assets/abc123');
+    expect(out).not.toContain('url("")');
+  });
+
+  it('given assetBaseUrl, should still block other HTTPS hosts in CSS url()', () => {
+    const out = renderPublishedPage({
+      html: '<style>body { background: url("https://evil.com/tracker.gif"); }</style>',
+      assetBaseUrl: 'https://pagespace-published.t3.tigrisfiles.io',
+    });
+    expect(out).not.toContain('evil.com');
+    expect(out).toContain('url("")');
+  });
+
+  it('given no assetBaseUrl, should block all external HTTPS url() values (existing default)', () => {
+    const out = renderPublishedPage({
+      html: '<style>body { background: url("https://pagespace-published.t3.tigrisfiles.io/assets/abc"); }</style>',
+    });
+    expect(out).not.toContain('pagespace-published.t3.tigrisfiles.io');
+    expect(out).toContain('url("")');
+  });
+
+  it('given assetBaseUrl with trailing slash, should derive host correctly and allow it', () => {
+    const out = renderPublishedPage({
+      html: '<style>body { background: url("https://cdn.example.com/assets/x"); }</style>',
+      assetBaseUrl: 'https://cdn.example.com/',
+    });
+    expect(out).toContain('https://cdn.example.com/assets/x');
+  });
+});

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -22,8 +22,8 @@ interface PublishAsset {
   contentType: string;
 }
 
-const fileRefPattern = String.raw`(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)\/(view|thumbnail)`;
-const createFileRefRegex = (): RegExp => new RegExp(fileRefPattern, 'g');
+const createFileRefRegex = (): RegExp =>
+  /(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)\/(view|thumbnail)(?=$|[?#"')\s>])/g;
 
 const referenceKey = ({ id, kind }: FileReference): string => `${id}:${kind}`;
 

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -1,0 +1,103 @@
+import 'server-only';
+
+import { type db as DbType } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { inArray } from '@pagespace/db/operators';
+import { buildAssetUrl, copyAssetToPublishBucket } from './published-storage';
+
+/**
+ * Regex that matches /api/files/{id}/view and /api/files/{id}/thumbnail in:
+ *  - HTML attributes (src, href, srcset)
+ *  - CSS url() values (single- or double-quoted, or unquoted)
+ *
+ * The id capture group is group 1.
+ *
+ * Anchored to the start of a possible absolute origin (https://…) or a bare
+ * relative path so we never accidentally match external non-PageSpace URLs
+ * that happen to contain `/api/files/`.
+ */
+const FILE_REF_REGEX = /(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)\/(?:view|thumbnail)/g;
+
+/**
+ * Extract all unique PageSpace file IDs referenced in canvas HTML.
+ *
+ * Scans `src`, `href`, CSS `url()` values — any occurrence of the pattern
+ * `/api/files/{id}/view` or `/api/files/{id}/thumbnail`.
+ *
+ * Pure function: no I/O, no env reads.
+ */
+export function extractFileIds(html: string): string[] {
+  const ids = new Set<string>();
+  let match: RegExpExecArray | null;
+  FILE_REF_REGEX.lastIndex = 0;
+  while ((match = FILE_REF_REGEX.exec(html)) !== null) {
+    ids.add(match[1]);
+  }
+  return Array.from(ids);
+}
+
+/**
+ * DB shape expected by rewriteCanvasAssets — only the columns we read.
+ */
+interface FilePageRow {
+  id: string;
+  contentHash: string | null;
+  mimeType: string | null;
+}
+
+/**
+ * Rewrite all `/api/files/{id}/view` (and `/thumbnail`) references in the
+ * canvas HTML to public CDN asset URLs, copying any referenced files to the
+ * publish bucket along the way.
+ *
+ * - Unresolvable IDs (file not found in DB, or page has no contentHash) are
+ *   left as-is — publish still succeeds; the image just won't load publicly.
+ * - DB is queried once for all IDs (batch, not N+1).
+ * - Copy is idempotent (HeadObject dedup in copyAssetToPublishBucket).
+ */
+export async function rewriteCanvasAssets(params: {
+  html: string;
+  db: Pick<typeof DbType, 'query'>;
+}): Promise<{ html: string }> {
+  const { html, db } = params;
+
+  const fileIds = extractFileIds(html);
+  if (fileIds.length === 0) return { html };
+
+  // Batch-query: only FILE-type pages, only the columns we need
+  const rows = (await db.query.pages.findMany({
+    where: inArray(pages.id, fileIds),
+    columns: { id: true, contentHash: true, mimeType: true },
+  })) as FilePageRow[];
+
+  // Build id → { contentHash, mimeType } map (skip pages with no hash)
+  const resolved = new Map<string, { contentHash: string; mimeType: string }>();
+  for (const row of rows) {
+    if (row.contentHash) {
+      resolved.set(row.id, {
+        contentHash: row.contentHash,
+        mimeType: row.mimeType ?? 'application/octet-stream',
+      });
+    }
+  }
+
+  if (resolved.size === 0) return { html };
+
+  // Copy all resolved assets to publish bucket (content-addressed → idempotent)
+  await Promise.all(
+    Array.from(resolved.values()).map((asset) =>
+      copyAssetToPublishBucket(asset).catch((err) => {
+        console.warn(`[asset-pipeline] Failed to copy asset ${asset.contentHash}:`, err);
+      }),
+    ),
+  );
+
+  // One-pass URL rewrite
+  FILE_REF_REGEX.lastIndex = 0;
+  const rewritten = html.replace(FILE_REF_REGEX, (match, id: string) => {
+    const asset = resolved.get(id);
+    return asset ? buildAssetUrl(asset.contentHash) : match;
+  });
+
+  return { html: rewritten };
+}

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -1,22 +1,31 @@
 import 'server-only';
 
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { type db as DbType } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { inArray } from '@pagespace/db/operators';
-import { buildAssetUrl, copyAssetToPublishBucket } from './published-storage';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { buildAssetKey, buildAssetUrlFromKey, copyObjectToPublishBucket } from './published-storage';
 
-/**
- * Regex that matches /api/files/{id}/view and /api/files/{id}/thumbnail in:
- *  - HTML attributes (src, href, srcset)
- *  - CSS url() values (single- or double-quoted, or unquoted)
- *
- * The id capture group is group 1.
- *
- * Anchored to the start of a possible absolute origin (https://…) or a bare
- * relative path so we never accidentally match external non-PageSpace URLs
- * that happen to contain `/api/files/`.
- */
-const FILE_REF_REGEX = /(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)\/(?:view|thumbnail)/g;
+type FileReferenceKind = 'view' | 'thumbnail';
+
+interface FileReference {
+  id: string;
+  kind: FileReferenceKind;
+}
+
+interface PublishAsset {
+  id: string;
+  kind: FileReferenceKind;
+  sourceKey: string;
+  assetKey: string;
+  contentType: string;
+}
+
+const fileRefPattern = String.raw`(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)\/(view|thumbnail)`;
+const createFileRefRegex = (): RegExp => new RegExp(fileRefPattern, 'g');
+
+const referenceKey = ({ id, kind }: FileReference): string => `${id}:${kind}`;
 
 /**
  * Extract all unique PageSpace file IDs referenced in canvas HTML.
@@ -28,12 +37,19 @@ const FILE_REF_REGEX = /(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)
  */
 export function extractFileIds(html: string): string[] {
   const ids = new Set<string>();
-  let match: RegExpExecArray | null;
-  FILE_REF_REGEX.lastIndex = 0;
-  while ((match = FILE_REF_REGEX.exec(html)) !== null) {
-    ids.add(match[1]);
+  for (const { id } of extractFileReferences(html)) {
+    ids.add(id);
   }
   return Array.from(ids);
+}
+
+function extractFileReferences(html: string): FileReference[] {
+  const refsByKey = new Map<string, FileReference>();
+  for (const match of html.matchAll(createFileRefRegex())) {
+    const ref = { id: match[1], kind: match[2] as FileReferenceKind };
+    refsByKey.set(referenceKey(ref), ref);
+  }
+  return Array.from(refsByKey.values());
 }
 
 /**
@@ -43,6 +59,59 @@ interface FilePageRow {
   id: string;
   contentHash: string | null;
   mimeType: string | null;
+  extractionMetadata: unknown;
+}
+
+function getThumbnailSourceKey(row: FilePageRow): string | null {
+  const metadata = row.extractionMetadata;
+  if (!metadata || typeof metadata !== 'object' || !('thumbnailKey' in metadata)) {
+    return null;
+  }
+
+  const thumbnailKey = (metadata as { thumbnailKey?: unknown }).thumbnailKey;
+  if (typeof thumbnailKey !== 'string') return null;
+
+  return /^cache\/[a-f0-9]+\/thumbnail\.webp$/i.test(thumbnailKey) ? thumbnailKey : null;
+}
+
+function resolvePublishAsset(row: FilePageRow, kind: FileReferenceKind): PublishAsset | null {
+  if (kind === 'thumbnail') {
+    const sourceKey = getThumbnailSourceKey(row);
+    if (!sourceKey) return null;
+    return {
+      id: row.id,
+      kind,
+      sourceKey,
+      assetKey: `assets/${sourceKey}`,
+      contentType: 'image/webp',
+    };
+  }
+
+  if (!row.contentHash) return null;
+  return {
+    id: row.id,
+    kind,
+    sourceKey: `files/${row.contentHash}/original`,
+    assetKey: buildAssetKey(row.contentHash),
+    contentType: row.mimeType ?? 'application/octet-stream',
+  };
+}
+
+async function filterViewableRows(userId: string, rows: FilePageRow[]): Promise<FilePageRow[]> {
+  const checks = await Promise.all(
+    rows.map(async (row) => ({
+      row,
+      canView: await canUserViewPage(userId, row.id).catch((err) => {
+        loggers.api.warn('asset-pipeline: failed to authorize referenced asset', {
+          fileId: row.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return false;
+      }),
+    })),
+  );
+
+  return checks.filter(({ canView }) => canView).map(({ row }) => row);
 }
 
 /**
@@ -57,46 +126,58 @@ interface FilePageRow {
  */
 export async function rewriteCanvasAssets(params: {
   html: string;
+  userId: string;
   db: Pick<typeof DbType, 'query'>;
 }): Promise<{ html: string }> {
-  const { html, db } = params;
+  const { html, userId, db } = params;
 
-  const fileIds = extractFileIds(html);
+  const references = extractFileReferences(html);
+  const fileIds = Array.from(new Set(references.map(({ id }) => id)));
   if (fileIds.length === 0) return { html };
 
-  // Batch-query: only FILE-type pages, only the columns we need
+  // Batch-query referenced page rows; permission checks below decide which assets can publish.
   const rows = (await db.query.pages.findMany({
     where: inArray(pages.id, fileIds),
-    columns: { id: true, contentHash: true, mimeType: true },
+    columns: { id: true, contentHash: true, mimeType: true, extractionMetadata: true },
   })) as FilePageRow[];
 
-  // Build id → { contentHash, mimeType } map (skip pages with no hash)
-  const resolved = new Map<string, { contentHash: string; mimeType: string }>();
-  for (const row of rows) {
-    if (row.contentHash) {
-      resolved.set(row.id, {
-        contentHash: row.contentHash,
-        mimeType: row.mimeType ?? 'application/octet-stream',
-      });
-    }
+  const rowsById = new Map((await filterViewableRows(userId, rows)).map((row) => [row.id, row]));
+  const resolved = new Map<string, PublishAsset>();
+  const uniqueAssets = new Map<string, PublishAsset>();
+
+  for (const ref of references) {
+    const row = rowsById.get(ref.id);
+    if (!row) continue;
+    const asset = resolvePublishAsset(row, ref.kind);
+    if (!asset) continue;
+    resolved.set(referenceKey(ref), asset);
+    uniqueAssets.set(asset.assetKey, asset);
   }
 
   if (resolved.size === 0) return { html };
 
-  // Copy all resolved assets to publish bucket (content-addressed → idempotent)
+  // Copy each distinct source object to the publish bucket; only successful copies are rewritten.
+  const copiedAssetKeys = new Set<string>();
   await Promise.all(
-    Array.from(resolved.values()).map((asset) =>
-      copyAssetToPublishBucket(asset).catch((err) => {
-        console.warn(`[asset-pipeline] Failed to copy asset ${asset.contentHash}:`, err);
-      }),
-    ),
+    Array.from(uniqueAssets.values()).map(async (asset) => {
+      try {
+        await copyObjectToPublishBucket(asset);
+        copiedAssetKeys.add(asset.assetKey);
+      } catch (err) {
+        loggers.api.warn('asset-pipeline: failed to copy asset', {
+          fileId: asset.id,
+          kind: asset.kind,
+          sourceKey: asset.sourceKey,
+          assetKey: asset.assetKey,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }),
   );
 
-  // One-pass URL rewrite
-  FILE_REF_REGEX.lastIndex = 0;
-  const rewritten = html.replace(FILE_REF_REGEX, (match, id: string) => {
-    const asset = resolved.get(id);
-    return asset ? buildAssetUrl(asset.contentHash) : match;
+  const rewritten = html.replace(createFileRefRegex(), (match, id: string, kind: FileReferenceKind) => {
+    const asset = resolved.get(referenceKey({ id, kind }));
+    return asset && copiedAssetKeys.has(asset.assetKey) ? buildAssetUrlFromKey(asset.assetKey) : match;
   });
 
   return { html: rewritten };

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -161,9 +161,58 @@ export function getPublishAssetBaseUrl(): string {
  * a double slash.
  */
 export function buildAssetUrl(contentHash: string): string {
+  return buildAssetUrlFromKey(buildAssetKey(contentHash));
+}
+
+/**
+ * Build the full public URL for an already-resolved publish-bucket asset key.
+ */
+export function buildAssetUrlFromKey(assetKey: string): string {
   const base = getPublishAssetBaseUrl();
   const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
-  return `${trimmedBase}/${buildAssetKey(contentHash)}`;
+  return `${trimmedBase}/${assetKey}`;
+}
+
+/**
+ * Copy an object from private file storage to a public publish-bucket asset key.
+ */
+export async function copyObjectToPublishBucket(params: {
+  sourceKey: string;
+  assetKey: string;
+  contentType: string;
+}): Promise<void> {
+  const { sourceKey, assetKey, contentType } = params;
+  const publishBucket = getPublishBucket();
+
+  // Dedup check — existence at the resolved public key means it was already promoted.
+  try {
+    await getPublishClient().send(new HeadObjectCommand({ Bucket: publishBucket, Key: assetKey }));
+    return;
+  } catch (err: unknown) {
+    const anyErr = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+    const is404 =
+      anyErr?.name === 'NotFound' ||
+      anyErr?.name === 'NoSuchKey' ||
+      anyErr?.$metadata?.httpStatusCode === 404;
+    if (!is404) throw err;
+  }
+
+  const getResult = await getS3Client().send(
+    new GetObjectCommand({ Bucket: getS3Bucket(), Key: sourceKey }),
+  );
+
+  const body = getResult.Body
+    ? await (getResult.Body as { transformToByteArray(): Promise<Uint8Array> }).transformToByteArray()
+    : new Uint8Array(0);
+
+  await getPublishClient().send(
+    new PutObjectCommand({
+      Bucket: publishBucket,
+      Key: assetKey,
+      Body: body,
+      ContentType: contentType,
+    }),
+  );
 }
 
 /**
@@ -181,38 +230,9 @@ export async function copyAssetToPublishBucket(params: {
   mimeType: string;
 }): Promise<void> {
   const { contentHash, mimeType } = params;
-  const assetKey = buildAssetKey(contentHash);
-  const publishBucket = getPublishBucket();
-
-  // Dedup check — content-addressed, so existence = already correct
-  try {
-    await getPublishClient().send(new HeadObjectCommand({ Bucket: publishBucket, Key: assetKey }));
-    return;
-  } catch (err: unknown) {
-    const anyErr = err as { name?: string; $metadata?: { httpStatusCode?: number } };
-    const is404 =
-      anyErr?.name === 'NotFound' ||
-      anyErr?.name === 'NoSuchKey' ||
-      anyErr?.$metadata?.httpStatusCode === 404;
-    if (!is404) throw err;
-    // Not found — proceed with copy
-  }
-
-  const privateKey = `files/${contentHash}/original`;
-  const getResult = await getS3Client().send(
-    new GetObjectCommand({ Bucket: getS3Bucket(), Key: privateKey }),
-  );
-
-  const body = getResult.Body
-    ? await (getResult.Body as { transformToByteArray(): Promise<Uint8Array> }).transformToByteArray()
-    : new Uint8Array(0);
-
-  await getPublishClient().send(
-    new PutObjectCommand({
-      Bucket: publishBucket,
-      Key: assetKey,
-      Body: body,
-      ContentType: mimeType,
-    }),
-  );
+  await copyObjectToPublishBucket({
+    sourceKey: `files/${contentHash}/original`,
+    assetKey: buildAssetKey(contentHash),
+    contentType: mimeType,
+  });
 }

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
-import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
 
 /**
  * Storage helper for PUBLISHED canvas artifacts.
@@ -111,6 +112,107 @@ export async function deletePublishedArtifact(key: string): Promise<void> {
     new DeleteObjectCommand({
       Bucket: getPublishBucket(),
       Key: key,
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Asset pipeline helpers (CDN copy of embedded PageSpace files)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the S3 object key for a content-addressed asset in the publish bucket.
+ *
+ * Assets are keyed by content hash so:
+ *  - identical files share a single object (no duplication)
+ *  - re-publishing the same canvas is fully idempotent
+ *  - orphaned keys are harmless (same content, never an old/wrong version)
+ */
+export function buildAssetKey(contentHash: string): string {
+  return `assets/${contentHash}`;
+}
+
+/**
+ * Resolve the public base URL for CDN assets.
+ *
+ * Priority:
+ *  1. `PUBLISH_ASSET_BASE_URL` — explicit override (e.g. a custom CDN)
+ *  2. Derived from `PUBLISH_BUCKET` → `https://{bucket}.t3.tigrisfiles.io`
+ *     (Tigris public domain; anonymous GET works here — NOT the authed S3 endpoint)
+ *  3. Throws if neither is set.
+ */
+export function getPublishAssetBaseUrl(): string {
+  if (process.env.PUBLISH_ASSET_BASE_URL) {
+    return process.env.PUBLISH_ASSET_BASE_URL;
+  }
+  const bucket = process.env.PUBLISH_BUCKET;
+  if (!bucket) {
+    throw new Error(
+      'Cannot derive asset base URL: PUBLISH_BUCKET is not configured and PUBLISH_ASSET_BASE_URL is not set',
+    );
+  }
+  return `https://${bucket}.t3.tigrisfiles.io`;
+}
+
+/**
+ * Build the full public URL for a content-addressed asset.
+ *
+ * Trailing slashes in the base URL are normalised so the result never contains
+ * a double slash.
+ */
+export function buildAssetUrl(contentHash: string): string {
+  const base = getPublishAssetBaseUrl();
+  const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  return `${trimmedBase}/${buildAssetKey(contentHash)}`;
+}
+
+/**
+ * Copy a file from the private uploads bucket to the public CDN publish bucket.
+ *
+ * Content-addressed: if the asset key already exists in the publish bucket
+ * (HeadObject → 200) the copy is skipped — the bytes are identical by hash.
+ * This makes concurrent publishes fully idempotent.
+ *
+ * Private key: `files/{contentHash}/original` (standard Tigris upload layout).
+ * Public key:  `assets/{contentHash}` (via buildAssetKey).
+ */
+export async function copyAssetToPublishBucket(params: {
+  contentHash: string;
+  mimeType: string;
+}): Promise<void> {
+  const { contentHash, mimeType } = params;
+  const assetKey = buildAssetKey(contentHash);
+  const publishBucket = getPublishBucket();
+
+  // Dedup check — content-addressed, so existence = already correct
+  try {
+    await getPublishClient().send(new HeadObjectCommand({ Bucket: publishBucket, Key: assetKey }));
+    return;
+  } catch (err: unknown) {
+    const anyErr = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+    const is404 =
+      anyErr?.name === 'NotFound' ||
+      anyErr?.name === 'NoSuchKey' ||
+      anyErr?.$metadata?.httpStatusCode === 404;
+    if (!is404) throw err;
+    // Not found — proceed with copy
+  }
+
+  const privateKey = `files/${contentHash}/original`;
+  const getResult = await getS3Client().send(
+    new GetObjectCommand({ Bucket: getS3Bucket(), Key: privateKey }),
+  );
+
+  const body = getResult.Body
+    ? await (getResult.Body as { transformToByteArray(): Promise<Uint8Array> }).transformToByteArray()
+    : new Uint8Array(0);
+
+  await getPublishClient().send(
+    new PutObjectCommand({
+      Bucket: publishBucket,
+      Key: assetKey,
+      Body: body,
+      ContentType: mimeType,
     }),
   );
 }

--- a/apps/web/src/lib/canvas/render-published.ts
+++ b/apps/web/src/lib/canvas/render-published.ts
@@ -14,11 +14,24 @@ import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
 export interface RenderPublishedPageInput {
   html: string;
   title?: string;
+  /**
+   * Base URL of the public CDN bucket used for published assets
+   * (e.g. `https://pagespace-published.t3.tigrisfiles.io`). When provided,
+   * that host is allowed through the CSS `url()` sanitizer so that
+   * background-image references to copied assets survive in the published
+   * artifact. Omit for in-app rendering — the sanitizer keeps blocking all
+   * external HTTPS `url()` values.
+   */
+  assetBaseUrl?: string;
 }
 
 /**
  * Render a complete, standalone HTML document for a published canvas page.
  */
 export function renderPublishedPage(input: RenderPublishedPageInput): string {
-  return renderCanvasDocument(input);
+  const { assetBaseUrl, ...rest } = input;
+  const allowedAssetHosts = assetBaseUrl
+    ? [new URL(assetBaseUrl.endsWith('/') ? assetBaseUrl.slice(0, -1) : assetBaseUrl).host]
+    : [];
+  return renderCanvasDocument({ ...rest, allowedAssetHosts });
 }

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -124,3 +124,48 @@ describe('renderCanvasDocument', () => {
     expect(out).not.toContain('<base');
   });
 });
+
+describe('renderCanvasDocument — allowedAssetHosts', () => {
+  it('given allowedAssetHosts containing the CDN host, should preserve that host in CSS url()', () => {
+    const out = renderCanvasDocument({
+      html: '<style>body { background: url("https://cdn.example.com/assets/abc"); }</style>',
+      allowedAssetHosts: ['cdn.example.com'],
+    });
+    expect(out).toContain('https://cdn.example.com/assets/abc');
+    expect(out).not.toContain('url("")');
+  });
+
+  it('given allowedAssetHosts set, should still block non-matching HTTPS hosts in CSS url()', () => {
+    const out = renderCanvasDocument({
+      html: '<style>body { background: url("https://tracker.evil.com/px.gif"); }</style>',
+      allowedAssetHosts: ['cdn.example.com'],
+    });
+    expect(out).not.toContain('tracker.evil.com');
+    expect(out).toContain('url("")');
+  });
+
+  it('given allowedAssetHosts, should NOT affect HTML img src attributes — they are never sanitized', () => {
+    const out = renderCanvasDocument({
+      html: '<img src="https://cdn.example.com/photo.jpg">',
+      allowedAssetHosts: ['cdn.example.com'],
+    });
+    expect(out).toContain('https://cdn.example.com/photo.jpg');
+  });
+
+  it('given allowedAssetHosts: [] (empty), should block all external HTTPS url() values', () => {
+    const out = renderCanvasDocument({
+      html: '<style>body { background: url("https://cdn.example.com/x.png"); }</style>',
+      allowedAssetHosts: [],
+    });
+    expect(out).not.toContain('cdn.example.com');
+    expect(out).toContain('url("")');
+  });
+
+  it('given no allowedAssetHosts field, should block all external HTTPS url() values (existing default)', () => {
+    const out = renderCanvasDocument({
+      html: '<style>body { background: url("https://cdn.example.com/x.png"); }</style>',
+    });
+    expect(out).not.toContain('cdn.example.com');
+    expect(out).toContain('url("")');
+  });
+});

--- a/packages/lib/src/canvas/__tests__/sanitize-css.test.ts
+++ b/packages/lib/src/canvas/__tests__/sanitize-css.test.ts
@@ -9,6 +9,20 @@ describe('sanitizeCSS — allowedHttpsHosts option', () => {
     expect(result).not.toContain('url("")')
   })
 
+  it('given an allowed HTTPS URL with uppercase host and explicit port, should preserve it', () => {
+    const css = 'background: url("https://ASSETS.PAGESPACE.AI:443/assets/abc123");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: ['assets.pagespace.ai'] })
+    expect(result).toContain('https://ASSETS.PAGESPACE.AI:443/assets/abc123')
+    expect(result).not.toContain('url("")')
+  })
+
+  it('given allowedHttpsHosts with uppercase host and port, should normalize before matching', () => {
+    const css = 'background: url("https://assets.pagespace.ai/assets/abc123");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: ['ASSETS.PAGESPACE.AI:443'] })
+    expect(result).toContain('https://assets.pagespace.ai/assets/abc123')
+    expect(result).not.toContain('url("")')
+  })
+
   it('given allowedHttpsHosts set but url host does not match, should still replace with url("")', () => {
     const css = 'background: url("https://evil.com/pixel.png");'
     const result = sanitizeCSS(css, { allowedHttpsHosts: ['assets.pagespace.ai'] })

--- a/packages/lib/src/canvas/__tests__/sanitize-css.test.ts
+++ b/packages/lib/src/canvas/__tests__/sanitize-css.test.ts
@@ -1,6 +1,51 @@
 import { describe, it, expect } from 'vitest'
 import { sanitizeCSS } from '../sanitize-css'
 
+describe('sanitizeCSS — allowedHttpsHosts option', () => {
+  it('given allowedHttpsHosts containing the url host, should preserve the url() unchanged', () => {
+    const css = 'background: url("https://assets.pagespace.ai/assets/abc123");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: ['assets.pagespace.ai'] })
+    expect(result).toContain('https://assets.pagespace.ai/assets/abc123')
+    expect(result).not.toContain('url("")')
+  })
+
+  it('given allowedHttpsHosts set but url host does not match, should still replace with url("")', () => {
+    const css = 'background: url("https://evil.com/pixel.png");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: ['assets.pagespace.ai'] })
+    expect(result).not.toContain('evil.com')
+    expect(result).toContain('url("")')
+  })
+
+  it('given allowedHttpsHosts: [] (empty), should replace any HTTPS url() with url("")', () => {
+    const css = 'background: url("https://assets.pagespace.ai/x.png");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: [] })
+    expect(result).not.toContain('assets.pagespace.ai')
+    expect(result).toContain('url("")')
+  })
+
+  it('given url uses HTTP (not HTTPS), should replace with url("") even if host is in allowedHttpsHosts', () => {
+    const css = 'background: url("http://assets.pagespace.ai/x.png");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: ['assets.pagespace.ai'] })
+    expect(result).not.toContain('http://assets.pagespace.ai')
+    expect(result).toContain('url("")')
+  })
+
+  it('given the host appears as a substring of another host, should not allow it through', () => {
+    // 'pagespace.ai' in allowlist must NOT allow 'evil-pagespace.ai'
+    const css = 'background: url("https://evil-pagespace.ai/x.png");'
+    const result = sanitizeCSS(css, { allowedHttpsHosts: ['pagespace.ai'] })
+    expect(result).not.toContain('evil-pagespace.ai')
+    expect(result).toContain('url("")')
+  })
+
+  it('given no opts argument, should block all external HTTPS url() values (existing default)', () => {
+    const css = 'background: url("https://assets.pagespace.ai/x.png");'
+    const result = sanitizeCSS(css)
+    expect(result).not.toContain('assets.pagespace.ai')
+    expect(result).toContain('url("")')
+  })
+})
+
 describe('sanitizeCSS', () => {
   it('given empty input, should return an empty string', () => {
     expect(sanitizeCSS('')).toBe('')

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -31,6 +31,7 @@ export interface RenderCanvasDocumentInput {
    * only restricts a `<base href>`, not `<base target>`, so this is allowed.
    */
   baseTarget?: '_blank' | '_self' | '_parent' | '_top';
+  allowedAssetHosts?: string[];
 }
 
 /**
@@ -84,14 +85,14 @@ export function escapeHtml(value: string): string {
  * source (e.g. a web-component template literal) is never mistaken for a real
  * stylesheet — the script is preserved verbatim.
  */
-function extractAndSanitizeStyles(html: string): { css: string; body: string } {
+function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[]): { css: string; body: string } {
   const scriptOrStyle = /<script\b[^>]*>[\s\S]*?<\/script\s*>|<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
   const cssParts: string[] = [];
   const body = html.replace(scriptOrStyle, (match, styleContent: string | undefined) => {
     // styleContent is the capture group; defined only when a real <style>
     // element matched (not a <script> block).
     if (styleContent !== undefined) {
-      cssParts.push(sanitizeCSS(styleContent));
+      cssParts.push(sanitizeCSS(styleContent, allowedHttpsHosts?.length ? { allowedHttpsHosts } : undefined));
       return '';
     }
     return match; // <script> block — leave verbatim
@@ -103,9 +104,9 @@ function extractAndSanitizeStyles(html: string): { css: string; body: string } {
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget } = input;
+  const { html, title, baseTarget, allowedAssetHosts } = input;
 
-  const { css, body } = extractAndSanitizeStyles(html ?? '');
+  const { css, body } = extractAndSanitizeStyles(html ?? '', allowedAssetHosts);
   const safeTitle = escapeHtml(title && title.trim() ? title : 'Untitled');
   const baseTag = baseTarget ? `<base target="${baseTarget}">` : '';
 

--- a/packages/lib/src/canvas/sanitize-css.ts
+++ b/packages/lib/src/canvas/sanitize-css.ts
@@ -20,6 +20,12 @@
 export function sanitizeCSS(css: string, opts?: { allowedHttpsHosts?: string[] }): string {
   if (!css) return '';
 
+  const allowedHttpsHosts = new Set(
+    (opts?.allowedHttpsHosts ?? [])
+      .map((host) => normalizeAllowedHttpsHost(host))
+      .filter((host): host is string => Boolean(host)),
+  );
+
   let sanitized = css;
 
   // Remove JavaScript execution vectors and dangerous URL schemes
@@ -43,9 +49,15 @@ export function sanitizeCSS(css: string, opts?: { allowedHttpsHosts?: string[] }
     /url\s*\(\s*(['"]?)(?!data:)([^'")]+)\1\s*\)/gi,
     (match, quote, url) => {
       const trimmed = url.trim();
-      if (trimmed.startsWith('https://') && opts?.allowedHttpsHosts?.length) {
-        const host = trimmed.slice('https://'.length).split('/')[0];
-        if (opts.allowedHttpsHosts.includes(host)) return match;
+      if (allowedHttpsHosts.size > 0) {
+        try {
+          const parsed = new URL(trimmed);
+          if (parsed.protocol === 'https:' && allowedHttpsHosts.has(parsed.hostname.toLowerCase())) {
+            return match;
+          }
+        } catch {
+          // Invalid URLs fall through to the default block.
+        }
       }
       if (process.env.NODE_ENV === 'development') {
         console.warn(`[Canvas Security] Blocked external URL: ${url}`);
@@ -76,4 +88,16 @@ export function sanitizeCSS(css: string, opts?: { allowedHttpsHosts?: string[] }
   );
 
   return sanitized;
+}
+
+function normalizeAllowedHttpsHost(host: string): string | null {
+  const trimmed = host.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`);
+    return parsed.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
 }

--- a/packages/lib/src/canvas/sanitize-css.ts
+++ b/packages/lib/src/canvas/sanitize-css.ts
@@ -17,7 +17,7 @@
  *
  * Pure string transform: no DOM dependency, safe to run server-side.
  */
-export function sanitizeCSS(css: string): string {
+export function sanitizeCSS(css: string, opts?: { allowedHttpsHosts?: string[] }): string {
   if (!css) return '';
 
   let sanitized = css;
@@ -42,11 +42,15 @@ export function sanitizeCSS(css: string): string {
   sanitized = sanitized.replace(
     /url\s*\(\s*(['"]?)(?!data:)([^'")]+)\1\s*\)/gi,
     (match, quote, url) => {
-      // Log blocked URL for monitoring (in development)
+      const trimmed = url.trim();
+      if (trimmed.startsWith('https://') && opts?.allowedHttpsHosts?.length) {
+        const host = trimmed.slice('https://'.length).split('/')[0];
+        if (opts.allowedHttpsHosts.includes(host)) return match;
+      }
       if (process.env.NODE_ENV === 'development') {
         console.warn(`[Canvas Security] Blocked external URL: ${url}`);
       }
-      return 'url("")'; // Replace with empty URL
+      return 'url("")';
     }
   );
 


### PR DESCRIPTION
## Summary

- Publish-time asset pipeline: `/api/files/{id}/view` and `/thumbnail` references in canvas HTML are extracted, the corresponding files are copied from the private `pagespace-files` bucket to the public `pagespace-published` bucket, and URLs are rewritten to content-addressed CDN paths (`assets/{contentHash}`)
- CSS sanitizer (`sanitizeCSS`) gains an `allowedHttpsHosts` option so published-page rendering can let CDN URLs through `url()` values without changing in-app CanvasFrame behavior
- `getPublishAssetBaseUrl()` → `PUBLISH_ASSET_BASE_URL` override or derived `https://{PUBLISH_BUCKET}.t3.tigrisfiles.io` (Tigris public domain, no-auth anonymous reads)
- Copy is idempotent (HeadObject dedup) and content-addressed (same hash = same bytes, no version collisions)

**Security**: only files embedded in a canvas the publisher has edit permission on get copied. Explicit publish is the consent gate. No `/api/files/*` endpoints are made public; no obscurity-based access.

## New files

- `apps/web/src/lib/canvas/asset-pipeline.ts` — `extractFileIds` (pure) + `rewriteCanvasAssets` (async, batch DB + S3)
- `apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts` — 15 tests

## Modified files

| File | Change |
|------|--------|
| `packages/lib/src/canvas/sanitize-css.ts` | `allowedHttpsHosts` option |
| `packages/lib/src/canvas/render-document.ts` | thread `allowedAssetHosts` |
| `apps/web/src/lib/canvas/render-published.ts` | accept + derive `assetBaseUrl` |
| `apps/web/src/lib/canvas/published-storage.ts` | `buildAssetKey`, `buildAssetUrl`, `getPublishAssetBaseUrl`, `copyAssetToPublishBucket` |
| `apps/web/src/app/api/pages/[pageId]/publish/route.ts` | call pipeline before render |

## Test plan

- [ ] 73 new/updated tests across 8 files — all GREEN; pre-existing failures unchanged
- [ ] `bun run --filter 'web' test` — publish route: 25/25, asset-pipeline: 15/15, published-storage: 21/21, render-published: 12/12
- [ ] `bun run --filter '@pagespace/lib' test` — sanitize-css: 22/22, render-document: 21/21, 5301 total passing
- [ ] Manual: upload image → embed in canvas → publish → visit in incognito → image loads from Tigris CDN

## Env vars

- `PUBLISH_ASSET_BASE_URL` (optional) — explicit CDN base URL override; defaults to `https://${PUBLISH_BUCKET}.t3.tigrisfiles.io`
- `PUBLISH_BUCKET` (existing, required for publishing) — used to derive the default asset base URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nd42diMPE8p4GNsTNQxWF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canvas publishing now rewrites embedded asset references to use CDN-style, content-hash URLs (including thumbnails when available).
  * Published artifacts preserve author CSS `url(...)` styling for the allowed published-asset host, improving visual consistency after publishing.
* **Bug Fixes**
  * Publishing asset rewriting now gracefully avoids copying/rewrite when assets can’t be resolved or the user lacks permission.
* **Tests**
  * Expanded coverage for asset URL/base-URL generation, rewriting behavior, and published rendering with allowed asset hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->