### PR TITLE
fix(sandbox): restrict terminal and prod code execution to admins

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/terminal/execute/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/terminal/execute/__tests__/route.test.ts
@@ -20,6 +20,7 @@ import { NextResponse } from 'next/server';
 
 vi.mock('@pagespace/lib/services/sandbox/can-run-code', () => ({
   isCodeExecutionEnabled: vi.fn().mockReturnValue(true),
+  canRunCode: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -80,7 +81,7 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 // ─── Import SUT and mocked modules ────────────────────────────────────────
 
 import { POST } from '../route';
-import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { canRunCode, isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { authenticateRequestWithOptions, canPrincipalEditPage } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { checkCodeExecutionQuota, acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
@@ -89,7 +90,6 @@ import { createSpritesSandboxClient } from '@pagespace/lib/services/sandbox/sand
 
 // ─── Type helpers ──────────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function asMock<T>(fn: T): ReturnType<typeof vi.fn> {
   return fn as unknown as ReturnType<typeof vi.fn>;
 }
@@ -105,7 +105,7 @@ const mockSessionAuth = {
   userId: mockUserId,
   tokenType: 'session' as const,
   sessionId: 'sess_1',
-  role: 'user' as const,
+  role: 'admin' as const,
   tokenVersion: 1,
   adminRoleVersion: 1,
 };
@@ -175,6 +175,7 @@ describe('POST /api/pages/[pageId]/terminal/execute', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     asMock(isCodeExecutionEnabled).mockReturnValue(true);
+    asMock(canRunCode).mockResolvedValue({ ok: true });
     asMock(authenticateRequestWithOptions).mockResolvedValue(mockSessionAuth);
     asMock(canPrincipalEditPage).mockResolvedValue(true);
     asMock(checkCodeExecutionQuota).mockResolvedValue({ allowed: true });
@@ -203,10 +204,32 @@ describe('POST /api/pages/[pageId]/terminal/execute', () => {
   });
 
   describe('authorization', () => {
+    it('returns 403 when a non-admin tries to execute a terminal command', async () => {
+      asMock(authenticateRequestWithOptions).mockResolvedValue({
+        ...mockSessionAuth,
+        role: 'user',
+      });
+
+      const res = await POST(makeRequest(), makeParams());
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(canPrincipalEditPage)).not.toHaveBeenCalled();
+    });
+
     it('returns 403 when user cannot edit page', async () => {
       asMock(canPrincipalEditPage).mockResolvedValue(false);
       const res = await POST(makeRequest(), makeParams());
       expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when shared code-execution authorization denies the user', async () => {
+      setupDbMocks();
+      asMock(canRunCode).mockResolvedValue({ ok: false, reason: 'app_admin_required' });
+
+      const res = await POST(makeRequest(), makeParams());
+
+      expect(res.status).toBe(403);
+      expect(vi.mocked(acquireCodeExecutionSlot)).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/pages/[pageId]/terminal/execute/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/terminal/execute/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError, canPrincipalEditPage } from '@/lib/auth';
-import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { canRunCode, isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/session-manager';
 import {
   acquireTerminalSandbox,
@@ -54,6 +54,10 @@ export async function POST(
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
   if (isAuthError(auth)) return auth.error;
   const userId = auth.userId;
+  if (auth.role !== 'admin') {
+    auditRequest(req, { eventType: 'authz.access.denied', userId, resourceType: 'terminal_session', resourceId: pageId, details: { reason: 'app_admin_required', method: 'POST' }, riskScore: 0.5 });
+    return NextResponse.json({ error: 'Terminal access requires administrator privileges' }, { status: 403 });
+  }
 
   // 3. Page permission: editor+ required to run code.
   const canEdit = await canPrincipalEditPage(auth, pageId);
@@ -85,6 +89,12 @@ export async function POST(
     return NextResponse.json({ error: 'Page not found' }, { status: 404 });
   }
   const { driveId } = pageRow;
+
+  const codeAuth = await canRunCode({ userId, driveId, requestOrigin: 'user' });
+  if (!codeAuth.ok) {
+    auditRequest(req, { eventType: 'authz.access.denied', userId, resourceType: 'terminal_session', resourceId: pageId, details: { reason: codeAuth.reason, method: 'POST' }, riskScore: 0.5 });
+    return NextResponse.json({ error: 'Code execution is not available for this user' }, { status: 403 });
+  }
 
   const [driveRow, actorRow] = await Promise.all([
     db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, driveId)).limit(1),

--- a/apps/web/src/app/api/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/route.test.ts
@@ -181,7 +181,6 @@ describe('POST /api/pages', () => {
 
       expect(response.status).toBe(400);
       expect(body.error).toContain('Invalid option');
-      expect(body.error).not.toContain('TERMINAL');
       expect(pageService.createPage).not.toHaveBeenCalled();
     });
 
@@ -309,6 +308,45 @@ describe('POST /api/pages', () => {
 
       expect(response.status).toBe(400);
       expect(body.error).toMatch(/not found/i);
+    });
+
+    it('returns 403 when a non-admin creates a TERMINAL page', async () => {
+      const response = await POST(createRequest({
+        title: 'Prod Shell',
+        type: 'TERMINAL',
+        driveId: mockDriveId,
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toMatch(/administrator/i);
+      expect(pageService.createPage).not.toHaveBeenCalled();
+    });
+
+    it('allows an admin to create a TERMINAL page', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+        ...mockWebAuth(mockUserId),
+        role: 'admin',
+      });
+      vi.mocked(pageService.createPage).mockResolvedValue({
+        ...successResult,
+        page: { ...mockPage, type: 'TERMINAL' },
+      });
+
+      const response = await POST(createRequest({
+        title: 'Prod Shell',
+        type: 'TERMINAL',
+        driveId: mockDriveId,
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.type).toBe('TERMINAL');
+      expect(pageService.createPage).toHaveBeenCalledWith(
+        mockUserId,
+        expect.objectContaining({ type: 'TERMINAL' }),
+        expect.objectContaining({ authorizeEdit: expect.any(Function) }),
+      );
     });
   });
 

--- a/apps/web/src/app/api/pages/route.ts
+++ b/apps/web/src/app/api/pages/route.ts
@@ -3,17 +3,22 @@ import { z } from 'zod/v4';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { getCreatablePageTypes } from '@pagespace/lib/content/page-types.config'
+import { PageType } from '@pagespace/lib/utils/enums'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isMCPAuthResult, canPrincipalEditPage } from '@/lib/auth';
 import { pageService, type CreatePageParams } from '@/services/api';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+const creatablePageTypes = [
+  ...getCreatablePageTypes(),
+  PageType.TERMINAL,
+] as unknown as [string, ...string[]];
 
 // Zod schema for page creation request
 const createPageSchema = z.object({
   title: z.string().min(1, 'Title is required'),
-  type: z.enum(getCreatablePageTypes() as [string, ...string[]]),
+  type: z.enum(creatablePageTypes),
   driveId: z.string().min(1, 'Drive ID is required'),
   parentId: z.string().nullable().optional(),
   content: z.string().optional(),
@@ -45,6 +50,10 @@ export async function POST(request: Request) {
     }
 
     const validatedData = parseResult.data;
+    if (validatedData.type === PageType.TERMINAL && auth.role !== 'admin') {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page', resourceId: validatedData.driveId, details: { reason: 'app_admin_required', type: validatedData.type, method: 'POST' }, riskScore: 0.5 });
+      return NextResponse.json({ error: 'Terminal pages require administrator privileges' }, { status: 403 });
+    }
 
     // Check MCP token scope - scoped tokens can only create pages in allowed drives
     const scopeError = checkMCPCreateScope(auth, validatedData.driveId);

--- a/apps/web/src/components/create/QuickCreatePalette.tsx
+++ b/apps/web/src/components/create/QuickCreatePalette.tsx
@@ -26,6 +26,7 @@ import { uploadFileToS3 } from '@/lib/upload/orchestrator';
 import { useUIStore } from '@/stores/useUIStore';
 import { usePageNavigation } from '@/hooks/usePageNavigation';
 import { useBreadcrumbs } from '@/hooks/useBreadcrumbs';
+import { useAuth } from '@/hooks/useAuth';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import { matchesKeyEvent, getEffectiveBinding } from '@/stores/useHotkeyStore';
 import { isEditingActive } from '@/stores/useEditingStore';
@@ -131,6 +132,7 @@ export default function QuickCreatePalette() {
   const closeQuickCreate = useUIStore((s) => s.closeQuickCreate);
 
   const { navigateToPage } = usePageNavigation();
+  const { user } = useAuth();
   const { preferences } = useDisplayPreferences();
   const { data: tree } = useCachedPageTree(driveId);
 
@@ -251,7 +253,7 @@ export default function QuickCreatePalette() {
     } finally {
       setIsCreating(false);
     }
-  }, [driveId, selectedType, isCreating, selectedFile, name, effectiveParentId, preferences, closeQuickCreate, navigateToPage]);
+  }, [driveId, selectedType, isCreating, selectedFile, name, effectiveParentId, preferences, closeQuickCreate, swrMutate, navigateToPage]);
 
   const handleKeyDownNameEntry = useCallback(
     (e: React.KeyboardEvent) => {
@@ -266,7 +268,10 @@ export default function QuickCreatePalette() {
     [handleCreate]
   );
 
-  const creatableTypes = getCreatablePageTypes();
+  const creatableTypes = useMemo(() => {
+    const types = getCreatablePageTypes();
+    return user?.role === 'admin' ? [...types, PageType.TERMINAL] : types;
+  }, [user?.role]);
 
   if (!quickCreateOpen) return null;
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -43,6 +43,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
   const socket = useSocket();
   const { user } = useAuth();
   const { resolvedTheme } = useTheme();
+  const isAdmin = user?.role === 'admin';
 
   const {
     document: documentState,
@@ -139,6 +140,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
   // Handle command submission — gated on document initialization
   const handleCommand = useCallback(async (command: string) => {
     if (!documentState) { toast.error('Terminal is still loading'); return; }
+    if (!isAdmin) { toast.error('Terminal access requires administrator privileges'); return; }
     if (isReadOnly) { toast.error('You do not have permission to edit this page'); return; }
 
     setIsExecuting(true);
@@ -177,7 +179,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
       saveWithDebounce(serialized);
       return updated;
     });
-  }, [isReadOnly, documentState, pageId, updateContent, saveWithDebounce]);
+  }, [isAdmin, isReadOnly, documentState, pageId, updateContent, saveWithDebounce]);
 
   // Handle clearing the terminal
   const handleClear = useCallback(() => {
@@ -238,7 +240,15 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
       transition={{ duration: 0.2 }}
       className="h-full flex flex-col relative"
     >
-      {isReadOnly && (
+      {!isAdmin && (
+        <div className="bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800 px-4 py-2">
+          <p className="text-sm text-yellow-800 dark:text-yellow-200 text-center">
+            Terminal access requires administrator privileges
+          </p>
+        </div>
+      )}
+
+      {isAdmin && isReadOnly && (
         <div className="bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800 px-4 py-2">
           <p className="text-sm text-yellow-800 dark:text-yellow-200 text-center">
             You don&apos;t have permission to edit this page
@@ -252,7 +262,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
           onCommand={handleCommand}
           onClear={handleClear}
           isDark={isDark}
-          isReadOnly={isReadOnly || isLoading || !documentState || isExecuting}
+          isReadOnly={!isAdmin || isReadOnly || isLoading || !documentState || isExecuting}
         />
       </div>
 

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -110,7 +110,7 @@ function sanitizeEmptyContent(content: string): string {
 /**
  * Page types
  */
-export type PageType = 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'SHEET' | 'TASK_LIST' | 'CODE';
+export type PageType = 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'SHEET' | 'TASK_LIST' | 'CODE' | 'TERMINAL';
 
 /**
  * Message with user info for page details

--- a/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
@@ -46,8 +46,10 @@ const agentViewOnlyPerms: PermissionLevel = {
 function makeDeps(overrides: Partial<CanRunCodeDeps> = {}): CanRunCodeDeps {
   return {
     getUserDrivePermissions: async () => adminPerms,
+    getUserRole: async () => 'admin',
     getAgentAccessLevel: async () => agentEditPerms,
     isCodeExecutionEnabled: () => true,
+    getNodeEnv: () => 'test',
     ...overrides,
   };
 }
@@ -92,6 +94,42 @@ describe('canRunCode', () => {
       deps: makeDeps({ getUserDrivePermissions: async () => memberPerms }),
     });
     expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+  });
+
+  it('given production and a non-admin app user, should deny even with drive admin access', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({
+        getUserRole: async () => 'user',
+        getNodeEnv: () => 'production',
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'app_admin_required' });
+  });
+
+  it('given production and an admin app user, should allow when drive authorization passes', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({
+        getUserRole: async () => 'admin',
+        getNodeEnv: () => 'production',
+      }),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('given development and a non-admin app user, should preserve the drive-role gate', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({
+        getUserRole: async () => 'user',
+        getNodeEnv: () => 'development',
+      }),
+    });
+    expect(result.ok).toBe(true);
   });
 
   it('given an agent actor with edit access, should allow', async () => {

--- a/packages/lib/src/services/sandbox/can-run-code.ts
+++ b/packages/lib/src/services/sandbox/can-run-code.ts
@@ -15,6 +15,11 @@
  * do not serve on-prem (a local execution path is future work, not wired here),
  * so gating on DEPLOYMENT_MODE / isOnPrem would only add a dead branch.
  *
+ * Production rollout gate: while Fly Sprites code execution is being tested in
+ * prod, the global kill-switch may be on, but only app admins may pass this
+ * chokepoint. Non-production keeps the drive owner/admin gate so local and
+ * staging workflows remain useful.
+ *
  * The actor user always clears the owner/admin drive-role gate, regardless of
  * origin. Agent-origin runs additionally require the agent page to hold drive
  * edit access (defence in depth): both the human who triggered the run and the
@@ -29,6 +34,7 @@ import type { DrivePermissionLevel, PermissionLevel } from '../../permissions/pe
 
 export type CodeExecutionDenialReason =
   | 'kill_switch_off'
+  | 'app_admin_required'
   | 'no_drive_access'
   | 'insufficient_role'
   | 'no_agent_access'
@@ -47,11 +53,13 @@ export interface CanRunCodeDeps {
     userId: string,
     driveId: string,
   ) => Promise<DrivePermissionLevel | null>;
+  getUserRole: (userId: string) => Promise<'user' | 'admin' | null>;
   getAgentAccessLevel: (
     agentPageId: string,
     targetPageId: string,
   ) => Promise<PermissionLevel | null>;
   isCodeExecutionEnabled: () => boolean;
+  getNodeEnv: () => string | undefined;
 }
 
 export interface CanRunCodeInput {
@@ -81,11 +89,24 @@ const defaultDeps: CanRunCodeDeps = {
     import('../../permissions/permissions').then((m) =>
       m.getUserDrivePermissions(userId, driveId),
     ),
+  getUserRole: async (userId) => {
+    const [{ db }, { eq }, { users }] = await Promise.all([
+      import('@pagespace/db/db'),
+      import('@pagespace/db/operators'),
+      import('@pagespace/db/schema/auth'),
+    ]);
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { role: true },
+    });
+    return user?.role ?? null;
+  },
   getAgentAccessLevel: (agentPageId, targetPageId) =>
     import('../../permissions/agent-permissions').then((m) =>
       m.getAgentAccessLevel(agentPageId, targetPageId),
     ),
   isCodeExecutionEnabled,
+  getNodeEnv: () => process.env.NODE_ENV,
 };
 
 const deny = (reason: CodeExecutionDenialReason): CanRunCodeResult => ({
@@ -118,6 +139,15 @@ async function authorizeUser(
   return { ok: true };
 }
 
+async function authorizeProductionAdmin(
+  userId: string,
+  deps: CanRunCodeDeps,
+): Promise<CanRunCodeResult> {
+  if (deps.getNodeEnv() !== 'production') return { ok: true };
+  const role = await deps.getUserRole(userId);
+  return role === 'admin' ? { ok: true } : deny('app_admin_required');
+}
+
 export async function canRunCode({
   userId,
   driveId,
@@ -127,6 +157,9 @@ export async function canRunCode({
 }: CanRunCodeInput): Promise<CanRunCodeResult> {
   try {
     if (!deps.isCodeExecutionEnabled()) return deny('kill_switch_off');
+
+    const productionAdminResult = await authorizeProductionAdmin(userId, deps);
+    if (!productionAdminResult.ok) return productionAdminResult;
 
     // The actor user must always clear the owner/admin drive-role gate. For
     // agent-origin runs this is the rung that stops a plain member escalating

--- a/packages/lib/src/services/sandbox/tool-gate.ts
+++ b/packages/lib/src/services/sandbox/tool-gate.ts
@@ -36,6 +36,7 @@ import { checkCodeExecutionQuota, type CodeExecutionQuotaDecision } from './quot
 
 export type SandboxToolGateDenialReason =
   | 'kill_switch_off'
+  | 'app_admin_required'
   | 'no_drive_access'
   | 'insufficient_role'
   | 'no_agent_access'
@@ -50,6 +51,7 @@ export type SandboxToolGateResult =
 /** Safe, model-facing messages. Mirrors the runner's denial copy for consistency. */
 const DENIAL_MESSAGES: Record<SandboxToolGateDenialReason, string> = {
   kill_switch_off: 'Code execution is disabled.',
+  app_admin_required: 'Code execution is currently limited to administrators.',
   no_drive_access: 'You do not have access to run code in this drive.',
   insufficient_role: 'Running code requires drive owner or admin access.',
   no_agent_access: 'This agent is not permitted to run code in this drive.',


### PR DESCRIPTION
## Summary
- allow `TERMINAL` page creation in API validation while enforcing app-admin-only authorization
- enforce admin access in terminal execute route and via shared `canRunCode` gate in production
- update UI creation/terminal surfaces and sandbox denial messaging to reflect admin-only behavior

## Testing
- bun run --filter '@pagespace/lib' test -- src/services/sandbox/__tests__/can-run-code.test.ts
- bun run --filter 'web' test -- src/app/api/pages/__tests__/route.test.ts src/app/api/pages/[pageId]/terminal/execute/__tests__/route.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal page type is now available for workspace administrators to create
  * Terminal access is restricted to administrators; non-administrators will see an access denied message and cannot execute commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->