### PR TITLE
fix(terminal): patch @gridland/web process.nextTick for browser bundles

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -90,6 +90,23 @@ const nextConfig: NextConfig = {
         "bun-ffi-structs": path.join(gridlandShims, "bun-ffi-structs.ts"),
         bun: bunFfiShim,
       };
+
+      // @gridland/web's dist ships a module-local `var process = { env: ... }`
+      // that omits `nextTick`, yet its scroll-box calls `process.nextTick(...)`
+      // to defer a render request out of the current pass. In the browser that
+      // throws `TypeError: B.nextTick is not a function`, breaking the whole
+      // app on any page rendering a terminal. Patch the dist at build time to
+      // attach a working `nextTick` (backed by queueMicrotask) to that object.
+      // Targeted to gridland's bundle only; the guard makes it a no-op if the
+      // upstream shape changes.
+      config.module = config.module ?? {};
+      config.module.rules = [
+        ...(config.module.rules ?? []),
+        {
+          test: /node_modules\/@gridland\/web\/dist\/[^/]+\.js$/,
+          loader: path.join(__dirname, "webpack-loaders", "gridland-process-nexttick.cjs"),
+        },
+      ];
     }
 
     return config;

--- a/apps/web/src/webpack-loaders/__tests__/gridland-process-nexttick.test.ts
+++ b/apps/web/src/webpack-loaders/__tests__/gridland-process-nexttick.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+
+/**
+ * Unit tests for the @gridland/web `process.nextTick` build-time patch loader.
+ *
+ * The loader is pure string transformation (no I/O), so it can be exercised
+ * directly with synthetic source strings. These lock in the three behaviors
+ * that must hold for the fix to be safe:
+ *   1. it injects a working `nextTick` onto gridland's `process` object,
+ *   2. it preserves the upstream `NODE_ENV` value (no hardcoding), and
+ *   3. it is a no-op when the upstream shape changes (so an upstream fix
+ *      doesn't double-define `nextTick`).
+ */
+
+// The loader is CJS (webpack loaders run in Node). Require it by absolute path
+// so vitest's src-scoped include picks this test up while still loading the
+// loader from its real location under webpack-loaders/.
+const loaderPath = path.resolve(__dirname, '../../../webpack-loaders/gridland-process-nexttick.cjs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const loader = require(loaderPath);
+const fakeContext = { cacheable: () => {} };
+
+function run(source: string): string {
+  return loader.call(fakeContext, source);
+}
+
+describe('gridland-process-nexttick loader', () => {
+  it('given gridland\'s process object, should inject a nextTick function', () => {
+    const source = 'var process = { env: { NODE_ENV: "production" } }';
+    const result = run(source);
+
+    expect(result).toContain('nextTick');
+    expect(result).toContain('function');
+    // The deferral primitives the implementation relies on.
+    expect(result).toContain('queueMicrotask');
+    expect(result).toContain('setTimeout');
+  });
+
+  it('given the process object, should produce balanced braces (valid JS)', () => {
+    const source = 'var process = { env: { NODE_ENV: "production" } }';
+    const result = run(source);
+
+    const opens = (result.match(/\{/g) ?? []).length;
+    const closes = (result.match(/\}/g) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+
+  it('given a non-production NODE_ENV, should preserve the original value', () => {
+    const source = 'var process = { env: { NODE_ENV: "development" } }';
+    const result = run(source);
+
+    expect(result).toContain('NODE_ENV: "development"');
+    expect(result).not.toContain('NODE_ENV: "production"');
+  });
+
+  it('given the production NODE_ENV, should preserve production exactly', () => {
+    const source = 'var process = { env: { NODE_ENV: "production" } }';
+    const result = run(source);
+
+    expect(result).toContain('NODE_ENV: "production"');
+  });
+
+  it('given a process object that already defines nextTick, should be a no-op', () => {
+    // If upstream fixes the bug (adds nextTick), the literal no longer matches
+    // the env-only shape, so the loader must return the source unchanged.
+    const source = 'var process = { env: { NODE_ENV: "production" }, nextTick: function() {} }';
+    const result = run(source);
+
+    expect(result).toBe(source);
+  });
+
+  it('given source that does not match the gridland process shape, should be a no-op', () => {
+    const source = 'var somethingElse = { env: { NODE_ENV: "production" } }';
+    const result = run(source);
+
+    expect(result).toBe(source);
+  });
+
+  it('given a full gridland-like source, should patch only the process literal', () => {
+    const source = [
+      'var process = { env: { NODE_ENV: "production" } }',
+      'function doWork() { process.nextTick(function() { render(); }); }',
+    ].join('\n');
+
+    const result = run(source);
+
+    // The process object gained nextTick...
+    expect(result).toMatch(/nextTick:\s*function/);
+    // ...and the existing call site is untouched.
+    expect(result).toContain('process.nextTick(function() { render(); })');
+  });
+});

--- a/apps/web/webpack-loaders/gridland-process-nexttick.cjs
+++ b/apps/web/webpack-loaders/gridland-process-nexttick.cjs
@@ -21,11 +21,14 @@ module.exports = function gridlandProcessNextTickLoader(source) {
 
   // The local `process` object gridland ships. Match the full object literal
   // (`var process = { env: { NODE_ENV: "production" } }`) and replace it with a
-  // complete object that also defines `nextTick`. Only patch when `nextTick` is
-  // NOT already present on that literal (so an upstream fix is a no-op).
-  const PROCESS_OBJECT_RE = /var\s+process\s*=\s*\{\s*env\s*:\s*\{\s*NODE_ENV\s*:\s*"[^"]*"\s*\}\s*\}/;
+  // complete object that also defines `nextTick`. Capture the original
+  // `NODE_ENV` value so we preserve upstream behavior exactly rather than
+  // hardcoding "production". Only patch when `nextTick` is NOT already present
+  // on that literal (so an upstream fix is a no-op).
+  const PROCESS_OBJECT_RE = /var\s+process\s*=\s*\{\s*env\s*:\s*\{\s*NODE_ENV\s*:\s*"([^"]*)"\s*\}\s*\}/;
 
-  if (!PROCESS_OBJECT_RE.test(source)) {
+  const match = PROCESS_OBJECT_RE.exec(source);
+  if (!match) {
     // Shape changed upstream (e.g. they fixed it or renamed). Don't guess.
     return source;
   }
@@ -33,9 +36,10 @@ module.exports = function gridlandProcessNextTickLoader(source) {
   // queueMicrotask is the closest browser analog to process.nextTick for a
   // single deferred microtask. Fallback to setTimeout(...,0) for very old
   // environments; both satisfy gridland's "defer this render request" intent.
+  const nodeEnv = match[1];
   const patched = source.replace(
     PROCESS_OBJECT_RE,
-    'var process = { env: { NODE_ENV: "production" }, ' +
+    'var process = { env: { NODE_ENV: "' + nodeEnv + '" }, ' +
     'nextTick: function(cb) { ' +
     'if (typeof queueMicrotask === "function") { queueMicrotask(function() { cb(); }); } ' +
     'else { setTimeout(function() { cb(); }, 0); } ' +

--- a/apps/web/webpack-loaders/gridland-process-nexttick.cjs
+++ b/apps/web/webpack-loaders/gridland-process-nexttick.cjs
@@ -1,0 +1,46 @@
+/**
+ * Webpack loader: patch `@gridland/web`'s module-local `process` object so its
+ * `process.nextTick(...)` call (in the scroll-box sticky-scroll handler) is
+ * defined in the browser.
+ *
+ * Background: @gridland/web's `dist/*.js` defines `var process = { env: ... }`
+ * without a `nextTick` member, then calls `process.nextTick(() => ...)`. In a
+ * Node runtime `nextTick` would exist on the real `process`; in the browser
+ * bundle it resolves to `undefined`, throwing
+ * `TypeError: B.nextTick is not a function` (B = the minified local `process`)
+ * and crashing the app on any terminal page.
+ *
+ * This loader injects a `nextTick` implementation onto that object at build
+ * time. It matches the object-literal shape gridland ships and is a no-op if
+ * the upstream shape changes (so an upstream fix doesn't double-define).
+ */
+
+/** @returns {string} */
+module.exports = function gridlandProcessNextTickLoader(source) {
+  if (this.cacheable) this.cacheable(true);
+
+  // The local `process` object gridland ships. Match the full object literal
+  // (`var process = { env: { NODE_ENV: "production" } }`) and replace it with a
+  // complete object that also defines `nextTick`. Only patch when `nextTick` is
+  // NOT already present on that literal (so an upstream fix is a no-op).
+  const PROCESS_OBJECT_RE = /var\s+process\s*=\s*\{\s*env\s*:\s*\{\s*NODE_ENV\s*:\s*"[^"]*"\s*\}\s*\}/;
+
+  if (!PROCESS_OBJECT_RE.test(source)) {
+    // Shape changed upstream (e.g. they fixed it or renamed). Don't guess.
+    return source;
+  }
+
+  // queueMicrotask is the closest browser analog to process.nextTick for a
+  // single deferred microtask. Fallback to setTimeout(...,0) for very old
+  // environments; both satisfy gridland's "defer this render request" intent.
+  const patched = source.replace(
+    PROCESS_OBJECT_RE,
+    'var process = { env: { NODE_ENV: "production" }, ' +
+    'nextTick: function(cb) { ' +
+    'if (typeof queueMicrotask === "function") { queueMicrotask(function() { cb(); }); } ' +
+    'else { setTimeout(function() { cb(); }, 0); } ' +
+    '}}',
+  );
+
+  return patched;
+};


### PR DESCRIPTION
## Problem
`TypeError: B.nextTick is not a function` crashes the whole app on any page rendering a Terminal (bash/terminal both die). Reproduced on pagespace.ai.

## Root cause
`@gridland/web`'s `dist` defines a module-local `var process = { env: { NODE_ENV: "production" } }` that **omits `nextTick`**, yet its scroll-box sticky-scroll handler calls `process.nextTick(() => this.requestRender())`. In Node `nextTick` exists on the real `process`; in the browser bundle it resolves to `undefined` → throws `TypeError: B.nextTick is not a function` (`B` = minified local `process`) and breaks the app.

Verified the bug is present in **all published versions** (0.2.53, 0.2.58, 0.4.3) — bumping `@gridland/web` does not fix it.

## Fix
A targeted webpack loader (`apps/web/webpack-loaders/gridland-process-nexttick.cjs`) that matches gridland's `process` object literal and injects a working `nextTick` backed by `queueMicrotask` (with a `setTimeout` fallback). Wired via a `module.rules` entry in `next.config.ts` scoped to `@gridland/web/dist/*.js` only.

- **No-op if upstream shape changes** — the loader matches the exact literal; if gridland fixes it or renames, the loader returns source unchanged (no double-define).
- Does **not** touch `process: false` in the client fallback (that's a separate webpack `process` module import, which gridland's local `var process` already shadows — hence why a plain fallback alias wouldn't reach the call site).

## Verification
- `bun run build` passes; the gridland chunk (`9c36c750`) now contains `nextTick:function` + `queueMicrotask` (definition present, not just the call site).
- `bun run typecheck` ✅ · `bun run lint` ✅ (no new warnings in changed files).

## Why not bump `@gridland/web`?
The same `var process = { env: ... }` (no `nextTick`) ships in 0.2.53 → 0.4.3. A version bump is orthogonal to this fix; it can be done separately once an upstream version includes `nextTick`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser crashes caused by bundled third-party package compatibility issues
  * Improved application stability through enhanced build-time compatibility handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->