### PR TITLE
fix(terminal): full color + TUI support (TERM env + drop convertEol)

### DIFF
--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -41,7 +41,7 @@ function buildFakeSprite(cmd: SpriteCommandLike): SpriteInstanceLike & { spawnCa
 }
 
 describe('openPtyShell', () => {
-  it('given a sprite and dimensions, should call spawn with bash + tty:true + correct dims', () => {
+  it('given a sprite and dimensions, should call spawn with bash + tty:true + correct dims + cwd + terminal env', () => {
     const cmd = buildFakeCommand();
     const sprite = buildFakeSprite(cmd);
     const onOutput = vi.fn();
@@ -49,7 +49,13 @@ describe('openPtyShell', () => {
 
     openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
 
-    expect(sprite.spawn).toHaveBeenCalledWith('bash', [], { tty: true, cols: 80, rows: 24, cwd: '/workspace' });
+    expect(sprite.spawn).toHaveBeenCalledWith('bash', [], {
+      tty: true,
+      cols: 80,
+      rows: 24,
+      cwd: '/workspace',
+      env: { TERM: 'xterm-256color', COLORTERM: 'truecolor', LANG: 'en_US.UTF-8' },
+    });
   });
 
   it('given sprite emits stdout data, should call onOutput with the string', () => {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -16,7 +16,13 @@ export type OpenPtyShellArgs = {
 };
 
 export function openPtyShell({ sprite, cols, rows, onOutput, onExit }: OpenPtyShellArgs): PtyShell {
-  const cmd = sprite.spawn('bash', [], { tty: true, cols, rows, cwd: SANDBOX_ROOT });
+  const cmd = sprite.spawn('bash', [], {
+    tty: true,
+    cols,
+    rows,
+    cwd: SANDBOX_ROOT,
+    env: { TERM: 'xterm-256color', COLORTERM: 'truecolor', LANG: 'en_US.UTF-8' },
+  });
 
   const toStr = (chunk: unknown) => (typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8'));
   cmd.stdout.on('data', (chunk) => onOutput(toStr(chunk)));

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
@@ -28,7 +28,7 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
 
         if (cancelled || !containerRef.current) return;
 
-        const terminal = new Terminal({ cursorBlink: true, convertEol: true });
+        const terminal = new Terminal({ cursorBlink: true });
         const fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
         terminal.open(containerRef.current);


### PR DESCRIPTION
## Summary

- **Root cause**: PTY was spawned without a `TERM` environment variable, so every program inside the shell ran in dumb-terminal mode — no color codes emitted, no alternate screen buffer used. Full-screen TUIs (Claude Code, vim, htop) wrote over the primary screen instead of switching cleanly, and `ls`/grep/etc. produced no color.
- **Fix 1** (`sprites-shell.ts`): pass `TERM=xterm-256color`, `COLORTERM=truecolor`, `LANG=en_US.UTF-8` to the PTY spawn. This is the root fix for both symptoms.
- **Fix 2** (`XtermTerminal.tsx`): drop `convertEol: true`. That option is for plain-text streams; a real PTY already emits `\r\n`. Having it on would double-process newlines and corrupt cursor positioning in full-screen programs.

## Test plan

- [ ] Open a terminal page → run `echo $TERM` → should print `xterm-256color`
- [ ] Run `ls --color=auto` → directory entries should be colored
- [ ] Run `claude` (Claude Code CLI) → full-screen TUI should open cleanly with no stale-content bleed-through
- [ ] Run `vim` or `htop` → alternate screen buffer switch is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eWGensibeGY3rhKYnE3Kv