### PR TITLE
feat(publish): per-site robots.txt, sitemap.xml, and 404

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -4,7 +4,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalEditPage } from '@/lib/auth';
 import { isPublishConfigured } from '@/lib/canvas/published-storage';
-import { publishCanvasPage, clearPublishedHomeRoot, PublishError, PUBLISH_HOST } from '@/lib/canvas/publish-page';
+import { publishCanvasPage, clearPublishedHomeRoot, regeneratePublishedSiteFiles, PublishError, PUBLISH_HOST } from '@/lib/canvas/publish-page';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
@@ -222,6 +222,11 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
       await clearPublishedHomeRoot(row.driveId);
     }
     await db.delete(publishedPages).where(eq(publishedPages.pageId, pageId));
+
+    // Rebuild the drive's sitemap so it no longer advertises the route we just
+    // removed (and refresh robots/404 alongside it). Best-effort — the page is
+    // already unpublished and the row deleted.
+    await regeneratePublishedSiteFiles(row.driveId);
 
     auditRequest(req, {
       eventType: 'data.delete',

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -33,6 +33,7 @@ vi.mock('../published-storage', () => ({
   buildPublishedKey: vi.fn((sub: string, path: string) => `published/${sub}/${path || 'index'}.html`),
   putPublishedArtifact: vi.fn().mockResolvedValue(undefined),
   putPublishedSiteFile: vi.fn().mockResolvedValue(undefined),
+  publishedArtifactExists: vi.fn().mockResolvedValue(true),
   deletePublishedArtifact: vi.fn().mockResolvedValue(undefined),
   isPublishConfigured: vi.fn().mockReturnValue(true),
   getPublishAssetBaseUrl: vi.fn().mockReturnValue('https://cdn.example.com'),
@@ -90,7 +91,7 @@ vi.mock('@pagespace/lib/utils/utils', () => ({
 }));
 
 import { db } from '@pagespace/db/db';
-import { putPublishedArtifact, putPublishedSiteFile, deletePublishedArtifact, isPublishConfigured } from '../published-storage';
+import { putPublishedArtifact, putPublishedSiteFile, publishedArtifactExists, deletePublishedArtifact, isPublishConfigured } from '../published-storage';
 import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, PublishError } from '../publish-page';
 
 // The mocked `db` keeps the real relational-query return types, so partial test
@@ -396,9 +397,10 @@ describe('regeneratePublishedSiteFiles', () => {
     vi.clearAllMocks();
     vi.mocked(isPublishConfigured).mockReturnValue(true);
     vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([]));
+    vi.mocked(publishedArtifactExists).mockResolvedValue(true);
   });
 
-  it('builds the sitemap from the live published_pages rows, home page canonicalized to root', async () => {
+  it('canonicalizes the home page to root when its root mirror exists', async () => {
     vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
       name: 'Acme', publishSubdomain: 'acme', homePageId: 'home-page',
     }));
@@ -406,6 +408,7 @@ describe('regeneratePublishedSiteFiles', () => {
       { pageId: 'home-page', path: 'welcome', updatedAt: new Date('2026-06-22T00:00:00.000Z') },
       { pageId: 'about-page', path: 'about', updatedAt: new Date('2026-06-21T00:00:00.000Z') },
     ]));
+    vi.mocked(publishedArtifactExists).mockResolvedValue(true);
 
     await regeneratePublishedSiteFiles('drive-1');
 
@@ -415,6 +418,38 @@ describe('regeneratePublishedSiteFiles', () => {
     expect(sitemapCall?.[0].body).toContain('https://acme.pagespace.site/');
     expect(sitemapCall?.[0].body).toContain('https://acme.pagespace.site/about');
     expect(sitemapCall?.[0].body).not.toContain('/welcome');
+  });
+
+  it('keeps the home page slug URL when no root mirror exists (homePageId set as metadata only)', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: 'home-page',
+    }));
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([
+      { pageId: 'home-page', path: 'welcome', updatedAt: new Date('2026-06-22T00:00:00.000Z') },
+    ]));
+    // The page was published at its slug, then set as home page without being
+    // re-published — so published/<sub>/index.html does NOT exist.
+    vi.mocked(publishedArtifactExists).mockResolvedValue(false);
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    const sitemapCall = vi.mocked(putPublishedSiteFile).mock.calls.find((c) => c[0].file === 'sitemap.xml');
+    // The live slug URL is advertised; the (nonexistent) root is NOT.
+    expect(sitemapCall?.[0].body).toContain('https://acme.pagespace.site/welcome');
+    expect(sitemapCall?.[0].body).not.toMatch(/acme\.pagespace\.site\/(?!welcome)/);
+  });
+
+  it('does not probe storage for the root mirror when the drive has no home page', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([
+      { pageId: 'about-page', path: 'about', updatedAt: new Date('2026-06-21T00:00:00.000Z') },
+    ]));
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    expect(publishedArtifactExists).not.toHaveBeenCalled();
   });
 
   it('regenerates the sitemap even with zero published pages (unpublish to empty)', async () => {

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -6,7 +6,7 @@ vi.mock('@pagespace/db/db', () => ({
     query: {
       pages: { findFirst: vi.fn() },
       drives: { findFirst: vi.fn() },
-      publishedPages: { findFirst: vi.fn() },
+      publishedPages: { findFirst: vi.fn(), findMany: vi.fn().mockResolvedValue([]) },
     },
     insert: vi.fn(() => ({ values: vi.fn(() => ({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) })) })),
     update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) })),
@@ -32,9 +32,19 @@ vi.mock('@pagespace/db/schema/published-pages', () => ({
 vi.mock('../published-storage', () => ({
   buildPublishedKey: vi.fn((sub: string, path: string) => `published/${sub}/${path || 'index'}.html`),
   putPublishedArtifact: vi.fn().mockResolvedValue(undefined),
+  putPublishedSiteFile: vi.fn().mockResolvedValue(undefined),
   deletePublishedArtifact: vi.fn().mockResolvedValue(undefined),
   isPublishConfigured: vi.fn().mockReturnValue(true),
   getPublishAssetBaseUrl: vi.fn().mockReturnValue('https://cdn.example.com'),
+}));
+
+// Pure builders run for real elsewhere (canvas/site-files.test.ts). Here we
+// only assert the wiring — that the lifecycle writes all three site files — so
+// stub the builders with deterministic stand-ins.
+vi.mock('@pagespace/lib/canvas/site-files', () => ({
+  buildRobotsTxt: vi.fn(({ sitemapUrl }: { sitemapUrl: string }) => `robots:${sitemapUrl}`),
+  buildSitemapXml: vi.fn((routes: { loc: string }[]) => `sitemap:${routes.map((r) => r.loc).join(',')}`),
+  buildNotFoundHtml: vi.fn(({ siteName }: { siteName?: string }) => `404:${siteName ?? ''}`),
 }));
 
 vi.mock('../render-published', () => ({
@@ -80,8 +90,8 @@ vi.mock('@pagespace/lib/utils/utils', () => ({
 }));
 
 import { db } from '@pagespace/db/db';
-import { putPublishedArtifact, deletePublishedArtifact, isPublishConfigured } from '../published-storage';
-import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, PublishError } from '../publish-page';
+import { putPublishedArtifact, putPublishedSiteFile, deletePublishedArtifact, isPublishConfigured } from '../published-storage';
+import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, PublishError } from '../publish-page';
 
 // The mocked `db` keeps the real relational-query return types, so partial test
 // fixtures are cast through `unknown` to the row shape (never `any`).
@@ -347,5 +357,101 @@ describe('clearPublishedHomeRoot', () => {
     vi.mocked(deletePublishedArtifact).mockRejectedValueOnce(new Error('S3 down'));
 
     await expect(clearPublishedHomeRoot('drive-1')).rejects.toThrow('S3 down');
+  });
+});
+
+// The mocked relational query keeps its real return types; published_pages rows
+// are cast through `unknown` to the partial-column shape (never `any`).
+type PublishedRow = Awaited<ReturnType<typeof db.query.publishedPages.findMany>>[number];
+const publishedRows = (rows: Record<string, unknown>[]) => rows as unknown as PublishedRow[];
+
+describe('publishCanvasPage site-file regeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isPublishConfigured).mockReturnValue(true);
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([]));
+  });
+
+  it('writes robots.txt, sitemap.xml, and 404.html after a successful publish', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CANVAS', title: 'Welcome', content: '<div>hi</div>', driveId: 'drive-1',
+    }));
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      id: 'drive-1', name: 'My Drive', slug: 'my-drive', publishSubdomain: 'my-drive', kind: 'STANDARD', homePageId: 'page-1',
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+
+    await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    const files = vi.mocked(putPublishedSiteFile).mock.calls.map((c) => c[0].file).sort();
+    expect(files).toEqual(['404.html', 'robots.txt', 'sitemap.xml']);
+    expect(putPublishedSiteFile).toHaveBeenCalledWith(
+      expect.objectContaining({ subdomain: 'my-drive', file: 'robots.txt' }),
+    );
+  });
+});
+
+describe('regeneratePublishedSiteFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isPublishConfigured).mockReturnValue(true);
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([]));
+  });
+
+  it('builds the sitemap from the live published_pages rows, home page canonicalized to root', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: 'home-page',
+    }));
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([
+      { pageId: 'home-page', path: 'welcome', updatedAt: new Date('2026-06-22T00:00:00.000Z') },
+      { pageId: 'about-page', path: 'about', updatedAt: new Date('2026-06-21T00:00:00.000Z') },
+    ]));
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    // The sitemap stub joins each route's loc; the home page resolves to the
+    // root, the other page to its slug.
+    const sitemapCall = vi.mocked(putPublishedSiteFile).mock.calls.find((c) => c[0].file === 'sitemap.xml');
+    expect(sitemapCall?.[0].body).toContain('https://acme.pagespace.site/');
+    expect(sitemapCall?.[0].body).toContain('https://acme.pagespace.site/about');
+    expect(sitemapCall?.[0].body).not.toContain('/welcome');
+  });
+
+  it('regenerates the sitemap even with zero published pages (unpublish to empty)', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([]));
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    expect(putPublishedSiteFile).toHaveBeenCalledTimes(3);
+  });
+
+  it('is a no-op when publishing is not configured', async () => {
+    vi.mocked(isPublishConfigured).mockReturnValue(false);
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    expect(putPublishedSiteFile).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the drive has no subdomain', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: null, homePageId: null,
+    }));
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    expect(putPublishedSiteFile).not.toHaveBeenCalled();
+  });
+
+  it('swallows storage failures so a publish/unpublish is never rolled back by a site-file write', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: null,
+    }));
+    vi.mocked(putPublishedSiteFile).mockRejectedValue(new Error('S3 down'));
+
+    await expect(regeneratePublishedSiteFiles('drive-1')).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -5,6 +5,7 @@ import {
   putPublishedArtifact,
   buildSiteFileKey,
   putPublishedSiteFile,
+  publishedArtifactExists,
   deletePublishedArtifact,
   isPublishConfigured,
   buildAssetKey,
@@ -128,6 +129,39 @@ describe('putPublishedSiteFile', () => {
   it('writes 404.html as text/html', async () => {
     await putPublishedSiteFile({ subdomain: 'acme', file: '404.html', body: '<!doctype html>' });
     expect(send.mock.calls[0][0].input.ContentType).toBe('text/html; charset=utf-8');
+  });
+});
+
+describe('publishedArtifactExists', () => {
+  beforeEach(() => {
+    send.mockReset();
+    process.env.PUBLISH_BUCKET = 'test-bucket';
+  });
+
+  it('returns true and sends a HeadObjectCommand when the object is present', async () => {
+    send.mockResolvedValue({});
+
+    const exists = await publishedArtifactExists('published/acme/index.html');
+
+    expect(exists).toBe(true);
+    const command = send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(HeadObjectCommand);
+    expect(command.input).toEqual({ Bucket: 'test-bucket', Key: 'published/acme/index.html' });
+  });
+
+  it('returns false on a NotFound error', async () => {
+    send.mockRejectedValue(Object.assign(new Error('not found'), { name: 'NotFound' }));
+    await expect(publishedArtifactExists('published/acme/index.html')).resolves.toBe(false);
+  });
+
+  it('returns false on a 404 status', async () => {
+    send.mockRejectedValue(Object.assign(new Error('nope'), { $metadata: { httpStatusCode: 404 } }));
+    await expect(publishedArtifactExists('published/acme/index.html')).resolves.toBe(false);
+  });
+
+  it('propagates non-404 errors rather than reporting a false negative', async () => {
+    send.mockRejectedValue(Object.assign(new Error('access denied'), { $metadata: { httpStatusCode: 403 } }));
+    await expect(publishedArtifactExists('published/acme/index.html')).rejects.toThrow('access denied');
   });
 });
 

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -3,6 +3,8 @@ import { PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectComm
 import {
   buildPublishedKey,
   putPublishedArtifact,
+  buildSiteFileKey,
+  putPublishedSiteFile,
   deletePublishedArtifact,
   isPublishConfigured,
   buildAssetKey,
@@ -86,6 +88,46 @@ describe('putPublishedArtifact', () => {
       Body: '<!doctype html><html></html>',
       ContentType: 'text/html; charset=utf-8',
     });
+  });
+});
+
+describe('buildSiteFileKey', () => {
+  it('places site files at a literal key directly under the subdomain prefix', () => {
+    expect(buildSiteFileKey('acme', 'robots.txt')).toBe('published/acme/robots.txt');
+    expect(buildSiteFileKey('acme', 'sitemap.xml')).toBe('published/acme/sitemap.xml');
+    expect(buildSiteFileKey('acme', '404.html')).toBe('published/acme/404.html');
+  });
+});
+
+describe('putPublishedSiteFile', () => {
+  beforeEach(() => {
+    send.mockReset();
+    send.mockResolvedValue({});
+    process.env.PUBLISH_BUCKET = 'test-bucket';
+  });
+
+  it('writes robots.txt as text/plain at the subdomain-root key', async () => {
+    const result = await putPublishedSiteFile({ subdomain: 'acme', file: 'robots.txt', body: 'User-agent: *' });
+
+    expect(result).toEqual({ key: 'published/acme/robots.txt' });
+    const command = send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(PutObjectCommand);
+    expect(command.input).toEqual({
+      Bucket: 'test-bucket',
+      Key: 'published/acme/robots.txt',
+      Body: 'User-agent: *',
+      ContentType: 'text/plain; charset=utf-8',
+    });
+  });
+
+  it('writes sitemap.xml as application/xml', async () => {
+    await putPublishedSiteFile({ subdomain: 'acme', file: 'sitemap.xml', body: '<urlset/>' });
+    expect(send.mock.calls[0][0].input.ContentType).toBe('application/xml; charset=utf-8');
+  });
+
+  it('writes 404.html as text/html', async () => {
+    await putPublishedSiteFile({ subdomain: 'acme', file: '404.html', body: '<!doctype html>' });
+    expect(send.mock.calls[0][0].input.ContentType).toBe('text/html; charset=utf-8');
   });
 });
 

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -14,6 +14,7 @@ import {
   buildPublishedKey,
   putPublishedArtifact,
   putPublishedSiteFile,
+  publishedArtifactExists,
   deletePublishedArtifact,
   isPublishConfigured,
   getPublishAssetBaseUrl,
@@ -321,16 +322,39 @@ export async function regeneratePublishedSiteFiles(driveId: string): Promise<voi
       columns: { pageId: true, path: true, updatedAt: true },
     });
 
-    // Build one sitemap entry per published page. The home page is canonicalised
-    // to the subdomain root (where it is mirror-served) instead of its slug, so
-    // the inventory has no duplicate for it.
+    // The home page is canonicalised to the subdomain root (where it is
+    // mirror-served) instead of its slug, so the inventory has no duplicate for
+    // it — but ONLY when the root mirror actually exists. Setting `homePageId` is
+    // metadata-only and never writes `published/<sub>/index.html`; a page
+    // published at its slug and later made the home page has no root mirror until
+    // it is re-published as such. Advertising `/` in that case would surface a
+    // dead route and drop the live slug URL, so confirm the mirror first.
+    const homeRow = drive.homePageId
+      ? published.find((row) => row.pageId === drive.homePageId)
+      : undefined;
+    let rootMirrorExists = false;
+    if (homeRow) {
+      try {
+        rootMirrorExists = await publishedArtifactExists(buildPublishedKey(subdomain, ''));
+      } catch (err) {
+        // If we can't determine whether the mirror exists, fall back to the
+        // slug URL (which always serves) rather than risk advertising a dead
+        // root — and don't let a probe failure abort the whole regeneration.
+        loggers.api.warn('Failed to probe published home-page root mirror; using slug URL in sitemap', {
+          driveId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Build one sitemap entry per published page.
     //
     // NOTE: there is no per-page `noindex` flag yet. When one lands, filter it
     // out HERE (e.g. `published.filter((p) => !p.noindex)`) so excluded pages
     // never enter the sitemap.
     const routes = published.map((row) => ({
       loc:
-        row.pageId === drive.homePageId
+        rootMirrorExists && row.pageId === drive.homePageId
           ? `${origin}/`
           : `${origin}/${row.path}`,
       lastmod: row.updatedAt?.toISOString(),

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -13,11 +13,13 @@ import { renderPublishedPage } from './render-published';
 import {
   buildPublishedKey,
   putPublishedArtifact,
+  putPublishedSiteFile,
   deletePublishedArtifact,
   isPublishConfigured,
   getPublishAssetBaseUrl,
 } from './published-storage';
 import { rewriteCanvasAssets, extractAndStripOgMeta } from './asset-pipeline';
+import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml } from '@pagespace/lib/canvas/site-files';
 
 export const PUBLISH_HOST = 'pagespace.site';
 const FAVICON_BASE_URL = 'https://pagespace.ai';
@@ -272,10 +274,83 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
     }
   }
 
+  // ------------------------------------------------------------------
+  // 10. Regenerate the drive's site-level files (robots / sitemap / 404)
+  // ------------------------------------------------------------------
+  // The published page is already live and the DB is committed, so a failure to
+  // refresh the crawl files must not roll back the publish — log and move on.
+  // The next publish/unpublish regenerates them.
+  await regeneratePublishedSiteFiles(driveId);
+
   // The home page's primary public URL is the subdomain root; it is also
   // reachable at its slug. Other pages live only at their slug.
   const rootUrl = `https://${subdomain}.${PUBLISH_HOST}/`;
   return { url: isHomePage ? rootUrl : publishedUrl, subdomain, path, isHomePage };
+}
+
+/**
+ * (Re)generate the site-level files for a published drive — `robots.txt`,
+ * `sitemap.xml`, and `404.html` — and write them to storage at the subdomain
+ * root (`published/<sub>/<file>`).
+ *
+ * Call this after EVERY publish AND unpublish in the drive: the sitemap is built
+ * from the live `published_pages` rows, so regenerating on unpublish is what keeps
+ * it from advertising a route that no longer serves anything.
+ *
+ * Best-effort by contract: these files make a published drive a "real" website
+ * but are secondary to the page artifacts themselves. A failure here is logged,
+ * not thrown — the caller's publish/unpublish has already succeeded, and the next
+ * lifecycle event will rebuild the files. No-op when publishing is unconfigured
+ * or the drive has not yet been allocated a subdomain.
+ */
+export async function regeneratePublishedSiteFiles(driveId: string): Promise<void> {
+  try {
+    if (!isPublishConfigured()) return;
+
+    const drive = await db.query.drives.findFirst({
+      where: eq(drives.id, driveId),
+      columns: { name: true, publishSubdomain: true, homePageId: true },
+    });
+    const subdomain = drive?.publishSubdomain;
+    if (!subdomain) return;
+
+    const origin = `https://${subdomain}.${PUBLISH_HOST}`;
+
+    const published = await db.query.publishedPages.findMany({
+      where: eq(publishedPages.driveId, driveId),
+      columns: { pageId: true, path: true, updatedAt: true },
+    });
+
+    // Build one sitemap entry per published page. The home page is canonicalised
+    // to the subdomain root (where it is mirror-served) instead of its slug, so
+    // the inventory has no duplicate for it.
+    //
+    // NOTE: there is no per-page `noindex` flag yet. When one lands, filter it
+    // out HERE (e.g. `published.filter((p) => !p.noindex)`) so excluded pages
+    // never enter the sitemap.
+    const routes = published.map((row) => ({
+      loc:
+        row.pageId === drive.homePageId
+          ? `${origin}/`
+          : `${origin}/${row.path}`,
+      lastmod: row.updatedAt?.toISOString(),
+    }));
+
+    const sitemapXml = buildSitemapXml(routes);
+    const robotsTxt = buildRobotsTxt({ sitemapUrl: `${origin}/sitemap.xml` });
+    const notFoundHtml = buildNotFoundHtml({ siteName: drive.name ?? undefined });
+
+    await Promise.all([
+      putPublishedSiteFile({ subdomain, file: 'robots.txt', body: robotsTxt }),
+      putPublishedSiteFile({ subdomain, file: 'sitemap.xml', body: sitemapXml }),
+      putPublishedSiteFile({ subdomain, file: '404.html', body: notFoundHtml }),
+    ]);
+  } catch (err) {
+    loggers.api.warn('Failed to regenerate published site files', {
+      driveId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -203,6 +203,36 @@ export async function putPublishedSiteFile(params: {
 }
 
 /**
+ * Whether an object exists at the given key in the publish bucket.
+ *
+ * Used to decide a page's canonical sitemap URL: the home page is served at the
+ * subdomain root only once it has been deliberately published *as* the home page
+ * (which writes `published/<sub>/index.html`). Setting `homePageId` is
+ * metadata-only and does NOT create that mirror, so the sitemap must confirm the
+ * root object is really there before advertising `/` instead of the slug.
+ *
+ * A 404/NotFound means "not present" → false. Any other error propagates so the
+ * caller (a best-effort regeneration) can log and skip rather than silently treat
+ * a transient failure as a definitive answer.
+ */
+export async function publishedArtifactExists(key: string): Promise<boolean> {
+  try {
+    await getPublishClient().send(
+      new HeadObjectCommand({ Bucket: getPublishBucket(), Key: key }),
+    );
+    return true;
+  } catch (err: unknown) {
+    const anyErr = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+    const is404 =
+      anyErr?.name === 'NotFound' ||
+      anyErr?.name === 'NoSuchKey' ||
+      anyErr?.$metadata?.httpStatusCode === 404;
+    if (is404) return false;
+    throw err;
+  }
+}
+
+/**
  * Delete a previously-published artifact by its storage key.
  */
 export async function deletePublishedArtifact(key: string): Promise<void> {

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -159,6 +159,50 @@ export async function putPublishedArtifact(params: {
 }
 
 /**
+ * Site-level files served at the root of every published drive. Unlike page
+ * artifacts (`.../<path>/index.html`) these live at a fixed, literal key directly
+ * under the subdomain prefix because the edge serves them by exact name, bypassing
+ * the `<path>/index.html` rewrite (see the deploy-repo Caddy snippet).
+ */
+const SITE_FILE_CONTENT_TYPES = {
+  'robots.txt': 'text/plain; charset=utf-8',
+  'sitemap.xml': 'application/xml; charset=utf-8',
+  '404.html': 'text/html; charset=utf-8',
+} as const;
+
+export type PublishedSiteFile = keyof typeof SITE_FILE_CONTENT_TYPES;
+
+/** Build the S3 object key for a drive's site-level file (`published/<sub>/<file>`). */
+export function buildSiteFileKey(subdomain: string, file: PublishedSiteFile): string {
+  return `published/${subdomain}/${file}`;
+}
+
+/**
+ * Upload a site-level file (robots.txt / sitemap.xml / 404.html) for a drive to
+ * the public publish bucket, with the correct content type for its kind. Kept
+ * separate from `putPublishedArtifact` so page-artifact accounting (key layout,
+ * call counts) is unaffected by site-file writes.
+ */
+export async function putPublishedSiteFile(params: {
+  subdomain: string;
+  file: PublishedSiteFile;
+  body: string;
+}): Promise<{ key: string }> {
+  const key = buildSiteFileKey(params.subdomain, params.file);
+
+  await getPublishClient().send(
+    new PutObjectCommand({
+      Bucket: getPublishBucket(),
+      Key: key,
+      Body: params.body,
+      ContentType: SITE_FILE_CONTENT_TYPES[params.file],
+    }),
+  );
+
+  return { key };
+}
+
+/**
  * Delete a previously-published artifact by its storage key.
  */
 export async function deletePublishedArtifact(key: string): Promise<void> {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -632,6 +632,11 @@
       "import": "./dist/canvas/render-document.js",
       "require": "./dist/canvas/render-document.js"
     },
+    "./canvas/site-files": {
+      "types": "./dist/canvas/site-files.d.ts",
+      "import": "./dist/canvas/site-files.js",
+      "require": "./dist/canvas/site-files.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -1311,6 +1316,9 @@
       ],
       "canvas/render-document": [
         "./dist/canvas/render-document.d.ts"
+      ],
+      "canvas/site-files": [
+        "./dist/canvas/site-files.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/src/canvas/__tests__/site-files.test.ts
+++ b/packages/lib/src/canvas/__tests__/site-files.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml } from '../site-files';
+
+describe('buildRobotsTxt', () => {
+  it('given a sitemap URL, allows all crawling and references the sitemap', () => {
+    const txt = buildRobotsTxt({ sitemapUrl: 'https://acme.pagespace.site/sitemap.xml' });
+
+    expect(txt).toContain('User-agent: *');
+    expect(txt).toContain('Allow: /');
+    expect(txt).toContain('Sitemap: https://acme.pagespace.site/sitemap.xml');
+  });
+
+  it('ends with a trailing newline so the file is well-formed', () => {
+    const txt = buildRobotsTxt({ sitemapUrl: 'https://acme.pagespace.site/sitemap.xml' });
+    expect(txt.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('buildSitemapXml', () => {
+  it('given routes, emits the sitemaps.org urlset with one <url> per route', () => {
+    const xml = buildSitemapXml([
+      { loc: 'https://acme.pagespace.site/' },
+      { loc: 'https://acme.pagespace.site/about' },
+    ]);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain('<loc>https://acme.pagespace.site/</loc>');
+    expect(xml).toContain('<loc>https://acme.pagespace.site/about</loc>');
+    expect((xml.match(/<url>/g) ?? []).length).toBe(2);
+    expect(xml).toContain('</urlset>');
+  });
+
+  it('emits <lastmod> only when provided', () => {
+    const xml = buildSitemapXml([
+      { loc: 'https://acme.pagespace.site/a', lastmod: '2026-06-22T00:00:00.000Z' },
+      { loc: 'https://acme.pagespace.site/b' },
+    ]);
+
+    expect(xml).toContain('<lastmod>2026-06-22T00:00:00.000Z</lastmod>');
+    expect((xml.match(/<lastmod>/g) ?? []).length).toBe(1);
+  });
+
+  it('orders entries deterministically by loc regardless of input order', () => {
+    const xml = buildSitemapXml([
+      { loc: 'https://acme.pagespace.site/zebra' },
+      { loc: 'https://acme.pagespace.site/apple' },
+      { loc: 'https://acme.pagespace.site/mango' },
+    ]);
+
+    const appleIdx = xml.indexOf('/apple');
+    const mangoIdx = xml.indexOf('/mango');
+    const zebraIdx = xml.indexOf('/zebra');
+    expect(appleIdx).toBeLessThan(mangoIdx);
+    expect(mangoIdx).toBeLessThan(zebraIdx);
+  });
+
+  it('is deterministic — same routes in any order produce identical output', () => {
+    const a = buildSitemapXml([{ loc: 'https://x/2' }, { loc: 'https://x/1' }]);
+    const b = buildSitemapXml([{ loc: 'https://x/1' }, { loc: 'https://x/2' }]);
+    expect(a).toBe(b);
+  });
+
+  it('XML-escapes special characters in loc so the document stays well-formed', () => {
+    const xml = buildSitemapXml([{ loc: 'https://acme.pagespace.site/search?q=a&b<c>' }]);
+
+    expect(xml).toContain('<loc>https://acme.pagespace.site/search?q=a&amp;b&lt;c&gt;</loc>');
+    expect(xml).not.toContain('q=a&b<c>');
+  });
+
+  it('given no routes, still emits a valid empty urlset', () => {
+    const xml = buildSitemapXml([]);
+
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain('</urlset>');
+    expect((xml.match(/<url>/g) ?? []).length).toBe(0);
+  });
+});
+
+describe('buildNotFoundHtml', () => {
+  it('renders a standalone branded 404 document', () => {
+    const html = buildNotFoundHtml({ siteName: 'Acme' });
+
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('404');
+    expect(html).toContain('Page not found');
+    expect(html).toContain('Acme');
+    expect(html).toContain('PageSpace');
+    // No external stylesheet — styles are inline so it renders on a bare storage hit.
+    expect(html).not.toContain('<link rel="stylesheet"');
+  });
+
+  it('marks itself noindex so error pages never enter the crawl index', () => {
+    const html = buildNotFoundHtml({ siteName: 'Acme' });
+    expect(html).toContain('name="robots" content="noindex"');
+  });
+
+  it('falls back to a generic name when none is given', () => {
+    expect(buildNotFoundHtml().toLowerCase()).toContain('this site');
+    expect(buildNotFoundHtml({ siteName: '   ' }).toLowerCase()).toContain('this site');
+  });
+
+  it('escapes the site name so it cannot inject markup', () => {
+    const html = buildNotFoundHtml({ siteName: '<script>alert(1)</script>' });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/packages/lib/src/canvas/site-files.ts
+++ b/packages/lib/src/canvas/site-files.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure builders for the site-level files every PUBLISHED drive needs.
+ *
+ * A PageSpace drive published at `<subdomain>.pagespace.site` is a real website,
+ * and a real website serves `/robots.txt`, `/sitemap.xml`, and a `404.html`.
+ * Because the edge (Caddy) rewrites every request path to `<path>/index.html`,
+ * these must exist as REAL objects in storage — they cannot be generated on the
+ * fly by an app server that is never in the serving path.
+ *
+ * These functions are PURE string transforms: input is plain data, output is the
+ * exact bytes written to storage. No DOM, no network, no env reads, no clock —
+ * the publish lifecycle (the thin shell) gathers the data (routes, publish time,
+ * site name) and persists whatever these return. Keeping them pure makes the
+ * non-trivial part — valid XML, deterministic ordering, escaping — fully unit
+ * testable without a DB or a bucket.
+ */
+
+/** Robots.txt input. */
+export interface BuildRobotsTxtInput {
+  /** Absolute URL of the site's sitemap, e.g. `https://acme.pagespace.site/sitemap.xml`. */
+  sitemapUrl: string;
+}
+
+/**
+ * Build a `robots.txt` that allows all crawling and points crawlers at the
+ * sitemap. Published canvas sites are public marketing/landing pages — there is
+ * nothing to hide from crawlers, and an explicit `Sitemap:` line is the standard
+ * way to advertise the URL inventory.
+ */
+export function buildRobotsTxt({ sitemapUrl }: BuildRobotsTxtInput): string {
+  return ['User-agent: *', 'Allow: /', '', `Sitemap: ${sitemapUrl}`, ''].join('\n');
+}
+
+/** A single sitemap entry. */
+export interface SitemapRoute {
+  /** Absolute URL of the page, e.g. `https://acme.pagespace.site/about`. */
+  loc: string;
+  /**
+   * Last-modified timestamp as a W3C-datetime string (e.g. an ISO-8601 value
+   * from `Date#toISOString()`). Omitted from the entry when absent.
+   */
+  lastmod?: string;
+}
+
+/**
+ * XML-escape a text value for inclusion in an element body. Escapes the five
+ * predefined XML entities so URLs containing `&`, `<`, `>`, `'`, or `"` (e.g. a
+ * query string) cannot break the document or inject markup.
+ */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Build a sitemaps.org-compliant `sitemap.xml` from the site's routes.
+ *
+ * One `<url>` per route. Ordering is deterministic (sorted by `loc`) so the same
+ * inventory always yields byte-identical output — re-publishing an unchanged site
+ * never churns the artifact. `loc` values are XML-escaped; a `lastmod` is emitted
+ * only when supplied. An empty route list still produces a valid (empty)
+ * `<urlset>`, which is exactly what should be served once the last page of a
+ * drive is unpublished.
+ */
+export function buildSitemapXml(routes: SitemapRoute[]): string {
+  const sorted = [...routes].sort((a, b) => (a.loc < b.loc ? -1 : a.loc > b.loc ? 1 : 0));
+
+  const urls = sorted.map((route) => {
+    const parts = [`    <loc>${escapeXml(route.loc)}</loc>`];
+    if (route.lastmod) {
+      parts.push(`    <lastmod>${escapeXml(route.lastmod)}</lastmod>`);
+    }
+    return `  <url>\n${parts.join('\n')}\n  </url>`;
+  });
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...urls,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+/** 404 document input. */
+export interface BuildNotFoundHtmlInput {
+  /** Human-readable site name shown on the page. Falls back to a generic label. */
+  siteName?: string;
+}
+
+/**
+ * Build a minimal, self-contained branded `404.html`. Inline styles only — the
+ * edge serves this as a standalone document on a storage miss, with no asset
+ * pipeline behind it, so it must render with zero external dependencies.
+ */
+export function buildNotFoundHtml({ siteName }: BuildNotFoundHtmlInput = {}): string {
+  const name = siteName?.trim() || 'This site';
+  const safeName = escapeXml(name);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Page not found</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #0b0b0f;
+    color: #e8e8ea;
+    padding: 24px;
+  }
+  main { text-align: center; max-width: 32rem; }
+  .code { font-size: 4rem; font-weight: 700; letter-spacing: -0.03em; margin: 0; line-height: 1; }
+  h1 { font-size: 1.5rem; font-weight: 600; margin: 0.75rem 0 0.5rem; }
+  p { margin: 0 0 1.5rem; opacity: 0.7; line-height: 1.5; }
+  a {
+    display: inline-block;
+    padding: 0.625rem 1.25rem;
+    border-radius: 0.5rem;
+    background: #e8e8ea;
+    color: #0b0b0f;
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .brand { margin-top: 2.5rem; font-size: 0.8125rem; opacity: 0.45; }
+  .brand a { background: none; color: inherit; padding: 0; text-decoration: underline; font-weight: inherit; }
+</style>
+</head>
+<body>
+<main>
+  <p class="code">404</p>
+  <h1>Page not found</h1>
+  <p>${safeName} doesn&apos;t have a page at this address. It may have been moved or unpublished.</p>
+  <a href="/">Go to the homepage</a>
+  <p class="brand">Published with <a href="https://pagespace.ai">PageSpace</a></p>
+</main>
+</body>
+</html>
+`;
+}


### PR DESCRIPTION
## What

A PageSpace drive published at `<sub>.pagespace.site` is a real website, served as **static artifacts** from object storage (Tigris) with the app server never in the path. A real site serves `/robots.txt`, `/sitemap.xml`, and a branded `404.html`. Because the edge rewrites every request path to `<path>/index.html`, these must exist as **real objects** in storage and be (re)generated whenever the site's published pages change.

Implements the **"Crawl & site-level files"** category of the Published Canvas Landing Pages epic (builds on #1673).

## App-side changes (this PR)

**Pure builders** — `packages/lib/src/canvas/site-files.ts`, fully unit-tested:
- `buildRobotsTxt({ sitemapUrl })` — allows all crawling, advertises the sitemap.
- `buildSitemapXml(routes)` — sitemaps.org-compliant XML, one `<url>` per route, `<lastmod>` from publish time, **deterministic ordering** (sorted by `loc`), XML-escaped. An empty route list still yields a valid empty `<urlset>` — the correct post-unpublish state.
- `buildNotFoundHtml({ siteName? })` — minimal, self-contained branded 404 (inline styles, `noindex`, escapes the site name).

**Lifecycle shell**:
- `putPublishedSiteFile` / `buildSiteFileKey` (`published-storage.ts`) write the files at literal subdomain-root keys `published/<sub>/{robots.txt,sitemap.xml,404.html}` with correct content types — kept separate from `putPublishedArtifact` so page-artifact accounting is unaffected.
- `regeneratePublishedSiteFiles(driveId)` (`publish-page.ts`) rebuilds all three from the live `published_pages` rows. Called after **both** publish (end of `publishCanvasPage`, covering per-page + home-page auto-publish) **and** unpublish (DELETE route) so the sitemap never advertises a dead route. The home page is canonicalized to the subdomain root (no duplicate entry) **only when its root mirror `published/<sub>/index.html` actually exists** — verified via `publishedArtifactExists` (HeadObject). Setting `homePageId` is metadata-only and writes no mirror, so a page published at its slug and later made the home page keeps its live slug URL in the sitemap until it is re-published as the home page. **Best-effort**: a site-file write failure is logged, never rolls back a committed publish/unpublish; the next lifecycle event rebuilds them.

**noindex hook**: there is no per-page `noindex` column yet, so all published pages are included. A clearly-commented filter point is left in `regeneratePublishedSiteFiles` for when that column lands.

## Tests
- `packages/lib/src/canvas/__tests__/site-files.test.ts` — pure builders (valid XML, escaping, determinism, empty urlset, robots references sitemap, 404 renders/noindex/fallback).
- `published-storage.test.ts` — `putPublishedSiteFile` keys + content types.
- `publish-page.test.ts` — publish writes all three artifacts; `regeneratePublishedSiteFiles` builds the sitemap from live rows (home→root), regenerates to an empty sitemap on unpublish, no-ops when unconfigured/no-subdomain, swallows storage failures.

All green: `lib` + `web` tests, typecheck (lib + web), lint, `web build`.

## Required paired Deploy-repo change (EDGE — different repo, not in this PR)

`PageSpace-Deploy/publishing/Caddyfile.pagespace-site.snippet` must serve `/robots.txt` and `/sitemap.xml` by **exact name** (bypassing the `<path>/index.html` rewrite) and serve `404.html` on a storage miss. Exact diff:

```diff
 	# Subdomain label -> {re.sub.1}; map request to the bucket key.
 	@valid header_regexp sub Host ^([a-z0-9-]+)\.pagespace\.site$
 	handle @valid {
-		# /<path>  ->  /published/<sub>/<path>/index.html   (root "/" -> .../index.html)
-		rewrite * /{$PUBLISH_BUCKET_PREFIX:published}/{re.sub.1}{uri}/index.html
-		reverse_proxy https://{$PUBLISH_BUCKET_HOST} {
-			header_up Host {$PUBLISH_BUCKET_HOST}
-			# 404 from storage for unpublished subdomains/paths is passed straight through.
-		}
+		# Site-level files (robots.txt, sitemap.xml) are REAL objects at the
+		# subdomain root and are served by EXACT name — they bypass the
+		# `<path>/index.html` page rewrite.
+		@sitefile path /robots.txt /sitemap.xml
+		handle @sitefile {
+			rewrite * /{$PUBLISH_BUCKET_PREFIX:published}/{re.sub.1}{uri}
+			reverse_proxy https://{$PUBLISH_BUCKET_HOST} {
+				header_up Host {$PUBLISH_BUCKET_HOST}
+			}
+		}
+
+		# Pages: /<path> -> /published/<sub>/<path>/index.html (root "/" -> .../index.html).
+		# On a storage miss serve the drive's branded 404.html. Tigris/S3 returns
+		# 403 (AccessDenied) as well as 404 for a missing key, so match both.
+		handle {
+			rewrite * /{$PUBLISH_BUCKET_PREFIX:published}/{re.sub.1}{uri}/index.html
+			reverse_proxy https://{$PUBLISH_BUCKET_HOST} {
+				header_up Host {$PUBLISH_BUCKET_HOST}
+				@miss status 403 404
+				handle_response @miss {
+					rewrite * /{$PUBLISH_BUCKET_PREFIX:published}/{re.sub.1}/404.html
+					reverse_proxy https://{$PUBLISH_BUCKET_HOST} {
+						header_up Host {$PUBLISH_BUCKET_HOST}
+					}
+					header Content-Type "text/html; charset=utf-8"
+				}
+			}
+		}
 	}
 	respond 404
```

This is the paired follow-up and does not block merging the app-side generation — until the edge change ships, the artifacts are written to storage and reachable, but `/robots.txt` and `/sitemap.xml` would resolve via the `index.html` rewrite and misses would return the bucket's raw error instead of the branded 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

