### PR TITLE
feat(sandbox): GitHub-integrated sandbox tools — 26 git/gh agent tools

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -291,6 +291,7 @@ describe('ai-tools', () => {
             writeFile: { name: 'writeFile' },
             readFile: { name: 'readFile' },
           }) as never,
+        sandboxGitToolsFactory: () => ({}),
       });
       expect(tools).toHaveProperty('bash');
       expect(tools).toHaveProperty('writeFile');

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -19,6 +19,7 @@ import { triggerTools } from '../tools/trigger-tools';
 import { modelTools } from '../tools/model-tools';
 import { commandTools } from '../tools/command-tools';
 import { buildSandboxTools } from '../tools/sandbox-tools-runtime';
+import { buildGitSandboxTools } from '../tools/sandbox-git-tools-runtime';
 import { CORE_TOOL_NAMES } from './stub-tools';
 
 const baseTools = {
@@ -59,12 +60,14 @@ const baseTools = {
 export function buildPageSpaceTools({
   codeExecutionEnabled = isCodeExecutionEnabled(),
   sandboxToolsFactory = buildSandboxTools,
+  sandboxGitToolsFactory = buildGitSandboxTools,
 }: {
   codeExecutionEnabled?: boolean;
   sandboxToolsFactory?: () => Record<string, Tool>;
+  sandboxGitToolsFactory?: () => Record<string, Tool>;
 } = {}) {
   if (!codeExecutionEnabled) return { ...baseTools };
-  return { ...baseTools, ...sandboxToolsFactory() };
+  return { ...baseTools, ...sandboxToolsFactory(), ...sandboxGitToolsFactory() };
 }
 
 export const pageSpaceTools = buildPageSpaceTools();

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -82,15 +82,26 @@ describe('git_clone', () => {
     );
     const calls = getRunCalls(deps);
     expect(calls[0].cmd).toBe('git');
-    expect(calls[0].args).toEqual(['clone', '--depth', '1', 'https://github.com/owner/repo.git']);
+    expect(calls[0].args).toEqual(['clone', '--depth', '1', 'https://github.com/owner/repo.git', '.']);
   });
 
-  it('omits trailing path arg when no path given', async () => {
+  it('clones into the default working directory when no path is given', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
     await git_clone.execute!({ repo_url: 'https://github.com/owner/repo.git' }, {} as never);
     const calls = getRunCalls(deps);
-    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git']);
+    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git', '.']);
+  });
+
+  it('uses the explicit clone path when provided', async () => {
+    const deps = makeDeps();
+    const { git_clone } = createSandboxGitTools(deps);
+    await git_clone.execute!(
+      { repo_url: 'https://github.com/owner/repo.git', path: 'repo' },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git', 'repo']);
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSandboxGitTools } from '../sandbox-git-tools';
+import type { GitSandboxToolsDeps } from '../sandbox-git-tools';
+
+const mockRun = vi.fn();
+let capturedToken: string | null = 'ghp_test';
+
+function makeDeps(token: string | null = 'ghp_test'): GitSandboxToolsDeps {
+  capturedToken = token;
+  const runCommandCalls: Array<{ cmd: string; args: string[]; env: Record<string, string> }> = [];
+  return {
+    gitRunDeps: {
+      isEnabled: () => true,
+      acquireSandbox: vi.fn().mockResolvedValue({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+      reconnect: vi.fn().mockResolvedValue({
+        sandboxId: 'sbx-1',
+        runCommand: vi.fn().mockImplementation(async (opts) => {
+          runCommandCalls.push(opts);
+          mockRun(opts);
+          return { exitCode: 0, stdout: 'ok', stderr: '' };
+        }),
+        writeFiles: vi.fn(),
+        readFileToBuffer: vi.fn(),
+      }),
+      quota: {
+        acquireSlot: vi.fn().mockReturnValue(true),
+        releaseSlot: vi.fn(),
+        preflight: vi.fn().mockResolvedValue({ allowed: true }),
+        charge: vi.fn().mockResolvedValue(undefined),
+      },
+      buildEnv: vi.fn().mockReturnValue({ NODE_ENV: 'test' }),
+      audit: vi.fn().mockResolvedValue(undefined),
+      now: () => new Date('2026-06-01T12:00:00Z'),
+      resolveGitHubToken: vi.fn().mockResolvedValue(token),
+    },
+    resolveContext: vi.fn().mockResolvedValue({
+      userId: 'u1', tenantId: 't1', driveId: 'd1', conversationId: 'c1',
+      actorEmail: 'u@test.com', tier: 'pro',
+    }),
+    gate: vi.fn().mockResolvedValue({ ok: true }),
+    _runCommandCalls: runCommandCalls,
+  } as unknown as GitSandboxToolsDeps & { _runCommandCalls: typeof runCommandCalls };
+}
+
+function getRunCalls(deps: GitSandboxToolsDeps) {
+  return (deps as unknown as { _runCommandCalls: Array<{ cmd: string; args: string[]; env: Record<string, string> }> })._runCommandCalls;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRun.mockReset();
+});
+
+// ── git_clone ──────────────────────────────────────────────────────────────
+
+describe('git_clone', () => {
+  it('rejects SSH git@ URLs', async () => {
+    const deps = makeDeps();
+    const { git_clone } = createSandboxGitTools(deps);
+    const result = await git_clone.execute(
+      { repo_url: 'git@github.com:owner/repo.git' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('rejects ssh:// URLs', async () => {
+    const deps = makeDeps();
+    const { git_clone } = createSandboxGitTools(deps);
+    const result = await git_clone.execute(
+      { repo_url: 'ssh://git@github.com/owner/repo.git' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it('builds correct args for clone with depth', async () => {
+    const deps = makeDeps();
+    const { git_clone } = createSandboxGitTools(deps);
+    await git_clone.execute(
+      { repo_url: 'https://github.com/owner/repo.git', depth: 1 },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('git');
+    expect(calls[0].args).toEqual(['clone', '--depth', '1', 'https://github.com/owner/repo.git']);
+  });
+
+  it('omits trailing path arg when no path given', async () => {
+    const deps = makeDeps();
+    const { git_clone } = createSandboxGitTools(deps);
+    await git_clone.execute({ repo_url: 'https://github.com/owner/repo.git' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git']);
+  });
+});
+
+// ── git_init ───────────────────────────────────────────────────────────────
+
+describe('git_init', () => {
+  it('defaults to "." when no path given', async () => {
+    const deps = makeDeps();
+    const { git_init } = createSandboxGitTools(deps);
+    await git_init.execute({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['init', '.']);
+  });
+});
+
+// ── git_config ─────────────────────────────────────────────────────────────
+
+describe('git_config', () => {
+  it('includes --global when global: true', async () => {
+    const deps = makeDeps();
+    const { git_config } = createSandboxGitTools(deps);
+    await git_config.execute({ key: 'user.name', value: 'Bot', global: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--global');
+  });
+});
+
+// ── git_add ────────────────────────────────────────────────────────────────
+
+describe('git_add', () => {
+  it('rejects empty paths with all: false', async () => {
+    const deps = makeDeps();
+    const { git_add } = createSandboxGitTools(deps);
+    const result = await git_add.execute({ paths: [] }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it('builds -A when all: true', async () => {
+    const deps = makeDeps();
+    const { git_add } = createSandboxGitTools(deps);
+    await git_add.execute({ all: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['add', '-A']);
+  });
+});
+
+// ── git_diff ───────────────────────────────────────────────────────────────
+
+describe('git_diff', () => {
+  it('includes --cached when staged: true', async () => {
+    const deps = makeDeps();
+    const { git_diff } = createSandboxGitTools(deps);
+    await git_diff.execute({ staged: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--cached');
+  });
+});
+
+// ── git_reset ──────────────────────────────────────────────────────────────
+
+describe('git_reset', () => {
+  it('builds --hard for mode hard', async () => {
+    const deps = makeDeps();
+    const { git_reset } = createSandboxGitTools(deps);
+    await git_reset.execute({ mode: 'hard' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--hard');
+  });
+});
+
+// ── git_stash ──────────────────────────────────────────────────────────────
+
+describe('git_stash', () => {
+  it('push with message includes -m', async () => {
+    const deps = makeDeps();
+    const { git_stash } = createSandboxGitTools(deps);
+    await git_stash.execute({ action: 'push', message: 'wip' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('-m');
+    expect(calls[0].args).toContain('wip');
+  });
+
+  it('list builds ["stash", "list"]', async () => {
+    const deps = makeDeps();
+    const { git_stash } = createSandboxGitTools(deps);
+    await git_stash.execute({ action: 'list' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['stash', 'list']);
+  });
+});
+
+// ── git_commit ─────────────────────────────────────────────────────────────
+
+describe('git_commit', () => {
+  it('rejects empty message', async () => {
+    const deps = makeDeps();
+    const { git_commit } = createSandboxGitTools(deps);
+    const result = await git_commit.execute({ message: '' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+});
+
+// ── git_log ────────────────────────────────────────────────────────────────
+
+describe('git_log', () => {
+  it('defaults to --oneline and -20', async () => {
+    const deps = makeDeps();
+    const { git_log } = createSandboxGitTools(deps);
+    await git_log.execute({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--oneline');
+    expect(calls[0].args).toContain('-20');
+  });
+
+  it('uses -5 when n: 5', async () => {
+    const deps = makeDeps();
+    const { git_log } = createSandboxGitTools(deps);
+    await git_log.execute({ n: 5 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('-5');
+  });
+});
+
+// ── git_merge ──────────────────────────────────────────────────────────────
+
+describe('git_merge', () => {
+  it('adds --squash for squash strategy', async () => {
+    const deps = makeDeps();
+    const { git_merge } = createSandboxGitTools(deps);
+    await git_merge.execute({ branch: 'feature', strategy: 'squash' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--squash');
+  });
+});
+
+// ── git_branch ─────────────────────────────────────────────────────────────
+
+describe('git_branch', () => {
+  it('rejects delete without name', async () => {
+    const deps = makeDeps();
+    const { git_branch } = createSandboxGitTools(deps);
+    const result = await git_branch.execute({ action: 'delete' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+});
+
+// ── git_push ───────────────────────────────────────────────────────────────
+
+describe('git_push', () => {
+  it('uses --force-with-lease, not --force', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute({ force: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--force-with-lease');
+    expect(calls[0].args).not.toContain('--force');
+  });
+
+  it('includes -u when set_upstream: true', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute({ set_upstream: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('-u');
+  });
+
+  it('returns no-connection error without opening sandbox when token is null', async () => {
+    const deps = makeDeps(null);
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── git_fetch ──────────────────────────────────────────────────────────────
+
+describe('git_fetch', () => {
+  it('defaults to ["fetch", "origin"]', async () => {
+    const deps = makeDeps();
+    const { git_fetch } = createSandboxGitTools(deps);
+    await git_fetch.execute({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['fetch', 'origin']);
+  });
+
+  it('returns no-connection error without opening sandbox when token is null', async () => {
+    const deps = makeDeps(null);
+    const { git_fetch } = createSandboxGitTools(deps);
+    const result = await git_fetch.execute({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_create ───────────────────────────────────────────────────────────
+
+describe('gh_pr_create', () => {
+  it('rejects empty title', async () => {
+    const deps = makeDeps();
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    const result = await gh_pr_create.execute({ title: '', body: 'desc' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it('includes --draft when draft: true', async () => {
+    const deps = makeDeps();
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    await gh_pr_create.execute({ title: 'My PR', body: 'desc', draft: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('--draft');
+  });
+
+  it('joins labels with comma in --label arg', async () => {
+    const deps = makeDeps();
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    await gh_pr_create.execute({ title: 'PR', body: 'b', labels: ['bug', 'ui'] }, {} as never);
+    const calls = getRunCalls(deps);
+    const labelIdx = calls[0].args.indexOf('--label');
+    expect(calls[0].args[labelIdx + 1]).toBe('bug,ui');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    const result = await gh_pr_create.execute({ title: 'PR', body: 'b' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_issue_create ────────────────────────────────────────────────────────
+
+describe('gh_issue_create', () => {
+  it('rejects empty title', async () => {
+    const deps = makeDeps();
+    const { gh_issue_create } = createSandboxGitTools(deps);
+    const result = await gh_issue_create.execute({ title: '', body: 'b' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_issue_create } = createSandboxGitTools(deps);
+    const result = await gh_issue_create.execute({ title: 'Issue', body: 'b' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── tool count ─────────────────────────────────────────────────────────────
+
+describe('createSandboxGitTools', () => {
+  it('exports exactly 26 tools', () => {
+    const deps = makeDeps();
+    const tools = createSandboxGitTools(deps);
+    expect(Object.keys(tools)).toHaveLength(26);
+  });
+
+  it('no tool passes sh or -c as the cmd or first arg', async () => {
+    const deps = makeDeps();
+    const tools = createSandboxGitTools(deps);
+    // Run a quick execute on tools that accept empty inputs to collect cmd values
+    await tools.git_status.execute({}, {} as never);
+    await tools.git_diff.execute({}, {} as never);
+    const calls = getRunCalls(deps);
+    for (const call of calls) {
+      expect(call.cmd).not.toBe('sh');
+      expect(call.args[0]).not.toBe('-c');
+    }
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -3,10 +3,8 @@ import { createSandboxGitTools } from '../sandbox-git-tools';
 import type { GitSandboxToolsDeps } from '../sandbox-git-tools';
 
 const mockRun = vi.fn();
-let capturedToken: string | null = 'ghp_test';
 
 function makeDeps(token: string | null = 'ghp_test'): GitSandboxToolsDeps {
-  capturedToken = token;
   const runCommandCalls: Array<{ cmd: string; args: string[]; env: Record<string, string> }> = [];
   return {
     gitRunDeps: {
@@ -57,7 +55,7 @@ describe('git_clone', () => {
   it('rejects SSH git@ URLs', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
-    const result = await git_clone.execute(
+    const result = await git_clone.execute!(
       { repo_url: 'git@github.com:owner/repo.git' },
       {} as never,
     );
@@ -68,7 +66,7 @@ describe('git_clone', () => {
   it('rejects ssh:// URLs', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
-    const result = await git_clone.execute(
+    const result = await git_clone.execute!(
       { repo_url: 'ssh://git@github.com/owner/repo.git' },
       {} as never,
     );
@@ -78,7 +76,7 @@ describe('git_clone', () => {
   it('builds correct args for clone with depth', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
-    await git_clone.execute(
+    await git_clone.execute!(
       { repo_url: 'https://github.com/owner/repo.git', depth: 1 },
       {} as never,
     );
@@ -90,7 +88,7 @@ describe('git_clone', () => {
   it('omits trailing path arg when no path given', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
-    await git_clone.execute({ repo_url: 'https://github.com/owner/repo.git' }, {} as never);
+    await git_clone.execute!({ repo_url: 'https://github.com/owner/repo.git' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git']);
   });
@@ -102,7 +100,7 @@ describe('git_init', () => {
   it('defaults to "." when no path given', async () => {
     const deps = makeDeps();
     const { git_init } = createSandboxGitTools(deps);
-    await git_init.execute({}, {} as never);
+    await git_init.execute!({}, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['init', '.']);
   });
@@ -114,7 +112,7 @@ describe('git_config', () => {
   it('includes --global when global: true', async () => {
     const deps = makeDeps();
     const { git_config } = createSandboxGitTools(deps);
-    await git_config.execute({ key: 'user.name', value: 'Bot', global: true }, {} as never);
+    await git_config.execute!({ key: 'user.name', value: 'Bot', global: true }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--global');
   });
@@ -126,14 +124,14 @@ describe('git_add', () => {
   it('rejects empty paths with all: false', async () => {
     const deps = makeDeps();
     const { git_add } = createSandboxGitTools(deps);
-    const result = await git_add.execute({ paths: [] }, {} as never);
+    const result = await git_add.execute!({ paths: [] }, {} as never);
     expect(result).toMatchObject({ success: false });
   });
 
   it('builds -A when all: true', async () => {
     const deps = makeDeps();
     const { git_add } = createSandboxGitTools(deps);
-    await git_add.execute({ all: true }, {} as never);
+    await git_add.execute!({ all: true }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['add', '-A']);
   });
@@ -145,7 +143,7 @@ describe('git_diff', () => {
   it('includes --cached when staged: true', async () => {
     const deps = makeDeps();
     const { git_diff } = createSandboxGitTools(deps);
-    await git_diff.execute({ staged: true }, {} as never);
+    await git_diff.execute!({ staged: true }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--cached');
   });
@@ -157,7 +155,7 @@ describe('git_reset', () => {
   it('builds --hard for mode hard', async () => {
     const deps = makeDeps();
     const { git_reset } = createSandboxGitTools(deps);
-    await git_reset.execute({ mode: 'hard' }, {} as never);
+    await git_reset.execute!({ mode: 'hard' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--hard');
   });
@@ -169,7 +167,7 @@ describe('git_stash', () => {
   it('push with message includes -m', async () => {
     const deps = makeDeps();
     const { git_stash } = createSandboxGitTools(deps);
-    await git_stash.execute({ action: 'push', message: 'wip' }, {} as never);
+    await git_stash.execute!({ action: 'push', message: 'wip' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('-m');
     expect(calls[0].args).toContain('wip');
@@ -178,7 +176,7 @@ describe('git_stash', () => {
   it('list builds ["stash", "list"]', async () => {
     const deps = makeDeps();
     const { git_stash } = createSandboxGitTools(deps);
-    await git_stash.execute({ action: 'list' }, {} as never);
+    await git_stash.execute!({ action: 'list' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['stash', 'list']);
   });
@@ -190,7 +188,7 @@ describe('git_commit', () => {
   it('rejects empty message', async () => {
     const deps = makeDeps();
     const { git_commit } = createSandboxGitTools(deps);
-    const result = await git_commit.execute({ message: '' }, {} as never);
+    const result = await git_commit.execute!({ message: '' }, {} as never);
     expect(result).toMatchObject({ success: false });
   });
 });
@@ -201,7 +199,7 @@ describe('git_log', () => {
   it('defaults to --oneline and -20', async () => {
     const deps = makeDeps();
     const { git_log } = createSandboxGitTools(deps);
-    await git_log.execute({}, {} as never);
+    await git_log.execute!({}, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--oneline');
     expect(calls[0].args).toContain('-20');
@@ -210,7 +208,7 @@ describe('git_log', () => {
   it('uses -5 when n: 5', async () => {
     const deps = makeDeps();
     const { git_log } = createSandboxGitTools(deps);
-    await git_log.execute({ n: 5 }, {} as never);
+    await git_log.execute!({ n: 5 }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('-5');
   });
@@ -222,7 +220,7 @@ describe('git_merge', () => {
   it('adds --squash for squash strategy', async () => {
     const deps = makeDeps();
     const { git_merge } = createSandboxGitTools(deps);
-    await git_merge.execute({ branch: 'feature', strategy: 'squash' }, {} as never);
+    await git_merge.execute!({ branch: 'feature', strategy: 'squash' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--squash');
   });
@@ -234,7 +232,7 @@ describe('git_branch', () => {
   it('rejects delete without name', async () => {
     const deps = makeDeps();
     const { git_branch } = createSandboxGitTools(deps);
-    const result = await git_branch.execute({ action: 'delete' }, {} as never);
+    const result = await git_branch.execute!({ action: 'delete' }, {} as never);
     expect(result).toMatchObject({ success: false });
   });
 });
@@ -245,7 +243,7 @@ describe('git_push', () => {
   it('uses --force-with-lease, not --force', async () => {
     const deps = makeDeps();
     const { git_push } = createSandboxGitTools(deps);
-    await git_push.execute({ force: true }, {} as never);
+    await git_push.execute!({ force: true }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--force-with-lease');
     expect(calls[0].args).not.toContain('--force');
@@ -254,7 +252,7 @@ describe('git_push', () => {
   it('includes -u when set_upstream: true', async () => {
     const deps = makeDeps();
     const { git_push } = createSandboxGitTools(deps);
-    await git_push.execute({ set_upstream: true }, {} as never);
+    await git_push.execute!({ set_upstream: true }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('-u');
   });
@@ -262,7 +260,7 @@ describe('git_push', () => {
   it('returns no-connection error without opening sandbox when token is null', async () => {
     const deps = makeDeps(null);
     const { git_push } = createSandboxGitTools(deps);
-    const result = await git_push.execute({}, {} as never);
+    const result = await git_push.execute!({}, {} as never);
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
@@ -274,7 +272,7 @@ describe('git_fetch', () => {
   it('defaults to ["fetch", "origin"]', async () => {
     const deps = makeDeps();
     const { git_fetch } = createSandboxGitTools(deps);
-    await git_fetch.execute({}, {} as never);
+    await git_fetch.execute!({}, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['fetch', 'origin']);
   });
@@ -282,7 +280,7 @@ describe('git_fetch', () => {
   it('returns no-connection error without opening sandbox when token is null', async () => {
     const deps = makeDeps(null);
     const { git_fetch } = createSandboxGitTools(deps);
-    const result = await git_fetch.execute({}, {} as never);
+    const result = await git_fetch.execute!({}, {} as never);
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
@@ -294,14 +292,14 @@ describe('gh_pr_create', () => {
   it('rejects empty title', async () => {
     const deps = makeDeps();
     const { gh_pr_create } = createSandboxGitTools(deps);
-    const result = await gh_pr_create.execute({ title: '', body: 'desc' }, {} as never);
+    const result = await gh_pr_create.execute!({ title: '', body: 'desc' }, {} as never);
     expect(result).toMatchObject({ success: false });
   });
 
   it('includes --draft when draft: true', async () => {
     const deps = makeDeps();
     const { gh_pr_create } = createSandboxGitTools(deps);
-    await gh_pr_create.execute({ title: 'My PR', body: 'desc', draft: true }, {} as never);
+    await gh_pr_create.execute!({ title: 'My PR', body: 'desc', draft: true }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].cmd).toBe('gh');
     expect(calls[0].args).toContain('--draft');
@@ -310,7 +308,7 @@ describe('gh_pr_create', () => {
   it('joins labels with comma in --label arg', async () => {
     const deps = makeDeps();
     const { gh_pr_create } = createSandboxGitTools(deps);
-    await gh_pr_create.execute({ title: 'PR', body: 'b', labels: ['bug', 'ui'] }, {} as never);
+    await gh_pr_create.execute!({ title: 'PR', body: 'b', labels: ['bug', 'ui'] }, {} as never);
     const calls = getRunCalls(deps);
     const labelIdx = calls[0].args.indexOf('--label');
     expect(calls[0].args[labelIdx + 1]).toBe('bug,ui');
@@ -319,7 +317,7 @@ describe('gh_pr_create', () => {
   it('returns no-connection error when token is null', async () => {
     const deps = makeDeps(null);
     const { gh_pr_create } = createSandboxGitTools(deps);
-    const result = await gh_pr_create.execute({ title: 'PR', body: 'b' }, {} as never);
+    const result = await gh_pr_create.execute!({ title: 'PR', body: 'b' }, {} as never);
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
@@ -331,14 +329,14 @@ describe('gh_issue_create', () => {
   it('rejects empty title', async () => {
     const deps = makeDeps();
     const { gh_issue_create } = createSandboxGitTools(deps);
-    const result = await gh_issue_create.execute({ title: '', body: 'b' }, {} as never);
+    const result = await gh_issue_create.execute!({ title: '', body: 'b' }, {} as never);
     expect(result).toMatchObject({ success: false });
   });
 
   it('returns no-connection error when token is null', async () => {
     const deps = makeDeps(null);
     const { gh_issue_create } = createSandboxGitTools(deps);
-    const result = await gh_issue_create.execute({ title: 'Issue', body: 'b' }, {} as never);
+    const result = await gh_issue_create.execute!({ title: 'Issue', body: 'b' }, {} as never);
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
@@ -357,8 +355,8 @@ describe('createSandboxGitTools', () => {
     const deps = makeDeps();
     const tools = createSandboxGitTools(deps);
     // Run a quick execute on tools that accept empty inputs to collect cmd values
-    await tools.git_status.execute({}, {} as never);
-    await tools.git_diff.execute({}, {} as never);
+    await tools.git_status.execute!({}, {} as never);
+    await tools.git_diff.execute!({}, {} as never);
     const calls = getRunCalls(deps);
     for (const call of calls) {
       expect(call.cmd).not.toBe('sh');

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools-runtime.ts
@@ -9,7 +9,6 @@
 import type { Tool } from 'ai';
 import { db } from '@pagespace/db/db';
 import { defaultBuildEnv, type SandboxRunDeps } from '@pagespace/lib/services/sandbox/tool-runners';
-import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { resolveGitHubTokenForSandbox } from '@pagespace/lib/services/sandbox/github-token';
 import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
 import { gateSandboxToolCall } from '@pagespace/lib/services/sandbox/tool-gate';

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools-runtime.ts
@@ -1,0 +1,43 @@
+/**
+ * Production wiring for the agent git/GitHub tools.
+ *
+ * Mirrors sandbox-tools-runtime.ts: binds the pure factory (createSandboxGitTools)
+ * to the real DB-backed token resolver and Sprites driver. The @fly/sprites SDK is
+ * never statically imported — see the comment in sandbox-tools-runtime.ts for why.
+ */
+
+import type { Tool } from 'ai';
+import { db } from '@pagespace/db/db';
+import { defaultBuildEnv, type SandboxRunDeps } from '@pagespace/lib/services/sandbox/tool-runners';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { resolveGitHubTokenForSandbox } from '@pagespace/lib/services/sandbox/github-token';
+import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
+import { gateSandboxToolCall } from '@pagespace/lib/services/sandbox/tool-gate';
+import { buildRealSandboxRunDeps, resolveSandboxActorContext } from './sandbox-tools-runtime';
+import { createSandboxGitTools } from './sandbox-git-tools';
+
+function buildGitSandboxRunDeps(): GitSandboxRunDeps {
+  const base: SandboxRunDeps = buildRealSandboxRunDeps();
+  return {
+    ...base,
+    buildEnv: defaultBuildEnv,
+    resolveGitHubToken: (userId: string) =>
+      resolveGitHubTokenForSandbox({ userId, db }),
+  };
+}
+
+export function buildGitSandboxTools(): Record<string, Tool> {
+  return createSandboxGitTools({
+    gitRunDeps: buildGitSandboxRunDeps(),
+    resolveContext: resolveSandboxActorContext,
+    gate: (ctx) =>
+      gateSandboxToolCall({
+        userId: ctx.userId,
+        driveId: ctx.driveId,
+        tenantId: ctx.tenantId,
+        requestOrigin: ctx.requestOrigin,
+        agentPageId: ctx.agentPageId,
+        tier: ctx.tier,
+      }),
+  });
+}

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -1,0 +1,530 @@
+/**
+ * Agent git/GitHub tools: all 26 tools over the 'dev' profile sandbox.
+ *
+ * Pure factory — no DB imports, no Sprites SDK. Production wiring lives in
+ * `sandbox-git-tools-runtime.ts`. Each tool's execute handler:
+ *   1. Resolves the actor context.
+ *   2. Runs the call-time gate (same gate as bash/writeFile/readFile).
+ *   3. For remote/gh tools: pre-checks the GitHub token (fails fast, no quota).
+ *   4. Delegates to `runGitInSandbox` with cmd + args[] (never sh -c).
+ *
+ * Security: cmd is always a literal ('git' or 'gh'). Args are string[]. No
+ * shell interpolation is possible. Token is injected per-command by the
+ * runner, never persisted.
+ */
+
+import { tool, type Tool } from 'ai';
+import { z } from 'zod';
+import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
+import { runGitInSandbox } from '@pagespace/lib/services/sandbox/git-tool-runners';
+import type { ResolveSandboxContext, SandboxGate } from './sandbox-tools';
+import type { ToolExecutionContext } from '../core/types';
+
+export interface GitSandboxToolsDeps {
+  gitRunDeps: GitSandboxRunDeps;
+  resolveContext: ResolveSandboxContext;
+  gate: SandboxGate;
+}
+
+function readContext(options: unknown): ToolExecutionContext | undefined {
+  return (options as { experimental_context?: ToolExecutionContext })?.experimental_context;
+}
+
+const NO_CONNECTION_ERROR = {
+  success: false as const,
+  error:
+    'No GitHub connection found. Connect your GitHub account in Settings → Integrations to use remote git operations.',
+  reason: 'error' as const,
+};
+
+export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitSandboxToolsDeps): Record<string, Tool> {
+  /** Resolve context + gate check shared by every tool. */
+  const open = async (
+    options: unknown,
+  ): Promise<
+    | { ok: true; userId: string; ctx: Parameters<typeof runGitInSandbox>[0]['ctx'] }
+    | { ok: false; error: { success: false; error: string } }
+  > => {
+    const ctx = await resolveContext(readContext(options));
+    if ('error' in ctx) return { ok: false, error: { success: false, error: ctx.error } };
+    const decision = await gate(ctx);
+    if (!decision.ok) return { ok: false, error: { success: false, error: decision.error } };
+    return { ok: true, userId: ctx.userId, ctx };
+  };
+
+  /** For remote/gh tools: check token BEFORE opening a sandbox (no quota charge on failure). */
+  const withToken = async (
+    options: unknown,
+    run: (ctx: Parameters<typeof runGitInSandbox>[0]['ctx'], token: string) => Promise<unknown>,
+  ) => {
+    const opened = await open(options);
+    if (!opened.ok) return opened.error;
+    const token = await gitRunDeps.resolveGitHubToken(opened.userId);
+    if (!token) return NO_CONNECTION_ERROR;
+    return run(opened.ctx, token);
+  };
+
+  const git = (cmd: string, args: string[], ctx: Parameters<typeof runGitInSandbox>[0]['ctx']) =>
+    runGitInSandbox({ cmd, args, ctx, deps: gitRunDeps });
+
+  // ── Repo + config ───────────────────────────────────────────────────────
+
+  const git_clone = tool({
+    description: 'Clone a GitHub repository into the sandbox. Use HTTPS URLs only.',
+    inputSchema: z.object({
+      repo_url: z
+        .string()
+        .url()
+        .refine(
+          (u) => !u.startsWith('git@') && !u.startsWith('ssh://'),
+          'Use HTTPS URLs for git clone (SSH is not supported with token auth)',
+        ),
+      path: z.string().optional(),
+      depth: z.number().int().positive().optional(),
+    }),
+    execute: async ({ repo_url, path, depth }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      const args = [
+        'clone',
+        ...(depth ? ['--depth', String(depth)] : []),
+        repo_url,
+        ...(path ? [path] : []),
+      ];
+      return git('git', args, opened.ctx);
+    },
+  });
+
+  const git_init = tool({
+    description: 'Initialize a new git repository in the sandbox.',
+    inputSchema: z.object({ path: z.string().optional() }),
+    execute: async ({ path }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['init', path ?? '.'], opened.ctx);
+    },
+  });
+
+  const git_config = tool({
+    description: 'Set a git config value.',
+    inputSchema: z.object({
+      key: z.string().min(1),
+      value: z.string(),
+      global: z.boolean().optional(),
+    }),
+    execute: async ({ key, value, global: isGlobal }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['config', ...(isGlobal ? ['--global'] : []), key, value], opened.ctx);
+    },
+  });
+
+  const git_remote_add = tool({
+    description: 'Add a remote to the repository.',
+    inputSchema: z.object({ name: z.string().min(1), url: z.string().url() }),
+    execute: async ({ name, url }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['remote', 'add', name, url], opened.ctx);
+    },
+  });
+
+  // ── Working tree ────────────────────────────────────────────────────────
+
+  const git_status = tool({
+    description: 'Show the working tree status in porcelain format.',
+    inputSchema: z.object({ path: z.string().optional() }),
+    execute: async ({ path }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['status', '--porcelain', ...(path ? ['--', path] : [])], opened.ctx);
+    },
+  });
+
+  const git_diff = tool({
+    description: 'Show changes in the working tree or staged changes.',
+    inputSchema: z.object({ staged: z.boolean().optional(), path: z.string().optional() }),
+    execute: async ({ staged, path }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git(
+        'git',
+        ['diff', ...(staged ? ['--cached'] : []), ...(path ? ['--', path] : [])],
+        opened.ctx,
+      );
+    },
+  });
+
+  const git_add = tool({
+    description: 'Stage files for commit.',
+    inputSchema: z
+      .object({ paths: z.array(z.string()).optional(), all: z.boolean().optional() })
+      .refine((d) => d.all || (d.paths && d.paths.length > 0), {
+        message: 'Provide paths or set all: true',
+      }),
+    execute: async ({ paths, all }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['add', ...(all ? ['-A'] : paths!)], opened.ctx);
+    },
+  });
+
+  const git_reset = tool({
+    description: 'Reset HEAD to a given ref.',
+    inputSchema: z.object({
+      mode: z.enum(['soft', 'mixed', 'hard']),
+      ref: z.string().optional(),
+    }),
+    execute: async ({ mode, ref }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['reset', `--${mode}`, ...(ref ? [ref] : [])], opened.ctx);
+    },
+  });
+
+  const git_stash = tool({
+    description: 'Stash, pop, list, or drop the stash.',
+    inputSchema: z.object({
+      action: z.enum(['push', 'pop', 'list', 'drop']),
+      message: z.string().optional(),
+    }),
+    execute: async ({ action, message }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      const args: string[] =
+        action === 'push'
+          ? ['stash', 'push', ...(message ? ['-m', message] : [])]
+          : ['stash', action];
+      return git('git', args, opened.ctx);
+    },
+  });
+
+  // ── Commits, history, branching ─────────────────────────────────────────
+
+  const git_commit = tool({
+    description: 'Create a commit with the given message.',
+    inputSchema: z.object({
+      message: z.string().min(1),
+      amend: z.boolean().optional(),
+    }),
+    execute: async ({ message, amend }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git(
+        'git',
+        ['commit', '-m', message, ...(amend ? ['--amend', '--no-edit'] : [])],
+        opened.ctx,
+      );
+    },
+  });
+
+  const git_log = tool({
+    description: 'Show commit history. Defaults to last 20 commits in oneline format.',
+    inputSchema: z.object({
+      n: z.number().int().positive().max(100).optional(),
+      path: z.string().optional(),
+      oneline: z.boolean().optional(),
+    }),
+    execute: async ({ n, path, oneline }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      const useOneline = oneline ?? true;
+      return git(
+        'git',
+        [
+          'log',
+          ...(useOneline ? ['--oneline'] : []),
+          `-${n ?? 20}`,
+          ...(path ? ['--', path] : []),
+        ],
+        opened.ctx,
+      );
+    },
+  });
+
+  const git_merge = tool({
+    description: 'Merge a branch.',
+    inputSchema: z.object({
+      branch: z.string().min(1),
+      strategy: z.enum(['merge', 'squash', 'ff-only']).optional(),
+    }),
+    execute: async ({ branch, strategy }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      const strategyFlag =
+        strategy === 'squash' ? ['--squash'] : strategy === 'ff-only' ? ['--ff-only'] : [];
+      return git('git', ['merge', ...strategyFlag, branch], opened.ctx);
+    },
+  });
+
+  const git_rebase = tool({
+    description: 'Rebase onto a branch or ref. Non-interactive only.',
+    inputSchema: z.object({ branch_or_ref: z.string().min(1) }),
+    execute: async ({ branch_or_ref }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['rebase', branch_or_ref], opened.ctx);
+    },
+  });
+
+  const git_checkout = tool({
+    description: 'Switch branches or create a new one.',
+    inputSchema: z.object({ ref: z.string().min(1), create: z.boolean().optional() }),
+    execute: async ({ ref, create }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['checkout', ...(create ? ['-b'] : []), ref], opened.ctx);
+    },
+  });
+
+  const git_branch = tool({
+    description: 'List, create, or delete branches.',
+    inputSchema: z
+      .object({ action: z.enum(['list', 'create', 'delete']), name: z.string().optional() })
+      .refine((d) => d.action === 'list' || !!d.name, { message: 'name required for create/delete' }),
+    execute: async ({ action, name }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      const args =
+        action === 'list' ? ['branch', '-a'] : action === 'delete' ? ['branch', '-d', name!] : ['branch', name!];
+      return git('git', args, opened.ctx);
+    },
+  });
+
+  // ── Remote sync (token required) ────────────────────────────────────────
+
+  const git_fetch = tool({
+    description: 'Fetch from a remote. Requires a connected GitHub account.',
+    inputSchema: z.object({ remote: z.string().optional(), branch: z.string().optional() }),
+    execute: async ({ remote, branch }, options) =>
+      withToken(options, (ctx) =>
+        git('git', ['fetch', remote ?? 'origin', ...(branch ? [branch] : [])], ctx),
+      ),
+  });
+
+  const git_pull = tool({
+    description: 'Pull from a remote. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      remote: z.string().optional(),
+      branch: z.string().optional(),
+      rebase: z.boolean().optional(),
+    }),
+    execute: async ({ remote, branch, rebase }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'git',
+          ['pull', ...(rebase ? ['--rebase'] : []), remote ?? 'origin', ...(branch ? [branch] : [])],
+          ctx,
+        ),
+      ),
+  });
+
+  const git_push = tool({
+    description: 'Push to a remote. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      remote: z.string().optional(),
+      branch: z.string().optional(),
+      force: z.boolean().optional(),
+      set_upstream: z.boolean().optional(),
+    }),
+    execute: async ({ remote, branch, force, set_upstream }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'git',
+          [
+            'push',
+            ...(force ? ['--force-with-lease'] : []),
+            ...(set_upstream ? ['-u'] : []),
+            remote ?? 'origin',
+            ...(branch ? [branch] : []),
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  // ── GitHub PRs (token required) ─────────────────────────────────────────
+
+  const gh_pr_create = tool({
+    description: 'Create a pull request. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      title: z.string().min(1),
+      body: z.string(),
+      base: z.string().optional(),
+      draft: z.boolean().optional(),
+      labels: z.array(z.string()).optional(),
+    }),
+    execute: async ({ title, body, base, draft, labels }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'pr', 'create',
+            '--title', title,
+            '--body', body,
+            ...(base ? ['--base', base] : []),
+            ...(draft ? ['--draft'] : []),
+            ...(labels?.length ? ['--label', labels.join(',')] : []),
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  const gh_pr_list = tool({
+    description: 'List pull requests. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      state: z.enum(['open', 'closed', 'merged', 'all']).optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    execute: async ({ state, limit }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'pr', 'list',
+            '--state', state ?? 'open',
+            '--limit', String(limit ?? 30),
+            '--json', 'number,title,state,url,headRefName,createdAt',
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  const gh_pr_view = tool({
+    description: 'View a pull request. Requires a connected GitHub account.',
+    inputSchema: z.object({ number: z.number().int().positive().optional() }),
+    execute: async ({ number }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'pr', 'view',
+            ...(number ? [String(number)] : []),
+            '--json', 'number,title,body,state,url,headRefName,baseRefName,mergeable',
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  const gh_pr_merge = tool({
+    description: 'Merge a pull request. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      number: z.number().int().positive().optional(),
+      strategy: z.enum(['merge', 'squash', 'rebase']),
+    }),
+    execute: async ({ number, strategy }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'pr', 'merge',
+            ...(number ? [String(number)] : []),
+            strategy === 'squash' ? '--squash' : strategy === 'rebase' ? '--rebase' : '--merge',
+            '--auto',
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  const gh_pr_checkout = tool({
+    description: 'Check out a pull request locally. Requires a connected GitHub account.',
+    inputSchema: z.object({ number: z.number().int().positive() }),
+    execute: async ({ number }, options) =>
+      withToken(options, (ctx) => git('gh', ['pr', 'checkout', String(number)], ctx)),
+  });
+
+  // ── GitHub Issues (token required) ──────────────────────────────────────
+
+  const gh_issue_create = tool({
+    description: 'Create an issue. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      title: z.string().min(1),
+      body: z.string(),
+      labels: z.array(z.string()).optional(),
+    }),
+    execute: async ({ title, body, labels }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'issue', 'create',
+            '--title', title,
+            '--body', body,
+            ...(labels?.length ? ['--label', labels.join(',')] : []),
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  const gh_issue_list = tool({
+    description: 'List issues. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      state: z.enum(['open', 'closed', 'all']).optional(),
+      limit: z.number().int().positive().max(100).optional(),
+    }),
+    execute: async ({ state, limit }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'issue', 'list',
+            '--state', state ?? 'open',
+            '--limit', String(limit ?? 30),
+            '--json', 'number,title,state,url,createdAt,labels',
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  const gh_issue_view = tool({
+    description: 'View an issue. Requires a connected GitHub account.',
+    inputSchema: z.object({ number: z.number().int().positive() }),
+    execute: async ({ number }, options) =>
+      withToken(options, (ctx) =>
+        git(
+          'gh',
+          [
+            'issue', 'view',
+            String(number),
+            '--json', 'number,title,body,state,url,labels,comments,assignees',
+          ],
+          ctx,
+        ),
+      ),
+  });
+
+  return {
+    git_clone,
+    git_init,
+    git_config,
+    git_remote_add,
+    git_status,
+    git_diff,
+    git_add,
+    git_reset,
+    git_stash,
+    git_commit,
+    git_log,
+    git_merge,
+    git_rebase,
+    git_checkout,
+    git_branch,
+    git_fetch,
+    git_pull,
+    git_push,
+    gh_pr_create,
+    gh_pr_list,
+    gh_pr_view,
+    gh_pr_merge,
+    gh_pr_checkout,
+    gh_issue_create,
+    gh_issue_list,
+    gh_issue_view,
+  };
+}

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -98,12 +98,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      const args = [
-        'clone',
-        ...(depth ? ['--depth', String(depth)] : []),
-        repo_url,
-        ...(path ? [path] : []),
-      ];
+      const args = ['clone', ...(depth ? ['--depth', String(depth)] : []), repo_url, path ?? '.'];
       return git('git', args, opened.ctx);
     },
   });

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -3,10 +3,11 @@
  *
  * Pure factory — no DB imports, no Sprites SDK. Production wiring lives in
  * `sandbox-git-tools-runtime.ts`. Each tool's execute handler:
- *   1. Resolves the actor context.
- *   2. Runs the call-time gate (same gate as bash/writeFile/readFile).
- *   3. For remote/gh tools: pre-checks the GitHub token (fails fast, no quota).
- *   4. Delegates to `runGitInSandbox` with cmd + args[] (never sh -c).
+ *   1. Validates input (defense-in-depth; schema validation happens at the AI layer).
+ *   2. Resolves the actor context.
+ *   3. Runs the call-time gate (same gate as bash/writeFile/readFile).
+ *   4. For remote/gh tools: pre-checks the GitHub token (fails fast, no quota).
+ *   5. Delegates to `runGitInSandbox` with cmd + args[] (never sh -c).
  *
  * Security: cmd is always a literal ('git' or 'gh'). Args are string[]. No
  * shell interpolation is possible. Token is injected per-command by the
@@ -15,6 +16,7 @@
 
 import { tool, type Tool } from 'ai';
 import { z } from 'zod';
+import type { SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
 import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
 import { runGitInSandbox } from '@pagespace/lib/services/sandbox/git-tool-runners';
 import type { ResolveSandboxContext, SandboxGate } from './sandbox-tools';
@@ -42,7 +44,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   const open = async (
     options: unknown,
   ): Promise<
-    | { ok: true; userId: string; ctx: Parameters<typeof runGitInSandbox>[0]['ctx'] }
+    | { ok: true; userId: string; ctx: SandboxActorContext }
     | { ok: false; error: { success: false; error: string } }
   > => {
     const ctx = await resolveContext(readContext(options));
@@ -52,10 +54,17 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     return { ok: true, userId: ctx.userId, ctx };
   };
 
-  /** For remote/gh tools: check token BEFORE opening a sandbox (no quota charge on failure). */
+  /** Direct-exec helper for local git commands (no token needed). */
+  const git = (cmd: 'git' | 'gh', args: string[], ctx: SandboxActorContext) =>
+    runGitInSandbox({ cmd, args, ctx, deps: gitRunDeps });
+
+  /**
+   * For remote/gh tools: pre-checks the GitHub token before opening a sandbox.
+   * Passes the already-resolved token to `runGitInSandbox` to avoid a second DB fetch.
+   */
   const withToken = async (
     options: unknown,
-    run: (ctx: Parameters<typeof runGitInSandbox>[0]['ctx'], token: string) => Promise<unknown>,
+    run: (ctx: SandboxActorContext, token: string) => Promise<unknown>,
   ) => {
     const opened = await open(options);
     if (!opened.ok) return opened.error;
@@ -64,25 +73,29 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     return run(opened.ctx, token);
   };
 
-  const git = (cmd: string, args: string[], ctx: Parameters<typeof runGitInSandbox>[0]['ctx']) =>
-    runGitInSandbox({ cmd, args, ctx, deps: gitRunDeps });
+  /** Remote-exec helper: passes the pre-resolved token to skip the second DB lookup. */
+  const gitR = (cmd: 'git' | 'gh', args: string[], ctx: SandboxActorContext, token: string) =>
+    runGitInSandbox({ cmd, args, ctx, deps: gitRunDeps, preResolvedToken: token });
 
   // ── Repo + config ───────────────────────────────────────────────────────
 
-  const git_clone = tool({
+  const gitClone = tool({
     description: 'Clone a GitHub repository into the sandbox. Use HTTPS URLs only.',
     inputSchema: z.object({
       repo_url: z
         .string()
         .url()
         .refine(
-          (u) => !u.startsWith('git@') && !u.startsWith('ssh://'),
-          'Use HTTPS URLs for git clone (SSH is not supported with token auth)',
+          (u) => u.startsWith('https://'),
+          'Only HTTPS URLs are supported (e.g. https://github.com/owner/repo.git)',
         ),
       path: z.string().optional(),
       depth: z.number().int().positive().optional(),
     }),
     execute: async ({ repo_url, path, depth }, options) => {
+      if (!repo_url.startsWith('https://')) {
+        return { success: false as const, error: 'Only HTTPS URLs are supported for git clone.' };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       const args = [
@@ -95,7 +108,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_init = tool({
+  const gitInit = tool({
     description: 'Initialize a new git repository in the sandbox.',
     inputSchema: z.object({ path: z.string().optional() }),
     execute: async ({ path }, options) => {
@@ -105,7 +118,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_config = tool({
+  const gitConfig = tool({
     description: 'Set a git config value.',
     inputSchema: z.object({
       key: z.string().min(1),
@@ -119,10 +132,19 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_remote_add = tool({
-    description: 'Add a remote to the repository.',
-    inputSchema: z.object({ name: z.string().min(1), url: z.string().url() }),
+  const gitRemoteAdd = tool({
+    description: 'Add a remote to the repository. Use HTTPS URLs only.',
+    inputSchema: z.object({
+      name: z.string().min(1),
+      url: z
+        .string()
+        .url()
+        .refine((u) => u.startsWith('https://'), 'Only HTTPS remote URLs are supported'),
+    }),
     execute: async ({ name, url }, options) => {
+      if (!url.startsWith('https://')) {
+        return { success: false as const, error: 'Only HTTPS URLs are supported for git remote add.' };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       return git('git', ['remote', 'add', name, url], opened.ctx);
@@ -131,7 +153,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   // ── Working tree ────────────────────────────────────────────────────────
 
-  const git_status = tool({
+  const gitStatus = tool({
     description: 'Show the working tree status in porcelain format.',
     inputSchema: z.object({ path: z.string().optional() }),
     execute: async ({ path }, options) => {
@@ -141,7 +163,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_diff = tool({
+  const gitDiff = tool({
     description: 'Show changes in the working tree or staged changes.',
     inputSchema: z.object({ staged: z.boolean().optional(), path: z.string().optional() }),
     execute: async ({ staged, path }, options) => {
@@ -155,7 +177,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_add = tool({
+  const gitAdd = tool({
     description: 'Stage files for commit.',
     inputSchema: z
       .object({ paths: z.array(z.string()).optional(), all: z.boolean().optional() })
@@ -163,13 +185,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         message: 'Provide paths or set all: true',
       }),
     execute: async ({ paths, all }, options) => {
+      if (!all && (!paths || paths.length === 0)) {
+        return { success: false as const, error: 'Provide paths or set all: true' };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       return git('git', ['add', ...(all ? ['-A'] : paths!)], opened.ctx);
     },
   });
 
-  const git_reset = tool({
+  const gitReset = tool({
     description: 'Reset HEAD to a given ref.',
     inputSchema: z.object({
       mode: z.enum(['soft', 'mixed', 'hard']),
@@ -182,7 +207,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_stash = tool({
+  const gitStash = tool({
     description: 'Stash, pop, list, or drop the stash.',
     inputSchema: z.object({
       action: z.enum(['push', 'pop', 'list', 'drop']),
@@ -201,13 +226,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   // ── Commits, history, branching ─────────────────────────────────────────
 
-  const git_commit = tool({
+  const gitCommit = tool({
     description: 'Create a commit with the given message.',
     inputSchema: z.object({
       message: z.string().min(1),
       amend: z.boolean().optional(),
     }),
     execute: async ({ message, amend }, options) => {
+      if (!message) {
+        return { success: false as const, error: 'commit message is required' };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       return git(
@@ -218,7 +246,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_log = tool({
+  const gitLog = tool({
     description: 'Show commit history. Defaults to last 20 commits in oneline format.',
     inputSchema: z.object({
       n: z.number().int().positive().max(100).optional(),
@@ -242,7 +270,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_merge = tool({
+  const gitMerge = tool({
     description: 'Merge a branch.',
     inputSchema: z.object({
       branch: z.string().min(1),
@@ -257,7 +285,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_rebase = tool({
+  const gitRebase = tool({
     description: 'Rebase onto a branch or ref. Non-interactive only.',
     inputSchema: z.object({ branch_or_ref: z.string().min(1) }),
     execute: async ({ branch_or_ref }, options) => {
@@ -267,7 +295,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_checkout = tool({
+  const gitCheckout = tool({
     description: 'Switch branches or create a new one.',
     inputSchema: z.object({ ref: z.string().min(1), create: z.boolean().optional() }),
     execute: async ({ ref, create }, options) => {
@@ -277,12 +305,15 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const git_branch = tool({
+  const gitBranch = tool({
     description: 'List, create, or delete branches.',
     inputSchema: z
       .object({ action: z.enum(['list', 'create', 'delete']), name: z.string().optional() })
       .refine((d) => d.action === 'list' || !!d.name, { message: 'name required for create/delete' }),
     execute: async ({ action, name }, options) => {
+      if ((action === 'create' || action === 'delete') && !name) {
+        return { success: false as const, error: 'name is required for create/delete' };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       const args =
@@ -293,16 +324,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   // ── Remote sync (token required) ────────────────────────────────────────
 
-  const git_fetch = tool({
+  const gitFetch = tool({
     description: 'Fetch from a remote. Requires a connected GitHub account.',
     inputSchema: z.object({ remote: z.string().optional(), branch: z.string().optional() }),
     execute: async ({ remote, branch }, options) =>
-      withToken(options, (ctx) =>
-        git('git', ['fetch', remote ?? 'origin', ...(branch ? [branch] : [])], ctx),
+      withToken(options, (ctx, token) =>
+        gitR('git', ['fetch', remote ?? 'origin', ...(branch ? [branch] : [])], ctx, token),
       ),
   });
 
-  const git_pull = tool({
+  const gitPull = tool({
     description: 'Pull from a remote. Requires a connected GitHub account.',
     inputSchema: z.object({
       remote: z.string().optional(),
@@ -310,16 +341,17 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       rebase: z.boolean().optional(),
     }),
     execute: async ({ remote, branch, rebase }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'git',
           ['pull', ...(rebase ? ['--rebase'] : []), remote ?? 'origin', ...(branch ? [branch] : [])],
           ctx,
+          token,
         ),
       ),
   });
 
-  const git_push = tool({
+  const gitPush = tool({
     description: 'Push to a remote. Requires a connected GitHub account.',
     inputSchema: z.object({
       remote: z.string().optional(),
@@ -328,8 +360,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       set_upstream: z.boolean().optional(),
     }),
     execute: async ({ remote, branch, force, set_upstream }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'git',
           [
             'push',
@@ -339,13 +371,14 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             ...(branch ? [branch] : []),
           ],
           ctx,
+          token,
         ),
       ),
   });
 
   // ── GitHub PRs (token required) ─────────────────────────────────────────
 
-  const gh_pr_create = tool({
+  const ghPrCreate = tool({
     description: 'Create a pull request. Requires a connected GitHub account.',
     inputSchema: z.object({
       title: z.string().min(1),
@@ -354,9 +387,12 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       draft: z.boolean().optional(),
       labels: z.array(z.string()).optional(),
     }),
-    execute: async ({ title, body, base, draft, labels }, options) =>
-      withToken(options, (ctx) =>
-        git(
+    execute: async ({ title, body, base, draft, labels }, options) => {
+      if (!title) {
+        return { success: false as const, error: 'title is required' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'pr', 'create',
@@ -367,19 +403,21 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             ...(labels?.length ? ['--label', labels.join(',')] : []),
           ],
           ctx,
+          token,
         ),
-      ),
+      );
+    },
   });
 
-  const gh_pr_list = tool({
+  const ghPrList = tool({
     description: 'List pull requests. Requires a connected GitHub account.',
     inputSchema: z.object({
       state: z.enum(['open', 'closed', 'merged', 'all']).optional(),
       limit: z.number().int().positive().max(100).optional(),
     }),
     execute: async ({ state, limit }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'pr', 'list',
@@ -388,16 +426,17 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             '--json', 'number,title,state,url,headRefName,createdAt',
           ],
           ctx,
+          token,
         ),
       ),
   });
 
-  const gh_pr_view = tool({
+  const ghPrView = tool({
     description: 'View a pull request. Requires a connected GitHub account.',
     inputSchema: z.object({ number: z.number().int().positive().optional() }),
     execute: async ({ number }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'pr', 'view',
@@ -405,19 +444,20 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             '--json', 'number,title,body,state,url,headRefName,baseRefName,mergeable',
           ],
           ctx,
+          token,
         ),
       ),
   });
 
-  const gh_pr_merge = tool({
+  const ghPrMerge = tool({
     description: 'Merge a pull request. Requires a connected GitHub account.',
     inputSchema: z.object({
       number: z.number().int().positive().optional(),
       strategy: z.enum(['merge', 'squash', 'rebase']),
     }),
     execute: async ({ number, strategy }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'pr', 'merge',
@@ -426,29 +466,33 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             '--auto',
           ],
           ctx,
+          token,
         ),
       ),
   });
 
-  const gh_pr_checkout = tool({
+  const ghPrCheckout = tool({
     description: 'Check out a pull request locally. Requires a connected GitHub account.',
     inputSchema: z.object({ number: z.number().int().positive() }),
     execute: async ({ number }, options) =>
-      withToken(options, (ctx) => git('gh', ['pr', 'checkout', String(number)], ctx)),
+      withToken(options, (ctx, token) => gitR('gh', ['pr', 'checkout', String(number)], ctx, token)),
   });
 
   // ── GitHub Issues (token required) ──────────────────────────────────────
 
-  const gh_issue_create = tool({
+  const ghIssueCreate = tool({
     description: 'Create an issue. Requires a connected GitHub account.',
     inputSchema: z.object({
       title: z.string().min(1),
       body: z.string(),
       labels: z.array(z.string()).optional(),
     }),
-    execute: async ({ title, body, labels }, options) =>
-      withToken(options, (ctx) =>
-        git(
+    execute: async ({ title, body, labels }, options) => {
+      if (!title) {
+        return { success: false as const, error: 'title is required' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'issue', 'create',
@@ -457,19 +501,21 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             ...(labels?.length ? ['--label', labels.join(',')] : []),
           ],
           ctx,
+          token,
         ),
-      ),
+      );
+    },
   });
 
-  const gh_issue_list = tool({
+  const ghIssueList = tool({
     description: 'List issues. Requires a connected GitHub account.',
     inputSchema: z.object({
       state: z.enum(['open', 'closed', 'all']).optional(),
       limit: z.number().int().positive().max(100).optional(),
     }),
     execute: async ({ state, limit }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'issue', 'list',
@@ -478,16 +524,17 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             '--json', 'number,title,state,url,createdAt,labels',
           ],
           ctx,
+          token,
         ),
       ),
   });
 
-  const gh_issue_view = tool({
+  const ghIssueView = tool({
     description: 'View an issue. Requires a connected GitHub account.',
     inputSchema: z.object({ number: z.number().int().positive() }),
     execute: async ({ number }, options) =>
-      withToken(options, (ctx) =>
-        git(
+      withToken(options, (ctx, token) =>
+        gitR(
           'gh',
           [
             'issue', 'view',
@@ -495,36 +542,37 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             '--json', 'number,title,body,state,url,labels,comments,assignees',
           ],
           ctx,
+          token,
         ),
       ),
   });
 
   return {
-    git_clone,
-    git_init,
-    git_config,
-    git_remote_add,
-    git_status,
-    git_diff,
-    git_add,
-    git_reset,
-    git_stash,
-    git_commit,
-    git_log,
-    git_merge,
-    git_rebase,
-    git_checkout,
-    git_branch,
-    git_fetch,
-    git_pull,
-    git_push,
-    gh_pr_create,
-    gh_pr_list,
-    gh_pr_view,
-    gh_pr_merge,
-    gh_pr_checkout,
-    gh_issue_create,
-    gh_issue_list,
-    gh_issue_view,
+    git_clone: gitClone,
+    git_init: gitInit,
+    git_config: gitConfig,
+    git_remote_add: gitRemoteAdd,
+    git_status: gitStatus,
+    git_diff: gitDiff,
+    git_add: gitAdd,
+    git_reset: gitReset,
+    git_stash: gitStash,
+    git_commit: gitCommit,
+    git_log: gitLog,
+    git_merge: gitMerge,
+    git_rebase: gitRebase,
+    git_checkout: gitCheckout,
+    git_branch: gitBranch,
+    git_fetch: gitFetch,
+    git_pull: gitPull,
+    git_push: gitPush,
+    gh_pr_create: ghPrCreate,
+    gh_pr_list: ghPrList,
+    gh_pr_view: ghPrView,
+    gh_pr_merge: ghPrMerge,
+    gh_pr_checkout: ghPrCheckout,
+    gh_issue_create: ghIssueCreate,
+    gh_issue_list: ghIssueList,
+    gh_issue_view: ghIssueView,
   };
 }

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -102,7 +102,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate }: SandboxToo
   return {
     bash: tool({
       description:
-        'Run a shell command in this conversation\'s isolated sandbox. Returns stdout, stderr, and the exit code. No network access; the filesystem is ephemeral and scoped to the sandbox.',
+        'Run a shell command in this conversation\'s isolated sandbox. Returns stdout, stderr, and the exit code. The filesystem is scoped to the sandbox.',
       inputSchema: bashInputSchema,
       execute: async ({ command, cwd }, options) => {
         const opened = await open(options);

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -357,6 +357,16 @@
       "import": "./dist/services/sandbox/tool-runners.js",
       "require": "./dist/services/sandbox/tool-runners.js"
     },
+    "./services/sandbox/git-tool-runners": {
+      "types": "./dist/services/sandbox/git-tool-runners.d.ts",
+      "import": "./dist/services/sandbox/git-tool-runners.js",
+      "require": "./dist/services/sandbox/git-tool-runners.js"
+    },
+    "./services/sandbox/github-token": {
+      "types": "./dist/services/sandbox/github-token.d.ts",
+      "import": "./dist/services/sandbox/github-token.js",
+      "require": "./dist/services/sandbox/github-token.js"
+    },
     "./services/sandbox/tool-gate": {
       "types": "./dist/services/sandbox/tool-gate.d.ts",
       "import": "./dist/services/sandbox/tool-gate.js",
@@ -1140,6 +1150,12 @@
       ],
       "services/sandbox/tool-runners": [
         "./dist/services/sandbox/tool-runners.d.ts"
+      ],
+      "services/sandbox/git-tool-runners": [
+        "./dist/services/sandbox/git-tool-runners.d.ts"
+      ],
+      "services/sandbox/github-token": [
+        "./dist/services/sandbox/github-token.d.ts"
       ],
       "services/sandbox/sandbox-client/types": [
         "./dist/services/sandbox/sandbox-client/types.d.ts"

--- a/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
@@ -1,6 +1,56 @@
 import { describe, it, expect } from 'vitest';
 import { resolveExecutionPolicy, SAFE_MINIMUM_PROFILE } from '../execution-policy';
 
+describe('resolveExecutionPolicy — dev profile', () => {
+  it('given the dev profile, should be persistent', () => {
+    expect(resolveExecutionPolicy({ profile: 'dev' }).persistent).toBe(true);
+  });
+
+  it('given the dev profile, should have extended resource bounds', () => {
+    const policy = resolveExecutionPolicy({ profile: 'dev' });
+    expect(policy.timeoutMs).toBe(120_000);
+    expect(policy.memoryMb).toBe(4096);
+    expect(policy.storageGb).toBe(20);
+    expect(policy.vcpus).toBe(2);
+  });
+
+  it('given the dev profile, should allow GitHub CDN egress', () => {
+    const { egressAllowlist } = resolveExecutionPolicy({ profile: 'dev' });
+    expect(egressAllowlist).toContain('github.com');
+    expect(egressAllowlist).toContain('api.github.com');
+    expect(egressAllowlist).toContain('raw.githubusercontent.com');
+  });
+
+  it('given the dev profile, should allow package registry egress', () => {
+    const { egressAllowlist } = resolveExecutionPolicy({ profile: 'dev' });
+    expect(egressAllowlist).toContain('registry.npmjs.org');
+    expect(egressAllowlist).toContain('pypi.org');
+    expect(egressAllowlist).toContain('crates.io');
+  });
+
+  it('given the dev profile, should have no wildcard entries in egress allowlist', () => {
+    const { egressAllowlist } = resolveExecutionPolicy({ profile: 'dev' });
+    for (const host of egressAllowlist) {
+      expect(host).not.toContain('*');
+    }
+  });
+
+  it('given the dev profile, should tag the policy with the dev profile name', () => {
+    expect(resolveExecutionPolicy({ profile: 'dev' }).profile).toBe('dev');
+  });
+
+  it('given the dev profile, should return an immutable policy (frozen egress array)', () => {
+    const policy = resolveExecutionPolicy({ profile: 'dev' });
+    expect(() => {
+      (policy.egressAllowlist as string[]).push('evil.example.com');
+    }).toThrow();
+  });
+
+  it('given the default profile, should still be non-persistent (dev profile should not affect others)', () => {
+    expect(resolveExecutionPolicy({ profile: 'default' }).persistent).toBe(false);
+  });
+});
+
 describe('resolveExecutionPolicy', () => {
   it('given no profile, should resolve the default profile with explicit caps', () => {
     const policy = resolveExecutionPolicy();

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -109,11 +109,33 @@ describe('runGitInSandbox', () => {
     });
   });
 
+  it('configures a one-shot credential helper for git HTTPS authentication', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy('ghp_abc123');
+    await runGitInSandbox({ cmd: 'git', args: ['fetch', 'origin'], ctx: makeCtx(), deps });
+    const call = runCommandCalls[0];
+    expect(call).toBeDefined();
+    if (!call) throw new Error('expected runCommand call');
+    const env = call.env;
+    expect(env).toBeDefined();
+    if (!env) throw new Error('expected runCommand env');
+    expect(env).toMatchObject({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'credential.helper',
+    });
+    const credentialHelper = env.GIT_CONFIG_VALUE_0;
+    expect(credentialHelper).toBeDefined();
+    if (!credentialHelper) throw new Error('expected credential helper');
+    expect(credentialHelper).toContain('username=x-access-token');
+    expect(credentialHelper).toContain('password=$GITHUB_TOKEN');
+    expect(credentialHelper).not.toContain('ghp_abc123');
+  });
+
   it('does not include GH_TOKEN or GITHUB_TOKEN when resolver returns null', async () => {
     const { deps, runCommandCalls } = makeDepsWithSpy(null);
     await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
     expect(runCommandCalls[0].env).not.toHaveProperty('GH_TOKEN');
     expect(runCommandCalls[0].env).not.toHaveProperty('GITHUB_TOKEN');
+    expect(runCommandCalls[0].env).not.toHaveProperty('GIT_CONFIG_VALUE_0');
   });
 
   it('always injects GIT_TERMINAL_PROMPT=0', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runGitInSandbox,
+  type GitSandboxRunDeps,
+} from '../git-tool-runners';
+import type { SandboxActorContext } from '../tool-runners';
+import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
+
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+
+function makeCtx(over: Partial<SandboxActorContext> = {}): SandboxActorContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    driveId: 'd1',
+    conversationId: 'c1',
+    actorEmail: 'u1@example.com',
+    tier: 'pro',
+    ...over,
+  };
+}
+
+function makeSandbox(over: Partial<ExecutableSandbox> = {}): {
+  sandbox: ExecutableSandbox;
+  runCommandCalls: Array<Parameters<ExecutableSandbox['runCommand']>[0]>;
+} {
+  const runCommandCalls: Array<Parameters<ExecutableSandbox['runCommand']>[0]> = [];
+  const sandbox: ExecutableSandbox = {
+    sandboxId: 'sbx-1',
+    runCommand: async (opts): Promise<SandboxRunResult> => {
+      runCommandCalls.push(opts);
+      return { exitCode: 0, stdout: 'ok', stderr: '' };
+    },
+    writeFiles: async () => {},
+    readFileToBuffer: async () => Buffer.from(''),
+    ...over,
+  };
+  return { sandbox, runCommandCalls };
+}
+
+function makeDeps(over: Partial<GitSandboxRunDeps> = {}, token: string | null = 'ghp_test_token') {
+  const slots = { acquired: 0, released: 0 };
+  const { sandbox, runCommandCalls } = makeSandbox(over.reconnect ? undefined : undefined);
+  const deps: GitSandboxRunDeps = {
+    isEnabled: () => true,
+    acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+    reconnect: async () => sandbox,
+    quota: {
+      acquireSlot: () => { slots.acquired += 1; return true; },
+      releaseSlot: () => { slots.released += 1; },
+      preflight: async () => ({ allowed: true }),
+      charge: async () => {},
+    },
+    buildEnv: () => ({ NODE_ENV: 'test' }),
+    audit: async () => {},
+    now: () => NOW,
+    resolveGitHubToken: async () => token,
+    ...over,
+  };
+  return { deps, slots, sandbox };
+}
+
+// Helper that captures runCommand calls by spying on the sandbox
+function makeDepsWithSpy(token: string | null = 'ghp_test_token') {
+  const runCommandCalls: Array<Parameters<ExecutableSandbox['runCommand']>[0]> = [];
+  const sandbox: ExecutableSandbox = {
+    sandboxId: 'sbx-1',
+    runCommand: async (opts): Promise<SandboxRunResult> => {
+      runCommandCalls.push(opts);
+      return { exitCode: 0, stdout: 'hello', stderr: '' };
+    },
+    writeFiles: async () => {},
+    readFileToBuffer: async () => Buffer.from(''),
+  };
+  const slots = { acquired: 0, released: 0 };
+  const deps: GitSandboxRunDeps = {
+    isEnabled: () => true,
+    acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+    reconnect: async () => sandbox,
+    quota: {
+      acquireSlot: () => { slots.acquired += 1; return true; },
+      releaseSlot: () => { slots.released += 1; },
+      preflight: async () => ({ allowed: true }),
+      charge: async () => {},
+    },
+    buildEnv: () => ({ NODE_ENV: 'test' }),
+    audit: async () => {},
+    now: () => NOW,
+    resolveGitHubToken: async () => token,
+  };
+  return { deps, slots, runCommandCalls };
+}
+
+describe('runGitInSandbox', () => {
+  it('passes cmd and args directly to sandbox.runCommand — no sh -c wrapping', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(runCommandCalls).toHaveLength(1);
+    expect(runCommandCalls[0].cmd).toBe('git');
+    expect(runCommandCalls[0].args).toEqual(['status']);
+  });
+
+  it('injects GH_TOKEN and GITHUB_TOKEN when resolver returns a token', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy('ghp_abc123');
+    await runGitInSandbox({ cmd: 'gh', args: ['pr', 'list'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].env).toMatchObject({
+      GH_TOKEN: 'ghp_abc123',
+      GITHUB_TOKEN: 'ghp_abc123',
+    });
+  });
+
+  it('does not include GH_TOKEN or GITHUB_TOKEN when resolver returns null', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy(null);
+    await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].env).not.toHaveProperty('GH_TOKEN');
+    expect(runCommandCalls[0].env).not.toHaveProperty('GITHUB_TOKEN');
+  });
+
+  it('always injects GIT_TERMINAL_PROMPT=0', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'git', args: ['fetch'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].env).toMatchObject({ GIT_TERMINAL_PROMPT: '0' });
+  });
+
+  it('always injects GIT_CONFIG_NOSYSTEM=1', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'git', args: ['clone', 'https://github.com/a/b'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].env).toMatchObject({ GIT_CONFIG_NOSYSTEM: '1' });
+  });
+
+  it('always injects GH_CONFIG_DIR=/tmp/gh-config', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'gh', args: ['auth', 'status'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].env).toMatchObject({ GH_CONFIG_DIR: '/tmp/gh-config' });
+  });
+
+  it('returns success result with stdout, stderr, exitCode, truncated', async () => {
+    const { deps } = makeDepsWithSpy();
+    const result = await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: true, stdout: 'hello', stderr: '', exitCode: 0, truncated: false });
+  });
+
+  it('uses the dev profile (persistent, egress-enabled) not the default profile', async () => {
+    // The dev profile has timeoutMs=120_000 — verify it's passed to runCommand
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].timeoutMs).toBe(120_000);
+  });
+
+  it('releases the concurrency slot in finally even when sandbox.runCommand throws', async () => {
+    const { deps, slots } = makeDepsWithSpy();
+    deps.reconnect = async () => ({
+      sandboxId: 'sbx-1',
+      runCommand: async () => { throw new Error('run failed'); },
+      writeFiles: async () => {},
+      readFileToBuffer: async () => null,
+    });
+    const result = await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false });
+    expect(slots.released).toBe(slots.acquired);
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/github-token.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/github-token.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveGitHubTokenForSandbox } from '../github-token';
+
+const mockGetProviderBySlug = vi.fn();
+const mockFindUserConnection = vi.fn();
+const mockDecryptCredentials = vi.fn();
+
+vi.mock('../../../integrations/repositories/provider-repository', () => ({
+  getProviderBySlug: (...args: unknown[]) => mockGetProviderBySlug(...args),
+}));
+
+vi.mock('../../../integrations/repositories/connection-repository', () => ({
+  findUserConnection: (...args: unknown[]) => mockFindUserConnection(...args),
+}));
+
+vi.mock('../../../integrations/credentials/encrypt-credentials', () => ({
+  decryptCredentials: (...args: unknown[]) => mockDecryptCredentials(...args),
+}));
+
+const fakeDb = {} as never;
+const userId = 'user-123';
+const providerId = 'provider-github';
+
+const activeConnection = {
+  id: 'conn-1',
+  userId,
+  providerId,
+  status: 'active',
+  credentials: { accessToken: 'encrypted-token' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveGitHubTokenForSandbox', () => {
+  it('returns null when getProviderBySlug resolves null', async () => {
+    mockGetProviderBySlug.mockResolvedValue(null);
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+    expect(mockFindUserConnection).not.toHaveBeenCalled();
+  });
+
+  it('returns null when findUserConnection resolves null', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue(null);
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+    expect(mockDecryptCredentials).not.toHaveBeenCalled();
+  });
+
+  it('returns null when connection status is inactive', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue({ ...activeConnection, status: 'inactive' });
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when connection status is pending', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue({ ...activeConnection, status: 'pending' });
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when connection credentials is null', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue({ ...activeConnection, credentials: null });
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+    expect(mockDecryptCredentials).not.toHaveBeenCalled();
+  });
+
+  it('returns null when connection credentials is empty object', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue({ ...activeConnection, credentials: {} });
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+    expect(mockDecryptCredentials).not.toHaveBeenCalled();
+  });
+
+  it('returns the accessToken when connection is active with valid credentials', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue(activeConnection);
+    mockDecryptCredentials.mockResolvedValue({ accessToken: 'ghp_real_token' });
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBe('ghp_real_token');
+  });
+
+  it('returns null (does not throw) when decryptCredentials throws', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue(activeConnection);
+    mockDecryptCredentials.mockRejectedValue(new Error('decrypt failed'));
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when decrypted credentials contain no accessToken', async () => {
+    mockGetProviderBySlug.mockResolvedValue({ id: providerId });
+    mockFindUserConnection.mockResolvedValue(activeConnection);
+    mockDecryptCredentials.mockResolvedValue({ refreshToken: 'some-refresh' });
+    const result = await resolveGitHubTokenForSandbox({ userId, db: fakeDb });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
@@ -153,6 +153,56 @@ describe('planTerminalLifecycle', () => {
     const result = planTerminalLifecycle({ canRun: true, now: NOW, intent: 'end' });
     expect(result).toEqual({ action: 'noop' });
   });
+
+  it('given persistent=true and an idle session, returns { action: noop } (let Sprites hibernate)', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      persistent: true,
+      existingSession: { sandboxId: 'sbx-idle', lastActiveAt: new Date(NOW.getTime() - 20 * 60 * 1000) },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'noop' });
+  });
+
+  it('given persistent=false and an idle session, returns teardown (unchanged ephemeral behaviour)', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      persistent: false,
+      existingSession: { sandboxId: 'sbx-idle', lastActiveAt: new Date(NOW.getTime() - 20 * 60 * 1000) },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'teardown', sandboxId: 'sbx-idle', reason: 'idle' });
+  });
+
+  it('given persistent=undefined and an idle session, returns teardown (default is ephemeral)', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      existingSession: { sandboxId: 'sbx-idle', lastActiveAt: new Date(NOW.getTime() - 20 * 60 * 1000) },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'teardown', sandboxId: 'sbx-idle', reason: 'idle' });
+  });
+
+  it('given persistent=true and intent=end, still tears down (explicit destroy always works)', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      persistent: true,
+      existingSession: { sandboxId: 'sbx-end', lastActiveAt: NOW },
+      now: NOW,
+      intent: 'end',
+    });
+    expect(result).toEqual({ action: 'teardown', sandboxId: 'sbx-end', reason: 'session_end' });
+  });
+
+  it('given persistent=true and a fresh session, still resumes normally', () => {
+    const result = planTerminalLifecycle({
+      canRun: true,
+      persistent: true,
+      existingSession: { sandboxId: 'sbx-warm', lastActiveAt: new Date(NOW.getTime() - 1000) },
+      now: NOW,
+    });
+    expect(result).toEqual({ action: 'resume', sandboxId: 'sbx-warm' });
+  });
 });
 
 describe('acquireTerminalSandbox', () => {

--- a/packages/lib/src/services/sandbox/execution-policy.ts
+++ b/packages/lib/src/services/sandbox/execution-policy.ts
@@ -11,7 +11,7 @@
  * policy — so a typo or an unknown caller can never widen the blast radius.
  */
 
-export type ExecutionProfile = 'default' | 'minimal';
+export type ExecutionProfile = 'default' | 'minimal' | 'dev';
 
 export interface ExecutionPolicy {
   /** Profile this policy represents (echoed back for audit/logging). */
@@ -33,6 +33,26 @@ export interface ExecutionPolicy {
   /** Explicit deployment region. */
   region: string;
 }
+
+// Literal egress hostname lists for the 'dev' profile. Frozen so a caller
+// cannot push to them and widen egress globally across runs.
+const GITHUB_EGRESS_HOSTS = Object.freeze([
+  'github.com',
+  'api.github.com',
+  'raw.githubusercontent.com',
+  'objects.githubusercontent.com',
+  'uploads.github.com',
+  'codeload.github.com',
+] as const);
+
+const REGISTRY_EGRESS_HOSTS = Object.freeze([
+  'registry.npmjs.org',
+  'pypi.org',
+  'files.pythonhosted.org',
+  'crates.io',
+  'static.crates.io',
+  'index.crates.io',
+] as const);
 
 // Policies are returned by reference from module constants. Freeze them (and
 // their egress arrays) so a downstream caller can never mutate the shared
@@ -66,9 +86,25 @@ const DEFAULT_PROFILE: ExecutionPolicy = Object.freeze({
   region: 'iad',
 });
 
+const DEV_PROFILE: ExecutionPolicy = Object.freeze({
+  profile: 'dev',
+  timeoutMs: 120_000,
+  vcpus: 2,
+  memoryMb: 4096,
+  storageGb: 20,
+  maxOutputBytes: 64 * 1024,
+  egressAllowlist: Object.freeze([
+    ...GITHUB_EGRESS_HOSTS,
+    ...REGISTRY_EGRESS_HOSTS,
+  ]) as readonly string[],
+  persistent: true,
+  region: 'iad',
+});
+
 const PROFILES: Record<ExecutionProfile, ExecutionPolicy> = {
   default: DEFAULT_PROFILE,
   minimal: SAFE_MINIMUM_PROFILE,
+  dev: DEV_PROFILE,
 };
 
 export function resolveExecutionPolicy({

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -28,12 +28,15 @@ export async function runGitInSandbox({
   cwd,
   ctx,
   deps,
+  preResolvedToken,
 }: {
-  cmd: string;
+  cmd: 'git' | 'gh';
   args: string[];
   cwd?: string;
   ctx: SandboxActorContext;
   deps: GitSandboxRunDeps;
+  /** If provided, skip the DB token lookup (avoids a double-fetch when the caller already resolved it). */
+  preResolvedToken?: string | null;
 }): Promise<GitToolResult> {
   if (!deps.isEnabled()) {
     return { success: false, error: 'Code execution is disabled.', reason: 'kill_switch_off' };
@@ -43,7 +46,10 @@ export async function runGitInSandbox({
 
   // Pre-fetch token BEFORE acquiring a sandbox slot — a missing token on a
   // network-requiring command must not consume quota.
-  const token = await deps.resolveGitHubToken(ctx.userId);
+  const token =
+    preResolvedToken !== undefined
+      ? preResolvedToken
+      : await deps.resolveGitHubToken(ctx.userId);
 
   const pre = await deps.quota.preflight({
     userId: ctx.userId,

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -1,0 +1,164 @@
+import { resolveExecutionPolicy } from './execution-policy';
+import { truncateToBytes } from './output-limit';
+import { SANDBOX_ROOT } from './sandbox-paths';
+import type { SandboxActorContext, SandboxRunDeps, BashToolResult } from './tool-runners';
+
+export interface GitSandboxRunDeps extends SandboxRunDeps {
+  /** Fetches the user's GitHub OAuth access token from their integration connection. */
+  resolveGitHubToken: (userId: string) => Promise<string | null>;
+}
+
+export type GitToolResult = BashToolResult;
+
+/**
+ * Runs a git or gh command inside a 'dev' profile sandbox.
+ *
+ * Security invariants:
+ * - cmd is a literal ('git' or 'gh'), never built by string concatenation.
+ * - args is a string[], never passed through a shell.
+ * - Token appears in env for this one runCommand call only — not persisted,
+ *   not logged, not included in returned output.
+ * - GIT_CONFIG_NOSYSTEM prevents system gitconfig credential caching.
+ * - GH_CONFIG_DIR isolates gh config from the persistent sandbox home dir.
+ * - GIT_TERMINAL_PROMPT=0 prevents git from blocking on a credential prompt.
+ */
+export async function runGitInSandbox({
+  cmd,
+  args,
+  cwd,
+  ctx,
+  deps,
+}: {
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  ctx: SandboxActorContext;
+  deps: GitSandboxRunDeps;
+}): Promise<GitToolResult> {
+  if (!deps.isEnabled()) {
+    return { success: false, error: 'Code execution is disabled.', reason: 'kill_switch_off' };
+  }
+
+  const policy = resolveExecutionPolicy({ profile: 'dev' });
+
+  // Pre-fetch token BEFORE acquiring a sandbox slot — a missing token on a
+  // network-requiring command must not consume quota.
+  const token = await deps.resolveGitHubToken(ctx.userId);
+
+  const pre = await deps.quota.preflight({
+    userId: ctx.userId,
+    driveId: ctx.driveId,
+    tenantId: ctx.tenantId,
+    tier: ctx.tier,
+  });
+  if (!pre.allowed) {
+    return {
+      success: false,
+      error: 'Daily code-execution budget reached. Try again later.',
+      reason: pre.reason,
+      retryAfter: pre.retryAfter,
+    };
+  }
+  if (!deps.quota.acquireSlot({ userId: ctx.userId, tier: ctx.tier })) {
+    return {
+      success: false,
+      error: 'Too many concurrent runs. Wait for a run to finish and retry.',
+      reason: 'concurrency_limit',
+    };
+  }
+
+  // Slot held — every exit path below must release it.
+  try {
+    const acquired = await deps.acquireSandbox({
+      tenantId: ctx.tenantId,
+      driveId: ctx.driveId,
+      conversationId: ctx.conversationId,
+      userId: ctx.userId,
+      requestOrigin: ctx.requestOrigin,
+      agentPageId: ctx.agentPageId,
+      policy,
+    });
+    if (!acquired.ok) {
+      return { success: false, error: 'Could not provision a sandbox.', reason: 'provision_failed' };
+    }
+
+    const sandbox = await deps.reconnect(acquired.sandboxId);
+    if (!sandbox) {
+      return { success: false, error: 'Could not provision a sandbox.', reason: 'provision_failed' };
+    }
+
+    await deps.quota.charge({ userId: ctx.userId, driveId: ctx.driveId, tenantId: ctx.tenantId });
+
+    const resolvedCwd = cwd ?? SANDBOX_ROOT;
+    const startedAt = deps.now();
+
+    let run: { exitCode: number; stdout: string; stderr: string };
+    try {
+      run = await sandbox.runCommand({
+        cmd,
+        args,
+        cwd: resolvedCwd,
+        env: {
+          ...deps.buildEnv(),
+          GIT_TERMINAL_PROMPT: '0',
+          GIT_CONFIG_NOSYSTEM: '1',
+          GH_CONFIG_DIR: '/tmp/gh-config',
+          ...(token ? { GH_TOKEN: token, GITHUB_TOKEN: token } : {}),
+        },
+        timeoutMs: policy.timeoutMs,
+        maxBytes: policy.maxOutputBytes,
+      });
+    } catch {
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      await safeAudit(deps, ctx, { cmd: `${cmd} ${args.join(' ')}`, exitCode: null, durationMs });
+      return { success: false, error: 'Command execution failed or timed out.', reason: 'execution_failed' };
+    }
+
+    const durationMs = deps.now().getTime() - startedAt.getTime();
+    const stdout = truncateToBytes({ text: run.stdout, maxBytes: policy.maxOutputBytes });
+    const stderr = truncateToBytes({ text: run.stderr, maxBytes: policy.maxOutputBytes });
+
+    await safeAudit(deps, ctx, {
+      cmd: `${cmd} ${args.join(' ')}`,
+      exitCode: run.exitCode,
+      durationMs,
+    });
+
+    return {
+      success: true,
+      stdout: stdout.text,
+      stderr: stderr.text,
+      exitCode: run.exitCode,
+      truncated: stdout.truncated || stderr.truncated,
+    };
+  } finally {
+    deps.quota.releaseSlot({ userId: ctx.userId });
+  }
+}
+
+async function safeAudit(
+  deps: GitSandboxRunDeps,
+  ctx: SandboxActorContext,
+  fields: { cmd: string; exitCode: number | null; durationMs: number },
+): Promise<void> {
+  try {
+    await deps.audit({
+      userId: ctx.userId,
+      actorEmail: ctx.actorEmail,
+      actorDisplayName: ctx.actorDisplayName,
+      driveId: ctx.driveId,
+      conversationId: ctx.conversationId,
+      requestOrigin: ctx.requestOrigin,
+      agentPageId: ctx.agentPageId,
+      aiProvider: ctx.aiProvider,
+      aiModel: ctx.aiModel,
+      timestamp: deps.now(),
+      profile: 'dev',
+      code: fields.cmd,
+      exitCode: fields.exitCode,
+      durationMs: fields.durationMs,
+    });
+  } catch {
+    // Fire-and-forget — audit failure must not break the run.
+  }
+}

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -10,6 +10,9 @@ export interface GitSandboxRunDeps extends SandboxRunDeps {
 
 export type GitToolResult = BashToolResult;
 
+const GITHUB_CREDENTIAL_HELPER =
+  '!f() { test "$1" = get || exit 0; echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f';
+
 /**
  * Runs a git or gh command inside a 'dev' profile sandbox.
  *
@@ -18,6 +21,8 @@ export type GitToolResult = BashToolResult;
  * - args is a string[], never passed through a shell.
  * - Token appears in env for this one runCommand call only — not persisted,
  *   not logged, not included in returned output.
+ * - Git receives the token through a one-shot credential helper configured via
+ *   env-only git config, so HTTPS remotes work without putting the token in argv.
  * - GIT_CONFIG_NOSYSTEM prevents system gitconfig credential caching.
  * - GH_CONFIG_DIR isolates gh config from the persistent sandbox home dir.
  * - GIT_TERMINAL_PROMPT=0 prevents git from blocking on a credential prompt.
@@ -109,7 +114,15 @@ export async function runGitInSandbox({
           GIT_TERMINAL_PROMPT: '0',
           GIT_CONFIG_NOSYSTEM: '1',
           GH_CONFIG_DIR: '/tmp/gh-config',
-          ...(token ? { GH_TOKEN: token, GITHUB_TOKEN: token } : {}),
+          ...(token
+            ? {
+                GH_TOKEN: token,
+                GITHUB_TOKEN: token,
+                GIT_CONFIG_COUNT: '1',
+                GIT_CONFIG_KEY_0: 'credential.helper',
+                GIT_CONFIG_VALUE_0: GITHUB_CREDENTIAL_HELPER,
+              }
+            : {}),
         },
         timeoutMs: policy.timeoutMs,
         maxBytes: policy.maxOutputBytes,

--- a/packages/lib/src/services/sandbox/github-token.ts
+++ b/packages/lib/src/services/sandbox/github-token.ts
@@ -1,0 +1,34 @@
+import type { db as defaultDb } from '@pagespace/db/db';
+import { getProviderBySlug } from '../../integrations/repositories/provider-repository';
+import { findUserConnection } from '../../integrations/repositories/connection-repository';
+import { decryptCredentials } from '../../integrations/credentials/encrypt-credentials';
+
+export async function resolveGitHubTokenForSandbox({
+  userId,
+  db,
+}: {
+  userId: string;
+  db: typeof defaultDb;
+}): Promise<string | null> {
+  try {
+    const provider = await getProviderBySlug(db, 'github');
+    if (!provider) return null;
+
+    const connection = await findUserConnection(db, userId, provider.id);
+    if (!connection || connection.status !== 'active') return null;
+
+    if (
+      !connection.credentials ||
+      Object.keys(connection.credentials as object).length === 0
+    ) {
+      return null;
+    }
+
+    const creds = await decryptCredentials(
+      connection.credentials as Record<string, string>
+    );
+    return creds.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -46,6 +46,8 @@ export interface PlanTerminalLifecycleInput {
   now: Date;
   idleTimeoutMs?: number;
   intent?: TerminalLifecycleIntent;
+  /** When true, idle sessions return noop instead of teardown — Sprites hibernates the VM. */
+  persistent?: boolean;
 }
 
 const DEFAULT_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
@@ -56,6 +58,7 @@ export function planTerminalLifecycle({
   now,
   idleTimeoutMs = DEFAULT_IDLE_TIMEOUT_MS,
   intent = 'run',
+  persistent = false,
 }: PlanTerminalLifecycleInput): TerminalLifecyclePlan {
   // Cleanup is unconditional on 'end' intent — authorization never gates cleanup.
   if (intent === 'end') {
@@ -76,6 +79,8 @@ export function planTerminalLifecycle({
 
   const idleFor = now.getTime() - existingSession.lastActiveAt.getTime();
   if (idleFor >= idleTimeoutMs) {
+    // Persistent sandboxes hibernate on their own — keep the session store record alive.
+    if (persistent) return { action: 'noop' };
     return { action: 'teardown', sandboxId: existingSession.sandboxId, reason: 'idle' };
   }
 


### PR DESCRIPTION
## Summary

Implements 26 sandboxed git/gh agent tools for AI agents, wiring the user's GitHub OAuth token server-side per-command (zero-trust: never stored, never visible to agent).

- **`'dev'` execution profile** — persistent sandbox, 4GB RAM, 20GB disk, 120s timeout, frozen egress allowlist (GitHub CDN + npm/PyPI/crates.io)
- **GitHub token resolver** (`github-token.ts`) — fetches from integration connection, decrypts, returns `accessToken | null`
- **`runGitInSandbox`** (`git-tool-runners.ts`) — `cmd + args[]` only, never `sh -c`; security env vars always injected; `cmd` typed as `'git' | 'gh'` union; optional `preResolvedToken` skips second DB fetch
- **`createSandboxGitTools` factory** (`sandbox-git-tools.ts`) — 26 tools: repo/config, working-tree, commit/history/branching, remote-sync, PR, issues; runtime input validation in execute handlers (defense-in-depth); `https://`-only URL enforcement; fail-fast no-connection error before any quota is charged
- **Production wiring** (`sandbox-git-tools-runtime.ts`) — binds real DB token resolver, Sprites driver, gate; registered under same `CODE_EXECUTION_ENABLED` kill-switch as bash/writeFile/readFile

**Security:** token injected per `runCommand` call, not in persistent sandbox env. `GIT_TERMINAL_PROMPT=0`, `GIT_CONFIG_NOSYSTEM=1`, `GH_CONFIG_DIR=/tmp/gh-config` always set. No shell expansion possible (`cmd`+`args[]` pattern throughout).

## Changes

| Commit | Description |
|--------|-------------|
| `7217b6b` | Initial implementation: 13 files, 1553 insertions — all 26 tools + tests + wiring |
| `493b269` | CI fixes + CodeRabbit review: lint, typecheck, URL validation, cmd type, double-token fix, camelCase |

## Test plan

- [x] `packages/lib` tests: 4168 passing (177 test files)
- [x] Typecheck: no new errors (pre-existing worktree module-resolution errors only)
- [x] Lint: unused `capturedToken` and `isCodeExecutionEnabled` removed
- [x] `tool.execute!` non-null assertions fix TS2722/TS18048 typecheck errors
- [x] Runtime input validation in execute handlers makes tests reliable when called directly
- [ ] CI green (in progress on 2nd push)

## Manual verification (requires `CODE_EXECUTION_ENABLED=true` + GitHub connected)

1. Open a Terminal page → `gh auth status` → shows authenticated as GitHub user
2. `git clone https://github.com/<your-org>/<repo>` → succeeds
3. Disconnect GitHub in Settings → Integrations → remote tools return `NO_CONNECTION_ERROR`
4. `git clone git@github.com:...` → rejected with "HTTPS only" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sfd68Q86S5ruvUhwXg9BGZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Git and GitHub integration with 26 new tools for the AI sandbox, including repository operations (clone, init, commit, push, pull) and GitHub interactions (PR creation, issue management).
  * Introduced "dev" execution profile with persistent sandbox sessions and pre-configured access to GitHub and package registry services.

* **Documentation**
  * Updated bash tool description for clarity on sandbox isolation and output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->