### PR TITLE
feat(publish): SEO + social meta in published canvas head

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -208,7 +208,12 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(updateWhere).toHaveBeenCalledTimes(2);
 
     expect(rewriteCanvasAssets).toHaveBeenCalledWith({ html: '<p>hi</p>', userId: 'user-1', db: expect.any(Object) });
-    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io', faviconBaseUrl: 'https://pagespace.ai', pageUrl: 'https://acme.pagespace.site/welcome', description: 'hi', robots: undefined }));
+    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io', faviconBaseUrl: 'https://pagespace.ai', pageUrl: 'https://acme.pagespace.site/welcome', description: 'hi' }));
+    // `robots` is forwarded EXPLICITLY (as undefined) so the renderer applies its
+    // index default — objectContaining alone can't prove the key was passed.
+    const firstCallArg = renderPublishedPage.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(firstCallArg, 'robots')).toBe(true);
+    expect(firstCallArg.robots).toBeUndefined();
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'acme', path: 'welcome', html: '<html>rendered</html>' });
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
 
@@ -227,6 +232,11 @@ describe('POST /api/pages/[pageId]/publish', () => {
 
     const res = await POST(makeReq({}), { params });
     expect(res.status).toBe(200);
+
+    // The home page's primary public URL is the subdomain ROOT, so its baked
+    // canonical/OG/JSON-LD URL must be the root — not the secondary slug path
+    // (otherwise the root page canonicalizes itself away to /welcome).
+    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ pageUrl: 'https://acme.pagespace.site/' }));
 
     // Two uploads: the slug artifact + the stable root mirror.
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'acme', path: 'welcome', html: '<html>rendered</html>' });

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -208,7 +208,7 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(updateWhere).toHaveBeenCalledTimes(2);
 
     expect(rewriteCanvasAssets).toHaveBeenCalledWith({ html: '<p>hi</p>', userId: 'user-1', db: expect.any(Object) });
-    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io', faviconBaseUrl: 'https://pagespace.ai', pageUrl: 'https://acme.pagespace.site/welcome' }));
+    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io', faviconBaseUrl: 'https://pagespace.ai', pageUrl: 'https://acme.pagespace.site/welcome', description: 'hi', robots: undefined }));
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'acme', path: 'welcome', html: '<html>rendered</html>' });
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(1);
 
@@ -251,6 +251,28 @@ describe('POST /api/pages/[pageId]/publish', () => {
     const res = await POST(makeReq({}), { params });
     expect(res.status).toBe(200);
     expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ ogImageUrl: ogImg, ogDescription: 'My gallery' }));
+  });
+
+  it('passes the author og:description through as the SEO meta description when present', async () => {
+    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CANVAS', title: 'Gallery', content: '<p>body text</p>', driveId: 'drive-1' });
+    findFirstDrive.mockResolvedValue({ id: 'drive-1', slug: 'acme', publishSubdomain: 'acme', kind: 'PERSONAL' });
+    findFirstPublished.mockResolvedValue(null);
+    extractAndStripOgMeta.mockReturnValue({ meta: { ogDescription: 'Curated blurb' }, html: '<p>body text</p>' });
+
+    const res = await POST(makeReq({}), { params });
+    expect(res.status).toBe(200);
+    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ description: 'Curated blurb' }));
+  });
+
+  it('derives the SEO meta description from page content when no og:description is set', async () => {
+    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CANVAS', title: 'Plain', content: '<h1>Title</h1><p>Real body copy.</p>', driveId: 'drive-1' });
+    findFirstDrive.mockResolvedValue({ id: 'drive-1', slug: 'acme', publishSubdomain: 'acme', kind: 'PERSONAL' });
+    findFirstPublished.mockResolvedValue(null);
+    extractAndStripOgMeta.mockReturnValue({ meta: {}, html: '<h1>Title</h1><p>Real body copy.</p>' });
+
+    const res = await POST(makeReq({}), { params });
+    expect(res.status).toBe(200);
+    expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ description: 'Title Real body copy.' }));
   });
 
   it('uses favicon from canvas link rel=icon when present and skips faviconBaseUrl', async () => {

--- a/apps/web/src/lib/canvas/__tests__/render-published.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/render-published.test.ts
@@ -5,7 +5,7 @@ describe('renderPublishedPage', () => {
   it('given any input, should return a full HTML document', () => {
     const out = renderPublishedPage({ html: '<p>hello</p>' });
     expect(out.startsWith('<!doctype html>')).toBe(true);
-    expect(out).toContain('<html>');
+    expect(out).toContain('<html lang="en">');
     expect(out).toContain('</html>');
     expect(out).toContain('<body>');
   });
@@ -114,5 +114,44 @@ describe('renderPublishedPage — assetBaseUrl', () => {
       html: '<style>body { background: url("https://cdn.example.com/assets/x"); }</style>',
       assetBaseUrl: 'https://user:pass@cdn.example.com',
     })).toThrow(/origin/i);
+  });
+});
+
+describe('renderPublishedPage — SEO + social passthrough', () => {
+  const pageUrl = 'https://acme.pagespace.site/my-page';
+
+  it('given pageUrl, should emit canonical, robots (default index), and JSON-LD', () => {
+    const out = renderPublishedPage({ html: '<p>About cats.</p>', title: 'Cats', pageUrl });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain(`<link rel="canonical" href="${pageUrl}">`);
+    expect(head).toContain('<meta name="robots" content="index, follow">');
+    expect(head).toContain('<script type="application/ld+json">');
+  });
+
+  it('given an explicit description, should emit it as the meta description', () => {
+    const out = renderPublishedPage({ html: '<p>x</p>', pageUrl, description: 'Hand-written summary' });
+    expect(out).toContain('<meta name="description" content="Hand-written summary">');
+  });
+
+  it('given robots="noindex", should emit a noindex robots directive', () => {
+    const out = renderPublishedPage({ html: '<p>x</p>', pageUrl, robots: 'noindex' });
+    expect(out).toContain('<meta name="robots" content="noindex">');
+  });
+
+  it('given ogImageUrl + ogDescription, should emit twitter card tags reusing them', () => {
+    const out = renderPublishedPage({
+      html: '<p>x</p>',
+      pageUrl,
+      ogImageUrl: 'https://pagespace.ai/og.png',
+      ogDescription: 'Social blurb',
+    });
+    expect(out).toContain('<meta name="twitter:card" content="summary_large_image">');
+    expect(out).toContain('<meta name="twitter:image" content="https://pagespace.ai/og.png">');
+    expect(out).toContain('<meta name="twitter:description" content="Social blurb">');
+  });
+
+  it('given a lang, should set <html lang>', () => {
+    const out = renderPublishedPage({ html: '<p>x</p>', pageUrl, lang: 'es' });
+    expect(out).toContain('<html lang="es">');
   });
 });

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -195,17 +195,22 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   const { html: rewrittenHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId, db });
   const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
   const assetBaseUrl = getPublishAssetBaseUrl();
-  // The canonical URL is exactly the page's published URL. The SEO description
-  // prefers the author's og:description, falling back to text derived from the
-  // page content. Robots defaults to indexable unless the caller opts out.
+  const rootUrl = `https://${subdomain}.${PUBLISH_HOST}/`;
   const publishedUrl = `https://${subdomain}.${PUBLISH_HOST}/${path}`;
+  // The canonical/OG/JSON-LD URL is the page's PRIMARY public URL. For the home
+  // page that is the subdomain root (the same artifact is also mirrored there),
+  // not the secondary slug path — using the slug would make the root page
+  // canonicalize itself away to `/<slug>`. Other pages are canonical at their
+  // slug. The SEO description prefers the author's og:description, falling back
+  // to text derived from the page content; robots defaults to indexable.
+  const canonicalUrl = isHomePage ? rootUrl : publishedUrl;
   const html = renderPublishedPage({
     html: bodyHtml,
     title: page.title ?? undefined,
     assetBaseUrl,
     faviconHref: meta.faviconHref,
     faviconBaseUrl: meta.faviconHref ? undefined : FAVICON_BASE_URL,
-    pageUrl: publishedUrl,
+    pageUrl: canonicalUrl,
     ogImageUrl: meta.ogImageUrl,
     ogDescription: meta.ogDescription,
     description: meta.ogDescription ?? deriveDescription(bodyHtml),
@@ -285,9 +290,9 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
     }
   }
 
-  // The home page's primary public URL is the subdomain root; it is also
-  // reachable at its slug. Other pages live only at their slug.
-  const rootUrl = `https://${subdomain}.${PUBLISH_HOST}/`;
+  // The home page's primary public URL is the subdomain root (matching the
+  // canonical tag baked above); it is also reachable at its slug. Other pages
+  // live only at their slug.
   return { url: isHomePage ? rootUrl : publishedUrl, subdomain, path, isHomePage };
 }
 

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -9,6 +9,7 @@ import { eq, and, isNull } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
 import { isHomeDrive } from '@pagespace/lib/services/drive-guards';
+import { deriveDescription } from '@pagespace/lib/canvas/render-document';
 import { renderPublishedPage } from './render-published';
 import {
   buildPublishedKey,
@@ -68,6 +69,13 @@ export interface PublishCanvasPageInput {
    * (or a new one is allocated from the drive slug).
    */
   subdomain?: string;
+  /**
+   * When true, the published page emits `<meta name="robots" content="noindex">`
+   * so search engines keep it out of their indexes. Defaults to indexable. The
+   * author-facing toggle + persistence is a separate task; this just honors the
+   * flag when a caller passes it.
+   */
+  noindex?: boolean;
 }
 
 export interface PublishCanvasPageResult {
@@ -187,6 +195,9 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   const { html: rewrittenHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId, db });
   const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
   const assetBaseUrl = getPublishAssetBaseUrl();
+  // The canonical URL is exactly the page's published URL. The SEO description
+  // prefers the author's og:description, falling back to text derived from the
+  // page content. Robots defaults to indexable unless the caller opts out.
   const publishedUrl = `https://${subdomain}.${PUBLISH_HOST}/${path}`;
   const html = renderPublishedPage({
     html: bodyHtml,
@@ -197,6 +208,8 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
     pageUrl: publishedUrl,
     ogImageUrl: meta.ogImageUrl,
     ogDescription: meta.ogDescription,
+    description: meta.ogDescription ?? deriveDescription(bodyHtml),
+    robots: input.noindex ? 'noindex' : undefined,
   });
   const key = buildPublishedKey(subdomain, path);
 

--- a/apps/web/src/lib/canvas/render-published.ts
+++ b/apps/web/src/lib/canvas/render-published.ts
@@ -28,19 +28,25 @@ export interface RenderPublishedPageInput {
   faviconBaseUrl?: string;
   /** Explicit favicon href from the canvas — see RenderCanvasDocumentInput.faviconHref. */
   faviconHref?: string;
-  /** Canonical public URL for OG meta tags — see RenderCanvasDocumentInput.pageUrl. */
+  /** Canonical public URL for OG/canonical meta tags — see RenderCanvasDocumentInput.pageUrl. */
   pageUrl?: string;
   /** Absolute URL of the OG social preview image — see RenderCanvasDocumentInput.ogImageUrl. */
   ogImageUrl?: string;
   /** Short description for og:description — see RenderCanvasDocumentInput.ogDescription. */
   ogDescription?: string;
+  /** Document language for `<html lang>` — see RenderCanvasDocumentInput.lang (defaults to "en"). */
+  lang?: string;
+  /** SEO meta description; derived from content when omitted — see RenderCanvasDocumentInput.description. */
+  description?: string;
+  /** Robots directive; defaults to "index, follow" — see RenderCanvasDocumentInput.robots. */
+  robots?: string;
 }
 
 /**
  * Render a complete, standalone HTML document for a published canvas page.
  */
 export function renderPublishedPage(input: RenderPublishedPageInput): string {
-  const { assetBaseUrl, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, ...rest } = input;
+  const { assetBaseUrl, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, ...rest } = input;
   const allowedAssetHosts = assetBaseUrl ? [getPublicAssetHost(assetBaseUrl)] : [];
-  return renderCanvasDocument({ ...rest, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription });
+  return renderCanvasDocument({ ...rest, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots });
 }

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { renderCanvasDocument, escapeHtml, BASELINE_CSP, BASELINE_RESET } from '../render-document';
+import { renderCanvasDocument, deriveDescription, escapeHtml, BASELINE_CSP, BASELINE_RESET } from '../render-document';
 
 describe('renderCanvasDocument', () => {
   it('given any input, should return a full HTML document', () => {
     const out = renderCanvasDocument({ html: '<p>hello</p>' });
     expect(out.startsWith('<!doctype html>')).toBe(true);
-    expect(out).toContain('<html>');
+    expect(out).toContain('<html lang="en">');
     expect(out).toContain('</html>');
     expect(out).toContain('<body>');
     expect(out).toContain('<p>hello</p>');
@@ -352,5 +352,224 @@ describe('renderCanvasDocument — allowedAssetHosts', () => {
     });
     expect(out).not.toContain('cdn.example.com');
     expect(out).toContain('url("")');
+  });
+});
+
+describe('renderCanvasDocument — <html lang>', () => {
+  it('given no lang, should default the html lang to "en"', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>' });
+    expect(out).toContain('<html lang="en">');
+  });
+
+  it('given an explicit lang, should use it', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', lang: 'fr' });
+    expect(out).toContain('<html lang="fr">');
+    expect(out).not.toContain('<html lang="en">');
+  });
+
+  it('given a blank lang, should fall back to "en"', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', lang: '   ' });
+    expect(out).toContain('<html lang="en">');
+  });
+
+  it('given a lang with a double-quote, should HTML-escape it', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', lang: 'en"><script>' });
+    expect(out).not.toContain('<html lang="en"><script>');
+    expect(out).toContain('&quot;&gt;&lt;script&gt;');
+  });
+});
+
+describe('deriveDescription', () => {
+  it('given plain text shorter than the limit, should return it unchanged', () => {
+    expect(deriveDescription('Hello world')).toBe('Hello world');
+  });
+
+  it('given HTML, should strip tags and collapse whitespace', () => {
+    expect(deriveDescription('<h1>Hi</h1>\n\n  <p>there   friend</p>')).toBe('Hi there friend');
+  });
+
+  it('given <script> and <style> blocks, should drop their contents entirely', () => {
+    const html = '<style>.x{color:red}</style><p>Visible copy</p><script>const t="hidden";</script>';
+    expect(deriveDescription(html)).toBe('Visible copy');
+  });
+
+  it('given HTML entities, should decode them (so re-escaping does not double-encode)', () => {
+    expect(deriveDescription('<p>Tom &amp; Jerry &lt;3 &#39;quotes&#39;</p>')).toBe("Tom & Jerry <3 'quotes'");
+  });
+
+  it('given text longer than ~155 chars, should truncate at a word boundary and add an ellipsis', () => {
+    const long = 'word '.repeat(60).trim(); // 60 words, ~299 chars
+    const out = deriveDescription(long);
+    expect(out.length).toBeLessThanOrEqual(156);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out).not.toContain('wor…'); // no mid-word cut
+  });
+
+  it('given empty/whitespace-only content, should return an empty string', () => {
+    expect(deriveDescription('   \n\t ')).toBe('');
+    expect(deriveDescription('')).toBe('');
+  });
+});
+
+describe('renderCanvasDocument — SEO meta (published only)', () => {
+  it('given pageUrl, should emit a canonical link with the exact published URL', () => {
+    const url = 'https://acme.pagespace.site/my-page';
+    const out = renderCanvasDocument({ html: '<p>x</p>', pageUrl: url });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain(`<link rel="canonical" href="${url}">`);
+  });
+
+  it('given pageUrl and no robots, should default robots to "index, follow"', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', pageUrl: 'https://acme.pagespace.site/p' });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="robots" content="index, follow">');
+  });
+
+  it('given robots="noindex", should emit that value', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', pageUrl: 'https://acme.pagespace.site/p', robots: 'noindex' });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="robots" content="noindex">');
+    expect(head).not.toContain('index, follow');
+  });
+
+  it('given a description input, should emit it as meta name=description', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      pageUrl: 'https://acme.pagespace.site/p',
+      description: 'A crafted summary',
+    });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="description" content="A crafted summary">');
+  });
+
+  it('given no description input, should derive the meta description from the body text', () => {
+    const out = renderCanvasDocument({
+      html: '<h1>Welcome</h1><p>This page is about cats.</p>',
+      pageUrl: 'https://acme.pagespace.site/p',
+    });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="description" content="Welcome This page is about cats.">');
+  });
+
+  it('given a description with HTML special chars, should escape it', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      pageUrl: 'https://acme.pagespace.site/p',
+      description: 'A & B <draft>',
+    });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('content="A &amp; B &lt;draft&gt;"');
+  });
+
+  it('given no pageUrl, should emit no canonical/robots/description SEO tags (in-app rendering unchanged)', () => {
+    const out = renderCanvasDocument({ html: '<p>some text</p>', title: 'My Page' });
+    expect(out).not.toContain('rel="canonical"');
+    expect(out).not.toContain('name="robots"');
+    expect(out).not.toContain('name="description"');
+  });
+
+  it('given pageUrl, SEO tags must appear inside <head> not <body>', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', pageUrl: 'https://acme.pagespace.site/p' });
+    const bodyStart = out.indexOf('<body>');
+    expect(out.indexOf('rel="canonical"')).toBeGreaterThanOrEqual(0);
+    expect(out.indexOf('rel="canonical"')).toBeLessThan(bodyStart);
+    expect(out.indexOf('name="robots"')).toBeLessThan(bodyStart);
+  });
+});
+
+describe('renderCanvasDocument — JSON-LD structured data', () => {
+  function extractJsonLd(out: string): unknown {
+    const m = out.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    if (!m) throw new Error('no JSON-LD script found');
+    return JSON.parse(m[1]);
+  }
+
+  it('given pageUrl, should emit a valid JSON-LD script with WebSite + WebPage nodes', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      title: 'My Page',
+      pageUrl: 'https://acme.pagespace.site/my-page',
+      description: 'A summary',
+    });
+    const data = extractJsonLd(out) as { '@context': string; '@graph': Array<Record<string, string>> };
+    expect(data['@context']).toBe('https://schema.org');
+    const types = data['@graph'].map((n) => n['@type']);
+    expect(types).toContain('WebSite');
+    expect(types).toContain('WebPage');
+    const webPage = data['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(webPage.name).toBe('My Page');
+    expect(webPage.url).toBe('https://acme.pagespace.site/my-page');
+    expect(webPage.description).toBe('A summary');
+    const webSite = data['@graph'].find((n) => n['@type'] === 'WebSite')!;
+    expect(webSite.url).toBe('https://acme.pagespace.site');
+  });
+
+  it('given a title containing </script>, should not break out of the JSON-LD script element', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      title: 'Pwn </script><script>alert(1)</script>',
+      pageUrl: 'https://acme.pagespace.site/p',
+    });
+    // The raw closing tag must be escaped inside the JSON-LD block.
+    const m = out.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/)!;
+    expect(m[1]).not.toContain('</script>');
+    // …and the JSON is still valid and round-trips the title.
+    const data = JSON.parse(m[1]) as { '@graph': Array<Record<string, string>> };
+    const webPage = data['@graph'].find((n) => n['@type'] === 'WebPage')!;
+    expect(webPage.name).toBe('Pwn </script><script>alert(1)</script>');
+  });
+
+  it('given no pageUrl, should emit no JSON-LD', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', title: 'My Page' });
+    expect(out).not.toContain('application/ld+json');
+  });
+});
+
+describe('renderCanvasDocument — Twitter Card', () => {
+  it('given pageUrl, should emit twitter:card=summary_large_image and twitter:title', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', title: 'My Page', pageUrl: 'https://acme.pagespace.site/p' });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="twitter:card" content="summary_large_image">');
+    expect(head).toContain('<meta name="twitter:title" content="My Page">');
+  });
+
+  it('given ogImageUrl, should reuse it for twitter:image', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      pageUrl: 'https://acme.pagespace.site/p',
+      ogImageUrl: 'https://pagespace.ai/og.png',
+    });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="twitter:image" content="https://pagespace.ai/og.png">');
+  });
+
+  it('given ogDescription, should reuse it for twitter:description', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      pageUrl: 'https://acme.pagespace.site/p',
+      ogDescription: 'Shared blurb',
+    });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="twitter:description" content="Shared blurb">');
+  });
+
+  it('given no ogDescription but derivable body text, should fall back to the SEO description for twitter:description', () => {
+    const out = renderCanvasDocument({
+      html: '<p>Body sentence here.</p>',
+      pageUrl: 'https://acme.pagespace.site/p',
+    });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('<meta name="twitter:description" content="Body sentence here.">');
+  });
+
+  it('given a title with special chars, should escape twitter:title', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', title: '<b>bold & bright</b>', pageUrl: 'https://acme.pagespace.site/p' });
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('name="twitter:title" content="&lt;b&gt;bold &amp; bright&lt;/b&gt;"');
+  });
+
+  it('given no pageUrl, should emit no twitter tags', () => {
+    const out = renderCanvasDocument({ html: '<p>x</p>', title: 'My Page' });
+    expect(out).not.toContain('twitter:');
   });
 });

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -64,6 +64,25 @@ export interface RenderCanvasDocumentInput {
    * set. Falls back to no description tag when omitted.
    */
   ogDescription?: string;
+  /**
+   * Document language, emitted as `<html lang>`. Defaults to `"en"`. Applies to
+   * both in-app and published rendering (it is a basic accessibility/SEO signal,
+   * not gated on `pageUrl`).
+   */
+  lang?: string;
+  /**
+   * SEO `<meta name="description">` content. Only emitted for the PUBLISHED page
+   * (i.e. when `pageUrl` is set). When omitted, a fallback is derived from the
+   * page's first text content via `deriveDescription`. Distinct from
+   * `ogDescription` (the author-supplied social blurb).
+   */
+  description?: string;
+  /**
+   * `<meta name="robots">` content. Only emitted when `pageUrl` is set. Defaults
+   * to `"index, follow"`; pass `"noindex"` (or `"noindex, nofollow"`) to keep a
+   * page out of search indexes.
+   */
+  robots?: string;
 }
 
 /**
@@ -136,10 +155,12 @@ function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[]): {
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription } = input;
+  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots } = input;
 
   const { css, body } = extractAndSanitizeStyles(html ?? '', allowedAssetHosts);
-  const safeTitle = escapeHtml(title && title.trim() ? title : 'Untitled');
+  const rawTitle = title && title.trim() ? title : 'Untitled';
+  const safeTitle = escapeHtml(rawTitle);
+  const safeLang = escapeHtml(lang && lang.trim() ? lang : 'en');
   const baseTag = baseTarget ? `<base target="${baseTarget}">` : '';
 
   const faviconTags = faviconHref
@@ -148,17 +169,29 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
       ? buildFaviconTags(faviconBaseUrl)
       : '';
 
-  const ogTags = pageUrl
-    ? buildOgTags({ title: safeTitle, pageUrl, ogImageUrl, ogDescription })
-    : '';
+  // SEO + social tags describe a PUBLIC landing page, so they are emitted only
+  // for the published artifact (signalled by `pageUrl`). The in-app iframe
+  // rendering — which never receives `pageUrl` — is left byte-for-byte unchanged.
+  let seoTags = '';
+  let ogTags = '';
+  if (pageUrl) {
+    const metaDescription = (description ?? deriveDescription(body)).trim();
+    const socialDescription = ogDescription ?? metaDescription;
+    ogTags = buildOgTags({ title: safeTitle, pageUrl, ogImageUrl, ogDescription });
+    seoTags =
+      buildSeoTags({ pageUrl, description: metaDescription, robots: robots ?? 'index, follow' }) +
+      buildTwitterTags({ title: safeTitle, description: socialDescription, imageUrl: ogImageUrl }) +
+      buildJsonLd({ title: rawTitle, pageUrl, description: metaDescription });
+  }
 
   return (
-    '<!doctype html><html><head>' +
+    `<!doctype html><html lang="${safeLang}"><head>` +
     '<meta charset="utf-8">' +
     '<meta name="viewport" content="width=device-width, initial-scale=1">' +
     baseTag +
     `<title>${safeTitle}</title>` +
     faviconTags +
+    seoTags +
     ogTags +
     `<meta http-equiv="Content-Security-Policy" content="${BASELINE_CSP}">` +
     `<style>${BASELINE_RESET}${css}</style>` +
@@ -196,4 +229,106 @@ function buildOgTags(params: { title: string; pageUrl: string; ogImageUrl?: stri
     descriptionTag +
     imageTags
   );
+}
+
+/**
+ * Core SEO `<head>` tags for a published page: meta description, robots
+ * directive, and the canonical link. `description` and `pageUrl` are raw and
+ * HTML-escaped here; an empty description simply omits the tag.
+ */
+function buildSeoTags(params: { pageUrl: string; description: string; robots: string }): string {
+  const { pageUrl, description, robots } = params;
+  const descriptionTag = description ? `<meta name="description" content="${escapeHtml(description)}">` : '';
+  return (
+    descriptionTag +
+    `<meta name="robots" content="${escapeHtml(robots)}">` +
+    `<link rel="canonical" href="${escapeHtml(pageUrl)}">`
+  );
+}
+
+/**
+ * Twitter Card tags. Reuses the OG title/description/image values: `title` is
+ * already HTML-escaped; `description` and `imageUrl` are raw and escaped here.
+ */
+function buildTwitterTags(params: { title: string; description?: string; imageUrl?: string }): string {
+  const { title, description, imageUrl } = params;
+  const descriptionTag = description ? `<meta name="twitter:description" content="${escapeHtml(description)}">` : '';
+  const imageTag = imageUrl ? `<meta name="twitter:image" content="${escapeHtml(imageUrl)}">` : '';
+  return (
+    `<meta name="twitter:card" content="summary_large_image">` +
+    `<meta name="twitter:title" content="${title}">` +
+    descriptionTag +
+    imageTag
+  );
+}
+
+/**
+ * Escape a JSON string for safe embedding inside an HTML `<script>` element.
+ * Neutralises `<`, `>` and `&` (so an author title containing `</script>` cannot
+ * break out of the block) using JSON-legal `\uXXXX` escapes — the result still
+ * parses as the same JSON value.
+ */
+function jsonLdEscape(json: string): string {
+  return json.replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026');
+}
+
+/**
+ * JSON-LD structured data: a `WebSite` node (the publish origin) plus a `WebPage`
+ * node for this page. `title`/`description` are RAW (JSON.stringify handles
+ * escaping); the result is then `jsonLdEscape`d for the script context.
+ */
+function buildJsonLd(params: { title: string; pageUrl: string; description: string }): string {
+  const { title, pageUrl, description } = params;
+  const origin = pageUrl.match(/^https?:\/\/[^/]+/)?.[0] ?? pageUrl;
+  const webPage: Record<string, string> = { '@type': 'WebPage', name: title, url: pageUrl };
+  if (description) webPage.description = description;
+  const data = {
+    '@context': 'https://schema.org',
+    '@graph': [{ '@type': 'WebSite', name: 'PageSpace', url: origin }, webPage],
+  };
+  return `<script type="application/ld+json">${jsonLdEscape(JSON.stringify(data))}</script>`;
+}
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+/**
+ * Derive a plain-text summary from author HTML (or text) for use as a fallback
+ * meta description. Pure: drops `<script>`/`<style>` blocks, strips remaining
+ * tags, decodes the common HTML entities (so the value can be safely
+ * re-escaped without double-encoding), collapses whitespace, and truncates to
+ * ~`maxLength` chars at a word boundary with an ellipsis.
+ */
+export function deriveDescription(htmlOrText: string, maxLength = 155): string {
+  const stripped = (htmlOrText ?? '')
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ');
+
+  const decoded = stripped.replace(/&(#x[0-9a-f]+|#\d+|[a-z0-9]+);/gi, (match, entity: string) => {
+    const key = entity.toLowerCase();
+    if (key in NAMED_ENTITIES) return NAMED_ENTITIES[key];
+    let code: number | undefined;
+    if (key.startsWith('#x')) code = parseInt(key.slice(2), 16);
+    else if (key.startsWith('#')) code = parseInt(key.slice(1), 10);
+    if (code === undefined || !Number.isFinite(code)) return match;
+    try {
+      return String.fromCodePoint(code);
+    } catch {
+      return match;
+    }
+  });
+
+  const text = decoded.replace(/\s+/g, ' ').trim();
+  if (text.length <= maxLength) return text;
+
+  const truncated = text.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  const base = (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated).trimEnd();
+  return `${base}…`;
 }


### PR DESCRIPTION
## Why

PageSpace bakes a published canvas page into a static HTML artifact served at `<sub>.pagespace.site/<path>` by Caddy from object storage — the app server is never in the request path. The published `<head>` already had title/charset/viewport/OG/favicon, but was missing the SEO and social tags a real landing page needs. This makes a published page **indexable and share-rich**.

Implements the **"SEO & indexing meta"** category (plus the Twitter-card item from "Social sharing & rich previews") of the **Published Canvas Landing Pages** epic.

## What

All head/meta logic is **pure** and lives in `packages/lib/src/canvas/render-document.ts` (`renderCanvasDocument`); the publish route/storage just passes values in. SEO/social tags are gated on `pageUrl`, so the in-app canvas iframe render is byte-for-byte unchanged. Only `<html lang>` always applies.

Added to the published `<head>`:

| Tag | Detail |
|-----|--------|
| `<html lang>` | Defaults to `"en"`, configurable via a `lang` input (escaped). |
| `<meta name="description">` | From a `description` input; falls back to a new pure `deriveDescription()` helper. |
| `<link rel="canonical">` | The page's PRIMARY public URL. For a home page that is the subdomain root (where the artifact is also mirrored), not the slug — so the root page is self-canonical instead of pointing at `/<slug>`. |
| `<meta name="robots">` | Defaults to `"index, follow"`; flips to `noindex` via a `noindex?` flag threaded from `publishCanvasPage`. |
| JSON-LD | `WebSite` + `WebPage` structured data (name/url/description) via a pure builder, `</script>`-breakout-safe and valid JSON. |
| Twitter Card | `summary_large_image`, `twitter:title`, `twitter:description`, `twitter:image` — reuses the OG title/description/image values. |

`deriveDescription(htmlOrText)` is a pure helper: drops `<script>`/`<style>` blocks, strips remaining tags, decodes common HTML entities (so the value re-escapes without double-encoding), collapses whitespace, and truncates to ~155 chars at a word boundary with an ellipsis.

### Wiring
- `render-published.ts` threads `lang`/`description`/`robots` through to the renderer.
- `publish-page.ts` computes the canonical URL (root for the home page, slug otherwise), passes `og:description ?? deriveDescription(content)` as the SEO description, defaults robots to indexable, and accepts a new `noindex?` on `PublishCanvasPageInput`. The author-facing toggle/persistence for `noindex` is a separate later task.

## Tests
- **`packages/lib`** (pure, runs in worktree): new `deriveDescription` unit tests + `<html lang>`, canonical, robots (index/noindex), description (explicit + derived + escaped), JSON-LD (valid JSON, WebSite+WebPage, `</script>` breakout), and Twitter Card blocks. 73 render-document tests green.
- **`apps/web`**: `render-published` SEO/social passthrough tests; publish-route tests assert the derived/og description and robots args. All publish + canvas suites green.
- `lint` ✓ · `typecheck` ✓ · lib + web canvas tests ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer published-page SEO/social tags: canonical links, language on the `<html>` element, meta description, robots directives (including `noindex`), Twitter Card tags, and JSON-LD structured data.
  * Improved description selection by preferring provided Open Graph description and falling back to content-derived summaries.
  * Canonical URL now points to the root (drive home) or the published page (other pages).
* **Tests**
  * Expanded coverage for SEO outputs, escaping/edge cases, and publish-page contract expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->