### PR TITLE
feat(ai-chat): live-update conversation history via socket

### DIFF
--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -48,6 +48,10 @@ vi.mock('@/lib/websocket', () => ({
   broadcastChatUserMessage: mockBroadcastChatUserMessage,
 }));
 
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastGlobalConversationAdded: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
@@ -105,7 +109,8 @@ vi.mock('@pagespace/db/operators', () => ({
 
 vi.mock('../resolve-or-create-conversation', () => ({
   resolveOrCreateConversation: vi.fn().mockResolvedValue({
-    id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true,
+    conversation: { id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
+    isNew: false,
   }),
   ConversationOwnershipError: class ConversationOwnershipError extends Error {},
 }));

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/resolve-or-create-conversation.test.ts
@@ -38,18 +38,18 @@ const makeDb = (selectResult: object[], insertResult: object[] = []) => ({
 const CONV = { id: 'conv1', userId: 'user1', isActive: true, type: 'global' };
 
 describe('resolveOrCreateConversation', () => {
-  it('given existing conversation owned by the user, returns it without inserting', async () => {
+  it('given existing conversation owned by the user, returns it without inserting and isNew=false', async () => {
     const db = makeDb([CONV]);
     const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
-    expect(result).toEqual(CONV);
+    expect(result).toEqual({ conversation: CONV, isNew: false });
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('given no existing conversation, creates one with the correct fields', async () => {
+  it('given no existing conversation, creates one with the correct fields and isNew=true', async () => {
     const created = { id: 'conv1', userId: 'user1', type: 'global', isActive: true };
     const db = makeDb([], [created]);
     const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
-    expect(result).toEqual(created);
+    expect(result).toEqual({ conversation: created, isNew: true });
     expect(db.insert).toHaveBeenCalled();
   });
 
@@ -73,8 +73,10 @@ describe('resolveOrCreateConversation', () => {
 
   it('given idempotent call (conversation already exists), does not insert a second row', async () => {
     const db = makeDb([CONV]);
-    await resolveOrCreateConversation('user1', 'conv1', db as never);
-    await resolveOrCreateConversation('user1', 'conv1', db as never);
+    const first = await resolveOrCreateConversation('user1', 'conv1', db as never);
+    const second = await resolveOrCreateConversation('user1', 'conv1', db as never);
+    expect(first.isNew).toBe(false);
+    expect(second.isNew).toBe(false);
     expect(db.insert).not.toHaveBeenCalled();
   });
 
@@ -95,7 +97,7 @@ describe('resolveOrCreateConversation', () => {
     expect(db.insert).not.toHaveBeenCalled();
   });
 
-  it('given a concurrent insert race (ON CONFLICT returns no row), falls back to select and returns winner', async () => {
+  it('given a concurrent insert race (ON CONFLICT returns no row), falls back to select and returns winner with isNew=true', async () => {
     // insert returns [] (another writer won the race), then fallback select finds the winner
     const winner = { ...CONV };
     const db = {
@@ -121,7 +123,7 @@ describe('resolveOrCreateConversation', () => {
       }),
     };
     const result = await resolveOrCreateConversation('user1', 'conv1', db as never);
-    expect(result).toEqual(winner);
+    expect(result).toEqual({ conversation: winner, isNew: true });
     expect(db.insert).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -529,10 +529,11 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
 
       await POST(makeRequest(), makeContext());
 
+      // extractMessageContent is mocked to return 'test content'; title is sliced from it.
       expect(mockBroadcastGlobalConversationAdded).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          conversation: expect.objectContaining({ title: 'Hello' }),
+          conversation: expect.objectContaining({ title: 'test content' }),
         }),
       );
     });

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -500,13 +500,16 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
     });
   });
 
+  const newConv = {
+    id: 'conv-1', userId: 'user-1', title: null, type: 'global',
+    contextId: null, isActive: true, isShared: false,
+    createdAt: new Date('2024-01-01'), updatedAt: new Date('2024-01-01'), lastMessageAt: null,
+  };
+
   describe('global conversation-added broadcast', () => {
     it('given isNew=true, should broadcast chat:global_conversation_added to the user channel', async () => {
       const { resolveOrCreateConversation } = await import('../resolve-or-create-conversation');
-      vi.mocked(resolveOrCreateConversation).mockResolvedValueOnce({
-        conversation: { id: 'conv-1', userId: 'user-1', title: null, type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
-        isNew: true,
-      });
+      vi.mocked(resolveOrCreateConversation).mockResolvedValueOnce({ conversation: newConv, isNew: true });
 
       await POST(makeRequest({ browserSessionId: 'session-z' }), makeContext());
 
@@ -522,10 +525,7 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
 
     it('given isNew=true and no prior title, broadcast carries the auto-generated title', async () => {
       const { resolveOrCreateConversation } = await import('../resolve-or-create-conversation');
-      vi.mocked(resolveOrCreateConversation).mockResolvedValueOnce({
-        conversation: { id: 'conv-1', userId: 'user-1', title: null, type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
-        isNew: true,
-      });
+      vi.mocked(resolveOrCreateConversation).mockResolvedValueOnce({ conversation: newConv, isNew: true });
 
       await POST(makeRequest(), makeContext());
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -13,12 +13,14 @@ const {
   mockLifecyclePushPart,
   mockLifecycleFinish,
   mockBroadcastChatUserMessage,
+  mockBroadcastGlobalConversationAdded,
   mockSaveGlobalAssistantMessageToDatabase,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
   mockLifecycleFinish: vi.fn(),
   mockBroadcastChatUserMessage: vi.fn().mockResolvedValue(undefined),
+  mockBroadcastGlobalConversationAdded: vi.fn().mockResolvedValue(undefined),
   mockSaveGlobalAssistantMessageToDatabase: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -47,7 +49,7 @@ vi.mock('@/lib/websocket', () => ({
 }));
 
 vi.mock('@/lib/websocket/socket-utils', () => ({
-  broadcastGlobalConversationAdded: vi.fn().mockResolvedValue(undefined),
+  broadcastGlobalConversationAdded: mockBroadcastGlobalConversationAdded,
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -495,6 +497,51 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
       mockBroadcastChatUserMessage.mockRejectedValueOnce(new Error('socket dead'));
 
       await expect(POST(makeRequest(), makeContext())).resolves.toBeDefined();
+    });
+  });
+
+  describe('global conversation-added broadcast', () => {
+    it('given isNew=true, should broadcast chat:global_conversation_added to the user channel', async () => {
+      const { resolveOrCreateConversation } = await import('../resolve-or-create-conversation');
+      vi.mocked(resolveOrCreateConversation).mockResolvedValueOnce({
+        conversation: { id: 'conv-1', userId: 'user-1', title: null, type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
+        isNew: true,
+      });
+
+      await POST(makeRequest({ browserSessionId: 'session-z' }), makeContext());
+
+      expect(mockBroadcastGlobalConversationAdded).toHaveBeenCalledTimes(1);
+      expect(mockBroadcastGlobalConversationAdded).toHaveBeenCalledWith(
+        'user:user-1:global',
+        expect.objectContaining({
+          conversation: expect.objectContaining({ id: 'conv-1', type: 'global' }),
+          triggeredBy: expect.objectContaining({ userId: 'user-1', browserSessionId: 'session-z' }),
+        }),
+      );
+    });
+
+    it('given isNew=true and no prior title, broadcast carries the auto-generated title', async () => {
+      const { resolveOrCreateConversation } = await import('../resolve-or-create-conversation');
+      vi.mocked(resolveOrCreateConversation).mockResolvedValueOnce({
+        conversation: { id: 'conv-1', userId: 'user-1', title: null, type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
+        isNew: true,
+      });
+
+      await POST(makeRequest(), makeContext());
+
+      expect(mockBroadcastGlobalConversationAdded).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          conversation: expect.objectContaining({ title: 'Hello' }),
+        }),
+      );
+    });
+
+    it('given isNew=false, should NOT broadcast chat:global_conversation_added', async () => {
+      // default resolveOrCreateConversation mock returns isNew: false
+      await POST(makeRequest(), makeContext());
+
+      expect(mockBroadcastGlobalConversationAdded).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -46,6 +46,10 @@ vi.mock('@/lib/websocket', () => ({
   broadcastChatUserMessage: mockBroadcastChatUserMessage,
 }));
 
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastGlobalConversationAdded: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
@@ -123,7 +127,8 @@ vi.mock('@pagespace/db/operators', () => ({
 // the route tests don't have to wire up the conversations db mock for it.
 vi.mock('../resolve-or-create-conversation', () => ({
   resolveOrCreateConversation: vi.fn().mockResolvedValue({
-    id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true,
+    conversation: { id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
+    isNew: false,
   }),
   ConversationOwnershipError: class ConversationOwnershipError extends Error {},
 }));

--- a/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/resolve-or-create-conversation.ts
@@ -15,6 +15,12 @@ const CUID2_RE = /^[a-z][a-z0-9]{1,31}$/;
 type ConversationRow = typeof conversations.$inferSelect;
 type Db = typeof defaultDb;
 
+export interface ResolveOrCreateResult {
+  conversation: ConversationRow;
+  /** True when the DB row was just inserted (lazy first-message creation). */
+  isNew: boolean;
+}
+
 /**
  * Pure-ish function: resolve an existing global conversation or create it on first message.
  * Throws ConversationOwnershipError if the conversation exists but belongs to a different user.
@@ -29,7 +35,7 @@ export async function resolveOrCreateConversation(
   userId: string,
   conversationId: string,
   db: Db = defaultDb,
-): Promise<ConversationRow> {
+): Promise<ResolveOrCreateResult> {
   if (!CUID2_RE.test(conversationId)) {
     throw new ConversationOwnershipError();
   }
@@ -46,7 +52,7 @@ export async function resolveOrCreateConversation(
   if (existing) {
     if (existing.userId !== userId) throw new ConversationOwnershipError();
     if (existing.type !== 'global') throw new ConversationOwnershipError();
-    return existing;
+    return { conversation: existing, isNew: false };
   }
 
   // Idempotent insert: ON CONFLICT DO NOTHING handles concurrent first-writes.
@@ -61,7 +67,7 @@ export async function resolveOrCreateConversation(
     .onConflictDoNothing()
     .returning();
 
-  if (created) return created;
+  if (created) return { conversation: created, isNew: true };
 
   // A concurrent insert won the race — select the winner.
   const [winner] = await db
@@ -72,5 +78,5 @@ export async function resolveOrCreateConversation(
 
   if (!winner) throw new Error(`Failed to resolve conversation ${conversationId}`);
   if (winner.userId !== userId) throw new ConversationOwnershipError();
-  return winner;
+  return { conversation: winner, isNew: true };
 }

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -13,6 +13,7 @@ import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { creditGateErrorResponse } from '@/lib/subscription/credit-gate-response';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { broadcastChatUserMessage } from '@/lib/websocket';
+import { broadcastGlobalConversationAdded } from '@/lib/websocket/socket-utils';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
@@ -107,9 +108,9 @@ export async function GET(
       ));
 
     if (!conversation) {
-      return NextResponse.json({ 
-        error: 'Conversation not found' 
-      }, { status: 404 });
+      // Conversation not yet persisted (lazy creation) — return empty rather than 404
+      // so browsers don't log a network error for brand-new conversations.
+      return NextResponse.json({ messages: [], hasMore: false });
     }
 
     // Parse pagination parameters
@@ -248,8 +249,9 @@ export async function POST(
     // Resolve existing conversation or auto-create on first message (lazy creation).
     // Clients generate the ID locally; this is the point where the DB row is guaranteed.
     let conversation: typeof conversations.$inferSelect;
+    let conversationIsNew = false;
     try {
-      conversation = await resolveOrCreateConversation(userId, conversationId);
+      ({ conversation, isNew: conversationIsNew } = await resolveOrCreateConversation(userId, conversationId));
     } catch (e) {
       if (e instanceof ConversationOwnershipError) {
         return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
@@ -955,6 +957,18 @@ MENTION PROCESSING:
     const authUserName = authUserResult.status === 'fulfilled' ? authUserResult.value[0]?.name ?? null : null;
     const profileDisplayName = profileResult.status === 'fulfilled' ? profileResult.value[0]?.displayName ?? null : null;
     const displayName = profileDisplayName ?? authUserName ?? 'Someone';
+
+    if (conversationIsNew) {
+      broadcastGlobalConversationAdded(channelId, {
+        conversation: {
+          id: conversation.id,
+          title: conversation.title ?? '',
+          type: conversation.type,
+          createdAt: conversation.createdAt.toISOString(),
+        },
+        triggeredBy: { userId, displayName, browserSessionId },
+      }).catch(() => {});
+    }
 
     if (userMessage && userMessage.role === 'user') {
       broadcastChatUserMessage({

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -110,7 +110,11 @@ export async function GET(
     if (!conversation) {
       // Conversation not yet persisted (lazy creation) — return empty rather than 404
       // so browsers don't log a network error for brand-new conversations.
-      return NextResponse.json({ messages: [], hasMore: false });
+      // Use the same { messages, pagination } shape as the persisted-conversation path.
+      return NextResponse.json({
+        messages: [],
+        pagination: { hasMore: false, nextCursor: null, prevCursor: null, limit: 50, direction: 'before' },
+      });
     }
 
     // Parse pagination parameters
@@ -367,6 +371,10 @@ export async function POST(
     // token, if present. Resolution degrades, never fails.
     let commandPlan: CommandExecutionPlan | null = null;
     let commandSystemPrompt = '';
+    // Title resolved at save time (auto-generated from first user message when null).
+    // Used in the broadcastGlobalConversationAdded call below so the sidebar
+    // shows the real title rather than an empty string.
+    let resolvedConversationTitle = conversation.title ?? '';
 
     // Save user's message immediately to database
     const userMessage = requestMessages[requestMessages.length - 1];
@@ -437,6 +445,7 @@ export async function POST(
           // Auto-generate title from first user message
           const title = messageContent.slice(0, 50) + (messageContent.length > 50 ? '...' : '');
           updateData.title = title;
+          resolvedConversationTitle = title;
         }
 
         await db
@@ -962,7 +971,7 @@ MENTION PROCESSING:
       broadcastGlobalConversationAdded(channelId, {
         conversation: {
           id: conversation.id,
-          title: conversation.title ?? '',
+          title: resolvedConversationTitle,
           type: conversation.type,
           createdAt: conversation.createdAt.toISOString(),
         },

--- a/apps/web/src/app/api/ai/global/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/__tests__/route.test.ts
@@ -40,6 +40,18 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
 }));
 
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastGlobalConversationAdded: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/ai/global-channel-id', () => ({
+  globalChannelId: vi.fn((userId: string) => `user:${userId}:global`),
+}));
+
+vi.mock('@/lib/websocket/broadcast-triggered-by', () => ({
+  resolveTriggeredBy: vi.fn().mockResolvedValue({ userId: 'user_123', displayName: 'Test User', browserSessionId: '' }),
+}));
+
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -4,6 +4,9 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import { broadcastGlobalConversationAdded } from '@/lib/websocket/socket-utils';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
 
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
@@ -97,6 +100,18 @@ export async function POST(request: Request) {
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'global_chat', resourceId: newConversation.id, details: {
       action: 'create_conversation',
     } });
+
+    void resolveTriggeredBy(userId, request).then((triggeredBy) =>
+      broadcastGlobalConversationAdded(globalChannelId(userId), {
+        conversation: {
+          id: newConversation.id,
+          title: newConversation.title ?? '',
+          type: newConversation.type,
+          createdAt: new Date(newConversation.createdAt).toISOString(),
+        },
+        triggeredBy,
+      })
+    ).catch(() => {});
 
     return NextResponse.json(newConversation);
   } catch (error) {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -516,12 +516,6 @@ const SidebarChatTab: React.FC = () => {
     fetchWithAuth(`/api/ai/global/${conversationId}/messages`)
       .then(async (res) => {
         if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;
-        if (res.status === 404) {
-          // Conversation not yet persisted (lazy creation) — treat as empty, not an error.
-          setGlobalMessages([]);
-          setGlobalMessagesLoadError(null);
-          return;
-        }
         if (!res.ok) throw new Error(`Failed to load messages (${res.status})`);
         const data = await res.json();
         if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarHistoryTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarHistoryTab.tsx
@@ -80,6 +80,11 @@ const SidebarHistoryTab: React.FC<SidebarHistoryTabProps> = ({
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Tracks the last conversation ID prepended via socket to prevent re-firing
+  // on remount or when selectedAgent flips back to global mode (sticky context state).
+  const lastHandledGlobalConversationIdRef = useRef<string | null>(
+    latestGlobalConversationAdded?.conversation.id ?? null,
+  );
 
   // Determine active conversation ID based on context
   const activeConversationId = useMemo(() => {
@@ -146,6 +151,8 @@ const SidebarHistoryTab: React.FC<SidebarHistoryTabProps> = ({
   useEffect(() => {
     if (!latestGlobalConversationAdded || selectedAgent) return;
     const { conversation } = latestGlobalConversationAdded;
+    if (lastHandledGlobalConversationIdRef.current === conversation.id) return;
+    lastHandledGlobalConversationIdRef.current = conversation.id;
     setConversations((prev) => {
       if (prev.some((c) => c.id === conversation.id)) return prev;
       return [

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarHistoryTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarHistoryTab.tsx
@@ -58,6 +58,7 @@ const SidebarHistoryTab: React.FC<SidebarHistoryTabProps> = ({
     loadConversation: loadGlobalConversation,
     createNewConversation: createNewGlobalConversation,
     currentConversationId: globalConversationId,
+    latestGlobalConversationAdded,
   } = useGlobalChatConversation();
 
   // Use sidebar agent state for agent conversation management (page context)
@@ -140,6 +141,25 @@ const SidebarHistoryTab: React.FC<SidebarHistoryTabProps> = ({
 
     loadConversations();
   }, [selectedAgent, globalConversationId, activeConversationId, pathname]); // Refetch when agent, conversation, or navigation changes
+
+  // Prepend a new global conversation when the socket signals one was created.
+  useEffect(() => {
+    if (!latestGlobalConversationAdded || selectedAgent) return;
+    const { conversation } = latestGlobalConversationAdded;
+    setConversations((prev) => {
+      if (prev.some((c) => c.id === conversation.id)) return prev;
+      return [
+        {
+          id: conversation.id,
+          title: conversation.title,
+          type: conversation.type,
+          lastMessageAt: conversation.createdAt,
+          createdAt: conversation.createdAt,
+        },
+        ...prev,
+      ];
+    });
+  }, [latestGlobalConversationAdded, selectedAgent]);
 
   // Load more conversations (for pagination)
   const handleLoadMore = useCallback(async () => {

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -12,6 +12,7 @@ import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useAuth } from '@/hooks/useAuth';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
+import type { ChatGlobalConversationAddedPayload } from '@/lib/websocket/socket-utils';
 import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
@@ -46,6 +47,8 @@ interface GlobalChatConversationContextValue {
   createNewConversation: () => Promise<void>;
   /** Re-runs the global channel bootstrap to rejoin any still-live own stream. */
   rejoinGlobalStream: () => void;
+  /** Most-recently received global conversation-added event (own-tab included). History surfaces watch this to prepend without a refresh. */
+  latestGlobalConversationAdded: ChatGlobalConversationAddedPayload | null;
 }
 
 interface GlobalChatStreamContextValue {
@@ -83,6 +86,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const [refreshSignal, setRefreshSignal] = useState(0);
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [stopStreaming, setStopStreaming] = useState<(() => void) | null>(null);
+  const [latestGlobalConversationAdded, setLatestGlobalConversationAdded] = useState<ChatGlobalConversationAddedPayload | null>(null);
 
   // Protects bootstrap-replayed own streams from SWR clobbers while useChat
   // on the surface is still at idle (before it re-engages after a refresh).
@@ -100,12 +104,6 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
         const messageData = await messagesResponse.json();
         const loadedMessages = Array.isArray(messageData) ? messageData : messageData.messages || [];
         setInitialMessages(loadedMessages);
-        setCurrentConversationId(conversationId);
-        conversationState.setActiveConversationId(conversationId);
-        setIsInitialized(true);
-      } else if (messagesResponse.status === 404) {
-        // Conversation not yet persisted (lazy creation) — treat as empty
-        setInitialMessages([]);
         setCurrentConversationId(conversationId);
         conversationState.setActiveConversationId(conversationId);
         setIsInitialized(true);
@@ -262,6 +260,9 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
       setIsStreamingRef.current(false);
       setStopStreamingRef.current(null);
     },
+    onGlobalConversationAdded: (payload) => {
+      setLatestGlobalConversationAdded(payload);
+    },
   });
 
   const prevConversationIdRef = useRef<string | null>(null);
@@ -303,6 +304,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     loadConversation,
     createNewConversation,
     rejoinGlobalStream,
+    latestGlobalConversationAdded,
   }), [
     currentConversationId,
     initialMessages,
@@ -311,6 +313,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     loadConversation,
     createNewConversation,
     rejoinGlobalStream,
+    latestGlobalConversationAdded,
   ]);
 
   const streamContextValue: GlobalChatStreamContextValue = useMemo(() => ({

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -102,6 +102,7 @@ import type {
   ChatMessageDeletedPayload,
   ChatUndoAppliedPayload,
   ChatConversationAddedPayload,
+  ChatGlobalConversationAddedPayload,
 } from '@/lib/websocket/socket-utils';
 
 const START_PAYLOAD: AiStreamStartPayload = {
@@ -156,6 +157,16 @@ const CONVERSATION_ADDED_PAYLOAD: ChatConversationAddedPayload = {
     createdAt: '2026-05-01T00:00:00.000Z',
   },
   triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
+};
+
+const GLOBAL_CONVERSATION_ADDED_PAYLOAD: ChatGlobalConversationAddedPayload = {
+  conversation: {
+    id: 'conv-global-1',
+    title: 'My first chat',
+    type: 'global',
+    createdAt: '2026-05-01T00:00:00.000Z',
+  },
+  triggeredBy: { userId: 'user-1', displayName: 'Me', browserSessionId: SESSION_ID_REMOTE },
 };
 
 describe('useChannelStreamSocket', () => {
@@ -509,6 +520,32 @@ describe('useChannelStreamSocket', () => {
       });
 
       expect(onConversationAdded).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('chat:global_conversation_added', () => {
+    it('given a chat:global_conversation_added event, should call onGlobalConversationAdded with the payload', () => {
+      const onGlobalConversationAdded = vi.fn();
+      renderHook(() => useChannelStreamSocket('user:u1:global', { onGlobalConversationAdded }));
+
+      act(() => { mockSocket._trigger('chat:global_conversation_added', GLOBAL_CONVERSATION_ADDED_PAYLOAD); });
+
+      expect(onGlobalConversationAdded).toHaveBeenCalledTimes(1);
+      expect(onGlobalConversationAdded).toHaveBeenCalledWith(GLOBAL_CONVERSATION_ADDED_PAYLOAD);
+    });
+
+    it('given own-session triggeredBy, should STILL call onGlobalConversationAdded (no own-tab dedup)', () => {
+      const onGlobalConversationAdded = vi.fn();
+      renderHook(() => useChannelStreamSocket('user:u1:global', { onGlobalConversationAdded }));
+
+      act(() => {
+        mockSocket._trigger('chat:global_conversation_added', {
+          ...GLOBAL_CONVERSATION_ADDED_PAYLOAD,
+          triggeredBy: { ...GLOBAL_CONVERSATION_ADDED_PAYLOAD.triggeredBy, browserSessionId: SESSION_ID_LOCAL },
+        });
+      });
+
+      expect(onGlobalConversationAdded).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -17,6 +17,7 @@ import type {
   ChatConversationAddedPayload,
   ChatConversationRenamedPayload,
   ChatConversationDeletedPayload,
+  ChatGlobalConversationAddedPayload,
 } from '@/lib/websocket/socket-utils';
 import type { UIMessage } from 'ai';
 
@@ -89,6 +90,12 @@ export interface UseChannelStreamSocketOptions {
    * `onConversationAdded`.
    */
   onConversationDeleted?: (payload: ChatConversationDeletedPayload) => void;
+  /**
+   * Fires when a new global (non-agent) conversation is created on the user's
+   * personal channel. No own-tab dedup — the history tab has no other signal
+   * and needs to update even when the conversation originated in this tab.
+   */
+  onGlobalConversationAdded?: (payload: ChatGlobalConversationAddedPayload) => void;
 }
 
 /** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
@@ -111,6 +118,7 @@ export function useChannelStreamSocket(
   const onConversationAddedRef = useRef(options?.onConversationAdded);
   const onConversationRenamedRef = useRef(options?.onConversationRenamed);
   const onConversationDeletedRef = useRef(options?.onConversationDeleted);
+  const onGlobalConversationAddedRef = useRef(options?.onGlobalConversationAdded);
   onStreamCompleteRef.current = options?.onStreamComplete;
   onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
   onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
@@ -121,6 +129,7 @@ export function useChannelStreamSocket(
   onConversationAddedRef.current = options?.onConversationAdded;
   onConversationRenamedRef.current = options?.onConversationRenamed;
   onConversationDeletedRef.current = options?.onConversationDeleted;
+  onGlobalConversationAddedRef.current = options?.onGlobalConversationAdded;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -303,6 +312,12 @@ export function useChannelStreamSocket(
       onConversationDeletedRef.current?.(payload);
     };
 
+    const handleGlobalConversationAdded = (payload: ChatGlobalConversationAddedPayload) => {
+      // No own-session filter: the history tab must update even when the conversation
+      // was created in the current tab (it has no other signal).
+      onGlobalConversationAddedRef.current?.(payload);
+    };
+
     socket.on('chat:stream_start', handleStreamStart);
     socket.on('chat:stream_complete', handleStreamComplete);
     socket.on('chat:user_message', handleUserMessage);
@@ -312,6 +327,7 @@ export function useChannelStreamSocket(
     socket.on('chat:conversation_added', handleConversationAdded);
     socket.on('chat:conversation_renamed', handleConversationRenamed);
     socket.on('chat:conversation_deleted', handleConversationDeleted);
+    socket.on('chat:global_conversation_added', handleGlobalConversationAdded);
 
     return () => {
       cancelled = true;
@@ -324,6 +340,7 @@ export function useChannelStreamSocket(
       socket.off('chat:conversation_added', handleConversationAdded);
       socket.off('chat:conversation_renamed', handleConversationRenamed);
       socket.off('chat:conversation_deleted', handleConversationDeleted);
+      socket.off('chat:global_conversation_added', handleGlobalConversationAdded);
       for (const [msgId, controller] of controllers.entries()) {
         controller.abort();
         releaseBootstrapConsumer(msgId);

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -1020,12 +1020,15 @@ export async function broadcastGlobalConversationAdded(
       payload,
     });
 
-    await fetch(`${realtimeUrl}/api/broadcast`, {
+    const response = await fetch(`${realtimeUrl}/api/broadcast`, {
       method: 'POST',
       headers: createSignedBroadcastHeaders(requestBody),
       body: requestBody,
       signal: AbortSignal.timeout(5000),
     });
+    if (!response.ok) {
+      throw new Error(`Broadcast failed with status ${response.status}`);
+    }
   } catch (error) {
     realtimeLogger.error(
       'Failed to broadcast global conversation-added',

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -735,6 +735,16 @@ export interface ChatConversationAddedPayload {
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 
+export interface ChatGlobalConversationAddedPayload {
+  conversation: {
+    id: string;
+    title: string;
+    type: string;
+    createdAt: string;
+  };
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
 export interface ChatConversationRenamedPayload {
   agentId: string;
   conversationId: string;
@@ -986,6 +996,43 @@ export async function broadcastAiConversationAdded(payload: ChatConversationAdde
       {
         event: 'chat:conversation_added',
         channel: maskIdentifier(payload.agentId),
+      }
+    );
+  }
+}
+
+export async function broadcastGlobalConversationAdded(
+  channelId: string,
+  payload: ChatGlobalConversationAddedPayload,
+): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping global conversation-added broadcast', {
+      event: 'chat:global_conversation_added',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId,
+      event: 'chat:global_conversation_added',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast global conversation-added',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:global_conversation_added',
+        channel: maskIdentifier(channelId),
       }
     );
   }


### PR DESCRIPTION
## Summary

- New global AI conversations now appear in the sidebar history list immediately (no page refresh) via a new `chat:global_conversation_added` socket event — mirrors the existing pattern for page-agent conversations
- Fixes console 404 errors for lazy-created conversations: `GET /api/ai/global/[id]/messages` now returns `200 + { messages: [] }` instead of 404 when the conversation hasn't been persisted yet
- Covers both creation paths: lazy (first message to a client-generated ID) and explicit (POST `/api/ai/global`)

## What changed

**Backend**
- `resolve-or-create-conversation.ts` — returns `{ conversation, isNew }` so callers broadcast only on actual creation
- `socket-utils.ts` — adds `ChatGlobalConversationAddedPayload` type + `broadcastGlobalConversationAdded(channelId, payload)` function (broadcasts to `globalChannelId(userId)`); checks `response.ok` to surface 4xx/5xx realtime failures
- `global/[id]/messages/route.ts` — GET returns `{ messages: [], pagination: {...} }` for missing conversations (same shape as persisted path); POST fires broadcast when `isNew`, using `resolvedConversationTitle` (auto-generated from first message) not the stale null title
- `global/route.ts` — POST fires broadcast after `createConversation`

**Frontend**
- `useChannelStreamSocket.ts` — adds `onGlobalConversationAdded` callback; no own-session filter (history tab must update even for same-tab creates)
- `GlobalChatContext.tsx` — threads the event into `latestGlobalConversationAdded` context state
- `SidebarHistoryTab.tsx` — watches `latestGlobalConversationAdded`, prepends deduped entry to conversation list; `lastHandledGlobalConversationIdRef` guard prevents stale-event replay on remount
- `SidebarChatTab.tsx` — removes now-redundant 404 guard (server returns 200 instead)

**Tests**
- Updated `resolveOrCreateConversation` test assertions for `{ conversation, isNew }` shape (7 tests)
- Added `@/lib/websocket/socket-utils` mock to route test files
- Added 2 new tests for `chat:global_conversation_added` in `useChannelStreamSocket.test.ts`: fires callback + no own-tab dedup
- Added 3 new tests in `stream-socket-events.test.ts`: broadcast fires on `isNew=true`, broadcast uses auto-generated title, broadcast skipped on `isNew=false`

## Test plan

- [ ] Start new conversation in sidebar chat tab → history tab updates immediately without refresh
- [ ] Open two tabs; start conversation in tab A → appears in tab B's history list
- [ ] Console shows no 404 for brand-new conversations
- [ ] Existing page-agent conversation flow unaffected
- [ ] `bun run --filter 'web' test -- resolve-or-create-conversation` passes (7/7)
- [ ] `bun run --filter 'web' test -- useChannelStreamSocket` passes
- [ ] `bun run --filter 'web' test -- stream-socket-events` passes (19 tests in global file)
- [ ] `bun run --filter 'web' test -- global` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxqKVYcisLJQMLgCqWsv5S