### PR TITLE
feat(mcp): list_pages ls-mode default with incremental navigation

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -262,9 +262,12 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
         return `${(result.drives as unknown[]).length} drives`;
       }
 
-      if (toolName === 'list_pages' && result.tree) {
-        const pageCount = countPages((result.tree as TreeItem[]) || []);
-        return `${pageCount} pages`;
+      if (toolName === 'list_pages') {
+        if (result.count !== undefined) return `${result.count} pages`;
+        if (result.tree) {
+          const pageCount = countPages((result.tree as TreeItem[]) || []);
+          return `${pageCount} pages`;
+        }
       }
 
       if (toolName === 'read_page') {

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -104,7 +104,39 @@ const getSendChannelMessagePreview = (
   return null;
 };
 
-// Parse the list_pages "paths" string format into a tree structure.
+// Convert the new list_pages structured pages array into a TreeItem tree.
+const pagesArrayToTree = (pages: Array<{ id: string; title: string; type: string; path: string }>): TreeItem[] => {
+  interface Entry { id: string; title: string; type: string; path: string; segments: string[] }
+  const entries: Entry[] = pages.map(p => ({ ...p, segments: p.path.split('/').filter(Boolean) }));
+
+  const build = (items: Entry[], depth: number): TreeItem[] => {
+    const result: TreeItem[] = [];
+    const seen = new Map<string, { entry?: Entry; children: Entry[] }>();
+    for (const e of items) {
+      if (e.segments.length <= depth) continue;
+      const isDirect = e.segments.length === depth + 1;
+      const key = isDirect ? e.id : e.segments[depth];
+      if (!seen.has(key)) seen.set(key, { children: [] });
+      const bucket = seen.get(key)!;
+      if (isDirect) bucket.entry = e;
+      else bucket.children.push(e);
+    }
+    for (const [, { entry, children }] of seen) {
+      result.push({
+        path: entry?.path ?? '',
+        title: entry?.title ?? children[0]?.segments[depth] ?? 'Folder',
+        type: entry?.type ?? 'FOLDER',
+        pageId: entry?.id,
+        children: build(children, depth + 1),
+      });
+    }
+    return result;
+  };
+
+  return build(entries, 1);
+};
+
+// Parse the legacy list_pages "paths" string format into a tree structure.
 // Path format: "📁 [FOLDER](Task) ID: xxx Path: /drive/folder"
 const parsePathsToTree = (paths: string[]): TreeItem[] => {
   const pathRegex = /^\S+\s+\[([^\]]+)\](?:\s+\(Task\))?\s+ID:\s+(\S+)\s+Path:\s+(.+)$/;
@@ -242,24 +274,21 @@ export const toolRenderers: Record<string, ToolRenderer> = {
 
   // === PAGE READ TOOLS ===
   list_pages: ({ parsedOutput }) => {
-    if (parsedOutput.tree) {
-      return (
-        <PageTreeRenderer
-          tree={parsedOutput.tree as TreeItem[]}
-          driveName={parsedOutput.driveName as string | undefined}
-          driveId={parsedOutput.driveId as string | undefined}
-        />
-      );
+    const driveName = (parsedOutput.driveName ?? parsedOutput.driveSlug) as string | undefined;
+    const driveId = parsedOutput.driveId as string | undefined;
+    // New structured format
+    if (parsedOutput.pages && Array.isArray(parsedOutput.pages)) {
+      const tree = pagesArrayToTree(parsedOutput.pages as Array<{ id: string; title: string; type: string; path: string }>);
+      return <PageTreeRenderer tree={tree} driveName={driveName} driveId={driveId} />;
     }
+    // Legacy: pre-built tree
+    if (parsedOutput.tree) {
+      return <PageTreeRenderer tree={parsedOutput.tree as TreeItem[]} driveName={driveName} driveId={driveId} />;
+    }
+    // Legacy: raw path strings
     if (parsedOutput.paths && Array.isArray(parsedOutput.paths)) {
       const tree = parsePathsToTree(parsedOutput.paths as string[]);
-      return (
-        <PageTreeRenderer
-          tree={tree}
-          driveName={(parsedOutput.driveName ?? parsedOutput.driveSlug) as string | undefined}
-          driveId={parsedOutput.driveId as string | undefined}
-        />
-      );
+      return <PageTreeRenderer tree={tree} driveName={driveName} driveId={driveId} />;
     }
     return null;
   },

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -108,6 +108,11 @@ const getSendChannelMessagePreview = (
 const pagesArrayToTree = (pages: Array<{ id: string; title: string; type: string; path: string }>): TreeItem[] => {
   interface Entry { id: string; title: string; type: string; path: string; segments: string[] }
   const entries: Entry[] = pages.map(p => ({ ...p, segments: p.path.split('/').filter(Boolean) }));
+  if (entries.length === 0) return [];
+
+  // Start at the shallowest depth present so subfolder ls-results render flat,
+  // not nested under a phantom parent node.
+  const startDepth = Math.min(...entries.map(e => e.segments.length)) - 1;
 
   const build = (items: Entry[], depth: number): TreeItem[] => {
     const result: TreeItem[] = [];
@@ -133,7 +138,7 @@ const pagesArrayToTree = (pages: Array<{ id: string; title: string; type: string
     return result;
   };
 
-  return build(entries, 1);
+  return build(entries, startDepth);
 };
 
 // Parse the legacy list_pages "paths" string format into a tree structure.

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -58,7 +58,7 @@ const AUTOMATION = `AUTOMATION:
 • After setting a trigger, tell the user what will run, when, and what the agent will receive as context`;
 
 const SEARCH = `SEARCH:
-• list_pages returns the full page tree — use it to explore structure before creating, not just to check one folder
+• list_pages returns one level at a time (ls-style) — navigate with parentId to drill into folders; use recursive: true for a full subtree dump
 • Escalate: list_pages (structure) → glob_search (name pattern) → regex_search (content) → multi_drive_search (location unknown)
 • When a task needs domain expertise, check list_agents — a workspace agent may already know the answer better than a page search will
 • Try at least two angles before declaring something not found; a single failed search is not "not found"

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -106,12 +106,13 @@ vi.mock('@/lib/logging/mask', () => ({
 
 import { pageReadTools } from '../page-read-tools';
 import { db } from '@pagespace/db/db';
-import { getUserAccessLevel, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions';
+import { getUserAccessLevel, getUserAccessiblePagesInDriveWithDetails, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockDb = vi.mocked(db);
 const mockGetUserAccessLevel = vi.mocked(getUserAccessLevel);
 const mockGetUserAccessiblePagesInDrive = vi.mocked(getUserAccessiblePagesInDriveWithDetails);
+const mockGetUserDriveAccess = vi.mocked(getUserDriveAccess);
 
 const createMockPage = (content: string, type = 'DOCUMENT') => ({
   id: 'page-1',
@@ -168,6 +169,173 @@ describe('page-read-tools', () => {
         context
       );
       expect(result).toMatchObject({ success: false });
+    });
+
+    describe('ls-mode navigation (new behavior)', () => {
+      const driveSlug = 'my-drive';
+      const driveId = 'drive-1';
+
+      const rootFolder = { id: 'folder-1', title: 'Docs', type: 'FOLDER', parentId: null, position: 1, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+      const rootDoc = { id: 'doc-1', title: 'README', type: 'DOCUMENT', parentId: null, position: 2, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+      const childPage = { id: 'child-1', title: 'Setup Guide', type: 'DOCUMENT', parentId: 'folder-1', position: 1, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+
+      const setupDriveAccess = () => {
+        mockGetUserDriveAccess.mockResolvedValue(true as unknown as never);
+        mockGetUserAccessiblePagesInDrive.mockResolvedValue([rootFolder, rootDoc, childPage] as unknown as never);
+        (mockDb.selectDistinct as ReturnType<typeof vi.fn>).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        });
+      };
+
+      it('returns only root-level pages when no parentId supplied', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        assert({
+          given: 'list_pages with no parentId',
+          should: 'return success',
+          actual: result.success,
+          expected: true,
+        });
+
+        const pages = result.pages as Array<{ id: string }>;
+        assert({
+          given: 'list_pages with no parentId',
+          should: 'return only root-level pages (2, not 3)',
+          actual: pages.length,
+          expected: 2,
+        });
+
+        assert({
+          given: 'list_pages with no parentId',
+          should: 'not include nested child page',
+          actual: pages.some(p => p.id === 'child-1'),
+          expected: false,
+        });
+      });
+
+      it('includes hasChildren flag indicating whether folder has children', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        const pages = result.pages as Array<{ id: string; hasChildren: boolean }>;
+        const folder = pages.find(p => p.id === 'folder-1');
+        const doc = pages.find(p => p.id === 'doc-1');
+
+        assert({
+          given: 'a folder that has children',
+          should: 'have hasChildren: true',
+          actual: folder?.hasChildren,
+          expected: true,
+        });
+
+        assert({
+          given: 'a document with no children',
+          should: 'have hasChildren: false',
+          actual: doc?.hasChildren,
+          expected: false,
+        });
+      });
+
+      it('returns only children of parentId when supplied', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, parentId: 'folder-1' },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        const pages = result.pages as Array<{ id: string }>;
+        assert({
+          given: 'list_pages with parentId = folder-1',
+          should: 'return only direct children of that folder',
+          actual: pages.length,
+          expected: 1,
+        });
+
+        assert({
+          given: 'list_pages with parentId = folder-1',
+          should: 'return the child page',
+          actual: pages[0]?.id,
+          expected: 'child-1',
+        });
+      });
+
+      it('returns error when parentId is not accessible', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, parentId: 'nonexistent-id' },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        assert({
+          given: 'list_pages with inaccessible parentId',
+          should: 'return success: false',
+          actual: result.success,
+          expected: false,
+        });
+      });
+
+      it('returns all pages when recursive is true', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, recursive: true },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        const pages = result.pages as Array<{ id: string }>;
+        assert({
+          given: 'list_pages with recursive: true',
+          should: 'return all 3 pages',
+          actual: pages.length,
+          expected: 3,
+        });
+      });
+
+      it('includes totalInDrive to signal overall drive scale', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        assert({
+          given: 'list_pages',
+          should: 'include totalInDrive count',
+          actual: result.totalInDrive,
+          expected: 3,
+        });
+      });
+
+      it('includes breadcrumb when parentId is supplied', async () => {
+        setupDriveAccess();
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, parentId: 'folder-1' },
+          createAuthContext()
+        ) as Record<string, unknown>;
+
+        const breadcrumb = result.breadcrumb as Array<{ id: string; title: string }>;
+        assert({
+          given: 'list_pages navigating into a folder',
+          should: 'include breadcrumb with parent folder',
+          actual: breadcrumb.length,
+          expected: 1,
+        });
+
+        assert({
+          given: 'breadcrumb entry',
+          should: 'contain folder id and title',
+          actual: breadcrumb[0],
+          expected: { id: 'folder-1', title: 'Docs' },
+        });
+      });
     });
 
   });

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -18,12 +18,14 @@ export const pageReadTools = {
    * Explore the folder structure and find content within a workspace
    */
   list_pages: tool({
-    description: 'List all pages in a workspace with their paths and types. Returns hierarchical structure showing folders, documents, AI chats, channels, canvas pages, sheets, and task lists. Pages marked with (Task) suffix are linked to task items.',
+    description: 'List pages at a location in a workspace. Defaults to direct children of the drive root (ls-style). Pass parentId to navigate into a folder. Set recursive: true to return the full subtree. Each result includes hasChildren so you know whether to drill in further.',
     inputSchema: z.object({
       driveSlug: z.string().optional().describe('The human-readable slug of the drive (for semantic understanding)'),
       driveId: z.string().describe('The unique ID of the drive (used for operations)'),
+      parentId: z.string().optional().describe('Page ID to list children of. Omit for drive root.'),
+      recursive: z.boolean().optional().describe('Set true to return the full subtree instead of direct children only. Default: false.'),
     }),
-    execute: async ({ driveSlug, driveId }, { experimental_context: context }) => {
+    execute: async ({ driveSlug, driveId, parentId, recursive = false }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
@@ -38,51 +40,104 @@ export const pageReadTools = {
         // Sort by position to maintain order
         visiblePages.sort((a, b) => a.position - b.position);
 
+        const pageMap = new Map(visiblePages.map(p => [p.id, p]));
+
+        if (parentId && !pageMap.has(parentId)) {
+          return { success: false, error: `Page "${parentId}" not found or not accessible in this workspace` };
+        }
+
         // Get task-linked page IDs to mark them
         const taskLinkedPageIds = await db.selectDistinct({ pageId: taskItems.pageId })
           .from(taskItems)
           .where(isNotNull(taskItems.pageId));
         const taskLinkedSet = new Set(taskLinkedPageIds.map(t => t.pageId));
 
-        // Build flat list of paths with type indicators
-        const buildPageList = (parentId: string | null = null, parentPath: string = `/${driveSlug || driveId}`): string[] => {
-          const pages: string[] = [];
-          const currentPages = visiblePages.filter(page => page.parentId === parentId);
-
-          for (const page of currentPages) {
-            const currentPath = `${parentPath}/${page.title}`;
-            // Add type indicator emoji
-            const typeIndicator = getPageTypeEmoji(page.type as PageType);
-            // Add (Task) suffix for task-linked pages
-            const taskSuffix = taskLinkedSet.has(page.id) ? ' (Task)' : '';
-
-            pages.push(`${typeIndicator} [${page.type}]${taskSuffix} ID: ${page.id} Path: ${currentPath}`);
-
-            // Recursively add children
-            pages.push(...buildPageList(page.id, currentPath));
-          }
-
-          return pages;
+        // Build full path for a page by walking up through the map
+        const buildPath = (pageId: string | null): string => {
+          if (!pageId) return `/${driveSlug || driveId}`;
+          const page = pageMap.get(pageId);
+          if (!page) return `/${driveSlug || driveId}`;
+          return `${buildPath(page.parentId)}/${page.title}`;
         };
 
-        const paths = buildPageList();
+        // Build breadcrumb from drive root down to a given page
+        const buildBreadcrumb = (id: string | undefined): { id: string; title: string }[] => {
+          if (!id) return [];
+          const crumbs: { id: string; title: string }[] = [];
+          let current = pageMap.get(id);
+          while (current) {
+            crumbs.unshift({ id: current.id, title: current.title });
+            current = current.parentId ? pageMap.get(current.parentId) : undefined;
+          }
+          return crumbs;
+        };
+
+        interface PageEntry {
+          id: string;
+          title: string;
+          type: string;
+          emoji: string;
+          hasChildren: boolean;
+          isTaskLinked: boolean;
+          path: string;
+        }
+
+        let resultPages: PageEntry[];
+
+        if (!recursive) {
+          const target = parentId ?? null;
+          const children = visiblePages.filter(p => p.parentId === target);
+          resultPages = children.map(p => ({
+            id: p.id,
+            title: p.title,
+            type: p.type,
+            emoji: getPageTypeEmoji(p.type as PageType),
+            hasChildren: visiblePages.some(c => c.parentId === p.id),
+            isTaskLinked: taskLinkedSet.has(p.id),
+            path: buildPath(p.id),
+          }));
+        } else {
+          const collectSubtree = (startParentId: string | null): PageEntry[] => {
+            const result: PageEntry[] = [];
+            const children = visiblePages.filter(p => p.parentId === startParentId);
+            for (const p of children) {
+              result.push({
+                id: p.id,
+                title: p.title,
+                type: p.type,
+                emoji: getPageTypeEmoji(p.type as PageType),
+                hasChildren: visiblePages.some(c => c.parentId === p.id),
+                isTaskLinked: taskLinkedSet.has(p.id),
+                path: buildPath(p.id),
+              });
+              result.push(...collectSubtree(p.id));
+            }
+            return result;
+          };
+          resultPages = collectSubtree(parentId ?? null);
+        }
+
+        const driveLabel = driveSlug || driveId;
+        const breadcrumb = buildBreadcrumb(parentId);
+        const location = parentId ? buildPath(parentId) : `/${driveLabel}`;
+        const locationLabel = breadcrumb.length > 0 ? breadcrumb.map(c => c.title).join(' / ') : driveLabel;
 
         return {
           success: true,
-          driveSlug: driveSlug || driveId,
-          paths,
-          count: paths.length,
-          summary: `Explored ${driveSlug || driveId} workspace and found ${paths.length} page${paths.length === 1 ? '' : 's'}`,
-          stats: {
-            totalPages: paths.length,
-            folderCount: paths.filter(p => p.includes('📁')).length,
-            documentCount: paths.filter(p => p.includes('📄')).length,
-            workspace: driveSlug || driveId
-          },
-          nextSteps: paths.length > 0 ? [
-            'Use read_page to examine specific documents',
-            'Use create_page to add new content to this workspace'
-          ] : ['This workspace is empty - consider creating some initial content']
+          driveSlug: driveLabel,
+          location,
+          breadcrumb,
+          pages: resultPages,
+          count: resultPages.length,
+          totalInDrive: visiblePages.length,
+          summary: recursive
+            ? `Found ${resultPages.length} page${resultPages.length === 1 ? '' : 's'} in "${driveLabel}" (full tree)`
+            : `Found ${resultPages.length} page${resultPages.length === 1 ? '' : 's'} in "${locationLabel}"`,
+          nextSteps: resultPages.length > 0 ? [
+            'Use read_page with a page ID to read its content',
+            'Pass parentId with a folder ID to navigate into it',
+            'Use create_page to add new content',
+          ] : [`"${locationLabel}" is empty — use create_page to add content`],
         };
       } catch (error) {
         console.error('Error reading drive tree:', error);


### PR DESCRIPTION
## Summary

- \`list_pages\` now defaults to **direct children only** (ls-style) instead of dumping the full drive tree
- New \`parentId\` param: pass a folder's page ID to navigate into it; omit for drive root
- New \`recursive: true\` param restores the old full-subtree behavior for callers that need it
- Every result includes \`hasChildren\` so agents know which folders are worth drilling into without a wasted call
- \`breadcrumb\` array keeps the agent oriented at its current location
- \`totalInDrive\` count signals drive scale even when only one level is shown
- Response shape changed from raw path strings to a structured \`pages[]\` array (each entry: \`id\`, \`title\`, \`type\`, \`emoji\`, \`hasChildren\`, \`isTaskLinked\`, \`path\`)
- Clean error returned if \`parentId\` is inaccessible or nonexistent

## Files changed

- \`apps/web/src/lib/ai/tools/page-read-tools.ts\` — core tool logic
- \`apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts\` — 7 new tests for ls-mode, parentId navigation, recursive mode, breadcrumb, totalInDrive
- \`apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx\` — UI renderer updated for new \`pages[]\` format; legacy \`paths\`/\`tree\` fallbacks kept for old cached results; depth bug fixed so subfolder ls-results render flat at the correct level
- \`apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx\` — compact summary uses \`result.count\` instead of \`result.tree\`
- \`apps/web/src/lib/ai/core/inline-instructions.ts\` — search guidance updated to reflect ls-default

## Test plan

- [x] \`list_pages({driveId})\` returns only root-level pages (unit tested)
- [x] \`parentId\` returns that folder's direct children only (unit tested)
- [x] \`recursive: true\` returns all pages (unit tested)
- [x] Invalid/inaccessible \`parentId\` returns \`success: false\` (unit tested)
- [x] \`hasChildren\` is correct for folders vs leaves (unit tested)
- [x] \`breadcrumb\` is populated when inside a folder (unit tested)
- [x] \`totalInDrive\` reflects total accessible page count (unit tested)
- [ ] UI renders correctly for new response shape (tree view from \`pages[]\`)
- [ ] Compact summary shows "N pages" count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLXA3XDqjNfFKkDoGWCP2L