### PR TITLE
feat(api): list_pages ls-mode on GET /api/drives/[driveId]/pages

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/__tests__/route.test.ts
@@ -526,6 +526,16 @@ describe('GET /api/drives/[driveId]/pages', () => {
       expect(body.error).toContain('parentId');
     });
 
+    it('should return 404 for empty-string parentId (not treated as root)', async () => {
+      const url = new URL(`https://example.com/api/drives/${mockDriveId}/pages`);
+      url.searchParams.set('ls', 'true');
+      url.searchParams.set('parentId', '');
+      const response = await GET(new Request(url.toString()) as never, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+    });
+
     it('should return full subtree when recursive=true', async () => {
       const response = await GET(
         createLsRequest(mockDriveId, { recursive: 'true' }) as never,

--- a/apps/web/src/app/api/drives/[driveId]/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/__tests__/route.test.ts
@@ -534,6 +534,7 @@ describe('GET /api/drives/[driveId]/pages', () => {
       const body = await response.json();
 
       expect(response.status).toBe(404);
+      expect(body.error).toContain('parentId');
     });
 
     it('should return full subtree when recursive=true', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/__tests__/route.test.ts
@@ -133,6 +133,13 @@ const createContext = (driveId: string) => ({
 const createRequest = (driveId = 'drive_abc') =>
   new Request(`https://example.com/api/drives/${driveId}/pages`);
 
+const createLsRequest = (driveId = 'drive_abc', params: Record<string, string> = {}) => {
+  const url = new URL(`https://example.com/api/drives/${driveId}/pages`);
+  url.searchParams.set('ls', 'true');
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new Request(url.toString());
+};
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -421,6 +428,150 @@ describe('GET /api/drives/[driveId]/pages', () => {
       await GET(createRequest() as never, createContext(mockDriveId));
 
       expect(loggers.api.error).toHaveBeenCalledWith('Error fetching pages:', error);
+    });
+  });
+
+  // ---------- ls-mode (?ls=true) ----------
+
+  describe('ls-mode (?ls=true)', () => {
+    const flatPages = [
+      { id: 'page_root1', parentId: null, position: 0, type: 'DOCUMENT', title: 'Root Doc' },
+      { id: 'page_folder', parentId: null, position: 1, type: 'FOLDER', title: 'Folder' },
+      { id: 'page_child1', parentId: 'page_folder', position: 0, type: 'DOCUMENT', title: 'Child Doc' },
+    ];
+
+    beforeEach(() => {
+      // Drive needs a slug for ls-mode location strings
+      mockFindFirst.mockResolvedValue({
+        id: mockDriveId,
+        ownerId: mockUserId,
+        name: 'Test Drive',
+        slug: 'test-drive',
+      });
+      mockFindMany.mockResolvedValue(flatPages);
+      mockSelectDistinctWhere.mockResolvedValue([]);
+    });
+
+    it('should return ls-mode shape instead of tree when ?ls=true', async () => {
+      const response = await GET(createLsRequest() as never, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.mode).toBe('ls');
+      expect(body.driveName).toBe('Test Drive');
+      expect(body.driveSlug).toBe('test-drive');
+      // buildTree should NOT be called in ls-mode
+      expect(buildTree).not.toHaveBeenCalled();
+    });
+
+    it('should return only root-level pages when no parentId is given', async () => {
+      const response = await GET(createLsRequest() as never, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(body.pages).toHaveLength(2);
+      expect(body.pages.map((p: { id: string }) => p.id)).toEqual(['page_root1', 'page_folder']);
+      expect(body.count).toBe(2);
+      expect(body.totalInDrive).toBe(3);
+    });
+
+    it('should set hasChildren=true on folder that has children', async () => {
+      const response = await GET(createLsRequest() as never, createContext(mockDriveId));
+      const body = await response.json();
+
+      const folder = body.pages.find((p: { id: string }) => p.id === 'page_folder');
+      const doc = body.pages.find((p: { id: string }) => p.id === 'page_root1');
+      expect(folder.hasChildren).toBe(true);
+      expect(doc.hasChildren).toBe(false);
+    });
+
+    it('should return root location when no parentId', async () => {
+      const response = await GET(createLsRequest() as never, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(body.location).toBe('/test-drive');
+      expect(body.breadcrumb).toEqual([]);
+    });
+
+    it('should return children of parentId when parentId is given', async () => {
+      const response = await GET(
+        createLsRequest(mockDriveId, { parentId: 'page_folder' }) as never,
+        createContext(mockDriveId)
+      );
+      const body = await response.json();
+
+      expect(body.pages).toHaveLength(1);
+      expect(body.pages[0].id).toBe('page_child1');
+      expect(body.pages[0].hasChildren).toBe(false);
+    });
+
+    it('should include breadcrumb when navigating into a folder', async () => {
+      const response = await GET(
+        createLsRequest(mockDriveId, { parentId: 'page_folder' }) as never,
+        createContext(mockDriveId)
+      );
+      const body = await response.json();
+
+      expect(body.breadcrumb).toEqual([{ id: 'page_folder', title: 'Folder' }]);
+      expect(body.location).toBe('/test-drive/Folder');
+    });
+
+    it('should return 404 when parentId does not exist in visible pages', async () => {
+      const response = await GET(
+        createLsRequest(mockDriveId, { parentId: 'nonexistent_page' }) as never,
+        createContext(mockDriveId)
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toContain('parentId');
+    });
+
+    it('should return full subtree when recursive=true', async () => {
+      const response = await GET(
+        createLsRequest(mockDriveId, { recursive: 'true' }) as never,
+        createContext(mockDriveId)
+      );
+      const body = await response.json();
+
+      // All 3 pages should appear in depth-first order: root1, folder, child1
+      expect(body.pages).toHaveLength(3);
+      expect(body.pages.map((p: { id: string }) => p.id)).toEqual([
+        'page_root1',
+        'page_folder',
+        'page_child1',
+      ]);
+    });
+
+    it('should mark isTaskLinked on pages linked to tasks', async () => {
+      mockSelectDistinctWhere.mockResolvedValue([{ pageId: 'page_root1' }]);
+
+      const response = await GET(createLsRequest() as never, createContext(mockDriveId));
+      const body = await response.json();
+
+      const doc = body.pages.find((p: { id: string }) => p.id === 'page_root1');
+      const folder = body.pages.find((p: { id: string }) => p.id === 'page_folder');
+      expect(doc.isTaskLinked).toBe(true);
+      expect(folder.isTaskLinked).toBe(false);
+    });
+
+    it('should NOT call buildTree in ls-mode (backward compat: tree still works without ?ls)', async () => {
+      // Tree mode (no ?ls)
+      await GET(createRequest() as never, createContext(mockDriveId));
+      expect(buildTree).toHaveBeenCalled();
+
+      vi.clearAllMocks();
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+      vi.mocked(isAuthError).mockReturnValue(false);
+      vi.mocked(checkMCPDriveScope).mockReturnValue(null);
+      mockFindFirst.mockResolvedValue({ id: mockDriveId, ownerId: mockUserId, name: 'Test Drive', slug: 'test-drive' });
+      mockFindMany.mockResolvedValue(flatPages);
+      mockSelectDistinctWhere.mockResolvedValue([]);
+      mockExecute.mockResolvedValue({ rows: [] });
+      vi.mocked(buildTree).mockImplementation((items: unknown[]) => items as ReturnType<typeof buildTree>);
+
+      // ls-mode
+      await GET(createLsRequest() as never, createContext(mockDriveId));
+      expect(buildTree).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/api/drives/[driveId]/pages/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/route.ts
@@ -105,6 +105,12 @@ export async function GET(
 
   const userId = auth.userId;
 
+  // ls-mode query params
+  const { searchParams } = new URL(request.url);
+  const lsMode = searchParams.get('ls') === 'true';
+  const lsParentId = searchParams.get('parentId') ?? null;
+  const lsRecursive = searchParams.get('recursive') === 'true';
+
   try {
     // Find drive by id, but don't scope to owner yet
     const drive = await db.query.drives.findFirst({
@@ -174,6 +180,89 @@ export async function GET(
         eq(pages.driveId, drive.id)
       ));
     const taskLinkedSet = new Set(taskLinkedPageIds.map(t => t.pageId));
+
+    // ── ls-mode: flat list of direct children (or full subtree) ──────────────
+    if (lsMode) {
+      const pageMap = new Map(pageResults.map(p => [p.id, p]));
+
+      if (lsParentId && !pageMap.has(lsParentId)) {
+        return NextResponse.json({ error: 'parentId not found or not accessible' }, { status: 404 });
+      }
+
+      // Walk parent chain to build breadcrumb and location string
+      const buildBreadcrumb = (id: string | null): { id: string; title: string }[] => {
+        if (!id) return [];
+        const crumbs: { id: string; title: string }[] = [];
+        let current = pageMap.get(id);
+        while (current) {
+          crumbs.unshift({ id: current.id, title: current.title });
+          current = current.parentId ? pageMap.get(current.parentId) : undefined;
+        }
+        return crumbs;
+      };
+
+      const buildLocation = (id: string | null): string => {
+        if (!id) return `/${drive.slug}`;
+        const page = pageMap.get(id);
+        if (!page) return `/${drive.slug}`;
+        return `${buildLocation(page.parentId)}/${page.title}`;
+      };
+
+      interface LsPage {
+        id: string;
+        title: string;
+        type: string;
+        hasChildren: boolean;
+        isTaskLinked: boolean;
+      }
+
+      let resultPages: LsPage[];
+
+      if (!lsRecursive) {
+        const target = lsParentId ?? null;
+        const children = pageResults.filter(p => p.parentId === target);
+        resultPages = children.map(p => ({
+          id: p.id,
+          title: p.title,
+          type: p.type,
+          hasChildren: pageResults.some(c => c.parentId === p.id),
+          isTaskLinked: taskLinkedSet.has(p.id),
+        }));
+      } else {
+        const collectSubtree = (startParentId: string | null): LsPage[] => {
+          const result: LsPage[] = [];
+          const children = pageResults.filter(p => p.parentId === startParentId);
+          for (const p of children) {
+            result.push({
+              id: p.id,
+              title: p.title,
+              type: p.type,
+              hasChildren: pageResults.some(c => c.parentId === p.id),
+              isTaskLinked: taskLinkedSet.has(p.id),
+            });
+            result.push(...collectSubtree(p.id));
+          }
+          return result;
+        };
+        resultPages = collectSubtree(lsParentId ?? null);
+      }
+
+      const breadcrumb = buildBreadcrumb(lsParentId);
+      const location = lsParentId ? buildLocation(lsParentId) : `/${drive.slug}`;
+
+      auditRequest(request, { eventType: 'data.read', userId, resourceType: 'drive_page_tree', resourceId: driveId, details: { action: 'list_pages_ls', count: resultPages.length } });
+      return jsonResponse({
+        mode: 'ls',
+        driveName: drive.name,
+        driveSlug: drive.slug,
+        location,
+        breadcrumb,
+        pages: resultPages,
+        count: resultPages.length,
+        totalInDrive: pageResults.length,
+      });
+    }
+    // ─────────────────────────────────────────────────────────────────────────
 
     // Query activity logs to find pages with changes by OTHER users or AI since last view
     // This is more accurate than comparing updatedAt because:

--- a/apps/web/src/app/api/drives/[driveId]/pages/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/route.ts
@@ -185,27 +185,33 @@ export async function GET(
     if (lsMode) {
       const pageMap = new Map(pageResults.map(p => [p.id, p]));
 
-      if (lsParentId && !pageMap.has(lsParentId)) {
+      // Use !== null so empty-string parentId (from ?parentId=) is caught, not treated as root
+      if (lsParentId !== null && !pageMap.has(lsParentId)) {
         return NextResponse.json({ error: 'parentId not found or not accessible' }, { status: 404 });
       }
 
-      // Walk parent chain to build breadcrumb and location string
+      // Walk parent chain to build breadcrumb — visited set guards against corrupt cycles
       const buildBreadcrumb = (id: string | null): { id: string; title: string }[] => {
         if (!id) return [];
         const crumbs: { id: string; title: string }[] = [];
+        const visited = new Set<string>();
         let current = pageMap.get(id);
         while (current) {
+          if (visited.has(current.id)) break;
+          visited.add(current.id);
           crumbs.unshift({ id: current.id, title: current.title });
           current = current.parentId ? pageMap.get(current.parentId) : undefined;
         }
         return crumbs;
       };
 
-      const buildLocation = (id: string | null): string => {
+      const buildLocation = (id: string | null, visited = new Set<string>()): string => {
         if (!id) return `/${drive.slug}`;
+        if (visited.has(id)) return `/${drive.slug}`;
+        visited.add(id);
         const page = pageMap.get(id);
         if (!page) return `/${drive.slug}`;
-        return `${buildLocation(page.parentId)}/${page.title}`;
+        return `${buildLocation(page.parentId, visited)}/${page.title}`;
       };
 
       interface LsPage {
@@ -219,8 +225,7 @@ export async function GET(
       let resultPages: LsPage[];
 
       if (!lsRecursive) {
-        const target = lsParentId ?? null;
-        const children = pageResults.filter(p => p.parentId === target);
+        const children = pageResults.filter(p => p.parentId === lsParentId);
         resultPages = children.map(p => ({
           id: p.id,
           title: p.title,
@@ -229,8 +234,12 @@ export async function GET(
           isTaskLinked: taskLinkedSet.has(p.id),
         }));
       } else {
-        const collectSubtree = (startParentId: string | null): LsPage[] => {
+        const collectSubtree = (startParentId: string | null, visited = new Set<string>()): LsPage[] => {
           const result: LsPage[] = [];
+          if (startParentId !== null) {
+            if (visited.has(startParentId)) return result;
+            visited.add(startParentId);
+          }
           const children = pageResults.filter(p => p.parentId === startParentId);
           for (const p of children) {
             result.push({
@@ -240,11 +249,11 @@ export async function GET(
               hasChildren: pageResults.some(c => c.parentId === p.id),
               isTaskLinked: taskLinkedSet.has(p.id),
             });
-            result.push(...collectSubtree(p.id));
+            result.push(...collectSubtree(p.id, visited));
           }
           return result;
         };
-        resultPages = collectSubtree(lsParentId ?? null);
+        resultPages = collectSubtree(lsParentId);
       }
 
       const breadcrumb = buildBreadcrumb(lsParentId);


### PR DESCRIPTION
## Summary

- Adds `?ls=true`, `?parentId`, `?recursive` query params to `GET /api/drives/[driveId]/pages`
- When `?ls=true`, returns a flat ls-mode response instead of the full nested tree: direct children of root (or `parentId`) with `hasChildren`, `isTaskLinked`, `breadcrumb`, and `location` — skips the unread/activity log query (UI-only)
- Existing tree response is unchanged when `?ls` is absent — full backward compat
- Guards against empty-string `?parentId=` (uses `!== null` check, not truthy check) — returns 404 rather than silently falling through to root listing
- Cycle protection in all three parent-chain traversal helpers (`buildBreadcrumb`, `buildLocation`, `collectSubtree`) via visited sets

## Why

The AI SDK `list_pages` tool already works like `ls` (incremental navigation, one level at a time, `hasChildren` flag). The REST endpoint backing the MCP path always returned the full nested tree. This PR adds the ls-mode to the endpoint so the MCP tool (`pagespace-mcp`) can be updated to match — see companion PR in [pagespace-mcp#5](https://github.com/2witstudios/pagespace-mcp/pull/5).

## Test plan

- [ ] `GET /api/drives/{id}/pages` (no params) → still returns tree (backward compat)
- [ ] `GET /api/drives/{id}/pages?ls=true` → flat list of root-level pages, each with `hasChildren`
- [ ] `GET /api/drives/{id}/pages?ls=true&parentId={folderId}` → children of that folder + breadcrumb
- [ ] `GET /api/drives/{id}/pages?ls=true&recursive=true` → full subtree as flat list
- [ ] `GET /api/drives/{id}/pages?ls=true&parentId={nonExistentId}` → 404
- [ ] `GET /api/drives/{id}/pages?ls=true&parentId=` (empty string) → 404, not root listing
- [ ] Sidebar / frontend page tree still works (uses tree endpoint without `?ls`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wx8tpzMz2NLFWnizAFq2vh