### PR TITLE
fix(terminal): spawn bash in /workspace to match agent sandbox cwd

### DIFF
--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -49,7 +49,7 @@ describe('openPtyShell', () => {
 
     openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
 
-    expect(sprite.spawn).toHaveBeenCalledWith('bash', [], { tty: true, cols: 80, rows: 24 });
+    expect(sprite.spawn).toHaveBeenCalledWith('bash', [], { tty: true, cols: 80, rows: 24, cwd: '/workspace' });
   });
 
   it('given sprite emits stdout data, should call onOutput with the string', () => {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -1,4 +1,5 @@
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 
 export type PtyShell = {
   write(data: string): void;
@@ -15,7 +16,7 @@ export type OpenPtyShellArgs = {
 };
 
 export function openPtyShell({ sprite, cols, rows, onOutput, onExit }: OpenPtyShellArgs): PtyShell {
-  const cmd = sprite.spawn('bash', [], { tty: true, cols, rows });
+  const cmd = sprite.spawn('bash', [], { tty: true, cols, rows, cwd: SANDBOX_ROOT });
 
   const toStr = (chunk: unknown) => (typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8'));
   cmd.stdout.on('data', (chunk) => onOutput(toStr(chunk)));


### PR DESCRIPTION
## Summary

- Terminal pages were spawning bash with no `cwd`, so Fly Sprites defaulted to `/home/sprite`
- Agent-level bash tool calls always use `SANDBOX_ROOT` (`/workspace`) — terminals should too
- Passes `cwd: SANDBOX_ROOT` to `sprite.spawn()` in `sprites-shell.ts`; `SpriteSpawnOptions.cwd` already supported this

## Test plan

- [ ] Open a Terminal page — prompt should show `/workspace` as the working directory
- [ ] Run `pwd` in the terminal — should print `/workspace`
- [ ] Verify agent bash tool calls are unaffected (they set cwd via `tool-runners.ts`, not this file)
- [ ] `bun run --filter realtime build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1ZSS3v8MF4vRQ9JMEyEg2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session initialization to use the correct working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->