### PR TITLE
feat(publish): rewrite inter-page links to published URLs

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -53,9 +53,11 @@ vi.mock('@/lib/canvas/published-storage', () => ({
 }));
 
 const rewriteCanvasAssets = vi.fn();
+const rewriteInterPageLinksForDrive = vi.fn();
 const extractAndStripOgMeta = vi.fn();
 vi.mock('@/lib/canvas/asset-pipeline', () => ({
   rewriteCanvasAssets: (...args: unknown[]) => rewriteCanvasAssets(...args),
+  rewriteInterPageLinksForDrive: (...args: unknown[]) => rewriteInterPageLinksForDrive(...args),
   extractAndStripOgMeta: (...args: unknown[]) => extractAndStripOgMeta(...args),
 }));
 
@@ -123,6 +125,7 @@ beforeEach(() => {
   isPublishConfigured.mockReturnValue(true);
   getPublishAssetBaseUrl.mockReturnValue('https://test-publish.t3.tigrisfiles.io');
   rewriteCanvasAssets.mockImplementation(async ({ html }: { html: string }) => ({ html }));
+  rewriteInterPageLinksForDrive.mockImplementation(async ({ html }: { html: string }) => ({ html }));
   extractAndStripOgMeta.mockImplementation((html: string) => ({ meta: {}, html }));
   buildPublishedKey.mockImplementation((subdomain: string, path: string) => `published/${subdomain}/${path}/index.html`);
   putPublishedArtifact.mockResolvedValue({ key: 'published/acme/welcome/index.html' });

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -337,6 +337,8 @@ describe('rewriteInterPageLinksForDrive', () => {
       driveId: 'drive-1',
       subdomain: 'acme',
       homePageId: null,
+      currentPageId: 'current-page',
+      currentPath: 'current',
       db: mockInterPageDb as never,
     });
 
@@ -355,6 +357,8 @@ describe('rewriteInterPageLinksForDrive', () => {
       driveId: 'drive-1',
       subdomain: 'acme',
       homePageId: null,
+      currentPageId: 'current-page',
+      currentPath: 'current',
       db: mockInterPageDb as never,
     });
 
@@ -380,6 +384,8 @@ describe('rewriteInterPageLinksForDrive', () => {
       driveId: 'drive-1',
       subdomain: 'acme',
       homePageId: null,
+      currentPageId: 'current-page',
+      currentPath: 'current',
       db: mockInterPageDb as never,
     });
 
@@ -397,6 +403,8 @@ describe('rewriteInterPageLinksForDrive', () => {
       driveId: 'drive-1',
       subdomain: 'acme',
       homePageId: 'home-1',
+      currentPageId: 'current-page',
+      currentPath: 'current',
       db: mockInterPageDb as never,
     });
 
@@ -412,10 +420,66 @@ describe('rewriteInterPageLinksForDrive', () => {
       driveId: 'drive-1',
       subdomain: 'acme',
       homePageId: null,
+      currentPageId: 'current-page',
+      currentPath: 'current',
       db: mockInterPageDb as never,
     });
 
     expect(result.html).toBe(html);
+  });
+
+  it('given a self-link to the page being published with no DB row yet (first publish), should rewrite from the computed path', async () => {
+    const html = '<a href="/dashboard/drive-1/page-self">home</a>';
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([]); // not upserted yet
+
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: null,
+      currentPageId: 'page-self',
+      currentPath: 'welcome',
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe('<a href="https://acme.pagespace.site/welcome">home</a>');
+  });
+
+  it('given a republish at a new path, should rewrite a self-link to the NEW path, not the stale DB row', async () => {
+    const html = '<a href="/dashboard/drive-1/page-self">me</a>';
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([
+      { pageId: 'page-self', path: 'old-path' },
+    ]);
+
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: null,
+      currentPageId: 'page-self',
+      currentPath: 'new-path',
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe('<a href="https://acme.pagespace.site/new-path">me</a>');
+    expect(result.html).not.toContain('old-path');
+  });
+
+  it('given the page being published is the drive home page, should rewrite a self-link to the site root even with no DB row', async () => {
+    const html = '<a href="/dashboard/drive-1/home-self">home</a>';
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([]);
+
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: 'home-self',
+      currentPageId: 'home-self',
+      currentPath: 'landing',
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe('<a href="/">home</a>');
   });
 });
 

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { extractFileIds, extractAndStripOgMeta, rewriteCanvasAssets } from '../asset-pipeline';
+import {
+  extractFileIds,
+  extractAndStripOgMeta,
+  rewriteCanvasAssets,
+  rewriteInterPageLinksForDrive,
+} from '../asset-pipeline';
 
 vi.mock('server-only', () => ({}));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { warn: vi.fn() } },
+}));
+
+// Capture the SQL operators so the shell test can assert the published_pages
+// lookup is scoped to the publishing drive. findMany itself is mocked, so the
+// shapes returned here are only inspected by assertions, never executed.
+vi.mock('@pagespace/db/operators', () => ({
+  and: (...conds: unknown[]) => ({ kind: 'and', conds }),
+  eq: (col: unknown, val: unknown) => ({ kind: 'eq', col, val }),
+  inArray: (col: unknown, vals: unknown) => ({ kind: 'inArray', col, vals }),
 }));
 
 const canUserViewPage = vi.fn();
@@ -295,6 +309,113 @@ describe('rewriteCanvasAssets', () => {
     const result = await rewriteCanvasAssets({ html, userId: 'user-1', db: mockDb as never });
 
     expect(result.html).toContain('/api/files/fileId1/view');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteInterPageLinksForDrive — shell: builds the drive-scoped map, mocked DB
+// ---------------------------------------------------------------------------
+
+const mockInterPageDb = {
+  query: {
+    publishedPages: {
+      findMany: vi.fn(),
+    },
+  },
+};
+
+describe('rewriteInterPageLinksForDrive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([]);
+  });
+
+  it('given no inter-page links, should return the HTML unchanged without querying', async () => {
+    const html = '<p>nothing to link</p>';
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: null,
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe(html);
+    expect(mockInterPageDb.query.publishedPages.findMany).not.toHaveBeenCalled();
+  });
+
+  it('should scope the published_pages lookup to the publishing drive and the referenced pages', async () => {
+    const html = [
+      '<a href="/dashboard/drive-1/page-a">a</a>',
+      '<a href="/dashboard/drive-1/page-b/view">b</a>',
+    ].join('');
+
+    await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: null,
+      db: mockInterPageDb as never,
+    });
+
+    expect(mockInterPageDb.query.publishedPages.findMany).toHaveBeenCalledTimes(1);
+    const arg = mockInterPageDb.query.publishedPages.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({
+      kind: 'and',
+      conds: [
+        expect.objectContaining({ kind: 'eq', val: 'drive-1' }),
+        expect.objectContaining({ kind: 'inArray', vals: ['page-a', 'page-b'] }),
+      ],
+    });
+  });
+
+  it('given a published sibling, should rewrite the link to its pagespace.site URL', async () => {
+    const html = '<a href="/dashboard/drive-1/page-a">a</a>';
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([
+      { pageId: 'page-a', path: 'about' },
+    ]);
+
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: null,
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe('<a href="https://acme.pagespace.site/about">a</a>');
+  });
+
+  it('given a link to the drive home page, should rewrite it to the site root', async () => {
+    const html = '<a href="/dashboard/drive-1/home-1">home</a>';
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([
+      { pageId: 'home-1', path: 'landing' },
+    ]);
+
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: 'home-1',
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe('<a href="/">home</a>');
+  });
+
+  it('given a link to an unpublished page (not returned by the query), should leave it unchanged', async () => {
+    const html = '<a href="/dashboard/drive-1/missing">x</a>';
+    mockInterPageDb.query.publishedPages.findMany.mockResolvedValue([]);
+
+    const result = await rewriteInterPageLinksForDrive({
+      html,
+      driveId: 'drive-1',
+      subdomain: 'acme',
+      homePageId: null,
+      db: mockInterPageDb as never,
+    });
+
+    expect(result.html).toBe(html);
   });
 });
 

--- a/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
@@ -68,6 +68,16 @@ describe('extractInterPageLinks', () => {
     expect(extractInterPageLinks('<a href="/dashboard/inbox">x</a>')).toEqual([]);
   });
 
+  it('given a protocol-relative dashboard link, should extract the page ref', () => {
+    expect(extractInterPageLinks('<a href="//app.pagespace.ai/dashboard/drive-1/page-1">x</a>')).toEqual([
+      { driveId: 'drive-1', pageId: 'page-1' },
+    ]);
+  });
+
+  it('given /dashboard/ embedded mid-token (not at a delimiter), should not extract it', () => {
+    expect(extractInterPageLinks('<a href="docs/dashboard/drive-1/page-1">x</a>')).toEqual([]);
+  });
+
   it('given no dashboard links, should return an empty array', () => {
     expect(extractInterPageLinks('<p>no links</p>')).toEqual([]);
     expect(extractInterPageLinks('')).toEqual([]);
@@ -106,6 +116,22 @@ describe('rewriteInterPageLinks', () => {
     const html = '<a href="/dashboard/drive-1/missing">x</a>';
 
     expect(rewriteInterPageLinks(html, new Map(), SUB)).toBe(html);
+  });
+
+  it('given a protocol-relative link, should replace the whole URL (no leftover prefix)', () => {
+    const html = '<a href="//app.pagespace.ai/dashboard/drive-1/page-1">go</a>';
+    const map = new Map([['page-1', 'about']]);
+
+    const out = rewriteInterPageLinks(html, map, SUB);
+    expect(out).toBe('<a href="https://acme.pagespace.site/about">go</a>');
+    expect(out).not.toContain('app.pagespace.ai');
+  });
+
+  it('given /dashboard/ embedded mid-token, should leave it untouched (no glued URL)', () => {
+    const html = '<a href="docs/dashboard/drive-1/page-1">x</a>';
+    const map = new Map([['page-1', 'about']]);
+
+    expect(rewriteInterPageLinks(html, map, SUB)).toBe(html);
   });
 
   it('given a mix of published and unpublished links, should rewrite only the published ones', () => {

--- a/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/file-view-links.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   extractDashboardFileViewRefs,
   rewriteDashboardFileViewLinks,
+  extractInterPageLinks,
+  rewriteInterPageLinks,
 } from '../file-view-links';
 
 describe('extractDashboardFileViewRefs', () => {
@@ -38,5 +40,83 @@ describe('rewriteDashboardFileViewLinks', () => {
 
     expect(rewritten).toContain('/dashboard/drive-1/file-1/view?token=signed');
     expect(rewritten).toContain('/dashboard/drive-2/file-2/view');
+  });
+});
+
+describe('extractInterPageLinks', () => {
+  it('given plain and /view dashboard page links, should extract unique drive/page refs', () => {
+    const html = [
+      '<a href="/dashboard/drive-1/page-1">one</a>',
+      '<a href="/dashboard/drive-1/page-2/view">two</a>',
+      '<a href="https://pagespace.ai/dashboard/drive-1/page-1">dup</a>',
+      '<a href="/dashboard/drive-1/page-3?ref=x">three</a>',
+    ].join('');
+
+    expect(extractInterPageLinks(html)).toEqual([
+      { driveId: 'drive-1', pageId: 'page-1' },
+      { driveId: 'drive-1', pageId: 'page-2' },
+      { driveId: 'drive-1', pageId: 'page-3' },
+    ]);
+  });
+
+  it('given a longer dashboard sub-path, should not extract a partial page link', () => {
+    expect(extractInterPageLinks('<a href="/dashboard/drive-1/page-1/edit">x</a>')).toEqual([]);
+    expect(extractInterPageLinks('<a href="/dashboard/drive-1/page-1/view/child">x</a>')).toEqual([]);
+  });
+
+  it('given a single-segment dashboard path, should extract nothing', () => {
+    expect(extractInterPageLinks('<a href="/dashboard/inbox">x</a>')).toEqual([]);
+  });
+
+  it('given no dashboard links, should return an empty array', () => {
+    expect(extractInterPageLinks('<p>no links</p>')).toEqual([]);
+    expect(extractInterPageLinks('')).toEqual([]);
+  });
+});
+
+describe('rewriteInterPageLinks', () => {
+  const SUB = 'acme';
+
+  it('given a link to a published sibling, should rewrite to its pagespace.site URL', () => {
+    const html = '<a href="/dashboard/drive-1/page-1">go</a>';
+    const map = new Map([['page-1', 'about/team']]);
+
+    expect(rewriteInterPageLinks(html, map, SUB)).toContain(
+      'href="https://acme.pagespace.site/about/team"',
+    );
+  });
+
+  it('given a link to the home page (empty path), should rewrite to the site root', () => {
+    const html = '<a href="/dashboard/drive-1/home-page">home</a>';
+    const map = new Map([['home-page', '']]);
+
+    expect(rewriteInterPageLinks(html, map, SUB)).toBe('<a href="/">home</a>');
+  });
+
+  it('given the /view form of a published page link, should rewrite it too', () => {
+    const html = '<a href="https://pagespace.ai/dashboard/drive-1/page-1/view">go</a>';
+    const map = new Map([['page-1', 'docs']]);
+
+    const out = rewriteInterPageLinks(html, map, SUB);
+    expect(out).toContain('href="https://acme.pagespace.site/docs"');
+    expect(out).not.toContain('/dashboard/');
+  });
+
+  it('given a link to an unpublished / out-of-drive page (absent from map), should leave it unchanged', () => {
+    const html = '<a href="/dashboard/drive-1/missing">x</a>';
+
+    expect(rewriteInterPageLinks(html, new Map(), SUB)).toBe(html);
+  });
+
+  it('given a mix of published and unpublished links, should rewrite only the published ones', () => {
+    const html = [
+      '<a href="/dashboard/drive-1/pub">pub</a>',
+      '<a href="/dashboard/drive-1/priv">priv</a>',
+    ].join('');
+    const map = new Map([['pub', 'p']]);
+
+    const out = rewriteInterPageLinks(html, map, SUB);
+    expect(out).toContain('href="https://acme.pagespace.site/p"');
+    expect(out).toContain('href="/dashboard/drive-1/priv"');
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -54,6 +54,7 @@ vi.mock('../render-published', () => ({
 
 vi.mock('../asset-pipeline', () => ({
   rewriteCanvasAssets: vi.fn(async ({ html }: { html: string }) => ({ html })),
+  rewriteInterPageLinksForDrive: vi.fn(async ({ html }: { html: string }) => ({ html })),
   extractAndStripOgMeta: vi.fn((html: string) => ({
     meta: { faviconHref: null, ogImageUrl: null, ogDescription: null },
     html,

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -279,15 +279,26 @@ export async function rewriteCanvasAssets(params: {
  * Runs AFTER `rewriteCanvasAssets`: file-view links to actual file pages are
  * already CDN URLs by then, so the only `/dashboard/.../view` links left for
  * this pass are page→page links.
+ *
+ * The page CURRENTLY being published (`currentPageId` / `currentPath`) is seeded
+ * into the map directly rather than read from the DB: its `published_pages` row
+ * does not exist yet on first publish, and still holds the OLD path when
+ * republishing at a new path (the upsert happens later in `publishCanvasPage`).
+ * Seeding from the freshly-computed path means a canvas link back to the page
+ * being published — common in nav/logo links, and the norm for a home page —
+ * resolves to the correct public URL instead of a dead `/dashboard/...` link or
+ * a stale path.
  */
 export async function rewriteInterPageLinksForDrive(params: {
   html: string;
   driveId: string;
   subdomain: string;
   homePageId: string | null;
+  currentPageId: string;
+  currentPath: string;
   db: Pick<typeof DbType, 'query'>;
 }): Promise<{ html: string }> {
-  const { html, driveId, subdomain, homePageId, db } = params;
+  const { html, driveId, subdomain, homePageId, currentPageId, currentPath, db } = params;
 
   const links = extractInterPageLinks(html);
   const pageIds = Array.from(new Set(links.map(({ pageId }) => pageId)));
@@ -305,6 +316,11 @@ export async function rewriteInterPageLinksForDrive(params: {
   if (homePageId && pathByPageId.has(homePageId)) {
     pathByPageId.set(homePageId, '');
   }
+
+  // Seed the page being published from its freshly-computed path, overriding any
+  // missing (first publish) or stale (republish at a new path) DB row. The home
+  // page is served at the root, so it resolves to '/'.
+  pathByPageId.set(currentPageId, currentPageId === homePageId ? '' : currentPath);
 
   return { html: rewriteInterPageLinks(html, pathByPageId, subdomain) };
 }

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -3,9 +3,11 @@ import 'server-only';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { type db as DbType } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
-import { inArray } from '@pagespace/db/operators';
+import { publishedPages } from '@pagespace/db/schema/published-pages';
+import { and, eq, inArray } from '@pagespace/db/operators';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { buildAssetKey, buildAssetUrlFromKey, copyObjectToPublishBucket } from './published-storage';
+import { extractInterPageLinks, rewriteInterPageLinks } from './file-view-links';
 
 type FileReferenceKind = 'view' | 'thumbnail';
 
@@ -257,4 +259,52 @@ export async function rewriteCanvasAssets(params: {
   });
 
   return { html: rewritten };
+}
+
+/**
+ * Rewrite canvas inter-page links (`/dashboard/{driveId}/{pageId}` and the
+ * `/view` variant) to the target page's PUBLIC published URL, so navigation
+ * between published pages works on `<subdomain>.pagespace.site`.
+ *
+ * This is the thin I/O shell around the pure `rewriteInterPageLinks` transform:
+ * it builds the `pageId → published path` map by querying `published_pages`,
+ * scoped to THIS drive (`driveId` in the WHERE clause) and restricted to the
+ * page ids actually referenced in the HTML. Because only same-drive published
+ * pages enter the map:
+ *  - a link to a published sibling rewrites to its `pagespace.site/<path>` URL;
+ *  - a link to the drive home page rewrites to the site root `/`;
+ *  - a link to an unpublished or out-of-drive page is left unchanged (the pure
+ *    transform's documented fallback) so it never fails the publish build.
+ *
+ * Runs AFTER `rewriteCanvasAssets`: file-view links to actual file pages are
+ * already CDN URLs by then, so the only `/dashboard/.../view` links left for
+ * this pass are page→page links.
+ */
+export async function rewriteInterPageLinksForDrive(params: {
+  html: string;
+  driveId: string;
+  subdomain: string;
+  homePageId: string | null;
+  db: Pick<typeof DbType, 'query'>;
+}): Promise<{ html: string }> {
+  const { html, driveId, subdomain, homePageId, db } = params;
+
+  const links = extractInterPageLinks(html);
+  const pageIds = Array.from(new Set(links.map(({ pageId }) => pageId)));
+  if (pageIds.length === 0) return { html };
+
+  // Drive-scoped: only pages published under THIS drive's site may be linked.
+  const rows = (await db.query.publishedPages.findMany({
+    where: and(eq(publishedPages.driveId, driveId), inArray(publishedPages.pageId, pageIds)),
+    columns: { pageId: true, path: true },
+  })) as Array<{ pageId: string; path: string }>;
+
+  const pathByPageId = new Map(rows.map((row) => [row.pageId, row.path]));
+
+  // The drive home page is also served at the site root; link to it as '/'.
+  if (homePageId && pathByPageId.has(homePageId)) {
+    pathByPageId.set(homePageId, '');
+  }
+
+  return { html: rewriteInterPageLinks(html, pathByPageId, subdomain) };
 }

--- a/apps/web/src/lib/canvas/file-view-links.ts
+++ b/apps/web/src/lib/canvas/file-view-links.ts
@@ -26,3 +26,81 @@ export function rewriteDashboardFileViewLinks(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Inter-page links (page → page navigation on the published site)
+// ---------------------------------------------------------------------------
+//
+// A published drive is a multi-page site: the home page at `/` and every other
+// published canvas page at `/<slug>`, all on `<subdomain>.pagespace.site`. In
+// the app, a canvas links to another page with an in-app dashboard URL, in one
+// of two forms:
+//
+//   /dashboard/{driveId}/{pageId}        (plain navigation link)
+//   /dashboard/{driveId}/{pageId}/view   (the file-view form, also used as a link)
+//
+// On the published artifact those URLs are dead — they point back into the app.
+// The functions below extract such links and rewrite them to the target page's
+// public published URL so navigation between published pages actually works.
+
+/** The apex host every published drive site is served under. */
+export const PUBLISH_HOST = 'pagespace.site';
+
+export interface InterPageLink {
+  driveId: string;
+  pageId: string;
+}
+
+// Matches both the plain (`/dashboard/{d}/{p}`) and file-view
+// (`/dashboard/{d}/{p}/view`) link forms, with an optional absolute origin
+// prefix and optional query string. The trailing boundary lookahead ensures a
+// longer path segment (`/edit`, `/viewer`, `/p/child`, …) never matches as an
+// inter-page link.
+const INTER_PAGE_LINK_RE =
+  /(?:https?:\/\/[^/'">\s]*)?\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(?:\/view)?(?:\?[^"')\s>]*)?(?=$|[#"')\s>])/g;
+
+const interPageKey = ({ driveId, pageId }: InterPageLink): string => `${driveId}:${pageId}`;
+
+/**
+ * Extract every unique inter-page link (`/dashboard/{driveId}/{pageId}` and the
+ * `/view` variant) from canvas HTML.
+ *
+ * Pure function: no I/O, no env reads.
+ */
+export function extractInterPageLinks(html: string): InterPageLink[] {
+  const byKey = new Map<string, InterPageLink>();
+  for (const match of html.matchAll(INTER_PAGE_LINK_RE)) {
+    const link = { driveId: match[1], pageId: match[2] };
+    byKey.set(interPageKey(link), link);
+  }
+  return Array.from(byKey.values());
+}
+
+/**
+ * Rewrite canvas inter-page links to their published-site URLs.
+ *
+ * `pathByPageId` maps a published page id to its published path. Only pages in
+ * the SAME drive belong in the map (the caller scopes the lookup by drive), so a
+ * link whose page id is absent is either unpublished or lives in another drive.
+ *
+ * Resolution rules:
+ *  - page id present, path is `''`  → the drive home page, served at the site
+ *    root → rewritten to `/`.
+ *  - page id present, non-empty path → rewritten to
+ *    `https://<subdomain>.pagespace.site/<path>`.
+ *  - page id ABSENT (unpublished / out-of-drive) → FALLBACK: the original href
+ *    is left unchanged so a dead inter-page link never fails the publish build.
+ *
+ * Pure function: no I/O, no env reads.
+ */
+export function rewriteInterPageLinks(
+  html: string,
+  pathByPageId: Map<string, string>,
+  subdomain: string,
+): string {
+  return html.replace(INTER_PAGE_LINK_RE, (match, _driveId: string, pageId: string) => {
+    const path = pathByPageId.get(pageId);
+    if (path === undefined) return match;
+    return path === '' ? '/' : `https://${subdomain}.${PUBLISH_HOST}/${path}`;
+  });
+}
+

--- a/apps/web/src/lib/canvas/file-view-links.ts
+++ b/apps/web/src/lib/canvas/file-view-links.ts
@@ -51,12 +51,16 @@ export interface InterPageLink {
 }
 
 // Matches both the plain (`/dashboard/{d}/{p}`) and file-view
-// (`/dashboard/{d}/{p}/view`) link forms, with an optional absolute origin
-// prefix and optional query string. The trailing boundary lookahead ensures a
-// longer path segment (`/edit`, `/viewer`, `/p/child`, …) never matches as an
-// inter-page link.
+// (`/dashboard/{d}/{p}/view`) link forms, with an optional absolute or
+// protocol-relative origin prefix and optional query string.
+//  - Leading lookbehind: the path must start at a delimiter (string start,
+//    whitespace, quote, `(`, `=`, `,`) so a `/dashboard/` embedded mid-token
+//    (e.g. a relative `docs/dashboard/...`) is not matched and corrupted by
+//    gluing the rewritten URL onto the leftover prefix.
+//  - Trailing lookahead: a longer path segment (`/edit`, `/viewer`, `/p/child`,
+//    …) never matches as an inter-page link.
 const INTER_PAGE_LINK_RE =
-  /(?:https?:\/\/[^/'">\s]*)?\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(?:\/view)?(?:\?[^"')\s>]*)?(?=$|[#"')\s>])/g;
+  /(?<=^|[\s"'(=,])(?:(?:https?:)?\/\/[^/'">\s]+)?\/dashboard\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)(?:\/view)?(?:\?[^"')\s>]*)?(?=$|[#"')\s>])/g;
 
 const interPageKey = ({ driveId, pageId }: InterPageLink): string => `${driveId}:${pageId}`;
 

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -20,7 +20,7 @@ import {
   isPublishConfigured,
   getPublishAssetBaseUrl,
 } from './published-storage';
-import { rewriteCanvasAssets, extractAndStripOgMeta } from './asset-pipeline';
+import { rewriteCanvasAssets, rewriteInterPageLinksForDrive, extractAndStripOgMeta } from './asset-pipeline';
 import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml } from '@pagespace/lib/canvas/site-files';
 
 export const PUBLISH_HOST = 'pagespace.site';
@@ -195,7 +195,17 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   // ------------------------------------------------------------------
   // 4. Rewrite assets + extract OG meta
   // ------------------------------------------------------------------
-  const { html: rewrittenHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId, db });
+  const { html: assetHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId, db });
+  // Rewrite page→page links to their public published URLs so navigation between
+  // published pages works on the subdomain site (drive-scoped; unpublished /
+  // out-of-drive targets are left unchanged).
+  const { html: rewrittenHtml } = await rewriteInterPageLinksForDrive({
+    html: assetHtml,
+    driveId,
+    subdomain,
+    homePageId: drive.homePageId,
+    db,
+  });
   const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
   const assetBaseUrl = getPublishAssetBaseUrl();
   const rootUrl = `https://${subdomain}.${PUBLISH_HOST}/`;

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -204,6 +204,8 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
     driveId,
     subdomain,
     homePageId: drive.homePageId,
+    currentPageId: pageId,
+    currentPath: path,
     db,
   });
   const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);


### PR DESCRIPTION
## Why

A published PageSpace drive is a **multi-page site** — the home page at `/`, every other published canvas page at `/<slug>`, all on `<sub>.pagespace.site`. Canvas content links to other pages using in-app dashboard URLs:

- `/dashboard/{driveId}/{pageId}` (plain navigation link)
- `/dashboard/{driveId}/{pageId}/view` (the file-view form, also used as a link)

`asset-pipeline.ts` already rewrites **file** references to public CDN URLs, but it never rewrote **page → page** links — so those URLs point back into the app and are dead on the published artifact. Navigation between published pages was broken. This is the critical gap for a published drive to work as an actual website.

Implements the inter-page-link items of the **"URL structure, links & redirects"** category of the **Published Canvas Landing Pages** epic. PR #1673 (home page at subdomain root) is its predecessor.

## What

**Pure core (`file-view-links.ts`)** — fully unit-tested, no I/O:
- `extractInterPageLinks(html)` — extracts unique `{driveId, pageId}` from both link forms. A trailing boundary lookahead rejects longer sub-paths (`/edit`, `/view/child`, single-segment `/dashboard/inbox`); a leading boundary lookbehind + protocol-relative (`//host`) origin handling means a `/dashboard/` embedded mid-token (e.g. `docs/dashboard/...`) is never matched and the whole URL is replaced (no prefix-glue corruption).
- `rewriteInterPageLinks(html, pathByPageId, subdomain)` — replaces each link:
  - published sibling → `https://<sub>.pagespace.site/<path>`
  - drive home page (path `''`) → site root `/`
  - **fallback**: page id absent from the map (unpublished / out-of-drive) → href left **unchanged**, so a dead inter-page link never fails the publish build.

**Shell (`asset-pipeline.ts`)** — `rewriteInterPageLinksForDrive(...)`:
- builds the `pageId → published path` map by querying `published_pages` **scoped to the publishing drive** (`driveId` in the WHERE) and the referenced page ids;
- marks the drive home page as root (`''`);
- **seeds the page being published** (`currentPageId` / `currentPath`) from its freshly-computed path, overriding any missing (first publish) or stale (republish at a new path) `published_pages` row. A canvas link back to the page being published — nav/logo links, and the norm for a home page — resolves correctly instead of staying a dead `/dashboard/...` link or pointing at the old path. (Addresses Codex review P2.)

**Integration (`publish-page.ts`)** — runs in `publishCanvasPage` after `rewriteCanvasAssets` (file-view links are already CDN URLs by then, so only page→page links remain for this pass). Edit is minimal/localized to avoid conflicts with sibling PRs.

## Tests

- **Pure** (`file-view-links.test.ts`): published sibling → `pagespace.site/<path>`; home page → `/`; `/view` form rewrites; unpublished/out-of-drive → unchanged; partial sub-paths not matched.
- **Shell** (`asset-pipeline.test.ts`): asserts the `published_pages` lookup is **drive-scoped**; home-page → root; unpublished → unchanged; no-links → no query; **first-publish self-link**, **republish-new-path** (asserts old path is gone), and **home-page self-link** seeding cases.
- **Route** (`publish/__tests__/route.test.ts`): mock updated for the new export.

## Acceptance criteria

- [x] Published sibling rewrites to `<sub>.pagespace.site/<path>`
- [x] Home page link rewrites to `/`
- [x] Unpublished / out-of-drive link hits the documented fallback
- [x] Self-link to the page being published resolves correctly on first publish / republish
- [x] Shell test asserts the map is drive-scoped
- [x] lint + typecheck + test + build green (CI confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
