### PR TITLE
perf(api): batch listDriveMembers permission counts into single query

### DIFF
--- a/packages/lib/src/services/__tests__/drive-member-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-member-service.test.ts
@@ -49,12 +49,15 @@ vi.mock('@pagespace/db/schema/members', () => ({
   driveRoles: { id: 'dr.id', name: 'dr.name', color: 'dr.color' },
   pagePermissions: { pageId: 'pp.pageId', userId: 'pp.userId', canView: 'pp.canView', canEdit: 'pp.canEdit', canShare: 'pp.canShare', grantedBy: 'pp.grantedBy', grantedAt: 'pp.grantedAt' },
 }));
-vi.mock('@pagespace/db/operators', () => ({
-  eq: vi.fn((a, b) => ({ op: 'eq', a, b })),
-  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
-  isNotNull: vi.fn((a) => ({ op: 'isNotNull', a })),
-  sql: vi.fn(),
-}));
+vi.mock('@pagespace/db/operators', () => {
+  const sqlFn = Object.assign(vi.fn(), { join: vi.fn(() => ({})) });
+  return {
+    eq: vi.fn((a, b) => ({ op: 'eq', a, b })),
+    and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+    isNotNull: vi.fn((a) => ({ op: 'isNotNull', a })),
+    sql: sqlFn,
+  };
+});
 
 import { db } from '@pagespace/db/db';
 import {
@@ -369,25 +372,50 @@ describe('drive-member-service', () => {
   });
 
   describe('listDriveMembers', () => {
-    it('should return members with permission counts', async () => {
+    it('should return empty array without querying permissions when no members', async () => {
+      const chain = { leftJoin: vi.fn().mockReturnThis(), where: vi.fn().mockResolvedValue([]) };
+      mockDb.select.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await listDriveMembers('drive-1');
+      expect(result).toEqual([]);
+      expect(mockDb.execute).not.toHaveBeenCalled();
+    });
+
+    it('should return members with permission counts from batched query', async () => {
       const members = [
-        { userId: 'u1', role: 'MEMBER', id: 'dm-1', invitedBy: null, invitedAt: null, acceptedAt: null, lastAccessedAt: null, user: { id: 'u1', email: 'a@b.com', name: 'A' }, profile: { username: 'a', displayName: 'A', avatarUrl: null }, customRole: { id: null, name: null, color: null } },
+        { userId: 'u1', role: 'MEMBER', id: 'dm-1', invitedBy: null, invitedAt: null,
+          acceptedAt: null, lastAccessedAt: null,
+          user: { id: 'u1', email: 'a@b.com', name: 'A' },
+          profile: { username: 'a', displayName: 'A', avatarUrl: null },
+          customRole: { id: null, name: null, color: null } },
       ];
-      const chain = {
-        leftJoin: vi.fn().mockReturnThis(),
-        where: vi.fn().mockResolvedValue(members),
-      };
-      mockDb.select.mockReturnValue({
-        from: vi.fn().mockReturnValue(chain),
-      });
+      const chain = { leftJoin: vi.fn().mockReturnThis(), where: vi.fn().mockResolvedValue(members) };
+      mockDb.select.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
 
       mockDb.execute.mockResolvedValue({
-        rows: [{ view_count: '3', edit_count: '1', share_count: '0' }],
+        rows: [{ userId: 'u1', view_count: '3', edit_count: '1', share_count: '0' }],
       });
 
       const result = await listDriveMembers('drive-1');
       expect(result).toHaveLength(1);
       expect(result[0].permissionCounts).toEqual({ view: 3, edit: 1, share: 0 });
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should default permission counts to zero for members with no page permissions', async () => {
+      const members = [
+        { userId: 'u2', role: 'MEMBER', id: 'dm-2', invitedBy: null, invitedAt: null,
+          acceptedAt: null, lastAccessedAt: null,
+          user: { id: 'u2', email: 'b@b.com', name: 'B' },
+          profile: null, customRole: null },
+      ];
+      const chain = { leftJoin: vi.fn().mockReturnThis(), where: vi.fn().mockResolvedValue(members) };
+      mockDb.select.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      mockDb.execute.mockResolvedValue({ rows: [] });
+
+      const result = await listDriveMembers('drive-1');
+      expect(result[0].permissionCounts).toEqual({ view: 0, edit: 0, share: 0 });
     });
   });
 });

--- a/packages/lib/src/services/drive-member-service.ts
+++ b/packages/lib/src/services/drive-member-service.ts
@@ -236,32 +236,39 @@ export async function listDriveMembers(driveId: string): Promise<MemberWithDetai
     .leftJoin(driveRoles, eq(driveMembers.customRoleId, driveRoles.id))
     .where(eq(driveMembers.driveId, driveId));
 
-  // Get permission counts for each member
-  const memberData = await Promise.all(
-    members.map(async (member) => {
-      const { rows: permCounts } = await db.execute(sql`
-        SELECT 
-          COUNT(CASE WHEN pp."canView" = true THEN 1 END) as view_count,
-          COUNT(CASE WHEN pp."canEdit" = true THEN 1 END) as edit_count,
-          COUNT(CASE WHEN pp."canShare" = true THEN 1 END) as share_count
-        FROM page_permissions pp
-        JOIN pages p ON pp."pageId" = p.id
-        WHERE pp."userId" = ${member.userId} AND p."driveId" = ${driveId}
-      `);
+  if (members.length === 0) return [];
 
-      return {
-        ...member,
-        role: member.role as 'OWNER' | 'ADMIN' | 'MEMBER',
-        permissionCounts: {
-          view: Number(permCounts[0]?.view_count || 0),
-          edit: Number(permCounts[0]?.edit_count || 0),
-          share: Number(permCounts[0]?.share_count || 0),
-        },
-      };
-    })
+  const memberUserIds = members.map((m) => m.userId);
+  const idList = sql.join(memberUserIds.map((id) => sql`${id}`), sql`, `);
+
+  const { rows: permCountRows } = await db.execute(sql`
+    SELECT pp."userId",
+      COUNT(CASE WHEN pp."canView" THEN 1 END) as view_count,
+      COUNT(CASE WHEN pp."canEdit" THEN 1 END) as edit_count,
+      COUNT(CASE WHEN pp."canShare" THEN 1 END) as share_count
+    FROM page_permissions pp
+    JOIN pages p ON pp."pageId" = p.id
+    WHERE p."driveId" = ${driveId}
+      AND pp."userId" IN (${idList})
+    GROUP BY pp."userId"
+  `);
+
+  const permMap = new Map(
+    (permCountRows as Array<Record<string, unknown>>).map((row) => [
+      row.userId as string,
+      {
+        view: Number(row.view_count || 0),
+        edit: Number(row.edit_count || 0),
+        share: Number(row.share_count || 0),
+      },
+    ])
   );
 
-  return memberData;
+  return members.map((member) => ({
+    ...member,
+    role: member.role as 'OWNER' | 'ADMIN' | 'MEMBER',
+    permissionCounts: permMap.get(member.userId) ?? { view: 0, edit: 0, share: 0 },
+  }));
 }
 
 /**


### PR DESCRIPTION
## Problem

`GET /api/drives/:driveId/members` timed out at ~4 minutes through the MCP connector. Root cause: `listDriveMembers()` ran **N separate `db.execute` calls** (one per member) via `Promise.all`, which competed for connection pool slots and caused the pool to exhaust on drives with non-trivial member counts.

## Fix

Replace the N+1 pattern with a single batched query using `sql.join` to build the `IN` list and `GROUP BY pp."userId"` to aggregate counts server-side. Results are merged back onto member objects via a `Map` lookup — total DB round-trips drop from **N+1 → 2**.

```typescript
// Before — N queries
const memberData = await Promise.all(
  members.map(async (member) => {
    const { rows } = await db.execute(sql`SELECT COUNT(...) WHERE userId = ${member.userId} ...`);
    ...
  })
);

// After — 1 batched query
const { rows: permCountRows } = await db.execute(sql`
  SELECT pp."userId", COUNT(...) ... WHERE pp."userId" IN (${idList}) GROUP BY pp."userId"
`);
const permMap = new Map(permCountRows.map(row => [row.userId, { ... }]));
return members.map(member => ({ ...member, permissionCounts: permMap.get(member.userId) ?? { view: 0, edit: 0, share: 0 } }));
```

Added an early-return for the empty-members case (skips the permission query entirely).

## Files changed

- `packages/lib/src/services/drive-member-service.ts` — batched query in `listDriveMembers()`
- `packages/lib/src/services/__tests__/drive-member-service.test.ts` — updated tests + added empty-members and zero-permissions cases; asserts `execute` is called exactly once

## Test plan

- [ ] `bun run --filter '@pagespace/lib' test -- drive-member-service` passes (20/20)
- [ ] Call `list_drive_members` via MCP on a drive with multiple members — should return promptly instead of timing out

Closes #1684
Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEiWJvPTqq2935j1d5uWWu