### PR TITLE
fix(ai-chat): durably persist assistant message server-side independent of client connection

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -568,6 +568,56 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     });
   });
 
+  describe('execute-end durable persistence', () => {
+    it('given buffered parts exist, should persist the assistant message before lifecycle.finish()', async () => {
+      mockCreateStreamLifecycle.mockResolvedValueOnce({
+        pushPart: mockLifecyclePushPart,
+        finish: mockLifecycleFinish,
+        getBufferedParts: vi.fn().mockReturnValue([{ type: 'text', text: 'server reply' }]),
+      });
+
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      const saveCalls = mockSaveMessageToDatabase.mock.calls;
+      const assistantSave = saveCalls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
+      expect(assistantSave).toBeDefined();
+      expect(assistantSave?.[0]).toMatchObject({
+        messageId: 'test-message-id',
+        pageId: 'page-1',
+        conversationId: 'conv-1',
+        userId: null,
+        role: 'assistant',
+      });
+    });
+
+    it('given buffered parts are empty, should NOT persist from the execute path', async () => {
+      // beforeEach already mocks getBufferedParts to return [] — no override needed
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      const saveCalls = mockSaveMessageToDatabase.mock.calls;
+      const assistantSave = saveCalls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
+      expect(assistantSave).toBeUndefined();
+    });
+
+    it('given saveMessageToDatabase rejects from the execute path, should not propagate the error', async () => {
+      mockCreateStreamLifecycle.mockResolvedValueOnce({
+        pushPart: mockLifecyclePushPart,
+        finish: mockLifecycleFinish,
+        getBufferedParts: vi.fn().mockReturnValue([{ type: 'text', text: 'will fail' }]),
+      });
+
+      await POST(makeRequest());
+      // User message save has already run; next call is the execute-end assistant persist
+      mockSaveMessageToDatabase.mockRejectedValueOnce(new Error('db down'));
+
+      await expect(
+        captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('finish forwarding', () => {
     it('given onFinish runs, should call lifecycle.finish(false)', async () => {
       await POST(makeRequest());

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -341,6 +341,7 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     mockCreateStreamLifecycle.mockResolvedValue({
       pushPart: mockLifecyclePushPart,
       finish: mockLifecycleFinish,
+      getBufferedParts: vi.fn().mockReturnValue([]),
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -39,6 +39,7 @@ import { createAIProvider, updateUserProviderSettings, createProviderErrorRespon
 import { buildProviderAvailabilityMap } from '@/lib/ai/core/ai-utils';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { extractMessageContent, extractToolCalls, extractToolResults, saveMessageToDatabase, sanitizeMessagesForModel, convertDbMessageToUIMessage } from '@/lib/ai/core/message-utils';
+import { buildAssistantPersistencePayload } from '@/lib/ai/core/persistAssistantParts';
 import { processMentionsInMessage, buildMentionSystemPrompt } from '@/lib/ai/core/mention-processor';
 import {
   buildCommandPromptSection,
@@ -1116,6 +1117,31 @@ export async function POST(request: Request) {
           // consumeCredits → one hold settle: no double-charge, but failed/partial
           // attempts ARE billed because the provider charged us for those tokens.
           agentRun = runResult;
+
+          // Durable server-side persistence — runs regardless of whether the client
+          // is still connected. onFinish is coupled to the response stream and may
+          // never fire when the mobile client backgrounds mid-stream. This is an
+          // idempotent upsert: onFinish, when it runs, refines this write with the
+          // richer SDK responseMessage (better tool ordering). When onFinish never
+          // runs, this write stands as the sole record of the message.
+          if (chatId && serverAssistantMessageId) {
+            const bufferedParts = lifecycle!.getBufferedParts();
+            if (bufferedParts.length > 0) {
+              const payload = buildAssistantPersistencePayload(serverAssistantMessageId, bufferedParts);
+              try {
+                await saveMessageToDatabase({
+                  messageId: serverAssistantMessageId,
+                  pageId: chatId,
+                  conversationId: conversationId!,
+                  userId: null,
+                  role: 'assistant',
+                  ...payload,
+                });
+              } catch (e) {
+                loggers.ai.error('AI Chat API: execute-end persist failed', e as Error);
+              }
+            }
+          }
         },
         onFinish: async ({ responseMessage }) => {
           // Clean up abort controller from registry
@@ -1155,9 +1181,12 @@ export async function POST(request: Request) {
           // Save the AI's response message with tool calls and results (database-first
           // approach). Best-effort: persistence errors must NOT skip usage/credit
           // settlement below — that would leak the gate's hold.
+          // Uses buildAssistantPersistencePayload so this path and the execute-end
+          // durable path share the same extraction logic and cannot diverge.
           if (chatId && responseMessage) {
             try {
-              const messageContent = extractMessageContent(responseMessage);
+              const { content: messageContent, toolCalls, toolResults, uiMessage } =
+                buildAssistantPersistencePayload(messageId, responseMessage.parts);
 
               loggers.ai.debug('AI Chat API: Saving AI response message', {
                 id: messageId,
@@ -1174,17 +1203,16 @@ export async function POST(request: Request) {
                 toolResults: extractedToolResults.length
               });
 
-              // Use the new helper function to save the message with complete UIMessage for chronological ordering
               await saveMessageToDatabase({
                 messageId,
                 pageId: chatId,
-                conversationId: conversationId!, // Group messages into conversation sessions
-                userId: null, // AI message
+                conversationId: conversationId!,
+                userId: null,
                 role: 'assistant',
                 content: messageContent,
-                toolCalls: extractedToolCalls.length > 0 ? extractedToolCalls : undefined,
-                toolResults: extractedToolResults.length > 0 ? extractedToolResults : undefined,
-                uiMessage: responseMessage, // Pass complete UIMessage to preserve part ordering
+                toolCalls,
+                toolResults,
+                uiMessage,
                 ...(page?.driveId && userId && isConversationShared && {
                   mentionNotify: {
                     driveId: page.driveId,

--- a/apps/web/src/lib/ai/core/__tests__/persistAssistantParts.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/persistAssistantParts.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildAssistantPersistencePayload } from '../persistAssistantParts';
+import type { UIMessagePart } from '../stream-multicast-registry';
+
+const textPart = (text: string): UIMessagePart => ({ type: 'text', text });
+
+const toolCallPart = (): UIMessagePart =>
+  ({
+    type: 'tool-search',
+    toolCallId: 'tc-1',
+    toolName: 'search',
+    input: { q: 'hello' },
+    state: 'input-available',
+  }) as UIMessagePart;
+
+const toolResultPart = (): UIMessagePart =>
+  ({
+    type: 'tool-search',
+    toolCallId: 'tc-1',
+    toolName: 'search',
+    input: { q: 'hello' },
+    output: { results: [] },
+    state: 'output-available',
+  }) as UIMessagePart;
+
+describe('buildAssistantPersistencePayload', () => {
+  it('text-only parts: extracts content and produces undefined tool fields', () => {
+    const parts: UIMessagePart[] = [textPart('Hello'), textPart(' world')];
+    const payload = buildAssistantPersistencePayload('msg-1', parts);
+
+    expect(payload.content).toBe('Hello world');
+    expect(payload.toolCalls).toBeUndefined();
+    expect(payload.toolResults).toBeUndefined();
+    expect(payload.uiMessage.id).toBe('msg-1');
+    expect(payload.uiMessage.role).toBe('assistant');
+    expect(payload.uiMessage.parts).toHaveLength(2);
+  });
+
+  it('text + tool parts: extracts content and tool calls/results', () => {
+    // extractToolCalls maps ALL tool-invocation parts (both call-only and result parts)
+    // extractToolResults filters to just output-available/output-error state parts
+    const parts: UIMessagePart[] = [textPart('Here'), toolCallPart(), toolResultPart()];
+    const payload = buildAssistantPersistencePayload('msg-2', parts);
+
+    expect(payload.content).toBe('Here');
+    expect(payload.toolCalls).toHaveLength(2); // both the call part and the result part
+    expect(payload.toolCalls![0].toolCallId).toBe('tc-1');
+    expect(payload.toolCalls![0].toolName).toBe('search');
+    expect(payload.toolResults).toHaveLength(1); // only the output-available part
+    expect(payload.toolResults![0].toolCallId).toBe('tc-1');
+    expect(payload.toolResults![0].state).toBe('output-available');
+    expect(payload.uiMessage.parts).toHaveLength(3);
+  });
+
+  it('empty parts array: returns empty content and undefined tool fields', () => {
+    const payload = buildAssistantPersistencePayload('msg-3', []);
+
+    expect(payload.content).toBe('');
+    expect(payload.toolCalls).toBeUndefined();
+    expect(payload.toolResults).toBeUndefined();
+    expect(payload.uiMessage.id).toBe('msg-3');
+    expect(payload.uiMessage.parts).toHaveLength(0);
+  });
+
+  it('does not mutate the input parts array', () => {
+    const parts: UIMessagePart[] = [textPart('immutable')];
+    buildAssistantPersistencePayload('msg-4', parts);
+
+    expect(parts).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
@@ -4,6 +4,7 @@ const {
   mockRegistryRegister,
   mockRegistryPush,
   mockRegistryFinish,
+  mockRegistryGetBufferedParts,
   mockBroadcastStart,
   mockBroadcastComplete,
   mockInsertValues,
@@ -16,6 +17,7 @@ const {
   mockRegistryRegister: vi.fn(),
   mockRegistryPush: vi.fn(),
   mockRegistryFinish: vi.fn(),
+  mockRegistryGetBufferedParts: vi.fn().mockReturnValue([]),
   mockBroadcastStart: vi.fn().mockResolvedValue(undefined),
   mockBroadcastComplete: vi.fn().mockResolvedValue(undefined),
   mockInsertValues: vi.fn(),
@@ -31,6 +33,7 @@ vi.mock('@/lib/ai/core/stream-multicast-registry', () => ({
     register: mockRegistryRegister,
     push: mockRegistryPush,
     finish: mockRegistryFinish,
+    getBufferedParts: mockRegistryGetBufferedParts,
     getMeta: vi.fn(),
     subscribe: vi.fn(),
   },
@@ -352,6 +355,26 @@ describe('createStreamLifecycle', () => {
 
       expect(mockUpdateSet).toHaveBeenCalled();
       expect(mockBroadcastComplete).toHaveBeenCalled();
+    });
+  });
+
+  describe('getBufferedParts', () => {
+    it('delegates to streamMulticastRegistry.getBufferedParts with the messageId', async () => {
+      const fakeParts = [{ type: 'text' as const, text: 'hi' }];
+      mockRegistryGetBufferedParts.mockReturnValueOnce(fakeParts);
+      const lifecycle = await createStreamLifecycle(params());
+
+      const result = lifecycle.getBufferedParts();
+
+      expect(mockRegistryGetBufferedParts).toHaveBeenCalledWith('msg-1');
+      expect(result).toBe(fakeParts);
+    });
+
+    it('returns an empty array when the registry returns none', async () => {
+      mockRegistryGetBufferedParts.mockReturnValueOnce([]);
+      const lifecycle = await createStreamLifecycle(params());
+
+      expect(lifecycle.getBufferedParts()).toEqual([]);
     });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
@@ -282,6 +282,42 @@ describe('StreamMulticastRegistry', () => {
     });
   });
 
+  describe('getBufferedParts', () => {
+    it('returns a copy of the accumulated parts', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', meta());
+      registry.push('msg-1', text('hello'));
+      registry.push('msg-1', text(' world'));
+
+      expect(registry.getBufferedParts('msg-1')).toEqual([text('hello'), text(' world')]);
+    });
+
+    it('returns an empty array for an unknown messageId', () => {
+      const registry = new StreamMulticastRegistry();
+      expect(registry.getBufferedParts('unknown')).toEqual([]);
+    });
+
+    it('returns an empty array after finish() deletes the entry', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', meta());
+      registry.push('msg-1', text('data'));
+      registry.finish('msg-1');
+
+      expect(registry.getBufferedParts('msg-1')).toEqual([]);
+    });
+
+    it('returns a defensive copy — mutating the result does not affect the internal buffer', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', meta());
+      registry.push('msg-1', text('original'));
+
+      const copy = registry.getBufferedParts('msg-1');
+      copy.push(text('injected'));
+
+      expect(registry.getBufferedParts('msg-1')).toHaveLength(1);
+    });
+  });
+
   describe('resilience', () => {
     it('given a subscriber whose onChunk throws, should not interrupt fanout to remaining subscribers', () => {
       const registry = new StreamMulticastRegistry();

--- a/apps/web/src/lib/ai/core/persistAssistantParts.ts
+++ b/apps/web/src/lib/ai/core/persistAssistantParts.ts
@@ -1,0 +1,36 @@
+import type { UIMessage } from 'ai';
+import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
+import {
+  extractMessageContent,
+  extractToolCalls,
+  extractToolResults,
+} from '@/lib/ai/core/message-utils';
+import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
+
+export interface AssistantPersistencePayload {
+  content: string;
+  toolCalls: ReturnType<typeof extractToolCalls> | undefined;
+  toolResults: ReturnType<typeof extractToolResults> | undefined;
+  uiMessage: UIMessage;
+}
+
+/**
+ * Builds the persistence payload for an assistant message from its accumulated
+ * stream parts. Used by both the execute-end durable path and the onFinish
+ * path so neither can silently diverge in its DB representation.
+ */
+export function buildAssistantPersistencePayload(
+  messageId: string,
+  parts: UIMessagePart[],
+): AssistantPersistencePayload {
+  const uiMessage = synthesizeAssistantMessage(messageId, parts);
+  const content = extractMessageContent(uiMessage);
+  const rawToolCalls = extractToolCalls(uiMessage);
+  const rawToolResults = extractToolResults(uiMessage);
+  return {
+    content,
+    toolCalls: rawToolCalls.length > 0 ? rawToolCalls : undefined,
+    toolResults: rawToolResults.length > 0 ? rawToolResults : undefined,
+    uiMessage,
+  };
+}

--- a/apps/web/src/lib/ai/core/stream-lifecycle.ts
+++ b/apps/web/src/lib/ai/core/stream-lifecycle.ts
@@ -20,6 +20,7 @@ export interface StreamLifecycleParams {
 export interface StreamLifecycleHandle {
   finish: (aborted: boolean) => void;
   pushPart: (part: UIMessagePart) => void;
+  getBufferedParts: () => UIMessagePart[];
 }
 
 export const createStreamLifecycle = async (
@@ -134,5 +135,8 @@ export const createStreamLifecycle = async (
     }
   };
 
-  return { finish, pushPart };
+  const getBufferedParts = (): UIMessagePart[] =>
+    streamMulticastRegistry.getBufferedParts(messageId);
+
+  return { finish, pushPart, getBufferedParts };
 };

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -101,6 +101,10 @@ export class StreamMulticastRegistry {
     }
   }
 
+  getBufferedParts(messageId: string): UIMessagePart[] {
+    return this.entries.get(messageId)?.buffer.slice() ?? [];
+  }
+
   getMeta(messageId: string): StreamMeta | undefined {
     return this.entries.get(messageId)?.meta;
   }


### PR DESCRIPTION
## Root cause

The assistant message was persisted in **exactly one place**: the `createUIMessageStream` `onFinish` callback (`route.ts` → `saveMessageToDatabase`). That callback is **coupled to the client response stream** — when a mobile (Capacitor) user backgrounds the app mid-stream, Next.js cancels the response `ReadableStream` before `onFinish` fires, so the message is never written to `chatMessages`. On refresh, there is nothing to show — the message is permanently lost.

The server buffers every streamed part in `streamMulticastRegistry.entry.buffer` (via `lifecycle.pushPart` → `onChunk`), and `execute()` always runs to completion server-side regardless of whether the client is connected. The buffered content was never used for durability — `lifecycle.finish()` deleted it without persisting.

## Fix (additive, idempotent)

Four small, focused changes:

**`stream-multicast-registry.ts`** — `getBufferedParts(messageId)` returns a defensive copy of the accumulated buffer (or `[]` if no entry). Called before `finish()` so the buffer still exists.

**`stream-lifecycle.ts`** — exposes `getBufferedParts: () => UIMessagePart[]` on `StreamLifecycleHandle`, delegating to the registry. Route code reaches it without importing the registry directly.

**`persistAssistantParts.ts`** (new) — pure function `buildAssistantPersistencePayload(messageId, parts)` that synthesizes a `UIMessage` from the parts array (via existing `synthesizeAssistantMessage`) and extracts `content` / `toolCalls` / `toolResults` via the same extractors already used in `onFinish`. Both persistence paths now share one extraction function and cannot silently diverge.

**`route.ts`** — two changes:
1. Inside `execute()`, **after `runAgentWithRetry` completes** (guaranteed server-side), read the buffered parts and `await saveMessageToDatabase(...)` wrapped in a try/catch that logs on failure and never throws. This is the durable write that survives a client disconnect.
2. Refactor the `onFinish` DB-save block to call `buildAssistantPersistencePayload` instead of inline `extractMessageContent` — so both paths share the same helper. All billing and hold settlement remain exclusively in `onFinish`, unchanged.

## Idempotence guarantee

`saveMessageToDatabase` is an `onConflictDoUpdate` upsert on `chatMessages.id` (verified at `message-utils.ts:498`). When `onFinish` runs, it upserts with the richer SDK `responseMessage` and wins. When `onFinish` never fires, the `execute()` write stands as the sole record. Zero double-write hazard.

## Test plan

- [x] `bun run --filter 'web' typecheck` — clean
- [x] 4 unit tests for `buildAssistantPersistencePayload`: text-only, text+tool, empty, immutability — all pass
- [x] 3 integration tests for execute-end durable persistence path: buffered parts → persists; empty buffer → no persist; reject → no throw
- [x] 4 unit tests for `StreamMulticastRegistry.getBufferedParts`: returns copy, unknown id, after finish, defensive copy
- [x] 2 unit tests for lifecycle `getBufferedParts`: delegation to registry, empty return
- [x] All 79 tests across changed modules pass locally (`stream-multicast-registry`, `stream-lifecycle`, `persistAssistantParts`, `stream-socket-events`)
- [ ] Manual: send message on iOS simulator, background before first token, foreground → message present on refresh (Part 1 durability)
- [ ] Manual: simulate mid-stream client abort → confirm partial assistant row in `chatMessages`

## Scope

This is **Part 1 (server durability)** only. Part 2 (mobile resume — re-attaching the live stream on foreground) is a separate branch `pu/ai-stream-resume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xk7a3Tn6Jyq9YuNxP7PAcZ