### PR TITLE
fix(sandbox): terminal kill_switch_off + drop resume-time relock

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -106,7 +106,6 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
     return { ok: false, reason: sandboxResult.reason };
   }
 
-  const sprite = await sdk.getSprite(sandboxResult.sandboxId);
   const sandboxId = sandboxResult.sandboxId;
 
   // Wake a resumed (possibly hibernated) Sprite before opening the PTY. The
@@ -114,8 +113,21 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
   // wake retry, so a dropped first wake would leave the terminal stuck
   // connecting. A fresh create was just warmed by the acquire's mkdir, so only
   // resumes need this extra wake.
-  if (sandboxResult.resumed) {
-    await ensureSpriteAwake(sprite);
+  //
+  // Both the getSprite handle lookup and the wake can throw (SDK error, or a
+  // resumed Sprite exhausting its wake retries). The concurrency slot is already
+  // held at this point, so release it on any throw — otherwise the in-process
+  // semaphore leaks a slot and later requests hit avoidable concurrency denials.
+  let sprite: Awaited<ReturnType<typeof sdk.getSprite>>;
+  try {
+    sprite = await sdk.getSprite(sandboxResult.sandboxId);
+    if (sandboxResult.resumed) {
+      await ensureSpriteAwake(sprite);
+    }
+  } catch {
+    releaseSlot();
+    loggers.realtime.warn('Terminal sandbox wake failed', { reason: 'provision_failed', userId, pageId });
+    return { ok: false, reason: 'provision_failed' };
   }
 
   // Write code execution audit record (PTY session open).

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -14,7 +14,7 @@ import { pages, drives } from '@pagespace/db/schema/core';
 import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/session-manager';
 import { acquireTerminalSandbox, createDbTerminalSessionStore } from '@pagespace/lib/services/sandbox/terminal-session-manager';
-import { createSpritesSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { createSpritesSandboxClient, ensureSpriteAwake } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { acquireCodeExecutionSlot, releaseCodeExecutionSlot, chargeCodeExecutionBudget } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -108,6 +108,15 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
 
   const sprite = await sdk.getSprite(sandboxResult.sandboxId);
   const sandboxId = sandboxResult.sandboxId;
+
+  // Wake a resumed (possibly hibernated) Sprite before opening the PTY. The
+  // interactive `bash` spawn in openPtyShell is NOT wrapped in the cold-start
+  // wake retry, so a dropped first wake would leave the terminal stuck
+  // connecting. A fresh create was just warmed by the acquire's mkdir, so only
+  // resumes need this extra wake.
+  if (sandboxResult.resumed) {
+    await ensureSpriteAwake(sprite);
+  }
 
   // Write code execution audit record (PTY session open).
   writeCodeExecutionAudit({

--- a/packages/lib/src/services/sandbox/__tests__/env-reads.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/env-reads.test.ts
@@ -44,9 +44,15 @@ describe('cross-service sandbox env reads', () => {
     expect(resolveSpritesToken()).toBe('');
   });
 
-  it('getSandboxSessionSecret returns the secret or "" when unset', () => {
+  it('getSandboxSessionSecret returns a >=32-char secret, or "" when unset or too short', () => {
     process.env.SANDBOX_SESSION_SECRET = 's'.repeat(32);
     expect(getSandboxSessionSecret()).toBe('s'.repeat(32));
+
+    // A non-empty but too-short secret is treated as unset (fail-closed): realtime
+    // bypasses the web schema's >=32-char guard, and a weak secret weakens the HMAC.
+    process.env.SANDBOX_SESSION_SECRET = 'short';
+    expect(getSandboxSessionSecret()).toBe('');
+
     delete process.env.SANDBOX_SESSION_SECRET;
     expect(getSandboxSessionSecret()).toBe('');
   });

--- a/packages/lib/src/services/sandbox/__tests__/env-reads.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/env-reads.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isCodeExecutionEnabled } from '../can-run-code';
+import { getSandboxSessionSecret } from '../session-manager';
+import { resolveSpritesToken } from '../sandbox-client/sprites';
+
+/**
+ * These three reads run in BOTH the web app and the realtime service (the
+ * terminal PTY path). They MUST read process.env directly rather than through
+ * getValidatedEnv(): realtime's lean env does not satisfy the full web schema, so
+ * a validated read would THROW there and (for the kill switch) deny every
+ * terminal with `kill_switch_off` even when the flag is on. This suite locks that
+ * decoupling — it deletes the unrelated web-only vars to prove these reads do not
+ * depend on a fully-valid environment.
+ */
+describe('cross-service sandbox env reads', () => {
+  const KEYS = ['CODE_EXECUTION_ENABLED', 'SPRITES_API_TOKEN', 'SANDBOX_SESSION_SECRET'];
+  const saved = new Map<string, string | undefined>();
+  for (const k of KEYS) saved.set(k, process.env[k]);
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      const v = saved.get(k);
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('isCodeExecutionEnabled is true ONLY for the literal "true", without validating the rest of the env', () => {
+    // No DATABASE_URL/CSRF_SECRET/etc. required here — a validated read would throw.
+    process.env.CODE_EXECUTION_ENABLED = 'true';
+    expect(isCodeExecutionEnabled()).toBe(true);
+
+    process.env.CODE_EXECUTION_ENABLED = '1';
+    expect(isCodeExecutionEnabled()).toBe(false);
+
+    delete process.env.CODE_EXECUTION_ENABLED;
+    expect(isCodeExecutionEnabled()).toBe(false);
+  });
+
+  it('resolveSpritesToken returns the token or "" when unset', () => {
+    process.env.SPRITES_API_TOKEN = 'tok_123';
+    expect(resolveSpritesToken()).toBe('tok_123');
+    delete process.env.SPRITES_API_TOKEN;
+    expect(resolveSpritesToken()).toBe('');
+  });
+
+  it('getSandboxSessionSecret returns the secret or "" when unset', () => {
+    process.env.SANDBOX_SESSION_SECRET = 's'.repeat(32);
+    expect(getSandboxSessionSecret()).toBe('s'.repeat(32));
+    delete process.env.SANDBOX_SESSION_SECRET;
+    expect(getSandboxSessionSecret()).toBe('');
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/lifecycle.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/lifecycle.test.ts
@@ -19,9 +19,9 @@ describe('planSandboxLifecycle', () => {
     expect(plan).toEqual({ action: 'create' });
   });
 
-  it('given an authorized actor with a fresh existing session (within the warm window), should resume WITHOUT a relock', () => {
+  it('given an authorized actor with a fresh existing session, should plan to resume that sandbox', () => {
     const plan = planSandboxLifecycle({ authorization: allowed, existingSession: fresh, now });
-    expect(plan).toEqual({ action: 'resume', sandboxId: 'sbx-1', relock: false });
+    expect(plan).toEqual({ action: 'resume', sandboxId: 'sbx-1' });
   });
 
   it('given an unauthorized actor with no session, should deny with the authorization reason', () => {
@@ -34,11 +34,11 @@ describe('planSandboxLifecycle', () => {
     expect(plan).toEqual({ action: 'deny', reason: 'insufficient_role' });
   });
 
-  it('given an idle (hibernated) session within the hard-expiry window but past the warm window, should resume WITH a relock — not destroy the sleeping VM', () => {
-    // `stale` is idle ~1h: past the 5-min warm window, so the egress policy is
-    // refreshed on hand-back, but well under the 24h hard-expiry, so it resumes.
+  it('given an idle (hibernated) session within the hard-expiry window, should resume — not destroy the sleeping VM', () => {
+    // `stale` is idle ~1h: well under the 24h hard-expiry, so the hibernated VM
+    // resumes (the platform wakes it on the next exec) rather than being torn down.
     const plan = planSandboxLifecycle({ authorization: allowed, existingSession: stale, now });
-    expect(plan).toEqual({ action: 'resume', sandboxId: 'sbx-1', relock: true });
+    expect(plan).toEqual({ action: 'resume', sandboxId: 'sbx-1' });
   });
 
   it('given a session abandoned past the hard-expiry ceiling, should plan to tear it down and reclaim', () => {
@@ -46,23 +46,11 @@ describe('planSandboxLifecycle', () => {
     expect(plan).toEqual({ action: 'teardown', sandboxId: 'sbx-1', reason: 'idle' });
   });
 
-  it('given a custom warm window, should relock a resume at/past it and not within it', () => {
-    const warmWindowMs = 30 * 60 * 1000; // 30 min
-    // `fresh` (1 min idle) is within the window → no relock.
-    expect(
-      planSandboxLifecycle({ authorization: allowed, existingSession: fresh, now, warmWindowMs }),
-    ).toEqual({ action: 'resume', sandboxId: 'sbx-1', relock: false });
-    // `stale` (1 h idle) is past the window → relock.
-    expect(
-      planSandboxLifecycle({ authorization: allowed, existingSession: stale, now, warmWindowMs }),
-    ).toEqual({ action: 'resume', sandboxId: 'sbx-1', relock: true });
-  });
-
   it('given a custom hard-expiry, should resume just under it and tear down at or past it', () => {
     const hardExpiryMs = 5 * 60 * 1000;
     expect(
       planSandboxLifecycle({ authorization: allowed, existingSession: fresh, now, hardExpiryMs }),
-    ).toEqual({ action: 'resume', sandboxId: 'sbx-1', relock: false });
+    ).toEqual({ action: 'resume', sandboxId: 'sbx-1' });
     expect(
       planSandboxLifecycle({ authorization: allowed, existingSession: stale, now, hardExpiryMs }),
     ).toEqual({ action: 'teardown', sandboxId: 'sbx-1', reason: 'idle' });

--- a/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
@@ -54,7 +54,6 @@ function makeClient(overrides: Partial<SandboxClient> = {}) {
   const calls = {
     getOrCreate: [] as Array<{ name: string }>,
     get: [] as string[],
-    getRelock: [] as boolean[],
     stop: [] as string[],
   };
   const client: SandboxClient = {
@@ -62,9 +61,8 @@ function makeClient(overrides: Partial<SandboxClient> = {}) {
       calls.getOrCreate.push({ name });
       return { sandboxId: 'sbx-new' };
     },
-    get: async ({ sandboxId, options }) => {
+    get: async ({ sandboxId }) => {
       calls.get.push(sandboxId);
-      calls.getRelock.push(options !== undefined);
       return { sandboxId };
     },
     stop: async ({ sandboxId }) => {
@@ -110,25 +108,8 @@ describe('acquireConversationSandbox', () => {
     });
     expect(result).toEqual({ ok: true, sandboxId: 'sbx-existing', resumed: true });
     expect(calls.get).toEqual(['sbx-existing']);
-    expect(calls.getRelock).toEqual([false]); // within the warm window → cheap reconnect, no relock
     expect(calls.getOrCreate).toEqual([]);
     expect(storeCalls.touch).toBe(1);
-  });
-
-  it('given a resume past the warm window, should reconnect WITH a relock (reapply egress)', async () => {
-    // Idle ~1 h: past the 5-min warm window, so the resume reapplies the egress
-    // lockdown (relock) instead of a bare reconnect.
-    const stale = seedRecord({ lastActiveAt: new Date('2026-06-01T11:00:00.000Z') });
-    const { store } = makeStore(stale);
-    const { client, calls } = makeClient();
-    const result = await acquireConversationSandbox({
-      ...actor,
-      deps: { store, client, authorize: async () => ({ ok: true }), now: () => NOW, secret: SECRET },
-    });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-existing', resumed: true });
-    expect(calls.get).toEqual(['sbx-existing']);
-    expect(calls.getRelock).toEqual([true]);
-    expect(calls.getOrCreate).toEqual([]);
   });
 
   it('given an UNAUTHORIZED actor with an existing warm session, should deny and never reconnect (resume re-authz)', async () => {

--- a/packages/lib/src/services/sandbox/can-run-code.ts
+++ b/packages/lib/src/services/sandbox/can-run-code.ts
@@ -29,7 +29,6 @@
  * `enabledTools` (agent config) is NOT a security boundary — this is.
  */
 
-import { getValidatedEnv } from '../../config/env-validation';
 import type { DrivePermissionLevel, PermissionLevel } from '../../permissions/permissions';
 
 export type CodeExecutionDenialReason =
@@ -74,14 +73,17 @@ export interface CanRunCodeInput {
 
 /**
  * Global kill-switch. Default OFF: only the literal env value 'true' enables
- * execution; an unset/invalid var (or a validation failure) keeps it disabled.
+ * execution; an unset value keeps it disabled.
+ *
+ * Read directly from `process.env`, NOT via `getValidatedEnv()`: this gate runs
+ * in BOTH the web app and the realtime service (the terminal PTY auth path), and
+ * realtime's lean env does not satisfy the full web schema — `getValidatedEnv()`
+ * THROWS there, which previously flipped the switch OFF and denied every terminal
+ * with `kill_switch_off` even when the flag was on. The flag is a non-secret
+ * string, so a direct, service-agnostic read is correct here.
  */
 export function isCodeExecutionEnabled(): boolean {
-  try {
-    return getValidatedEnv().CODE_EXECUTION_ENABLED === 'true';
-  } catch {
-    return false;
-  }
+  return process.env.CODE_EXECUTION_ENABLED === 'true';
 }
 
 // The real authz helpers pull in the database; import them lazily so callers

--- a/packages/lib/src/services/sandbox/lifecycle.ts
+++ b/packages/lib/src/services/sandbox/lifecycle.ts
@@ -34,10 +34,7 @@ export interface SandboxSessionRef {
 
 export type SandboxLifecyclePlan =
   | { action: 'create' }
-  /** `relock`: reapply the egress lockdown on hand-back. Set once the session has
-   *  been idle past the warm window (the VM has likely hibernated, so its policy
-   *  may be stale); a rapid in-window resume leaves it false to reconnect cheaply. */
-  | { action: 'resume'; sandboxId: string; relock: boolean }
+  | { action: 'resume'; sandboxId: string }
   | { action: 'teardown'; sandboxId: string; reason: TeardownReason }
   | { action: 'noop' }
   | { action: 'deny'; reason: CodeExecutionDenialReason };
@@ -55,12 +52,6 @@ export interface PlanLifecycleInput {
    * destroy it. This ceiling only reclaims genuinely abandoned sessions.
    */
   hardExpiryMs?: number;
-  /**
-   * Resumes idle longer than this reapply the egress lockdown (the VM has likely
-   * hibernated, so its policy may be stale). Resumes WITHIN it reconnect cheaply
-   * without a relock round-trip — so a burst of sequential commands isn't taxed.
-   */
-  warmWindowMs?: number;
   intent?: LifecycleIntent;
 }
 
@@ -69,16 +60,11 @@ export interface PlanLifecycleInput {
 // command); only a session abandoned for a full day is reclaimed.
 const DEFAULT_HARD_EXPIRY_MS = 24 * 60 * 60 * 1000;
 
-// 5 minutes: a resume after a longer gap reapplies egress; rapid back-to-back
-// commands stay cheap.
-const DEFAULT_WARM_WINDOW_MS = 5 * 60 * 1000;
-
 export function planSandboxLifecycle({
   authorization,
   existingSession = null,
   now,
   hardExpiryMs = DEFAULT_HARD_EXPIRY_MS,
-  warmWindowMs = DEFAULT_WARM_WINDOW_MS,
   intent = 'run',
 }: PlanLifecycleInput): SandboxLifecyclePlan {
   // Cleanup first, and unconditionally: an ending session is reclaimed whether
@@ -111,9 +97,8 @@ export function planSandboxLifecycle({
     return { action: 'teardown', sandboxId: existingSession.sandboxId, reason: 'idle' };
   }
 
-  // Within the hard-expiry window: resume. A hibernated VM wakes on the next exec,
-  // so we keep the session and its state rather than destroying a sleeping (near-
-  // free) VM. Relock once the session has been idle past the warm window, so a
-  // stale egress policy on a long-hibernated VM is refreshed before hand-back.
-  return { action: 'resume', sandboxId: existingSession.sandboxId, relock: idleFor >= warmWindowMs };
+  // Within the hard-expiry window: resume. A hibernated VM wakes on the next exec
+  // (and the driver's per-op cold-start retry recovers a dropped first wake), so we
+  // keep the session and its state rather than destroying a sleeping (near-free) VM.
+  return { action: 'resume', sandboxId: existingSession.sandboxId };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import {
   createSpritesSandboxClient,
+  ensureSpriteAwake,
   isSpriteNotFoundError,
   classifyProvisionError,
   SandboxCommandTimeoutError,
@@ -371,27 +372,7 @@ describe('createSpritesSandboxClient.get / stop', () => {
     expect(calls.deleted).toEqual(['k']);
   });
 
-  it('get WITH options (resume relock) reapplies the egress policy and warms the VM', async () => {
-    let policies = 0;
-    let spawned = 0;
-    const sprite = fakeSprite({
-      updateNetworkPolicy: async () => {
-        policies += 1;
-      },
-      spawn: () => {
-        spawned += 1;
-        return fakeCommand({ exitCode: 0 });
-      },
-    });
-    const { sdk } = makeSdk({ getSprite: async () => sprite });
-    const client = createSpritesSandboxClient({ sdk });
-    const handle = await client.get({ sandboxId: 'k', options });
-    expect(handle).not.toBeNull();
-    expect(policies).toBe(1); // egress reapplied on resume
-    expect(spawned).toBe(1); // VM warmed via the retrying mkdir
-  });
-
-  it('get WITHOUT options is a cheap reconnect — no egress reapplication', async () => {
+  it('get is a cheap reconnect — does NOT reapply egress (policy persists across hibernation)', async () => {
     let policies = 0;
     const sprite = fakeSprite({
       updateNetworkPolicy: async () => {
@@ -403,24 +384,21 @@ describe('createSpritesSandboxClient.get / stop', () => {
     await client.get({ sandboxId: 'k' });
     expect(policies).toBe(0);
   });
+});
 
-  it('get WITH options whose relock fails rejects WITHOUT destroying the warm session', async () => {
-    let destroyed = false;
+describe('ensureSpriteAwake', () => {
+  it('warms the VM via a no-op exec, retrying the cold-start wake drop', async () => {
+    let attempts = 0;
     const sprite = fakeSprite({
-      updateNetworkPolicy: async () => {
-        throw new Error('policy api down');
+      spawn: () => {
+        attempts += 1;
+        return attempts === 1
+          ? fakeCommand({ error: new Error('WebSocket closed before open: code=1006') })
+          : fakeCommand({ exitCode: 0 });
       },
     });
-    const sdk: SpritesSdk = {
-      getSprite: async () => sprite,
-      createSprite: async () => sprite,
-      deleteSprite: async () => {
-        destroyed = true;
-      },
-    };
-    const client = createSpritesSandboxClient({ sdk });
-    await expect(client.get({ sandboxId: 'k', options })).rejects.toThrow('policy api down');
-    expect(destroyed).toBe(false);
+    await ensureSpriteAwake(sprite);
+    expect(attempts).toBe(2); // first wake dropped, retried, then awake
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -315,10 +315,15 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
   });
 }
 
-/** Force a hibernated VM awake via the designated exec/WebSocket path (a cheap
- *  no-op), with the same cold-start retry as a real command. Used to recover a
- *  filesystem op that hit a cold VM before retrying it. */
-async function wakeSprite(sprite: SpriteInstanceLike): Promise<void> {
+/**
+ * Force a hibernated VM awake via the designated exec/WebSocket path (a cheap
+ * no-op), with the same cold-start retry as a real command. Used to recover a
+ * filesystem op that hit a cold VM before retrying it, and by the realtime
+ * terminal path to wake a resumed Sprite BEFORE opening the interactive PTY
+ * (`openPtyShell`'s `bash` spawn isn't wrapped in the cold-start retry, so a
+ * dropped first wake would otherwise leave the terminal stuck connecting).
+ */
+export async function ensureSpriteAwake(sprite: SpriteInstanceLike): Promise<void> {
   await runSpawnedWithWakeRetry(
     () => sprite.spawn('sh', ['-c', ':']),
     DEFAULT_MAX_OUTPUT_BYTES,
@@ -340,7 +345,7 @@ async function fsWithWakeRetry<T>(
   try {
     return await withTimeout(op(), FS_OP_TIMEOUT_MS, label);
   } catch {
-    await wakeSprite(sprite);
+    await ensureSpriteAwake(sprite);
     return await withTimeout(op(), FS_OP_TIMEOUT_MS, label);
   }
 }
@@ -535,21 +540,15 @@ export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSa
       }
     },
 
-    async get({ sandboxId, options }) {
+    async get({ sandboxId }) {
       // Reconnect by name; a genuinely vanished Sprite (not-found) → null so the
       // lifecycle re-provisions under the same key. Other errors (auth, rate
       // limit, outage) surface rather than masquerading as a vanished session.
+      // We do NOT reapply egress here: the policy persists across hibernation
+      // (the platform's configure-once model), and a dropped first wake is
+      // recovered by runCommand's cold-start retry.
       try {
-        const sprite = await sdk.getSprite(sandboxId);
-        if (options) {
-          // Resume relock: reapply the deny-default egress policy (and warm the VM
-          // via the retrying mkdir) before hand-back, so a tightened allowlist or a
-          // recovered older VM is enforced rather than left stale. Never destroy a
-          // warm session on failure — but DO surface it (the call rejects) so no
-          // command runs without a confirmed policy.
-          await applyEgressLockdown({ sdk, sprite, options, destroyOnFailure: false });
-        }
-        return wrap(sprite);
+        return wrap(await sdk.getSprite(sandboxId));
       } catch (error) {
         if (isSpriteNotFoundError(error)) return null;
         throw error;

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -45,7 +45,6 @@
 // where Next.js handles the ESM import correctly. This module only holds the
 // pure transformation logic and type-safe wrappers; it never touches the SDK.
 import type { NetworkPolicy, SpriteConfig } from '@fly/sprites';
-import { getValidatedEnv } from '../../../config/env-validation';
 import { buildSpriteNetworkPolicy } from '../egress';
 import { SANDBOX_ROOT } from '../sandbox-paths';
 import type {
@@ -139,17 +138,17 @@ export interface SpritesSdk {
 }
 
 /**
- * Resolve the Sprites API token from validated env. Returns '' (→ the SDK's
- * calls fail-closed with an auth error, surfaced as a provisioning failure)
- * rather than throwing at construction, so a missing token disables execution
- * instead of crashing the app.
+ * Resolve the Sprites API token. Returns '' (→ the SDK's calls fail-closed with
+ * an auth error, surfaced as a provisioning failure) when unset, so a missing
+ * token disables execution instead of crashing the app.
+ *
+ * Read directly from `process.env`, NOT via `getValidatedEnv()`: the token is
+ * resolved in the realtime service too (terminal PTY), whose lean env does not
+ * satisfy the full web schema — `getValidatedEnv()` would throw there, blanking
+ * the token and breaking terminals even when it is set.
  */
 export function resolveSpritesToken(): string {
-  try {
-    return getValidatedEnv().SPRITES_API_TOKEN ?? '';
-  } catch {
-    return '';
-  }
+  return process.env.SPRITES_API_TOKEN ?? '';
 }
 
 function toBuffer(chunk: Buffer | string): Buffer {

--- a/packages/lib/src/services/sandbox/sandbox-client/types.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/types.ts
@@ -58,7 +58,5 @@ export interface ExecutableSandbox extends SandboxHandle {
 /** Extends the PR2 lifecycle seam so one client serves both layers. */
 export interface ExecSandboxClient extends SandboxClient {
   getOrCreate(args: { name: string; options: SandboxCreateOptions }): Promise<ExecutableSandbox>;
-  /** `options` (resume relock) reapplies the egress lockdown + warms the VM
-   *  before hand-back; omit it for a cheap reconnect on an already-locked VM. */
-  get(args: { sandboxId: string; options?: SandboxCreateOptions }): Promise<ExecutableSandbox | null>;
+  get(args: { sandboxId: string }): Promise<ExecutableSandbox | null>;
 }

--- a/packages/lib/src/services/sandbox/session-manager.ts
+++ b/packages/lib/src/services/sandbox/session-manager.ts
@@ -88,7 +88,11 @@ export type AcquireSandboxResult =
  * secret and denying every terminal.
  */
 export function getSandboxSessionSecret(): string {
-  return process.env.SANDBOX_SESSION_SECRET ?? '';
+  const secret = process.env.SANDBOX_SESSION_SECRET ?? '';
+  // The web schema enforces >=32 chars; realtime bypasses full validation, so guard
+  // here — a too-short secret weakens the session-key HMAC. Treat it as unset
+  // (fail-closed) rather than deriving keys from a weak secret.
+  return secret.length >= 32 ? secret : '';
 }
 
 // Stop a sandbox best-effort, reporting whether the stop was CONFIRMED. Never

--- a/packages/lib/src/services/sandbox/session-manager.ts
+++ b/packages/lib/src/services/sandbox/session-manager.ts
@@ -40,9 +40,7 @@ export interface SandboxHandle {
  */
 export interface SandboxClient {
   getOrCreate(args: { name: string; options: SandboxCreateOptions }): Promise<SandboxHandle>;
-  /** `options` (resume relock) reapplies the egress lockdown before hand-back;
-   *  omit it for a cheap reconnect on an already-locked, still-warm VM. */
-  get(args: { sandboxId: string; options?: SandboxCreateOptions }): Promise<SandboxHandle | null>;
+  get(args: { sandboxId: string }): Promise<SandboxHandle | null>;
   stop(args: { sandboxId: string }): Promise<void>;
 }
 
@@ -218,14 +216,11 @@ export async function acquireConversationSandbox(
         return await provisionFresh({ key, input });
 
       case 'resume': {
-        // Past the warm window the VM has likely hibernated, so relock: reapply
-        // the egress policy (a tightened allowlist / recovered VM must be enforced,
-        // not left stale until hard-expiry) and warm the VM. A rapid follow-up
-        // command (within the warm window) skips the relock and reconnects cheaply.
-        const options = plan.relock
-          ? { egressAllowlist: SANDBOX_EGRESS_ALLOWLIST, caps: SANDBOX_RESOURCE_CAPS }
-          : undefined;
-        const handle = await deps.client.get({ sandboxId: plan.sandboxId, options });
+        // Reconnect to the (possibly hibernating) VM. The egress policy persists
+        // across hibernation, so we do NOT reapply it here — the platform's
+        // "configure once" model — and a dropped first wake is recovered by the
+        // driver's per-command cold-start retry (runCommand) and fs wake-retry.
+        const handle = await deps.client.get({ sandboxId: plan.sandboxId });
         if (!handle) {
           // The recorded sandbox is gone (platform-expired/crashed). Drop the stale
           // link and provision a fresh one under the same conversation key.

--- a/packages/lib/src/services/sandbox/session-manager.ts
+++ b/packages/lib/src/services/sandbox/session-manager.ts
@@ -18,7 +18,6 @@
  *    reclaimable (by retry / the idle reaper) instead of orphaned.
  */
 
-import { getValidatedEnv } from '../../config/env-validation';
 import { loggers } from '../../logging/logger-config';
 import type { CanRunCodeResult, CanRunCodeInput, CodeExecutionDenialReason } from './can-run-code';
 import { SANDBOX_EGRESS_ALLOWLIST, SANDBOX_RESOURCE_CAPS } from './execution-policy';
@@ -79,16 +78,17 @@ export type AcquireSandboxResult =
     };
 
 /**
- * Read the session-key secret from validated env. Returns '' (→ fail-closed deny
- * in the lifecycle effects) when unset or when validation fails, so a missing
- * secret disables sandbox acquisition rather than throwing at the call site.
+ * Read the session-key secret. Returns '' (→ fail-closed deny in the lifecycle
+ * effects) when unset, so a missing secret disables sandbox acquisition rather
+ * than throwing at the call site.
+ *
+ * Read directly from `process.env`, NOT via `getValidatedEnv()`: this runs in the
+ * realtime service too (terminal session keys), whose lean env does not satisfy
+ * the full web schema — `getValidatedEnv()` would throw there, blanking the
+ * secret and denying every terminal.
  */
 export function getSandboxSessionSecret(): string {
-  try {
-    return getValidatedEnv().SANDBOX_SESSION_SECRET ?? '';
-  } catch {
-    return '';
-  }
+  return process.env.SANDBOX_SESSION_SECRET ?? '';
 }
 
 // Stop a sandbox best-effort, reporting whether the stop was CONFIRMED. Never

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -214,13 +214,11 @@ export async function acquireTerminalSandbox(
     // Reconnect to a known-live (possibly hibernating) sandbox, re-provisioning
     // under the same key only if it has genuinely vanished. Shared by `resume`
     // (within the warm window) and `noop` (persistent-idle: the VM is sleeping,
-    // not gone — wake it). A terminal acquire happens once per connection (not per
-    // keystroke), so we always relock: passing `options` reapplies the egress
-    // policy AND warms the VM via the retrying exec path, so the PTY's `bash`
-    // spawn lands on an awake, locked-down VM instead of racing a cold-start drop.
-    const relockOptions = { egressAllowlist: SANDBOX_EGRESS_ALLOWLIST, caps: SANDBOX_RESOURCE_CAPS };
+    // not gone). The VM is warmed before the PTY opens by the realtime path
+    // (ensureSpriteAwake), so a hibernated terminal's `bash` spawn lands on an
+    // awake VM instead of racing a cold-start drop.
     const reconnectExisting = async (sandboxId: string): Promise<AcquireTerminalSandboxResult> => {
-      const handle = await deps.client.get({ sandboxId, options: relockOptions });
+      const handle = await deps.client.get({ sandboxId });
       if (!handle) {
         await deps.store.remove(key);
         return await provisionFreshTerminal({ key, input });


### PR DESCRIPTION
Follow-up to #1674 (which merged at the interim relock version). Two changes — plus a **required deploy step** for terminals to actually work.

## 1. Terminal `kill_switch_off` — code half (load-bearing, not sufficient alone)

Agent chat (web) can run code, but terminals were denied with **"Terminal access denied: kill_switch_off"**.

**Root cause:** the terminal PTY auth runs in the **realtime** service. `isCodeExecutionEnabled()` / `resolveSpritesToken()` / `getSandboxSessionSecret()` resolved their values through `getValidatedEnv()`, which validates `process.env` against the **full web schema**. The `pagespace-realtime` Fly app does **not** carry `CSRF_SECRET` / `ENCRYPTION_KEY` (the schema requires both when `NODE_ENV != test`), so `getValidatedEnv()` **throws** there — the kill-switch read catches it and returns `false`, denying every terminal even if the flag were set. The same throw blanks `SPRITES_API_TOKEN` / `SANDBOX_SESSION_SECRET`. Agent chat works because it runs in **web**, where the full schema validates.

**Fix:** read these three cross-service values directly from `process.env`, decoupled from full web-env validation. New `env-reads.test.ts` locks it.

⚠️ **This code change alone does NOT enable terminals** — it stops the throw, but the three vars must also be present in realtime's env (see Deploy below).

## 2. Drop the resume-time egress relock (the agreed simplification)

Reverts the interim relock/warm-window/`get(options)` (Codex P2): policy persists across hibernation, allowlist is static deny-all, dropped wakes are recovered by the per-op cold-start retry, future widening is bounded by the 24h reclaim. Terminal P1 wake kept via `ensureSpriteAwake` (warms a resumed VM before the PTY). Net −69 lines.

## Required deploy step (separate, in PageSpace-Deploy)

Set the three vars on the realtime Fly app (token + secret must match the web app's):

```
flyctl secrets set --app pagespace-realtime \
  CODE_EXECUTION_ENABLED=true \
  SPRITES_API_TOKEN=<same as web> \
  SANDBOX_SESSION_SECRET=<same as web>
```

(or add `CODE_EXECUTION_ENABLED="true"` to `fly.realtime.toml [env]` + the two secrets.) Until this is done, terminals stay `kill_switch_off`.

## Validation

- `@pagespace/lib` + `realtime` typecheck, lint
- 250 sandbox unit tests green (incl. new `env-reads` regression + `ensureSpriteAwake`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)