### PR TITLE
fix(realtime): load ESM-only @fly/sprites via native dynamic import so terminals work under Node CJS

### DIFF
--- a/apps/realtime/src/terminal/__tests__/realtime-sprites-client.test.ts
+++ b/apps/realtime/src/terminal/__tests__/realtime-sprites-client.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Regression guard for the ESM/CJS terminal bug (PR #1678).
+//
+// @fly/sprites is ESM-only (its package.json `exports` defines only import/types,
+// no require). The realtime service builds with tsc (module:commonjs) and runs
+// under plain Node with no bundler, so tsc DOWN-LEVELS a bare
+// `await import('@fly/sprites')` into a require() — which Node refuses for an
+// import-only package ("No exports main defined"), breaking terminals in prod.
+//
+// The fix indirects the dynamic import through `new Function('s','return import(s)')`
+// so the compiler can't see/transform it and a NATIVE import() survives to runtime.
+// This failure is silent at build time (tsc emits clean) and only blows up at
+// runtime, so we assert the invariant at the source level where it can be caught
+// in CI without building the dist.
+describe('realtime-sprites-client ESM loading invariant', () => {
+  const source = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), '../realtime-sprites-client.ts'),
+    'utf8',
+  );
+
+  it('does not use a bare dynamic import of @fly/sprites that tsc would lower to require()', () => {
+    expect(source).not.toMatch(/await\s+import\(\s*['"]@fly\/sprites['"]\s*\)/);
+  });
+
+  it('loads @fly/sprites through an indirect import the compiler cannot down-level', () => {
+    expect(source).toMatch(/new Function\([^)]*return import\(/);
+    expect(source).toMatch(/importEsm[^)]*\(\s*['"]@fly\/sprites['"]\s*\)/);
+  });
+});

--- a/apps/realtime/src/terminal/realtime-sprites-client.ts
+++ b/apps/realtime/src/terminal/realtime-sprites-client.ts
@@ -28,9 +28,13 @@ function assertSandboxRuntime(): void {
 export async function getRealtimeSpritesSdk(): Promise<SpritesSdk> {
   if (cachedSdk) return cachedSdk;
   assertSandboxRuntime();
-  // @fly/sprites is ESM-only. TS 5.8 with module:commonjs preserves dynamic import()
-  // as-is (does not lower to require()), so Node 24 in production handles it natively.
-  const { SpritesClient } = await import('@fly/sprites');
+  // tsc(module:commonjs) lowers a direct `import()` to require(), which Node refuses
+  // for the ESM-only @fly/sprites ("No exports main defined"). Indirecting through the
+  // Function constructor hides the import from the compiler so a NATIVE dynamic import
+  // survives — Node's import() loads the ESM SDK from this CJS module.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  const importEsm = new Function('s', 'return import(s)') as <T = unknown>(s: string) => Promise<T>;
+  const { SpritesClient } = await importEsm<typeof import('@fly/sprites')>('@fly/sprites');
   const client = new SpritesClient(resolveSpritesToken());
   cachedSdk = {
     getSprite: (name) => client.getSprite(name) as unknown as Promise<SpriteInstanceLike>,


### PR DESCRIPTION
## Problem

Terminals are broken in production. Opening a terminal throws:

```
No "exports" main defined in /app/apps/realtime/node_modules/@fly/sprites/package.json
```

## Root cause (ESM/CJS)

`@fly/sprites` is **ESM-only** — its `package.json` `exports` defines only `import`/`types`, no `require`. The realtime service builds with `tsc` (`module: "commonjs"`, no `"type": "module"`) and runs under **plain Node** (`CMD ["node", …]`) with **no bundler**.

`tsc` with `module: commonjs` **down-levels** the `await import('@fly/sprites')` in `apps/realtime/src/terminal/realtime-sprites-client.ts` into a `require()`. Node refuses to `require()` an import-only package → the error. (The previous in-file comment claiming "module:commonjs preserves dynamic import() as-is" was wrong — that is exactly what fails.)

The **web** app avoids this only because Next.js bundles the ESM SDK; realtime has no bundler, so that fix does not transfer. `apps/web/src/lib/sandbox/sprites-client.ts` is untouched.

## Fix

Indirect the dynamic import through the `Function` constructor so the compiler can't see/transform it, leaving a **native** `import()` that survives to runtime — Node's `import()` loads ESM from a CJS module. This is the standard Node pattern for "CJS must load an ESM-only dependency."

```ts
const importEsm = new Function('s', 'return import(s)') as <T = unknown>(s: string) => Promise<T>;
const { SpritesClient } = await importEsm<typeof import('@fly/sprites')>('@fly/sprites');
```

The `assertSandboxRuntime()` Node-24 guard, `resolveSpritesToken()`, cached SDK shape, and `createSprite(name, config)` are all unchanged.

## Regression test

This failure is **silent at build time** (tsc emits clean) and only blows up at runtime, which is why it reached prod. Added `apps/realtime/src/terminal/__tests__/realtime-sprites-client.test.ts` — a source-level invariant guard that:
- fails if a bare `await import('@fly/sprites')` (which tsc lowers to `require()`) is reintroduced, and
- asserts the indirect `new Function` native-import pattern stays in place.

It runs in CI via `vitest run` without needing the built dist.

## Emit verification (the whole bug is tsc's emit)

```
$ grep -n '@fly/sprites' apps/realtime/dist/apps/realtime/src/terminal/realtime-sprites-client.js
6:// The @fly/sprites SDK is Node >= 24 / ESM-only: ...
16:  `(the @fly/sprites SDK is Node ${MIN_SANDBOX_NODE_MAJOR}+ / ESM-only); ` +
26:  // for the ESM-only @fly/sprites ("No exports main defined"). ...
31:  const { SpritesClient } = await importEsm('@fly/sprites');
```

Compiled emit contains a native `import(` inside the `new Function('s', 'return import(s)')` and **no** `require("@fly/sprites")`.

End-to-end reproduction under Node confirms both directions:
- `require('@fly/sprites')` → `No "exports" main defined …` (the prod bug)
- native `import('@fly/sprites')` → loads OK, `SpritesClient typeof: function`

## Checks
- `bun run --filter 'realtime' build` ✅ (tsc clean)
- `bun run --filter 'realtime' typecheck` ✅
- `bun run --filter 'realtime' lint` ✅
- `bun run --filter 'realtime' test` ✅ (402 tests, incl. 2 new guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)