### PR TITLE
feat(sandbox): ergonomics — auth boundary, git cwd, editFile, persistence guidance

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -49,6 +49,7 @@ import {
 import { planCommandExecution } from '@/lib/ai/core/command-resolver';
 import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import { buildSystemPrompt, buildPersonalizationPrompt } from '@/lib/ai/core/system-prompt';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
 import { filterToolsForReadOnly } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
@@ -836,7 +837,8 @@ export async function POST(request: Request) {
           breadcrumbs: pageContext.breadcrumbs,
         } : undefined,
         readOnlyMode,
-        personalization ?? undefined
+        personalization ?? undefined,
+        isCodeExecutionEnabled()
       );
 
       // Append workspace knowledge (tool-aware). Custom systemPrompt = opt-out (blank slate).

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -31,6 +31,7 @@ import {
 import { planCommandExecution } from '@/lib/ai/core/command-resolver';
 import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import { buildSystemPrompt, buildNonCoreToolNamesPrompt, TOOL_DISCOVERY_PROMPT } from '@/lib/ai/core/system-prompt';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { buildAgentAwarenessPrompt } from '@/lib/ai/core/agent-awareness';
 import { filterToolsForReadOnly, filterToolsForWebSearch } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree-context';
@@ -595,7 +596,8 @@ export async function POST(
         breadcrumbs: locationContext.breadcrumbs,
       } : undefined,
       readOnlyMode,
-      personalization ?? undefined
+      personalization ?? undefined,
+      isCodeExecutionEnabled()
     );
 
     // Build timestamp system prompt for temporal awareness (using user's timezone)

--- a/apps/web/src/lib/ai/core/__tests__/system-prompt.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/system-prompt.test.ts
@@ -75,6 +75,37 @@ describe('buildSystemPrompt — general', () => {
   });
 });
 
+describe('buildSystemPrompt — sandbox guidance', () => {
+  it('given codeExecutionEnabled true, should include the sandbox guidance section', () => {
+    const result = buildSystemPrompt('drive', { driveSlug: 'd', driveId: '1' }, false, undefined, true);
+    expect(result).toContain('/workspace');
+    expect(result).toContain('persists');
+  });
+
+  it('given the default call (no flag), should NOT include sandbox guidance', () => {
+    const result = buildSystemPrompt('drive', { driveSlug: 'd', driveId: '1' });
+    expect(result).not.toContain('/workspace');
+  });
+
+  it('given codeExecutionEnabled false explicitly, should NOT include sandbox guidance', () => {
+    const result = buildSystemPrompt('dashboard', undefined, false, undefined, false);
+    expect(result).not.toContain('/workspace');
+  });
+
+  it('given the sandbox guidance, should cover the auth boundary, cwd, editFile, persistence, and key tools', () => {
+    const result = buildSystemPrompt('dashboard', undefined, false, undefined, true);
+    // Auth boundary → dedicated tools
+    expect(result).toContain('gh_pr_create');
+    expect(result).toContain('git_*');
+    // cwd / fresh-process
+    expect(result).toContain('cwd');
+    // editFile vs writeFile
+    expect(result).toContain('editFile');
+    // reuse-don't-recreate
+    expect(result).toContain('gh_pr_list');
+  });
+});
+
 describe('buildPersonalizationPrompt', () => {
   it('returns null when personalization is disabled', () => {
     const result = buildPersonalizationPrompt({ enabled: false });

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -186,4 +186,59 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(filtered).not.toHaveProperty('delete_task_trigger');
     expect(filtered).toHaveProperty('list_calendar_events');
   });
+
+  it('classifies sandbox mutators (bash/writeFile/editFile + writing git/gh) as write tools', () => {
+    for (const name of [
+      'bash',
+      'writeFile',
+      'editFile',
+      'git_clone',
+      'git_add',
+      'git_commit',
+      'git_push',
+      'git_checkout',
+      'gh_pr_create',
+      'gh_pr_merge',
+      'gh_issue_create',
+    ]) {
+      expect(isWriteTool(name)).toBe(true);
+    }
+  });
+
+  it('keeps read-only sandbox tools available (readFile, git_status/diff/log, gh_pr_view/list)', () => {
+    for (const name of [
+      'readFile',
+      'git_status',
+      'git_diff',
+      'git_log',
+      'gh_pr_list',
+      'gh_pr_view',
+      'gh_issue_list',
+      'gh_issue_view',
+    ]) {
+      expect(isWriteTool(name)).toBe(false);
+    }
+  });
+
+  it('excludes sandbox mutators in read-only mode but keeps readFile and git_status', () => {
+    const tools = {
+      bash: 'w',
+      writeFile: 'w',
+      editFile: 'w',
+      git_push: 'w',
+      gh_pr_create: 'w',
+      readFile: 'r',
+      git_status: 'r',
+      gh_pr_view: 'r',
+    };
+    const filtered = filterToolsForReadOnly(tools, true);
+    expect(filtered).not.toHaveProperty('bash');
+    expect(filtered).not.toHaveProperty('writeFile');
+    expect(filtered).not.toHaveProperty('editFile');
+    expect(filtered).not.toHaveProperty('git_push');
+    expect(filtered).not.toHaveProperty('gh_pr_create');
+    expect(filtered).toHaveProperty('readFile');
+    expect(filtered).toHaveProperty('git_status');
+    expect(filtered).toHaveProperty('gh_pr_view');
+  });
 });

--- a/apps/web/src/lib/ai/core/complete-request-builder.ts
+++ b/apps/web/src/lib/ai/core/complete-request-builder.ts
@@ -19,6 +19,7 @@ import {
   type JsonSchema,
 } from './schema-introspection';
 import { estimateSystemPromptTokens } from '@pagespace/lib/monitoring/ai-context-calculator';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { pageSpaceTools } from './ai-tools';
 import { buildTimestampSystemPrompt } from './timestamp-utils';
 import { buildMentionSystemPrompt } from './mention-processor';
@@ -126,7 +127,9 @@ export function buildCompleteRequest(
           breadcrumbs: locationContext.breadcrumbs?.map((b) => b.title),
         }
       : undefined,
-    isReadOnly
+    isReadOnly,
+    undefined,
+    isCodeExecutionEnabled()
   );
 
   // Build inline instructions based on context type

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -85,6 +85,17 @@ const READ_ONLY_CONSTRAINT = `READ-ONLY MODE:
 • Focus on exploring, analyzing, and planning
 • Create actionable plans for the user to execute later`;
 
+// Appended only when the code-execution sandbox tools are registered for the
+// request (same gate as ai-tools.ts). Deliberately short — the basics that make
+// the sandbox smooth to use, not a wall of instructions.
+const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
+• Working dir is /workspace; writeFile/readFile/editFile paths are relative to it.
+• The /workspace filesystem persists across turns and tool calls in this conversation — your clone, branch checkout, and commits are still there next turn. Check state before recreating it: git_status / git_branch before re-cloning or branching; gh_pr_list / gh_pr_view before opening a PR. To update an open PR, push more commits to its branch (force-push is fine for your PR branch, never to main/master) — don't open a second PR.
+• Each tool call is a fresh process — cd does NOT persist between calls (the filesystem persists, the shell does not). Pass cwd to operate inside a subdirectory (e.g. a cloned repo).
+• bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
+• Use editFile for targeted string edits; writeFile rewrites the whole file.
+• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view.`;
+
 /**
  * Build personalization prompt section from user preferences
  */
@@ -155,7 +166,8 @@ export function buildSystemPrompt(
   contextType: 'dashboard' | 'drive' | 'page',
   contextInfo?: ContextInfo,
   isReadOnly: boolean = false,
-  personalization?: PersonalizationInfo
+  personalization?: PersonalizationInfo,
+  codeExecutionEnabled: boolean = false
 ): string {
   const contextPrompt = buildContextPrompt(contextType, contextInfo);
   const personalizationPrompt = buildPersonalizationPrompt(personalization);
@@ -172,6 +184,7 @@ export function buildSystemPrompt(
     contextPrompt,
     BEHAVIOR_PROMPT,
     isReadOnly ? READ_ONLY_CONSTRAINT : null,
+    codeExecutionEnabled ? SANDBOX_INSTRUCTIONS : null,
   ].filter(Boolean);
 
   return sections.join('\n\n');

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -61,6 +61,33 @@ export const WRITE_TOOLS = new Set([
   'create_command',
   'update_command',
   'delete_command',
+  // Sandbox / code-execution operations — all mutate the persistent sandbox
+  // filesystem or a remote. bash can run arbitrary mutations, so it is excluded
+  // in read-only mode too. Read-only sandbox tools (readFile, git_status,
+  // git_diff, git_log, gh_pr_list, gh_pr_view, gh_issue_list, gh_issue_view) are
+  // intentionally NOT listed and remain available.
+  'bash',
+  'writeFile',
+  'editFile',
+  'git_clone',
+  'git_init',
+  'git_config',
+  'git_remote_add',
+  'git_add',
+  'git_reset',
+  'git_stash',
+  'git_commit',
+  'git_merge',
+  'git_rebase',
+  'git_checkout',
+  'git_branch',
+  'git_fetch',
+  'git_pull',
+  'git_push',
+  'gh_pr_create',
+  'gh_pr_merge',
+  'gh_pr_checkout',
+  'gh_issue_create',
 ]);
 
 // Web search tools (excluded when web search is disabled)

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -291,6 +291,41 @@ describe('git_push', () => {
     expect(calls[0].args).toContain('pu/fix-x');
   });
 
+  it('rejects a force-push refspec whose destination is the default branch (HEAD:main)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!({ force: true, branch: 'HEAD:main' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('rejects a force-push refspec to a fully-qualified default ref (feature:refs/heads/master)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!(
+      { force: true, branch: 'feature:refs/heads/master' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('rejects a +-prefixed force refspec to the default branch even without the force flag', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!({ branch: '+main' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('allows a force-push whose refspec destination is a feature branch (main:feature)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute!({ force: true, branch: 'main:feature' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('main:feature');
+  });
+
   it('allows a non-force push with no branch (current branch)', async () => {
     const deps = makeDeps();
     const { git_push } = createSandboxGitTools(deps);

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -252,10 +252,51 @@ describe('git_push', () => {
   it('uses --force-with-lease, not --force', async () => {
     const deps = makeDeps();
     const { git_push } = createSandboxGitTools(deps);
-    await git_push.execute!({ force: true }, {} as never);
+    await git_push.execute!({ force: true, branch: 'feature' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--force-with-lease');
     expect(calls[0].args).not.toContain('--force');
+  });
+
+  it('rejects force-push to main without opening a sandbox', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!({ force: true, branch: 'main' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('rejects force-push to master (case-insensitive)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!({ force: true, branch: 'MASTER' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('rejects force-push without an explicit branch (cannot verify the target)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!({ force: true }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('allows force-push to a feature branch', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute!({ force: true, branch: 'pu/fix-x' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--force-with-lease');
+    expect(calls[0].args).toContain('pu/fix-x');
+  });
+
+  it('allows a non-force push with no branch (current branch)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args[0]).toBe('push');
   });
 
   it('includes -u when set_upstream: true', async () => {
@@ -348,6 +389,42 @@ describe('gh_issue_create', () => {
     const result = await gh_issue_create.execute!({ title: 'Issue', body: 'b' }, {} as never);
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── cwd threading ────────────────────────────────────────────────────────────
+
+describe('cwd threading', () => {
+  it('git_status forwards cwd into the runner, resolved under /workspace', async () => {
+    const deps = makeDeps();
+    const { git_status } = createSandboxGitTools(deps);
+    await git_status.execute!({ cwd: 'repo' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect((calls[0] as unknown as { cwd: string }).cwd).toBe('/workspace/repo');
+  });
+
+  it('git_commit forwards cwd into the runner', async () => {
+    const deps = makeDeps();
+    const { git_commit } = createSandboxGitTools(deps);
+    await git_commit.execute!({ message: 'msg', cwd: 'repo' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect((calls[0] as unknown as { cwd: string }).cwd).toBe('/workspace/repo');
+  });
+
+  it('gh_pr_create forwards cwd into the runner', async () => {
+    const deps = makeDeps();
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    await gh_pr_create.execute!({ title: 'PR', body: 'b', cwd: 'repo' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect((calls[0] as unknown as { cwd: string }).cwd).toBe('/workspace/repo');
+  });
+
+  it('defaults to the sandbox root when no cwd is given', async () => {
+    const deps = makeDeps();
+    const { git_status } = createSandboxGitTools(deps);
+    await git_status.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect((calls[0] as unknown as { cwd: string }).cwd).toBe('/workspace');
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -326,6 +326,22 @@ describe('git_push', () => {
     expect(calls[0].args).toContain('main:feature');
   });
 
+  it('rejects deleting the default branch via an empty-source refspec (:main)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    const result = await git_push.execute!({ branch: ':main' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('allows deleting a feature branch (:feature)', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute!({ branch: ':feature' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain(':feature');
+  });
+
   it('allows a non-force push with no branch (current branch)', async () => {
     const deps = makeDeps();
     const { git_push } = createSandboxGitTools(deps);

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -123,4 +123,39 @@ describe('createSandboxTools', () => {
     expect(schema.safeParse({ command: '' }).success).toBe(false);
     expect(schema.safeParse({ command: 'ls' }).success).toBe(true);
   });
+
+  it('editFile: should delegate and report replacements', async () => {
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
+    const result = await exec(tools.editFile, { path: 'a.txt', oldString: 'data', newString: 'X' }, {});
+    expect(result).toMatchObject({ success: true, path: 'a.txt', replacements: 1 });
+  });
+
+  it('editFile: given the gate denies, should not edit', async () => {
+    let wrote = false;
+    const runDeps = fakeRunDeps();
+    runDeps.reconnect = async () => ({
+      sandboxId: 'sbx',
+      runCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      writeFiles: async () => {
+        wrote = true;
+      },
+      readFileToBuffer: async () => Buffer.from('data'),
+    });
+    const tools = createSandboxTools({
+      runDeps,
+      resolveContext: okResolve,
+      gate: async () => ({ ok: false, reason: 'kill_switch_off', error: 'disabled' }),
+    });
+    const result = await exec(tools.editFile, { path: 'a.txt', oldString: 'data', newString: 'X' }, {});
+    expect(result).toEqual({ success: false, error: 'disabled' });
+    expect(wrote).toBe(false);
+  });
+
+  it('editFile inputSchema: should require path/oldString/newString and accept replaceAll', () => {
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
+    const schema = tools.editFile.inputSchema as { safeParse: (v: unknown) => { success: boolean } };
+    expect(schema.safeParse({ path: 'a', oldString: 'x', newString: 'y' }).success).toBe(true);
+    expect(schema.safeParse({ path: 'a', oldString: 'x', newString: 'y', replaceAll: true }).success).toBe(true);
+    expect(schema.safeParse({ path: 'a', oldString: 'x' }).success).toBe(false);
+  });
 });

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -19,8 +19,17 @@ import { z } from 'zod';
 import type { SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
 import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
 import { runGitInSandbox } from '@pagespace/lib/services/sandbox/git-tool-runners';
-import type { ResolveSandboxContext, SandboxGate } from './sandbox-tools';
+import { MAX_PATH_LENGTH, type ResolveSandboxContext, type SandboxGate } from './sandbox-tools';
 import type { ToolExecutionContext } from '../core/types';
+
+// Optional per-call working directory, relative to the sandbox root (/workspace).
+// Each tool call is a fresh process, so cwd never persists between calls — pass it
+// to operate inside a cloned subdirectory. The runner validates it (path_escape).
+const cwdField = z.string().max(MAX_PATH_LENGTH).optional();
+
+// Default branch names we refuse to force-push to. Heuristic: only these common
+// names are auto-protected (a custom default branch is not).
+const DEFAULT_BRANCHES = new Set(['main', 'master']);
 
 export interface GitSandboxToolsDeps {
   gitRunDeps: GitSandboxRunDeps;
@@ -55,8 +64,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   };
 
   /** Direct-exec helper for local git commands (no token needed). */
-  const git = (cmd: 'git' | 'gh', args: string[], ctx: SandboxActorContext) =>
-    runGitInSandbox({ cmd, args, ctx, deps: gitRunDeps });
+  const git = (cmd: 'git' | 'gh', args: string[], ctx: SandboxActorContext, cwd?: string) =>
+    runGitInSandbox({ cmd, args, cwd, ctx, deps: gitRunDeps });
 
   /**
    * For remote/gh tools: pre-checks the GitHub token before opening a sandbox.
@@ -74,8 +83,13 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   };
 
   /** Remote-exec helper: passes the pre-resolved token to skip the second DB lookup. */
-  const gitR = (cmd: 'git' | 'gh', args: string[], ctx: SandboxActorContext, token: string) =>
-    runGitInSandbox({ cmd, args, ctx, deps: gitRunDeps, preResolvedToken: token });
+  const gitR = (
+    cmd: 'git' | 'gh',
+    args: string[],
+    ctx: SandboxActorContext,
+    token: string,
+    cwd?: string,
+  ) => runGitInSandbox({ cmd, args, cwd, ctx, deps: gitRunDeps, preResolvedToken: token });
 
   // ── Repo + config ───────────────────────────────────────────────────────
 
@@ -119,11 +133,12 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       key: z.string().min(1),
       value: z.string(),
       global: z.boolean().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ key, value, global: isGlobal }, options) => {
+    execute: async ({ key, value, global: isGlobal, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['config', ...(isGlobal ? ['--global'] : []), key, value], opened.ctx);
+      return git('git', ['config', ...(isGlobal ? ['--global'] : []), key, value], opened.ctx, cwd);
     },
   });
 
@@ -135,14 +150,15 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         .string()
         .url()
         .refine((u) => u.startsWith('https://'), 'Only HTTPS remote URLs are supported'),
+      cwd: cwdField,
     }),
-    execute: async ({ name, url }, options) => {
+    execute: async ({ name, url, cwd }, options) => {
       if (!url.startsWith('https://')) {
         return { success: false as const, error: 'Only HTTPS URLs are supported for git remote add.' };
       }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['remote', 'add', name, url], opened.ctx);
+      return git('git', ['remote', 'add', name, url], opened.ctx, cwd);
     },
   });
 
@@ -150,24 +166,25 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitStatus = tool({
     description: 'Show the working tree status in porcelain format.',
-    inputSchema: z.object({ path: z.string().optional() }),
-    execute: async ({ path }, options) => {
+    inputSchema: z.object({ path: z.string().optional(), cwd: cwdField }),
+    execute: async ({ path, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['status', '--porcelain', ...(path ? ['--', path] : [])], opened.ctx);
+      return git('git', ['status', '--porcelain', ...(path ? ['--', path] : [])], opened.ctx, cwd);
     },
   });
 
   const gitDiff = tool({
     description: 'Show changes in the working tree or staged changes.',
-    inputSchema: z.object({ staged: z.boolean().optional(), path: z.string().optional() }),
-    execute: async ({ staged, path }, options) => {
+    inputSchema: z.object({ staged: z.boolean().optional(), path: z.string().optional(), cwd: cwdField }),
+    execute: async ({ staged, path, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       return git(
         'git',
         ['diff', ...(staged ? ['--cached'] : []), ...(path ? ['--', path] : [])],
         opened.ctx,
+        cwd,
       );
     },
   });
@@ -175,17 +192,17 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   const gitAdd = tool({
     description: 'Stage files for commit.',
     inputSchema: z
-      .object({ paths: z.array(z.string()).optional(), all: z.boolean().optional() })
+      .object({ paths: z.array(z.string()).optional(), all: z.boolean().optional(), cwd: cwdField })
       .refine((d) => d.all || (d.paths && d.paths.length > 0), {
         message: 'Provide paths or set all: true',
       }),
-    execute: async ({ paths, all }, options) => {
+    execute: async ({ paths, all, cwd }, options) => {
       if (!all && (!paths || paths.length === 0)) {
         return { success: false as const, error: 'Provide paths or set all: true' };
       }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['add', ...(all ? ['-A'] : paths!)], opened.ctx);
+      return git('git', ['add', ...(all ? ['-A'] : paths!)], opened.ctx, cwd);
     },
   });
 
@@ -194,11 +211,12 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       mode: z.enum(['soft', 'mixed', 'hard']),
       ref: z.string().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ mode, ref }, options) => {
+    execute: async ({ mode, ref, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['reset', `--${mode}`, ...(ref ? [ref] : [])], opened.ctx);
+      return git('git', ['reset', `--${mode}`, ...(ref ? [ref] : [])], opened.ctx, cwd);
     },
   });
 
@@ -207,15 +225,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       action: z.enum(['push', 'pop', 'list', 'drop']),
       message: z.string().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ action, message }, options) => {
+    execute: async ({ action, message, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       const args: string[] =
         action === 'push'
           ? ['stash', 'push', ...(message ? ['-m', message] : [])]
           : ['stash', action];
-      return git('git', args, opened.ctx);
+      return git('git', args, opened.ctx, cwd);
     },
   });
 
@@ -226,8 +245,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       message: z.string().min(1),
       amend: z.boolean().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ message, amend }, options) => {
+    execute: async ({ message, amend, cwd }, options) => {
       if (!message) {
         return { success: false as const, error: 'commit message is required' };
       }
@@ -237,6 +257,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         'git',
         ['commit', '-m', message, ...(amend ? ['--amend', '--no-edit'] : [])],
         opened.ctx,
+        cwd,
       );
     },
   });
@@ -247,8 +268,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       n: z.number().int().positive().max(100).optional(),
       path: z.string().optional(),
       oneline: z.boolean().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ n, path, oneline }, options) => {
+    execute: async ({ n, path, oneline, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       const useOneline = oneline ?? true;
@@ -261,6 +283,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ...(path ? ['--', path] : []),
         ],
         opened.ctx,
+        cwd,
       );
     },
   });
@@ -270,42 +293,43 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       branch: z.string().min(1),
       strategy: z.enum(['merge', 'squash', 'ff-only']).optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ branch, strategy }, options) => {
+    execute: async ({ branch, strategy, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       const strategyFlag =
         strategy === 'squash' ? ['--squash'] : strategy === 'ff-only' ? ['--ff-only'] : [];
-      return git('git', ['merge', ...strategyFlag, branch], opened.ctx);
+      return git('git', ['merge', ...strategyFlag, branch], opened.ctx, cwd);
     },
   });
 
   const gitRebase = tool({
     description: 'Rebase onto a branch or ref. Non-interactive only.',
-    inputSchema: z.object({ branch_or_ref: z.string().min(1) }),
-    execute: async ({ branch_or_ref }, options) => {
+    inputSchema: z.object({ branch_or_ref: z.string().min(1), cwd: cwdField }),
+    execute: async ({ branch_or_ref, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['rebase', branch_or_ref], opened.ctx);
+      return git('git', ['rebase', branch_or_ref], opened.ctx, cwd);
     },
   });
 
   const gitCheckout = tool({
     description: 'Switch branches or create a new one.',
-    inputSchema: z.object({ ref: z.string().min(1), create: z.boolean().optional() }),
-    execute: async ({ ref, create }, options) => {
+    inputSchema: z.object({ ref: z.string().min(1), create: z.boolean().optional(), cwd: cwdField }),
+    execute: async ({ ref, create, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['checkout', ...(create ? ['-b'] : []), ref], opened.ctx);
+      return git('git', ['checkout', ...(create ? ['-b'] : []), ref], opened.ctx, cwd);
     },
   });
 
   const gitBranch = tool({
     description: 'List, create, or delete branches.',
     inputSchema: z
-      .object({ action: z.enum(['list', 'create', 'delete']), name: z.string().optional() })
+      .object({ action: z.enum(['list', 'create', 'delete']), name: z.string().optional(), cwd: cwdField })
       .refine((d) => d.action === 'list' || !!d.name, { message: 'name required for create/delete' }),
-    execute: async ({ action, name }, options) => {
+    execute: async ({ action, name, cwd }, options) => {
       if ((action === 'create' || action === 'delete') && !name) {
         return { success: false as const, error: 'name is required for create/delete' };
       }
@@ -313,7 +337,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       if (!opened.ok) return opened.error;
       const args =
         action === 'list' ? ['branch', '-a'] : action === 'delete' ? ['branch', '-d', name!] : ['branch', name!];
-      return git('git', args, opened.ctx);
+      return git('git', args, opened.ctx, cwd);
     },
   });
 
@@ -321,10 +345,10 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitFetch = tool({
     description: 'Fetch from a remote. Requires a connected GitHub account.',
-    inputSchema: z.object({ remote: z.string().optional(), branch: z.string().optional() }),
-    execute: async ({ remote, branch }, options) =>
+    inputSchema: z.object({ remote: z.string().optional(), branch: z.string().optional(), cwd: cwdField }),
+    execute: async ({ remote, branch, cwd }, options) =>
       withToken(options, (ctx, token) =>
-        gitR('git', ['fetch', remote ?? 'origin', ...(branch ? [branch] : [])], ctx, token),
+        gitR('git', ['fetch', remote ?? 'origin', ...(branch ? [branch] : [])], ctx, token, cwd),
       ),
   });
 
@@ -334,28 +358,51 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       remote: z.string().optional(),
       branch: z.string().optional(),
       rebase: z.boolean().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ remote, branch, rebase }, options) =>
+    execute: async ({ remote, branch, rebase, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
           'git',
           ['pull', ...(rebase ? ['--rebase'] : []), remote ?? 'origin', ...(branch ? [branch] : [])],
           ctx,
           token,
+          cwd,
         ),
       ),
   });
 
   const gitPush = tool({
-    description: 'Push to a remote. Requires a connected GitHub account.',
+    description:
+      'Push to a remote. Requires a connected GitHub account. cwd defaults to /workspace — pass it to push from a cloned subdir. Force-push (--force-with-lease) is allowed on feature/PR branches but refused for the default branch (main/master); to update an open PR, push to its branch rather than opening a new one.',
     inputSchema: z.object({
       remote: z.string().optional(),
       branch: z.string().optional(),
       force: z.boolean().optional(),
       set_upstream: z.boolean().optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ remote, branch, force, set_upstream }, options) =>
-      withToken(options, (ctx, token) =>
+    execute: async ({ remote, branch, force, set_upstream, cwd }, options) => {
+      // Force-push is fine for a feature/PR branch, but never the default branch.
+      // Require an explicit branch under force so we can verify the target — we
+      // can't see the sandbox's current branch from here.
+      if (force) {
+        if (!branch) {
+          return {
+            success: false as const,
+            error:
+              'Force-push requires an explicit branch so the target can be verified. Name the feature/PR branch to push to.',
+          };
+        }
+        if (DEFAULT_BRANCHES.has(branch.toLowerCase())) {
+          return {
+            success: false as const,
+            error:
+              'Refusing to force-push to the default branch (main/master). Force-push is allowed on feature/PR branches only.',
+          };
+        }
+      }
+      return withToken(options, (ctx, token) =>
         gitR(
           'git',
           [
@@ -367,8 +414,10 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
-      ),
+      );
+    },
   });
 
   // ── GitHub PRs (token required) ─────────────────────────────────────────
@@ -381,8 +430,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       base: z.string().optional(),
       draft: z.boolean().optional(),
       labels: z.array(z.string()).optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ title, body, base, draft, labels }, options) => {
+    execute: async ({ title, body, base, draft, labels, cwd }, options) => {
       if (!title) {
         return { success: false as const, error: 'title is required' };
       }
@@ -399,6 +449,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       );
     },
@@ -409,8 +460,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       state: z.enum(['open', 'closed', 'merged', 'all']).optional(),
       limit: z.number().int().positive().max(100).optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ state, limit }, options) =>
+    execute: async ({ state, limit, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
           'gh',
@@ -422,14 +474,15 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       ),
   });
 
   const ghPrView = tool({
     description: 'View a pull request. Requires a connected GitHub account.',
-    inputSchema: z.object({ number: z.number().int().positive().optional() }),
-    execute: async ({ number }, options) =>
+    inputSchema: z.object({ number: z.number().int().positive().optional(), cwd: cwdField }),
+    execute: async ({ number, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
           'gh',
@@ -440,6 +493,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       ),
   });
@@ -449,8 +503,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       number: z.number().int().positive().optional(),
       strategy: z.enum(['merge', 'squash', 'rebase']),
+      cwd: cwdField,
     }),
-    execute: async ({ number, strategy }, options) =>
+    execute: async ({ number, strategy, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
           'gh',
@@ -462,15 +517,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       ),
   });
 
   const ghPrCheckout = tool({
     description: 'Check out a pull request locally. Requires a connected GitHub account.',
-    inputSchema: z.object({ number: z.number().int().positive() }),
-    execute: async ({ number }, options) =>
-      withToken(options, (ctx, token) => gitR('gh', ['pr', 'checkout', String(number)], ctx, token)),
+    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) => gitR('gh', ['pr', 'checkout', String(number)], ctx, token, cwd)),
   });
 
   // ── GitHub Issues (token required) ──────────────────────────────────────
@@ -481,8 +537,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       title: z.string().min(1),
       body: z.string(),
       labels: z.array(z.string()).optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ title, body, labels }, options) => {
+    execute: async ({ title, body, labels, cwd }, options) => {
       if (!title) {
         return { success: false as const, error: 'title is required' };
       }
@@ -497,6 +554,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       );
     },
@@ -507,8 +565,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({
       state: z.enum(['open', 'closed', 'all']).optional(),
       limit: z.number().int().positive().max(100).optional(),
+      cwd: cwdField,
     }),
-    execute: async ({ state, limit }, options) =>
+    execute: async ({ state, limit, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
           'gh',
@@ -520,14 +579,15 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       ),
   });
 
   const ghIssueView = tool({
     description: 'View an issue. Requires a connected GitHub account.',
-    inputSchema: z.object({ number: z.number().int().positive() }),
-    execute: async ({ number }, options) =>
+    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }),
+    execute: async ({ number, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
           'gh',
@@ -538,6 +598,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           ],
           ctx,
           token,
+          cwd,
         ),
       ),
   });

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -41,6 +41,14 @@ function pushDestinationBranch(refspec: string): string {
   return dst.replace(/^refs\/heads\//, '').trim().toLowerCase();
 }
 
+// A delete refspec has an empty source: `:dst` (or `+:dst`). `git push origin
+// :main` deletes the remote default branch — as destructive as a force-push, so
+// the same guard must catch it.
+function isDeleteRefspec(refspec: string): boolean {
+  const spec = refspec.startsWith('+') ? refspec.slice(1) : refspec;
+  return spec.includes(':') && spec.slice(0, spec.lastIndexOf(':')).trim() === '';
+}
+
 export interface GitSandboxToolsDeps {
   gitRunDeps: GitSandboxRunDeps;
   resolveContext: ResolveSandboxContext;
@@ -400,21 +408,22 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       // from here — and check the refspec DESTINATION, not the raw value, so
       // `HEAD:main` / `feature:refs/heads/master` can't slip past.
       const forcing = force === true || (branch?.startsWith('+') ?? false);
-      if (forcing) {
-        if (!branch) {
-          return {
-            success: false as const,
-            error:
-              'Force-push requires an explicit branch so the target can be verified. Name the feature/PR branch to push to.',
-          };
-        }
-        if (DEFAULT_BRANCHES.has(pushDestinationBranch(branch))) {
-          return {
-            success: false as const,
-            error:
-              'Refusing to force-push to the default branch (main/master). Force-push is allowed on feature/PR branches only.',
-          };
-        }
+      if (forcing && !branch) {
+        return {
+          success: false as const,
+          error:
+            'Force-push requires an explicit branch so the target can be verified. Name the feature/PR branch to push to.',
+        };
+      }
+      // Destructive = force-push (rewrites history) or delete (`:branch`). Either
+      // one against the default branch is refused; a normal fast-forward push is not.
+      const destructive = forcing || (branch ? isDeleteRefspec(branch) : false);
+      if (destructive && branch && DEFAULT_BRANCHES.has(pushDestinationBranch(branch))) {
+        return {
+          success: false as const,
+          error:
+            'Refusing to force-push or delete the default branch (main/master). These are allowed on feature/PR branches only.',
+        };
       }
       return withToken(options, (ctx, token) =>
         gitR(

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -31,6 +31,16 @@ const cwdField = z.string().max(MAX_PATH_LENGTH).optional();
 // names are auto-protected (a custom default branch is not).
 const DEFAULT_BRANCHES = new Set(['main', 'master']);
 
+// The ref a push actually writes on the remote. A push target is a refspec
+// `[+]<src>:<dst>` (or `[+]<branch>`), so the destination is the segment after
+// the last ':' — a bare-name check misses `HEAD:main` or `feature:refs/heads/master`.
+// Returns the lowercased short branch name for comparison against DEFAULT_BRANCHES.
+function pushDestinationBranch(refspec: string): string {
+  const spec = refspec.startsWith('+') ? refspec.slice(1) : refspec;
+  const dst = spec.includes(':') ? spec.slice(spec.lastIndexOf(':') + 1) : spec;
+  return dst.replace(/^refs\/heads\//, '').trim().toLowerCase();
+}
+
 export interface GitSandboxToolsDeps {
   gitRunDeps: GitSandboxRunDeps;
   resolveContext: ResolveSandboxContext;
@@ -384,9 +394,13 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     }),
     execute: async ({ remote, branch, force, set_upstream, cwd }, options) => {
       // Force-push is fine for a feature/PR branch, but never the default branch.
-      // Require an explicit branch under force so we can verify the target — we
-      // can't see the sandbox's current branch from here.
-      if (force) {
+      // A push forces when the `force` flag is set OR the refspec is `+`-prefixed
+      // (per-refspec force), so guard both. Require an explicit branch under force
+      // so the target can be verified — we can't see the sandbox's current branch
+      // from here — and check the refspec DESTINATION, not the raw value, so
+      // `HEAD:main` / `feature:refs/heads/master` can't slip past.
+      const forcing = force === true || (branch?.startsWith('+') ?? false);
+      if (forcing) {
         if (!branch) {
           return {
             success: false as const,
@@ -394,7 +408,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
               'Force-push requires an explicit branch so the target can be verified. Name the feature/PR branch to push to.',
           };
         }
-        if (DEFAULT_BRANCHES.has(branch.toLowerCase())) {
+        if (DEFAULT_BRANCHES.has(pushDestinationBranch(branch))) {
           return {
             success: false as const,
             error:

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -250,7 +250,7 @@ export const resolveSandboxActorContext: ResolveSandboxContext =
  * default-OFF feature flag — importing this object does not expose anything by
  * itself.
  */
-export function buildSandboxTools(): { bash: Tool; writeFile: Tool; readFile: Tool } {
+export function buildSandboxTools(): { bash: Tool; writeFile: Tool; readFile: Tool; editFile: Tool } {
   return createSandboxTools({
     runDeps: buildRealSandboxRunDeps(),
     resolveContext: resolveSandboxActorContext,

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -31,7 +31,7 @@ import { MAX_COMMAND_BYTES } from '@pagespace/lib/services/sandbox/command-polic
 import type { SandboxToolGateResult } from '@pagespace/lib/services/sandbox/tool-gate';
 import type { ToolExecutionContext } from '../core/types';
 
-const MAX_PATH_LENGTH = 1024;
+export const MAX_PATH_LENGTH = 1024;
 
 export const bashInputSchema = z.object({
   command: z

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -23,6 +23,7 @@ import {
   runBashInSandbox,
   writeSandboxFile,
   readSandboxFile,
+  editSandboxFile,
   MAX_WRITE_BYTES,
   type SandboxActorContext,
   type SandboxRunDeps,
@@ -48,6 +49,13 @@ export const writeFileInputSchema = z.object({
 
 export const readFileInputSchema = z.object({
   path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
+});
+
+export const editFileInputSchema = z.object({
+  path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
+  oldString: z.string().min(1, 'oldString is required'),
+  newString: z.string(),
+  replaceAll: z.boolean().optional(),
 });
 
 /** Resolves the actor context for a turn, or an error to surface to the model. */
@@ -84,6 +92,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate }: SandboxToo
   bash: Tool;
   writeFile: Tool;
   readFile: Tool;
+  editFile: Tool;
 } {
   // Resolve the actor, then run the call-time gate (kill-switch + canRunCode +
   // quota) BEFORE delegating to the runner — a denial returns a safe error and
@@ -130,6 +139,17 @@ export function createSandboxTools({ runDeps, resolveContext, gate }: SandboxToo
         const opened = await open(options);
         if (!opened.ok) return opened.error;
         return readSandboxFile({ path, ctx: opened.ctx, deps: runDeps });
+      },
+    }),
+
+    editFile: tool({
+      description:
+        'Edit a file in this conversation\'s sandbox by replacing oldString with newString. oldString must be unique in the file unless replaceAll is set. Prefer this over writeFile for targeted changes — it does not rewrite the whole file. The path is relative to the sandbox root and cannot escape it.',
+      inputSchema: editFileInputSchema,
+      execute: async ({ path, oldString, newString, replaceAll }, options) => {
+        const opened = await open(options);
+        if (!opened.ok) return opened.error;
+        return editSandboxFile({ path, oldString, newString, replaceAll, ctx: opened.ctx, deps: runDeps });
       },
     }),
   };

--- a/packages/lib/src/services/sandbox/__tests__/command-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/command-policy.test.ts
@@ -52,3 +52,67 @@ describe('evaluateCommandPolicy', () => {
     });
   });
 });
+
+describe('evaluateCommandPolicy — github-over-bash redirect', () => {
+  // bash has no GitHub credentials; these must redirect to the dedicated tools.
+  const denied = [
+    'gh',
+    'gh pr list',
+    'gh pr create --title x --body y',
+    'git push',
+    'git push origin main',
+    'git push --force-with-lease',
+    'git clone https://github.com/o/r.git',
+    'git fetch origin',
+    'git pull --rebase',
+  ];
+  for (const command of denied) {
+    it(`given "${command}" in bash, should deny with github_over_bash`, () => {
+      expect(evaluateCommandPolicy({ command })).toEqual({
+        ok: false,
+        reason: 'github_over_bash',
+      });
+    });
+  }
+
+  // Local, credential-free git works fine in bash — do not block it.
+  const allowed = [
+    'git status',
+    'git status --porcelain',
+    'git log --oneline',
+    'git add -A',
+    'git commit -m "msg"',
+    'git diff --cached',
+    'echo gh', // gh as an argument, not a command
+    'echo git push', // not at a command boundary
+    'github --help', // not the gh CLI
+    'legit push', // git inside a word
+  ];
+  for (const command of allowed) {
+    it(`given "${command}", should allow it (credential-free)`, () => {
+      expect(evaluateCommandPolicy({ command })).toEqual({ ok: true });
+    });
+  }
+
+  it('given a GitHub op after a command separator, should still deny (chained)', () => {
+    expect(evaluateCommandPolicy({ command: 'cd repo && gh pr create' })).toEqual({
+      ok: false,
+      reason: 'github_over_bash',
+    });
+    expect(evaluateCommandPolicy({ command: 'echo hi; git push' })).toEqual({
+      ok: false,
+      reason: 'github_over_bash',
+    });
+    expect(evaluateCommandPolicy({ command: 'foo | git fetch' })).toEqual({
+      ok: false,
+      reason: 'github_over_bash',
+    });
+  });
+
+  it('given a pathological input (under the size cap), should terminate (ReDoS-safe) and return a decision', () => {
+    // Stay under MAX_COMMAND_BYTES so the size guard doesn't short-circuit before
+    // the regex runs — this exercises the matcher's linear scan on a long input.
+    const command = ' '.repeat(10_000) + 'git status';
+    expect(evaluateCommandPolicy({ command })).toEqual({ ok: true });
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/edit-file.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/edit-file.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { applyEdit } from '../edit-file';
+
+describe('applyEdit', () => {
+  it('given a unique oldString, should replace it once and report one replacement', () => {
+    const result = applyEdit({ content: 'a b c', oldString: 'b', newString: 'X' });
+    expect(result).toEqual({ ok: true, content: 'a X c', replacements: 1 });
+  });
+
+  it('given an oldString that does not occur, should fail with edit_no_match', () => {
+    const result = applyEdit({ content: 'a b c', oldString: 'zzz', newString: 'X' });
+    expect(result).toEqual({ ok: false, reason: 'edit_no_match' });
+  });
+
+  it('given multiple occurrences without replaceAll, should fail with edit_not_unique', () => {
+    const result = applyEdit({ content: 'x x x', oldString: 'x', newString: 'Y' });
+    expect(result).toEqual({ ok: false, reason: 'edit_not_unique' });
+  });
+
+  it('given multiple occurrences with replaceAll, should replace all and report the count', () => {
+    const result = applyEdit({ content: 'x x x', oldString: 'x', newString: 'Y', replaceAll: true });
+    expect(result).toEqual({ ok: true, content: 'Y Y Y', replacements: 3 });
+  });
+
+  it('given an empty newString, should delete the matched text', () => {
+    const result = applyEdit({ content: 'foo-bar', oldString: '-bar', newString: '' });
+    expect(result).toEqual({ ok: true, content: 'foo', replacements: 1 });
+  });
+
+  it('given an oldString with regex-special characters, should match it literally', () => {
+    const result = applyEdit({ content: 'value = a.b+c', oldString: 'a.b+c', newString: 'z' });
+    expect(result).toEqual({ ok: true, content: 'value = z', replacements: 1 });
+  });
+
+  it('given replaceAll with a regex-special oldString, should replace every literal occurrence', () => {
+    const result = applyEdit({ content: '$x $x', oldString: '$x', newString: 'q', replaceAll: true });
+    expect(result).toEqual({ ok: true, content: 'q q', replacements: 2 });
+  });
+
+  it('given a multi-line unique oldString, should replace across lines', () => {
+    const result = applyEdit({
+      content: 'line1\nline2\nline3',
+      oldString: 'line2\nline3',
+      newString: 'merged',
+    });
+    expect(result).toEqual({ ok: true, content: 'line1\nmerged', replacements: 1 });
+  });
+
+  it('given inputs, should not mutate the original content string', () => {
+    const content = 'a b c';
+    applyEdit({ content, oldString: 'b', newString: 'X' });
+    expect(content).toBe('a b c');
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../git-tool-runners';
 import type { SandboxActorContext } from '../tool-runners';
 import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
+import { SANDBOX_ROOT } from '../sandbox-paths';
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
 
@@ -163,6 +164,32 @@ describe('runGitInSandbox', () => {
     const { deps, runCommandCalls } = makeDepsWithSpy();
     await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
     expect(runCommandCalls[0].timeoutMs).toBe(120_000);
+  });
+
+  it('given no cwd, should default the working directory to the sandbox root', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].cwd).toBe(SANDBOX_ROOT);
+  });
+
+  it('given a valid relative cwd, should forward the resolved absolute path to runCommand', async () => {
+    const { deps, runCommandCalls } = makeDepsWithSpy();
+    await runGitInSandbox({ cmd: 'git', args: ['status'], cwd: 'myrepo', ctx: makeCtx(), deps });
+    expect(runCommandCalls[0].cwd).toBe(`${SANDBOX_ROOT}/myrepo`);
+  });
+
+  it('given a cwd that escapes the sandbox root, should deny path_escape before acquiring a slot', async () => {
+    const { deps, slots, runCommandCalls } = makeDepsWithSpy();
+    const result = await runGitInSandbox({
+      cmd: 'git',
+      args: ['status'],
+      cwd: '../../etc',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: false, reason: 'path_escape' });
+    expect(slots.acquired).toBe(0);
+    expect(runCommandCalls).toHaveLength(0);
   });
 
   it('releases the concurrency slot in finally even when sandbox.runCommand throws', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -345,7 +345,7 @@ describe('writeSandboxFile', () => {
 
 describe('editSandboxFile', () => {
   function makeEditDeps(fileContents: string | null) {
-    const written: Array<{ path: string; content: string }> = [];
+    const written: Array<{ path: string; content: string | Uint8Array }> = [];
     const { deps, slots, audits } = makeDeps({
       reconnect: async () =>
         makeSandbox({

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -3,6 +3,7 @@ import {
   runBashInSandbox,
   writeSandboxFile,
   readSandboxFile,
+  editSandboxFile,
   MAX_WRITE_BYTES,
   type SandboxActorContext,
   type SandboxRunDeps,
@@ -339,6 +340,119 @@ describe('writeSandboxFile', () => {
     expect(result).toEqual({ success: true, path: 'a/b.txt', bytesWritten: 2 });
     expect(writtenPaths[0]).toBe(`${SANDBOX_ROOT}/a/b.txt`);
     expect(slots.released).toBe(1);
+  });
+});
+
+describe('editSandboxFile', () => {
+  function makeEditDeps(fileContents: string | null) {
+    const written: Array<{ path: string; content: string }> = [];
+    const { deps, slots, audits } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          readFileToBuffer: async () => (fileContents === null ? null : Buffer.from(fileContents)),
+          writeFiles: async (files) => {
+            written.push(...files);
+          },
+        }),
+    });
+    return { deps, slots, audits, written };
+  }
+
+  it('given a unique oldString, should write the edited content and report one replacement', async () => {
+    const { deps, written, slots } = makeEditDeps('hello world');
+    const result = await editSandboxFile({
+      path: 'a.txt',
+      oldString: 'world',
+      newString: 'there',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: true, path: 'a.txt', replacements: 1 });
+    expect(written[0]).toEqual({ path: `${SANDBOX_ROOT}/a.txt`, content: 'hello there' });
+    expect(slots.released).toBe(1);
+  });
+
+  it('given replaceAll, should replace every occurrence', async () => {
+    const { deps, written } = makeEditDeps('x x x');
+    const result = await editSandboxFile({
+      path: 'a.txt',
+      oldString: 'x',
+      newString: 'Y',
+      replaceAll: true,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: true, replacements: 3 });
+    expect(written[0].content).toBe('Y Y Y');
+  });
+
+  it('given a traversal path, should deny path_escape before provisioning and audit a blocked_command', async () => {
+    let acquired = false;
+    const { deps, audits } = makeDeps({
+      acquireSandbox: async () => {
+        acquired = true;
+        return { ok: true, sandboxId: 'sbx-1', resumed: false };
+      },
+    });
+    const result = await editSandboxFile({
+      path: '../../etc/passwd',
+      oldString: 'a',
+      newString: 'b',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: false, reason: 'path_escape' });
+    expect(acquired).toBe(false);
+    expect(audits[0]?.anomaly).toBe('blocked_command');
+  });
+
+  it('given a missing file, should deny not_found', async () => {
+    const { deps } = makeEditDeps(null);
+    const result = await editSandboxFile({
+      path: 'nope.txt',
+      oldString: 'a',
+      newString: 'b',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: false, reason: 'not_found' });
+  });
+
+  it('given an oldString that does not occur, should deny edit_no_match', async () => {
+    const { deps } = makeEditDeps('hello');
+    const result = await editSandboxFile({
+      path: 'a.txt',
+      oldString: 'zzz',
+      newString: 'b',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: false, reason: 'edit_no_match' });
+  });
+
+  it('given a non-unique oldString without replaceAll, should deny edit_not_unique', async () => {
+    const { deps } = makeEditDeps('x x');
+    const result = await editSandboxFile({
+      path: 'a.txt',
+      oldString: 'x',
+      newString: 'Y',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: false, reason: 'edit_not_unique' });
+  });
+
+  it('given an edit that grows the file past the write cap, should deny content_too_large', async () => {
+    const { deps } = makeEditDeps('SEED');
+    const huge = 'a'.repeat(MAX_WRITE_BYTES + 10);
+    const result = await editSandboxFile({
+      path: 'a.txt',
+      oldString: 'SEED',
+      newString: huge,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ success: false, reason: 'content_too_large' });
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -90,6 +90,20 @@ describe('runBashInSandbox', () => {
     expect(audits[0]?.exitCode).toBeNull();
   });
 
+  it('given a GitHub op over bash (no creds there), should deny github_over_bash, audit blocked_command, and never provision', async () => {
+    let acquireCalls = 0;
+    const { deps, audits } = makeDeps({
+      acquireSandbox: async () => {
+        acquireCalls += 1;
+        return { ok: true, sandboxId: 'sbx-1', resumed: false };
+      },
+    });
+    const result = await runBashInSandbox({ command: 'gh pr list', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'github_over_bash' });
+    expect(acquireCalls).toBe(0);
+    expect(audits[0]?.anomaly).toBe('blocked_command');
+  });
+
   it('given a saturated concurrency limit, should deny with concurrency_limit', async () => {
     const { deps } = makeDeps({
       quota: {

--- a/packages/lib/src/services/sandbox/command-policy.ts
+++ b/packages/lib/src/services/sandbox/command-policy.ts
@@ -27,7 +27,8 @@ export const MAX_COMMAND_BYTES = 16 * 1024;
 export type CommandPolicyDenialReason =
   | 'empty_command'
   | 'command_too_large'
-  | 'blocked_metadata_access';
+  | 'blocked_metadata_access'
+  | 'github_over_bash';
 
 export type CommandPolicyDecision =
   | { ok: true }
@@ -36,6 +37,17 @@ export type CommandPolicyDecision =
 // The IPv4 link-local metadata address and its common decimal/hex encodings.
 // Each alternative is a fixed literal — the alternation is linear.
 const METADATA_ADDRESS = /169\.254\.169\.254|0xa9fea9fe|2852039166/i;
+
+// The `gh` CLI (any subcommand) or git's auth-requiring subcommands run in `bash`,
+// which carries NO GitHub credentials — only the dedicated git_*/gh_* tools do.
+// This is a UX redirect to those tools, NOT a security control (isolation + egress
+// own security; see this file's header). Anchored to a command-start boundary
+// (start of string, or just after `;`/`&`/`|`/newline) to limit false positives,
+// and local credential-free git (status/diff/log/add/commit) is intentionally NOT
+// matched. The trailing `(?![\w-])` requires the command token to end, so `github`
+// and `git pushy` do not match. One linear scan — no nested/overlapping
+// quantifiers (CodeQL js/polynomial-redos safe).
+const GITHUB_OVER_BASH = /(?:^|[\n;&|])[ \t]*(?:gh|git[ \t]+(?:clone|fetch|pull|push))(?![\w-])/i;
 
 const deny = (reason: CommandPolicyDenialReason): CommandPolicyDecision => ({
   ok: false,
@@ -58,6 +70,9 @@ export function evaluateCommandPolicy({
   }
   if (METADATA_ADDRESS.test(command)) {
     return deny('blocked_metadata_access');
+  }
+  if (GITHUB_OVER_BASH.test(command)) {
+    return deny('github_over_bash');
   }
   return { ok: true };
 }

--- a/packages/lib/src/services/sandbox/edit-file.ts
+++ b/packages/lib/src/services/sandbox/edit-file.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure string-replacement core for the sandbox `editFile` tool.
+ *
+ * Targeted edits without rewriting the whole file: replace `oldString` with
+ * `newString`. By default `oldString` must be unique so an edit can't silently
+ * hit the wrong occurrence; `replaceAll` opts into replacing every match.
+ *
+ * Literal, not regex: matching and replacement use split/join, so neither
+ * `oldString`'s regex metacharacters nor `newString`'s `$` replacement patterns
+ * are interpreted. Pure and never throws — the runner maps the failure reasons
+ * onto tool denials.
+ */
+
+export type ApplyEditResult =
+  | { ok: true; content: string; replacements: number }
+  | { ok: false; reason: 'edit_no_match' | 'edit_not_unique' };
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle === '') return 0;
+  return haystack.split(needle).length - 1;
+}
+
+export function applyEdit({
+  content,
+  oldString,
+  newString,
+  replaceAll = false,
+}: {
+  content: string;
+  oldString: string;
+  newString: string;
+  replaceAll?: boolean;
+}): ApplyEditResult {
+  const count = countOccurrences(content, oldString);
+  if (count === 0) return { ok: false, reason: 'edit_no_match' };
+  if (count > 1 && !replaceAll) return { ok: false, reason: 'edit_not_unique' };
+
+  // count === 1, or replaceAll with count >= 1: split/join replaces literally,
+  // interpreting nothing in either string.
+  return { ok: true, content: content.split(oldString).join(newString), replacements: count };
+}

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -1,6 +1,6 @@
 import { SANDBOX_TIMEOUT_MS, SANDBOX_MAX_OUTPUT_BYTES } from './execution-policy';
 import { truncateToBytes } from './output-limit';
-import { SANDBOX_ROOT } from './sandbox-paths';
+import { SANDBOX_ROOT, resolveSandboxPath } from './sandbox-paths';
 import type { SandboxActorContext, SandboxRunDeps, BashToolResult } from './tool-runners';
 
 export interface GitSandboxRunDeps extends SandboxRunDeps {
@@ -47,6 +47,21 @@ export async function runGitInSandbox({
     return { success: false, error: 'Code execution is disabled.', reason: 'kill_switch_off' };
   }
 
+  // A provided working directory must stay inside the sandbox root — mirror the
+  // bash path. Validate BEFORE acquiring a slot so a bad cwd consumes no quota.
+  let resolvedCwd: string = SANDBOX_ROOT;
+  if (cwd !== undefined) {
+    const candidate = resolveSandboxPath(cwd);
+    if (!candidate) {
+      return {
+        success: false,
+        error: 'The path is invalid or escapes the sandbox root.',
+        reason: 'path_escape',
+      };
+    }
+    resolvedCwd = candidate;
+  }
+
   // Pre-fetch token BEFORE acquiring a sandbox slot — a missing token on a
   // network-requiring command must not consume quota.
   const token =
@@ -81,7 +96,6 @@ export async function runGitInSandbox({
       return { success: false, error: 'Could not provision a sandbox.', reason: 'provision_failed' };
     }
 
-    const resolvedCwd = cwd ?? SANDBOX_ROOT;
     const startedAt = deps.now();
 
     let run: { exitCode: number; stdout: string; stderr: string };

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -114,6 +114,7 @@ export type SandboxToolDenialReason =
   | 'empty_command'
   | 'command_too_large'
   | 'blocked_metadata_access'
+  | 'github_over_bash'
   | 'path_escape'
   | 'content_too_large'
   | 'provision_failed'
@@ -144,6 +145,8 @@ const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   empty_command: 'No command was provided.',
   command_too_large: 'The command is too large.',
   blocked_metadata_access: 'This command is blocked by policy.',
+  github_over_bash:
+    'The bash sandbox has no GitHub credentials. Use the dedicated git_*/gh_* tools for GitHub operations (e.g. git_clone, git_push, gh_pr_create) — they carry your connected GitHub auth.',
   path_escape: 'The path is invalid or escapes the sandbox root.',
   content_too_large: 'The file content is too large.',
   provision_failed: 'Could not provision a sandbox for this run.',

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -29,6 +29,7 @@ import { SANDBOX_TIMEOUT_MS, SANDBOX_MAX_OUTPUT_BYTES } from './execution-policy
 import { evaluateCommandPolicy } from './command-policy';
 import { truncateToBytes } from './output-limit';
 import { resolveSandboxPath, SANDBOX_ROOT } from './sandbox-paths';
+import { applyEdit } from './edit-file';
 import { buildSandboxEnv } from './sandbox-env';
 import { getValidatedEnv } from '../../config/env-validation';
 import type { AcquireSandboxInput, AcquireSandboxResult } from './session-manager';
@@ -117,6 +118,8 @@ export type SandboxToolDenialReason =
   | 'github_over_bash'
   | 'path_escape'
   | 'content_too_large'
+  | 'edit_no_match'
+  | 'edit_not_unique'
   | 'provision_failed'
   | 'provision_rate_limited'
   | 'execution_failed'
@@ -135,6 +138,10 @@ export type ReadFileToolResult =
   | { success: true; path: string; content: string; truncated: boolean }
   | { success: false; error: string; reason: SandboxToolDenialReason; retryAfter?: number };
 
+export type EditFileToolResult =
+  | { success: true; path: string; replacements: number }
+  | { success: false; error: string; reason: SandboxToolDenialReason; retryAfter?: number };
+
 const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   kill_switch_off: 'Code execution is disabled.',
   app_admin_required: 'Code execution is currently restricted to application administrators.',
@@ -149,6 +156,8 @@ const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
     'The bash sandbox has no GitHub credentials. Use the dedicated git_*/gh_* tools for GitHub operations (e.g. git_clone, git_push, gh_pr_create) — they carry your connected GitHub auth.',
   path_escape: 'The path is invalid or escapes the sandbox root.',
   content_too_large: 'The file content is too large.',
+  edit_no_match: 'The oldString was not found in the file. Read the file and copy the exact text to replace.',
+  edit_not_unique: 'The oldString is not unique in the file. Include more surrounding context, or set replaceAll to replace every occurrence.',
   provision_failed: 'Could not provision a sandbox for this run.',
   provision_rate_limited: 'The sandbox service is busy (rate limited). Retry shortly.',
   execution_failed: 'Command execution failed or timed out.',
@@ -514,6 +523,82 @@ export async function readSandboxFile({
       durationMs,
     });
     return { success: true, path, content: text, truncated };
+  } finally {
+    session.release();
+  }
+}
+
+export async function editSandboxFile({
+  path,
+  oldString,
+  newString,
+  replaceAll,
+  ctx,
+  deps,
+}: {
+  path: string;
+  oldString: string;
+  newString: string;
+  replaceAll?: boolean;
+  ctx: SandboxActorContext;
+  deps: SandboxRunDeps;
+}): Promise<EditFileToolResult> {
+  if (!deps.isEnabled()) return fail('kill_switch_off');
+
+  const resolved = resolveSandboxPath(path);
+  if (!resolved) {
+    await safeAudit(deps, ctx, {
+      code: `editFile ${path}`,
+      exitCode: null,
+      durationMs: 0,
+      anomaly: 'blocked_command',
+    });
+    return fail('path_escape');
+  }
+
+  const session = await openSession(ctx, deps);
+  if (!session.ok) return fail(session.reason, session.retryAfter);
+
+  try {
+    const startedAt = deps.now();
+    let buffer: Buffer | null;
+    try {
+      buffer = await session.sandbox.readFileToBuffer({ path: resolved });
+    } catch {
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      await safeAudit(deps, ctx, { code: `editFile ${path}`, exitCode: null, durationMs, anomaly: 'nonzero_exit' });
+      return fail('execution_failed');
+    }
+    if (buffer === null) {
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      await safeAudit(deps, ctx, { code: `editFile ${path}`, exitCode: 1, durationMs, anomaly: 'nonzero_exit' });
+      return fail('not_found');
+    }
+
+    const edit = applyEdit({ content: buffer.toString('utf8'), oldString, newString, replaceAll });
+    if (!edit.ok) {
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      await safeAudit(deps, ctx, { code: `editFile ${path}`, exitCode: 1, durationMs, anomaly: 'nonzero_exit' });
+      return fail(edit.reason);
+    }
+
+    const bytes = Buffer.byteLength(edit.content, 'utf8');
+    if (bytes > MAX_WRITE_BYTES) return fail('content_too_large');
+
+    try {
+      await session.sandbox.writeFiles([{ path: resolved, content: edit.content }]);
+    } catch {
+      const durationMs = deps.now().getTime() - startedAt.getTime();
+      await safeAudit(deps, ctx, { code: `editFile ${path}`, exitCode: null, durationMs, anomaly: 'nonzero_exit' });
+      return fail('execution_failed');
+    }
+    const durationMs = deps.now().getTime() - startedAt.getTime();
+    await safeAudit(deps, ctx, {
+      code: `editFile ${path} (${edit.replacements} replaced)`,
+      exitCode: 0,
+      durationMs,
+    });
+    return { success: true, path, replacements: edit.replacements };
   } finally {
     session.release();
   }


### PR DESCRIPTION
## Sandbox Ergonomics — auth boundary · git cwd · editFile

Five friction points an agent hit using the agent code-execution sandbox, captured from a real bug-fix run (it re-cloned a repo 3+ times, created divergent branches, lost track of its PR, and thrashed on blocked force-pushes). All changes stay behind the default-OFF `CODE_EXECUTION_ENABLED` kill-switch.

### What changed

1. **GitHub auth boundary made explicit.** `bash` has no GitHub credentials — only the dedicated `git_*`/`gh_*` tools carry OAuth. `command-policy` now redirects `gh …` / `git clone|fetch|pull|push` run in bash to those tools (UX redirect, ReDoS-safe linear regex; local git like `status`/`add`/`commit` still runs).
2. **Per-call `cwd` for git/gh tools.** `runGitInSandbox` already accepted `cwd` but the tools never passed it, pinning every op to `/workspace`. Now every repo-operating git/gh tool takes an optional `cwd` (validated, `path_escape` on escape), so the agent can operate on a repo cloned into a subdir.
3. **`editFile` tool.** Targeted string replacement (pure `applyEdit`, literal match, unique-unless-`replaceAll`) instead of whole-file `writeFile` rewrites or fragile `sed`.
4. **Workspace persistence made visible.** The sandbox filesystem *does* persist across turns (resume by session key + Fly hibernation, verified in `lifecycle.ts`/`session-key.ts`), but the model got no signal, so it re-cloned and re-opened PRs defensively. A short `SANDBOX_INSTRUCTIONS` block (gated on `codeExecutionEnabled`, threaded at the three chat prompt builders) tells it: `/workspace` persists — check `git_status`/`git_branch`/`gh_pr_list` before recreating; update the existing PR's branch.
5. **Tool-discovery overhead.** The same block names the key sandbox tools so the model skips a `tool_search` round-trip on the common path.

Plus **`git_push` force guard** (2c): `--force-with-lease` stays allowed on feature/PR branches but is refused for the default branch (`main`/`master`), and requires an explicit branch under `force`.

### Tests
TDD throughout (RED→GREEN). 282 lib sandbox tests + 88 web sandbox/system-prompt tests pass; full monorepo `typecheck` (incl. web build) and `lint` green. Covers: interceptor (allow/deny/chained/ReDoS), cwd validation + threading, force guard, `applyEdit` edge cases, `editSandboxFile` (escape/not-found/no-match/not-unique/oversize), `editFile` wiring, and `SANDBOX_INSTRUCTIONS` gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review feedback addressed
- **P1 (force-push refspec bypass):** the force guard now parses the refspec *destination* (strips `+`, takes the segment after the last `:`, strips `refs/heads/`), so `HEAD:main` / `feature:refs/heads/master` can't slip past; `+`-prefixed refspecs count as forcing. Also refuses **deleting** the default branch via `:main`.
- **P2 (read-only exposure):** `editFile` — and the rest of the sandbox mutation surface (`bash`, `writeFile`, writing `git_*`/`gh_*`) — added to `WRITE_TOOLS`, so `filterToolsForReadOnly` strips them in read-only mode. Read-only sandbox tools (`readFile`, `git_status/diff/log`, `gh_*_list/view`) stay available.
- Fixed the CI `@pagespace/lib` typecheck failure (`WriteFileEntry.content` is `string | Uint8Array`).
