### PR TITLE
fix(publish): route the subdomain root to the home page on home-page change

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -10,6 +10,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isMCPA
 import { getAppDriveMembership, getAppDriveAccessLevel } from '@pagespace/lib/permissions/app-permissions';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { trackDriveOperation } from '@pagespace/lib/monitoring/activity-tracker';
+import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -210,10 +211,14 @@ export async function PATCH(
 
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'drive', resourceId: driveId, details: { operation: 'update' } });
 
-    // Setting a drive's home page is metadata only — it never publishes the page.
-    // The home page is served at the subdomain root only once it is deliberately
-    // published (via the page publish API), like setting a repo's entry point and
-    // then deploying.
+    // When the home page changes, sync the subdomain root immediately so `/`
+    // reflects the new home without requiring a manual republish. Best-effort,
+    // fire-and-forget — never blocks the response. An unpublished page set as
+    // home stays private (syncPublishedHomeRoot checks the published_pages table).
+    if (validatedBody.homePageId !== undefined) {
+      void syncPublishedHomeRoot(driveId);
+    }
+
     return NextResponse.json(updatedDrive);
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
@@ -118,9 +118,14 @@ vi.mock('@/services/api/task-sync-service', () => ({
   syncTaskItemOnMove: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('@/lib/canvas/publish-page', () => ({
+  syncPublishedHomeRoot: vi.fn().mockResolvedValue(undefined),
+}));
+
 // ── Imports (after mocks) ───────────────────────────────────────────────
 
 import { POST } from '../route';
+import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 import { authenticateRequestWithOptions, checkMCPDriveScope, getAllowedDriveIds, isMCPAuthResult } from '@/lib/auth';
 import { broadcastPageEvent } from '@/lib/websocket';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
@@ -721,6 +726,27 @@ describe('POST /api/pages/bulk-move', () => {
       expect(response.status).toBe(200);
       expect(txQueryDrivesFindFirst).not.toHaveBeenCalled();
       expect(txUpdateSet).not.toHaveBeenCalledWith({ homePageId: null });
+    });
+
+    it('fires syncPublishedHomeRoot (fire-and-forget) for each drive whose home page moved out', async () => {
+      setupSuccessScenario();
+      txQueryDrivesFindFirst.mockResolvedValue({ homePageId: 'page-1' });
+      // After move the page is no longer in the source drive
+      txQueryPagesFindFirst.mockResolvedValue(undefined);
+
+      await POST(createRequest(validBody));
+
+      expect(syncPublishedHomeRoot).toHaveBeenCalledWith(mockSourceDriveId);
+    });
+
+    it('does not fire syncPublishedHomeRoot when homePageId was not cleared', async () => {
+      setupSuccessScenario();
+      // Source drive has no home page set
+      txQueryDrivesFindFirst.mockResolvedValue({ homePageId: null });
+
+      await POST(createRequest(validBody));
+
+      expect(syncPublishedHomeRoot).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/pages/bulk-move/route.ts
+++ b/apps/web/src/app/api/pages/bulk-move/route.ts
@@ -13,6 +13,7 @@ import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard'
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
 import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
+import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -167,6 +168,9 @@ export async function POST(request: Request) {
     const affectedDriveIds = new Set<string>();
     affectedDriveIds.add(targetDriveId);
 
+    // Drives whose homePageId was cleared during the move (synced after tx commits).
+    const clearedHomePageDriveIds: string[] = [];
+
     // Move pages in transaction
     await db.transaction(async (tx) => {
       for (const page of sourcePages) {
@@ -218,6 +222,7 @@ export async function POST(request: Request) {
           await tx.update(drives)
             .set({ homePageId: null })
             .where(eq(drives.id, sourceDriveId));
+          clearedHomePageDriveIds.push(sourceDriveId);
         }
       }
     });
@@ -251,6 +256,12 @@ export async function POST(request: Request) {
       await broadcastPageEvent(
         createPageEventPayload(driveId, '', 'moved')
       );
+    }
+
+    // Sync the subdomain root for drives whose home page was bulk-moved away.
+    // Fire-and-forget: never blocks the response; syncPublishedHomeRoot swallows errors.
+    for (const driveId of clearedHomePageDriveIds) {
+      void syncPublishedHomeRoot(driveId);
     }
 
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'page', resourceId: 'bulk', details: { operation: 'bulk_move', count: pageIds.length } });

--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -52,9 +52,32 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
   allocatePublishSubdomain: vi.fn().mockResolvedValue('test-drive'),
 }));
 
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  logDriveActivity: vi.fn(),
+  getActorInfo: vi.fn().mockResolvedValue({ actorType: 'user' }),
+}));
+
+vi.mock('../actor-permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../actor-permissions')>();
+  return {
+    ...actual,
+    canActorManageDrive: vi.fn().mockResolvedValue(true),
+  };
+});
+
+vi.mock('@/lib/canvas/publish-page', () => ({
+  syncPublishedHomeRoot: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { driveTools } from '../drive-tools';
 import { db } from '@pagespace/db/db';
 import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
+import { getDriveById, isValidDriveHomePage, updateDrive } from '@pagespace/lib/services/drive-service';
+import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockDb = vi.mocked(db);
@@ -181,6 +204,12 @@ describe('drive-tools', () => {
   });
 
   describe('set_home_page', () => {
+    const authedContext = {
+      toolCallId: '1',
+      messages: [],
+      experimental_context: { userId: 'user-1' } as ToolExecutionContext,
+    };
+
     it('has correct tool definition', () => {
       expect(typeof driveTools.set_home_page).toBe('object');
       expect(typeof driveTools.set_home_page.description).toBe('string');
@@ -193,6 +222,39 @@ describe('drive-tools', () => {
       await expect(
         driveTools.set_home_page.execute!({ driveId: 'drive-1', pageId: 'page-1' }, context)
       ).rejects.toThrow('User authentication required');
+    });
+
+    it('fires syncPublishedHomeRoot (fire-and-forget) after setting the home page', async () => {
+      vi.mocked(getDriveById).mockResolvedValue({
+        id: 'drive-1', name: 'My Drive', homePageId: null,
+      } as Awaited<ReturnType<typeof getDriveById>>);
+      vi.mocked(isValidDriveHomePage).mockResolvedValue(true);
+      vi.mocked(updateDrive).mockResolvedValue({
+        id: 'drive-1', name: 'My Drive', homePageId: 'page-1',
+      } as Awaited<ReturnType<typeof updateDrive>>);
+
+      await driveTools.set_home_page.execute!(
+        { driveId: 'drive-1', pageId: 'page-1' },
+        authedContext,
+      );
+
+      expect(syncPublishedHomeRoot).toHaveBeenCalledWith('drive-1');
+    });
+
+    it('fires syncPublishedHomeRoot when clearing the home page', async () => {
+      vi.mocked(getDriveById).mockResolvedValue({
+        id: 'drive-1', name: 'My Drive', homePageId: 'page-1',
+      } as Awaited<ReturnType<typeof getDriveById>>);
+      vi.mocked(updateDrive).mockResolvedValue({
+        id: 'drive-1', name: 'My Drive', homePageId: null,
+      } as Awaited<ReturnType<typeof updateDrive>>);
+
+      await driveTools.set_home_page.execute!(
+        { driveId: 'drive-1', pageId: null },
+        authedContext,
+      );
+
+      expect(syncPublishedHomeRoot).toHaveBeenCalledWith('drive-1');
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -13,6 +13,7 @@ import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-s
 import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
 import type { ToolExecutionContext } from '../core/types';
 import { getAgentPageId, filterDriveIdsByAppTokenScope, driveDeniedByAppToken, isMcpScoped, canActorManageDrive } from './actor-permissions';
+import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 
 // Helper: Extract AI attribution context with actor info for activity logging
 async function getAiContextWithActor(context: ToolExecutionContext) {
@@ -566,9 +567,10 @@ This context persists across conversations and helps provide better assistance. 
           console.error('Home page updated, but activity logging failed:', sideEffectError);
         }
 
-        // Setting the home page is metadata only — it never publishes the page.
-        // The home page reaches the subdomain root only when deliberately
-        // published via the page publish API.
+        // Sync the subdomain root so `/` immediately reflects the new home page
+        // without requiring a manual republish. Fire-and-forget: never blocks
+        // the tool response. An unpublished page set as home stays private.
+        void syncPublishedHomeRoot(driveId);
 
         const message = pageId
           ? `Successfully set home page for "${drive.name}"`

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -35,6 +35,7 @@ vi.mock('../published-storage', () => ({
   putPublishedSiteFile: vi.fn().mockResolvedValue(undefined),
   publishedArtifactExists: vi.fn().mockResolvedValue(true),
   deletePublishedArtifact: vi.fn().mockResolvedValue(undefined),
+  copyPublishedArtifact: vi.fn().mockResolvedValue(undefined),
   isPublishConfigured: vi.fn().mockReturnValue(true),
   getPublishAssetBaseUrl: vi.fn().mockReturnValue('https://cdn.example.com'),
 }));
@@ -92,8 +93,8 @@ vi.mock('@pagespace/lib/utils/utils', () => ({
 }));
 
 import { db } from '@pagespace/db/db';
-import { putPublishedArtifact, putPublishedSiteFile, publishedArtifactExists, deletePublishedArtifact, isPublishConfigured } from '../published-storage';
-import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, PublishError } from '../publish-page';
+import { putPublishedArtifact, putPublishedSiteFile, publishedArtifactExists, deletePublishedArtifact, copyPublishedArtifact, isPublishConfigured } from '../published-storage';
+import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, syncPublishedHomeRoot, PublishError } from '../publish-page';
 
 // The mocked `db` keeps the real relational-query return types, so partial test
 // fixtures are cast through `unknown` to the row shape (never `any`).
@@ -489,5 +490,104 @@ describe('regeneratePublishedSiteFiles', () => {
     vi.mocked(putPublishedSiteFile).mockRejectedValue(new Error('S3 down'));
 
     await expect(regeneratePublishedSiteFiles('drive-1')).resolves.toBeUndefined();
+  });
+});
+
+// Published-page row cast helper (parallel to the PageRow helper above).
+type PublishedPageRow = NonNullable<Awaited<ReturnType<typeof db.query.publishedPages.findFirst>>>;
+const publishedPageRow = (row: Record<string, unknown>) => row as unknown as PublishedPageRow;
+
+describe('syncPublishedHomeRoot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isPublishConfigured).mockReturnValue(true);
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue([]);
+  });
+
+  it('is a no-op when publishing is not configured', async () => {
+    vi.mocked(isPublishConfigured).mockReturnValue(false);
+
+    await syncPublishedHomeRoot('drive-1');
+
+    expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(deletePublishedArtifact).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the drive has no publishSubdomain', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      publishSubdomain: null, homePageId: 'page-1',
+    }));
+
+    await syncPublishedHomeRoot('drive-1');
+
+    expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(deletePublishedArtifact).not.toHaveBeenCalled();
+  });
+
+  it('deletes the root when homePageId is cleared (null)', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      publishSubdomain: 'sub', homePageId: null,
+    }));
+
+    await syncPublishedHomeRoot('drive-1');
+
+    expect(deletePublishedArtifact).toHaveBeenCalledWith('published/sub/index.html');
+    expect(copyPublishedArtifact).not.toHaveBeenCalled();
+  });
+
+  it('copies the slug artifact to the root when the home page is published', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      publishSubdomain: 'sub', homePageId: 'page-1',
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(publishedPageRow({
+      artifactKey: 'published/sub/home/index.html',
+    }));
+
+    await syncPublishedHomeRoot('drive-1');
+
+    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+      'published/sub/home/index.html',
+      'published/sub/index.html',
+    );
+    // Site files regenerated so the sitemap lists `/`.
+    expect(putPublishedSiteFile).toHaveBeenCalled();
+  });
+
+  it('deletes the root when the home page is not yet published (unpublished stays private)', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      publishSubdomain: 'sub', homePageId: 'page-1',
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+
+    await syncPublishedHomeRoot('drive-1');
+
+    expect(deletePublishedArtifact).toHaveBeenCalledWith('published/sub/index.html');
+    expect(copyPublishedArtifact).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: re-marking the same published home page re-copies without error', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      publishSubdomain: 'sub', homePageId: 'page-1',
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(publishedPageRow({
+      artifactKey: 'published/sub/home/index.html',
+    }));
+
+    await syncPublishedHomeRoot('drive-1');
+    await syncPublishedHomeRoot('drive-1');
+
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(2);
+  });
+
+  it('swallows errors so the metadata update is never blocked', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      publishSubdomain: 'sub', homePageId: 'page-1',
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(publishedPageRow({
+      artifactKey: 'published/sub/home/index.html',
+    }));
+    vi.mocked(copyPublishedArtifact).mockRejectedValueOnce(new Error('S3 down'));
+
+    await expect(syncPublishedHomeRoot('drive-1')).resolves.toBeUndefined();
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -524,7 +524,7 @@ describe('syncPublishedHomeRoot', () => {
     expect(deletePublishedArtifact).not.toHaveBeenCalled();
   });
 
-  it('deletes the root when homePageId is cleared (null)', async () => {
+  it('deletes the root and regenerates site files when homePageId is cleared (null)', async () => {
     vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
       publishSubdomain: 'sub', homePageId: null,
     }));
@@ -533,6 +533,8 @@ describe('syncPublishedHomeRoot', () => {
 
     expect(deletePublishedArtifact).toHaveBeenCalledWith('published/sub/index.html');
     expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    // Sitemap must no longer advertise the dead `/` route.
+    expect(putPublishedSiteFile).toHaveBeenCalled();
   });
 
   it('copies the slug artifact to the root when the home page is published', async () => {
@@ -553,7 +555,7 @@ describe('syncPublishedHomeRoot', () => {
     expect(putPublishedSiteFile).toHaveBeenCalled();
   });
 
-  it('deletes the root when the home page is not yet published (unpublished stays private)', async () => {
+  it('deletes the root and regenerates site files when the home page is not yet published (unpublished stays private)', async () => {
     vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
       publishSubdomain: 'sub', homePageId: 'page-1',
     }));
@@ -563,6 +565,8 @@ describe('syncPublishedHomeRoot', () => {
 
     expect(deletePublishedArtifact).toHaveBeenCalledWith('published/sub/index.html');
     expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    // Sitemap must no longer advertise the dead `/` route.
+    expect(putPublishedSiteFile).toHaveBeenCalled();
   });
 
   it('is idempotent: re-marking the same published home page re-copies without error', async () => {

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand, CopyObjectCommand } from '@aws-sdk/client-s3';
 import {
   buildPublishedKey,
   putPublishedArtifact,
@@ -7,6 +7,7 @@ import {
   putPublishedSiteFile,
   publishedArtifactExists,
   deletePublishedArtifact,
+  copyPublishedArtifact,
   isPublishConfigured,
   buildAssetKey,
   buildAssetUrl,
@@ -182,6 +183,41 @@ describe('deletePublishedArtifact', () => {
       Bucket: 'test-bucket',
       Key: 'published/acme/index.html',
     });
+  });
+});
+
+describe('copyPublishedArtifact', () => {
+  beforeEach(() => {
+    send.mockReset();
+    send.mockResolvedValue({});
+    process.env.PUBLISH_BUCKET = 'test-bucket';
+  });
+
+  it('sends a CopyObjectCommand within the publish bucket', async () => {
+    await copyPublishedArtifact(
+      'published/acme/about/index.html',
+      'published/acme/index.html',
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0][0];
+    expect(command).toBeInstanceOf(CopyObjectCommand);
+    expect(command.input).toMatchObject({
+      Bucket: 'test-bucket',
+      CopySource: 'test-bucket/published/acme/about/index.html',
+      Key: 'published/acme/index.html',
+      ContentType: 'text/html; charset=utf-8',
+      MetadataDirective: 'REPLACE',
+    });
+  });
+
+  it('uses the publish bucket for both source and destination', async () => {
+    process.env.PUBLISH_BUCKET = 'my-site-bucket';
+    await copyPublishedArtifact('published/sub/slug/index.html', 'published/sub/index.html');
+
+    const command = send.mock.calls[0][0];
+    expect(command.input.Bucket).toBe('my-site-bucket');
+    expect(command.input.CopySource).toContain('my-site-bucket/');
   });
 });
 

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -17,6 +17,7 @@ import {
   putPublishedSiteFile,
   publishedArtifactExists,
   deletePublishedArtifact,
+  copyPublishedArtifact,
   isPublishConfigured,
   getPublishAssetBaseUrl,
 } from './published-storage';
@@ -354,11 +355,11 @@ export async function regeneratePublishedSiteFiles(driveId: string): Promise<voi
 
     // The home page is canonicalised to the subdomain root (where it is
     // mirror-served) instead of its slug, so the inventory has no duplicate for
-    // it — but ONLY when the root mirror actually exists. Setting `homePageId` is
-    // metadata-only and never writes `published/<sub>/index.html`; a page
-    // published at its slug and later made the home page has no root mirror until
-    // it is re-published as such. Advertising `/` in that case would surface a
-    // dead route and drop the live slug URL, so confirm the mirror first.
+    // it — but ONLY when the root mirror actually exists. `syncPublishedHomeRoot`
+    // writes `published/<sub>/index.html` whenever a published page is made the
+    // home, but a page published at its slug and made home BEFORE the first sync
+    // may still not have the mirror. Confirm the root object exists before
+    // advertising `/` to avoid surfacing a dead route.
     const homeRow = drive.homePageId
       ? published.find((row) => row.pageId === drive.homePageId)
       : undefined;
@@ -436,6 +437,68 @@ export async function publishHomePageAtRoot(
     driveId,
     userId,
   });
+}
+
+/**
+ * Sync the subdomain root to reflect the drive's current home page.
+ *
+ * Called (fire-and-forget) after `homePageId` changes on a drive — both from
+ * the PATCH /api/drives/[driveId] route and the `set_home_page` AI tool. Never
+ * blocks the metadata update; all errors are logged and swallowed.
+ *
+ * Decision matrix (implements Option B — route bytes already in storage):
+ *   - not configured / no subdomain        → no-op
+ *   - homePageId cleared (null)            → delete root (clears stale home)
+ *   - homePageId set, page not published   → delete root (unpublished ≠ public)
+ *   - homePageId set, page IS published    → S3-copy slug artifact to root +
+ *                                            regenerate site files
+ *
+ * Idempotent: re-marking the same home page just re-copies. The copy is
+ * byte-for-byte identical to the slug artifact — no re-render, no new content
+ * pushed live. An unpublished page set as home is never written to the root.
+ */
+export async function syncPublishedHomeRoot(driveId: string): Promise<void> {
+  try {
+    if (!isPublishConfigured()) return;
+
+    const drive = await db.query.drives.findFirst({
+      where: eq(drives.id, driveId),
+      columns: { publishSubdomain: true, homePageId: true },
+    });
+    const subdomain = drive?.publishSubdomain;
+    if (!subdomain) return;
+
+    const rootKey = buildPublishedKey(subdomain, '');
+
+    if (!drive.homePageId) {
+      await deletePublishedArtifact(rootKey);
+      return;
+    }
+
+    const publishedRow = await db.query.publishedPages.findFirst({
+      where: eq(publishedPages.pageId, drive.homePageId),
+      columns: { artifactKey: true },
+    });
+
+    if (!publishedRow) {
+      // Home page designated but not yet published — clear any stale root mirror
+      // so `/` never serves content that is no longer the intended home page.
+      await deletePublishedArtifact(rootKey);
+      return;
+    }
+
+    // Home page is already published at its slug — copy those live bytes to the
+    // root key. This is a storage-layer copy (no re-render), so only content
+    // that was deliberately published ever reaches the root.
+    await copyPublishedArtifact(publishedRow.artifactKey, rootKey);
+    // Regenerate site files so the sitemap advertises `/` for the home page.
+    await regeneratePublishedSiteFiles(driveId);
+  } catch (err) {
+    loggers.api.warn('Failed to sync published home-page root mirror', {
+      driveId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -448,8 +448,8 @@ export async function publishHomePageAtRoot(
  *
  * Decision matrix (implements Option B — route bytes already in storage):
  *   - not configured / no subdomain        → no-op
- *   - homePageId cleared (null)            → delete root (clears stale home)
- *   - homePageId set, page not published   → delete root (unpublished ≠ public)
+ *   - homePageId cleared (null)            → delete root + regenerate site files
+ *   - homePageId set, page not published   → delete root + regenerate site files
  *   - homePageId set, page IS published    → S3-copy slug artifact to root +
  *                                            regenerate site files
  *
@@ -472,6 +472,8 @@ export async function syncPublishedHomeRoot(driveId: string): Promise<void> {
 
     if (!drive.homePageId) {
       await deletePublishedArtifact(rootKey);
+      // Regenerate so the sitemap stops advertising the now-dead `/` route.
+      await regeneratePublishedSiteFiles(driveId);
       return;
     }
 
@@ -484,6 +486,8 @@ export async function syncPublishedHomeRoot(driveId: string): Promise<void> {
       // Home page designated but not yet published — clear any stale root mirror
       // so `/` never serves content that is no longer the intended home page.
       await deletePublishedArtifact(rootKey);
+      // Regenerate so the sitemap stops advertising the now-dead `/` route.
+      await regeneratePublishedSiteFiles(driveId);
       return;
     }
 

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { S3Client, PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, DeleteObjectCommand, HeadObjectCommand, GetObjectCommand, CopyObjectCommand } from '@aws-sdk/client-s3';
 import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
 
 const CONTENT_HASH_RE = /^[0-9a-f]{64}$/i;
@@ -240,6 +240,29 @@ export async function deletePublishedArtifact(key: string): Promise<void> {
     new DeleteObjectCommand({
       Bucket: getPublishBucket(),
       Key: key,
+    }),
+  );
+}
+
+/**
+ * Copy an already-published artifact to another key within the same publish
+ * bucket. Used to route an existing slug artifact to the subdomain root when a
+ * page is designated the drive's home page.
+ *
+ * Copies bytes as-is — no re-render. The root carries the slug's canonical URL
+ * (since it is the slug render); that is acceptable (slug is a valid canonical).
+ * MetadataDirective=REPLACE ensures the text/html content-type is always set
+ * correctly regardless of what the source object's stored metadata says.
+ */
+export async function copyPublishedArtifact(fromKey: string, toKey: string): Promise<void> {
+  const bucket = getPublishBucket();
+  await getPublishClient().send(
+    new CopyObjectCommand({
+      Bucket: bucket,
+      CopySource: `${bucket}/${fromKey}`,
+      Key: toKey,
+      ContentType: 'text/html; charset=utf-8',
+      MetadataDirective: 'REPLACE',
     }),
   );
 }

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -206,10 +206,11 @@ export async function putPublishedSiteFile(params: {
  * Whether an object exists at the given key in the publish bucket.
  *
  * Used to decide a page's canonical sitemap URL: the home page is served at the
- * subdomain root only once it has been deliberately published *as* the home page
- * (which writes `published/<sub>/index.html`). Setting `homePageId` is
- * metadata-only and does NOT create that mirror, so the sitemap must confirm the
- * root object is really there before advertising `/` instead of the slug.
+ * subdomain root only once the root mirror exists at `published/<sub>/index.html`.
+ * `syncPublishedHomeRoot` creates that mirror automatically after `homePageId`
+ * changes, but there is a brief async window and legacy drives may predate the
+ * auto-sync. Confirming the object exists before advertising `/` prevents
+ * surfacing a dead route in the sitemap.
  *
  * A 404/NotFound means "not present" → false. Any other error propagates so the
  * caller (a best-effort regeneration) can log and skip rather than silently treat


### PR DESCRIPTION
## Summary

Eliminates the publish gotcha where setting a page as a drive's home page didn't update \`/\` — the publish-status endpoint was already reporting the home page's URL as \`<sub>.pagespace.site/\` while that URL actually 404'd until the user manually republished.

**Option B implementation**: when a published page is made the home page (or the home page changes/clears), immediately sync the subdomain root by **routing the bytes already in storage** — no re-render. An unpublished page set as home stays private.

### What changed

- **\`published-storage.ts\`**: \`copyPublishedArtifact(fromKey, toKey)\` — same-bucket \`CopyObjectCommand\` with \`MetadataDirective: REPLACE\` to ensure correct content-type regardless of source metadata
- **\`publish-page.ts\`**: \`syncPublishedHomeRoot(driveId)\` — decision matrix: published home → S3-copy slug artifact to root + regenerate site files; unpublished home or cleared home → delete root (clears stale); no subdomain / not configured → no-op. Swallows all errors (best-effort, logged).
- **\`PATCH /api/drives/[driveId]\`**: fire-and-forget \`void syncPublishedHomeRoot(driveId)\` after \`homePageId\` persists; stale metadata-only comment removed
- **\`set_home_page\` AI tool**: same fire-and-forget sync; stale metadata-only comment removed
- **\`POST /api/pages/bulk-move\`**: tracks drives whose \`homePageId\` was cleared when the home page was bulk-moved to another drive, then fires \`syncPublishedHomeRoot\` (fire-and-forget) for each after the transaction — closes the gap where the published root would serve an evicted page until manual republish

### Key safety properties preserved
- **Copy, not re-render**: marking-as-home never pushes newer or unreviewed canvas edits live. Root bytes are identical to the slug artifact.
- **Unpublished stays private**: \`syncPublishedHomeRoot\` checks \`published_pages\` before writing anything to the root.
- **Idempotent**: re-marking the same published page just re-copies.
- **Non-blocking**: fire-and-forget in all call sites; the metadata update completes regardless of S3 status.
- **Note on canonical URL**: the copied root carries the slug's canonical/og:url (it's the slug render). That's acceptable (slug is a valid canonical); \`canonical=/\` is a separate follow-up if desired — not addressed here.

### Tests added
- \`copyPublishedArtifact\`: verifies \`CopyObjectCommand\` shape (bucket, CopySource, Key, content-type, MetadataDirective)
- \`syncPublishedHomeRoot\`: full decision matrix — published→copy-to-root+regenerate; unpublished→clear; cleared(null)→clear; no-subdomain→noop; not-configured→noop; idempotent; swallows errors
- \`drive-tools set_home_page\`: both set and clear paths invoke \`syncPublishedHomeRoot\`
- \`bulk-move\`: fires sync for cleared home page drive; no-op when homePageId unchanged

### Related epic
Published Canvas Landing Pages — \`lng6q95adrfndmdnnf9z8g6p\` / epic \`cavywjsvr5mh2earyinn8xrl\` / task \`y6z1pxm42cquciqaa6pry6so\`. Follows PRs #1673/#1679/#1680/#1681.

## Test plan
- [ ] lint + typecheck + build: green (confirmed locally)
- [ ] \`publish-page.test.ts\` / \`published-storage.test.ts\`: 96 tests pass
- [ ] \`drive-tools.test.ts\`: 20 tests pass (including 2 new sync-wiring tests)
- [ ] \`bulk-move/route.test.ts\`: 44 tests pass (including 2 new sync-wiring tests)
- [ ] Pre-existing failures (auth/admin-role-version, chat/completions abort, activity-tools, messages/grouping) are unchanged from master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LouDrkvGaE1UWdVY6rMHFn