### PR TITLE
fix(sandbox): remove per-run daily code-execution budget

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -15,7 +15,7 @@ import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/session-manager';
 import { acquireTerminalSandbox, createDbTerminalSessionStore } from '@pagespace/lib/services/sandbox/terminal-session-manager';
 import { createSpritesSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
-import { acquireCodeExecutionSlot, releaseCodeExecutionSlot, chargeCodeExecutionBudget } from '@pagespace/lib/services/sandbox/quota';
+import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { buildTerminalHandlers, type CheckAuthResult, type SocketLike } from './terminal/terminal-handler';
@@ -123,9 +123,6 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
       timestamp: new Date(),
     },
   }).catch(() => {});
-
-  // Charge the sliding-window budget fire-and-forget after successful sandbox acquire.
-  chargeCodeExecutionBudget({ userId, driveId, tenantId }).catch(() => {});
 
   return { ok: true, sandboxId, sprite, releaseSlot };
 }

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -23,8 +23,6 @@ function makeDeps(token: string | null = 'ghp_test'): GitSandboxToolsDeps {
       quota: {
         acquireSlot: vi.fn().mockReturnValue(true),
         releaseSlot: vi.fn(),
-        preflight: vi.fn().mockResolvedValue({ allowed: true }),
-        charge: vi.fn().mockResolvedValue(undefined),
       },
       buildEnv: vi.fn().mockReturnValue({ NODE_ENV: 'test' }),
       audit: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -31,8 +31,6 @@ function fakeRunDeps(): SandboxRunDeps {
     quota: {
       acquireSlot: () => true,
       releaseSlot: () => {},
-      preflight: async () => ({ allowed: true }),
-      charge: async () => {},
     },
     buildEnv: () => ({}),
     audit: async () => {},
@@ -79,10 +77,10 @@ describe('createSandboxTools', () => {
     const tools = createSandboxTools({
       runDeps,
       resolveContext: okResolve,
-      gate: async () => ({ ok: false, reason: 'rate_limited', error: 'over budget', retryAfter: 30 }),
+      gate: async () => ({ ok: false, reason: 'concurrency_limit', error: 'too many runs', retryAfter: 30 }),
     });
     const result = await exec(tools.bash, { command: 'echo hi' }, {});
-    expect(result).toEqual({ success: false, error: 'over budget', retryAfter: 30 });
+    expect(result).toEqual({ success: false, error: 'too many runs', retryAfter: 30 });
     expect(acquired).toBe(false);
   });
 

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -28,8 +28,6 @@ import { createDbSandboxSessionStore } from '@pagespace/lib/services/sandbox/ses
 import {
   acquireCodeExecutionSlot,
   releaseCodeExecutionSlot,
-  checkCodeExecutionQuota,
-  chargeCodeExecutionBudget,
 } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import { gateSandboxToolCall } from '@pagespace/lib/services/sandbox/tool-gate';
@@ -110,8 +108,6 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
     quota: {
       acquireSlot: acquireCodeExecutionSlot,
       releaseSlot: releaseCodeExecutionSlot,
-      preflight: (args) => checkCodeExecutionQuota(args),
-      charge: (args) => chargeCodeExecutionBudget(args),
     },
     buildEnv: defaultBuildEnv,
     audit: (input) => writeCodeExecutionAudit({ input }),

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -582,17 +582,6 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 15 * 60 * 1000,
     progressiveDelay: false,
   },
-  // Agent code execution daily run budget. Applied per scoped identifier
-  // (user / drive / tenant) so one actor cannot exhaust another's allowance.
-  // Fly Sprites (the execution driver) exposes NO platform spend cap, so this
-  // app-level run-count control — alongside per-tier concurrency limits — is the
-  // only cost ceiling for code execution.
-  CODE_EXECUTION: {
-    maxAttempts: 100,
-    windowMs: 24 * 60 * 60 * 1000,
-    blockDurationMs: 24 * 60 * 60 * 1000,
-    progressiveDelay: false,
-  },
 } as const;
 
 // =============================================================================

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -48,8 +48,6 @@ function makeDeps(over: Partial<GitSandboxRunDeps> = {}, token: string | null = 
     quota: {
       acquireSlot: () => { slots.acquired += 1; return true; },
       releaseSlot: () => { slots.released += 1; },
-      preflight: async () => ({ allowed: true }),
-      charge: async () => {},
     },
     buildEnv: () => ({ NODE_ENV: 'test' }),
     audit: async () => {},
@@ -80,8 +78,6 @@ function makeDepsWithSpy(token: string | null = 'ghp_test_token') {
     quota: {
       acquireSlot: () => { slots.acquired += 1; return true; },
       releaseSlot: () => { slots.released += 1; },
-      preflight: async () => ({ allowed: true }),
-      charge: async () => {},
     },
     buildEnv: () => ({ NODE_ENV: 'test' }),
     audit: async () => {},

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -6,19 +6,13 @@ import {
   getCodeExecutionConcurrencyLimit,
   resetCodeExecutionConcurrency,
   checkCodeExecutionQuota,
-  chargeCodeExecutionBudget,
   type CodeExecutionQuotaDeps,
 } from '../quota';
-
-const allowAll: CodeExecutionQuotaDeps['checkRateLimitStatus'] = async () => ({
-  blocked: false,
-});
 
 function makeDeps(
   overrides: Partial<CodeExecutionQuotaDeps> = {},
 ): CodeExecutionQuotaDeps {
   return {
-    checkRateLimitStatus: allowAll,
     canAcquireSlot: () => true,
     ...overrides,
   };
@@ -58,14 +52,14 @@ describe('checkCodeExecutionQuota', () => {
     resetCodeExecutionConcurrency();
   });
 
-  it('given capacity and budget, should allow', async () => {
+  it('given concurrency capacity, should allow', async () => {
     const decision = await checkCodeExecutionQuota({
       userId: 'u1',
       driveId: 'd1',
       tier: 'pro',
       deps: makeDeps(),
     });
-    expect(decision.allowed).toBe(true);
+    expect(decision).toEqual({ allowed: true });
   });
 
   it('given no concurrency capacity, should deny with concurrency_limit', async () => {
@@ -78,126 +72,12 @@ describe('checkCodeExecutionQuota', () => {
     expect(decision).toEqual({ allowed: false, reason: 'concurrency_limit' });
   });
 
-  it('given the per-user daily budget is exhausted, should deny with rate_limited', async () => {
-    const decision = await checkCodeExecutionQuota({
-      userId: 'u1',
-      driveId: 'd1',
-      tier: 'pro',
-      deps: makeDeps({
-        checkRateLimitStatus: async (id: string) =>
-          id.includes('user:u1')
-            ? { blocked: true, retryAfter: 3600 }
-            : { blocked: false },
-      }),
-    });
-    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 3600 });
-  });
-
-  it('given the drive-scoped budget is exhausted, should deny with rate_limited', async () => {
-    const decision = await checkCodeExecutionQuota({
-      userId: 'u1',
-      driveId: 'd1',
-      tier: 'pro',
-      deps: makeDeps({
-        checkRateLimitStatus: async (id: string) =>
-          id.includes('drive:d1')
-            ? { blocked: true, retryAfter: 60 }
-            : { blocked: false },
-      }),
-    });
-    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 60 });
-  });
-
-  it('given a tenant-scoped budget exhaustion, should deny with rate_limited', async () => {
-    const decision = await checkCodeExecutionQuota({
-      userId: 'u1',
-      driveId: 'd1',
-      tenantId: 't1',
-      tier: 'pro',
-      deps: makeDeps({
-        checkRateLimitStatus: async (id: string) =>
-          id.includes('tenant:t1')
-            ? { blocked: true, retryAfter: 120 }
-            : { blocked: false },
-      }),
-    });
-    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 120 });
-  });
-
-  it('should check concurrency before reading budget so a full system never queries quota', async () => {
-    let statusCalls = 0;
-    await checkCodeExecutionQuota({
-      userId: 'u1',
-      driveId: 'd1',
-      tier: 'pro',
-      deps: makeDeps({
-        canAcquireSlot: () => false,
-        checkRateLimitStatus: async () => {
-          statusCalls += 1;
-          return { blocked: false };
-        },
-      }),
-    });
-    expect(statusCalls).toBe(0);
-  });
-});
-
-describe('checkCodeExecutionQuota — no driveId (global context)', () => {
-  beforeEach(() => {
-    resetCodeExecutionConcurrency();
-  });
-
-  it('given no driveId and user not rate limited, should check only user scope and allow', async () => {
-    const checked: string[] = [];
+  it('given no driveId (global context) and concurrency capacity, should allow', async () => {
     const decision = await checkCodeExecutionQuota({
       userId: 'u1',
       tier: 'pro',
-      deps: makeDeps({
-        checkRateLimitStatus: async (id: string) => {
-          checked.push(id);
-          return { blocked: false };
-        },
-      }),
+      deps: makeDeps(),
     });
-    expect(decision.allowed).toBe(true);
-    expect(checked).toEqual(['code-exec:user:u1']);
-    expect(checked.some((id) => id.includes('drive:'))).toBe(false);
-  });
-
-  it('given no driveId and user rate limited, should deny with rate_limited', async () => {
-    const decision = await checkCodeExecutionQuota({
-      userId: 'u1',
-      tier: 'pro',
-      deps: makeDeps({
-        checkRateLimitStatus: async (id: string) =>
-          id.includes('user:u1') ? { blocked: true, retryAfter: 3600 } : { blocked: false },
-      }),
-    });
-    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 3600 });
-  });
-});
-
-describe('chargeCodeExecutionBudget', () => {
-  it('given user, drive, and tenant, should charge all three scopes exactly once', async () => {
-    const charged: string[] = [];
-    await chargeCodeExecutionBudget({
-      userId: 'u1',
-      driveId: 'd1',
-      tenantId: 't1',
-      deps: { charge: async (id) => { charged.push(id); } },
-    });
-    expect(charged.sort()).toEqual(
-      ['code-exec:drive:d1', 'code-exec:tenant:t1', 'code-exec:user:u1'].sort(),
-    );
-  });
-
-  it('given no tenant, should charge only the user and drive scopes', async () => {
-    const charged: string[] = [];
-    await chargeCodeExecutionBudget({
-      userId: 'u1',
-      driveId: 'd1',
-      deps: { charge: async (id) => { charged.push(id); } },
-    });
-    expect(charged.sort()).toEqual(['code-exec:drive:d1', 'code-exec:user:u1']);
+    expect(decision).toEqual({ allowed: true });
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/tool-gate.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-gate.test.ts
@@ -58,16 +58,6 @@ describe('gateSandboxToolCall', () => {
     expect(quotaChecked).toBe(false);
   });
 
-  it('given an authorized actor over the daily budget, should deny with rate_limited and retryAfter', async () => {
-    const result = await gateSandboxToolCall({
-      ...input,
-      deps: allowDeps({
-        checkQuota: async () => ({ allowed: false, reason: 'rate_limited', retryAfter: 42 }),
-      }),
-    });
-    expect(result).toMatchObject({ ok: false, reason: 'rate_limited', retryAfter: 42 });
-  });
-
   it('given an authorized actor at the concurrency ceiling, should deny with concurrency_limit', async () => {
     const result = await gateSandboxToolCall({
       ...input,

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -51,8 +51,6 @@ function makeDeps(over: Partial<SandboxRunDeps> = {}) {
       releaseSlot: () => {
         slots.released += 1;
       },
-      preflight: async () => ({ allowed: true }),
-      charge: async () => {},
     },
     buildEnv: () => ({ NODE_ENV: 'test' }),
     audit: async (input) => {
@@ -97,41 +95,19 @@ describe('runBashInSandbox', () => {
       quota: {
         acquireSlot: () => false,
         releaseSlot: () => {},
-        preflight: async () => ({ allowed: true }),
-        charge: async () => {},
       },
     });
     const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
     expect(result).toMatchObject({ success: false, reason: 'concurrency_limit' });
   });
 
-  it('given a rate-limited preflight, should deny with rate_limited and a retryAfter', async () => {
-    const { deps, slots } = makeDeps({
-      quota: {
-        acquireSlot: () => true,
-        releaseSlot: () => {},
-        preflight: async () => ({ allowed: false, reason: 'rate_limited', retryAfter: 60 }),
-        charge: async () => {},
-      },
-    });
-    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
-    expect(result).toMatchObject({ success: false, reason: 'rate_limited', retryAfter: 60 });
-    // Preflight denies before reserving a slot.
-    expect(slots.acquired).toBe(0);
-  });
-
-  it('given an authz denial from acquire, should map the reason, release the slot, and never charge budget', async () => {
-    let charges = 0;
+  it('given an authz denial from acquire, should map the reason and release the slot', async () => {
     const { deps, slots } = makeDeps({
       acquireSandbox: async () => ({ ok: false, reason: 'insufficient_role' }),
     });
-    deps.quota.charge = async () => {
-      charges += 1;
-    };
     const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
     expect(result).toMatchObject({ success: false, reason: 'insufficient_role' });
     expect(slots.released).toBe(1);
-    expect(charges).toBe(0);
   });
 
   it('given an authz denial from acquire and a throwing logger, should still release the slot and map the reason', async () => {
@@ -148,16 +124,6 @@ describe('runBashInSandbox', () => {
 
     expect(result).toMatchObject({ success: false, reason: 'insufficient_role' });
     expect(slots.released).toBe(1);
-  });
-
-  it('given a successful run, should charge the budget exactly once', async () => {
-    let charges = 0;
-    const { deps } = makeDeps();
-    deps.quota.charge = async () => {
-      charges += 1;
-    };
-    await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
-    expect(charges).toBe(1);
   });
 
   it('given a vanished sandbox on reconnect, should deny provision_failed and release the slot', async () => {

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -54,20 +54,6 @@ export async function runGitInSandbox({
       ? preResolvedToken
       : await deps.resolveGitHubToken(ctx.userId);
 
-  const pre = await deps.quota.preflight({
-    userId: ctx.userId,
-    driveId: ctx.driveId,
-    tenantId: ctx.tenantId,
-    tier: ctx.tier,
-  });
-  if (!pre.allowed) {
-    return {
-      success: false,
-      error: 'Daily code-execution budget reached. Try again later.',
-      reason: pre.reason,
-      retryAfter: pre.retryAfter,
-    };
-  }
   if (!deps.quota.acquireSlot({ userId: ctx.userId, tier: ctx.tier })) {
     return {
       success: false,
@@ -94,8 +80,6 @@ export async function runGitInSandbox({
     if (!sandbox) {
       return { success: false, error: 'Could not provision a sandbox.', reason: 'provision_failed' };
     }
-
-    await deps.quota.charge({ userId: ctx.userId, driveId: ctx.driveId, tenantId: ctx.tenantId });
 
     const resolvedCwd = cwd ?? SANDBOX_ROOT;
     const startedAt = deps.now();

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -8,7 +8,7 @@
  * cost tracks active time, not provisioned count) this bounds active compute.
  *
  * There is intentionally NO per-run daily budget: a run-count window meters tool
- * calls, not compute, and punished long agentic sessions for being productive.
+ * calls, not compute, and punishes long agentic sessions for being productive.
  * Real usage metering (sandbox-hours / active runtime) is tracked as a follow-up.
  *
  * `checkCodeExecutionQuota` is an ADVISORY preflight: it reports whether a run

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -1,27 +1,21 @@
 /**
- * Code execution quota: per-tier concurrency + per-scope daily run budget.
+ * Code execution quota: per-tier concurrency.
  *
- * Vercel's concurrency and spend limits are account-wide — without our own
- * sub-limits one tenant's runaway agent starves and bills everyone. This module
- * provides two app-level controls:
+ * Fly Sprites exposes no platform spend cap, so the app owns the cost ceiling.
+ * The control here is concurrency: an in-process per-user semaphore whose ceiling
+ * scales by subscription tier (mirrors `upload-semaphore.ts`, expressed
+ * functionally). Combined with sandbox hibernation (idle sandboxes hibernate, so
+ * cost tracks active time, not provisioned count) this bounds active compute.
  *
- *  - Concurrency: an in-process per-user semaphore whose ceiling scales by
- *    subscription tier (mirrors `upload-semaphore.ts`, expressed functionally).
- *  - Daily budget: a NON-incrementing read of the `CODE_EXECUTION` sliding
- *    window (`getDistributedRateLimitStatus`) for the user, drive, and tenant
- *    identifiers independently, so checking one scope never charges another.
+ * There is intentionally NO per-run daily budget: a run-count window meters tool
+ * calls, not compute, and punished long agentic sessions for being productive.
+ * Real usage metering (sandbox-hours / active runtime) is tracked as a follow-up.
  *
  * `checkCodeExecutionQuota` is an ADVISORY preflight: it reports whether a run
- * would be allowed without consuming anything. It must not increment the
- * budget, because checking multiple scopes in sequence would otherwise charge
- * the earlier scopes even when a later one denies — letting an exhausted drive
- * drain a user's allowance in unrelated drives. The single real charge per run
- * (one increment per scope via `checkDistributedRateLimit`) and the matching
- * `acquireCodeExecutionSlot()` are wired at execution time in PR3; that caller
- * must treat a passing preflight as advisory and handle `acquire === false`.
- *
- * Concurrency is checked first (free, in-process) so a saturated system rejects
- * without even reading the budget.
+ * would be allowed (i.e. whether a concurrency slot is free) without consuming
+ * one. The single real reservation (`acquireCodeExecutionSlot`) happens at
+ * execution time; that caller must treat a passing preflight as advisory and
+ * handle `acquire === false`.
  */
 
 import type { SubscriptionTier } from '../subscription-utils';
@@ -77,122 +71,36 @@ export function resetCodeExecutionConcurrency(): void {
   activeByUser.clear();
 }
 
-export type QuotaDenialReason = 'concurrency_limit' | 'rate_limited';
+export type QuotaDenialReason = 'concurrency_limit';
 
 export type CodeExecutionQuotaDecision =
   | { allowed: true }
-  | { allowed: false; reason: QuotaDenialReason; retryAfter?: number };
+  | { allowed: false; reason: QuotaDenialReason };
 
 export interface CodeExecutionQuotaDeps {
-  /** Read (do NOT increment) the daily budget for one scoped identifier. Config
-   *  binding (the CODE_EXECUTION window) is the dependency's concern. */
-  checkRateLimitStatus: (id: string) => Promise<{ blocked: boolean; retryAfter?: number }>;
   canAcquireSlot: (args: { userId: string; tier: SubscriptionTier }) => boolean;
 }
 
-// getDistributedRateLimitStatus pulls in the database; import it (and the
-// CODE_EXECUTION config) lazily so the unit tests, which inject a fake, never
-// load the DB module graph. Status is the read-only sibling of
-// checkDistributedRateLimit — it does not consume the window.
 const defaultDeps: CodeExecutionQuotaDeps = {
-  checkRateLimitStatus: (id) =>
-    import('../../security/distributed-rate-limit').then((m) =>
-      m.getDistributedRateLimitStatus(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION),
-    ),
   canAcquireSlot: canAcquireCodeExecutionSlot,
 };
 
 export interface CheckCodeExecutionQuotaInput {
   userId: string;
-  /** Absent for global (non-drive) contexts; drive scope is omitted from the
-   *  budget check when driveId is not provided. */
+  /** Carried for call-site symmetry; concurrency is per-user, so scope is unused. */
   driveId?: string;
   tenantId?: string;
   tier: SubscriptionTier;
   deps?: CodeExecutionQuotaDeps;
 }
 
-// The scope identifiers a single run is metered against. Shared by the
-// non-incrementing preflight and the real charge so the two never diverge.
-// Drive scope is omitted when driveId is absent (global context).
-function budgetScopeIds({
-  userId,
-  driveId,
-  tenantId,
-}: {
-  userId: string;
-  driveId?: string;
-  tenantId?: string;
-}): string[] {
-  return [
-    `code-exec:user:${userId}`,
-    ...(driveId ? [`code-exec:drive:${driveId}`] : []),
-    ...(tenantId ? [`code-exec:tenant:${tenantId}`] : []),
-  ];
-}
-
 export async function checkCodeExecutionQuota({
   userId,
-  driveId,
-  tenantId,
   tier,
   deps = defaultDeps,
 }: CheckCodeExecutionQuotaInput): Promise<CodeExecutionQuotaDecision> {
   if (!deps.canAcquireSlot({ userId, tier })) {
     return { allowed: false, reason: 'concurrency_limit' };
   }
-
-  for (const id of budgetScopeIds({ userId, driveId, tenantId })) {
-    const status = await deps.checkRateLimitStatus(id);
-    if (status.blocked) {
-      return { allowed: false, reason: 'rate_limited', retryAfter: status.retryAfter };
-    }
-  }
-
   return { allowed: true };
-}
-
-export interface ChargeBudgetDeps {
-  /** Increment the daily budget for one scoped identifier (consumes the window). */
-  charge: (id: string) => Promise<void>;
-}
-
-// The real charge increments the CODE_EXECUTION sliding window. Lazily imported
-// so unit tests that inject a fake never load the DB module graph.
-const defaultChargeDeps: ChargeBudgetDeps = {
-  charge: (id) =>
-    import('../../security/distributed-rate-limit').then((m) =>
-      m.checkDistributedRateLimit(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION).then(() => undefined),
-    ),
-};
-
-/**
- * The single real per-run budget charge: increment every scope (user, drive,
- * and — when known — tenant) exactly once. Call this only after a passing
- * preflight and a successful concurrency reservation, so a denied run never
- * charges. Charges run together; a sink failure rejects and the caller treats a
- * failed charge as an `error` denial rather than running uncharged.
- *
- * NOT atomic across scopes: each scope is an independent sliding-window key, and
- * the distributed rate limiter exposes no multi-key transaction, so a partial
- * failure (one scope incremented, a later one rejected) leaves those scopes
- * charged for a run that does not execute. This skew is intentionally
- * FAIL-SAFE — it over-counts, never under-counts, so it can only ever tighten a
- * budget, never let a run exceed it; it cannot be driven by the actor (they do
- * not control which sink fails). True cross-scope atomicity would require a
- * transactional multi-key primitive in `distributed-rate-limit` and is tracked
- * as a follow-up, not a blocker for a dark-shipped feature.
- */
-export async function chargeCodeExecutionBudget({
-  userId,
-  driveId,
-  tenantId,
-  deps = defaultChargeDeps,
-}: {
-  userId: string;
-  driveId?: string;
-  tenantId?: string;
-  deps?: ChargeBudgetDeps;
-}): Promise<void> {
-  await Promise.all(budgetScopeIds({ userId, driveId, tenantId }).map((id) => deps.charge(id)));
 }

--- a/packages/lib/src/services/sandbox/tool-gate.ts
+++ b/packages/lib/src/services/sandbox/tool-gate.ts
@@ -3,23 +3,21 @@
  *
  * This is the single authorization chokepoint the `bash` / `writeFile` /
  * `readFile` tools run BEFORE they touch the runner — kill-switch, then
- * `canRunCode` authz, then the advisory quota preflight — so a denied call
+ * `canRunCode` authz, then the advisory concurrency preflight — so a denied call
  * returns a safe tool error and never reaches provisioning. It composes the PR1
  * primitives unchanged:
  *
  *   - `isCodeExecutionEnabled` — the global env kill-switch (default OFF);
  *   - `canRunCode` — drive membership + role (and the agent's own drive access
  *     for agent-origin runs), fail-closed;
- *   - `checkCodeExecutionQuota` — the NON-incrementing read of concurrency +
- *     daily budget.
+ *   - `checkCodeExecutionQuota` — the NON-reserving read of per-tier concurrency.
  *
  * It is defence in depth, not a replacement: the runner (`tool-runners.ts`)
- * still re-checks the kill-switch, reserves the concurrency slot, re-authorizes
- * on sandbox resume (via the lifecycle), and issues the single real budget
- * charge. The gate's quota call is advisory and non-incrementing, so running it
- * here never double-charges — it only short-circuits an obviously-denied call at
- * the tool boundary, where the result is a clean `{ ok: false }` instead of a
- * half-provisioned run.
+ * still re-checks the kill-switch, reserves the concurrency slot, and
+ * re-authorizes on sandbox resume (via the lifecycle). The gate's quota call is
+ * advisory and non-reserving, so running it here never holds a slot — it only
+ * short-circuits an obviously-denied call at the tool boundary, where the result
+ * is a clean `{ ok: false }` instead of a half-provisioned run.
  *
  * Fail-closed by construction: every dependency is injected (defaults wire the
  * real implementations) and any thrown error resolves to a denial.
@@ -41,7 +39,6 @@ export type SandboxToolGateDenialReason =
   | 'insufficient_role'
   | 'no_agent_access'
   | 'concurrency_limit'
-  | 'rate_limited'
   | 'error';
 
 export type SandboxToolGateResult =
@@ -56,7 +53,6 @@ const DENIAL_MESSAGES: Record<SandboxToolGateDenialReason, string> = {
   insufficient_role: 'Running code requires drive owner or admin access.',
   no_agent_access: 'This agent is not permitted to run code in this drive.',
   concurrency_limit: 'Too many concurrent runs. Wait for a run to finish and retry.',
-  rate_limited: 'Daily code-execution budget reached. Try again later.',
   error: 'Code execution could not be authorized.',
 };
 
@@ -123,7 +119,7 @@ export async function gateSandboxToolCall({
     }
 
     const quota = await deps.checkQuota({ userId, driveId, tenantId, tier });
-    if (!quota.allowed) return deny(quota.reason, quota.retryAfter);
+    if (!quota.allowed) return deny(quota.reason);
 
     return { ok: true };
   } catch {

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -9,8 +9,7 @@
  *   1. kill-switch re-check (defence in depth on top of the lifecycle's authz);
  *   2. inline command/path policy BEFORE any VM work — a blocked command never
  *      provisions a sandbox, and a blocked command is audited as an anomaly;
- *   3. quota — advisory non-incrementing preflight, then a real concurrency
- *      reservation, then the single real per-run budget charge;
+ *   3. quota — reserve a per-tier concurrency slot (the only cost ceiling here);
  *   4. `acquireConversationSandbox` (authz + lifecycle, re-authz on resume) and
  *      reconnect to the executable handle;
  *   5. run / write / read against the injected sandbox client;
@@ -20,9 +19,9 @@
  *
  * All IO — the sandbox acquire/reconnect, the quota ops, the audit writer, the
  * clock, the kill-switch read, the env builder — is injected, so the whole
- * orchestration is unit-tested with fakes and never touches the real Vercel API
- * or the database. Pure policy (`evaluateCommandPolicy`, `resolveSandboxPath`,
- * `truncateToBytes`) is called directly.
+ * orchestration is unit-tested with fakes and never touches the real sandbox
+ * driver or the database. Pure policy (`evaluateCommandPolicy`,
+ * `resolveSandboxPath`, `truncateToBytes`) is called directly.
  */
 
 import type { SubscriptionTier } from '../subscription-utils';

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -34,7 +34,6 @@ import { buildSandboxEnv } from './sandbox-env';
 import { getValidatedEnv } from '../../config/env-validation';
 import type { AcquireSandboxInput, AcquireSandboxResult } from './session-manager';
 import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
-import type { CodeExecutionQuotaDecision } from './quota';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
 
 /** Largest file body a single `writeFile` may submit, in bytes. */
@@ -60,15 +59,6 @@ export interface SandboxQuotaDeps {
   /** Reserve an in-process concurrency slot; false when the tier ceiling is hit. */
   acquireSlot: (args: { userId: string; tier: SubscriptionTier }) => boolean;
   releaseSlot: (args: { userId: string }) => void;
-  /** Non-incrementing advisory read across user/drive/tenant scopes. */
-  preflight: (args: {
-    userId: string;
-    driveId?: string;
-    tenantId?: string;
-    tier: SubscriptionTier;
-  }) => Promise<CodeExecutionQuotaDecision>;
-  /** The single real budget charge for an allowed run (increments every scope). */
-  charge: (args: { userId: string; driveId?: string; tenantId?: string }) => Promise<void>;
 }
 
 export interface SandboxRunDeps {
@@ -122,7 +112,6 @@ export type SandboxToolDenialReason =
   | 'insufficient_role'
   | 'no_agent_access'
   | 'concurrency_limit'
-  | 'rate_limited'
   | 'empty_command'
   | 'command_too_large'
   | 'blocked_metadata_access'
@@ -153,7 +142,6 @@ const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   insufficient_role: 'Running code requires drive owner or admin access.',
   no_agent_access: 'This agent is not permitted to run code in this drive.',
   concurrency_limit: 'Too many concurrent runs. Wait for a run to finish and retry.',
-  rate_limited: 'Daily code-execution budget reached. Try again later.',
   empty_command: 'No command was provided.',
   command_too_large: 'The command is too large.',
   blocked_metadata_access: 'This command is blocked by policy.',
@@ -256,15 +244,6 @@ async function openSession(
   | { ok: true; sandbox: ExecutableSandbox; release: () => void }
   | { ok: false; reason: SandboxToolDenialReason; retryAfter?: number }
 > {
-  const pre = await deps.quota.preflight({
-    userId: ctx.userId,
-    driveId: ctx.driveId,
-    tenantId: ctx.tenantId,
-    tier: ctx.tier,
-  });
-  if (!pre.allowed) {
-    return { ok: false, reason: pre.reason, retryAfter: pre.retryAfter };
-  }
   if (!deps.quota.acquireSlot({ userId: ctx.userId, tier: ctx.tier })) {
     return { ok: false, reason: 'concurrency_limit' };
   }
@@ -293,9 +272,6 @@ async function openSession(
       });
       return { ok: false, reason: 'provision_failed' };
     }
-    // Charge only once a live, authorized sandbox is in hand — a denied authz or
-    // a failed provision never consumes the daily budget.
-    await deps.quota.charge({ userId: ctx.userId, driveId: ctx.driveId, tenantId: ctx.tenantId });
     return { ok: true, sandbox, release: () => deps.quota.releaseSlot({ userId: ctx.userId }) };
   } catch (error) {
     safeLogError(


### PR DESCRIPTION
## Why

A user running an agent on a free model hit **"Daily code-execution budget reached. Try again later."** while AI chat still worked. The message comes from the agent **code-execution** gate (the Sprites sandbox: `bash`/`writeFile`/`readFile`/git/PTY tools) — a subsystem entirely separate from AI chat, so the free model and working chat were red herrings.

The gate enforced a hard-coded **100 runs / 24h** sliding window (`DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION`), charged **once per individual tool call** across three scopes: `code-exec:user:*`, `code-exec:drive:*`, and `code-exec:tenant:<driveOwner>`. Two problems:

1. It meters **tool-call count, not compute** — an agentic loop burns 100 in a single session, and a sandbox is reused per-conversation (and hibernates when idle), so the count has little to do with actual cost.
2. The `tenant` scope is the **drive owner's whole account**, aggregating every run across all their drives/agents/conversations — so it trips at 100 even when any single drive is lightly used. (Observed in prod: the reporting user sat at 100/100 on `user`+`tenant` while their drives were at 28 and 23.)

## What

Remove the per-run daily budget entirely. **Per-tier concurrency limits** (`quota.ts` semaphore) + **sandbox hibernation** are the cost ceilings now; real usage metering (sandbox-hours) is deferred.

- `quota.ts` → concurrency-only (deleted `chargeCodeExecutionBudget`, `budgetScopeIds`, budget deps; `QuotaDenialReason` = `'concurrency_limit'`)
- `tool-runners.ts` / `git-tool-runners.ts` → removed preflight + charge from `openSession`; dropped the `rate_limited` reason/message
- `tool-gate.ts` → dropped `rate_limited`
- `sandbox-tools-runtime.ts` → dropped charge/preflight bindings
- `apps/realtime` PTY terminal path → dropped the budget charge (concurrency slot still enforced)
- `distributed-rate-limit.ts` → deleted the `CODE_EXECUTION` config block
- tests updated to match

**Deliberately untouched:** the `provision_rate_limited` path (Fly Sprites 429 backpressure in `session-manager.ts` / `sprites.ts` / `reasonFromAcquire`) — a separate, legitimate concern.

This feature is admin-gated / default-OFF and unreleased, so it's a clean cutover with no backwards-compat shims.

## Verification

- `@pagespace/lib` sandbox + rate-limit tests: **240 pass**
- web sandbox tool tests: **46 pass**
- typecheck clean (lib / realtime / web), lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)