### PR TITLE
fix(ai-chat): rejoin live stream on mobile resume instead of restarting the run (stops duplicate generations)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -72,6 +72,7 @@ import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
+import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
   ProviderSetupCard,
@@ -102,7 +103,7 @@ const GlobalAssistantView: React.FC = () => {
   // ============================================
   const { chatConfig: globalChatConfig, setIsStreaming: setGlobalIsStreaming, setStopStreaming: setGlobalStopStreaming } = useGlobalChatConfig();
   const { isStreaming: contextIsStreaming, stopStreaming: contextStopStreaming } = useGlobalChatStream();
-  const { currentConversationId: globalConversationId, isInitialized: globalIsInitialized, createNewConversation, refreshSignal } = useGlobalChatConversation();
+  const { currentConversationId: globalConversationId, isInitialized: globalIsInitialized, createNewConversation, refreshSignal, rejoinGlobalStream } = useGlobalChatConversation();
 
   // ============================================
   // AGENT STORE - for agent selection and conversation management
@@ -180,6 +181,9 @@ const GlobalAssistantView: React.FC = () => {
   const inputRef = useRef<ChatInputRef>(null);
   const prevStatusRef = useRef<string>('ready');
   const prevAgentStatusRef = useRef<string>('ready');
+  // Populated after useAgentChannelMultiplayer runs (called further down); used
+  // in tryRecover via ref so the callback doesn't depend on hook ordering.
+  const rejoinAgentStreamRef = useRef<() => void>(() => {});
 
   // ============================================
   // SHARED HOOKS
@@ -417,8 +421,74 @@ const GlobalAssistantView: React.FC = () => {
       regenerate,
     });
 
-  // Auto-retry on network errors (e.g. ERR_NETWORK_CHANGED killing mid-stream)
-  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2 });
+  // Rejoin-first recovery probe for useStreamRecovery.
+  // On a network error (e.g. iOS backgrounding kills the fetch):
+  //   1. Check /api/ai/chat/active-streams — if the original run is still live, rejoin it.
+  //   2. Else fetch messages from the DB — if the run already persisted a reply, surface it.
+  //   3. Only fall through to regenerate() when neither path finds anything to recover.
+  const tryRecover = useCallback(async (): Promise<boolean> => {
+    if (!currentConversationId) return false;
+    const channelId = selectedAgent?.id ?? (user?.id ? globalChannelId(user.id) : null);
+    if (!channelId) return false;
+
+    // Step 1: live stream check
+    try {
+      const res = await fetchWithAuth(
+        `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
+      );
+      if (res.ok) {
+        const data = (await res.json()) as {
+          streams?: Array<{ conversationId: string; triggeredBy: { userId: string } }>;
+        };
+        const hasLiveStream = (data.streams ?? []).some(
+          (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
+        );
+        if (decideRecovery({ hasLiveStream, hasPersistedReply: false }) === 'rejoin') {
+          if (selectedAgent) {
+            rejoinAgentStreamRef.current();
+          } else {
+            rejoinGlobalStream();
+          }
+          return true;
+        }
+      }
+    } catch { /* network error — fall through to DB check */ }
+
+    // Step 2: DB check for persisted reply
+    try {
+      const url = selectedAgent
+        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
+        : `/api/ai/global/${currentConversationId}/messages`;
+      const res = await fetchWithAuth(url);
+      if (res.ok) {
+        const data = await res.json();
+        const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{ role: string }>;
+        const hasPersistedReply = msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant';
+        if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
+          if (selectedAgent) {
+            setAgentMessages(data.messages);
+            setAgentStoreMessages(data.messages);
+          } else {
+            setGlobalLocalMessages(data.messages);
+          }
+          return true;
+        }
+      }
+    } catch { /* network error — fall through to regenerate */ }
+
+    return false;
+  }, [
+    currentConversationId,
+    selectedAgent,
+    user,
+    rejoinGlobalStream,
+    setAgentMessages,
+    setAgentStoreMessages,
+    setGlobalLocalMessages,
+  ]);
+
+  // Auto-retry on network errors — rejoin-first, regenerate only as last resort
+  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover });
 
   const handleUndoSuccess = useCallback(async () => {
     if (!currentConversationId) return;
@@ -622,7 +692,7 @@ const GlobalAssistantView: React.FC = () => {
   // is null. Encapsulates page-room subscription, stream bootstrap/socket
   // events, dashboard-store stop-slot single-writer claim, channel-id-keyed
   // editing-store registration, and reconnect-refresh.
-  useAgentChannelMultiplayer({
+  const { rejoinActiveStreams: rejoinAgentStream } = useAgentChannelMultiplayer({
     selectedAgent,
     agentConversationId,
     setLocalMessages: setAgentMessages,
@@ -630,6 +700,9 @@ const GlobalAssistantView: React.FC = () => {
     surfaceComponentName: 'GlobalAssistantView',
     loadConversation: loadAgentConversation,
   });
+  // Keep the ref current so tryRecover (defined above) can call it without
+  // depending on hook-call ordering.
+  rejoinAgentStreamRef.current = rejoinAgentStream;
 
   // Register streaming state with editing store
   useStreamingRegistration(

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -343,6 +343,11 @@ const GlobalAssistantView: React.FC = () => {
   }, [messages, isStreaming]);
   const latestAgentMessagesRef = useRef(agentMessages);
   const latestGlobalMessagesRef = useRef(globalLocalMessages);
+  // Synchronously updated each render — lets tryRecover read the live message
+  // count without adding messages to its useCallback deps (which would cause
+  // the useStreamRecovery effect to re-subscribe on every message update).
+  const currentMessagesRef = useRef(messages);
+  currentMessagesRef.current = messages;
 
   useEffect(() => {
     latestAgentMessagesRef.current = agentMessages;
@@ -454,7 +459,11 @@ const GlobalAssistantView: React.FC = () => {
       }
     } catch { /* network error — fall through to DB check */ }
 
-    // Step 2: DB check for persisted reply
+    // Step 2: DB check for persisted reply for the CURRENT turn.
+    // Only accept when the DB has at least as many user messages as we have locally —
+    // this guards against the case where the network error fired before the user's
+    // message reached the server, making the DB end with the PREVIOUS turn's
+    // assistant reply and causing us to silently drop the new user prompt.
     try {
       const url = selectedAgent
         ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
@@ -463,7 +472,14 @@ const GlobalAssistantView: React.FC = () => {
       if (res.ok) {
         const data = await res.json();
         const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{ role: string }>;
-        const hasPersistedReply = msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant';
+        const localUserCount = currentMessagesRef.current.filter((m) => m.role === 'user').length;
+        const dbUserCount = msgs.filter((m) => m.role === 'user').length;
+        // DB must have at least as many user messages as local (the user's turn
+        // was persisted) AND end with an assistant reply (the run completed).
+        const hasPersistedReply =
+          msgs.length > 0 &&
+          msgs[msgs.length - 1].role === 'assistant' &&
+          dbUserCount >= localUserCount;
         if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
           if (selectedAgent) {
             setAgentMessages(data.messages);

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -43,6 +43,7 @@ import { isEditingActive } from '@/stores/useEditingStore';
 import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
+import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
 
@@ -185,6 +186,7 @@ const SidebarChatTab: React.FC = () => {
     isInitialized: globalIsInitialized,
     createNewConversation: createGlobalConversation,
     refreshSignal,
+    rejoinGlobalStream,
   } = useGlobalChatConversation();
 
   const {
@@ -298,7 +300,7 @@ const SidebarChatTab: React.FC = () => {
   // registers `ai-channel-${agent.id}` with the editing store (same key as
   // GlobalAssistantView agent mode → natural same-channel de-dup), and
   // re-fetches the active conversation on socket reconnect.
-  useAgentChannelMultiplayer({
+  const { rejoinActiveStreams: rejoinAgentStream } = useAgentChannelMultiplayer({
     selectedAgent,
     agentConversationId,
     setLocalMessages: setMessages,
@@ -807,8 +809,74 @@ const SidebarChatTab: React.FC = () => {
       regenerate,
     });
 
-  // Auto-retry on network errors (e.g. ERR_NETWORK_CHANGED killing mid-stream)
-  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2 });
+  // Rejoin-first recovery probe for useStreamRecovery.
+  // On a network error (e.g. iOS backgrounding kills the fetch):
+  //   1. Check /api/ai/chat/active-streams — if the original run is still live, rejoin it.
+  //   2. Else fetch messages from the DB — if the run persisted a reply, surface it.
+  //   3. Only fall through to regenerate() when neither path finds anything to recover.
+  const tryRecover = useCallback(async (): Promise<boolean> => {
+    if (!currentConversationId) return false;
+    const channelId = selectedAgent?.id ?? channelIdForGlobal;
+    if (!channelId) return false;
+
+    // Step 1: live stream check
+    try {
+      const res = await fetchWithAuth(
+        `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
+      );
+      if (res.ok) {
+        const data = (await res.json()) as {
+          streams?: Array<{ conversationId: string; triggeredBy: { userId: string } }>;
+        };
+        const hasLiveStream = (data.streams ?? []).some(
+          (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
+        );
+        if (decideRecovery({ hasLiveStream, hasPersistedReply: false }) === 'rejoin') {
+          if (selectedAgent) {
+            rejoinAgentStream();
+          } else {
+            rejoinGlobalStream();
+          }
+          return true;
+        }
+      }
+    } catch { /* network error — fall through to DB check */ }
+
+    // Step 2: DB check for persisted reply
+    try {
+      const url = selectedAgent
+        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
+        : `/api/ai/global/${currentConversationId}/messages`;
+      const res = await fetchWithAuth(url);
+      if (res.ok) {
+        const data = await res.json();
+        const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{ role: string }>;
+        const hasPersistedReply = msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant';
+        if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
+          if (selectedAgent) {
+            setMessages(data.messages);
+          } else {
+            setGlobalMessages(data.messages);
+          }
+          return true;
+        }
+      }
+    } catch { /* network error — fall through to regenerate */ }
+
+    return false;
+  }, [
+    currentConversationId,
+    selectedAgent,
+    channelIdForGlobal,
+    user,
+    rejoinGlobalStream,
+    rejoinAgentStream,
+    setMessages,
+    setGlobalMessages,
+  ]);
+
+  // Auto-retry on network errors — rejoin-first, regenerate only as last resort
+  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover });
 
   // Adapter for AgentSelector (converts SidebarAgentInfo to AgentInfo shape)
   const handleSelectAgent = useCallback((agent: SidebarAgentInfo | null) => {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -348,6 +348,10 @@ const SidebarChatTab: React.FC = () => {
   const [globalMessagesLoadError, setGlobalMessagesLoadError] = useState<Error | null>(null);
   // Stale-request guard: holds the conversationId of the most recent load request.
   const globalLoadRequestedIdRef = useRef<string | null>(null);
+  // Synchronously updated each render — lets tryRecover read the live message
+  // count without adding messages to its useCallback deps.
+  const currentMessagesRef = useRef(messages);
+  currentMessagesRef.current = messages;
 
   // Voice mode state
   const isVoiceModeEnabled = useVoiceModeStore((s) => s.isEnabled);
@@ -842,7 +846,11 @@ const SidebarChatTab: React.FC = () => {
       }
     } catch { /* network error — fall through to DB check */ }
 
-    // Step 2: DB check for persisted reply
+    // Step 2: DB check for persisted reply for the CURRENT turn.
+    // Only accept when the DB has at least as many user messages as we have locally —
+    // this guards against the case where the network error fired before the user's
+    // message reached the server, making the DB end with the PREVIOUS turn's
+    // assistant reply and causing us to silently drop the new user prompt.
     try {
       const url = selectedAgent
         ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
@@ -851,7 +859,12 @@ const SidebarChatTab: React.FC = () => {
       if (res.ok) {
         const data = await res.json();
         const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{ role: string }>;
-        const hasPersistedReply = msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant';
+        const localUserCount = currentMessagesRef.current.filter((m) => m.role === 'user').length;
+        const dbUserCount = msgs.filter((m) => m.role === 'user').length;
+        const hasPersistedReply =
+          msgs.length > 0 &&
+          msgs[msgs.length - 1].role === 'assistant' &&
+          dbUserCount >= localUserCount;
         if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
           if (selectedAgent) {
             setMessages(data.messages);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -44,6 +44,8 @@ interface GlobalChatConversationContextValue {
   setCurrentConversationId: (id: string | null) => void;
   loadConversation: (id: string) => Promise<void>;
   createNewConversation: () => Promise<void>;
+  /** Re-runs the global channel bootstrap to rejoin any still-live own stream. */
+  rejoinGlobalStream: () => void;
 }
 
 interface GlobalChatStreamContextValue {
@@ -222,7 +224,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const setRefreshSignalRef = useRef(setRefreshSignal);
   setRefreshSignalRef.current = setRefreshSignal;
 
-  useChannelStreamSocket(channelId, {
+  const { rejoinActiveStreams: rejoinGlobalStream } = useChannelStreamSocket(channelId, {
     // Cross-tab same-user events: signal surfaces to re-fetch rather than
     // updating context state that nobody renders from.
     onUserMessage: (_message, payload) => {
@@ -300,6 +302,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     setCurrentConversationId,
     loadConversation,
     createNewConversation,
+    rejoinGlobalStream,
   }), [
     currentConversationId,
     initialMessages,
@@ -307,6 +310,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     refreshSignal,
     loadConversation,
     createNewConversation,
+    rejoinGlobalStream,
   ]);
 
   const streamContextValue: GlobalChatStreamContextValue = useMemo(() => ({

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -63,7 +63,7 @@ export function useAgentChannelMultiplayer({
   isLocallyStreaming,
   surfaceComponentName,
   loadConversation,
-}: UseAgentChannelMultiplayerOptions): void {
+}: UseAgentChannelMultiplayerOptions): { rejoinActiveStreams: () => void } {
   const channelId = selectedAgent?.id;
 
   usePageSocketRoom(channelId);
@@ -92,7 +92,7 @@ export function useAgentChannelMultiplayer({
     };
   }, []);
 
-  useChannelStreamSocket(channelId, {
+  const { rejoinActiveStreams } = useChannelStreamSocket(channelId, {
     onUserMessage: (message, payload) => {
       if (payload.conversationId !== agentConversationIdRef.current) return;
       setLocalMessagesRef.current((prev) =>
@@ -186,4 +186,6 @@ export function useAgentChannelMultiplayer({
       hasInitialConnectRef.current = true;
     }
   }, [selectedAgent, socketConnectionStatus, agentConversationId]);
+
+  return { rejoinActiveStreams };
 }

--- a/apps/web/src/lib/ai/shared/hooks/useStreamRecovery.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useStreamRecovery.ts
@@ -11,6 +11,13 @@ interface UseStreamRecoveryOptions {
   handleRetry: () => Promise<void>;
   /** Max auto-retry attempts before giving up (default: 2) */
   maxRetries?: number;
+  /**
+   * Optional rejoin-first recovery probe. Called before handleRetry (regenerate).
+   * Should attempt to rejoin a live server stream or refetch the persisted result.
+   * Return true if recovery succeeded (skip regenerate); false to fall through to
+   * handleRetry. When absent, handleRetry is always called on network error.
+   */
+  tryRecover?: () => Promise<boolean>;
 }
 
 /** Returns true if the error looks like a network/connection failure (not an API error) */
@@ -48,6 +55,7 @@ export function useStreamRecovery({
   clearError,
   handleRetry,
   maxRetries = 2,
+  tryRecover,
 }: UseStreamRecoveryOptions) {
   const retryCountRef = useRef(0);
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -77,6 +85,7 @@ export function useStreamRecovery({
       isRetryingRef.current = true;
       clearError();
       try {
+        if (tryRecover && await tryRecover()) return;
         await handleRetry();
       } finally {
         isRetryingRef.current = false;
@@ -89,7 +98,7 @@ export function useStreamRecovery({
         retryTimeoutRef.current = null;
       }
     };
-  }, [error, status, clearError, handleRetry, maxRetries]);
+  }, [error, status, clearError, handleRetry, maxRetries, tryRecover]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/apps/web/src/lib/ai/streams/__tests__/decideRecovery.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/decideRecovery.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { decideRecovery } from '../decideRecovery';
+
+describe('decideRecovery', () => {
+  it('live stream → rejoin (highest priority, stream is still running)', () => {
+    expect(decideRecovery({ hasLiveStream: true, hasPersistedReply: false })).toBe('rejoin');
+  });
+
+  it('live stream + persisted reply → rejoin (stream takes precedence)', () => {
+    expect(decideRecovery({ hasLiveStream: true, hasPersistedReply: true })).toBe('rejoin');
+  });
+
+  it('no live stream + persisted reply → refetch (run finished while backgrounded)', () => {
+    expect(decideRecovery({ hasLiveStream: false, hasPersistedReply: true })).toBe('refetch');
+  });
+
+  it('no live stream + no persisted reply → regenerate (genuine failure, nothing to recover)', () => {
+    expect(decideRecovery({ hasLiveStream: false, hasPersistedReply: false })).toBe('regenerate');
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/resolveResumeAction.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/resolveResumeAction.test.ts
@@ -6,12 +6,12 @@ describe('resolveResumeAction', () => {
     expect(resolveResumeAction({ native: true, isStreaming: true })).toBe('rejoin-and-refresh');
   });
 
-  it('web (non-native) + streaming → noop (must not clobber live fetch)', () => {
-    expect(resolveResumeAction({ native: false, isStreaming: true })).toBe('noop');
+  it('native + not streaming → rejoin-and-refresh (fetch is dead after backgrounding regardless)', () => {
+    expect(resolveResumeAction({ native: true, isStreaming: false })).toBe('rejoin-and-refresh');
   });
 
-  it('native + not streaming → refresh', () => {
-    expect(resolveResumeAction({ native: true, isStreaming: false })).toBe('refresh');
+  it('web (non-native) + streaming → noop (must not clobber live fetch)', () => {
+    expect(resolveResumeAction({ native: false, isStreaming: true })).toBe('noop');
   });
 
   it('web (non-native) + not streaming → refresh', () => {

--- a/apps/web/src/lib/ai/streams/decideRecovery.ts
+++ b/apps/web/src/lib/ai/streams/decideRecovery.ts
@@ -1,0 +1,19 @@
+export type RecoveryDecision = 'rejoin' | 'refetch' | 'regenerate';
+
+/**
+ * Pure decision helper for the rejoin-first recovery tree.
+ *
+ * Priority: rejoin a still-live server stream > return the already-persisted
+ * result > regenerate (last resort, genuine failure).
+ */
+export function decideRecovery({
+  hasLiveStream,
+  hasPersistedReply,
+}: {
+  hasLiveStream: boolean;
+  hasPersistedReply: boolean;
+}): RecoveryDecision {
+  if (hasLiveStream) return 'rejoin';
+  if (hasPersistedReply) return 'refetch';
+  return 'regenerate';
+}

--- a/apps/web/src/lib/ai/streams/resolveResumeAction.ts
+++ b/apps/web/src/lib/ai/streams/resolveResumeAction.ts
@@ -7,6 +7,10 @@ export function resolveResumeAction({
   native: boolean;
   isStreaming: boolean;
 }): ResumeAction {
-  if (isStreaming) return native ? 'rejoin-and-refresh' : 'noop';
+  // On native (Capacitor) the local fetch is always dead after backgrounding —
+  // regardless of whether useChat still reports streaming — so we always rejoin.
+  if (native) return 'rejoin-and-refresh';
+  // Web + live fetch: don't clobber it; the existing stream is healthy.
+  if (isStreaming) return 'noop';
   return 'refresh';
 }


### PR DESCRIPTION
## Problem

On mobile (Capacitor), when a user sends a message and backgrounds the app mid-stream, the app RESTARTS the AI run on resume instead of rejoining the original. Because #1690 made the server durable (client disconnect ≠ server abort), the original run keeps executing server-side while the new one starts → **two concurrent agent runs for one user message = duplicate/divergent tool side-effects + double billing**. This is a correctness/safety bug.

## Root cause

`useStreamRecovery` fires on `status==='error'` with a network-type message (iOS kills the streaming fetch when the app backgrounds; the error + 1–2s backoff timer fire on resume). It calls `handleRetry()` which **deletes assistant messages and calls `regenerate()`** — a fresh `/api/ai/chat` POST. It never checked for a still-live server stream and never tried to rejoin first.

`GlobalAssistantView` and `SidebarChatTab` ran **both** `useAppStateRecovery` (rejoin) AND `useStreamRecovery` (regenerate). They raced; the delayed regenerate won.

## Fix: rejoin-first, regenerate only as last resort

### 2a. `resolveResumeAction` — unconditional native rejoin

```ts
if (native) return 'rejoin-and-refresh';  // fetch is dead after backgrounding regardless
if (isStreaming) return 'noop';           // web + live fetch: don't clobber it
return 'refresh';
```

Previously returned `'refresh'` when `isStreaming` was false (= the resumed state, because the dead fetch dropped `useChat` out of streaming) — so rejoin never ran. Updated test matrix: native always `rejoin-and-refresh`, web+streaming→`noop`, web+idle→`refresh`.

### 2b. `decideRecovery` — new pure, unit-tested helper

```ts
decideRecovery({ hasLiveStream, hasPersistedReply }): 'rejoin' | 'refetch' | 'regenerate'
```

Priority: rejoin live stream > return already-persisted result > regenerate. 4 tests covering all branches.

### 2c. `useStreamRecovery` — rejoin-first gate

Added `tryRecover?: () => Promise<boolean>`. Before `handleRetry()`:
```ts
if (tryRecover && await tryRecover()) return;  // recovered → skip regenerate
await handleRetry();                            // genuine failure → regenerate
```

### 2d. `GlobalChatContext` — expose `rejoinGlobalStream`

Captured `useChannelStreamSocket`'s `rejoinActiveStreams` return value (previously discarded) and exposed it via `useGlobalChatConversation()`.

### 2e. `useAgentChannelMultiplayer` — return `rejoinActiveStreams`

Changed return type from `void` to `{ rejoinActiveStreams: () => void }`.

### 2f. `GlobalAssistantView` + `SidebarChatTab` — wire `tryRecover`

Both surfaces pass a `tryRecover` that runs the recovery decision tree:
1. GET `/api/ai/chat/active-streams` for this conversation's channel. If own stream is still live → call `rejoinGlobalStream()` or `rejoinAgentStream()` (bootstrap dedups via `claimBootstrapConsumer`) → return `true` (skip regenerate).
2. Else fetch messages from the DB. If the last message is from the assistant AND the DB has at least as many user messages as we have locally (`dbUserCount >= localUserCount`) → update local state → return `true`.
3. Else return `false` → regenerate proceeds (genuine failure: no live stream, no persisted result).

**Step 2 false-positive guard** (`dbUserCount >= localUserCount`): Without this check, a previous-turn assistant reply in the DB was incorrectly treated as recovery success when the network error fires before the current user message has reached the server, silently dropping the user's new prompt. A `currentMessagesRef` (synchronously updated each render, stable ref identity) lets `tryRecover` read the current local message count without adding `messages` to the `useCallback` dep array.

Rejoin is idempotent (`claimBootstrapConsumer` dedups), so the `useAppStateRecovery` resume-rejoin (2a) and the `useStreamRecovery` recover-rejoin (2f) cannot double-attach.

## Scope note

Cross-instance live rejoin is out of scope: Fly config has `min_machines_running = 1` (single web instance), so same-instance `streamMulticastRegistry` covers all cases. Realtime is strictly single-process.

## Test plan

- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bun run --filter 'web' test` — all `ai/streams` + `ai/shared` tests pass (new `resolveResumeAction` 4-case matrix + `decideRecovery` 4-case suite)
- [ ] **Manual e2e (iOS, Global Assistant):** send a message that triggers tool calls → background mid-run → resume → it re-attaches to the SAME run (same tool calls continue), no second divergent run, no double-charge
- [ ] **Background until after completion:** finished message appears via refetch, no regenerate
- [ ] **Foreground network blip mid-stream:** rejoins, doesn't restart