### PR TITLE
fix(ai-chat): apply localStorage toggles synchronously in loadSettings to prevent race

### DIFF
--- a/apps/web/src/stores/__tests__/useAssistantSettingsStore.test.ts
+++ b/apps/web/src/stores/__tests__/useAssistantSettingsStore.test.ts
@@ -408,5 +408,68 @@ describe('useAssistantSettingsStore', () => {
       expect(result.current.isLoading).toBe(false);
       expect(result.current.currentProvider).toBeNull();
     });
+
+    // ============================================
+    // Race condition tests
+    // ============================================
+    it('should apply webSearchEnabled from localStorage before fetch resolves', async () => {
+      localStorageMock.store['pagespace:assistant:webSearchEnabled'] = 'true';
+
+      let resolvePromise!: (value: unknown) => void;
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockFetchWithAuth.mockReturnValue(pendingPromise);
+
+      const { result } = renderHook(() => useAssistantSettingsStore());
+
+      // Start loading but don't await it — fetch is still in-flight
+      act(() => {
+        result.current.loadSettings();
+      });
+
+      // localStorage value must be applied immediately, before the fetch resolves
+      expect(result.current.webSearchEnabled).toBe(true);
+
+      // Clean up: resolve the fetch
+      await act(async () => {
+        resolvePromise({ ok: false, status: 500 });
+        await pendingPromise;
+      });
+    });
+
+    it('should set currentProvider and currentModel after fetch resolves', async () => {
+      mockFetchWithAuth.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          currentProvider: 'anthropic',
+          currentModel: 'claude-3-opus',
+          isAnyProviderConfigured: true,
+        }),
+      });
+
+      const { result } = renderHook(() => useAssistantSettingsStore());
+
+      await act(async () => {
+        await result.current.loadSettings();
+      });
+
+      expect(result.current.currentProvider).toBe('anthropic');
+      expect(result.current.currentModel).toBe('claude-3-opus');
+      expect(result.current.isAnyProviderConfigured).toBe(true);
+      expect(result.current.isInitialized).toBe(true);
+    });
+
+    it('should default webSearchEnabled to false when localStorage has no value', async () => {
+      // localStorage has no entry for webSearchEnabled
+
+      const { result } = renderHook(() => useAssistantSettingsStore());
+
+      await act(async () => {
+        await result.current.loadSettings();
+      });
+
+      expect(result.current.webSearchEnabled).toBe(false);
+    });
   });
 });

--- a/apps/web/src/stores/__tests__/useAssistantSettingsStore.test.ts
+++ b/apps/web/src/stores/__tests__/useAssistantSettingsStore.test.ts
@@ -44,6 +44,8 @@ describe('useAssistantSettingsStore', () => {
       isAnyProviderConfigured: false,
       isLoading: false,
       isInitialized: false,
+      webSearchEnabled: false,
+      writeMode: true,
     });
 
     // Clear all mocks
@@ -208,6 +210,57 @@ describe('useAssistantSettingsStore', () => {
       expect(result.current.isInitialized).toBe(true);
       expect(result.current.currentProvider).toBe('openai');
       expect(result.current.currentModel).toBe('gpt-4');
+    });
+  });
+
+  // ============================================
+  // Toggle action tests
+  // ============================================
+  describe('toggleWebSearch', () => {
+    it('should flip webSearchEnabled from false to true', () => {
+      const { result } = renderHook(() => useAssistantSettingsStore());
+      act(() => { result.current.toggleWebSearch(); });
+      expect(result.current.webSearchEnabled).toBe(true);
+    });
+
+    it('should flip webSearchEnabled from true to false', () => {
+      useAssistantSettingsStore.setState({ webSearchEnabled: true });
+      const { result } = renderHook(() => useAssistantSettingsStore());
+      act(() => { result.current.toggleWebSearch(); });
+      expect(result.current.webSearchEnabled).toBe(false);
+    });
+
+    it('should persist to localStorage', () => {
+      const { result } = renderHook(() => useAssistantSettingsStore());
+      act(() => { result.current.toggleWebSearch(); });
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'pagespace:assistant:webSearchEnabled',
+        'true'
+      );
+    });
+  });
+
+  describe('toggleWriteMode', () => {
+    it('should flip writeMode from true to false', () => {
+      const { result } = renderHook(() => useAssistantSettingsStore());
+      act(() => { result.current.toggleWriteMode(); });
+      expect(result.current.writeMode).toBe(false);
+    });
+
+    it('should flip writeMode from false to true', () => {
+      useAssistantSettingsStore.setState({ writeMode: false });
+      const { result } = renderHook(() => useAssistantSettingsStore());
+      act(() => { result.current.toggleWriteMode(); });
+      expect(result.current.writeMode).toBe(true);
+    });
+
+    it('should persist to localStorage', () => {
+      const { result } = renderHook(() => useAssistantSettingsStore());
+      act(() => { result.current.toggleWriteMode(); });
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'pagespace:assistant:writeMode',
+        'false'
+      );
     });
   });
 

--- a/apps/web/src/stores/useAssistantSettingsStore.ts
+++ b/apps/web/src/stores/useAssistantSettingsStore.ts
@@ -96,8 +96,13 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
   },
 
   toggleWebSearch: () => {
-    const current = get().webSearchEnabled;
-    get().setWebSearchEnabled(!current);
+    set((state) => {
+      const next = !state.webSearchEnabled;
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(WEB_SEARCH_KEY, String(next));
+      }
+      return { webSearchEnabled: next };
+    });
   },
 
   setWriteMode: (enabled: boolean) => {
@@ -110,8 +115,13 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
   },
 
   toggleWriteMode: () => {
-    const current = get().writeMode;
-    get().setWriteMode(!current);
+    set((state) => {
+      const next = !state.writeMode;
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(WRITE_MODE_KEY, String(next));
+      }
+      return { writeMode: next };
+    });
   },
 
   loadSettings: async () => {
@@ -120,37 +130,28 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
 
     set({ isLoading: true });
 
-    // Load settings from localStorage (client-side only) - outside try block
-    // so values are available in both success and error paths
+    // Apply localStorage values immediately (synchronously) so components
+    // that read the store before the API responds see the correct toggle state.
     let showPageTree = false;
     let webSearchEnabled = false;
     let writeMode = true;
 
     if (typeof window !== 'undefined') {
       const storedShowPageTree = localStorage.getItem(SHOW_PAGE_TREE_KEY);
-      if (storedShowPageTree !== null) {
-        showPageTree = storedShowPageTree === 'true';
-      }
-
+      if (storedShowPageTree !== null) showPageTree = storedShowPageTree === 'true';
       const storedWebSearch = localStorage.getItem(WEB_SEARCH_KEY);
-      if (storedWebSearch !== null) {
-        webSearchEnabled = storedWebSearch === 'true';
-      }
-
+      if (storedWebSearch !== null) webSearchEnabled = storedWebSearch === 'true';
       const storedWriteMode = localStorage.getItem(WRITE_MODE_KEY);
-      if (storedWriteMode !== null) {
-        writeMode = storedWriteMode === 'true';
-      }
+      if (storedWriteMode !== null) writeMode = storedWriteMode === 'true';
     }
+
+    set({ showPageTree, webSearchEnabled, writeMode });
 
     try {
       const response = await fetchWithAuth('/api/ai/settings');
       if (response.ok) {
         const data = await response.json();
         set({
-          showPageTree,
-          webSearchEnabled,
-          writeMode,
           currentProvider: data.currentProvider || null,
           currentModel: data.currentModel || null,
           isAnyProviderConfigured: data.isAnyProviderConfigured || false,
@@ -159,13 +160,13 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
           isLoading: false,
         });
       } else {
-        set({ showPageTree, webSearchEnabled, writeMode, isInitialized: true, isLoading: false });
+        set({ isInitialized: true, isLoading: false });
       }
     } catch (error) {
       if (process.env.NODE_ENV === 'development') {
         console.warn('Failed to load assistant settings:', error);
       }
-      set({ showPageTree, webSearchEnabled, writeMode, isInitialized: true, isLoading: false });
+      set({ isInitialized: true, isLoading: false });
     }
   },
 }))

--- a/apps/web/src/stores/useAssistantSettingsStore.ts
+++ b/apps/web/src/stores/useAssistantSettingsStore.ts
@@ -73,8 +73,13 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
   },
 
   toggleShowPageTree: () => {
-    const current = get().showPageTree;
-    get().setShowPageTree(!current);
+    set((state) => {
+      const next = !state.showPageTree;
+      if (typeof window !== 'undefined') {
+        localStorage.setItem(SHOW_PAGE_TREE_KEY, String(next));
+      }
+      return { showPageTree: next };
+    });
   },
 
   setProviderSettings: (provider: string, model: string) => {
@@ -128,8 +133,6 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
     // Prevent duplicate loads
     if (get().isLoading || get().isInitialized) return;
 
-    set({ isLoading: true });
-
     // Apply localStorage values immediately (synchronously) so components
     // that read the store before the API responds see the correct toggle state.
     let showPageTree = false;
@@ -145,7 +148,7 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
       if (storedWriteMode !== null) writeMode = storedWriteMode === 'true';
     }
 
-    set({ showPageTree, webSearchEnabled, writeMode });
+    set({ isLoading: true, showPageTree, webSearchEnabled, writeMode });
 
     try {
       const response = await fetchWithAuth('/api/ai/settings');


### PR DESCRIPTION
## Summary

- `loadSettings()` previously read localStorage values into local vars, but only committed them to the store **after** the async `fetchWithAuth('/api/ai/settings')` resolved — a 200–1000ms window where `webSearchEnabled` was `false`, causing messages sent during that window to be dispatched without the web_search tool even when the toggle was on
- Fix: read localStorage and call `set({ isLoading: true, showPageTree, webSearchEnabled, writeMode })` as a single synchronous call before the `await`; the post-fetch `set()` only touches API-owned fields (`currentProvider`, `currentModel`, etc.) — no clobber path
- Convert all three toggle functions (`toggleWebSearch`, `toggleWriteMode`, `toggleShowPageTree`) to Zustand functional updates (`set(state => ...)`) for consistency and to eliminate any stale-closure risk
- Merge the two sequential `set()` calls that previously fired at load-start into one (saves one extra render per page load)

## Test plan

- [x] 32 tests pass, including:
  - `webSearchEnabled` reflects localStorage value **before** fetch resolves (direct race condition regression test)
  - `toggleWebSearch` / `toggleWriteMode` persist to localStorage (previously only the `set*` paths were covered)
  - `beforeEach` now resets `webSearchEnabled` and `writeMode` to prevent state leaking between tests
  - Regression: `currentProvider`/`currentModel` still populated after fetch resolves
  - Default fallback: `webSearchEnabled` is `false` when localStorage has no entry
- [ ] Manually: enable web search toggle, reload the page, send a message immediately — web search tool should be active without needing to re-toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Sy7BNSo4uoyNqCwruy678