### PR TITLE
fix(billing): subscribed users see stale past date and missing renewal date

### DIFF
--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -224,15 +224,20 @@ export default function BillingPage() {
     : null;
   const displayPeriodEnd = (() => {
     if (!rawPeriodEnd) return null;
-    if (rawPeriodEnd >= new Date()) return rawPeriodEnd;
-    // Project forward one month from the last known period end.
-    const d = new Date(rawPeriodEnd);
-    const day = d.getUTCDate();
-    d.setUTCDate(1);
-    d.setUTCMonth(d.getUTCMonth() + 1);
-    const lastDay = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
-    d.setUTCDate(Math.min(day, lastDay));
-    return d;
+    const now = new Date();
+    if (rawPeriodEnd >= now) return rawPeriodEnd;
+    const addMonth = (from: Date): Date => {
+      const d = new Date(from);
+      const day = d.getUTCDate();
+      d.setUTCDate(1);
+      d.setUTCMonth(d.getUTCMonth() + 1);
+      const lastDay = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+      d.setUTCDate(Math.min(day, lastDay));
+      return d;
+    };
+    let projected = addMonth(rawPeriodEnd);
+    while (projected <= now) projected = addMonth(projected);
+    return projected;
   })();
 
   return (

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -217,6 +217,24 @@ export default function BillingPage() {
   const scheduledPlan = scheduledPriceId ? getPlanFromPriceId(scheduledPriceId) : null;
   const scheduledChangeDate = subscriptionData?.subscription?.scheduledChangeDate;
 
+  // Never display a past period-end date. If Stripe's currentPeriodEnd is stale (webhook
+  // delay or renewal in progress), project the next expected date instead.
+  const rawPeriodEnd = subscriptionData?.subscription?.currentPeriodEnd
+    ? new Date(subscriptionData.subscription.currentPeriodEnd)
+    : null;
+  const displayPeriodEnd = (() => {
+    if (!rawPeriodEnd) return null;
+    if (rawPeriodEnd >= new Date()) return rawPeriodEnd;
+    // Project forward one month from the last known period end.
+    const d = new Date(rawPeriodEnd);
+    const day = d.getUTCDate();
+    d.setUTCDate(1);
+    d.setUTCMonth(d.getUTCMonth() + 1);
+    const lastDay = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+    d.setUTCDate(Math.min(day, lastDay));
+    return d;
+  })();
+
   return (
     <div className="container mx-auto p-6 space-y-8 max-w-4xl">
       <div>
@@ -282,11 +300,11 @@ export default function BillingPage() {
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                {isPaid && subscriptionData?.subscription && (
+                {isPaid && displayPeriodEnd && (
                   <div className="text-sm text-muted-foreground flex items-center gap-1 mr-4">
                     <Clock className="h-4 w-4" />
                     {isCanceling ? 'Ends' : 'Renews'}{' '}
-                    {new Date(subscriptionData.subscription.currentPeriodEnd).toLocaleDateString()}
+                    {displayPeriodEnd.toLocaleDateString()}
                   </div>
                 )}
                 <Link href="/settings/plan">
@@ -302,7 +320,7 @@ export default function BillingPage() {
                 <AlertTriangle className="h-4 w-4" />
                 <AlertDescription>
                   Your subscription will end on{' '}
-                  {new Date(subscriptionData!.subscription!.currentPeriodEnd).toLocaleDateString()}.
+                  {displayPeriodEnd?.toLocaleDateString()}.
                   You can reactivate anytime before then.
                 </AlertDescription>
               </Alert>

--- a/apps/web/src/components/billing/UsageBreakdownCard.tsx
+++ b/apps/web/src/components/billing/UsageBreakdownCard.tsx
@@ -77,7 +77,8 @@ export function UsageBreakdownCard() {
     };
   }, [socket, mutate]);
 
-  const renewDate = data?.periodEnd ? new Date(data.periodEnd) : null;
+  const renewDate =
+    data?.periodEnd && new Date(data.periodEnd) > new Date() ? new Date(data.periodEnd) : null;
 
   return (
     <Card>

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -231,7 +231,7 @@ describe('getCreditBalance', () => {
       expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('returns null for a paid user with an expired period — hides the line rather than showing stale Stripe date', async () => {
+    it('projects addOneMonth(pastPeriodEnd) for a paid user with an expired period — shows next expected Stripe cycle date', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 900,
@@ -241,7 +241,8 @@ describe('getCreditBalance', () => {
         },
       ];
       const b = await getCreditBalance('u1', 'pro');
-      expect(b.monthly.periodEnd).toBeNull();
+      expect(b.monthly.periodEnd).not.toBeNull();
+      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
     });
 
     it('projects addOneMonth(now) for a free user when no periodEnd has been stamped yet (null in DB)', async () => {
@@ -259,7 +260,7 @@ describe('getCreditBalance', () => {
       expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
     });
 
-    it('returns null for a paid user when no periodEnd has been stamped yet (null in DB)', async () => {
+    it('projects addOneMonth(now) for a paid user when no periodEnd has been stamped yet (null in DB)', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 1500,
@@ -269,7 +270,8 @@ describe('getCreditBalance', () => {
         },
       ];
       const b = await getCreditBalance('u1', 'pro');
-      expect(b.monthly.periodEnd).toBeNull();
+      expect(b.monthly.periodEnd).not.toBeNull();
+      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
     });
   });
 });

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -244,7 +244,7 @@ describe('getCreditBalance', () => {
       expect(b.monthly.periodEnd).toBeNull();
     });
 
-    it('returns null when no periodEnd has been stamped yet (null in DB)', async () => {
+    it('projects addOneMonth(now) for a free user when no periodEnd has been stamped yet (null in DB)', async () => {
       balanceRows = [
         {
           monthlyRemainingCents: 500,
@@ -257,6 +257,19 @@ describe('getCreditBalance', () => {
       const b = await getCreditBalance('u1', 'free');
       expect(b.monthly.periodEnd).not.toBeNull();
       expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns null for a paid user when no periodEnd has been stamped yet (null in DB)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 1500,
+          monthlyAllowanceCents: 1500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: null,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'pro');
+      expect(b.monthly.periodEnd).toBeNull();
     });
   });
 });

--- a/packages/lib/src/billing/__tests__/credit-balance.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-balance.test.ts
@@ -201,6 +201,64 @@ describe('getCreditBalance', () => {
     expect(b.reserved).toBe(50);
     expect(b.spendable).toBe(10);
   });
+
+  describe('monthly.periodEnd display projection', () => {
+    it('returns an active periodEnd as-is (ISO string)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 400,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: future,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'free');
+      expect(b.monthly.periodEnd).toBe(future.toISOString());
+    });
+
+    it('projects addOneMonth(now) for a free user with an expired period — never shows a past date', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 0,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: past,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'free');
+      // periodEnd must be in the future (not the stale past date from the DB)
+      expect(b.monthly.periodEnd).not.toBeNull();
+      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns null for a paid user with an expired period — hides the line rather than showing stale Stripe date', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 900,
+          monthlyAllowanceCents: 1500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: past,
+        },
+      ];
+      const b = await getCreditBalance('u1', 'pro');
+      expect(b.monthly.periodEnd).toBeNull();
+    });
+
+    it('returns null when no periodEnd has been stamped yet (null in DB)', async () => {
+      balanceRows = [
+        {
+          monthlyRemainingCents: 500,
+          monthlyAllowanceCents: 500,
+          topupRemainingCents: 0,
+          monthlyPeriodEnd: null,
+        },
+      ];
+      // null DB periodEnd counts as expired; free tier projects addOneMonth
+      const b = await getCreditBalance('u1', 'free');
+      expect(b.monthly.periodEnd).not.toBeNull();
+      expect(new Date(b.monthly.periodEnd!).getTime()).toBeGreaterThan(Date.now());
+    });
+  });
 });
 
 describe('resolveTier', () => {

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -146,11 +146,11 @@ export async function getCreditBalance(
   const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
   const periodEnd = row.monthlyPeriodEnd;
   const expired = periodEnd === null || periodEnd < now;
-  // For display: never show a past renewal date. Free users will get addOneMonth(now)
-  // stamped by the gate on their next AI call; project that for display. Paid users
-  // wait for invoice.paid — we don't know the date, so show nothing.
+  // For display: never show a past renewal date. Project addOneMonth from the last known
+  // period end (or now if none recorded) — free users get the same date the gate will stamp
+  // on their next call; paid users get the Stripe cycle date (same day next month).
   const displayPeriodEnd: Date | null = expired
-    ? (tier === 'free' ? addOneMonth(now) : null)
+    ? addOneMonth(periodEnd ?? now)
     : periodEnd;
 
   // Rollover: credits never expire. The carry balance is always spendable (both

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -32,6 +32,7 @@ import { users } from '@pagespace/db/schema/auth';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import { TIER_MONTHLY_ALLOWANCE_CENTS } from './credit-pricing';
+import { addOneMonth } from './credit-gate';
 import type { SubscriptionTier } from '../services/subscription-utils';
 
 export interface CreditBalanceSummary {
@@ -134,6 +135,12 @@ export async function getCreditBalance(
   const allowance = row.monthlyAllowanceCents || allowanceFor(tier);
   const periodEnd = row.monthlyPeriodEnd;
   const expired = periodEnd === null || periodEnd < now;
+  // For display: never show a past renewal date. Free users will get addOneMonth(now)
+  // stamped by the gate on their next AI call; project that for display. Paid users
+  // wait for invoice.paid — we don't know the date, so show nothing.
+  const displayPeriodEnd: Date | null = expired
+    ? (tier === 'free' ? addOneMonth(now) : null)
+    : periodEnd;
 
   // Rollover: credits never expire. The carry balance is always spendable (both
   // in the gate and here) — the renewal adds the allowance and nets outstanding debt.
@@ -166,7 +173,7 @@ export async function getCreditBalance(
     monthly: {
       remaining: monthlyRemaining,
       allowance,
-      periodEnd: periodEnd ? periodEnd.toISOString() : null,
+      periodEnd: displayPeriodEnd ? displayPeriodEnd.toISOString() : null,
     },
     topup: { remaining: topupRemaining },
     debt,

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -149,9 +149,14 @@ export async function getCreditBalance(
   // For display: never show a past renewal date. Project addOneMonth from the last known
   // period end (or now if none recorded) — free users get the same date the gate will stamp
   // on their next call; paid users get the Stripe cycle date (same day next month).
-  const displayPeriodEnd: Date | null = expired
-    ? addOneMonth(periodEnd ?? now)
-    : periodEnd;
+  const displayPeriodEnd: Date | null = (() => {
+    if (!expired) return periodEnd;
+    let projected = addOneMonth(periodEnd ?? now);
+    while (projected <= now) {
+      projected = addOneMonth(projected);
+    }
+    return projected;
+  })();
 
   // Rollover: credits never expire. The carry balance is always spendable (both
   // in the gate and here) — the renewal adds the allowance and nets outstanding debt.

--- a/packages/lib/src/billing/credit-balance.ts
+++ b/packages/lib/src/billing/credit-balance.ts
@@ -32,8 +32,19 @@ import { users } from '@pagespace/db/schema/auth';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import { TIER_MONTHLY_ALLOWANCE_CENTS } from './credit-pricing';
-import { addOneMonth } from './credit-gate';
 import type { SubscriptionTier } from '../services/subscription-utils';
+
+// Mirror of addOneMonth in credit-gate (same logic, kept local to avoid pulling
+// credit-gate's DB imports into this display-only module and its unit-test mocks).
+function addOneMonth(from: Date): Date {
+  const d = new Date(from.getTime());
+  const day = d.getUTCDate();
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() + 1);
+  const lastDay = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+  d.setUTCDate(Math.min(day, lastDay));
+  return d;
+}
 
 export interface CreditBalanceSummary {
   /** false on billing-disabled deployments (tenant/onprem); the widget then hides. */


### PR DESCRIPTION
## Summary

Two bugs affecting subscribed (paid) users when their current billing period has lapsed but the next renewal hasn't processed yet:

1. **Credit balance widget and card showed no renewal date** — the \"Renews\" line disappeared entirely, leaving the user with no indication of when their next credits arrive
2. **Settings → Billing showed a past date** (e.g. \"Renews 6/13/2026\") — the stale Stripe `currentPeriodEnd` was rendered directly with no staleness check

## What changed

- **`getCreditBalance`**: when the stored period end is in the past, project the next expected date with `addOneMonth(periodEnd ?? now)` for all tiers — free users get the date the gate will stamp on their next AI call, paid users get the expected next Stripe cycle date (same day next month)
- **`settings/billing/page.tsx`**: compute a `displayPeriodEnd` that projects one month forward when `currentPeriodEnd` is stale, so the billing page always shows a future date
- **`UsageBreakdownCard.tsx`**: guard the renewal date to only render when it's in the future
- **Tests**: two paid+expired test assertions updated from `null` to future-date (18/18 passing)

## Test plan

- [ ] Subscribed user with lapsed period: credit balance widget shows projected next-month date (not blank)
- [ ] Settings → Billing: shows projected date (not "Renews 6/13/2026")
- [ ] Settings → Usage breakdown: no past date shown
- [ ] Free user with expired period: shows projected ~1 month out (unchanged)
- [ ] Active (non-expired) period: shows the real stored date (unchanged)
- [ ] `bun run test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01313yfGFVDsKMc8ctBUrg3S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed billing period end dates incorrectly displaying past dates; renewal and expiration dates now accurately project to future dates.
* Billing renewal information displays consistently across all subscription types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->