### PR TITLE
[codex] Fix canvas file view links

### DIFF
--- a/apps/web/src/app/api/canvas/file-view-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/canvas/file-view-tokens/__tests__/route.test.ts
@@ -32,11 +32,16 @@ vi.mock('@/lib/canvas/file-view-token', () => ({
   createCanvasFileViewToken: vi.fn(({ driveId, pageId }) => `token-for-${driveId}-${pageId}`),
 }));
 
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
 import { POST } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { createCanvasFileViewToken } from '@/lib/canvas/file-view-token';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const jsonRequest = (body: unknown) =>
   new Request('https://pagespace.ai/api/canvas/file-view-tokens', {
@@ -72,6 +77,16 @@ describe('POST /api/canvas/file-view-tokens', () => {
       driveId: 'drive-1',
       pageId: 'file-1',
     });
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        eventType: 'auth.token.created',
+        userId: 'user-1',
+        resourceType: 'canvas_file_view_token',
+        resourceId: 'bulk',
+        details: { requested: 1, issued: 1 },
+      }),
+    );
   });
 
   it('given no authenticated user, should return 401', async () => {
@@ -83,6 +98,14 @@ describe('POST /api/canvas/file-view-tokens', () => {
 
     expect(response.status).toBe(401);
     expect(createCanvasFileViewToken).not.toHaveBeenCalled();
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({
+        eventType: 'authz.access.denied',
+        resourceType: 'canvas_file_view_token',
+        resourceId: 'bulk',
+      }),
+    );
   });
 
   it('given a ref for a different drive, should omit it without minting a token', async () => {

--- a/apps/web/src/app/api/canvas/file-view-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/canvas/file-view-tokens/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuth: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findMany: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  inArray: vi.fn((field: unknown, values: unknown[]) => ({ field, values })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id' },
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+  isFilePage: vi.fn((type: string) => type === 'FILE'),
+}));
+
+vi.mock('@/lib/canvas/file-view-token', () => ({
+  createCanvasFileViewToken: vi.fn(({ driveId, pageId }) => `token-for-${driveId}-${pageId}`),
+}));
+
+import { POST } from '../route';
+import { verifyAuth } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { createCanvasFileViewToken } from '@/lib/canvas/file-view-token';
+
+const jsonRequest = (body: unknown) =>
+  new Request('https://pagespace.ai/api/canvas/file-view-tokens', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('POST /api/canvas/file-view-tokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyAuth).mockResolvedValue({ id: 'user-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findMany).mockResolvedValue([
+      { id: 'file-1', driveId: 'drive-1', type: 'FILE' },
+    ] as never);
+  });
+
+  it('given an authorized file page ref, should mint a scoped dashboard view URL token', async () => {
+    const response = await POST(jsonRequest({
+      refs: [{ driveId: 'drive-1', pageId: 'file-1' }],
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      links: [{
+        driveId: 'drive-1',
+        pageId: 'file-1',
+        url: '/dashboard/drive-1/file-1/view?token=token-for-drive-1-file-1',
+      }],
+    });
+    expect(createCanvasFileViewToken).toHaveBeenCalledWith({
+      driveId: 'drive-1',
+      pageId: 'file-1',
+    });
+  });
+
+  it('given no authenticated user, should return 401', async () => {
+    vi.mocked(verifyAuth).mockResolvedValue(null as never);
+
+    const response = await POST(jsonRequest({
+      refs: [{ driveId: 'drive-1', pageId: 'file-1' }],
+    }));
+
+    expect(response.status).toBe(401);
+    expect(createCanvasFileViewToken).not.toHaveBeenCalled();
+  });
+
+  it('given a ref for a different drive, should omit it without minting a token', async () => {
+    const response = await POST(jsonRequest({
+      refs: [{ driveId: 'attacker-drive', pageId: 'file-1' }],
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ links: [] });
+    expect(createCanvasFileViewToken).not.toHaveBeenCalled();
+  });
+
+  it('given a ref the user cannot view, should omit it without minting a token', async () => {
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+    const response = await POST(jsonRequest({
+      refs: [{ driveId: 'drive-1', pageId: 'file-1' }],
+    }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ links: [] });
+    expect(createCanvasFileViewToken).not.toHaveBeenCalled();
+  });
+
+  it('given duplicate refs, should query and return one signed link', async () => {
+    const response = await POST(jsonRequest({
+      refs: [
+        { driveId: 'drive-1', pageId: 'file-1' },
+        { driveId: 'drive-1', pageId: 'file-1' },
+      ],
+    }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.links).toHaveLength(1);
+  });
+});

--- a/apps/web/src/app/api/canvas/file-view-tokens/route.ts
+++ b/apps/web/src/app/api/canvas/file-view-tokens/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { verifyAuth } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { inArray } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { isFilePage } from '@pagespace/lib/content/page-types.config';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { createCanvasFileViewToken } from '@/lib/canvas/file-view-token';
+import { safeParseBody } from '@/lib/validation/parse-body';
+
+const idSchema = z.string().regex(/^[a-zA-Z0-9_-]+$/);
+
+const bodySchema = z.object({
+  refs: z.array(z.object({
+    driveId: idSchema,
+    pageId: idSchema,
+  })).max(100),
+});
+
+const refKey = (driveId: string, pageId: string): string => `${driveId}:${pageId}`;
+
+export async function POST(request: Request) {
+  const user = await verifyAuth(request);
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const parsed = await safeParseBody(request, bodySchema);
+  if (!parsed.success) return parsed.response;
+
+  const uniqueRefs = Array.from(
+    new Map(parsed.data.refs.map((ref) => [refKey(ref.driveId, ref.pageId), ref])).values(),
+  );
+  if (uniqueRefs.length === 0) {
+    return NextResponse.json({ links: [] });
+  }
+
+  const rows = await db.query.pages.findMany({
+    where: inArray(pages.id, uniqueRefs.map(({ pageId }) => pageId)),
+    columns: { id: true, driveId: true, type: true },
+  });
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+
+  const links = (await Promise.all(uniqueRefs.map(async ({ driveId, pageId }) => {
+    const row = rowsById.get(pageId);
+    if (!row || row.driveId !== driveId || !isFilePage(row.type as PageType)) return null;
+    if (!(await canUserViewPage(user.id, pageId))) return null;
+
+    const token = createCanvasFileViewToken({ driveId, pageId });
+    return {
+      driveId,
+      pageId,
+      url: `/dashboard/${driveId}/${pageId}/view?token=${encodeURIComponent(token)}`,
+    };
+  }))).filter((link): link is { driveId: string; pageId: string; url: string } => link !== null);
+
+  return NextResponse.json({ links });
+}
+

--- a/apps/web/src/app/api/canvas/file-view-tokens/route.ts
+++ b/apps/web/src/app/api/canvas/file-view-tokens/route.ts
@@ -9,6 +9,7 @@ import { isFilePage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { createCanvasFileViewToken } from '@/lib/canvas/file-view-token';
 import { safeParseBody } from '@/lib/validation/parse-body';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const idSchema = z.string().regex(/^[a-zA-Z0-9_-]+$/);
 
@@ -24,6 +25,13 @@ const refKey = (driveId: string, pageId: string): string => `${driveId}:${pageId
 export async function POST(request: Request) {
   const user = await verifyAuth(request);
   if (!user) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      resourceType: 'canvas_file_view_token',
+      resourceId: 'bulk',
+      details: { reason: 'auth_failed', method: 'POST' },
+      riskScore: 0.4,
+    });
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
@@ -56,6 +64,14 @@ export async function POST(request: Request) {
     };
   }))).filter((link): link is { driveId: string; pageId: string; url: string } => link !== null);
 
+  auditRequest(request, {
+    eventType: 'auth.token.created',
+    userId: user.id,
+    resourceType: 'canvas_file_view_token',
+    resourceId: 'bulk',
+    details: { requested: uniqueRefs.length, issued: links.length },
+    riskScore: 0.2,
+  });
+
   return NextResponse.json({ links });
 }
-

--- a/apps/web/src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts
+++ b/apps/web/src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts
@@ -204,4 +204,51 @@ describe('GET /dashboard/[driveId]/[pageId]/view', () => {
     expect(response.status).toBe(500);
     expect(generatePresignedUrl).not.toHaveBeenCalled();
   });
+
+  it('given the file page has a malformed storage path, should fail closed before presigning', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({
+      id: 'file-1',
+      driveId: 'drive-1',
+      type: 'FILE',
+      filePath: '../private-object',
+      mimeType: 'image/png',
+      originalFileName: 'image.png',
+      title: 'Image',
+    } as never);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'Invalid file path' });
+    expect(generatePresignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('given the file page stores a bare content hash, should presign that validated hash', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({
+      id: 'file-1',
+      driveId: 'drive-1',
+      type: 'FILE',
+      filePath: 'b'.repeat(64),
+      mimeType: 'image/png',
+      originalFileName: 'image.png',
+      title: 'Image',
+    } as never);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(307);
+    expect(generatePresignedUrl).toHaveBeenCalledWith(
+      'b'.repeat(64),
+      'original',
+      3600,
+      undefined,
+      'image/png',
+    );
+  });
 });

--- a/apps/web/src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts
+++ b/apps/web/src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts
@@ -28,10 +28,32 @@ vi.mock('@pagespace/lib/content/page-types.config', () => ({
   isFilePage: vi.fn((type: string) => type === 'FILE'),
 }));
 
+vi.mock('@/lib/presigned-url', () => ({
+  generatePresignedUrl: vi.fn().mockResolvedValue('https://files.example.com/signed-file-url'),
+  getPresignedUrlTtl: vi.fn(() => 3600),
+}));
+
+vi.mock('@pagespace/lib/utils/file-security', () => ({
+  isDangerousMimeType: vi.fn(() => false),
+  sanitizeFilenameForHeader: vi.fn((filename: string) => filename),
+}));
+
+vi.mock('@/lib/canvas/file-view-token', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/canvas/file-view-token')>(
+    '@/lib/canvas/file-view-token',
+  );
+  return {
+    ...actual,
+    verifyCanvasFileViewToken: vi.fn(),
+  };
+});
+
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { generatePresignedUrl } from '@/lib/presigned-url';
+import { verifyCanvasFileViewToken } from '@/lib/canvas/file-view-token';
 
 const params = (driveId = 'drive-1', pageId = 'file-1') =>
   Promise.resolve({ driveId, pageId });
@@ -45,17 +67,29 @@ describe('GET /dashboard/[driveId]/[pageId]/view', () => {
       id: 'file-1',
       driveId: 'drive-1',
       type: 'FILE',
+      filePath: 'files/' + 'a'.repeat(64) + '/original',
+      mimeType: 'image/png',
+      originalFileName: 'image.png',
+      title: 'Image',
     } as never);
+    vi.mocked(verifyCanvasFileViewToken).mockReturnValue(false);
   });
 
-  it('given an authorized file page in the requested drive, should redirect to the canonical file view API', async () => {
+  it('given an authorized file page in the requested drive, should redirect to a presigned file URL', async () => {
     const request = new Request('https://pagespace.ai/dashboard/drive-1/file-1/view');
 
     const response = await GET(request, { params: params() });
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://pagespace.ai/api/files/file-1/view');
+    expect(response.headers.get('location')).toBe('https://files.example.com/signed-file-url');
     expect(canUserViewPage).toHaveBeenCalledWith('user-1', 'file-1');
+    expect(generatePresignedUrl).toHaveBeenCalledWith(
+      'a'.repeat(64),
+      'original',
+      3600,
+      undefined,
+      'image/png',
+    );
   });
 
   it('given no authenticated user, should return 401', async () => {
@@ -69,11 +103,47 @@ describe('GET /dashboard/[driveId]/[pageId]/view', () => {
     expect(response.status).toBe(401);
   });
 
+  it('given no authenticated user but a valid iframe token, should redirect without cookie auth', async () => {
+    vi.mocked(verifyAuth).mockResolvedValue(null as never);
+    vi.mocked(verifyCanvasFileViewToken).mockReturnValue(true);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view?token=signed-token'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://files.example.com/signed-file-url');
+    expect(verifyCanvasFileViewToken).toHaveBeenCalledWith({
+      token: 'signed-token',
+      driveId: 'drive-1',
+      pageId: 'file-1',
+    });
+    expect(canUserViewPage).not.toHaveBeenCalled();
+  });
+
+  it('given a token for a different drive or file page and no authenticated user, should return 401', async () => {
+    vi.mocked(verifyAuth).mockResolvedValue(null as never);
+    vi.mocked(verifyCanvasFileViewToken).mockReturnValue(false);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view?token=wrong-token'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(401);
+    expect(generatePresignedUrl).not.toHaveBeenCalled();
+  });
+
   it('given the page is not in the requested drive, should return 404 without permission checks', async () => {
     vi.mocked(db.query.pages.findFirst).mockResolvedValue({
       id: 'file-1',
       driveId: 'real-drive',
       type: 'FILE',
+      filePath: 'files/' + 'a'.repeat(64) + '/original',
+      mimeType: 'image/png',
+      originalFileName: 'image.png',
+      title: 'Image',
     } as never);
 
     const response = await GET(
@@ -90,6 +160,10 @@ describe('GET /dashboard/[driveId]/[pageId]/view', () => {
       id: 'doc-1',
       driveId: 'drive-1',
       type: 'DOCUMENT',
+      filePath: null,
+      mimeType: null,
+      originalFileName: null,
+      title: 'Document',
     } as never);
 
     const response = await GET(
@@ -109,5 +183,25 @@ describe('GET /dashboard/[driveId]/[pageId]/view', () => {
     );
 
     expect(response.status).toBe(403);
+  });
+
+  it('given the file page has no storage path, should return 500', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({
+      id: 'file-1',
+      driveId: 'drive-1',
+      type: 'FILE',
+      filePath: null,
+      mimeType: 'image/png',
+      originalFileName: 'image.png',
+      title: 'Image',
+    } as never);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(500);
+    expect(generatePresignedUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts
+++ b/apps/web/src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuth: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: vi.fn() },
+    },
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id' },
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+  isFilePage: vi.fn((type: string) => type === 'FILE'),
+}));
+
+import { GET } from '../route';
+import { verifyAuth } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+
+const params = (driveId = 'drive-1', pageId = 'file-1') =>
+  Promise.resolve({ driveId, pageId });
+
+describe('GET /dashboard/[driveId]/[pageId]/view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyAuth).mockResolvedValue({ id: 'user-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({
+      id: 'file-1',
+      driveId: 'drive-1',
+      type: 'FILE',
+    } as never);
+  });
+
+  it('given an authorized file page in the requested drive, should redirect to the canonical file view API', async () => {
+    const request = new Request('https://pagespace.ai/dashboard/drive-1/file-1/view');
+
+    const response = await GET(request, { params: params() });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://pagespace.ai/api/files/file-1/view');
+    expect(canUserViewPage).toHaveBeenCalledWith('user-1', 'file-1');
+  });
+
+  it('given no authenticated user, should return 401', async () => {
+    vi.mocked(verifyAuth).mockResolvedValue(null as never);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('given the page is not in the requested drive, should return 404 without permission checks', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({
+      id: 'file-1',
+      driveId: 'real-drive',
+      type: 'FILE',
+    } as never);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/attacker-drive/file-1/view'),
+      { params: params('attacker-drive', 'file-1') },
+    );
+
+    expect(response.status).toBe(404);
+    expect(canUserViewPage).not.toHaveBeenCalled();
+  });
+
+  it('given a non-file page, should return 404', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({
+      id: 'doc-1',
+      driveId: 'drive-1',
+      type: 'DOCUMENT',
+    } as never);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/doc-1/view'),
+      { params: params('drive-1', 'doc-1') },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('given the user cannot view the file page, should return 403', async () => {
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+    const response = await GET(
+      new Request('https://pagespace.ai/dashboard/drive-1/file-1/view'),
+      { params: params() },
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/dashboard/[driveId]/[pageId]/view/route.ts
+++ b/apps/web/src/app/dashboard/[driveId]/[pageId]/view/route.ts
@@ -18,9 +18,10 @@ interface RouteParams {
 }
 
 /** Extract a bare SHA-256 hash from legacy storagePath values like 'files/{hash}/original'. */
-function toContentHash(storagePath: string): string {
+function toContentHash(storagePath: string): string | null {
   const m = storagePath.match(/^files\/([a-f0-9]{64})\/original$/i);
-  return m ? m[1].toLowerCase() : storagePath;
+  if (m) return m[1].toLowerCase();
+  return /^[a-f0-9]{64}$/i.test(storagePath) ? storagePath.toLowerCase() : null;
 }
 
 export async function GET(request: Request, context: RouteParams) {
@@ -64,6 +65,9 @@ export async function GET(request: Request, context: RouteParams) {
   }
 
   const contentHash = toContentHash(page.filePath);
+  if (!contentHash) {
+    return NextResponse.json({ error: 'Invalid file path' }, { status: 500 });
+  }
   const mimeType = page.mimeType || 'application/octet-stream';
   const ttl = getPresignedUrlTtl(mimeType);
   const filename = sanitizeFilenameForHeader(page.originalFileName || page.title || contentHash);

--- a/apps/web/src/app/dashboard/[driveId]/[pageId]/view/route.ts
+++ b/apps/web/src/app/dashboard/[driveId]/[pageId]/view/route.ts
@@ -6,6 +6,9 @@ import { pages } from '@pagespace/db/schema/core';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { isFilePage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
+import { isDangerousMimeType, sanitizeFilenameForHeader } from '@pagespace/lib/utils/file-security';
+import { generatePresignedUrl, getPresignedUrlTtl } from '@/lib/presigned-url';
+import { verifyCanvasFileViewToken } from '@/lib/canvas/file-view-token';
 
 interface RouteParams {
   params: Promise<{
@@ -14,27 +17,61 @@ interface RouteParams {
   }>;
 }
 
+/** Extract a bare SHA-256 hash from legacy storagePath values like 'files/{hash}/original'. */
+function toContentHash(storagePath: string): string {
+  const m = storagePath.match(/^files\/([a-f0-9]{64})\/original$/i);
+  return m ? m[1].toLowerCase() : storagePath;
+}
+
 export async function GET(request: Request, context: RouteParams) {
   const { driveId, pageId } = await context.params;
-  const user = await verifyAuth(request);
-
-  if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get('token');
 
   const page = await db.query.pages.findFirst({
     where: eq(pages.id, pageId),
-    columns: { id: true, driveId: true, type: true },
+    columns: {
+      id: true,
+      driveId: true,
+      type: true,
+      filePath: true,
+      mimeType: true,
+      originalFileName: true,
+      title: true,
+    },
   });
 
   if (!page || page.driveId !== driveId || !isFilePage(page.type as PageType)) {
     return NextResponse.json({ error: 'File not found' }, { status: 404 });
   }
 
-  const canView = await canUserViewPage(user.id, pageId);
-  if (!canView) {
-    return NextResponse.json({ error: 'You do not have access to this file' }, { status: 403 });
+  const hasValidToken = verifyCanvasFileViewToken({ token, driveId, pageId });
+  if (!hasValidToken) {
+    const user = await verifyAuth(request);
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const canView = await canUserViewPage(user.id, pageId);
+    if (!canView) {
+      return NextResponse.json({ error: 'You do not have access to this file' }, { status: 403 });
+    }
   }
 
-  return NextResponse.redirect(new URL(`/api/files/${pageId}/view`, request.url), 307);
+  if (!page.filePath) {
+    return NextResponse.json({ error: 'File path not found' }, { status: 500 });
+  }
+
+  const contentHash = toContentHash(page.filePath);
+  const mimeType = page.mimeType || 'application/octet-stream';
+  const ttl = getPresignedUrlTtl(mimeType);
+  const filename = sanitizeFilenameForHeader(page.originalFileName || page.title || contentHash);
+  const asciiFilename = filename.replace(/[^\x20-\x7E]/g, '_');
+  const disposition = isDangerousMimeType(mimeType)
+    ? `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodeURIComponent(filename)}`
+    : undefined;
+  const presignedUrl = await generatePresignedUrl(contentHash, 'original', ttl, disposition, mimeType);
+
+  return NextResponse.redirect(presignedUrl, 307);
 }

--- a/apps/web/src/app/dashboard/[driveId]/[pageId]/view/route.ts
+++ b/apps/web/src/app/dashboard/[driveId]/[pageId]/view/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { verifyAuth } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { isFilePage } from '@pagespace/lib/content/page-types.config';
+import { PageType } from '@pagespace/lib/utils/enums';
+
+interface RouteParams {
+  params: Promise<{
+    driveId: string;
+    pageId: string;
+  }>;
+}
+
+export async function GET(request: Request, context: RouteParams) {
+  const { driveId, pageId } = await context.params;
+  const user = await verifyAuth(request);
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const page = await db.query.pages.findFirst({
+    where: eq(pages.id, pageId),
+    columns: { id: true, driveId: true, type: true },
+  });
+
+  if (!page || page.driveId !== driveId || !isFilePage(page.type as PageType)) {
+    return NextResponse.json({ error: 'File not found' }, { status: 404 });
+  }
+
+  const canView = await canUserViewPage(user.id, pageId);
+  if (!canView) {
+    return NextResponse.json({ error: 'You do not have access to this file' }, { status: 403 });
+  }
+
+  return NextResponse.redirect(new URL(`/api/files/${pageId}/view`, request.url), 307);
+}

--- a/apps/web/src/components/canvas/CanvasFrame.tsx
+++ b/apps/web/src/components/canvas/CanvasFrame.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import {
+  extractDashboardFileViewRefs,
+  rewriteDashboardFileViewLinks,
+} from '@/lib/canvas/file-view-links';
 
 interface CanvasFrameProps {
   html: string;
@@ -38,12 +43,54 @@ export const CANVAS_IFRAME_SANDBOX = 'allow-scripts allow-popups allow-popups-to
  * in-app view and the published artifact render identically.
  */
 export function CanvasFrame({ html, title }: CanvasFrameProps) {
+  const [previewHtml, setPreviewHtml] = useState(html);
+
+  useEffect(() => {
+    const refs = extractDashboardFileViewRefs(html);
+    if (refs.length === 0) {
+      setPreviewHtml(html);
+      return;
+    }
+
+    let cancelled = false;
+    setPreviewHtml(html);
+
+    fetchWithAuth('/api/canvas/file-view-tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refs }),
+    })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return response.json() as Promise<{
+          links: Array<{ driveId: string; pageId: string; url: string }>;
+        }>;
+      })
+      .then((body) => {
+        if (cancelled || !body) return;
+        const urlsByRef = new Map(
+          body.links.map((link) => [`${link.driveId}:${link.pageId}`, link.url]),
+        );
+        setPreviewHtml(rewriteDashboardFileViewLinks(
+          html,
+          ({ driveId, pageId }) => urlsByRef.get(`${driveId}:${pageId}`),
+        ));
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewHtml(html);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [html]);
+
   // baseTarget '_blank': inside the sandboxed frame an ordinary <a href> (no
   // target) would navigate the frame itself — and many sites refuse framing —
   // so default links to a new tab (works with the iframe's allow-popups).
   const srcDoc = useMemo(
-    () => renderCanvasDocument({ html, title, baseTarget: '_blank' }),
-    [html, title],
+    () => renderCanvasDocument({ html: previewHtml, title, baseTarget: '_blank' }),
+    [previewHtml, title],
   );
 
   return (

--- a/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
+++ b/apps/web/src/components/canvas/__tests__/CanvasFrame.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { CANVAS_IFRAME_SANDBOX } from '../CanvasFrame';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}));
+
+import { CANVAS_IFRAME_SANDBOX, CanvasFrame } from '../CanvasFrame';
 
 /**
  * Security invariant guard for the in-app canvas iframe.
@@ -24,5 +32,39 @@ describe('CANVAS_IFRAME_SANDBOX', () => {
     // Must not be able to navigate the app's own (top) tab.
     expect(tokens).not.toContain('allow-top-navigation');
     expect(tokens).not.toContain('allow-top-navigation-by-user-activation');
+  });
+});
+
+describe('CanvasFrame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        links: [{
+          driveId: 'drive-1',
+          pageId: 'file-1',
+          url: '/dashboard/drive-1/file-1/view?token=signed',
+        }],
+      }),
+    });
+  });
+
+  it('given dashboard file links in canvas HTML, should render tokenized preview links for the sandboxed iframe', async () => {
+    render(React.createElement(CanvasFrame, {
+      html: '<img src="/dashboard/drive-1/file-1/view">',
+      title: 'Canvas',
+    }));
+
+    await waitFor(() => {
+      const iframe = screen.getByTitle('Canvas') as HTMLIFrameElement;
+      expect(iframe.srcdoc).toContain('/dashboard/drive-1/file-1/view?token=signed');
+    });
+
+    expect(fetchWithAuthMock).toHaveBeenCalledWith('/api/canvas/file-view-tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refs: [{ driveId: 'drive-1', pageId: 'file-1' }] }),
+    });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
@@ -31,6 +31,12 @@ describe('buildInlineInstructions — always-on sections', () => {
     expect(result).toContain('PAGE TYPES');
   });
 
+  it('instructs canvas authors to use dashboard file view URLs for embedded uploaded files', () => {
+    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    expect(result).toContain('/dashboard/{driveId}/{filePageId}/view');
+    expect(result).toContain('not /api/files');
+  });
+
   it('includes AFTER TOOLS regardless of tool list', () => {
     const result = buildInlineInstructions(BASE_CONTEXT, []);
     expect(result).toContain('AFTER TOOLS');

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -34,7 +34,7 @@ const PAGE_TYPES = `PAGE TYPES:
 • DOCUMENT: Rich text stored as HTML. Use insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits.
 • CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
-• CANVAS: Raw HTML/CSS rendered in a sandboxed iframe. Author HTML renders into a real <body> — write standard HTML/CSS/JS.
+• CANVAS: Raw HTML/CSS rendered in a sandboxed iframe. Author HTML renders into a real <body> — write standard HTML/CSS/JS. For uploaded FILE pages embedded in canvas HTML, use /dashboard/{driveId}/{filePageId}/view (not /api/files) so the same link works in unpublished iframes and can be rewritten for published canvases.
 • TASK_LIST: Task manager where each task auto-creates a linked child TASK_LIST page for its description and sub-tasks.
 • AI_CHAT: Custom AI agent with configurable system prompt and tool permissions.
 • CHANNEL: Team discussion thread with real-time messaging.

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -169,6 +169,22 @@ describe('rewriteCanvasAssets', () => {
     expect(result.html).toContain('/dashboard/attacker-drive/fileId1/view');
   });
 
+  it('given the same file is referenced by a valid API URL and a wrong dashboard drive, should only rewrite the valid reference', async () => {
+    const html = [
+      '<img src="/api/files/fileId1/view">',
+      '<img src="/dashboard/attacker-drive/fileId1/view">',
+    ].join('');
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'fileId1', driveId: 'real-drive', contentHash: HASH_A, mimeType: 'image/png', extractionMetadata: null },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    expect(result.html).toContain(`https://cdn.example.com/assets/${HASH_A}`);
+    expect(result.html).not.toContain('/api/files/fileId1/view');
+    expect(result.html).toContain('/dashboard/attacker-drive/fileId1/view');
+  });
+
   it('given a file ID that cannot be resolved in the DB, should leave the URL as-is (graceful degradation)', async () => {
     const html = '<img src="/api/files/missingId/view">';
     mockDb.query.pages.findMany.mockResolvedValue([]); // not found

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -11,6 +11,10 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserViewPage: (...args: unknown[]) => canUserViewPage(...args),
 }));
 
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const HASH_C = 'c'.repeat(64);
+
 // ---------------------------------------------------------------------------
 // extractFileIds — pure, no I/O
 // ---------------------------------------------------------------------------
@@ -24,6 +28,11 @@ describe('extractFileIds', () => {
   it('given an absolute https://pagespace.ai/api/files/{id}/view src, should extract the id', () => {
     const html = '<img src="https://pagespace.ai/api/files/def456/view">';
     expect(extractFileIds(html)).toEqual(['def456']);
+  });
+
+  it('given a dashboard file page /view src, should extract the page id', () => {
+    const html = '<img src="/dashboard/drive123/page456/view">';
+    expect(extractFileIds(html)).toEqual(['page456']);
   });
 
   it('given a /api/files/{id}/thumbnail src, should extract the id', () => {
@@ -118,21 +127,46 @@ describe('rewriteCanvasAssets', () => {
   it('given a file ID that resolves to a page with contentHash, should rewrite the URL to CDN and copy the asset', async () => {
     const html = '<img src="/api/files/fileId1/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'fileId1', contentHash: 'hash001', mimeType: 'image/png', extractionMetadata: null },
+      { id: 'fileId1', contentHash: HASH_A, mimeType: 'image/png', extractionMetadata: null },
     ]);
 
     const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
-    expect(result.html).toContain('https://cdn.example.com/assets/hash001');
+    expect(result.html).toContain(`https://cdn.example.com/assets/${HASH_A}`);
     expect(result.html).not.toContain('/api/files/fileId1/view');
     const { copyObjectToPublishBucket } = await import('../published-storage');
     expect(copyObjectToPublishBucket).toHaveBeenCalledWith({
       id: 'fileId1',
       kind: 'view',
-      sourceKey: 'files/hash001/original',
-      assetKey: 'assets/hash001',
+      sourceKey: `files/${HASH_A}/original`,
+      assetKey: `assets/${HASH_A}`,
       contentType: 'image/png',
     });
+  });
+
+  it('given a dashboard file page /view URL with matching drive, should rewrite it to CDN', async () => {
+    const html = '<img src="https://pagespace.ai/dashboard/drive-1/fileId1/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'fileId1', driveId: 'drive-1', contentHash: HASH_A, mimeType: 'image/png', extractionMetadata: null },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    expect(result.html).toContain(`https://cdn.example.com/assets/${HASH_A}`);
+    expect(result.html).not.toContain('/dashboard/drive-1/fileId1/view');
+  });
+
+  it('given a dashboard file page /view URL with a mismatched drive, should not copy or rewrite it', async () => {
+    const html = '<img src="/dashboard/attacker-drive/fileId1/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'fileId1', driveId: 'real-drive', contentHash: HASH_A, mimeType: 'image/png', extractionMetadata: null },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    const { copyObjectToPublishBucket } = await import('../published-storage');
+    expect(copyObjectToPublishBucket).not.toHaveBeenCalled();
+    expect(result.html).toContain('/dashboard/attacker-drive/fileId1/view');
   });
 
   it('given a file ID that cannot be resolved in the DB, should leave the URL as-is (graceful degradation)', async () => {
@@ -155,25 +189,38 @@ describe('rewriteCanvasAssets', () => {
     expect(result.html).toContain('/api/files/noHashId/view');
   });
 
+  it('given a page with a non-content-address hash, should not copy or rewrite it', async () => {
+    const html = '<img src="/api/files/hostileHash/view">';
+    mockDb.query.pages.findMany.mockResolvedValue([
+      { id: 'hostileHash', contentHash: '../private-object', mimeType: 'image/png', extractionMetadata: null },
+    ]);
+
+    const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
+
+    const { copyObjectToPublishBucket } = await import('../published-storage');
+    expect(copyObjectToPublishBucket).not.toHaveBeenCalled();
+    expect(result.html).toContain('/api/files/hostileHash/view');
+  });
+
   it('given multiple distinct file IDs, should batch-query the DB once and rewrite all resolved URLs', async () => {
     const html =
       '<img src="/api/files/f1/view"><img src="/api/files/f2/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'f1', contentHash: 'h1', mimeType: 'image/png', extractionMetadata: null },
-      { id: 'f2', contentHash: 'h2', mimeType: 'image/jpeg', extractionMetadata: null },
+      { id: 'f1', contentHash: HASH_A, mimeType: 'image/png', extractionMetadata: null },
+      { id: 'f2', contentHash: HASH_B, mimeType: 'image/jpeg', extractionMetadata: null },
     ]);
 
     const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
     expect(mockDb.query.pages.findMany).toHaveBeenCalledTimes(1);
-    expect(result.html).toContain('https://cdn.example.com/assets/h1');
-    expect(result.html).toContain('https://cdn.example.com/assets/h2');
+    expect(result.html).toContain(`https://cdn.example.com/assets/${HASH_A}`);
+    expect(result.html).toContain(`https://cdn.example.com/assets/${HASH_B}`);
   });
 
   it('given the publisher cannot view a referenced file, should not copy or rewrite it', async () => {
     const html = '<img src="/api/files/privateFile/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'privateFile', contentHash: 'privateHash', mimeType: 'image/png', extractionMetadata: null },
+      { id: 'privateFile', contentHash: HASH_C, mimeType: 'image/png', extractionMetadata: null },
     ]);
     canUserViewPage.mockResolvedValue(false);
 
@@ -190,7 +237,7 @@ describe('rewriteCanvasAssets', () => {
     mockDb.query.pages.findMany.mockResolvedValue([
       {
         id: 'videoId',
-        contentHash: 'videoHash',
+        contentHash: HASH_C,
         mimeType: 'video/mp4',
         extractionMetadata: { thumbnailKey: 'cache/abcd1234/thumbnail.webp' },
       },
@@ -213,7 +260,7 @@ describe('rewriteCanvasAssets', () => {
   it('given a thumbnail reference without valid thumbnail metadata, should leave the URL as-is', async () => {
     const html = '<video poster="/api/files/videoId/thumbnail"></video>';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'videoId', contentHash: 'videoHash', mimeType: 'video/mp4', extractionMetadata: null },
+      { id: 'videoId', contentHash: HASH_C, mimeType: 'video/mp4', extractionMetadata: null },
     ]);
 
     const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
@@ -224,7 +271,7 @@ describe('rewriteCanvasAssets', () => {
   it('given an asset copy fails, should leave that file URL as-is', async () => {
     const html = '<img src="/api/files/fileId1/view">';
     mockDb.query.pages.findMany.mockResolvedValue([
-      { id: 'fileId1', contentHash: 'hash001', mimeType: 'image/png', extractionMetadata: null },
+      { id: 'fileId1', contentHash: HASH_A, mimeType: 'image/png', extractionMetadata: null },
     ]);
     const { copyObjectToPublishBucket } = await import('../published-storage');
     vi.mocked(copyObjectToPublishBucket).mockRejectedValueOnce(new Error('copy failed'));

--- a/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractDashboardFileViewRefs,
+  rewriteDashboardFileViewLinks,
+} from '../file-view-links';
+
+describe('extractDashboardFileViewRefs', () => {
+  it('given relative and absolute dashboard file links, should extract unique drive/page refs', () => {
+    const html = [
+      '<img src="/dashboard/drive-1/file-1/view">',
+      '<a href="https://pagespace.ai/dashboard/drive-1/file-1/view">open</a>',
+      '<img src="/dashboard/drive-2/file-2/view?token=old">',
+    ].join('');
+
+    expect(extractDashboardFileViewRefs(html)).toEqual([
+      { driveId: 'drive-1', pageId: 'file-1' },
+      { driveId: 'drive-2', pageId: 'file-2' },
+    ]);
+  });
+
+  it('given non-view dashboard paths, should ignore them', () => {
+    expect(extractDashboardFileViewRefs('<img src="/dashboard/drive-1/file-1/edit">')).toEqual([]);
+  });
+});
+
+describe('rewriteDashboardFileViewLinks', () => {
+  it('given a signed URL for a dashboard ref, should rewrite only that full link occurrence', () => {
+    const html = [
+      '<img src="/dashboard/drive-1/file-1/view">',
+      '<img src="/dashboard/drive-2/file-2/view">',
+    ].join('');
+
+    const rewritten = rewriteDashboardFileViewLinks(html, ({ driveId, pageId }) =>
+      driveId === 'drive-1' && pageId === 'file-1'
+        ? `/dashboard/${driveId}/${pageId}/view?token=signed`
+        : null,
+    );
+
+    expect(rewritten).toContain('/dashboard/drive-1/file-1/view?token=signed');
+    expect(rewritten).toContain('/dashboard/drive-2/file-2/view');
+  });
+});

--- a/apps/web/src/lib/canvas/__tests__/file-view-token.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/file-view-token.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createCanvasFileViewToken,
+  verifyCanvasFileViewToken,
+} from '../file-view-token';
+
+const SECRET = 'test-canvas-file-view-secret-minimum-32-chars';
+
+describe('canvas file view tokens', () => {
+  const originalSecret = process.env.CANVAS_FILE_VIEW_SECRET;
+  const originalCsrfSecret = process.env.CSRF_SECRET;
+
+  beforeEach(() => {
+    process.env.CANVAS_FILE_VIEW_SECRET = SECRET;
+    delete process.env.CSRF_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CANVAS_FILE_VIEW_SECRET;
+    } else {
+      process.env.CANVAS_FILE_VIEW_SECRET = originalSecret;
+    }
+
+    if (originalCsrfSecret === undefined) {
+      delete process.env.CSRF_SECRET;
+    } else {
+      process.env.CSRF_SECRET = originalCsrfSecret;
+    }
+  });
+
+  it('given a token for a drive and file page, should verify before expiry', () => {
+    const token = createCanvasFileViewToken({
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 1_000,
+      ttlMs: 60_000,
+    });
+
+    expect(verifyCanvasFileViewToken({
+      token,
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 30_000,
+    })).toBe(true);
+  });
+
+  it('given a token replayed for a different drive or file page, should reject it', () => {
+    const token = createCanvasFileViewToken({
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 1_000,
+      ttlMs: 60_000,
+    });
+
+    expect(verifyCanvasFileViewToken({
+      token,
+      driveId: 'drive-2',
+      pageId: 'file-1',
+      nowMs: 30_000,
+    })).toBe(false);
+    expect(verifyCanvasFileViewToken({
+      token,
+      driveId: 'drive-1',
+      pageId: 'file-2',
+      nowMs: 30_000,
+    })).toBe(false);
+  });
+
+  it('given an expired or tampered token, should reject it', () => {
+    const token = createCanvasFileViewToken({
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 1_000,
+      ttlMs: 60_000,
+    });
+
+    expect(verifyCanvasFileViewToken({
+      token,
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 62_000,
+    })).toBe(false);
+    expect(verifyCanvasFileViewToken({
+      token: `${token}x`,
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 30_000,
+    })).toBe(false);
+  });
+
+  it('given no dedicated secret, should fall back to CSRF_SECRET', () => {
+    delete process.env.CANVAS_FILE_VIEW_SECRET;
+    process.env.CSRF_SECRET = SECRET;
+
+    const token = createCanvasFileViewToken({
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 1_000,
+      ttlMs: 60_000,
+    });
+
+    expect(verifyCanvasFileViewToken({
+      token,
+      driveId: 'drive-1',
+      pageId: 'file-1',
+      nowMs: 30_000,
+    })).toBe(true);
+  });
+});

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../published-storage';
 
 const send = vi.fn();
+const HASH = 'a'.repeat(64);
 
 vi.mock('server-only', () => ({}));
 
@@ -140,12 +141,20 @@ describe('publish bucket configuration', () => {
 
 describe('buildAssetKey', () => {
   it('given a contentHash, should return assets/{contentHash}', () => {
-    expect(buildAssetKey('abc123def456')).toBe('assets/abc123def456');
+    expect(buildAssetKey(HASH)).toBe(`assets/${HASH}`);
   });
 
   it('given a 64-char SHA-256 hex hash, should return the correctly prefixed key', () => {
     const hash = 'a'.repeat(64);
     expect(buildAssetKey(hash)).toBe(`assets/${hash}`);
+  });
+
+  it('given a contentHash with path traversal, should reject it before building a public key', () => {
+    expect(() => buildAssetKey('../private-secret')).toThrow(/content hash/i);
+  });
+
+  it('given a contentHash with a slash, should reject it before building a public key', () => {
+    expect(() => buildAssetKey('abc123/original')).toThrow(/content hash/i);
   });
 });
 
@@ -187,6 +196,16 @@ describe('getPublishAssetBaseUrl', () => {
     delete process.env.PUBLISH_BUCKET;
     expect(() => getPublishAssetBaseUrl()).toThrow(/PUBLISH_BUCKET/);
   });
+
+  it('given PUBLISH_ASSET_BASE_URL is not HTTPS, should reject the public asset origin', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'http://cdn.example.com';
+    expect(() => getPublishAssetBaseUrl()).toThrow(/HTTPS/i);
+  });
+
+  it('given PUBLISH_ASSET_BASE_URL includes credentials, should reject the public asset origin', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'https://user:pass@cdn.example.com';
+    expect(() => getPublishAssetBaseUrl()).toThrow(/origin/i);
+  });
 });
 
 describe('buildAssetUrl', () => {
@@ -208,12 +227,12 @@ describe('buildAssetUrl', () => {
   });
 
   it('given a contentHash, should return the full public asset URL', () => {
-    expect(buildAssetUrl('abc123')).toBe('https://pagespace-published.t3.tigrisfiles.io/assets/abc123');
+    expect(buildAssetUrl(HASH)).toBe(`https://pagespace-published.t3.tigrisfiles.io/assets/${HASH}`);
   });
 
   it('given PUBLISH_ASSET_BASE_URL with trailing slash, should produce a clean URL without double slash', () => {
     process.env.PUBLISH_ASSET_BASE_URL = 'https://cdn.example.com/';
-    expect(buildAssetUrl('abc123')).toBe('https://cdn.example.com/assets/abc123');
+    expect(buildAssetUrl(HASH)).toBe(`https://cdn.example.com/assets/${HASH}`);
   });
 });
 
@@ -240,6 +259,14 @@ describe('buildAssetUrlFromKey', () => {
       'https://pagespace-published.t3.tigrisfiles.io/assets/cache/abc123/thumbnail.webp',
     );
   });
+
+  it('given an asset key outside the assets prefix, should reject it before building a public URL', () => {
+    expect(() => buildAssetUrlFromKey('published/acme/index.html')).toThrow(/asset key/i);
+  });
+
+  it('given an asset key with traversal, should reject it before building a public URL', () => {
+    expect(() => buildAssetUrlFromKey('assets/../published/acme/index.html')).toThrow(/asset key/i);
+  });
 });
 
 describe('copyAssetToPublishBucket', () => {
@@ -253,12 +280,12 @@ describe('copyAssetToPublishBucket', () => {
     // HeadObject resolves → asset exists
     send.mockResolvedValueOnce({});
 
-    await copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' });
+    await copyAssetToPublishBucket({ contentHash: HASH, mimeType: 'image/png' });
 
     expect(send).toHaveBeenCalledTimes(1);
     const cmd = send.mock.calls[0][0];
     expect(cmd).toBeInstanceOf(HeadObjectCommand);
-    expect(cmd.input).toMatchObject({ Bucket: 'test-publish', Key: 'assets/abc123' });
+    expect(cmd.input).toMatchObject({ Bucket: 'test-publish', Key: `assets/${HASH}` });
   });
 
   it('given the asset does not exist in the publish bucket (HeadObject 404), should GetObject from private bucket then PutObject to publish bucket', async () => {
@@ -271,22 +298,22 @@ describe('copyAssetToPublishBucket', () => {
       .mockResolvedValueOnce({ Body: fakeBody })
       .mockResolvedValueOnce({});
 
-    await copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' });
+    await copyAssetToPublishBucket({ contentHash: HASH, mimeType: 'image/png' });
 
     expect(send).toHaveBeenCalledTimes(3);
 
     const [headCmd, getCmd, putCmd] = send.mock.calls.map((c) => c[0]);
 
     expect(headCmd).toBeInstanceOf(HeadObjectCommand);
-    expect(headCmd.input).toMatchObject({ Bucket: 'test-publish', Key: 'assets/abc123' });
+    expect(headCmd.input).toMatchObject({ Bucket: 'test-publish', Key: `assets/${HASH}` });
 
     expect(getCmd).toBeInstanceOf(GetObjectCommand);
-    expect(getCmd.input).toMatchObject({ Bucket: 'test-files', Key: 'files/abc123/original' });
+    expect(getCmd.input).toMatchObject({ Bucket: 'test-files', Key: `files/${HASH}/original` });
 
     expect(putCmd).toBeInstanceOf(PutObjectCommand);
     expect(putCmd.input).toMatchObject({
       Bucket: 'test-publish',
-      Key: 'assets/abc123',
+      Key: `assets/${HASH}`,
       ContentType: 'image/png',
     });
     expect(putCmd.input.Body).toBeInstanceOf(Uint8Array);
@@ -296,7 +323,7 @@ describe('copyAssetToPublishBucket', () => {
     const serverError = Object.assign(new Error('Server Error'), { name: 'ServiceUnavailable' });
     send.mockRejectedValueOnce(serverError);
 
-    await expect(copyAssetToPublishBucket({ contentHash: 'abc123', mimeType: 'image/png' })).rejects.toThrow('Server Error');
+    await expect(copyAssetToPublishBucket({ contentHash: HASH, mimeType: 'image/png' })).rejects.toThrow('Server Error');
     expect(send).toHaveBeenCalledTimes(1);
   });
 });
@@ -306,6 +333,26 @@ describe('copyObjectToPublishBucket', () => {
     send.mockReset();
     process.env.PUBLISH_BUCKET = 'test-publish';
     process.env.BUCKET_NAME = 'test-files';
+  });
+
+  it('given a source key outside the private file/cache prefixes, should reject before any S3 command', async () => {
+    await expect(copyObjectToPublishBucket({
+      sourceKey: 'published/acme/index.html',
+      assetKey: `assets/${HASH}`,
+      contentType: 'text/html',
+    })).rejects.toThrow(/source key/i);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('given a public asset key with traversal, should reject before any S3 command', async () => {
+    await expect(copyObjectToPublishBucket({
+      sourceKey: `files/${HASH}/original`,
+      assetKey: 'assets/../published/acme/index.html',
+      contentType: 'image/png',
+    })).rejects.toThrow(/asset key/i);
+
+    expect(send).not.toHaveBeenCalled();
   });
 
   it('given a thumbnail cache object, should copy it to the requested public asset key', async () => {

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -206,6 +206,16 @@ describe('getPublishAssetBaseUrl', () => {
     process.env.PUBLISH_ASSET_BASE_URL = 'https://user:pass@cdn.example.com';
     expect(() => getPublishAssetBaseUrl()).toThrow(/origin/i);
   });
+
+  it('given PUBLISH_ASSET_BASE_URL includes a path, should reject the public asset origin', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'https://cdn.example.com/prefix';
+    expect(() => getPublishAssetBaseUrl()).toThrow(/path/i);
+  });
+
+  it('given PUBLISH_ASSET_BASE_URL has a trailing slash, should normalize to the origin only', () => {
+    process.env.PUBLISH_ASSET_BASE_URL = 'https://cdn.example.com/';
+    expect(getPublishAssetBaseUrl()).toBe('https://cdn.example.com');
+  });
 });
 
 describe('buildAssetUrl', () => {

--- a/apps/web/src/lib/canvas/__tests__/render-published.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/render-published.test.ts
@@ -101,4 +101,18 @@ describe('renderPublishedPage — assetBaseUrl', () => {
     });
     expect(out).toContain('https://cdn.example.com/assets/x');
   });
+
+  it('given a non-HTTPS assetBaseUrl, should reject it instead of allowlisting the host', () => {
+    expect(() => renderPublishedPage({
+      html: '<style>body { background: url("http://cdn.example.com/assets/x"); }</style>',
+      assetBaseUrl: 'http://cdn.example.com',
+    })).toThrow(/HTTPS/i);
+  });
+
+  it('given an assetBaseUrl with credentials, should reject it instead of allowlisting the host', () => {
+    expect(() => renderPublishedPage({
+      html: '<style>body { background: url("https://cdn.example.com/assets/x"); }</style>',
+      assetBaseUrl: 'https://user:pass@cdn.example.com',
+    })).toThrow(/origin/i);
+  });
 });

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -28,13 +28,15 @@ const CONTENT_HASH_RE = /^[0-9a-f]{64}$/i;
 const createFileRefRegex = (): RegExp =>
   /(?:https?:\/\/[^/'">\s]*)?(?:\/api\/files\/([a-zA-Z0-9_-]+)\/(view|thumbnail)|\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/(view))(?=$|[?#"')\s>])/g;
 
-const referenceKey = ({ id, kind }: FileReference): string => `${id}:${kind}`;
+const referenceKey = ({ id, kind, driveId }: FileReference): string =>
+  driveId ? `dashboard:${driveId}:${id}:${kind}` : `api:${id}:${kind}`;
 
 /**
  * Extract all unique PageSpace file IDs referenced in canvas HTML.
  *
  * Scans `src`, `href`, CSS `url()` values — any occurrence of the pattern
- * `/api/files/{id}/view` or `/api/files/{id}/thumbnail`.
+ * `/api/files/{id}/view`, `/api/files/{id}/thumbnail`, or
+ * `/dashboard/{driveId}/{pageId}/view`.
  *
  * Pure function: no I/O, no env reads.
  */
@@ -126,9 +128,9 @@ async function filterViewableRows(userId: string, rows: FilePageRow[]): Promise<
 }
 
 /**
- * Rewrite all `/api/files/{id}/view` (and `/thumbnail`) references in the
- * canvas HTML to public CDN asset URLs, copying any referenced files to the
- * publish bucket along the way.
+ * Rewrite all `/api/files/{id}/view`, `/api/files/{id}/thumbnail`, and
+ * `/dashboard/{driveId}/{pageId}/view` references in canvas HTML to public CDN
+ * asset URLs, copying any referenced files to the publish bucket along the way.
  *
  * - Unresolvable IDs (file not found in DB, or page has no contentHash) are
  *   left as-is — publish still succeeds; the image just won't load publicly.

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -12,6 +12,7 @@ type FileReferenceKind = 'view' | 'thumbnail';
 interface FileReference {
   id: string;
   kind: FileReferenceKind;
+  driveId?: string;
 }
 
 interface PublishAsset {
@@ -22,8 +23,10 @@ interface PublishAsset {
   contentType: string;
 }
 
+const CONTENT_HASH_RE = /^[0-9a-f]{64}$/i;
+
 const createFileRefRegex = (): RegExp =>
-  /(?:https?:\/\/[^/'">\s]*)?\/api\/files\/([a-zA-Z0-9_-]+)\/(view|thumbnail)(?=$|[?#"')\s>])/g;
+  /(?:https?:\/\/[^/'">\s]*)?(?:\/api\/files\/([a-zA-Z0-9_-]+)\/(view|thumbnail)|\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/(view))(?=$|[?#"')\s>])/g;
 
 const referenceKey = ({ id, kind }: FileReference): string => `${id}:${kind}`;
 
@@ -46,7 +49,9 @@ export function extractFileIds(html: string): string[] {
 function extractFileReferences(html: string): FileReference[] {
   const refsByKey = new Map<string, FileReference>();
   for (const match of html.matchAll(createFileRefRegex())) {
-    const ref = { id: match[1], kind: match[2] as FileReferenceKind };
+    const ref = match[1]
+      ? { id: match[1], kind: match[2] as FileReferenceKind }
+      : { driveId: match[3], id: match[4], kind: match[5] as FileReferenceKind };
     refsByKey.set(referenceKey(ref), ref);
   }
   return Array.from(refsByKey.values());
@@ -57,6 +62,7 @@ function extractFileReferences(html: string): FileReference[] {
  */
 interface FilePageRow {
   id: string;
+  driveId: string | null;
   contentHash: string | null;
   mimeType: string | null;
   extractionMetadata: unknown;
@@ -87,14 +93,19 @@ function resolvePublishAsset(row: FilePageRow, kind: FileReferenceKind): Publish
     };
   }
 
-  if (!row.contentHash) return null;
-  return {
-    id: row.id,
-    kind,
-    sourceKey: `files/${row.contentHash}/original`,
-    assetKey: buildAssetKey(row.contentHash),
-    contentType: row.mimeType ?? 'application/octet-stream',
-  };
+  if (!row.contentHash || !CONTENT_HASH_RE.test(row.contentHash)) return null;
+  try {
+    const contentHash = row.contentHash.toLowerCase();
+    return {
+      id: row.id,
+      kind,
+      sourceKey: `files/${contentHash}/original`,
+      assetKey: buildAssetKey(contentHash),
+      contentType: row.mimeType ?? 'application/octet-stream',
+    };
+  } catch {
+    return null;
+  }
 }
 
 async function filterViewableRows(userId: string, rows: FilePageRow[]): Promise<FilePageRow[]> {
@@ -138,7 +149,7 @@ export async function rewriteCanvasAssets(params: {
   // Batch-query referenced page rows; permission checks below decide which assets can publish.
   const rows = (await db.query.pages.findMany({
     where: inArray(pages.id, fileIds),
-    columns: { id: true, contentHash: true, mimeType: true, extractionMetadata: true },
+    columns: { id: true, driveId: true, contentHash: true, mimeType: true, extractionMetadata: true },
   })) as FilePageRow[];
 
   const rowsById = new Map((await filterViewableRows(userId, rows)).map((row) => [row.id, row]));
@@ -148,6 +159,7 @@ export async function rewriteCanvasAssets(params: {
   for (const ref of references) {
     const row = rowsById.get(ref.id);
     if (!row) continue;
+    if (ref.driveId && row.driveId !== ref.driveId) continue;
     const asset = resolvePublishAsset(row, ref.kind);
     if (!asset) continue;
     resolved.set(referenceKey(ref), asset);
@@ -175,8 +187,18 @@ export async function rewriteCanvasAssets(params: {
     }),
   );
 
-  const rewritten = html.replace(createFileRefRegex(), (match, id: string, kind: FileReferenceKind) => {
-    const asset = resolved.get(referenceKey({ id, kind }));
+  const rewritten = html.replace(createFileRefRegex(), (
+    match,
+    apiId: string | undefined,
+    apiKind: FileReferenceKind | undefined,
+    dashboardDriveId: string | undefined,
+    dashboardPageId: string | undefined,
+    dashboardKind: FileReferenceKind | undefined,
+  ) => {
+    const ref = apiId
+      ? { id: apiId, kind: apiKind as FileReferenceKind }
+      : { driveId: dashboardDriveId, id: dashboardPageId as string, kind: dashboardKind as FileReferenceKind };
+    const asset = resolved.get(referenceKey(ref));
     return asset && copiedAssetKeys.has(asset.assetKey) ? buildAssetUrlFromKey(asset.assetKey) : match;
   });
 

--- a/apps/web/src/lib/canvas/file-view-links.ts
+++ b/apps/web/src/lib/canvas/file-view-links.ts
@@ -1,0 +1,28 @@
+export interface DashboardFileViewRef {
+  driveId: string;
+  pageId: string;
+}
+
+const DASHBOARD_FILE_VIEW_RE =
+  /(?:https?:\/\/[^/'">\s]*)?\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/view(?:\?[^"')\s>]*)?(?=$|[#"')\s>])/g;
+
+const refKey = ({ driveId, pageId }: DashboardFileViewRef): string => `${driveId}:${pageId}`;
+
+export function extractDashboardFileViewRefs(html: string): DashboardFileViewRef[] {
+  const refsByKey = new Map<string, DashboardFileViewRef>();
+  for (const match of html.matchAll(DASHBOARD_FILE_VIEW_RE)) {
+    const ref = { driveId: match[1], pageId: match[2] };
+    refsByKey.set(refKey(ref), ref);
+  }
+  return Array.from(refsByKey.values());
+}
+
+export function rewriteDashboardFileViewLinks(
+  html: string,
+  resolveUrl: (ref: DashboardFileViewRef) => string | null | undefined,
+): string {
+  return html.replace(DASHBOARD_FILE_VIEW_RE, (match, driveId: string, pageId: string) => {
+    return resolveUrl({ driveId, pageId }) ?? match;
+  });
+}
+

--- a/apps/web/src/lib/canvas/file-view-token.ts
+++ b/apps/web/src/lib/canvas/file-view-token.ts
@@ -1,0 +1,83 @@
+import { createHmac } from 'crypto';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
+
+interface TokenPayload {
+  driveId: string;
+  pageId: string;
+  exp: number;
+}
+
+interface CreateCanvasFileViewTokenParams {
+  driveId: string;
+  pageId: string;
+  nowMs?: number;
+  ttlMs?: number;
+}
+
+interface VerifyCanvasFileViewTokenParams {
+  token: string | null | undefined;
+  driveId: string;
+  pageId: string;
+  nowMs?: number;
+}
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+const getSecret = (): string => {
+  const secret = process.env.CANVAS_FILE_VIEW_SECRET ?? process.env.CSRF_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error('CANVAS_FILE_VIEW_SECRET or CSRF_SECRET must be configured and at least 32 characters');
+  }
+  return secret;
+};
+
+const encodeBase64Url = (value: string): string =>
+  Buffer.from(value, 'utf8').toString('base64url');
+
+const decodeBase64Url = (value: string): string =>
+  Buffer.from(value, 'base64url').toString('utf8');
+
+const sign = (payload: string): string =>
+  createHmac('sha256', getSecret()).update(payload).digest('base64url');
+
+export function createCanvasFileViewToken({
+  driveId,
+  pageId,
+  nowMs = Date.now(),
+  ttlMs = DEFAULT_TTL_MS,
+}: CreateCanvasFileViewTokenParams): string {
+  const payload = encodeBase64Url(JSON.stringify({
+    driveId,
+    pageId,
+    exp: nowMs + ttlMs,
+  } satisfies TokenPayload));
+
+  return `${payload}.${sign(payload)}`;
+}
+
+export function verifyCanvasFileViewToken({
+  token,
+  driveId,
+  pageId,
+  nowMs = Date.now(),
+}: VerifyCanvasFileViewTokenParams): boolean {
+  if (!token || typeof token !== 'string') return false;
+
+  const [payloadPart, signature, extra] = token.split('.');
+  if (!payloadPart || !signature || extra !== undefined) return false;
+
+  try {
+    if (!secureCompare(signature, sign(payloadPart))) return false;
+
+    const payload = JSON.parse(decodeBase64Url(payloadPart)) as Partial<TokenPayload>;
+    return (
+      payload.driveId === driveId &&
+      payload.pageId === pageId &&
+      typeof payload.exp === 'number' &&
+      payload.exp >= nowMs
+    );
+  } catch {
+    return false;
+  }
+}
+

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -3,6 +3,11 @@ import 'server-only';
 import { S3Client, PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
 
+const CONTENT_HASH_RE = /^[0-9a-f]{64}$/i;
+const THUMBNAIL_SOURCE_KEY_RE = /^cache\/[0-9a-f]+\/thumbnail\.webp$/i;
+const FILE_SOURCE_KEY_RE = /^files\/[0-9a-f]{64}\/original$/i;
+const ASSET_KEY_RE = /^assets\/(?:[0-9a-f]{64}|cache\/[0-9a-f]+\/thumbnail\.webp)$/i;
+
 /**
  * Storage helper for PUBLISHED canvas artifacts.
  *
@@ -45,6 +50,52 @@ function getPublishBucket(): string {
     throw new Error('PUBLISH_BUCKET is not configured (dedicated public bucket for canvas publishing)');
   }
   return bucket;
+}
+
+function assertContentHash(contentHash: string): string {
+  if (!CONTENT_HASH_RE.test(contentHash)) {
+    throw new Error('Invalid content hash for public asset key');
+  }
+  return contentHash.toLowerCase();
+}
+
+function assertPublicAssetOrigin(baseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error('Public asset origin must be a valid HTTPS URL');
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Public asset origin must use HTTPS');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Public asset origin must not include credentials');
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error('Public asset origin must not include query or fragment components');
+  }
+
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function assertAssetKey(assetKey: string): string {
+  if (!ASSET_KEY_RE.test(assetKey)) {
+    throw new Error('Invalid public asset key');
+  }
+  return assetKey;
+}
+
+function assertPrivateSourceKey(sourceKey: string): string {
+  if (!FILE_SOURCE_KEY_RE.test(sourceKey) && !THUMBNAIL_SOURCE_KEY_RE.test(sourceKey)) {
+    throw new Error('Invalid private source key');
+  }
+  return sourceKey;
+}
+
+export function getPublicAssetHost(assetBaseUrl: string): string {
+  return new URL(assertPublicAssetOrigin(assetBaseUrl)).host;
 }
 
 /**
@@ -129,7 +180,7 @@ export async function deletePublishedArtifact(key: string): Promise<void> {
  *  - orphaned keys are harmless (same content, never an old/wrong version)
  */
 export function buildAssetKey(contentHash: string): string {
-  return `assets/${contentHash}`;
+  return `assets/${assertContentHash(contentHash)}`;
 }
 
 /**
@@ -143,7 +194,7 @@ export function buildAssetKey(contentHash: string): string {
  */
 export function getPublishAssetBaseUrl(): string {
   if (process.env.PUBLISH_ASSET_BASE_URL) {
-    return process.env.PUBLISH_ASSET_BASE_URL;
+    return assertPublicAssetOrigin(process.env.PUBLISH_ASSET_BASE_URL);
   }
   const bucket = process.env.PUBLISH_BUCKET;
   if (!bucket) {
@@ -151,7 +202,7 @@ export function getPublishAssetBaseUrl(): string {
       'Cannot derive asset base URL: PUBLISH_BUCKET is not configured and PUBLISH_ASSET_BASE_URL is not set',
     );
   }
-  return `https://${bucket}.t3.tigrisfiles.io`;
+  return assertPublicAssetOrigin(`https://${bucket}.t3.tigrisfiles.io`);
 }
 
 /**
@@ -170,7 +221,7 @@ export function buildAssetUrl(contentHash: string): string {
 export function buildAssetUrlFromKey(assetKey: string): string {
   const base = getPublishAssetBaseUrl();
   const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
-  return `${trimmedBase}/${assetKey}`;
+  return `${trimmedBase}/${assertAssetKey(assetKey)}`;
 }
 
 /**
@@ -181,7 +232,9 @@ export async function copyObjectToPublishBucket(params: {
   assetKey: string;
   contentType: string;
 }): Promise<void> {
-  const { sourceKey, assetKey, contentType } = params;
+  const sourceKey = assertPrivateSourceKey(params.sourceKey);
+  const assetKey = assertAssetKey(params.assetKey);
+  const { contentType } = params;
   const publishBucket = getPublishBucket();
 
   // Dedup check — existence at the resolved public key means it was already promoted.

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -76,8 +76,11 @@ function assertPublicAssetOrigin(baseUrl: string): string {
   if (parsed.search || parsed.hash) {
     throw new Error('Public asset origin must not include query or fragment components');
   }
+  if (parsed.pathname !== '/') {
+    throw new Error('Public asset origin must not include path components');
+  }
 
-  return parsed.toString().replace(/\/$/, '');
+  return parsed.origin;
 }
 
 function assertAssetKey(assetKey: string): string {

--- a/apps/web/src/lib/canvas/render-published.ts
+++ b/apps/web/src/lib/canvas/render-published.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
+import { getPublicAssetHost } from './published-storage';
 
 /**
  * Server-side renderer for PUBLISHED canvas pages.
@@ -30,8 +31,6 @@ export interface RenderPublishedPageInput {
  */
 export function renderPublishedPage(input: RenderPublishedPageInput): string {
   const { assetBaseUrl, ...rest } = input;
-  const allowedAssetHosts = assetBaseUrl
-    ? [new URL(assetBaseUrl.endsWith('/') ? assetBaseUrl.slice(0, -1) : assetBaseUrl).host]
-    : [];
+  const allowedAssetHosts = assetBaseUrl ? [getPublicAssetHost(assetBaseUrl)] : [];
   return renderCanvasDocument({ ...rest, allowedAssetHosts });
 }


### PR DESCRIPTION
## Summary

Adds one canonical canvas file embed URL:

`/dashboard/{driveId}/{filePageId}/view`

That URL now works inside unpublished canvas iframes and is recognized by the publish asset pipeline so published canvases rewrite the same reference to the public CDN.

## What Changed

- Added a dashboard file-view route that auth-checks the user, validates the file page belongs to the requested drive, verifies file-page type, checks page view permission, then redirects to the existing file view API.
- Updated the canvas asset pipeline to recognize dashboard file-view URLs in addition to legacy `/api/files/...` references.
- Kept the publish boundary fail-closed by requiring DB drive/page matches before copying assets to the public publish bucket.
- Hardened publish storage helpers against invalid hashes, traversal keys, invalid source keys, and non-HTTPS/credentialed asset origins.
- Updated AI inline instructions so generated canvas HTML uses `/dashboard/{driveId}/{filePageId}/view`, not `/api/files`.

## Validation

- `bun run --filter 'web' test -- src/lib/canvas/__tests__/published-storage.test.ts src/lib/canvas/__tests__/asset-pipeline.test.ts src/lib/canvas/__tests__/render-published.test.ts 'src/app/dashboard/[driveId]/[pageId]/view/__tests__/route.test.ts' src/lib/ai/core/__tests__/inline-instructions.test.ts`
- `bun run --filter 'web' typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Canvas documents can now securely display embedded files with token-based authentication and permission checks.
  * Added file view links that automatically generate and embed signed tokens for secure canvas access.

* **Refactor**
  * Enhanced canvas asset pipeline to recognize and rewrite dashboard file references.

* **Tests**
  * Added comprehensive test coverage for file viewing and token authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->