### PR TITLE
feat(terminal): persistent sessions survive navigation

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -145,7 +145,7 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
     },
   }).catch(() => {});
 
-  return { ok: true, sandboxId, sprite, releaseSlot };
+  return { ok: true, sandboxId, sessionKey: sandboxResult.sessionKey, sprite, releaseSlot };
 }
 
 /**
@@ -1024,9 +1024,9 @@ io.on('connection', (socket: AuthSocket) => {
 
   socket.on('terminal:connect', (payload) => {
     terminalHandlers.onConnect(payload).then(() => {
-      const session = terminalSessionMap.get(socket.id);
+      const session = terminalSessionMap.getBySocket(socket.id);
       if (session) {
-        loggers.realtime.info('Terminal session opened', { userId: user?.id, socketId: socket.id, sandboxId: session.sandboxId });
+        loggers.realtime.info('Terminal session opened', { userId: user?.id, sessionKey: session.sessionKey, sandboxId: session.sandboxId });
       }
     }).catch((err: unknown) => {
       const msg = err instanceof Error ? err.message : 'Internal error';

--- a/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { buildTerminalHandlers, MAX_INPUT_BYTES } from '../terminal-handler';
-import { createTerminalSessionMap } from '../terminal-session-map';
+import { createTerminalSessionMap, DETACHED_IDLE_MS } from '../terminal-session-map';
 import type { CheckAuthFn, OpenShellFn, SocketLike } from '../terminal-handler';
 import type { PtyShell } from '../sprites-shell';
 
-function makeSocket(userId = 'user1'): SocketLike & { emit: ReturnType<typeof vi.fn> } {
-  return { id: 'sock1', data: { user: { id: userId } }, emit: vi.fn() };
+function makeSocket(id = 'sock1', userId = 'user1'): SocketLike & { emit: ReturnType<typeof vi.fn> } {
+  return { id, data: { user: { id: userId } }, emit: vi.fn() };
 }
 
 function makeShell(): PtyShell & { write: ReturnType<typeof vi.fn>; resize: ReturnType<typeof vi.fn>; kill: ReturnType<typeof vi.fn> } {
@@ -16,8 +16,8 @@ function makeSprite() {
   return { name: 'sbx1', spawn: vi.fn(), filesystem: vi.fn(), updateNetworkPolicy: vi.fn(), destroy: vi.fn() };
 }
 
-function makeAuthSuccess() {
-  return { ok: true as const, sandboxId: 'sbx1', sprite: makeSprite(), releaseSlot: vi.fn() };
+function makeAuthSuccess(sessionKey = 'key1') {
+  return { ok: true as const, sandboxId: 'sbx1', sessionKey, sprite: makeSprite(), releaseSlot: vi.fn() };
 }
 
 const validPayload = { pageId: 'page1', cols: 80, rows: 24 };
@@ -48,23 +48,24 @@ describe('buildTerminalHandlers', () => {
       await onConnect(validPayload);
 
       expect(openShell).toHaveBeenCalledWith(expect.objectContaining({ cols: 80, rows: 24 }));
-      expect(socket.emit).toHaveBeenCalledWith('terminal:ready');
+      expect(socket.emit).toHaveBeenCalledWith('terminal:ready', {});
     });
 
     it('given valid payload and auth succeeds, should store session in sessionMap', async () => {
       const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
       await onConnect(validPayload);
 
-      expect(sessionMap.has('sock1')).toBe(true);
+      expect(sessionMap.getBySocket('sock1')).toBeDefined();
+      expect(sessionMap.getByKey('key1')).toBeDefined();
     });
 
-    it('given auth fails with not_admin, should emit terminal:error and not store session', async () => {
+    it('given auth fails, should emit terminal:error and not store session', async () => {
       checkAuth = vi.fn().mockResolvedValue({ ok: false, reason: 'not_admin' }) as unknown as ReturnType<typeof vi.fn> & CheckAuthFn;
       const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
       await onConnect(validPayload);
 
       expect(socket.emit).toHaveBeenCalledWith('terminal:error', expect.objectContaining({ message: expect.any(String) }));
-      expect(sessionMap.has('sock1')).toBe(false);
+      expect(sessionMap.getBySocket('sock1')).toBeUndefined();
       expect(openShell).not.toHaveBeenCalled();
     });
 
@@ -82,23 +83,7 @@ describe('buildTerminalHandlers', () => {
       await onConnect(validPayload);
 
       expect(socket.emit).toHaveBeenCalledWith('terminal:error', expect.objectContaining({ message: expect.any(String) }));
-      expect(sessionMap.has('sock1')).toBe(false);
-    });
-
-    it('given terminal:connect called twice, should kill the existing session before opening a new one', async () => {
-      const firstAuth = makeAuthSuccess();
-      checkAuth.mockResolvedValueOnce(firstAuth);
-      const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
-      await onConnect(validPayload);
-      const firstShell = shell;
-
-      const secondShell = makeShell();
-      openShell.mockReturnValue(secondShell);
-      await onConnect(validPayload);
-
-      expect(firstShell.kill).toHaveBeenCalled();
-      expect(firstAuth.releaseSlot).toHaveBeenCalled();
-      expect(sessionMap.has('sock1')).toBe(true);
+      expect(sessionMap.getBySocket('sock1')).toBeUndefined();
     });
 
     it('given openShell throws, should release the concurrency slot', async () => {
@@ -117,7 +102,7 @@ describe('buildTerminalHandlers', () => {
       await onConnect(validPayload);
 
       expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
-      const session = sessionMap.get('sock1');
+      const session = sessionMap.getByKey('key1');
       expect(session?.reAuthInterval).toBeDefined();
     });
 
@@ -125,24 +110,65 @@ describe('buildTerminalHandlers', () => {
       const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
       await onConnect(validPayload);
 
-      // Advance time to trigger the re-auth interval
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(shell.kill).not.toHaveBeenCalled();
-      expect(sessionMap.has('sock1')).toBe(true);
+      expect(sessionMap.getByKey('key1')).toBeDefined();
     });
 
     it('given re-auth fires and checkAuth now fails, should kill shell, remove session, and emit terminal:closed with exitCode -2', async () => {
       const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
       await onConnect(validPayload);
 
-      // Revoke access
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
       expect(shell.kill).toHaveBeenCalledWith('SIGKILL');
-      expect(sessionMap.has('sock1')).toBe(false);
+      expect(sessionMap.getByKey('key1')).toBeUndefined();
       expect(socket.emit).toHaveBeenCalledWith('terminal:closed', { exitCode: -2 });
+    });
+
+    it('given an existing live session for the same pageId, should reattach rather than spawn a new shell', async () => {
+      // First connect from sock1
+      const { onConnect: connect1 } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await connect1(validPayload);
+      expect(openShell).toHaveBeenCalledTimes(1);
+
+      // Second connect from a different socket (e.g., page reload) with same sessionKey
+      const socket2 = makeSocket('sock2');
+      const auth2 = makeAuthSuccess('key1'); // same sessionKey → same page
+      checkAuth.mockResolvedValue(auth2);
+      const { onConnect: connect2 } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2 });
+      await connect2(validPayload);
+
+      // Shell should not be re-spawned — reattach path
+      expect(openShell).toHaveBeenCalledTimes(1);
+      // The extra concurrency slot from re-auth should be released
+      expect(auth2.releaseSlot).toHaveBeenCalled();
+      // terminal:ready is emitted with a scrollback field
+      expect(socket2.emit).toHaveBeenCalledWith('terminal:ready', expect.objectContaining({ scrollback: expect.any(String) }));
+      // New socket is now routed to the session
+      expect(sessionMap.getBySocket('sock2')).toBeDefined();
+    });
+
+    it('given reattach, output is routed to the new socket, not the old one', async () => {
+      // First connect
+      const { onConnect: connect1 } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await connect1(validPayload);
+
+      // Get the onOutput callback that was passed to openShell
+      const onOutputArg = openShell.mock.calls[0][0].onOutput as (data: string) => void;
+
+      // Reattach with a second socket
+      const socket2 = makeSocket('sock2');
+      checkAuth.mockResolvedValue(makeAuthSuccess('key1'));
+      const { onConnect: connect2 } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2 });
+      await connect2(validPayload);
+
+      // Now fire output — should go to socket2, not socket1
+      onOutputArg('hello');
+      expect(socket2.emit).toHaveBeenCalledWith('terminal:output', { data: 'hello' });
+      expect(socket.emit).not.toHaveBeenCalledWith('terminal:output', { data: 'hello' });
     });
   });
 
@@ -217,7 +243,7 @@ describe('buildTerminalHandlers', () => {
   });
 
   describe('onDisconnect', () => {
-    it('given a connected session, should kill the shell, release the slot, and remove from sessionMap', async () => {
+    it('given a connected session, should detach the socket but keep the shell alive', async () => {
       const auth = makeAuthSuccess();
       checkAuth.mockResolvedValue(auth);
       const { onConnect, onDisconnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
@@ -225,9 +251,37 @@ describe('buildTerminalHandlers', () => {
 
       onDisconnect();
 
-      expect(shell.kill).toHaveBeenCalled();
+      expect(shell.kill).not.toHaveBeenCalled();
+      expect(auth.releaseSlot).not.toHaveBeenCalled();
+      expect(sessionMap.getBySocket('sock1')).toBeUndefined();
+      expect(sessionMap.getByKey('key1')).toBeDefined();
+    });
+
+    it('given a connected session, should kill the shell and release the slot after the idle timeout', async () => {
+      const auth = makeAuthSuccess();
+      checkAuth.mockResolvedValue(auth);
+      const { onConnect, onDisconnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      onDisconnect();
+      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
+
+      expect(shell.kill).toHaveBeenCalledWith('SIGKILL');
       expect(auth.releaseSlot).toHaveBeenCalled();
-      expect(sessionMap.has('sock1')).toBe(false);
+      expect(sessionMap.getByKey('key1')).toBeUndefined();
+    });
+
+    it('given a connected session, should NOT clear the re-auth interval on disconnect (keeps running for detached shell)', async () => {
+      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+      const { onConnect, onDisconnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      const session = sessionMap.getByKey('key1');
+      const storedInterval = session?.reAuthInterval;
+
+      onDisconnect();
+
+      expect(clearIntervalSpy).not.toHaveBeenCalledWith(storedInterval);
     });
 
     it('given no active session, should be a silent no-op', () => {
@@ -235,17 +289,28 @@ describe('buildTerminalHandlers', () => {
       expect(() => onDisconnect()).not.toThrow();
     });
 
-    it('given a connected session, should clear the re-auth interval on disconnect', async () => {
-      const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    it('given a reconnect before the idle timer fires, should cancel the timer and not kill the shell', async () => {
+      const auth = makeAuthSuccess();
+      checkAuth.mockResolvedValue(auth);
       const { onConnect, onDisconnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
       await onConnect(validPayload);
 
-      const session = sessionMap.get('sock1');
-      const storedInterval = session?.reAuthInterval;
-
       onDisconnect();
+      // Advance partway through idle timeout (but not all the way)
+      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS / 2);
 
-      expect(clearIntervalSpy).toHaveBeenCalledWith(storedInterval);
+      // Reconnect from a new socket
+      const socket2 = makeSocket('sock2');
+      const auth2 = makeAuthSuccess('key1');
+      checkAuth.mockResolvedValue(auth2);
+      const { onConnect: connect2 } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2 });
+      await connect2(validPayload);
+
+      // Advance past original idle timeout — shell should still be alive
+      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
+
+      expect(shell.kill).not.toHaveBeenCalled();
+      expect(sessionMap.getByKey('key1')).toBeDefined();
     });
   });
 });

--- a/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
@@ -289,6 +289,32 @@ describe('buildTerminalHandlers', () => {
       expect(() => onDisconnect()).not.toThrow();
     });
 
+    it('given a shell that exits while the session is detached, should clean up immediately and cancel the idle timer', async () => {
+      const auth = makeAuthSuccess();
+      checkAuth.mockResolvedValue(auth);
+      const { onConnect, onDisconnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      // Get the onExit callback that was registered with openShell
+      const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+
+      onDisconnect();
+      // Idle timer is now running
+
+      // Shell exits while detached (e.g., the user's script finished)
+      onExitArg(0);
+
+      // Session should be cleaned up immediately
+      expect(sessionMap.getByKey('key1')).toBeUndefined();
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
+      // kill() should NOT be called — the shell already exited naturally
+      expect(shell.kill).not.toHaveBeenCalled();
+
+      // Advance past the idle timeout — idle timer was cancelled by onExit, so no second releaseSlot
+      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
+    });
+
     it('given a reconnect before the idle timer fires, should cancel the timer and not kill the shell', async () => {
       const auth = makeAuthSuccess();
       checkAuth.mockResolvedValue(auth);

--- a/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
@@ -123,7 +123,7 @@ describe('buildTerminalHandlers', () => {
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(shell.kill).toHaveBeenCalledWith();
       expect(sessionMap.getByKey('key1')).toBeUndefined();
       expect(socket.emit).toHaveBeenCalledWith('terminal:closed', { exitCode: -2 });
     });
@@ -266,7 +266,7 @@ describe('buildTerminalHandlers', () => {
       onDisconnect();
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
 
-      expect(shell.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(shell.kill).toHaveBeenCalledWith();
       expect(auth.releaseSlot).toHaveBeenCalled();
       expect(sessionMap.getByKey('key1')).toBeUndefined();
     });

--- a/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
@@ -1,66 +1,137 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createTerminalSessionMap, type TerminalSession } from '../terminal-session-map';
 
-function fakeSession(sandboxId = 'sbx1'): TerminalSession {
+function fakeSession(sessionKey = 'key1', sandboxId = 'sbx1'): TerminalSession {
   return {
     command: { write: vi.fn(), kill: vi.fn(), resize: vi.fn() },
     sandboxId,
+    sessionKey,
+    releaseSlot: vi.fn(),
+    outputFn: vi.fn(),
+    closedFn: vi.fn(),
+    scrollback: [],
+    scrollbackBytes: 0,
+    reAuthInterval: undefined,
+    idleTimer: undefined,
   };
 }
 
 describe('createTerminalSessionMap', () => {
-  it('given a new map, has() should return false for an unknown key', () => {
-    const map = createTerminalSessionMap();
-    expect(map.has('unknown')).toBe(false);
+  describe('getBySocket / setNew', () => {
+    it('given setNew, getBySocket returns the session for that socket', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      expect(map.getBySocket('sock1')).toBe(session);
+    });
+
+    it('given an unknown socketId, getBySocket returns undefined', () => {
+      const map = createTerminalSessionMap();
+      expect(map.getBySocket('unknown')).toBeUndefined();
+    });
+
+    it('given setNew twice with same sessionKey but different sockets, getByKey returns the last set session', () => {
+      const map = createTerminalSessionMap();
+      const a = fakeSession('key1', 'sbx1');
+      const b = fakeSession('key1', 'sbx2');
+      map.setNew('key1', 'sock1', a);
+      map.setNew('key1', 'sock2', b);
+      expect(map.getByKey('key1')).toBe(b);
+    });
   });
 
-  it('given set(id, session), get(id) should return that session', () => {
-    const map = createTerminalSessionMap();
-    const session = fakeSession();
-    map.set('sock1', session);
-    expect(map.get('sock1')).toBe(session);
+  describe('getByKey', () => {
+    it('given setNew, getByKey returns the session for that sessionKey', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      expect(map.getByKey('key1')).toBe(session);
+    });
+
+    it('given an unknown sessionKey, getByKey returns undefined', () => {
+      const map = createTerminalSessionMap();
+      expect(map.getByKey('unknown')).toBeUndefined();
+    });
   });
 
-  it('given an unknown key, get() should return undefined', () => {
-    const map = createTerminalSessionMap();
-    expect(map.get('missing')).toBeUndefined();
+  describe('reattach', () => {
+    it('given reattach with a new socketId, getBySocket returns session for the new socket', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      map.reattach('key1', 'sock2');
+      expect(map.getBySocket('sock2')).toBe(session);
+    });
+
+    it('given reattach, getBySocket for the old socketId returns undefined', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      map.reattach('key1', 'sock2');
+      expect(map.getBySocket('sock1')).toBeUndefined();
+    });
+
+    it('given reattach, getByKey still returns the same session', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      map.reattach('key1', 'sock2');
+      expect(map.getByKey('key1')).toBe(session);
+    });
   });
 
-  it('given set then delete, has() should return false', () => {
-    const map = createTerminalSessionMap();
-    map.set('sock1', fakeSession());
-    map.delete('sock1');
-    expect(map.has('sock1')).toBe(false);
+  describe('detach', () => {
+    it('given detach, getBySocket returns undefined for that socket', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      map.detach('sock1');
+      expect(map.getBySocket('sock1')).toBeUndefined();
+    });
+
+    it('given detach, getByKey still returns the session (shell survives)', () => {
+      const map = createTerminalSessionMap();
+      const session = fakeSession();
+      map.setNew('key1', 'sock1', session);
+      map.detach('sock1');
+      expect(map.getByKey('key1')).toBe(session);
+    });
+
+    it('given detach on unknown socketId, should be a no-op', () => {
+      const map = createTerminalSessionMap();
+      expect(() => map.detach('nope')).not.toThrow();
+    });
   });
 
-  it('given set then delete, get() should return undefined', () => {
-    const map = createTerminalSessionMap();
-    map.set('sock1', fakeSession());
-    map.delete('sock1');
-    expect(map.get('sock1')).toBeUndefined();
-  });
+  describe('deleteByKey', () => {
+    it('given deleteByKey, getByKey returns undefined', () => {
+      const map = createTerminalSessionMap();
+      map.setNew('key1', 'sock1', fakeSession());
+      map.deleteByKey('key1');
+      expect(map.getByKey('key1')).toBeUndefined();
+    });
 
-  it('given two sessions, deleting one should not affect the other', () => {
-    const map = createTerminalSessionMap();
-    const a = fakeSession('a');
-    const b = fakeSession('b');
-    map.set('sock1', a);
-    map.set('sock2', b);
-    map.delete('sock1');
-    expect(map.get('sock2')).toBe(b);
-  });
+    it('given deleteByKey, getBySocket for the associated socket returns undefined', () => {
+      const map = createTerminalSessionMap();
+      map.setNew('key1', 'sock1', fakeSession());
+      map.deleteByKey('key1');
+      expect(map.getBySocket('sock1')).toBeUndefined();
+    });
 
-  it('given delete on a non-existent key, should be a no-op', () => {
-    const map = createTerminalSessionMap();
-    expect(() => map.delete('nope')).not.toThrow();
-  });
+    it('given deleteByKey on unknown key, should be a no-op', () => {
+      const map = createTerminalSessionMap();
+      expect(() => map.deleteByKey('nope')).not.toThrow();
+    });
 
-  it('given set twice with same key, get() should return the latest session', () => {
-    const map = createTerminalSessionMap();
-    const a = fakeSession('a');
-    const b = fakeSession('b');
-    map.set('sock1', a);
-    map.set('sock1', b);
-    expect(map.get('sock1')).toBe(b);
+    it('given two sessions, deleteByKey for one should not affect the other', () => {
+      const map = createTerminalSessionMap();
+      const a = fakeSession('key1', 'sbx1');
+      const b = fakeSession('key2', 'sbx2');
+      map.setNew('key1', 'sock1', a);
+      map.setNew('key2', 'sock2', b);
+      map.deleteByKey('key1');
+      expect(map.getByKey('key2')).toBe(b);
+      expect(map.getBySocket('sock2')).toBe(b);
+    });
   });
 });

--- a/apps/realtime/src/terminal/terminal-handler.ts
+++ b/apps/realtime/src/terminal/terminal-handler.ts
@@ -135,7 +135,7 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
           clearInterval(reAuthInterval);
           if (liveSession.idleTimer !== undefined) clearTimeout(liveSession.idleTimer);
           liveSession.releaseSlot();
-          liveSession.command.kill('SIGKILL');
+          liveSession.command.kill();
           sessionMap.deleteByKey(sessionKey);
           liveSession.closedFn(-2);
         } else {
@@ -180,7 +180,7 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
       session.idleTimer = setTimeout(() => {
         if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
         session.releaseSlot();
-        session.command.kill('SIGKILL');
+        session.command.kill();
         sessionMap.deleteByKey(sessionKey);
         loggers.realtime.info('Terminal session reaped (idle)', { sessionKey, sandboxId: session.sandboxId });
       }, DETACHED_IDLE_MS);

--- a/apps/realtime/src/terminal/terminal-handler.ts
+++ b/apps/realtime/src/terminal/terminal-handler.ts
@@ -1,4 +1,5 @@
-import type { TerminalSessionMap } from './terminal-session-map';
+import type { TerminalSessionMap, TerminalSession } from './terminal-session-map';
+import { MAX_SCROLLBACK_BYTES, DETACHED_IDLE_MS } from './terminal-session-map';
 import type { OpenPtyShellArgs, PtyShell } from './sprites-shell';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { validateTerminalConnectPayload, clampTerminalDimensions } from './validation';
@@ -7,7 +8,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 export const MAX_INPUT_BYTES = 4096;
 
 export type CheckAuthResult =
-  | { ok: true; sandboxId: string; sprite: SpriteInstanceLike; releaseSlot: () => void }
+  | { ok: true; sandboxId: string; sessionKey: string; sprite: SpriteInstanceLike; releaseSlot: () => void }
   | { ok: false; reason: string };
 
 export type CheckAuthFn = (args: { userId: string; pageId: string }) => Promise<CheckAuthResult>;
@@ -34,6 +35,16 @@ export type TerminalHandlers = {
   onDisconnect(): void;
 };
 
+function appendScrollback(session: Pick<TerminalSession, 'scrollback' | 'scrollbackBytes'>, data: string): void {
+  const bytes = Buffer.byteLength(data, 'utf8');
+  session.scrollback.push(data);
+  session.scrollbackBytes += bytes;
+  while (session.scrollbackBytes > MAX_SCROLLBACK_BYTES && session.scrollback.length > 0) {
+    const removed = session.scrollback.shift()!;
+    session.scrollbackBytes -= Buffer.byteLength(removed, 'utf8');
+  }
+}
+
 export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket }: TerminalHandlerDeps): TerminalHandlers {
   return {
     async onConnect(payload: unknown) {
@@ -52,16 +63,39 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
         return;
       }
 
-      // Kill any existing session for this socket (reconnect scenario)
-      const existing = sessionMap.get(socket.id);
-      if (existing) {
-        if (existing.reAuthInterval !== undefined) clearInterval(existing.reAuthInterval);
-        existing.releaseSlot();
-        existing.command.kill('SIGKILL');
-        sessionMap.delete(socket.id);
+      const { sessionKey } = authResult;
+
+      // Reattach to a live session that survived a previous navigation away.
+      const existingSession = sessionMap.getByKey(sessionKey);
+      if (existingSession) {
+        if (existingSession.idleTimer !== undefined) {
+          clearTimeout(existingSession.idleTimer);
+          existingSession.idleTimer = undefined;
+        }
+        existingSession.outputFn = (data) => socket.emit('terminal:output', { data });
+        existingSession.closedFn = (exitCode) => socket.emit('terminal:closed', { exitCode });
+        sessionMap.reattach(sessionKey, socket.id);
+        // Release the extra concurrency slot acquired by the re-auth check above.
+        authResult.releaseSlot();
+        socket.emit('terminal:ready', { scrollback: existingSession.scrollback.join('') });
+        return;
       }
 
+      // New session: spawn a fresh shell.
       const { sandboxId } = authResult;
+
+      const session: TerminalSession = {
+        command: null as unknown as PtyShell, // assigned below before any async
+        sandboxId,
+        sessionKey,
+        releaseSlot: authResult.releaseSlot,
+        outputFn: (data) => socket.emit('terminal:output', { data }),
+        closedFn: (exitCode) => socket.emit('terminal:closed', { exitCode }),
+        scrollback: [],
+        scrollbackBytes: 0,
+        reAuthInterval: undefined,
+        idleTimer: undefined,
+      };
 
       let shell: PtyShell;
       try {
@@ -69,14 +103,17 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
           sprite: authResult.sprite,
           cols: clampedCols,
           rows: clampedRows,
-          onOutput: (data) => socket.emit('terminal:output', { data }),
+          onOutput: (data) => {
+            appendScrollback(session, data);
+            session.outputFn(data);
+          },
           onExit: (exitCode) => {
-            const session = sessionMap.get(socket.id);
-            if (session?.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
-            session?.releaseSlot();
-            loggers.realtime.info('Terminal session closed', { exitCode, sandboxId, socketId: socket.id });
-            socket.emit('terminal:closed', { exitCode });
-            sessionMap.delete(socket.id);
+            if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
+            if (session.idleTimer !== undefined) clearTimeout(session.idleTimer);
+            session.releaseSlot();
+            loggers.realtime.info('Terminal session closed', { exitCode, sandboxId, sessionKey });
+            session.closedFn(exitCode);
+            sessionMap.deleteByKey(sessionKey);
           },
         });
       } catch {
@@ -85,35 +122,34 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
         return;
       }
 
-      sessionMap.set(socket.id, { command: shell, sandboxId: authResult.sandboxId, releaseSlot: authResult.releaseSlot });
+      session.command = shell;
+      sessionMap.setNew(sessionKey, socket.id, session);
 
       // Periodically re-check authorization while the session is alive.
-      // If access is revoked, kill the shell and close the terminal.
+      // Routes closed notification through closedFn so it reaches the current socket.
       const reAuthInterval = setInterval(async () => {
-        const liveSession = sessionMap.get(socket.id);
+        const liveSession = sessionMap.getByKey(sessionKey);
         if (!liveSession) { clearInterval(reAuthInterval); return; }
         const result = await checkAuth({ userId, pageId });
         if (!result.ok) {
           clearInterval(reAuthInterval);
+          if (liveSession.idleTimer !== undefined) clearTimeout(liveSession.idleTimer);
           liveSession.releaseSlot();
           liveSession.command.kill('SIGKILL');
-          sessionMap.delete(socket.id);
-          socket.emit('terminal:closed', { exitCode: -2 });
+          sessionMap.deleteByKey(sessionKey);
+          liveSession.closedFn(-2);
         } else {
-          // Re-auth check succeeded; release the slot acquired by re-auth (we already hold one).
           result.releaseSlot();
         }
       }, 60_000);
 
-      // Store the interval on the session so onDisconnect can clear it.
-      const session = sessionMap.get(socket.id);
-      if (session) session.reAuthInterval = reAuthInterval;
+      session.reAuthInterval = reAuthInterval;
 
-      socket.emit('terminal:ready');
+      socket.emit('terminal:ready', {});
     },
 
     onInput(payload: unknown) {
-      const session = sessionMap.get(socket.id);
+      const session = sessionMap.getBySocket(socket.id);
       if (!session) return;
       const p = payload as { data?: string };
       if (typeof p?.data === 'string' && p.data.length <= MAX_INPUT_BYTES) {
@@ -122,7 +158,7 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
     },
 
     onResize(payload: unknown) {
-      const session = sessionMap.get(socket.id);
+      const session = sessionMap.getBySocket(socket.id);
       if (!session) return;
       const p = payload as { cols?: number; rows?: number };
       if (typeof p?.cols === 'number' && typeof p?.rows === 'number' &&
@@ -133,12 +169,21 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
     },
 
     onDisconnect() {
-      const session = sessionMap.get(socket.id);
+      const session = sessionMap.getBySocket(socket.id);
       if (!session) return;
-      if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
-      session.releaseSlot();
-      session.command.kill('SIGKILL');
-      sessionMap.delete(socket.id);
+      const { sessionKey } = session;
+      // Silence output and detach from socket routing — shell keeps running.
+      session.outputFn = () => {};
+      session.closedFn = () => {};
+      sessionMap.detach(socket.id);
+      // Kill and release resources after idle timeout.
+      session.idleTimer = setTimeout(() => {
+        if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
+        session.releaseSlot();
+        session.command.kill('SIGKILL');
+        sessionMap.deleteByKey(sessionKey);
+        loggers.realtime.info('Terminal session reaped (idle)', { sessionKey, sandboxId: session.sandboxId });
+      }, DETACHED_IDLE_MS);
     },
   };
 }

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -1,27 +1,60 @@
+import type { PtyShell } from './sprites-shell';
+
+export const MAX_SCROLLBACK_BYTES = 64 * 1024;
+export const DETACHED_IDLE_MS = 30 * 60 * 1000;
+
 export type TerminalSession = {
-  command: {
-    write(data: string): void;
-    kill(signal?: string): void;
-    resize(cols: number, rows: number): void;
-  };
+  command: PtyShell;
   sandboxId: string;
+  sessionKey: string;
   reAuthInterval?: ReturnType<typeof setInterval>;
+  idleTimer?: ReturnType<typeof setTimeout>;
   releaseSlot(): void;
+  outputFn: (data: string) => void;
+  closedFn: (exitCode: number) => void;
+  scrollback: string[];
+  scrollbackBytes: number;
 };
 
 export type TerminalSessionMap = {
-  get(id: string): TerminalSession | undefined;
-  set(id: string, session: TerminalSession): void;
-  delete(id: string): void;
-  has(id: string): boolean;
+  getBySocket(socketId: string): TerminalSession | undefined;
+  getByKey(sessionKey: string): TerminalSession | undefined;
+  setNew(sessionKey: string, socketId: string, session: TerminalSession): void;
+  reattach(sessionKey: string, newSocketId: string): void;
+  detach(socketId: string): void;
+  deleteByKey(sessionKey: string): void;
 };
 
 export function createTerminalSessionMap(): TerminalSessionMap {
-  const store = new Map<string, TerminalSession>();
+  const bySocket = new Map<string, string>();        // socketId → sessionKey
+  const byKey = new Map<string, TerminalSession>();  // sessionKey → session
+
   return {
-    get: (id) => store.get(id),
-    set: (id, session) => { store.set(id, session); },
-    delete: (id) => { store.delete(id); },
-    has: (id) => store.has(id),
+    getBySocket(socketId) {
+      const key = bySocket.get(socketId);
+      return key !== undefined ? byKey.get(key) : undefined;
+    },
+    getByKey(sessionKey) {
+      return byKey.get(sessionKey);
+    },
+    setNew(sessionKey, socketId, session) {
+      byKey.set(sessionKey, session);
+      bySocket.set(socketId, sessionKey);
+    },
+    reattach(sessionKey, newSocketId) {
+      for (const [sid, key] of bySocket) {
+        if (key === sessionKey) { bySocket.delete(sid); break; }
+      }
+      bySocket.set(newSocketId, sessionKey);
+    },
+    detach(socketId) {
+      bySocket.delete(socketId);
+    },
+    deleteByKey(sessionKey) {
+      for (const [sid, key] of bySocket) {
+        if (key === sessionKey) { bySocket.delete(sid); break; }
+      }
+      byKey.delete(sessionKey);
+    },
   };
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -14,14 +14,22 @@ interface TerminalViewProps {
 
 const XtermTerminal = dynamic(() => import('./XtermTerminal'), { ssr: false });
 
+const SESSION_FLAG_KEY = (pageId: string) => `terminal-session:${pageId}`;
+
 const TerminalView = ({ pageId }: TerminalViewProps) => {
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isReconnect = typeof sessionStorage !== 'undefined' && !!sessionStorage.getItem(SESSION_FLAG_KEY(pageId));
   const socket = useSocket();
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
 
-  const handleReady = useCallback(() => setConnected(true), []);
+  const handleReady = useCallback(() => {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(SESSION_FLAG_KEY(pageId), '1');
+    }
+    setConnected(true);
+  }, [pageId]);
   const handleError = useCallback((message: string) => {
     setError(message);
     toast.error(`Terminal error: ${message}`);
@@ -60,7 +68,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
             ) : (
               <div className="flex items-center gap-2">
                 <div className="w-4 h-4 border-2 border-green-400 border-t-transparent rounded-full animate-spin" />
-                <span className="text-sm text-green-400">Connecting to shell...</span>
+                <span className="text-sm text-green-400">{isReconnect ? 'Reconnecting to shell...' : 'Connecting to shell...'}</span>
               </div>
             )}
           </div>

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
@@ -37,7 +37,10 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
         const onData = terminal.onData((data) => socket.emit('terminal:input', { data }));
 
         const handleOutput = ({ data }: { data: string }) => terminal.write(data);
-        const handleReady = () => onReady?.();
+        const handleReady = ({ scrollback }: { scrollback?: string } = {}) => {
+          if (scrollback) terminal.write(scrollback);
+          onReady?.();
+        };
         const handleClosed = ({ exitCode }: { exitCode: number }) =>
           terminal.writeln(`\r\n\x1b[90mProcess exited with code ${exitCode}\x1b[0m`);
         const handleError = ({ message }: { message: string }) => {
@@ -67,7 +70,6 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
           socket.off('terminal:ready', handleReady);
           socket.off('terminal:closed', handleClosed);
           socket.off('terminal:error', handleError);
-          socket.emit('terminal:disconnect');
           terminal.dispose();
         };
 

--- a/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
@@ -237,7 +237,8 @@ describe('acquireTerminalSandbox', () => {
       canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: false });
+    if (result.ok) expect(result.sessionKey).toBe(keyFor());
     expect(calls.getOrCreate).toMatchObject([{ name: keyFor() }]);
     expect(storeCalls.save).toBe(1);
   });
@@ -250,7 +251,8 @@ describe('acquireTerminalSandbox', () => {
       canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: true });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: true });
+    if (result.ok) expect(result.sessionKey).toBe(keyFor());
     // getOrCreate is used for reconnects (reapplies policy); get is never called.
     expect(calls.getOrCreate).toMatchObject([{ name: keyFor() }]);
     expect(calls.get).toEqual([]);
@@ -268,7 +270,7 @@ describe('acquireTerminalSandbox', () => {
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
     // getOrCreate handles the VM-gone case transparently — no explicit remove + re-provision.
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: true });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: true });
     expect(calls.getOrCreate).toMatchObject([{ name: keyFor() }]);
     expect(storeCalls.remove).toBe(0);
     expect(storeCalls.touch).toBe(1);
@@ -299,7 +301,7 @@ describe('acquireTerminalSandbox', () => {
       canRun: false,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: false, reason: 'deny' });
+    expect(result).toMatchObject({ ok: false, reason: 'deny' });
     expect(calls.get).toEqual([]);
     expect(calls.getOrCreate).toEqual([]);
     expect(calls.stop).toEqual([]);
@@ -317,7 +319,7 @@ describe('acquireTerminalSandbox', () => {
       canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: true });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: true });
     expect(calls.getOrCreate).toMatchObject([{ name: keyFor() }]);
     expect(calls.get).toEqual([]);
     expect(calls.stop).toEqual([]);
@@ -332,7 +334,7 @@ describe('acquireTerminalSandbox', () => {
       canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: false });
     expect(calls.getOrCreate).toHaveLength(1);
     expect(calls.getOrCreate[0].options).toMatchObject({ egressMode: 'open' });
     // The tight SANDBOX_EGRESS_ALLOWLIST must NOT appear on the terminal path.
@@ -349,7 +351,7 @@ describe('acquireTerminalSandbox', () => {
       canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: true });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: true });
     expect(calls.getOrCreate).toHaveLength(1);
     expect(calls.getOrCreate[0].options).toMatchObject({ egressMode: 'open' });
     expect(calls.get).toEqual([]);
@@ -367,7 +369,7 @@ describe('acquireTerminalSandbox', () => {
       canRun: true,
       deps: { store, client, now: () => NOW, secret: SECRET },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: true });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new', resumed: true });
     expect(calls.getOrCreate).toMatchObject([{ name: keyFor() }]);
     expect(storeCalls.remove).toBe(0);
     expect(storeCalls.touch).toBe(1);

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -120,7 +120,7 @@ export interface AcquireTerminalSandboxInput {
 }
 
 export type AcquireTerminalSandboxResult =
-  | { ok: true; sandboxId: string; resumed: boolean }
+  | { ok: true; sandboxId: string; sessionKey: string; resumed: boolean }
   | { ok: false; reason: 'deny' | 'provision_failed' | 'error'; cause?: unknown };
 
 async function safeStop(client: SandboxClient, sandboxId: string): Promise<boolean> {
@@ -189,7 +189,7 @@ async function provisionFreshTerminal({
     return { ok: false, reason: 'provision_failed', cause: error };
   }
 
-  return { ok: true, sandboxId, resumed: false };
+  return { ok: true, sandboxId, sessionKey: key, resumed: false };
 }
 
 export async function acquireTerminalSandbox(
@@ -233,7 +233,7 @@ export async function acquireTerminalSandbox(
       try {
         const handle = await deps.client.getOrCreate({ name: key, options: TERMINAL_SANDBOX_OPTIONS });
         await safeTouch(deps.store, key, deps.now());
-        return { ok: true, sandboxId: handle.sandboxId, resumed: true };
+        return { ok: true, sandboxId: handle.sandboxId, sessionKey: key, resumed: true };
       } catch (error) {
         const meta = { reason: 'provision_failed', userId, pageId, driveId };
         if (error instanceof Error) {


### PR DESCRIPTION
## Summary

- **Shell survives navigation**: when a user navigates away from a terminal page, the bash process keeps running in the Fly Sprites sandbox instead of being killed immediately
- **Instant reconnect with scrollback**: navigating back reattaches to the live session in <1 round trip and replays up to 64KB of recent output so you see where you left off
- **30-minute idle reap**: detached sessions are cleaned up after 30 minutes with no reconnect (kills shell, releases concurrency slot)

## What changed

### Core model change
`TerminalSessionMap` redesigned from `Map<socketId, session>` to a two-level map (`socketId → sessionKey` routing + `sessionKey → session` storage). Sessions now outlive their originating socket connection.

### Server (`apps/realtime`)
- `terminal-session-map.ts` — new API: `getBySocket`, `getByKey`, `setNew`, `reattach`, `detach`, `deleteByKey`
- `terminal-handler.ts` — `onDisconnect` detaches socket + starts idle timer (no kill); `onConnect` reattaches to live session if one exists for the same `sessionKey`
- `index.ts` — exposes `sessionKey` in `makeTerminalCheckAuth` return value

### Lib (`packages/lib`)
- `terminal-session-manager.ts` — `AcquireTerminalSandboxResult` `ok:true` branch now includes `sessionKey`

### Frontend (`apps/web`)
- `XtermTerminal.tsx` — `terminal:ready` accepts optional `{ scrollback }` payload; removed `terminal:disconnect` emit on unmount
- `TerminalView.tsx` — shows "Reconnecting to shell…" vs "Connecting to shell…" based on `sessionStorage` flag per page

## Test plan

- [ ] Run a long-running process (`sleep 1000` or `watch date`) in a terminal page
- [ ] Navigate to another page and back — should reconnect in <1s with scrollback visible and process still running
- [ ] Hard-refresh the browser — should reattach to the same session
- [ ] Wait 30+ min idle → navigate back → should start a fresh shell
- [ ] `bun run test --filter realtime` — 413 tests pass
- [ ] `bun run test --filter '@pagespace/lib'` — 5556 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U31oCbTghgXHprfX2sWJZN