### PR TITLE
fix(sandbox): move SpritesClient to apps/web IO boundary (fixes ERR_REQUIRE_ESM)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -22,10 +22,10 @@ const nextConfig: NextConfig = {
   // contains no "node_modules" segment, so Next.js's path-based heuristic
   // fails to auto-externalize it. List it explicitly here as a backstop; the
   // webpack function below handles @pagespace/db and @pagespace/lib the same way.
-  // @fly/sprites is ESM-only; marking it external ensures Next.js's standalone
-  // file tracer copies it into the output node_modules instead of attempting to
-  // bundle an ESM package (which would be excluded and missing at runtime).
-  serverExternalPackages: ["pg", "@fly/sprites"],
+  // NOTE: @fly/sprites must NOT be listed here. serverExternalPackages makes
+  // Next.js emit require() at runtime, which fails for ESM-only packages. Instead
+  // it is a direct dependency of apps/web so webpack bundles it as a server chunk.
+  serverExternalPackages: ["pg"],
   webpack: (config, { isServer }) => {
     if (isServer) {
       // Externalize pg unconditionally (bun cache path bypasses Next's heuristic).

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@fly/sprites": "0.0.1-rc37",
     "@ai-sdk/anthropic": "^2.0.4",
     "@ai-sdk/google": "^2.0.6",
     "@ai-sdk/openai": "^2.0.15",

--- a/apps/web/src/app/api/pages/[pageId]/terminal/execute/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/terminal/execute/__tests__/route.test.ts
@@ -62,8 +62,8 @@ vi.mock('@pagespace/lib/services/sandbox/session-manager', () => ({
   getSandboxSessionSecret: vi.fn().mockReturnValue('test-secret'),
 }));
 
-vi.mock('@pagespace/lib/services/sandbox/sandbox-client/sprites', () => ({
-  createSpritesSandboxClient: vi.fn(),
+vi.mock('@/lib/sandbox/sprites-client', () => ({
+  createProductionSpritesSandboxClient: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/services/sandbox/output-limit', () => ({
@@ -86,7 +86,7 @@ import { authenticateRequestWithOptions, canPrincipalEditPage } from '@/lib/auth
 import { db } from '@pagespace/db/db';
 import { checkCodeExecutionQuota, acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
 import { acquireTerminalSandbox, createDbTerminalSessionStore } from '@pagespace/lib/services/sandbox/terminal-session-manager';
-import { createSpritesSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { createProductionSpritesSandboxClient } from '@/lib/sandbox/sprites-client';
 
 // ─── Type helpers ──────────────────────────────────────────────────────────
 
@@ -164,7 +164,7 @@ function setupHappyPath() {
     get: vi.fn().mockResolvedValue(sprite),
     stop: vi.fn(),
   };
-  asMock(createSpritesSandboxClient).mockReturnValue(mockClient);
+  asMock(createProductionSpritesSandboxClient).mockResolvedValue(mockClient);
   asMock(acquireTerminalSandbox).mockResolvedValue({ ok: true, sandboxId: 'sprite-123', resumed: false });
   return { sprite, mockClient };
 }
@@ -289,7 +289,7 @@ describe('POST /api/pages/[pageId]/terminal/execute', () => {
     it('returns 500 when sandbox acquisition fails', async () => {
       setupDbMocks();
       const mockClient = { getOrCreate: vi.fn(), get: vi.fn(), stop: vi.fn() };
-      asMock(createSpritesSandboxClient).mockReturnValue(mockClient);
+      asMock(createProductionSpritesSandboxClient).mockResolvedValue(mockClient);
       asMock(acquireTerminalSandbox).mockResolvedValue({ ok: false, reason: 'provision_failed' });
       const res = await POST(makeRequest(), makeParams());
       expect(res.status).toBe(500);
@@ -298,7 +298,7 @@ describe('POST /api/pages/[pageId]/terminal/execute', () => {
     it('returns 403 when sandbox acquisition is denied', async () => {
       setupDbMocks();
       const mockClient = { getOrCreate: vi.fn(), get: vi.fn(), stop: vi.fn() };
-      asMock(createSpritesSandboxClient).mockReturnValue(mockClient);
+      asMock(createProductionSpritesSandboxClient).mockResolvedValue(mockClient);
       asMock(acquireTerminalSandbox).mockResolvedValue({ ok: false, reason: 'deny' });
       const res = await POST(makeRequest(), makeParams());
       expect(res.status).toBe(403);
@@ -307,7 +307,7 @@ describe('POST /api/pages/[pageId]/terminal/execute', () => {
     it('returns 500 when sprite is gone after acquire succeeds', async () => {
       setupDbMocks();
       const mockClient = { getOrCreate: vi.fn(), get: vi.fn().mockResolvedValue(null), stop: vi.fn() };
-      asMock(createSpritesSandboxClient).mockReturnValue(mockClient);
+      asMock(createProductionSpritesSandboxClient).mockResolvedValue(mockClient);
       asMock(acquireTerminalSandbox).mockResolvedValue({ ok: true, sandboxId: 'sprite-123', resumed: false });
       const res = await POST(makeRequest(), makeParams());
       expect(res.status).toBe(500);
@@ -352,7 +352,7 @@ describe('POST /api/pages/[pageId]/terminal/execute', () => {
     it('calls releaseCodeExecutionSlot in finally even when sandbox acquire fails', async () => {
       setupDbMocks();
       const mockClient = { getOrCreate: vi.fn(), get: vi.fn(), stop: vi.fn() };
-      asMock(createSpritesSandboxClient).mockReturnValue(mockClient);
+      asMock(createProductionSpritesSandboxClient).mockResolvedValue(mockClient);
       asMock(acquireTerminalSandbox).mockResolvedValue({ ok: false, reason: 'provision_failed' });
 
       await POST(makeRequest(), makeParams());

--- a/apps/web/src/app/api/pages/[pageId]/terminal/execute/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/terminal/execute/route.ts
@@ -118,13 +118,14 @@ export async function POST(
   const startMs = Date.now();
   try {
     // 8. Acquire (or resume) the page's terminal sandbox.
-    // @fly/sprites is ESM-only — import dynamically so webpack does not attempt
-    // to bundle it at build time (same pattern as sandbox-tools-runtime.ts).
-    const [store, { createSpritesSandboxClient }] = await Promise.all([
+    // createProductionSpritesSandboxClient lives in apps/web (not @pagespace/lib)
+    // so Next.js handles the ESM import of @fly/sprites correctly. See
+    // apps/web/src/lib/sandbox/sprites-client.ts for the full explanation.
+    const [store, { createProductionSpritesSandboxClient }] = await Promise.all([
       createDbTerminalSessionStore(),
-      import('@pagespace/lib/services/sandbox/sandbox-client/sprites'),
+      import('@/lib/sandbox/sprites-client'),
     ]);
-    const client = createSpritesSandboxClient();
+    const client = await createProductionSpritesSandboxClient();
 
     const sandboxResult = await acquireTerminalSandbox({
       pageId,

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -48,13 +48,13 @@ function getStore() {
   return storePromise;
 }
 
-// The Fly Sprites driver is loaded via a DYNAMIC import, never a static one:
-// `@fly/sprites` is ESM-only and declares `engines.node >= 24`, while the web
-// images run Node 22. A static import would pull the SDK into the module graph
-// at load — i.e. on every chat request, including the default code-execution-OFF
-// path — and evaluate an unsupported SDK. Deferring it here keeps `@fly/sprites`
-// out of the graph until a sandbox tool actually runs (only possible once the
-// kill-switch is on), so the off-path never touches it.
+// The Fly Sprites driver is loaded via a DYNAMIC import, never a static one.
+// @fly/sprites is ESM-only and @pagespace/lib compiles to CJS, so a static
+// import in lib would emit require('@fly/sprites') which Node rejects with
+// ERR_REQUIRE_ESM. The factory lives in apps/web/src/lib/sandbox/sprites-client.ts
+// instead, where Next.js handles the ESM import correctly. Deferring it here
+// also keeps the SDK out of the module graph until code execution is actually
+// invoked (only possible once the kill-switch is on).
 const MIN_SANDBOX_NODE_MAJOR = 24;
 
 // Deferring the import only protects the OFF path; the ENABLED path still has to
@@ -77,8 +77,8 @@ function assertSandboxRuntime(): void {
 function getSandboxClient(): Promise<ExecSandboxClient> {
   sandboxClientPromise ??= (async () => {
     assertSandboxRuntime();
-    const m = await import('@pagespace/lib/services/sandbox/sandbox-client/sprites');
-    return m.createSpritesSandboxClient();
+    const { createProductionSpritesSandboxClient } = await import('@/lib/sandbox/sprites-client');
+    return createProductionSpritesSandboxClient();
   })().catch((error) => {
     // Never memoize a rejection: a transient lazy-load failure (or a fixable
     // runtime/version misconfiguration) must not poison every later

--- a/apps/web/src/lib/sandbox/sprites-client.ts
+++ b/apps/web/src/lib/sandbox/sprites-client.ts
@@ -1,0 +1,44 @@
+/**
+ * App-boundary factory for the Fly Sprites sandbox client.
+ *
+ * @fly/sprites is ESM-only. @pagespace/lib compiles to CommonJS, so a static
+ * import there becomes `require('@fly/sprites')` in the dist — which Node.js
+ * rejects with ERR_REQUIRE_ESM. This file lives in apps/web where Next.js
+ * handles the ESM import correctly: with @fly/sprites listed in
+ * serverExternalPackages, webpack emits a native `import()` expression that
+ * Node.js CJS can execute at runtime.
+ *
+ * The SpritesClient instance is created lazily and cached for the process
+ * lifetime so the SDK is never touched on the code-execution-OFF path.
+ */
+
+import {
+  createSpritesSandboxClient,
+  resolveSpritesToken,
+  type SpritesSdk,
+  type SpriteInstanceLike,
+} from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/types';
+
+let cachedSdk: SpritesSdk | null = null;
+
+async function getSpritesSDK(): Promise<SpritesSdk> {
+  if (cachedSdk) return cachedSdk;
+  // Dynamic import: @fly/sprites is in serverExternalPackages so webpack emits
+  // a native import() here rather than require() — the only form that works for
+  // an ESM-only package from a CJS runtime.
+  const { SpritesClient } = await import('@fly/sprites');
+  const client = new SpritesClient(resolveSpritesToken());
+  cachedSdk = {
+    getSprite: (name) => client.getSprite(name) as unknown as Promise<SpriteInstanceLike>,
+    createSprite: (name, config) =>
+      client.createSprite(name, config) as unknown as Promise<SpriteInstanceLike>,
+    deleteSprite: (name) => client.deleteSprite(name),
+  };
+  return cachedSdk;
+}
+
+export async function createProductionSpritesSandboxClient(): Promise<ExecSandboxClient> {
+  const sdk = await getSpritesSDK();
+  return createSpritesSandboxClient({ sdk });
+}

--- a/apps/web/src/lib/sandbox/sprites-client.ts
+++ b/apps/web/src/lib/sandbox/sprites-client.ts
@@ -3,10 +3,11 @@
  *
  * @fly/sprites is ESM-only. @pagespace/lib compiles to CommonJS, so a static
  * import there becomes `require('@fly/sprites')` in the dist — which Node.js
- * rejects with ERR_REQUIRE_ESM. This file lives in apps/web where Next.js
- * handles the ESM import correctly: with @fly/sprites listed in
- * serverExternalPackages, webpack emits a native `import()` expression that
- * Node.js CJS can execute at runtime.
+ * rejects with ERR_REQUIRE_ESM. This file lives in apps/web where @fly/sprites
+ * is a direct dependency, so webpack can bundle it as a server async chunk.
+ * The dynamic import() below is what triggers that async bundling path instead
+ * of a synchronous CJS require() — the only form that works for an ESM-only
+ * package.
  *
  * The SpritesClient instance is created lazily and cached for the process
  * lifetime so the SDK is never touched on the code-execution-OFF path.
@@ -24,9 +25,10 @@ let cachedSdk: SpritesSdk | null = null;
 
 async function getSpritesSDK(): Promise<SpritesSdk> {
   if (cachedSdk) return cachedSdk;
-  // Dynamic import: @fly/sprites is in serverExternalPackages so webpack emits
-  // a native import() here rather than require() — the only form that works for
-  // an ESM-only package from a CJS runtime.
+  // Dynamic import: @fly/sprites is a direct dep of apps/web (NOT listed in
+  // serverExternalPackages), so webpack bundles it as a server async chunk.
+  // The dynamic import() here is what triggers that async bundling path rather
+  // than a CJS require() — the only form that works for an ESM-only package.
   const { SpritesClient } = await import('@fly/sprites');
   const client = new SpritesClient(resolveSpritesToken());
   cachedSdk = {

--- a/bun.lock
+++ b/bun.lock
@@ -334,6 +334,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@fly/sprites": "0.0.1-rc37",
         "@gridland/utils": "^0.2.53",
         "@gridland/web": "^0.2.53",
         "@monaco-editor/react": "^4.7.0",

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -41,7 +41,10 @@
  * Sprite — is unit-tested with a fake, never against the real Sprites API.
  */
 
-import { SpritesClient, type NetworkPolicy } from '@fly/sprites';
+// SpritesClient is ESM-only. Instantiation lives in apps/web (sprites-client.ts)
+// where Next.js handles the ESM import correctly. This module only holds the
+// pure transformation logic and type-safe wrappers; it never touches the SDK.
+import type { NetworkPolicy } from '@fly/sprites';
 import { getValidatedEnv } from '../../../config/env-validation';
 import { buildSpriteNetworkPolicy } from '../egress';
 import { SANDBOX_ROOT } from '../sandbox-paths';
@@ -318,16 +321,6 @@ export function isSpriteNotFoundError(error: unknown): boolean {
   return /\bnot found\b|no such|does not exist|\b404\b|\b410\b|\bgone\b|vanished/.test(message);
 }
 
-const defaultSdk = (): SpritesSdk => {
-  const client = new SpritesClient(resolveSpritesToken());
-  return {
-    getSprite: (name) => client.getSprite(name) as unknown as Promise<SpriteInstanceLike>,
-    createSprite: (name, config) =>
-      client.createSprite(name, config) as unknown as Promise<SpriteInstanceLike>,
-    deleteSprite: (name) => client.deleteSprite(name),
-  };
-};
-
 // Apply the deny-by-default egress policy and ensure the sandbox root exists.
 // Called on every hand-back (fresh or resumed) so a Sprite is never returned
 // with open/unknown egress. When `destroyOnFailure` is set (a FRESH create), a
@@ -360,9 +353,7 @@ async function applyEgressLockdown({
   }
 }
 
-export function createSpritesSandboxClient({
-  sdk = defaultSdk(),
-}: { sdk?: SpritesSdk } = {}): ExecSandboxClient {
+export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSandboxClient {
   return {
     async getOrCreate({ name, options }) {
       // Resume by name when the Sprite already exists; create fresh ONLY on a


### PR DESCRIPTION
## Problem

Terminal commands and agent bash/writeFile/readFile tools were silently failing — Sprites API saw zero traffic.

Root cause: `@pagespace/lib` compiles to CommonJS (`module: commonjs` in `tsconfig.build.json`). The static `import { SpritesClient } from '@fly/sprites'` in `sprites.ts` compiled to `require('@fly/sprites')` in the dist. Node.js rejects `require()` of an ESM-only package with `ERR_REQUIRE_ESM`. The route's outer `try/catch` caught it and returned 500 before Sprites was ever called.

The previous fix (#1665 — `serverExternalPackages: ["@fly/sprites"]`) changed the error from "Cannot find package" to `ERR_REQUIRE_ESM` but didn't fix the underlying cause. The Next.js docs confirm `serverExternalPackages` uses native Node.js `require()` at runtime — wrong for an ESM-only package.

## Fix: pure-core / IO-shell split

`@pagespace/lib` is the pure core — it should hold interfaces and transformation logic only, no IO side effects from its own imports. Instantiating `SpritesClient` is an IO effect and belongs at the application boundary (`apps/web`), where Next.js bundles it as an ESM-aware server-side webpack chunk instead of emitting `require()`.

## Changes

- **`packages/lib/.../sprites.ts`** — `import { SpritesClient }` → `import type { NetworkPolicy }` (type-only, erased at compile time). Remove `defaultSdk()`. Make `sdk` required: `createSpritesSandboxClient({ sdk: SpritesSdk })`.
- **`apps/web/src/lib/sandbox/sprites-client.ts`** (new) — the only file that imports `@fly/sprites`. Lazily creates and caches the `SpritesClient`, returns an `ExecSandboxClient` via the lib factory. Next.js/webpack bundles this as a server async chunk (ESM → CJS-compatible). `@fly/sprites` must NOT be in `serverExternalPackages` — that forces `require()` which fails for ESM-only packages.
- **`apps/web/package.json`** — add `@fly/sprites` as a direct dep so webpack can resolve and bundle it and TypeScript can find its types.
- **`next.config.ts`** — remove `@fly/sprites` from `serverExternalPackages` (wrong fix: forces `require()` at runtime). Add a comment explaining why it must not be listed there.
- **`terminal/execute/route.ts`** and **`sandbox-tools-runtime.ts`** — import `createProductionSpritesSandboxClient` from the new app-boundary module instead of from `@pagespace/lib`.
- Fix stale "Node 22" comment in `sandbox-tools-runtime.ts` (web image has been 24.x).

## Tests

- All 23 sprites unit tests pass. Tests inject a fake `sdk` and are unaffected by the interface change.
- Updated `terminal/execute/route.test.ts` to mock `@/lib/sandbox/sprites-client` (the new import path) and stub `createProductionSpritesSandboxClient` as `mockResolvedValue` (async, matching the route's `await` call). All 21 terminal route tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2ogJhXAnbtKnbGikjZz31