### PR TITLE
fix(editing-guard): narrow isAnyActive() to isAnyEditing() across all SWR hooks

### DIFF
--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -279,7 +279,7 @@ export function EventModal({
     componentName: 'EventModal',
   });
 
-  const isAnyActive = useEditingStore((s) => s.isAnyActive());
+  const isAnyEditing = useEditingStore((s) => s.isAnyEditing());
   const triggerLoadedRef = useRef(false);
   const agentsLoadedRef = useRef(false);
 
@@ -296,7 +296,7 @@ export function EventModal({
     triggerFetcher,
     {
       revalidateOnFocus: false,
-      isPaused: () => triggerLoadedRef.current && isAnyActive,
+      isPaused: () => triggerLoadedRef.current && isAnyEditing,
       onSuccess: () => {
         triggerLoadedRef.current = true;
       },
@@ -308,7 +308,7 @@ export function EventModal({
     agentsFetcher,
     {
       revalidateOnFocus: false,
-      isPaused: () => agentsLoadedRef.current && isAnyActive,
+      isPaused: () => agentsLoadedRef.current && isAnyEditing,
       onSuccess: () => {
         agentsLoadedRef.current = true;
       },

--- a/apps/web/src/components/calendar/useCalendarData.ts
+++ b/apps/web/src/components/calendar/useCalendarData.ts
@@ -45,7 +45,7 @@ export function useCalendarData({
   includeTasks = true,
 }: UseCalendarDataOptions) {
   const hasLoadedRef = useRef(false);
-  const isAnyActive = useEditingStore((state) => state.isAnyActive());
+  const isAnyEditing = useEditingStore((state) => state.isAnyEditing());
 
   // Calculate date range for the current view (include buffer for multi-day events)
   const dateRange = useMemo(() => {
@@ -78,7 +78,7 @@ export function useCalendarData({
     isLoading: eventsLoading,
   } = useSWR<CalendarEventsResponse>(eventsUrl, fetcher, {
     revalidateOnFocus: false,
-    isPaused: () => hasLoadedRef.current && isAnyActive,
+    isPaused: () => hasLoadedRef.current && isAnyEditing,
     onSuccess: () => {
       hasLoadedRef.current = true;
     },
@@ -105,7 +105,7 @@ export function useCalendarData({
     tasksUrl ? fetcher : null,
     {
       revalidateOnFocus: false,
-      isPaused: () => hasLoadedRef.current && isAnyActive,
+      isPaused: () => hasLoadedRef.current && isAnyEditing,
       refreshInterval: 60000,
     }
   );

--- a/apps/web/src/components/inbox/ChannelsCenterList.tsx
+++ b/apps/web/src/components/inbox/ChannelsCenterList.tsx
@@ -11,7 +11,7 @@ import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { ThreadUnreadBadge } from '@/components/inbox/ThreadUnreadBadge';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 
@@ -43,7 +43,7 @@ export default function ChannelsCenterList({ driveId }: ChannelsCenterListProps)
 
   const { data, error, isLoading } = useSWR<InboxResponse>(apiUrl, fetcher, {
     refreshInterval: 0,
-    isPaused: () => hasLoadedRef.current && isEditingActive(),
+    isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
     revalidateOnFocus: false,
   });

--- a/apps/web/src/components/inbox/DMCenterList.tsx
+++ b/apps/web/src/components/inbox/DMCenterList.tsx
@@ -13,7 +13,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { ThreadUnreadBadge } from '@/components/inbox/ThreadUnreadBadge';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 
@@ -39,7 +39,7 @@ export default function DMCenterList() {
 
   const { data, error, isLoading } = useSWR<InboxResponse>(API_URL, fetcher, {
     refreshInterval: 0,
-    isPaused: () => hasLoadedRef.current && isEditingActive(),
+    isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
     revalidateOnFocus: false,
   });

--- a/apps/web/src/components/layout/left-sidebar/ChannelsSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/ChannelsSidebar.tsx
@@ -19,7 +19,7 @@ import PrimaryNavigation from './PrimaryNavigation';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { useDriveStore } from '@/hooks/useDrive';
 import { canManageDrive } from '@/hooks/usePermissions';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
@@ -59,7 +59,7 @@ export default function ChannelsSidebar({ className }: SidebarProps) {
 
   const { data, error } = useSWR<InboxResponse>(apiUrl, fetcher, {
     refreshInterval: 0,
-    isPaused: () => hasLoadedRef.current && isEditingActive(),
+    isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
     revalidateOnFocus: false,
   });

--- a/apps/web/src/components/layout/left-sidebar/DMSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DMSidebar.tsx
@@ -19,7 +19,7 @@ import PrimaryNavigation from './PrimaryNavigation';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 
 const fetcher = async (url: string) => {
@@ -47,7 +47,7 @@ export default function DMSidebar({ className }: SidebarProps) {
 
   const { data, error } = useSWR<InboxResponse>(API_URL, fetcher, {
     refreshInterval: 0,
-    isPaused: () => hasLoadedRef.current && isEditingActive(),
+    isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
     onSuccess: () => { hasLoadedRef.current = true; },
     revalidateOnFocus: false,
   });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -69,7 +69,7 @@ import {
 } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
@@ -566,7 +566,7 @@ const GlobalAssistantView: React.FC = () => {
   useAppStateRecovery({
     onResume: handlePullUpRefresh,
     // Block recovery if streaming OR pending send OR any editing active
-    enabled: !isStreaming && currentConversationId !== null && !isEditingActive(),
+    enabled: !isStreaming && currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
   });
 
   // Clean up stream tracking on unmount

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -116,7 +116,7 @@ export function TaskAgentTriggersDialog({
   const triggersKey = open ? `/api/tasks/${taskId}/triggers` : null;
   const agentsKey = open && driveId ? `/api/drives/${driveId}/agents` : null;
 
-  // Pause background revalidation while any editing session is active so a remote
+  // Pause background revalidation during document/form editing so a remote
   // task_updated broadcast cannot refetch this dialog and clobber in-progress prompt
   // typing. Initial load and explicit mutate() (e.g. refetchTriggers after save) are
   // unaffected because *LoadedRef gates the pause until first success.

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -120,7 +120,7 @@ export function TaskAgentTriggersDialog({
   // task_updated broadcast cannot refetch this dialog and clobber in-progress prompt
   // typing. Initial load and explicit mutate() (e.g. refetchTriggers after save) are
   // unaffected because *LoadedRef gates the pause until first success.
-  const isAnyActive = useEditingStore((s) => s.isAnyActive());
+  const isAnyEditing = useEditingStore((s) => s.isAnyEditing());
   const triggersLoadedRef = useRef(false);
   const agentsLoadedRef = useRef(false);
 
@@ -129,7 +129,7 @@ export function TaskAgentTriggersDialog({
     triggersFetcher,
     {
       revalidateOnFocus: false,
-      isPaused: () => triggersLoadedRef.current && isAnyActive,
+      isPaused: () => triggersLoadedRef.current && isAnyEditing,
       onSuccess: () => {
         triggersLoadedRef.current = true;
       },
@@ -140,7 +140,7 @@ export function TaskAgentTriggersDialog({
     agentsFetcher,
     {
       revalidateOnFocus: false,
-      isPaused: () => agentsLoadedRef.current && isAnyActive,
+      isPaused: () => agentsLoadedRef.current && isAnyEditing,
       onSuccess: () => {
         agentsLoadedRef.current = true;
       },

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -418,7 +418,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const canEdit = permissions?.canEdit || false;
   const drive = useDriveStore((s) => s.drives.find((d) => d.id === page.driveId));
   const canManageWorkflows = canManageDrive(drive);
-  const isAnyActive = useEditingStore(state => state.isAnyActive());
+  const isAnyEditing = useEditingStore(state => state.isAnyEditing());
 
   const [filter, setFilter] = useTaskListPageFilter(page.id);
   const [search, setSearch] = useState('');
@@ -474,7 +474,7 @@ function TaskListView({ page }: TaskListViewProps) {
     fetcher,
     {
       revalidateOnFocus: false,
-      isPaused: () => hasLoadedRef.current && isAnyActive,
+      isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 300000, // 5 minutes
     }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -78,11 +78,11 @@ function PageLabel({ pageId }: { pageId: string }) {
   // Pause background revalidation while any editing session is active so a remote
   // task_updated broadcast cannot refetch and clobber the chip label mid-edit.
   // Initial load is unaffected because pageLoadedRef gates the pause until first success.
-  const isAnyActive = useEditingStore((s) => s.isAnyActive());
+  const isAnyEditing = useEditingStore((s) => s.isAnyEditing());
   const pageLoadedRef = useRef(false);
   const { data, error } = useSWR(`/api/pages/${pageId}`, pageFetcher, {
     revalidateOnFocus: false,
-    isPaused: () => pageLoadedRef.current && isAnyActive,
+    isPaused: () => pageLoadedRef.current && isAnyEditing,
     onSuccess: () => {
       pageLoadedRef.current = true;
     },

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -69,13 +69,13 @@ type Props = SingleProps | MultiProps;
 // are read-only display: they fetch search results and chip titles, but neither writes
 // back to selection. PageLabel retains the hasLoadedRef + isPaused guard so the chip
 // label doesn't flicker mid-edit. The search SWR intentionally omits it: revalidateOnFocus:
-// false already blocks background refetch, and pausing on isAnyActive() froze results
-// whenever EventModal's long-lived 'form' session was open.
+// false already blocks background refetch, and pausing on isAnyEditing() during EventModal's
+// long-lived 'form' session is correct — label chips should stay frozen mid-form-edit.
 // No dedicated "remote refetch must not clobber selection" test is added because the
 // data flow makes that property structural rather than behavioural.
 
 function PageLabel({ pageId }: { pageId: string }) {
-  // Pause background revalidation while any editing session is active so a remote
+  // Pause background revalidation during document/form editing so a remote
   // task_updated broadcast cannot refetch and clobber the chip label mid-edit.
   // Initial load is unaffected because pageLoadedRef gates the pause until first success.
   const isAnyEditing = useEditingStore((s) => s.isAnyEditing());

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -39,7 +39,7 @@ import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
@@ -651,7 +651,7 @@ const SidebarChatTab: React.FC = () => {
   useAppStateRecovery({
     onResume: handleAppResume,
     // Block recovery if streaming OR pending send OR any editing active
-    enabled: !isStreaming && currentConversationId !== null && !isEditingActive(),
+    enabled: !isStreaming && currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
   });
 
   // Clean up stream tracking on unmount or conversation change

--- a/apps/web/src/hooks/__tests__/useDevices.test.ts
+++ b/apps/web/src/hooks/__tests__/useDevices.test.ts
@@ -79,8 +79,8 @@ describe('useDevices', () => {
       expect(swrConfig.isPaused!()).toBe(true);
     });
 
-    it('given user is not editing or streaming, should allow device revalidation', () => {
-      // Arrange: No active editing/streaming
+    it('given user is not document or form editing, should allow device revalidation', () => {
+      // Arrange: No active document/form editing (AI streaming no longer blocks)
       vi.mocked(useEditingStore).mockReturnValue(false);
 
       vi.mocked(useSWR).mockReturnValue({
@@ -100,7 +100,7 @@ describe('useDevices', () => {
       // Simulate onSuccess
       swrConfig.onSuccess!();
 
-      // Assert: isPaused returns false because isAnyActive is false
+      // Assert: isPaused returns false because isAnyEditing is false
       expect(swrConfig.isPaused).toBeDefined();
       expect(swrConfig.isPaused!()).toBe(false);
     });

--- a/apps/web/src/hooks/__tests__/usePageTree.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTree.test.ts
@@ -25,7 +25,7 @@ const {
   },
   mockIsAnyEditing: vi.fn(() => false),
   mockIsAnyActive: vi.fn(() => false),
-  mockSubscribe: vi.fn((_cb: (state: { isAnyActive: () => boolean }) => void): (() => void) => vi.fn()),
+  mockSubscribe: vi.fn((_cb: (state: { isAnyEditing: () => boolean }) => void): (() => void) => vi.fn()),
 }));
 
 // Mock dependencies with hoisted mocks
@@ -39,7 +39,7 @@ vi.mock('@/stores/useEditingStore', () => ({
       isAnyEditing: mockIsAnyEditing,
       isAnyActive: mockIsAnyActive,
     }),
-    subscribe: (cb: (state: { isAnyActive: () => boolean }) => void) => mockSubscribe(cb),
+    subscribe: (cb: (state: { isAnyEditing: () => boolean }) => void) => mockSubscribe(cb),
   },
   isEditingActive: () => mockIsAnyActive(),
 }));
@@ -307,7 +307,7 @@ describe('usePageTree', () => {
 
     it('given active document editing, should skip invalidation', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyActive.mockReturnValue(true);
+      mockIsAnyEditing.mockReturnValue(true);
       const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
 
       const { result } = renderHook(() => usePageTree('drive-123'));
@@ -319,15 +319,15 @@ describe('usePageTree', () => {
       expect(mockMutate).not.toHaveBeenCalled();
       expect(mockCacheDelete).not.toHaveBeenCalled();
       expect(consoleLog).toHaveBeenCalledWith(
-        '⏸️ Skipping tree revalidation - document editing, AI streaming, or pending send in progress'
+        '⏸️ Skipping tree revalidation - document or form editing in progress'
       );
       consoleLog.mockRestore();
     });
 
-    it('given any active state (AI streaming or pending send), should skip invalidation', () => {
+    it('given active AI streaming (but no document editing), should revalidate immediately', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyActive.mockReturnValue(true);
-      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
+      mockIsAnyEditing.mockReturnValue(false);
+      mockIsAnyActive.mockReturnValue(true); // streaming is active, but that no longer blocks
 
       const { result } = renderHook(() => usePageTree('drive-123'));
 
@@ -335,36 +335,36 @@ describe('usePageTree', () => {
         result.current.invalidateTree();
       });
 
-      expect(mockMutate).not.toHaveBeenCalled();
+      // AI streaming must not block tree revalidation — users need live sidebar updates
+      expect(mockMutate).toHaveBeenCalled();
       expect(mockCacheDelete).not.toHaveBeenCalled();
-      consoleLog.mockRestore();
     });
 
-    it('given skipped invalidation, should flush mutate once active state clears', () => {
+    it('given skipped invalidation, should flush mutate once editing ends', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyActive.mockReturnValue(true);
+      mockIsAnyEditing.mockReturnValue(true);
       const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
 
       // Capture the subscriber registered by the hook
-      let capturedSubscriber: ((state: { isAnyActive: () => boolean }) => void) | null = null;
-      mockSubscribe.mockImplementation((cb: (state: { isAnyActive: () => boolean }) => void) => {
+      let capturedSubscriber: ((state: { isAnyEditing: () => boolean }) => void) | null = null;
+      mockSubscribe.mockImplementation((cb: (state: { isAnyEditing: () => boolean }) => void) => {
         capturedSubscriber = cb;
         return vi.fn(); // unsubscribe noop
       });
 
       const { result } = renderHook(() => usePageTree('drive-123'));
 
-      // Invalidate during active state — deferred, not fired immediately
+      // Invalidate during editing — deferred, not fired immediately
       act(() => {
         result.current.invalidateTree();
       });
       expect(mockMutate).not.toHaveBeenCalled();
       expect(capturedSubscriber).not.toBeNull();
 
-      // Simulate store transitioning to inactive
-      mockIsAnyActive.mockReturnValue(false);
+      // Simulate store transitioning to no editing
+      mockIsAnyEditing.mockReturnValue(false);
       act(() => {
-        capturedSubscriber!({ isAnyActive: () => false });
+        capturedSubscriber!({ isAnyEditing: () => false });
       });
 
       // Pending invalidation should now be flushed
@@ -374,18 +374,18 @@ describe('usePageTree', () => {
 
     it('given multiple skipped invalidations, should flush mutate only once', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyActive.mockReturnValue(true);
+      mockIsAnyEditing.mockReturnValue(true);
       const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
 
-      let capturedSubscriber: ((state: { isAnyActive: () => boolean }) => void) | null = null;
-      mockSubscribe.mockImplementation((cb: (state: { isAnyActive: () => boolean }) => void) => {
+      let capturedSubscriber: ((state: { isAnyEditing: () => boolean }) => void) | null = null;
+      mockSubscribe.mockImplementation((cb: (state: { isAnyEditing: () => boolean }) => void) => {
         capturedSubscriber = cb;
         return vi.fn();
       });
 
       const { result } = renderHook(() => usePageTree('drive-123'));
 
-      // Multiple invalidations during active state — all coalesced
+      // Multiple invalidations during editing — all coalesced
       act(() => {
         result.current.invalidateTree();
         result.current.invalidateTree();
@@ -393,10 +393,10 @@ describe('usePageTree', () => {
       });
       expect(mockMutate).not.toHaveBeenCalled();
 
-      // Store goes inactive
-      mockIsAnyActive.mockReturnValue(false);
+      // Editing ends
+      mockIsAnyEditing.mockReturnValue(false);
       act(() => {
-        capturedSubscriber!({ isAnyActive: () => false });
+        capturedSubscriber!({ isAnyEditing: () => false });
       });
 
       // Only one mutate despite three invalidateTree calls
@@ -404,12 +404,12 @@ describe('usePageTree', () => {
       consoleLog.mockRestore();
     });
 
-    it('given no skipped invalidation, should not flush when state clears', () => {
+    it('given no skipped invalidation, should not flush when editing ends', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyActive.mockReturnValue(false);
+      mockIsAnyEditing.mockReturnValue(false);
 
-      let capturedSubscriber: ((state: { isAnyActive: () => boolean }) => void) | null = null;
-      mockSubscribe.mockImplementation((cb: (state: { isAnyActive: () => boolean }) => void) => {
+      let capturedSubscriber: ((state: { isAnyEditing: () => boolean }) => void) | null = null;
+      mockSubscribe.mockImplementation((cb: (state: { isAnyEditing: () => boolean }) => void) => {
         capturedSubscriber = cb;
         return vi.fn();
       });
@@ -418,7 +418,7 @@ describe('usePageTree', () => {
 
       // No invalidateTree called — subscriber fires but nothing pending
       act(() => {
-        capturedSubscriber!({ isAnyActive: () => false });
+        capturedSubscriber!({ isAnyEditing: () => false });
       });
 
       expect(mockMutate).not.toHaveBeenCalled();

--- a/apps/web/src/hooks/page-agents/usePageAgents.ts
+++ b/apps/web/src/hooks/page-agents/usePageAgents.ts
@@ -73,7 +73,7 @@ export function usePageAgents(
 ) {
   const { includeSystemPrompt = false, refreshInterval = 60000 } = options;
   const hasLoadedRef = useRef(false);
-  const isAnyActive = useEditingStore(state => state.isAnyActive());
+  const isAnyEditing = useEditingStore(state => state.isAnyEditing());
 
   // Build the API URL with query params
   const swrKey = useMemo(() => {
@@ -94,7 +94,7 @@ export function usePageAgents(
     swrKey,
     fetcher,
     {
-      isPaused: () => hasLoadedRef.current && isAnyActive,
+      isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval,
       revalidateOnFocus: false,

--- a/apps/web/src/hooks/useDevices.ts
+++ b/apps/web/src/hooks/useDevices.ts
@@ -30,13 +30,13 @@ const fetcher = async (url: string): Promise<Device[]> => {
 
 export function useDevices() {
   const hasLoadedRef = useRef(false);
-  const isAnyActive = useEditingStore((state) => state.isAnyActive());
+  const isAnyEditing = useEditingStore((state) => state.isAnyEditing());
 
   const { data, error, mutate } = useSWR<Device[]>(
     '/api/account/devices',
     fetcher,
     {
-      isPaused: () => hasLoadedRef.current && isAnyActive,
+      isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 60000,
       revalidateOnFocus: true,

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useSWRConfig } from 'swr';
 import { useSocket } from './useSocket';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { useThreadInboxStore } from '@/stores/useThreadInboxStore';
 import type { InboxEventPayload } from '@/lib/websocket/socket-utils';
 import type { InboxResponse } from '@pagespace/lib/types';
@@ -39,7 +39,7 @@ export function useInboxSocket({ driveId, hasLoadedRef: externalRef }: UseInboxS
 
     const handleInboxUpdate = (payload: InboxEventPayload) => {
       // Skip updates if we haven't loaded yet or if editing is active
-      if (!hasLoadedRef.current || isEditingActive()) {
+      if (!hasLoadedRef.current || useEditingStore.getState().isAnyEditing()) {
         return;
       }
 

--- a/apps/web/src/hooks/usePageTree.ts
+++ b/apps/web/src/hooks/usePageTree.ts
@@ -126,13 +126,14 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
 
   const invalidateTree = useCallback(() => {
     if (swrKey) {
-      // Guard: defer revalidation during any active state (document editing, AI streaming,
-      // or pending send) to prevent editor remounting and stream abort. The deferred flag
-      // is flushed by the store subscriber below once all sessions end.
-      const isActive = useEditingStore.getState().isAnyActive();
-      if (isActive) {
+      // Guard: defer revalidation only during document or form editing to prevent
+      // the editor from receiving stale tree data mid-keystroke. AI streaming
+      // sessions do NOT block — users need to see pages created by AI tool calls
+      // appear in the sidebar in real time.
+      const isEditing = useEditingStore.getState().isAnyEditing();
+      if (isEditing) {
         pendingInvalidateRef.current = true;
-        console.log('⏸️ Skipping tree revalidation - document editing, AI streaming, or pending send in progress');
+        console.log('⏸️ Skipping tree revalidation - document or form editing in progress');
         return;
       }
 
@@ -141,11 +142,11 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
     }
   }, [swrKey, mutate]);
 
-  // Flush any deferred invalidation once all active sessions end.
+  // Flush any deferred invalidation once document/form editing ends.
   useEffect(() => {
     const unsubscribe = useEditingStore.subscribe((state) => {
       if (!swrKey || !pendingInvalidateRef.current) return;
-      if (state.isAnyActive()) return;
+      if (state.isAnyEditing()) return;
       pendingInvalidateRef.current = false;
       mutate();
     });

--- a/apps/web/src/hooks/useWorkflows.ts
+++ b/apps/web/src/hooks/useWorkflows.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react';
 import useSWR from 'swr';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
 import type { Workflow } from '@/components/workflows/types';
 import { useSocket } from './useSocket';
@@ -19,7 +19,7 @@ export function useWorkflows(driveId: string) {
     driveId ? `/api/workflows?driveId=${driveId}` : null,
     fetcher,
     {
-      isPaused: () => hasLoadedRef.current && isEditingActive(),
+      isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 300000,
       revalidateOnFocus: false,

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -9,7 +9,7 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import type { UIMessage } from 'ai';
-import { isEditingActive } from '@/stores/useEditingStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { useOptimisticConversationsStore } from '@/stores/useOptimisticConversationsStore';
 import {
   ConversationData,
@@ -116,7 +116,7 @@ export function useConversations({
     },
     {
       // Only pause revalidation after initial load - never block the first fetch
-      isPaused: () => hasLoadedRef.current && isEditingActive(),
+      isPaused: () => hasLoadedRef.current && useEditingStore.getState().isAnyEditing(),
       onSuccess: () => {
         hasLoadedRef.current = true;
       },

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -718,10 +718,10 @@ export const authStoreHelpers = {
       import('@/stores/useEditingStore').then(({ useEditingStore, getEditingDebugInfo }) => {
         const editingState = useEditingStore.getState();
 
-        // Check if any editing or streaming is active
-        if (editingState.isAnyActive()) {
+        // Check if document/form editing is active (AI streaming no longer defers auth logging)
+        if (editingState.isAnyEditing()) {
           const debugInfo = getEditingDebugInfo();
-          console.log('[AUTH_STORE] Token refreshed during active editing/streaming', {
+          console.log('[AUTH_STORE] Token refreshed during active editing', {
             sessionCount: debugInfo.sessionCount,
             isEditing: debugInfo.isAnyEditing,
             isStreaming: debugInfo.isAnyStreaming,


### PR DESCRIPTION
## Summary

- \`isAnyActive()\` returns true for document editing, form editing, AI streaming, AND pending sends. Every SWR \`isPaused()\` hook used it — meaning all background data refreshes were blocked while AI was streaming.
- Narrow all guards to \`isAnyEditing()\` (document/form only) so the page tree, calendar events, task lists, agent lists, device list, trigger pickers, inbox lists, conversation histories, auth refresh handler, and app-state recovery hooks all resume their normal SWR/socket cycles during AI streaming.
- Users now see live data from AI tool calls without waiting for the stream to finish.

## Files changed

| File | Change |
|------|--------|
| \`hooks/usePageTree.ts\` | \`invalidateTree\` guard + deferred flush subscriber |
| \`hooks/useDevices.ts\` | Device list \`isPaused\` |
| \`hooks/useWorkflows.ts\` | Workflow list \`isPaused\` |
| \`hooks/useInboxSocket.ts\` | Socket-driven inbox update guard |
| \`hooks/page-agents/usePageAgents.ts\` | Agent list \`isPaused\` |
| \`lib/ai/shared/hooks/useConversations.ts\` | Conversation list \`isPaused\` |
| \`components/calendar/useCalendarData.ts\` | Calendar events + tasks \`isPaused\` (×2) |
| \`components/calendar/EventModal.tsx\` | Trigger + agents \`isPaused\` inside dialog |
| \`task-list/TaskListView.tsx\` | Task list \`isPaused\` |
| \`task-list/TaskAgentTriggersDialog.tsx\` | Triggers + agents \`isPaused\` inside dialog |
| \`task-list/TriggerPagePicker.tsx\` | Page label chip \`isPaused\` |
| \`inbox/DMCenterList.tsx\` | DM inbox list \`isPaused\` |
| \`inbox/ChannelsCenterList.tsx\` | Channels inbox list \`isPaused\` |
| \`layout/left-sidebar/ChannelsSidebar.tsx\` | Channels sidebar \`isPaused\` |
| \`layout/left-sidebar/DMSidebar.tsx\` | DM sidebar \`isPaused\` |
| \`layout/…/GlobalAssistantView.tsx\` | App-state recovery \`enabled\` guard |
| \`layout/…/SidebarChatTab.tsx\` | App-state recovery \`enabled\` guard |
| \`stores/useAuthStore.ts\` | Auth refresh handler guard |

Deliberately unchanged (correct semantics for their context):
- \`AiChatView.tsx\` — no \`!isStreaming\` guard, narrowing risks recovery state issues during streaming
- \`QuickCreatePalette.tsx\` — keyboard shortcut, intentionally blocked during any active session

Already correct (untouched): \`useChatPullToRefresh.ts\`, drive-settings \`page.tsx\`.

## Test plan

- [x] 22 unit tests pass: \`hooks/__tests__/usePageTree\`, \`hooks/__tests__/useDevices\` (including new "AI streaming no longer blocks" assertion)
- [ ] Manual: trigger an AI prompt that creates/updates tasks, pages, or calendar events — those views refresh while the stream is still running
- [ ] Manual: edit a document while socket events arrive — SWR still defers (document editing protection preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EooA6ApxcPZ9yuutemxZKG