### PR TITLE
fix(ai-chat): never render a selected conversation blank — load latest messages from server on both surfaces

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -430,15 +430,20 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                 `/api/ai/page-agents/${page.id}/conversations/${conv.id}/messages`,
                 { signal: controller.signal }
               );
-              const { messages: loaded } = msgResponse.ok
-                ? ((await msgResponse.json()) as ConversationMessagesResponse)
-                : { messages: [] as UIMessage[] };
+              // undefined = fetch failed; keep undefined so loadMessagesForConversation
+              // takes the network path and shows the error banner on failure.
+              const loaded = msgResponse.ok
+                ? (((await msgResponse.json()) as ConversationMessagesResponse).messages ?? [])
+                : undefined;
               if (controller.signal.aborted) return;
               // Supply pre-fetched messages directly to the one-writer path and suppress
               // the load-on-select effect so we don't re-fetch what we just loaded.
-              skipLoadEffectRef.current = conv.id;
+              // Only suppress when the fetch actually succeeded (loaded !== undefined).
+              if (loaded !== undefined) {
+                skipLoadEffectRef.current = conv.id;
+              }
               setCurrentConversationId(conv.id);
-              void loadMessagesForConversation(conv.id, loaded ?? []);
+              void loadMessagesForConversation(conv.id, loaded);
               setIsInitialized(true);
               return;
             }

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -43,6 +43,8 @@ import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo'
 import { shouldPrependConversation } from '@/lib/ai/streams/shouldPrependConversation';
 import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
+import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
+import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { useShallow } from 'zustand/react/shallow';
 
 // Shared hooks and components
@@ -103,6 +105,10 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const [currentConversationId, setCurrentConversationId] = useState<string | null>(null);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
   const [lastAIResponse, setLastAIResponse] = useState<{ id: string; text: string } | null>(null);
+  // Message-load state — tracks in-progress DB fetches and their failures independently
+  // of the useChat streaming state so blank → spinner instead of blank → blank.
+  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+  const [messagesLoadError, setMessagesLoadError] = useState<Error | null>(null);
   // undefined = uninitialized, null = initialized with no baseline message, string = baseline message ID
   const voiceBaselineRef = useRef<string | null | undefined>(undefined);
   // Voice mode state
@@ -126,6 +132,12 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // Always reflects the current page.id so async callbacks can detect stale pages
   const pageIdRef = useRef(page.id);
   useEffect(() => { pageIdRef.current = page.id; }, [page.id]);
+  // Tracks the conversationId of the most recent loadMessagesForConversation call so
+  // stale in-flight fetches (from a previous conversation) are silently dropped.
+  const loadRequestedIdRef = useRef<string | null>(null);
+  // When set to a conversationId, the load-on-select effect skips the fetch for that
+  // id on its next fire (messages are already provided inline, avoiding a double-fetch).
+  const skipLoadEffectRef = useRef<string | null>(null);
 
   // ============================================
   // SHARED HOOKS
@@ -171,11 +183,21 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     currentConversationId,
     enabled: activeTab === 'history',
     onConversationLoad: (conversationId, messages) => {
+      // Use the pre-fetched messages directly (no re-fetch) and suppress the
+      // load-on-select effect for this id so we don't double-request the server.
+      skipLoadEffectRef.current = conversationId;
       setCurrentConversationId(conversationId);
-      setMessages(messages);
       setActiveTab('chat');
+      void loadMessagesForConversation(conversationId, messages);
+    },
+    onConversationLoadError: (_conversationId, error) => {
+      // The conversation list fetch failed — show the error inline without
+      // clearing existing messages (caller's toast already announced the failure).
+      setMessagesLoadError(error);
     },
     onConversationCreate: (conversationId) => {
+      // New conversation has no messages — skip the load effect.
+      skipLoadEffectRef.current = conversationId;
       setCurrentConversationId(conversationId);
       setMessages([]);
       setActiveTab('chat');
@@ -235,6 +257,71 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   const isStreaming = status === 'submitted' || status === 'streaming';
 
+  // ============================================
+  // AUTHORITATIVE MESSAGE LOADER (the ONE setMessages writer)
+  // ============================================
+  // Fetches the latest DB messages for a conversation and writes them to useChat
+  // via setMessages. All other paths (init, history-select, pull-up, undo) funnel
+  // through here so there is never a competing write from a stale in-flight fetch.
+  //
+  // Pass preloadedMessages to skip the network round-trip when the caller already
+  // has fresh data (e.g. useConversations.loadConversation already fetched them).
+  // The stale-guard and pending-stream reconciliation still run in both paths.
+  const loadMessagesForConversation = useCallback(async (
+    conversationId: string,
+    preloadedMessages?: UIMessage[],
+  ): Promise<void> => {
+    // Skip the placeholder id — it has no server-side messages yet.
+    if (conversationId === `${page.id}-default`) return;
+
+    loadRequestedIdRef.current = conversationId;
+    setIsLoadingMessages(true);
+    setMessagesLoadError(null);
+
+    try {
+      let serverMessages: UIMessage[];
+
+      if (preloadedMessages !== undefined) {
+        // Fast path: caller already did the fetch (history-select, init).
+        serverMessages = preloadedMessages;
+      } else {
+        const res = await fetchWithAuth(
+          `/api/ai/page-agents/${page.id}/conversations/${conversationId}/messages`,
+        );
+        // Stale check after await — user may have switched conversation.
+        if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+        if (!res.ok) throw new Error(`Failed to load messages (${res.status})`);
+        const data = await res.json();
+        if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+        serverMessages = (data as ConversationMessagesResponse).messages ?? [];
+      }
+
+      if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+
+      // Reconcile with any in-flight own stream so a DB reload during an active
+      // stream doesn't drop the streaming bubble or duplicate it once persisted.
+      // NOTE: prod runs multiple web instances — live tokens from a stream on another
+      // instance won't be in the pending store; the persisted message still shows up
+      // on the next DB load. Cross-instance live-token rejoin is a known follow-up.
+      const ownStream = usePendingStreamsStore.getState().getOwnStreams(page.id)[0];
+      const merged =
+        ownStream?.conversationId === conversationId && ownStream.messageId
+          ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId)
+          : serverMessages;
+
+      setMessages(merged);
+      setMessagesLoadError(null);
+    } catch (err) {
+      if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+      // Keep the messages the user was already looking at — never silently blank on failure.
+      setMessagesLoadError(err instanceof Error ? err : new Error('Failed to load messages'));
+    } finally {
+      if (shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) {
+        setIsLoadingMessages(false);
+      }
+    }
+  }, [page.id, setMessages]);
+
   // Find in page
   const findQuery = useFindStore((s) => s.query);
   const findIndex = useFindStore((s) => s.currentIndex);
@@ -275,7 +362,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       .map((p) => (p as { type: 'text'; text: string }).text)
       .join('');
   }, [messages, isStreaming]);
-  const isLoading = !isInitialized;
+  // Show a loading indicator (not a blank) both during init and during any
+  // subsequent message-fetch triggered by conversation switch or refresh.
+  const isLoading = !isInitialized || isLoadingMessages;
 
   // ============================================
   // MESSAGE ACTIONS (shared hook)
@@ -345,8 +434,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                 ? ((await msgResponse.json()) as ConversationMessagesResponse)
                 : { messages: [] as UIMessage[] };
               if (controller.signal.aborted) return;
+              // Supply pre-fetched messages directly to the one-writer path and suppress
+              // the load-on-select effect so we don't re-fetch what we just loaded.
+              skipLoadEffectRef.current = conv.id;
               setCurrentConversationId(conv.id);
-              setMessages(loaded ?? []);
+              void loadMessagesForConversation(conv.id, loaded ?? []);
               setIsInitialized(true);
               return;
             }
@@ -377,6 +469,20 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page.id]);
+
+  // Load-on-select guarantee: whenever currentConversationId changes to a real
+  // (non-placeholder) id, reload the latest messages from the DB. This fires for
+  // conversation switches triggered from sources other than the init / history-select
+  // paths (which use the preloaded fast-path and set skipLoadEffectRef to opt out).
+  useEffect(() => {
+    if (!currentConversationId) return;
+    if (currentConversationId === `${page.id}-default`) return;
+    if (skipLoadEffectRef.current === currentConversationId) {
+      skipLoadEffectRef.current = null; // consume the skip token
+      return;
+    }
+    void loadMessagesForConversation(currentConversationId);
+  }, [currentConversationId, page.id, loadMessagesForConversation]);
 
   // Register streaming state with editing store
   useStreamingRegistration(
@@ -674,34 +780,14 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   const handleUndoSuccess = useCallback(async () => {
     if (!currentConversationId) return;
-    try {
-      const res = await fetchWithAuth(
-        `/api/ai/page-agents/${page.id}/conversations/${currentConversationId}/messages`
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setMessages(data.messages);
-      }
-    } catch (error) {
-      console.error('Failed to refresh messages after undo:', error);
-    }
-  }, [currentConversationId, page.id, setMessages]);
+    await loadMessagesForConversation(currentConversationId);
+  }, [currentConversationId, loadMessagesForConversation]);
 
   // Pull-up refresh handler for mobile - check for missed messages
   const handlePullUpRefresh = useCallback(async () => {
     if (!currentConversationId) return;
-    try {
-      const res = await fetchWithAuth(
-        `/api/ai/page-agents/${page.id}/conversations/${currentConversationId}/messages`
-      );
-      if (res.ok) {
-        const data = await res.json();
-        setMessages(data.messages);
-      }
-    } catch (error) {
-      console.error('Failed to refresh messages:', error);
-    }
-  }, [currentConversationId, page.id, setMessages]);
+    await loadMessagesForConversation(currentConversationId);
+  }, [currentConversationId, loadMessagesForConversation]);
 
   // App state recovery - re-attach/refetch AI stream when returning from background.
   // On native (Capacitor): if streaming, stop the local fetch, rejoin any still-live
@@ -833,6 +919,25 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
         {/* Chat Tab */}
         <TabsContent value="chat" className="flex flex-col flex-1 overflow-hidden relative">
+          {/* Inline error shown when a message-load fails — never silently blank. */}
+          {messagesLoadError && (
+            <div className="flex items-center justify-between gap-2 px-4 py-2 bg-destructive/10 text-destructive text-sm border-b border-destructive/20">
+              <span className="truncate">Failed to load messages: {messagesLoadError.message}</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+                onClick={() => {
+                  if (currentConversationId) {
+                    setMessagesLoadError(null);
+                    void loadMessagesForConversation(currentConversationId);
+                  }
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
           <ChatLayout
             ref={chatLayoutRef}
             messages={messages}

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -77,7 +77,11 @@ vi.mock('@/stores/useEditingStore', () => ({
 
 vi.mock('@/stores/usePendingStreamsStore', () => ({
   usePendingStreamsStore: Object.assign(vi.fn(() => []), {
-    getState: vi.fn(() => ({ streams: new Map() })),
+    getState: vi.fn(() => ({
+      streams: new Map(),
+      getOwnStreams: vi.fn(() => []),
+      getRemotePageStreams: vi.fn(() => []),
+    })),
   }),
 }));
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -494,27 +494,10 @@ const SidebarChatTab: React.FC = () => {
     { conversationId: currentConversationId || undefined, componentName: 'SidebarChatTab' }
   );
 
-  // When remote events fire (reconnect, undo from another tab, cross-tab
-  // edit/delete), GlobalChatContext increments refreshSignal. If
-  // GlobalAssistantView is not mounted (user is on a page, not the dashboard),
-  // this sidebar is responsible for re-fetching global messages.
-  const prevSidebarRefreshSignalRef = useRef(refreshSignal);
-  const globalIsInitializedRef = useRef(globalIsInitialized);
-  globalIsInitializedRef.current = globalIsInitialized;
-  useEffect(() => {
-    if (refreshSignal === prevSidebarRefreshSignalRef.current) return;
-    prevSidebarRefreshSignalRef.current = refreshSignal;
-    if (!selectedAgent && globalIsInitializedRef.current && globalConversationId && !displayIsStreaming) {
-      fetchWithAuth(`/api/ai/global/${globalConversationId}/messages`)
-        .then((res) => res.ok ? res.json() : null)
-        .then((data) => { if (data) setGlobalMessages(data.messages); })
-        .catch((err) => console.error('Sidebar refreshSignal fetch failed:', err));
-    }
-  }, [refreshSignal, selectedAgent, globalConversationId, displayIsStreaming, setGlobalMessages]);
-
   // Fetches the latest DB messages for the active global conversation and writes
   // them to the useChat instance via setGlobalMessages. Single writer for the
-  // global-mode server→view path; shared by the load-on-select effect and retry.
+  // global-mode server→view path; shared by the load-on-select effect, the
+  // refreshSignal handler, and the retry button.
   //
   // NOTE: prod runs multiple web instances — live tokens from a stream on another
   // instance won't be in the pending store; the persisted message still shows up
@@ -551,6 +534,23 @@ const SidebarChatTab: React.FC = () => {
         }
       });
   }, [setGlobalMessages]);
+
+  // When remote events fire (reconnect, undo from another tab, cross-tab
+  // edit/delete), GlobalChatContext increments refreshSignal. If
+  // GlobalAssistantView is not mounted (user is on a page, not the dashboard),
+  // this sidebar is responsible for re-fetching global messages.
+  // Routed through loadGlobalMessages so the stale-request guard prevents a
+  // race where a slow refreshSignal fetch overwrites a newer conversation's messages.
+  const prevSidebarRefreshSignalRef = useRef(refreshSignal);
+  const globalIsInitializedRef = useRef(globalIsInitialized);
+  globalIsInitializedRef.current = globalIsInitialized;
+  useEffect(() => {
+    if (refreshSignal === prevSidebarRefreshSignalRef.current) return;
+    prevSidebarRefreshSignalRef.current = refreshSignal;
+    if (!selectedAgent && globalIsInitializedRef.current && globalConversationId && !displayIsStreaming) {
+      loadGlobalMessages(globalConversationId);
+    }
+  }, [refreshSignal, selectedAgent, globalConversationId, displayIsStreaming, loadGlobalMessages]);
 
   // Load-on-select guarantee for global mode (1B).
   //
@@ -862,23 +862,24 @@ const SidebarChatTab: React.FC = () => {
   const handleUndoSuccess = useCallback(async () => {
     setUndoDialogMessageId(null);
     if (!currentConversationId) return;
-    try {
-      const url = selectedAgent
-        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
-        : `/api/ai/global/${currentConversationId}/messages`;
-      const res = await fetchWithAuth(url);
-      if (res.ok) {
-        const data = await res.json();
-        if (selectedAgent) {
+    if (selectedAgent) {
+      // Agent mode: direct fetch (loadGlobalMessages is global-only).
+      try {
+        const res = await fetchWithAuth(
+          `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`,
+        );
+        if (res.ok) {
+          const data = await res.json();
           setMessages(data.messages);
-        } else {
-          setGlobalMessages(data.messages);
         }
+      } catch (error) {
+        console.error('Failed to refresh messages after undo:', error);
       }
-    } catch (error) {
-      console.error('Failed to refresh messages after undo:', error);
+    } else {
+      // Global mode: route through loadGlobalMessages for stale guard + pending merge.
+      loadGlobalMessages(currentConversationId);
     }
-  }, [currentConversationId, selectedAgent, setMessages, setGlobalMessages]);
+  }, [currentConversationId, selectedAgent, setMessages, loadGlobalMessages]);
 
   // ============================================
   // Computed Values for Rendering

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
-import { UIMessage } from 'ai';
+import type { UIMessage } from 'ai';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { ChatInput, type ChatInputRef } from '@/components/ai/chat/input';
@@ -41,6 +41,8 @@ import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
+import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
+import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
 
@@ -338,6 +340,13 @@ const SidebarChatTab: React.FC = () => {
   // undefined = uninitialized, null = initialized with no baseline message, string = baseline message ID
   const voiceBaselineRef = useRef<string | null | undefined>(undefined);
 
+  // Global-mode load-on-select state: tracks in-progress DB fetches and their
+  // failures so the sidebar never shows a silent blank on conversation select.
+  const [isLoadingGlobalMessages, setIsLoadingGlobalMessages] = useState(false);
+  const [globalMessagesLoadError, setGlobalMessagesLoadError] = useState<Error | null>(null);
+  // Stale-request guard: holds the conversationId of the most recent load request.
+  const globalLoadRequestedIdRef = useRef<string | null>(null);
+
   // Voice mode state
   const isVoiceModeEnabled = useVoiceModeStore((s) => s.isEnabled);
   const voiceOwner = useVoiceModeStore((s) => s.owner);
@@ -503,6 +512,60 @@ const SidebarChatTab: React.FC = () => {
     }
   }, [refreshSignal, selectedAgent, globalConversationId, displayIsStreaming, setGlobalMessages]);
 
+  // Fetches the latest DB messages for the active global conversation and writes
+  // them to the useChat instance via setGlobalMessages. Single writer for the
+  // global-mode server→view path; shared by the load-on-select effect and retry.
+  //
+  // NOTE: prod runs multiple web instances — live tokens from a stream on another
+  // instance won't be in the pending store; the persisted message still shows up
+  // on the next DB load. Cross-instance live-token rejoin is a known follow-up.
+  const loadGlobalMessages = useCallback((conversationId: string) => {
+    globalLoadRequestedIdRef.current = conversationId;
+    setIsLoadingGlobalMessages(true);
+    setGlobalMessagesLoadError(null);
+
+    fetchWithAuth(`/api/ai/global/${conversationId}/messages`)
+      .then(async (res) => {
+        if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;
+        if (!res.ok) throw new Error(`Failed to load messages (${res.status})`);
+        const data = await res.json();
+        if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;
+        const serverMessages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
+        // Reconcile with any in-flight own stream to avoid dropping the streaming bubble.
+        const ownStream = Array.from(usePendingStreamsStore.getState().streams.values())
+          .find((s) => s.isOwn && s.conversationId === conversationId);
+        const merged = ownStream
+          ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId)
+          : serverMessages;
+        setGlobalMessages(merged);
+        setGlobalMessagesLoadError(null);
+      })
+      .catch((err) => {
+        if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;
+        // Keep prior messages — never silently blank on failure.
+        setGlobalMessagesLoadError(err instanceof Error ? err : new Error('Failed to load messages'));
+      })
+      .finally(() => {
+        if (shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) {
+          setIsLoadingGlobalMessages(false);
+        }
+      });
+  }, [setGlobalMessages]);
+
+  // Load-on-select guarantee for global mode (1B).
+  //
+  // Whenever the active global conversation changes (or the context finishes
+  // initialising), explicitly fetch the latest DB messages and write them
+  // directly to the useChat instance via setGlobalMessages. This does NOT rely
+  // on GlobalChatContext seeding useChat via chatConfig.messages (which only
+  // fires on the useChat `id` prop changing — a path prone to timing gaps when
+  // the conversation id is the same across refreshes).
+  useEffect(() => {
+    if (selectedAgent) return; // agent mode handled by useAgentChannelMultiplayer
+    if (!globalIsInitialized || !globalConversationId) return;
+    loadGlobalMessages(globalConversationId);
+  }, [globalConversationId, globalIsInitialized, selectedAgent, loadGlobalMessages]);
+
   // ============================================
   // Effects: UI State
   // ============================================
@@ -607,6 +670,11 @@ const SidebarChatTab: React.FC = () => {
   // ============================================
   // Handlers
   // ============================================
+
+  const handleRetryGlobalMessageLoad = useCallback(() => {
+    if (selectedAgent || !globalConversationId || !globalIsInitialized) return;
+    loadGlobalMessages(globalConversationId);
+  }, [selectedAgent, globalConversationId, globalIsInitialized, loadGlobalMessages]);
 
   const handleNewConversation = useCallback(async () => {
     try {
@@ -873,25 +941,47 @@ const SidebarChatTab: React.FC = () => {
         )}
       </div>
 
+      {/* Global-mode message-load error — shown above messages so it's always visible. */}
+      {!selectedAgent && globalMessagesLoadError && (
+        <div className="flex items-center justify-between gap-2 px-3 py-1.5 bg-destructive/10 text-destructive text-xs border-b border-destructive/20">
+          <span className="truncate">Failed to load messages</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs shrink-0 text-destructive hover:text-destructive hover:bg-destructive/10"
+            onClick={handleRetryGlobalMessageLoad}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+
       {/* Messages - using use-stick-to-bottom for pinned scrolling */}
       <div className="flex-1 min-h-0 min-w-0 overflow-hidden" style={{ contain: 'layout' }}>
-        <Conversation className="h-full">
-          <SidebarMessagesContent
-            messages={displayMessages}
-            assistantName={assistantName}
-            locationContext={locationContext}
-            handleEdit={handleEdit}
-            handleDelete={handleDelete}
-            handleRetry={handleRetry}
-            handleUndoFromHere={handleUndoFromHere}
-            lastAssistantMessageId={lastAssistantMessageId}
-            lastUserMessageId={lastUserMessageId}
-            displayIsStreaming={displayIsStreaming}
-            remoteStreams={remoteStreams}
-          />
-          {/* Scroll-to-bottom button - visible when user scrolls up */}
-          <ConversationScrollButton className="z-10 bottom-8" />
-        </Conversation>
+        {/* Loading indicator during global-mode message fetch (prevents blank). */}
+        {!selectedAgent && isLoadingGlobalMessages && displayMessages.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <Conversation className="h-full">
+            <SidebarMessagesContent
+              messages={displayMessages}
+              assistantName={assistantName}
+              locationContext={locationContext}
+              handleEdit={handleEdit}
+              handleDelete={handleDelete}
+              handleRetry={handleRetry}
+              handleUndoFromHere={handleUndoFromHere}
+              lastAssistantMessageId={lastAssistantMessageId}
+              lastUserMessageId={lastUserMessageId}
+              displayIsStreaming={displayIsStreaming}
+              remoteStreams={remoteStreams}
+            />
+            {/* Scroll-to-bottom button - visible when user scrolls up */}
+            <ConversationScrollButton className="z-10 bottom-8" />
+          </Conversation>
+        )}
       </div>
 
       {/* Input - adds keyboard height padding on mobile to stay above keyboard */}

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -178,12 +178,12 @@ export function useConversations({
           const messages = messagesData.messages || [];
           onConversationLoad?.(conversationId, messages);
         } else {
-          const err = new Error('Failed to load conversation');
-          onConversationLoadError?.(conversationId, err);
-          throw err;
+          throw new Error('Failed to load conversation');
         }
       } catch (error) {
-        console.error('Failed to load conversation:', error);
+        const err = error instanceof Error ? error : new Error('Failed to load conversation');
+        onConversationLoadError?.(conversationId, err);
+        console.error('Failed to load conversation:', err);
         toast.error('Failed to load conversation');
       }
     },

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -40,6 +40,7 @@ interface UseConversationsOptions {
    * Callbacks for state updates
    */
   onConversationLoad?: (conversationId: string, messages: UIMessage[]) => void;
+  onConversationLoadError?: (conversationId: string, error: Error) => void;
   onConversationCreate?: (conversationId: string) => void;
   onConversationDelete?: (conversationId: string) => void;
 }
@@ -81,6 +82,7 @@ export function useConversations({
   currentConversationId,
   enabled = true,
   onConversationLoad,
+  onConversationLoadError,
   onConversationCreate,
   onConversationDelete,
 }: UseConversationsOptions): UseConversationsResult {
@@ -176,14 +178,16 @@ export function useConversations({
           const messages = messagesData.messages || [];
           onConversationLoad?.(conversationId, messages);
         } else {
-          throw new Error('Failed to load conversation');
+          const err = new Error('Failed to load conversation');
+          onConversationLoadError?.(conversationId, err);
+          throw err;
         }
       } catch (error) {
         console.error('Failed to load conversation:', error);
         toast.error('Failed to load conversation');
       }
     },
-    [isAgentMode, agentId, onConversationLoad]
+    [isAgentMode, agentId, onConversationLoad, onConversationLoadError]
   );
 
   // Create a new conversation

--- a/apps/web/src/lib/ai/streams/__tests__/mergeServerAndPending.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/mergeServerAndPending.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { mergeServerAndPending } from '../mergeServerAndPending';
+import type { UIMessage } from 'ai';
+
+const makeMsg = (id: string, text: string): UIMessage => ({
+  id,
+  role: 'assistant',
+  parts: [{ type: 'text', text }],
+});
+
+describe('mergeServerAndPending', () => {
+  it('returns serverMessages unchanged when pendingMessageId is undefined (no in-flight stream)', () => {
+    const server = [makeMsg('m1', 'hello'), makeMsg('m2', 'world')];
+    const result = mergeServerAndPending(server, [], undefined);
+    expect(result).toBe(server);
+  });
+
+  it('appends a synthesized message when the pending id is absent from the server list', () => {
+    const server = [makeMsg('m1', 'hello')];
+    const parts = [{ type: 'text' as const, text: 'streaming...' }];
+    const result = mergeServerAndPending(server, parts, 'pending-1');
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('m1');
+    expect(result[1].id).toBe('pending-1');
+    expect(result[1].role).toBe('assistant');
+    expect(result[1].parts).toEqual(parts);
+  });
+
+  it('returns serverMessages unchanged (deduplicated) when the pending id is already in the server list', () => {
+    const server = [makeMsg('m1', 'hello'), makeMsg('pending-1', 'finished response')];
+    const parts = [{ type: 'text' as const, text: 'streaming...' }];
+    const result = mergeServerAndPending(server, parts, 'pending-1');
+    expect(result).toBe(server);
+    expect(result).toHaveLength(2);
+  });
+
+  it('handles an empty server list with a pending stream — produces a single synthesized message', () => {
+    const parts = [{ type: 'text' as const, text: 'first response' }];
+    const result = mergeServerAndPending([], parts, 'pending-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('pending-1');
+  });
+
+  it('does not mutate the serverMessages array when appending', () => {
+    const server = [makeMsg('m1', 'hello')];
+    const parts = [{ type: 'text' as const, text: 'streaming...' }];
+    const result = mergeServerAndPending(server, parts, 'pending-1');
+    expect(result).not.toBe(server);
+    expect(server).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldApplyLoadedMessages.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldApplyLoadedMessages.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { shouldApplyLoadedMessages } from '../shouldApplyLoadedMessages';
+
+describe('shouldApplyLoadedMessages', () => {
+  it('returns true when the requested id matches the in-flight id', () => {
+    expect(shouldApplyLoadedMessages('conv-1', 'conv-1')).toBe(true);
+  });
+
+  it('returns false when the requested id differs from the in-flight id (stale response)', () => {
+    expect(shouldApplyLoadedMessages('conv-1', 'conv-2')).toBe(false);
+  });
+
+  it('returns false when the in-flight id is null (no active request)', () => {
+    expect(shouldApplyLoadedMessages('conv-1', null)).toBe(false);
+  });
+
+  it('returns true for any equal non-empty string pair', () => {
+    expect(shouldApplyLoadedMessages('abc-def-123', 'abc-def-123')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/streams/mergeServerAndPending.ts
+++ b/apps/web/src/lib/ai/streams/mergeServerAndPending.ts
@@ -1,0 +1,23 @@
+import type { UIMessage } from 'ai';
+import { synthesizeAssistantMessage } from './synthesizeAssistantMessage';
+
+type UIMessagePart = UIMessage['parts'][number];
+
+/**
+ * Reconciles a server-loaded message list with an in-flight pending stream so
+ * a DB reload during an active own-stream never drops or double-renders the
+ * streaming assistant message.
+ *
+ * - No pending stream (pendingMessageId undefined): returns serverMessages as-is.
+ * - Pending id absent from server list: appends a synthesized assistant message.
+ * - Pending id already present in server list: returns serverMessages (deduped to one).
+ */
+export const mergeServerAndPending = (
+  serverMessages: UIMessage[],
+  pendingParts: readonly UIMessagePart[],
+  pendingMessageId: string | undefined,
+): UIMessage[] => {
+  if (pendingMessageId === undefined) return serverMessages;
+  if (serverMessages.some((m) => m.id === pendingMessageId)) return serverMessages;
+  return [...serverMessages, synthesizeAssistantMessage(pendingMessageId, pendingParts)];
+};

--- a/apps/web/src/lib/ai/streams/shouldApplyLoadedMessages.ts
+++ b/apps/web/src/lib/ai/streams/shouldApplyLoadedMessages.ts
@@ -1,0 +1,13 @@
+/**
+ * Stale-response guard for conversation message loads.
+ *
+ * Returns true only when the fetch that just resolved is for the conversation
+ * the view currently wants. When the user switches conversation while a fetch
+ * is in-flight, `inFlightConversationId` (a ref updated on every new request)
+ * will have moved on, and this returns false — the caller should drop the
+ * stale result rather than clobbering the newer conversation's messages.
+ */
+export const shouldApplyLoadedMessages = (
+  requestedConversationId: string,
+  inFlightConversationId: string | null,
+): boolean => requestedConversationId === inFlightConversationId;


### PR DESCRIPTION
## Root cause

Both the page-AI chat and the Global Assistant sidebar render \`useChat\`'s **ephemeral client state** seeded from a server fetch only at mount/select. Three concrete failure modes produce a blank:

1. **useChat reset-on-config-change:** When the conversation switches, \`useChat\`'s internal SWR key changes, resetting messages to the empty \`EMPTY_MESSAGES\` config seed before the next fetch completes — producing a blank frame.
2. **No failure-path on history select:** \`useConversations.loadConversation\` only called \`onConversationLoad\` on \`response.ok\`; a 4xx/5xx silently left the view unchanged (blank if messages had been cleared).
3. **Global Assistant divergence:** \`SidebarChatTab\` renders \`useChat\`'s \`messages\`, but \`loadConversation\`/\`refreshSignal\` only updated \`initialMessages\` in \`GlobalChatContext\` — which only seeds \`useChat\` when its \`id\` prop changes. Refreshing the same conversation (same id) did not re-populate the rendered messages.
4. **Stale-race in refreshSignal handler (fixed):** The refreshSignal handler fetched directly, bypassing the stale-request guard. If the user switched conversations while a refreshSignal fetch was in-flight, the stale response would call \`setGlobalMessages\` with the OLD conversation's messages — overwriting the new one.

## Load-on-select guarantee (same principle, separate implementations)

The server is the source of truth. For both surfaces:
- A single authoritative writer fetches the latest DB messages and calls \`setMessages\`.
- An effect keyed on the active conversation id fires on every switch (including on init).
- A stale-request ref (\`loadRequestedIdRef\` / \`globalLoadRequestedIdRef\`) drops in-flight fetches whose conversation id is no longer current.
- On fetch failure: prior messages are **preserved** (never cleared to \`[]\`); an inline error banner with Retry is shown.
- \`mergeServerAndPending\` reconciles the loaded server messages with any in-flight own-stream bubble so a DB reload during an active stream never drops or duplicates the streaming message.
- During the fetch gap: a loading indicator is shown instead of a blank welcome state.

## Changes

### Shared pure helpers (\`apps/web/src/lib/ai/streams/\`)
- **\`shouldApplyLoadedMessages.ts\`** — stale-response guard comparing requested vs. in-flight conversation id.
- **\`mergeServerAndPending.ts\`** — dedupe-by-id reconciliation for DB load + in-flight pending stream; reuses \`synthesizeAssistantMessage\`.
- **\`__tests__/shouldApplyLoadedMessages.test.ts\`** — 4 tests (match → true; mismatch → false; null → false).
- **\`__tests__/mergeServerAndPending.test.ts\`** — 5 tests (no pending; absent → append; present → dedupe; empty server; no mutation).

### 1A — Page-AI chat (\`AiChatView.tsx\`, \`useConversations.ts\`)
- \`loadMessagesForConversation(conversationId, preloadedMessages?)\`: the ONE \`setMessages\` writer. Preloaded fast-path skips the network round-trip when init/history-select already has fresh messages.
- \`skipLoadEffectRef\`: prevents double-fetch — when a caller already provides messages, the load-on-select effect is suppressed for that id.
- Load-on-select effect keyed on \`currentConversationId\` (skips \`${page.id}-default\` placeholder).
- \`isLoading = !isInitialized || isLoadingMessages\` — ChatLayout sees a spinner, not a blank, during the fetch gap.
- Inline \`messagesLoadError\` banner above messages with Retry button.
- \`onConversationLoad\` funnels history-select through \`loadMessagesForConversation\` (preloaded path).
- \`handlePullUpRefresh\` and \`handleUndoSuccess\` both delegate to \`loadMessagesForConversation\`.
- \`useConversations.ts\`: added \`onConversationLoadError\` callback so fetch failures on history-select surface inline rather than silently passing.

### 1B — Global Assistant sidebar (\`SidebarChatTab.tsx\`)
- \`loadGlobalMessages(conversationId)\`: single writer for global-mode server→view path. Writes directly to \`setGlobalMessages\` (the \`useChat\` setter) — does not rely on \`chatConfig.messages\` seeding. Includes stale guard, \`mergeServerAndPending\` reconciliation, and error banner.
- Load-on-select effect keyed on \`globalConversationId + globalIsInitialized\` (skips agent mode).
- \`refreshSignal\` handler (cross-tab edit/delete/undo events) now routes through \`loadGlobalMessages\` — fixes pre-existing stale race where a slow cross-tab refresh fetch could overwrite a newer conversation's messages.
- \`handleUndoSuccess\` global path now routes through \`loadGlobalMessages\` for consistent stale guard and pending-stream reconciliation.
- \`handleRetryGlobalMessageLoad\` uses the same \`loadGlobalMessages\` callback.
- \`isLoadingGlobalMessages\`: spinner shown when messages=[] and fetch is in-flight.
- Inline \`globalMessagesLoadError\` banner above messages with Retry button.
- Implementations are **intentionally separate** from page-AI — no shared hook between surfaces.

## Out of scope / known follow-up

- **Cross-instance live stream rejoin:** prod runs multiple web instances on Fly. Live tokens from a stream on a _different_ instance are unavailable in the local pending store. The persisted message still appears on the next DB load (Stage 0 guarantees server-side durability at \`execute()\` end), so the user-visible blank symptom is fully fixed. True cross-instance live-token streaming requires a shared pub/sub broker or sticky sessions — deferred to a follow-up epic.
- Merging page-AI and Global Assistant into one primitive.
- Unifying the \`chatMessages\` and \`conversations.messages\` tables.

## Verification
- \`bun run --filter 'web' typecheck\` — ✅ clean
- \`bun run vitest run src/lib/ai/streams/__tests__/\` — ✅ 128 tests (23 files), all pass, 13 new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141iWM82pQNoBVofvR5ii4v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message loading reliability by adding safeguards against stale fetches and preventing duplicate messages
  * Enhanced error handling with visible error alerts and retry functionality when message loading fails

* **Tests**
  * Added comprehensive test coverage for message reconciliation and stale-response detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->