### PR TITLE
fix(ai-chat): handle 404 gracefully in sidebar for lazy-created conversations

### DIFF
--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -510,6 +510,12 @@ const SidebarChatTab: React.FC = () => {
     fetchWithAuth(`/api/ai/global/${conversationId}/messages`)
       .then(async (res) => {
         if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;
+        if (res.status === 404) {
+          // Conversation not yet persisted (lazy creation) — treat as empty, not an error.
+          setGlobalMessages([]);
+          setGlobalMessagesLoadError(null);
+          return;
+        }
         if (!res.ok) throw new Error(`Failed to load messages (${res.status})`);
         const data = await res.json();
         if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;

--- a/apps/web/src/lib/repositories/__tests__/global-conversation-list-filter.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/global-conversation-list-filter.test.ts
@@ -121,6 +121,20 @@ describe('globalConversationRepository.listConversations — EXISTS filter', () 
   });
 });
 
+describe('globalConversationRepository.getActiveGlobalConversation — hasMessages filter', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('includes the EXISTS condition in the WHERE clause', async () => {
+    const { db, mockWhere } = makeDb([CONV]);
+    Object.assign(dbRef, db);
+
+    await globalConversationRepository.getActiveGlobalConversation('user1');
+
+    const whereArg = mockWhere.mock.calls[0]?.[0];
+    expect(JSON.stringify(whereArg)).toContain('exists');
+  });
+});
+
 describe('globalConversationRepository.getActiveGlobalConversation — ordering', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/apps/web/src/lib/repositories/global-conversation-repository.ts
+++ b/apps/web/src/lib/repositories/global-conversation-repository.ts
@@ -324,7 +324,8 @@ export const globalConversationRepository = {
       .where(and(
         eq(conversations.userId, userId),
         eq(conversations.type, 'global'),
-        eq(conversations.isActive, true)
+        eq(conversations.isActive, true),
+        hasMessages,
       ))
       .orderBy(sql`${conversations.lastMessageAt} DESC NULLS LAST`, desc(conversations.createdAt))
       .limit(1);


### PR DESCRIPTION
## Summary

- **`SidebarChatTab.tsx`**: `loadGlobalMessages` now treats a 404 response as "not yet persisted" (lazy creation) — sets empty messages and clears any prior error instead of throwing. Removes the spurious red "Failed to load messages" banner that appeared on every new global chat session.
- **`global-conversation-repository.ts`**: `getActiveGlobalConversation` now includes the `hasMessages` filter (same guard used by the history list). Stale empty conversation rows no longer surface as the resume target; the init flow falls through to `createNewConversation()` instead.

## Root cause

PR #1693 added a `loadGlobalMessages` effect to `SidebarChatTab` that fires whenever the active global conversation changes. This is correct for existing conversations, but regressed **new** ones: with lazy creation, a fresh conversation has a client-generated CUID2 ID but no DB row until the first POST. `loadGlobalMessages` got a 404 and threw it as an error, while `GlobalChatContext.loadConversation` already handled 404 gracefully (lines 104–109). The sidebar had no equivalent guard.

The `getActiveGlobalConversation` gap is related: without `hasMessages`, stale empty rows from aborted first-POSTs could be returned as the active conversation, showing a confusingly blank chat instead of a true fresh session.

## Test plan

- [ ] **New user (no prior conversations):** Open dashboard + sidebar — no error banner, chat input ready, sending a message creates the conversation lazily
- [ ] **Existing user clicks "New Chat":** No error banner in sidebar, URL/cookie update, sidebar shows empty welcome state
- [ ] **Page refresh after "New Chat" (cookie holds lazy ID):** Both context and sidebar handle 404 as empty, no error shown
- [ ] **Existing conversation resumes:** `getActiveGlobalConversation` returns a conversation with messages, sidebar loads them correctly
- [ ] **Stale empty conversation in DB:** Skipped by `hasMessages` filter, falls through to `createNewConversation()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169TjBg9NuWAHnwgztqzS2t