### PR TITLE
feat(mcp): return structured task list data for TASK_LIST page reads

### DIFF
--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -53,14 +53,18 @@ vi.mock('@pagespace/lib/sheets/sheet', () => ({
   updateSheetCells: vi.fn(),
   isValidCellAddress: vi.fn(() => true),
 }));
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-    api: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
-    security: { warn: vi.fn() },
-  },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
-}));
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  const namedLogger = { ...childLogger, child: vi.fn(() => childLogger) };
+  return {
+    loggers: {
+      api: namedLogger,
+      security: { warn: vi.fn() },
+      ai: namedLogger,
+    },
+    logger: { child: vi.fn(() => childLogger) },
+  };
+});
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   audit: vi.fn(),
   auditRequest: vi.fn(),
@@ -86,9 +90,23 @@ vi.mock('@pagespace/db/db', () => ({
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
+  asc: vi.fn(),
+  and: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'pages.id' },
+}));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskLists: { pageId: 'taskLists.pageId' },
+  taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
+  DEFAULT_TASK_STATUSES: [],
+}));
+vi.mock('@/lib/ai/tools/task-helpers', () => ({
+  fetchEnrichedTasks: vi.fn().mockResolvedValue([]),
+  serializeTaskItem: vi.fn((t: unknown) => t),
+}));
+vi.mock('@/services/api/task-sync-service', () => ({
+  backfillMissingTaskItems: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/websocket', () => ({

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -92,7 +92,6 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   asc: vi.fn(),
   and: vi.fn(),
-  inArray: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -7,6 +7,8 @@ const mockFindFirstPage = vi.fn();
 const mockFindFirstTaskList = vi.fn();
 const mockFindManyStatusConfigs = vi.fn();
 const mockInsertReturning = vi.fn();
+const mockSelectChildPages = vi.fn();
+const mockBackfillMissingTaskItems = vi.fn();
 const mockFetchEnrichedTasks = vi.fn();
 const mockSerializeTaskItem = vi.fn();
 
@@ -74,12 +76,23 @@ vi.mock('@pagespace/db/db', () => ({
         returning: (...args: unknown[]) => mockInsertReturning(...args),
       }),
     }),
+    select: () => ({
+      from: () => ({
+        where: (..._args: unknown[]) => mockSelectChildPages(),
+      }),
+    }),
   },
+}));
+
+vi.mock('@/services/api/task-sync-service', () => ({
+  backfillMissingTaskItems: (...args: unknown[]) => mockBackfillMissingTaskItems(...args),
 }));
 
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   asc: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -156,6 +169,8 @@ describe('MCP Documents API — TASK_LIST read', () => {
     mockFindFirstPage.mockResolvedValue(TASK_LIST_PAGE);
     mockFindFirstTaskList.mockResolvedValue(EXISTING_TASK_LIST);
     mockFindManyStatusConfigs.mockResolvedValue([]);
+    mockSelectChildPages.mockResolvedValue([{ id: 'child_1' }, { id: 'child_2' }]);
+    mockBackfillMissingTaskItems.mockResolvedValue(undefined);
     mockFetchEnrichedTasks.mockResolvedValue([]);
     mockSerializeTaskItem.mockImplementation((t: unknown) => t);
   });
@@ -286,6 +301,27 @@ describe('MCP Documents API — TASK_LIST read', () => {
     await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
 
     expect(mockFetchEnrichedTasks).toHaveBeenCalledWith('page_tl');
+  });
+
+  it('calls backfillMissingTaskItems with child page ids before fetching tasks', async () => {
+    mockSelectChildPages.mockResolvedValue([{ id: 'cp_1' }, { id: 'cp_2' }]);
+
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockBackfillMissingTaskItems).toHaveBeenCalledWith(
+      expect.anything(), // db
+      { parentId: 'page_tl', childPageIds: ['cp_1', 'cp_2'], userId: 'user_123' },
+    );
+  });
+
+  it('skips backfill when task list has no child pages', async () => {
+    mockSelectChildPages.mockResolvedValue([]);
+
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockBackfillMissingTaskItems).not.toHaveBeenCalled();
   });
 
   it('maps enriched tasks through serializeTaskItem', async () => {

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -90,10 +90,10 @@ vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: { pageId: 'taskLists.pageId' },
   taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
   DEFAULT_TASK_STATUSES: [
-    { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#6b7280' },
-    { slug: 'in_progress', name: 'In Progress', group: 'in_progress', position: 1, color: '#3b82f6' },
-    { slug: 'blocked', name: 'Blocked', group: 'in_progress', position: 2, color: '#ef4444' },
-    { slug: 'completed', name: 'Done', group: 'done', position: 3, color: '#22c55e' },
+    { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300' },
+    { slug: 'in_progress', name: 'In Progress', group: 'in_progress', position: 1, color: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300' },
+    { slug: 'blocked', name: 'Blocked', group: 'in_progress', position: 2, color: 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300' },
+    { slug: 'completed', name: 'Done', group: 'done', position: 3, color: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300' },
   ],
 }));
 

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockAuthenticateMCPRequest = vi.fn();
+const mockGetUserAccessLevel = vi.fn();
+const mockFindFirstPage = vi.fn();
+const mockFindFirstTaskList = vi.fn();
+const mockFindManyStatusConfigs = vi.fn();
+const mockInsertReturning = vi.fn();
+const mockFetchEnrichedTasks = vi.fn();
+const mockSerializeTaskItem = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  authenticateMCPRequest: (...args: unknown[]) => mockAuthenticateMCPRequest(...args),
+  isAuthError: (result: unknown) => 'error' in (result as object),
+  isMCPAuthResult: (result: unknown) =>
+    !('error' in (result as object)) && (result as { tokenType?: string }).tokenType === 'mcp',
+  getPrincipalAccessLevel: async (_auth: unknown, _pageId: string) => ({
+    canView: true,
+    canEdit: false,
+    canShare: false,
+    canDelete: false,
+  }),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+}));
+vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
+  getAppAccessLevel: vi.fn(),
+}));
+vi.mock('@pagespace/lib/utils/enums', () => ({
+  PageType: { TASK_LIST: 'TASK_LIST' },
+}));
+vi.mock('@pagespace/lib/sheets/sheet', () => ({
+  isSheetType: vi.fn(() => false),
+  parseSheetContent: vi.fn(),
+  serializeSheetContent: vi.fn(),
+  updateSheetCells: vi.fn(),
+  isValidCellAddress: vi.fn(() => true),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+    security: { warn: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn(),
+}));
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(),
+}));
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn(),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: (...args: unknown[]) => mockFindFirstPage(...args) },
+      taskLists: { findFirst: (...args: unknown[]) => mockFindFirstTaskList(...args) },
+      taskStatusConfigs: { findMany: (...args: unknown[]) => mockFindManyStatusConfigs(...args) },
+    },
+    insert: () => ({
+      values: () => ({
+        returning: (...args: unknown[]) => mockInsertReturning(...args),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  asc: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id' },
+}));
+
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskLists: { pageId: 'taskLists.pageId' },
+  taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
+  DEFAULT_TASK_STATUSES: [
+    { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#6b7280' },
+    { slug: 'in_progress', name: 'In Progress', group: 'in_progress', position: 1, color: '#3b82f6' },
+    { slug: 'blocked', name: 'Blocked', group: 'in_progress', position: 2, color: '#ef4444' },
+    { slug: 'completed', name: 'Done', group: 'done', position: 3, color: '#22c55e' },
+  ],
+}));
+
+vi.mock('@/lib/ai/tools/task-helpers', () => ({
+  fetchEnrichedTasks: (...args: unknown[]) => mockFetchEnrichedTasks(...args),
+  serializeTaskItem: (...args: unknown[]) => mockSerializeTaskItem(...args),
+}));
+
+const TASK_LIST_PAGE = {
+  id: 'page_tl',
+  title: 'My Task List',
+  content: '',
+  type: 'TASK_LIST',
+  revision: 1,
+  parentId: null,
+  driveId: 'drive_123',
+};
+
+const DOCUMENT_PAGE = {
+  id: 'page_doc',
+  title: 'My Doc',
+  content: 'line 1\nline 2\nline 3',
+  type: 'DOCUMENT',
+  revision: 1,
+  parentId: null,
+  driveId: 'drive_123',
+};
+
+const EXISTING_TASK_LIST = {
+  id: 'tl_1',
+  pageId: 'page_tl',
+  userId: 'user_123',
+  title: 'My Task List',
+  status: 'pending',
+  description: null,
+  metadata: null,
+};
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/mcp/documents', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('MCP Documents API — TASK_LIST read', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAuthenticateMCPRequest.mockResolvedValue({
+      userId: 'user_123',
+      tokenType: 'mcp',
+      tokenId: 'token_123',
+      role: 'user',
+      tokenVersion: 1,
+      adminRoleVersion: 0,
+      allowedDriveIds: [],
+    });
+
+    mockFindFirstPage.mockResolvedValue(TASK_LIST_PAGE);
+    mockFindFirstTaskList.mockResolvedValue(EXISTING_TASK_LIST);
+    mockFindManyStatusConfigs.mockResolvedValue([]);
+    mockFetchEnrichedTasks.mockResolvedValue([]);
+    mockSerializeTaskItem.mockImplementation((t: unknown) => t);
+  });
+
+  it('returns structured task list data (not numberedLines) for TASK_LIST pages', async () => {
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.pageType).toBe('TASK_LIST');
+    expect(data.taskListId).toBe('tl_1');
+    expect(data.tasks).toBeDefined();
+    expect(data.availableStatuses).toBeDefined();
+    expect(data.progress).toBeDefined();
+    expect(data.numberedLines).toBeUndefined();
+    expect(data.content).toBeUndefined();
+  });
+
+  it('returns numberedLines for non-TASK_LIST pages (regression guard)', async () => {
+    mockFindFirstPage.mockResolvedValue(DOCUMENT_PAGE);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_doc' }));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(data.numberedLines).toBeDefined();
+    expect(data.content).toBeDefined();
+    expect(data.pageType).toBeUndefined();
+    expect(data.tasks).toBeUndefined();
+  });
+
+  it('auto-creates taskLists record when none exists', async () => {
+    mockFindFirstTaskList.mockResolvedValue(null);
+    mockInsertReturning.mockResolvedValue([{ ...EXISTING_TASK_LIST, id: 'tl_new' }]);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.taskListId).toBe('tl_new');
+    expect(mockInsertReturning).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not insert when taskLists record already exists', async () => {
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it('uses custom status configs when present', async () => {
+    const customConfigs = [
+      { slug: 'backlog', name: 'Backlog', group: 'todo', position: 0, color: '#aaa' },
+      { slug: 'shipped', name: 'Shipped', group: 'done', position: 1, color: '#0f0' },
+    ];
+    mockFindManyStatusConfigs.mockResolvedValue(customConfigs);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(data.availableStatuses).toHaveLength(2);
+    expect(data.availableStatuses[0].slug).toBe('backlog');
+    expect(data.availableStatuses[0].label).toBe('Backlog');
+    expect(data.availableStatuses[1].slug).toBe('shipped');
+  });
+
+  it('falls back to DEFAULT_TASK_STATUSES when no custom configs exist', async () => {
+    mockFindManyStatusConfigs.mockResolvedValue([]);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(data.availableStatuses).toHaveLength(4);
+    expect(data.availableStatuses.map((s: { slug: string }) => s.slug)).toEqual([
+      'pending', 'in_progress', 'blocked', 'completed',
+    ]);
+  });
+
+  it('computes progress from task statuses', async () => {
+    const enrichedTasks = [
+      { id: 't1', status: 'pending', completedAt: null },
+      { id: 't2', status: 'in_progress', completedAt: null },
+      { id: 't3', status: 'completed', completedAt: new Date().toISOString() },
+      { id: 't4', status: 'completed', completedAt: new Date().toISOString() },
+    ];
+    mockFetchEnrichedTasks.mockResolvedValue(enrichedTasks);
+    mockSerializeTaskItem.mockImplementation((t: unknown) => t);
+    // custom configs so 'completed' maps to 'done'
+    mockFindManyStatusConfigs.mockResolvedValue([
+      { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#gray' },
+      { slug: 'in_progress', name: 'In Progress', group: 'in_progress', position: 1, color: '#blue' },
+      { slug: 'completed', name: 'Done', group: 'done', position: 2, color: '#green' },
+    ]);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(data.progress.total).toBe(4);
+    expect(data.progress.percentage).toBe(50); // 2/4 done
+    expect(data.progress.byGroup.done).toBe(2);
+    expect(data.progress.byGroup.in_progress).toBe(1);
+    expect(data.progress.byGroup.todo).toBe(1);
+    expect(data.progress.bySlug.completed).toBe(2);
+    expect(data.progress.bySlug.pending).toBe(1);
+  });
+
+  it('reports 0% progress for empty task list', async () => {
+    mockFetchEnrichedTasks.mockResolvedValue([]);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(data.progress.total).toBe(0);
+    expect(data.progress.percentage).toBe(0);
+  });
+
+  it('calls fetchEnrichedTasks with the correct pageId', async () => {
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockFetchEnrichedTasks).toHaveBeenCalledWith('page_tl');
+  });
+
+  it('maps enriched tasks through serializeTaskItem', async () => {
+    const raw = [{ id: 't1', status: 'pending', completedAt: null }];
+    const serialized = { id: 't1', title: 'Task 1', status: 'pending' };
+    mockFetchEnrichedTasks.mockResolvedValue(raw);
+    mockSerializeTaskItem.mockReturnValue(serialized);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(mockSerializeTaskItem).toHaveBeenCalledWith(raw[0]);
+    expect(data.tasks[0]).toEqual(serialized);
+  });
+});

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
+import { eq, asc } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
+import { taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
+import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
 import { z } from 'zod/v4';
@@ -173,10 +175,69 @@ export async function POST(req: NextRequest) {
     
     switch (operation) {
       case 'read': {
-        const numberedLines = getNumberedLines(currentContent);
-
         auditRequest(req, { eventType: 'data.read', userId, resourceType: 'page', resourceId: pageId, details: { source: 'mcp', operation: 'read' } });
 
+        if (page.type === PageType.TASK_LIST) {
+          let taskList = await db.query.taskLists.findFirst({
+            where: eq(taskLists.pageId, pageId),
+          });
+
+          if (!taskList) {
+            const [newTaskList] = await db.insert(taskLists).values({
+              userId,
+              pageId,
+              title: page.title,
+              status: 'pending',
+              metadata: {
+                createdAt: new Date().toISOString(),
+                autoCreated: true,
+              },
+            }).returning();
+            taskList = newTaskList;
+          }
+
+          const tasks = await fetchEnrichedTasks(pageId);
+
+          const statusConfigs = await db.query.taskStatusConfigs.findMany({
+            where: eq(taskStatusConfigs.taskListId, taskList.id),
+            orderBy: [asc(taskStatusConfigs.position)],
+          });
+
+          const availableStatuses = statusConfigs.length > 0
+            ? statusConfigs.map(c => ({ slug: c.slug, label: c.name, group: c.group, position: c.position, color: c.color }))
+            : DEFAULT_TASK_STATUSES.map(s => ({ slug: s.slug, label: s.name, group: s.group, position: s.position, color: s.color }));
+
+          const slugToGroup = new Map(availableStatuses.map(s => [s.slug, s.group]));
+
+          const totalTasks = tasks.length;
+          const byGroup: Record<string, number> = { todo: 0, in_progress: 0, done: 0 };
+          const bySlug: Record<string, number> = {};
+          for (const t of tasks) {
+            bySlug[t.status] = (bySlug[t.status] || 0) + 1;
+            const group = slugToGroup.get(t.status)
+              || (t.completedAt ? 'done' : t.status === 'in_progress' || t.status === 'blocked' ? 'in_progress' : 'todo');
+            byGroup[group] = (byGroup[group] || 0) + 1;
+          }
+          const completedCount = byGroup.done || 0;
+          const progressPercentage = totalTasks > 0 ? Math.round((completedCount / totalTasks) * 100) : 0;
+
+          return NextResponse.json({
+            pageId,
+            pageTitle: page.title,
+            pageType: 'TASK_LIST',
+            taskListId: taskList.id,
+            tasks: tasks.map(serializeTaskItem),
+            availableStatuses,
+            progress: {
+              total: totalTasks,
+              percentage: progressPercentage,
+              byGroup,
+              bySlug,
+            },
+          });
+        }
+
+        const numberedLines = getNumberedLines(currentContent);
         return NextResponse.json({
           pageId,
           pageTitle: page.title,

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -243,7 +243,7 @@ export async function POST(req: NextRequest) {
             pageTitle: page.title,
             pageType: 'TASK_LIST',
             taskListId: taskList.id,
-            tasks: tasks.map(serializeTaskItem),
+            tasks: tasks.map(t => serializeTaskItem(t)),
             availableStatuses,
             progress: {
               total: totalTasks,

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, asc } from '@pagespace/db/operators'
+import { eq, asc, and, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
 import { taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';
+import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
 import { z } from 'zod/v4';
@@ -194,6 +195,21 @@ export async function POST(req: NextRequest) {
               },
             }).returning();
             taskList = newTaskList;
+          }
+
+          // Self-heal: ensure every child TASK_LIST page has a task_items row.
+          // Mirrors the same call in /api/pages/[pageId]/tasks/route.ts:143.
+          const childPages = await db
+            .select({ id: pages.id })
+            .from(pages)
+            .where(and(
+              eq(pages.parentId, pageId),
+              eq(pages.type, PageType.TASK_LIST),
+              eq(pages.isTrashed, false),
+            ));
+          const childPageIds = childPages.map(p => p.id);
+          if (childPageIds.length > 0) {
+            await backfillMissingTaskItems(db, { parentId: pageId, childPageIds, userId });
           }
 
           const [tasks, statusConfigs] = await Promise.all([

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -196,12 +196,13 @@ export async function POST(req: NextRequest) {
             taskList = newTaskList;
           }
 
-          const tasks = await fetchEnrichedTasks(pageId);
-
-          const statusConfigs = await db.query.taskStatusConfigs.findMany({
-            where: eq(taskStatusConfigs.taskListId, taskList.id),
-            orderBy: [asc(taskStatusConfigs.position)],
-          });
+          const [tasks, statusConfigs] = await Promise.all([
+            fetchEnrichedTasks(pageId),
+            db.query.taskStatusConfigs.findMany({
+              where: eq(taskStatusConfigs.taskListId, taskList.id),
+              orderBy: [asc(taskStatusConfigs.position)],
+            }),
+          ]);
 
           const availableStatuses = statusConfigs.length > 0
             ? statusConfigs.map(c => ({ slug: c.slug, label: c.name, group: c.group, position: c.position, color: c.color }))

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, asc, and, inArray } from '@pagespace/db/operators'
+import { eq, asc, and } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
 import { taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';

--- a/apps/web/src/lib/ai/tools/task-helpers.ts
+++ b/apps/web/src/lib/ai/tools/task-helpers.ts
@@ -171,7 +171,7 @@ export async function syncTaskAssignees(
   }
 }
 
-async function fetchEnrichedTasks(parentPageId: string) {
+export async function fetchEnrichedTasks(parentPageId: string) {
   return db.query.taskItems.findMany({
     where: inArray(taskItems.pageId, db.select({ id: pages.id }).from(pages).where(and(
       eq(pages.parentId, parentPageId),


### PR DESCRIPTION
## Summary

- The MCP \`/api/mcp/documents\` \`read\` operation previously returned \`page.content\` as numbered lines for every page type, making TASK_LIST pages opaque to external MCP clients
- The AI SDK \`read_page\` tool already had a full TASK_LIST branch; this brings the MCP surface to parity
- Non-TASK_LIST pages continue to return \`numberedLines\`/\`content\` unchanged

## Changes

**\`apps/web/src/app/api/mcp/documents/route.ts\`**

When \`operation: 'read'\` hits a \`TASK_LIST\` page:
1. Finds or auto-creates the \`taskLists\` record (idempotent, same pattern as the AI SDK tool)
2. Self-heals missing \`task_items\` rows via \`backfillMissingTaskItems\` — mirrors \`/api/pages/[pageId]/tasks/route.ts:143\`, ensuring tasks created/moved via paths that skipped sync still appear
3. Fetches tasks + status configs in parallel (\`Promise.all\`) via \`fetchEnrichedTasks\` + \`serializeTaskItem\`
4. Resolves status configs: custom \`taskStatusConfigs\` or falls back to \`DEFAULT_TASK_STATUSES\`
5. Computes progress breakdown: \`byGroup\` (\`todo\`/\`in_progress\`/\`done\`), \`bySlug\`, and \`percentage\`
6. Response shape: \`{ pageId, pageTitle, pageType, taskListId, tasks, availableStatuses, progress }\`

**\`apps/web/src/lib/ai/tools/task-helpers.ts\`**

Exported \`fetchEnrichedTasks\` so the MCP route can reuse the enriched query.

**\`apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts\`** (new, 11 tests)

Covers: structured response shape, DOCUMENT regression guard, auto-create idempotency, custom vs default status configs, progress calculation, empty list, \`fetchEnrichedTasks\` delegation, \`serializeTaskItem\` mapping, backfill called with child IDs, backfill skipped when no children.

## Test plan

- [ ] Existing security tests pass unchanged (\`route.security.test.ts\` — 13 tests)
- [ ] New task list tests pass (\`route.task-list.test.ts\` — 11 tests)
- [ ] MCP \`read\` on a TASK_LIST page returns \`tasks\`, \`availableStatuses\`, \`progress\` (not \`numberedLines\`)
- [ ] MCP \`read\` on a DOCUMENT/CODE/etc page still returns \`numberedLines\` and \`content\`
- [ ] Tasks missing \`task_items\` rows (created/moved via skipped-sync paths) appear after backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7DB1aRPo6RiLydBzrJyta