### PR TITLE
fix(sandbox): self-heal working dir so a deleted /workspace doesn't brick the sandbox

### DIFF
--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -481,7 +481,45 @@ describe('ExecutableSandbox.runCommand', () => {
     await expect(handle!.runCommand({ cmd: 'sh' })).rejects.toThrow('websocket closed');
   });
 
-  it('should spawn with a structured (file, args[]) form and the policy cwd/env (no host shell string)', async () => {
+  it('given a cwd, should route through the self-healing sh wrapper with cwd/cmd/args as positional data args (no host shell string)', async () => {
+    let seen: { file: string; args?: string[]; opts?: { cwd?: string; env?: Record<string, string> } } | null = null;
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          spawn: (file, args, opts) => {
+            seen = { file, args, opts };
+            return fakeCommand({ exitCode: 0 });
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+    await handle!.runCommand({
+      cmd: 'git',
+      args: ['status', '--short'],
+      cwd: '/workspace',
+      env: { NODE_ENV: 'test' },
+    });
+    // The wrapper recreates + enters the cwd, then execs the real command. cwd/cmd/
+    // args ride along as positional DATA args (never interpolated into the script),
+    // so a deleted /workspace self-heals on the next command instead of bricking.
+    // cwd is entered by the wrapper, NOT passed in spawn opts.
+    expect(seen).toEqual({
+      file: 'sh',
+      args: [
+        '-c',
+        'mkdir -p "$1" 2>/dev/null; cd "$1" || exit 1; shift; exec "$@"',
+        'sh',
+        '/workspace',
+        'git',
+        'status',
+        '--short',
+      ],
+      opts: { env: { NODE_ENV: 'test' } },
+    });
+  });
+
+  it('given NO cwd, should spawn the command directly (structured file/args, no wrapper)', async () => {
     let seen: { file: string; args?: string[]; opts?: { cwd?: string; env?: Record<string, string> } } | null = null;
     const { sdk } = makeSdk({
       getSprite: async () =>
@@ -497,13 +535,12 @@ describe('ExecutableSandbox.runCommand', () => {
     await handle!.runCommand({
       cmd: 'sh',
       args: ['-c', 'echo $(whoami)'],
-      cwd: '/workspace',
       env: { NODE_ENV: 'test' },
     });
     expect(seen).toEqual({
       file: 'sh',
       args: ['-c', 'echo $(whoami)'],
-      opts: { cwd: '/workspace', env: { NODE_ENV: 'test' } },
+      opts: { env: { NODE_ENV: 'test' } },
     });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -357,7 +357,24 @@ function wrap(sprite: SpriteInstanceLike): ExecutableSandbox {
       // spawn (arg array), never a host-side shell string. The untrusted command
       // runs under the Sprite's own `sh -c`, contained by the VM. Re-spawned per
       // attempt so a cold-start wake drop reconnects on a fresh WebSocket.
-      return runSpawnedWithWakeRetry(() => sprite.spawn(cmd, args, { cwd, env }), maxBytes ?? 0, timeoutMs);
+      //
+      // Self-healing cwd: when a cwd is given, don't hand it to spawn as an
+      // immutable precondition (a deleted cwd makes spawn fail outright — an agent
+      // that `rm -rf`s `/workspace` would otherwise brick the sandbox for the rest
+      // of the conversation). Instead route through a tiny `sh` wrapper that
+      // recreates + enters the cwd first, so it self-heals on the next command.
+      // cwd/cmd/args are passed as positional DATA args (`$1`=cwd; `shift` drops it
+      // so `"$@"` = cmd args…; `exec` preserves the real exit code) — never
+      // interpolated into the script, preserving the arg-array no-injection
+      // invariant. With no cwd, spawn directly as before.
+      const spawnFn = cwd === undefined
+        ? () => sprite.spawn(cmd, args, { env })
+        : () => sprite.spawn(
+            'sh',
+            ['-c', 'mkdir -p "$1" 2>/dev/null; cd "$1" || exit 1; shift; exec "$@"', 'sh', cwd, cmd, ...args],
+            { env },
+          );
+      return runSpawnedWithWakeRetry(spawnFn, maxBytes ?? 0, timeoutMs);
     },
 
     async writeFiles(files: WriteFileEntry[]): Promise<void> {


### PR DESCRIPTION
## The brick

PageSpace agents run code in per-conversation Fly Sprites sandboxes. An agent that ran `rm -rf /workspace` **bricked its sandbox**: every later bash/git tool sets `cwd=/workspace`, and the Sprite `spawn` fails outright when that directory is missing, so **all** code execution in that conversation stayed dead until the 24h hard-expiry.

The root defect: the command runner treated its working directory as an immutable precondition — created once at provisioning (`mkdir -p SANDBOX_ROOT`) and never recreated.

## The self-heal fix

A single focused change in the Fly Sprites driver's `runCommand` (`packages/lib/src/services/sandbox/sandbox-client/sprites.ts`). When a `cwd` is provided, instead of handing it to `spawn` as an immutable precondition, route through a tiny `sh` wrapper that **recreates + enters** the cwd before exec'ing the real command:

```
sprite.spawn(
  'sh',
  ['-c', 'mkdir -p "$1" 2>/dev/null; cd "$1" || exit 1; shift; exec "$@"',
   'sh', cwd, cmd, ...args],
  { env },
)
```

- `$1` = cwd; `shift` drops it so `"$@"` = `cmd args…`; `exec "$@"` replaces the shell with the real command, **preserving its exit code** (identical to today's behavior).
- cwd/cmd/args are passed as positional **DATA args** — never string-interpolated into the script — so the existing "arg array, never a host-side shell string" no-injection invariant is preserved.
- When `cwd` is absent, `spawn` runs directly as before.
- The cold-start `runSpawnedWithWakeRetry(...)` wrapper is unchanged.

The provisioning `mkdir -p SANDBOX_ROOT` is left as-is (it also serves as the create-time VM warm-up); the wrapper just makes it non-load-bearing.

## Coverage

Both command paths route through the central `runCommand`, so this covers both with one change:
- **bash** — `tool-runners.ts` `runBashInSandbox`
- **git** — `git-tool-runners.ts`

each defaulting `cwd` to `SANDBOX_ROOT` (`/workspace`).

It also **auto-recovers already-bricked sandboxes** on their next command after deploy — no manual cleanup needed.

## Tests

`__tests__/sprites.test.ts`:
- cwd path → asserts the `sh` wrapper spawn with `['-c', <script>, 'sh', cwd, cmd, ...args]` and cwd entered by the wrapper (not in spawn opts).
- no-cwd path → asserts direct structured `(file, args)` spawn, unchanged.

All 241 sandbox unit tests green; lib build, realtime build, and lib+realtime lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)