### PR TITLE
fix(ai-chat): re-attach/refetch AI stream on mobile app resume

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -30,7 +30,9 @@ import { clearActiveStreamId } from '@/lib/ai/core/client';
 import { abortActiveStream, abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
 import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
+import { isCapacitorApp } from '@/hooks/useCapacitor';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
@@ -422,7 +424,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   }, [chatStop, ownStreamMessageId, isStreaming, lastAssistantMessageId, streamTrackingId, page.id]);
 
   usePageSocketRoom(page.id);
-  useChannelStreamSocket(page.id, {
+  const { rejoinActiveStreams } = useChannelStreamSocket(page.id, {
     onUserMessage: (message, payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
@@ -701,12 +703,27 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     }
   }, [currentConversationId, page.id, setMessages]);
 
-  // App state recovery - refresh messages when returning from background
-  // This catches completed AI responses that finished while the app was backgrounded
+  // App state recovery - re-attach/refetch AI stream when returning from background.
+  // On native (Capacitor): if streaming, stop the local fetch, rejoin any still-live
+  // server stream, then refetch to recover a stream that finished while backgrounded.
+  // On web: never interrupt a live fetch on tab-switch (the fetch stays alive).
+  // Known limitation (pre-existing): if the user switched conversation while backgrounded,
+  // onStreamComplete's conversationId guard suppresses the append; the message is still
+  // persisted and appears on navigating back to the conversation.
   useAppStateRecovery({
-    onResume: handlePullUpRefresh,
-    // Block recovery if streaming OR pending send OR any editing active
-    enabled: !isStreaming && currentConversationId !== null && !isEditingActive(),
+    onResume: useCallback(async () => {
+      const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
+      if (action === 'noop') return;
+      if (action === 'rejoin-and-refresh') {
+        // chatStop is local-only; it does NOT signal the server (the existing effectiveStop
+        // does that separately via abortActiveStreamByMessageId). We only need to clear the
+        // local useChat streaming state so rejoin can attach cleanly.
+        chatStop();
+        rejoinActiveStreams();
+      }
+      await handlePullUpRefresh();
+    }, [effectiveIsStreaming, chatStop, rejoinActiveStreams, handlePullUpRefresh]),
+    enabled: currentConversationId !== null && !isEditingActive(),
   });
 
   // Clean up stream tracking when conversation changes or on unmount

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -82,7 +82,9 @@ vi.mock('@/stores/usePendingStreamsStore', () => ({
 }));
 
 vi.mock('@/hooks/usePageSocketRoom', () => ({ usePageSocketRoom: vi.fn() }));
-vi.mock('@/hooks/useChannelStreamSocket', () => ({ useChannelStreamSocket: vi.fn() }));
+vi.mock('@/hooks/useChannelStreamSocket', () => ({
+  useChannelStreamSocket: vi.fn(() => ({ rejoinActiveStreams: vi.fn() })),
+}));
 vi.mock('@/hooks/useAppStateRecovery', () => ({ useAppStateRecovery: vi.fn() }));
 
 vi.mock('@/hooks/useDisplayPreferences', () => ({
@@ -495,6 +497,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
       capturedCallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
     });
 
     setupNoConversationsInit();
@@ -536,6 +539,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
       capturedCallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
     });
 
     setupNoConversationsInit();
@@ -578,6 +582,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
       capturedCallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
     });
 
     setupNoConversationsInit();
@@ -618,6 +623,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
       capturedCallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
     });
 
     setupNoConversationsInit();
@@ -659,6 +665,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
       capturedCallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
     });
 
     setupNoConversationsInit();
@@ -709,6 +716,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     let capturedPageACallback: ((messageId: string) => void) | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((pageId, opts) => {
       if (pageId === PAGE_ID) capturedPageACallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
     });
 
     let resolveSyncFetch!: () => void;
@@ -787,6 +795,7 @@ describe('AiChatView remote user-message broadcast', () => {
     let captured: UserMsgCallback | undefined;
     vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
       captured = opts?.onUserMessage as UserMsgCallback | undefined;
+      return { rejoinActiveStreams: vi.fn() };
     });
     return () => captured;
   };

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/hooks/useChannelStreamSocket', () => ({
     capturedChannel.channelId = channelId;
     capturedChannel.options = options;
     mockUseChannelStreamSocket(channelId, options);
+    return { rejoinActiveStreams: vi.fn() };
   },
 }));
 

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useSocket } from './useSocket';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { consumeStreamJoin } from '@/lib/ai/core/stream-join-client';
@@ -95,8 +95,11 @@ export interface UseChannelStreamSocketOptions {
 export function useChannelStreamSocket(
   channelId: string | undefined,
   options?: UseChannelStreamSocketOptions,
-): void {
+): { rejoinActiveStreams: () => void } {
   const socket = useSocket();
+  // Holds the latest runBootstrap closure so rejoinActiveStreams can call it without
+  // needing to be in the effect's dep array (the effect re-creates this on every run).
+  const bootstrapRef = useRef<(() => void) | null>(null);
   // Stable refs so callback identity changes never trigger handler re-registration.
   const onStreamCompleteRef = useRef(options?.onStreamComplete);
   const onOwnStreamBootstrapRef = useRef(options?.onOwnStreamBootstrap);
@@ -186,8 +189,10 @@ export function useChannelStreamSocket(
     };
 
     // Bootstrap: replay in-flight streams from the DB so a refresh mid-stream
-    // doesn't lose visibility on what's currently happening in this channel.
-    (async () => {
+    // (or a mobile resume) doesn't lose visibility on what's currently happening
+    // in this channel. Re-running is idempotent: claimBootstrapConsumer +
+    // shouldSkipBootstrappedStream skip streams already being consumed.
+    const runBootstrap = async () => {
       try {
         const res = await fetchWithAuth(
           `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
@@ -217,7 +222,13 @@ export function useChannelStreamSocket(
         if (cancelled) return;
         console.warn('[useChannelStreamSocket] bootstrap failed', err);
       }
-    })();
+    };
+
+    // Expose runBootstrap so rejoinActiveStreams (returned from the hook) can
+    // trigger it on mobile resume — always points at the live closure.
+    bootstrapRef.current = runBootstrap;
+
+    void runBootstrap();
 
     const handleStreamStart = (payload: AiStreamStartPayload) => {
       if (payload.pageId !== channelId) return;
@@ -320,4 +331,9 @@ export function useChannelStreamSocket(
       clearPageStreams(channelId);
     };
   }, [socket, channelId]);
+
+  // Stable callback; the ref always points at the latest runBootstrap closure.
+  const rejoinActiveStreams = useCallback(() => { bootstrapRef.current?.(); }, []);
+
+  return { rejoinActiveStreams };
 }

--- a/apps/web/src/lib/ai/streams/__tests__/resolveResumeAction.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/resolveResumeAction.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolveResumeAction } from '../resolveResumeAction';
+
+describe('resolveResumeAction', () => {
+  it('native + streaming → rejoin-and-refresh', () => {
+    expect(resolveResumeAction({ native: true, isStreaming: true })).toBe('rejoin-and-refresh');
+  });
+
+  it('web (non-native) + streaming → noop (must not clobber live fetch)', () => {
+    expect(resolveResumeAction({ native: false, isStreaming: true })).toBe('noop');
+  });
+
+  it('native + not streaming → refresh', () => {
+    expect(resolveResumeAction({ native: true, isStreaming: false })).toBe('refresh');
+  });
+
+  it('web (non-native) + not streaming → refresh', () => {
+    expect(resolveResumeAction({ native: false, isStreaming: false })).toBe('refresh');
+  });
+});

--- a/apps/web/src/lib/ai/streams/resolveResumeAction.ts
+++ b/apps/web/src/lib/ai/streams/resolveResumeAction.ts
@@ -1,0 +1,12 @@
+export type ResumeAction = 'rejoin-and-refresh' | 'refresh' | 'noop';
+
+export function resolveResumeAction({
+  native,
+  isStreaming,
+}: {
+  native: boolean;
+  isStreaming: boolean;
+}): ResumeAction {
+  if (isStreaming) return native ? 'rejoin-and-refresh' : 'noop';
+  return 'refresh';
+}


### PR DESCRIPTION
## Summary

On Capacitor (iOS/Android), backgrounding the app mid-AI-stream silently dropped the assistant message on resume. The root cause was a gating bug in `useAppStateRecovery`: its `enabled` condition included `!isStreaming`, which is `false` (disabled) in exactly the case we need it — when a stream is in flight while the app goes to background.

This PR is the **client-side resume recovery** (Part 2). The companion server-durability PR (`pu/ai-stream-durability`) ensures the message is reliably persisted server-side so a DB refetch can always recover it.

## Changes

**`useChannelStreamSocket.ts`**
- Extracted the bootstrap IIFE into a named `runBootstrap()` inside the effect, stored in a hook-scope `bootstrapRef` (always closes over the live `controllers`/`processed` maps)
- Returns `{ rejoinActiveStreams }` — a stable `useCallback` that calls `bootstrapRef.current?.()` on demand
- Re-running is idempotent via `claimBootstrapConsumer` + `shouldSkipBootstrappedStream` (already-consumed streams are skipped)
- Additive change: `GlobalChatContext` and `useAgentChannelMultiplayer` callers that ignore the return are unaffected

**`lib/ai/streams/resolveResumeAction.ts`** (new)
- Pure function deciding the resume strategy from `{ native, isStreaming }`:
  - `native + streaming` → `'rejoin-and-refresh'`
  - `web + streaming` → `'noop'` (live fetch stays alive in the tab — must not clobber it)
  - `not streaming` → `'refresh'` (today's behavior)
- 4 colocated unit tests covering all combinations

**`AiChatView.tsx`**
- Captures `rejoinActiveStreams` from the hook
- Drops `!isStreaming` from `useAppStateRecovery`'s `enabled` guard (was the bug)
- Replaces the plain `onResume: handlePullUpRefresh` with a `useCallback` that dispatches on `resolveResumeAction`:
  - `'noop'`: return immediately — web tab-switch case
  - `'rejoin-and-refresh'`: `chatStop()` (local-only, does not signal the server), then `rejoinActiveStreams()`, then `handlePullUpRefresh()`
  - `'refresh'`: `handlePullUpRefresh()` unchanged

## Why rejoin + refresh together on native-streaming

- **Rejoin** re-attaches to a still-live server stream via `usePendingStreamsStore` (rendered separately from `useChat` messages, deduped by id in `ChatMessagesArea`)
- **Refresh** recovers a stream that finished while backgrounded — the companion PR makes that reliably persisted
- The refetch cannot clobber the live pending bubble nor duplicate `onStreamComplete`'s id-guarded append

## Known limitation (pre-existing)

If the user switched conversation while backgrounded, `onStreamComplete`'s `conversationId` guard suppresses the append. The message is still persisted and appears on navigating back. Noted in a code comment; not fixed here.

## Test plan

- [ ] `bun run --filter 'web' typecheck` — clean ✅
- [ ] `resolveResumeAction` — 4 unit tests pass ✅
- [ ] All 119 `lib/ai/streams` tests pass ✅
- [ ] Manual iOS: send message → background before first token → resume → bubble re-attaches live
- [ ] Manual iOS: background → wait for server to finish → resume → message recovered via DB refetch
- [ ] Web desktop: switch tabs mid-stream and back → stream uninterrupted, nothing clobbered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8rfqAbKJfjv63uM1iwzCw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced app recovery when resuming active AI chat conversations—the app now intelligently reconnects to active server streams on both mobile and web, preventing loss of chat continuity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->