### PR TITLE
feat(publish): custom-domain canonical/OG/sitemap host + tier caps (PR5)

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
@@ -58,6 +58,11 @@ vi.mock('@/lib/canvas/custom-domain-mirror', () => ({
   clearCustomHost: (...args: unknown[]) => clearCustomHost(...args),
 }));
 
+const regeneratePublishedSiteFiles = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/canvas/publish-page', () => ({
+  regeneratePublishedSiteFiles: (...args: unknown[]) => regeneratePublishedSiteFiles(...args),
+}));
+
 const DRIVE_ID = 'drive-1';
 const DOMAIN_ID = 'dom-1';
 const USER_ID = 'user-1';
@@ -306,6 +311,15 @@ describe('POST /api/drives/[driveId]/domains/[domainId]/cert/refresh', () => {
       await POST(makeReq(), ctx());
 
       expect(mirrorDriveToCustomHost).toHaveBeenCalledWith(DRIVE_ID, 'docs.acme.com');
+    });
+
+    it('regenerates site files before mirroring when domain becomes active', async () => {
+      setupSelectReturning([VERIFIED_DOMAIN]);
+      addCertificate.mockResolvedValue({ ok: true, configured: true });
+
+      await POST(makeReq(), ctx());
+
+      expect(regeneratePublishedSiteFiles).toHaveBeenCalledWith(DRIVE_ID);
     });
 
     it('triggers mirrorDriveToCustomHost when provisioning domain becomes active', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
@@ -377,5 +377,17 @@ describe('POST /api/drives/[driveId]/domains/[domainId]/cert/refresh', () => {
 
       expect(clearCustomHost).not.toHaveBeenCalled();
     });
+
+    it('returns 200 (not 500) when clearCustomHost throws — status already committed to DB', async () => {
+      setupSelectReturning([ACTIVE_DOMAIN]);
+      addCertificate.mockResolvedValue({ ok: false, error: 'Fly cert revoked' });
+      clearCustomHost.mockRejectedValueOnce(new Error('S3 down'));
+
+      const res = await POST(makeReq(), ctx());
+
+      expect(res.status).toBe(200);
+      const body = await res.json() as { status: string };
+      expect(body.status).toBe('cert_failed');
+    });
   });
 });

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
@@ -350,7 +350,7 @@ describe('POST /api/drives/[driveId]/domains/[domainId]/cert/refresh', () => {
     });
   });
 
-  describe('mirror cleanup on deactivation (active → cert_failed)', () => {
+  describe('mirror cleanup on cert_failed (any status → cert_failed)', () => {
     it('calls clearCustomHost when an active domain transitions to cert_failed', async () => {
       setupSelectReturning([ACTIVE_DOMAIN]);
       addCertificate.mockResolvedValue({ ok: false, error: 'Fly cert revoked' });
@@ -360,13 +360,13 @@ describe('POST /api/drives/[driveId]/domains/[domainId]/cert/refresh', () => {
       expect(clearCustomHost).toHaveBeenCalledWith('docs.acme.com');
     });
 
-    it('does NOT call clearCustomHost when a non-active domain transitions to cert_failed', async () => {
+    it('calls clearCustomHost even when a non-active domain transitions to cert_failed (idempotent retry)', async () => {
       setupSelectReturning([VERIFIED_DOMAIN]);
       addCertificate.mockResolvedValue({ ok: false, error: 'Fly error' });
 
       await POST(makeReq(), ctx());
 
-      expect(clearCustomHost).not.toHaveBeenCalled();
+      expect(clearCustomHost).toHaveBeenCalledWith('docs.acme.com');
     });
 
     it('does NOT call clearCustomHost when an active domain stays active (re-check succeeds)', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/__tests__/route.test.ts
@@ -52,8 +52,10 @@ vi.mock('@pagespace/db/schema/custom-domains', () => ({
 }));
 
 const mirrorDriveToCustomHost = vi.fn().mockResolvedValue(undefined);
+const clearCustomHost = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/lib/canvas/custom-domain-mirror', () => ({
   mirrorDriveToCustomHost: (...args: unknown[]) => mirrorDriveToCustomHost(...args),
+  clearCustomHost: (...args: unknown[]) => clearCustomHost(...args),
 }));
 
 const DRIVE_ID = 'drive-1';
@@ -331,6 +333,35 @@ describe('POST /api/drives/[driveId]/domains/[domainId]/cert/refresh', () => {
       await POST(makeReq(), ctx());
 
       expect(mirrorDriveToCustomHost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mirror cleanup on deactivation (active → cert_failed)', () => {
+    it('calls clearCustomHost when an active domain transitions to cert_failed', async () => {
+      setupSelectReturning([ACTIVE_DOMAIN]);
+      addCertificate.mockResolvedValue({ ok: false, error: 'Fly cert revoked' });
+
+      await POST(makeReq(), ctx());
+
+      expect(clearCustomHost).toHaveBeenCalledWith('docs.acme.com');
+    });
+
+    it('does NOT call clearCustomHost when a non-active domain transitions to cert_failed', async () => {
+      setupSelectReturning([VERIFIED_DOMAIN]);
+      addCertificate.mockResolvedValue({ ok: false, error: 'Fly error' });
+
+      await POST(makeReq(), ctx());
+
+      expect(clearCustomHost).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call clearCustomHost when an active domain stays active (re-check succeeds)', async () => {
+      setupSelectReturning([ACTIVE_DOMAIN]);
+      addCertificate.mockResolvedValue({ ok: true, configured: true });
+
+      await POST(makeReq(), ctx());
+
+      expect(clearCustomHost).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
@@ -14,6 +14,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
 import { mirrorDriveToCustomHost, clearCustomHost } from '@/lib/canvas/custom-domain-mirror';
+import { regeneratePublishedSiteFiles } from '@/lib/canvas/publish-page';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -67,10 +68,11 @@ export async function POST(
       .where(eq(customDomains.id, domainId));
 
     // When the cert is freshly provisioned and the domain just became active,
-    // backfill all currently-published artifacts to the custom-host prefix so
-    // the site is immediately ready to serve. Best-effort: failure does not
-    // roll back the status update.
+    // regenerate site files first (so sitemap/robots embed the custom domain as
+    // primary host), then backfill all currently-published artifacts to the
+    // custom-host prefix. Best-effort: failure does not roll back the status update.
     if (nextStatus === 'active' && domain.status !== 'active') {
+      await regeneratePublishedSiteFiles(driveId);
       mirrorDriveToCustomHost(driveId, domain.hostname).catch((err) => {
         loggers.api.warn('Failed to backfill artifacts after cert activation', {
           driveId,
@@ -83,12 +85,7 @@ export async function POST(
     // When an active domain transitions to cert_failed, purge its mirrored
     // prefix so stale content is not served until the cert is recovered.
     if (domain.status === 'active' && nextStatus === 'cert_failed') {
-      clearCustomHost(domain.hostname).catch((err) => {
-        loggers.api.warn('Failed to clear custom host artifacts after cert failure', {
-          hostname: domain.hostname,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+      await clearCustomHost(domain.hostname);
     }
 
     auditRequest(request, {

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
@@ -13,7 +13,7 @@ import { addCertificate } from '@/lib/fly/certs';
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
-import { mirrorDriveToCustomHost } from '@/lib/canvas/custom-domain-mirror';
+import { mirrorDriveToCustomHost, clearCustomHost } from '@/lib/canvas/custom-domain-mirror';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -74,6 +74,17 @@ export async function POST(
       mirrorDriveToCustomHost(driveId, domain.hostname).catch((err) => {
         loggers.api.warn('Failed to backfill artifacts after cert activation', {
           driveId,
+          hostname: domain.hostname,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+
+    // When an active domain transitions to cert_failed, purge its mirrored
+    // prefix so stale content is not served until the cert is recovered.
+    if (domain.status === 'active' && nextStatus === 'cert_failed') {
+      clearCustomHost(domain.hostname).catch((err) => {
+        loggers.api.warn('Failed to clear custom host artifacts after cert failure', {
           hostname: domain.hostname,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
@@ -84,8 +84,18 @@ export async function POST(
 
     // When an active domain transitions to cert_failed, purge its mirrored
     // prefix so stale content is not served until the cert is recovered.
+    // Awaited so the response reflects completion, but failures are caught and
+    // logged rather than thrown — the DB status is already committed and the
+    // caller should not get a 500 for a best-effort storage cleanup.
     if (domain.status === 'active' && nextStatus === 'cert_failed') {
-      await clearCustomHost(domain.hostname);
+      try {
+        await clearCustomHost(domain.hostname);
+      } catch (err) {
+        loggers.api.warn('Failed to clear custom host artifacts after cert failure', {
+          hostname: domain.hostname,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
 
     auditRequest(request, {

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
@@ -82,12 +82,14 @@ export async function POST(
       });
     }
 
-    // When an active domain transitions to cert_failed, purge its mirrored
-    // prefix so stale content is not served until the cert is recovered.
-    // Awaited so the response reflects completion, but failures are caught and
-    // logged rather than thrown — the DB status is already committed and the
-    // caller should not get a 500 for a best-effort storage cleanup.
-    if (domain.status === 'active' && nextStatus === 'cert_failed') {
+    // When a domain transitions to cert_failed, purge its mirrored prefix so
+    // stale content is not served until the cert is recovered. Run on every
+    // cert_failed outcome (not just active → cert_failed) so that retries
+    // after a failed clearCustomHost() still clean up — the delete is
+    // idempotent/no-op when nothing remains.
+    // Awaited with errors caught and logged so a storage failure doesn't return
+    // 500 when the DB status has already been committed.
+    if (nextStatus === 'cert_failed') {
       try {
         await clearCustomHost(domain.hostname);
       } catch (err) {

--- a/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
@@ -26,10 +26,12 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 const dbSelect = vi.fn();
 const dbInsert = vi.fn();
+const dbTransaction = vi.fn();
 vi.mock('@pagespace/db/db', () => ({
   db: {
     select: (...args: unknown[]) => dbSelect(...args),
     insert: (...args: unknown[]) => dbInsert(...args),
+    transaction: (...args: unknown[]) => dbTransaction(...args),
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
@@ -70,12 +72,18 @@ const makeReq = (body?: unknown): Request =>
   } as unknown as Request);
 const ctx = (driveId = DRIVE_ID) => ({ params: Promise.resolve({ driveId }) });
 
-/** Mock for POST: owner tier + count in separate selects. */
+/**
+ * Mock for POST: three sequential dbSelect calls inside the handler.
+ *  1. Tier lookup (outside transaction): drives JOIN users → [{tier}]
+ *  2. Drive row lock (inside transaction): SELECT drives.id FOR UPDATE
+ *  3. Count query (inside transaction): SELECT count() FROM customDomains
+ */
 function mockPostSelects({ ownerTier = 'pro', domainCount = 0 } = {}) {
   let callIndex = 0;
   dbSelect.mockImplementation(() => {
     callIndex++;
     if (callIndex === 1) {
+      // Tier lookup
       return {
         from: vi.fn().mockReturnThis(),
         innerJoin: vi.fn().mockReturnThis(),
@@ -83,13 +91,18 @@ function mockPostSelects({ ownerTier = 'pro', domainCount = 0 } = {}) {
         limit: vi.fn().mockResolvedValue([{ tier: ownerTier }]),
       };
     }
-    // Count query
+    if (callIndex === 2) {
+      // Drive row lock: tx.select({id}).from(drives).where().for('update')
+      return {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        for: vi.fn().mockResolvedValue([{ id: DRIVE_ID }]),
+      };
+    }
+    // Count query: tx.select({n}).from(customDomains).where()
     return {
       from: vi.fn().mockReturnThis(),
-      where: vi.fn().mockReturnThis().mockImplementation(function (this: unknown) {
-        return Promise.resolve([{ n: domainCount }]);
-      }),
-      then: vi.fn((cb: (v: unknown) => unknown) => Promise.resolve(cb([{ n: domainCount }]))),
+      where: vi.fn().mockResolvedValue([{ n: domainCount }]),
     };
   });
 }
@@ -99,6 +112,13 @@ beforeEach(() => {
   authenticateRequestWithOptions.mockResolvedValue(mockAuth);
   checkMCPDriveScope.mockReturnValue(null);
   isPrincipalDriveOwnerOrAdmin.mockResolvedValue(true);
+  // Default transaction: pass a tx stub that delegates to the same dbSelect/dbInsert mocks.
+  dbTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
+    cb({
+      select: (...args: unknown[]) => dbSelect(...args),
+      insert: (...args: unknown[]) => dbInsert(...args),
+    }),
+  );
 });
 
 // ── GET ──────────────────────────────────────────────────────────────────────

--- a/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
@@ -35,6 +35,7 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
   and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  count: vi.fn(() => ({ _count: true })),
 }));
 vi.mock('@pagespace/db/schema/custom-domains', () => ({
   customDomains: {
@@ -45,6 +46,20 @@ vi.mock('@pagespace/db/schema/custom-domains', () => ({
     createdAt: 'col_createdAt',
   },
 }));
+vi.mock('@pagespace/db/schema/core', () => ({
+  drives: { id: 'col_drives_id', ownerId: 'col_drives_ownerId' },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'col_users_id', subscriptionTier: 'col_subscriptionTier' },
+}));
+
+vi.mock('@/lib/subscription/plans', () => ({
+  getPlan: vi.fn((tier: string) => ({
+    limits: {
+      maxCustomDomains: tier === 'free' ? 0 : tier === 'pro' ? 1 : tier === 'founder' ? 3 : 10,
+    },
+  })),
+}));
 
 const DRIVE_ID = 'drive-1';
 const USER_ID = 'user-1';
@@ -54,6 +69,30 @@ const makeReq = (body?: unknown): Request =>
     json: () => Promise.resolve(body ?? {}),
   } as unknown as Request);
 const ctx = (driveId = DRIVE_ID) => ({ params: Promise.resolve({ driveId }) });
+
+/** Mock for POST: owner tier + count in separate selects. */
+function mockPostSelects({ ownerTier = 'pro', domainCount = 0 } = {}) {
+  let callIndex = 0;
+  dbSelect.mockImplementation(() => {
+    callIndex++;
+    if (callIndex === 1) {
+      return {
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([{ tier: ownerTier }]),
+      };
+    }
+    // Count query
+    return {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis().mockImplementation(function (this: unknown) {
+        return Promise.resolve([{ n: domainCount }]);
+      }),
+      then: vi.fn((cb: (v: unknown) => unknown) => Promise.resolve(cb([{ n: domainCount }]))),
+    };
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -83,10 +122,19 @@ describe('GET /api/drives/[driveId]/domains', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns domains list on success', async () => {
+  it('returns domains list and limit on success', async () => {
     const fakeDomains = [{ id: 'd1', driveId: DRIVE_ID, hostname: 'acme.com', status: 'pending', createdAt: new Date() }];
-    dbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(fakeDomains) }),
+    // Promise.all([domains_select, getMaxCustomDomainsForDrive()]) evaluates synchronously:
+    // call 1 = domain list (first item in the array); call 2 = tier lookup (inside helper)
+    let callIndex = 0;
+    dbSelect.mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        // domain list
+        return { from: vi.fn().mockReturnThis(), where: vi.fn().mockResolvedValue(fakeDomains) };
+      }
+      // owner tier lookup
+      return { from: vi.fn().mockReturnThis(), innerJoin: vi.fn().mockReturnThis(), where: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue([{ tier: 'pro' }]) };
     });
 
     const res = await GET(makeReq(), ctx());
@@ -94,12 +142,16 @@ describe('GET /api/drives/[driveId]/domains', () => {
     expect(res.status).toBe(200);
     expect(body.domains).toHaveLength(1);
     expect(body.domains[0].hostname).toBe('acme.com');
+    expect(body.limit).toBe(1); // pro tier = 1
   });
 
   it('returns 500 on unexpected db error', async () => {
-    dbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({ where: vi.fn().mockRejectedValue(new Error('db down')) }),
-    });
+    dbSelect.mockImplementation(() => ({
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockRejectedValue(new Error('db down')),
+      limit: vi.fn().mockRejectedValue(new Error('db down')),
+    }));
     const res = await GET(makeReq(), ctx());
     expect(res.status).toBe(500);
   });
@@ -135,7 +187,35 @@ describe('POST /api/drives/[driveId]/domains', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 403 when the free tier tries to add a domain', async () => {
+    mockPostSelects({ ownerTier: 'free', domainCount: 0 });
+
+    const res = await POST(makeReq({ hostname: 'acme.com' }), ctx());
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/not available on your current plan/i);
+  });
+
+  it('returns 403 when the drive is at the pro tier cap (1 domain)', async () => {
+    mockPostSelects({ ownerTier: 'pro', domainCount: 1 });
+
+    const res = await POST(makeReq({ hostname: 'newdomain.com' }), ctx());
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/maximum of 1 custom domain/i);
+  });
+
+  it('returns 403 when the drive is at the founder tier cap (3 domains)', async () => {
+    mockPostSelects({ ownerTier: 'founder', domainCount: 3 });
+
+    const res = await POST(makeReq({ hostname: 'fourth.com' }), ctx());
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/maximum of 3 custom domains/i);
+  });
+
   it('normalizes the hostname before insert (strips scheme/path)', async () => {
+    mockPostSelects({ ownerTier: 'pro', domainCount: 0 });
     const inserted = { id: 'dom-1', driveId: DRIVE_ID, hostname: 'acme.com', status: 'pending', createdAt: new Date() };
     const returningMock = vi.fn().mockResolvedValue([inserted]);
     const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
@@ -145,7 +225,8 @@ describe('POST /api/drives/[driveId]/domains', () => {
     expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ hostname: 'acme.com' }));
   });
 
-  it('returns 201 + domain on success', async () => {
+  it('returns 201 + domain on success (pro tier, 0 existing)', async () => {
+    mockPostSelects({ ownerTier: 'pro', domainCount: 0 });
     const inserted = { id: 'dom-1', driveId: DRIVE_ID, hostname: 'acme.com', status: 'pending', createdAt: new Date() };
     const returningMock = vi.fn().mockResolvedValue([inserted]);
     dbInsert.mockReturnValue({ values: vi.fn().mockReturnValue({ returning: returningMock }) });
@@ -157,6 +238,7 @@ describe('POST /api/drives/[driveId]/domains', () => {
   });
 
   it('calls auditRequest on success', async () => {
+    mockPostSelects({ ownerTier: 'business', domainCount: 0 });
     const inserted = { id: 'dom-1', driveId: DRIVE_ID, hostname: 'acme.com', status: 'pending', createdAt: new Date() };
     dbInsert.mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([inserted]) }) });
 
@@ -167,7 +249,8 @@ describe('POST /api/drives/[driveId]/domains', () => {
     }));
   });
 
-  it('returns 409 when hostname is already registered', async () => {
+  it('returns 409 when hostname is already registered (cross-drive duplicate)', async () => {
+    mockPostSelects({ ownerTier: 'pro', domainCount: 0 });
     const uniqueErr = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
     dbInsert.mockReturnValue({
       values: vi.fn().mockReturnValue({

--- a/apps/web/src/app/api/drives/[driveId]/domains/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/route.ts
@@ -10,8 +10,12 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { normalizeHostname, validateCustomDomain } from '@pagespace/lib/validators/custom-domain';
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { eq, count } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
+import { drives } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { getPlan } from '@/lib/subscription/plans';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -19,6 +23,19 @@ const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: tr
 const addDomainSchema = z.object({
   hostname: z.string().min(1),
 });
+
+/** Resolve the maximum custom domains allowed for the drive owner's tier. */
+async function getMaxCustomDomainsForDrive(driveId: string): Promise<number> {
+  const [row] = await db
+    .select({ tier: users.subscriptionTier })
+    .from(drives)
+    .innerJoin(users, eq(drives.ownerId, users.id))
+    .where(eq(drives.id, driveId))
+    .limit(1);
+
+  const tier = ((row?.tier ?? 'free') as SubscriptionTier);
+  return getPlan(tier).limits.maxCustomDomains;
+}
 
 export async function GET(
   request: Request,
@@ -36,8 +53,12 @@ export async function GET(
       return NextResponse.json({ error: 'Only drive owners and admins can view custom domains' }, { status: 403 });
     }
 
-    const domains = await db.select().from(customDomains).where(eq(customDomains.driveId, driveId));
-    return NextResponse.json({ domains });
+    const [domains, limit] = await Promise.all([
+      db.select().from(customDomains).where(eq(customDomains.driveId, driveId)),
+      getMaxCustomDomainsForDrive(driveId),
+    ]);
+
+    return NextResponse.json({ domains, limit });
   } catch (error) {
     loggers.api.error('Error listing custom domains:', error as Error);
     return NextResponse.json({ error: 'Failed to list domains' }, { status: 500 });
@@ -76,6 +97,26 @@ export async function POST(
     const validation = validateCustomDomain(hostname);
     if (!validation.valid) {
       return NextResponse.json({ error: validation.reason }, { status: 400 });
+    }
+
+    // Enforce tier cap: check the drive owner's plan limit and the current domain count.
+    const [maxAllowed, existingCount] = await Promise.all([
+      getMaxCustomDomainsForDrive(driveId),
+      db.select({ n: count() }).from(customDomains).where(eq(customDomains.driveId, driveId)).then((rows) => rows[0]?.n ?? 0),
+    ]);
+
+    if (maxAllowed === 0) {
+      return NextResponse.json(
+        { error: 'Custom domains are not available on your current plan. Upgrade to add a custom domain.' },
+        { status: 403 },
+      );
+    }
+
+    if (existingCount >= maxAllowed) {
+      return NextResponse.json(
+        { error: `Your plan allows a maximum of ${maxAllowed} custom domain${maxAllowed === 1 ? '' : 's'} per drive.` },
+        { status: 403 },
+      );
     }
 
     try {

--- a/apps/web/src/app/api/drives/[driveId]/domains/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/route.ts
@@ -99,11 +99,9 @@ export async function POST(
       return NextResponse.json({ error: validation.reason }, { status: 400 });
     }
 
-    // Enforce tier cap: check the drive owner's plan limit and the current domain count.
-    const [maxAllowed, existingCount] = await Promise.all([
-      getMaxCustomDomainsForDrive(driveId),
-      db.select({ n: count() }).from(customDomains).where(eq(customDomains.driveId, driveId)).then((rows) => rows[0]?.n ?? 0),
-    ]);
+    // Enforce tier cap: check the drive owner's plan limit outside the transaction
+    // (subscription tier doesn't change mid-request).
+    const maxAllowed = await getMaxCustomDomainsForDrive(driveId);
 
     if (maxAllowed === 0) {
       return NextResponse.json(
@@ -112,31 +110,48 @@ export async function POST(
       );
     }
 
-    if (existingCount >= maxAllowed) {
-      return NextResponse.json(
-        { error: `Your plan allows a maximum of ${maxAllowed} custom domain${maxAllowed === 1 ? '' : 's'} per drive.` },
-        { status: 403 },
-      );
-    }
-
+    // Atomic count-check + insert. Lock the drive row first to serialize
+    // concurrent requests on the same drive and prevent over-the-cap inserts.
+    let inserted: { id: string; driveId: string; hostname: string; status: string; createdAt: Date };
     try {
-      const [inserted] = await db.insert(customDomains).values({ driveId, hostname }).returning();
+      const rows = await db.transaction(async (tx) => {
+        await tx.select({ id: drives.id }).from(drives).where(eq(drives.id, driveId)).for('update');
 
-      auditRequest(request, {
-        eventType: 'data.write',
-        userId: auth.userId,
-        resourceType: 'drive',
-        resourceId: driveId,
-        details: { operation: 'add-custom-domain', hostname },
+        const [countRow] = await tx.select({ n: count() }).from(customDomains).where(eq(customDomains.driveId, driveId));
+        const existingCount = countRow?.n ?? 0;
+
+        if (existingCount >= maxAllowed) {
+          const e = Object.assign(new Error('at cap'), { code: 'cap_exceeded', maxAllowed });
+          throw e;
+        }
+
+        return tx.insert(customDomains).values({ driveId, hostname }).returning();
       });
-
-      return NextResponse.json({ domain: inserted }, { status: 201 });
+      inserted = rows[0];
     } catch (err) {
-      if ((err as { code?: string }).code === '23505') {
+      const anyErr = err as { code?: string; maxAllowed?: number };
+      if (anyErr.code === 'cap_exceeded') {
+        const max = anyErr.maxAllowed!;
+        return NextResponse.json(
+          { error: `Your plan allows a maximum of ${max} custom domain${max === 1 ? '' : 's'} per drive.` },
+          { status: 403 },
+        );
+      }
+      if (anyErr.code === '23505') {
         return NextResponse.json({ error: 'Domain is already registered' }, { status: 409 });
       }
       throw err;
     }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { operation: 'add-custom-domain', hostname },
+    });
+
+    return NextResponse.json({ domain: inserted }, { status: 201 });
   } catch (error) {
     loggers.api.error('Error adding custom domain:', error as Error);
     return NextResponse.json({ error: 'Failed to add domain' }, { status: 500 });

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -74,6 +74,13 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
 
+vi.mock('@/lib/canvas/custom-domain-mirror', () => ({
+  mirrorPublishedPageToHosts: vi.fn().mockResolvedValue(undefined),
+  mirror404ToHosts: vi.fn().mockResolvedValue(undefined),
+  deletePageFromCustomHosts: vi.fn().mockResolvedValue(undefined),
+  getActiveDomainRecords: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ eq: [a, b] })),
   and: vi.fn((...args: unknown[]) => ({ and: args })),

--- a/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx
@@ -49,6 +49,8 @@ interface CustomDomain {
 
 interface DomainsResponse {
   domains: CustomDomain[];
+  /** Maximum custom domains allowed by the drive owner's plan (0 = not available). */
+  limit: number;
 }
 
 const fetcher = (url: string) => fetchWithAuth(url).then((r) => r.json());
@@ -134,6 +136,8 @@ export default function GeneralSettingsPage() {
         const data = await res.json().catch(() => ({})) as { error?: string };
         if (res.status === 409) {
           toast.error('That domain is already registered');
+        } else if (res.status === 403) {
+          toast.error(data.error ?? 'Custom domains are not available on your current plan');
         } else {
           toast.error(data.error ?? 'Failed to add domain');
         }
@@ -416,6 +420,7 @@ export default function GeneralSettingsPage() {
 
       <CustomDomainsCard
         domains={domainsData?.domains ?? []}
+        limit={domainsData?.limit ?? null}
         newDomain={newDomain}
         onNewDomainChange={setNewDomain}
         onAdd={handleAddDomain}
@@ -436,6 +441,8 @@ export default function GeneralSettingsPage() {
 
 interface CustomDomainsCardProps {
   domains: CustomDomain[];
+  /** null = still loading; 0 = not available on plan; N = max allowed */
+  limit: number | null;
   newDomain: string;
   onNewDomainChange: (v: string) => void;
   onAdd: () => void;
@@ -453,34 +460,60 @@ const EDGE_IPV4 = process.env.NEXT_PUBLIC_PUBLISH_EDGE_IPV4 ?? '';
 const EDGE_IPV6 = process.env.NEXT_PUBLIC_PUBLISH_EDGE_IPV6 ?? '';
 const CNAME_TARGET = process.env.NEXT_PUBLIC_PUBLISH_EDGE_CNAME_TARGET ?? '';
 
-function CustomDomainsCard({ domains, newDomain, onNewDomainChange, onAdd, onRemove, onVerify, onRefreshCert, isAdding, removingId, verifyingId, refreshingCertId, verifyReasons }: CustomDomainsCardProps) {
+function CustomDomainsCard({ domains, limit, newDomain, onNewDomainChange, onAdd, onRemove, onVerify, onRefreshCert, isAdding, removingId, verifyingId, refreshingCertId, verifyReasons }: CustomDomainsCardProps) {
+  const atCap = limit !== null && limit > 0 && domains.length >= limit;
+  const notAvailable = limit === 0;
+  const addDisabled = isAdding || !newDomain.trim() || atCap || notAvailable;
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Globe className="h-4 w-4" />
-          Custom Domains
-        </CardTitle>
-        <CardDescription>
-          Point your own domain at this drive&apos;s published canvas site
-        </CardDescription>
+        <div className="flex items-start justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Globe className="h-4 w-4" />
+              Custom Domains
+            </CardTitle>
+            <CardDescription>
+              Point your own domain at this drive&apos;s published canvas site
+            </CardDescription>
+          </div>
+          {limit !== null && limit > 0 && (
+            <span className="text-xs text-muted-foreground tabular-nums mt-1">
+              {domains.length} / {limit}
+            </span>
+          )}
+        </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex gap-2">
-          <Label htmlFor="new-custom-domain" className="sr-only">Custom domain</Label>
-          <Input
-            id="new-custom-domain"
-            placeholder="e.g. docs.acme.com or acme.com"
-            value={newDomain}
-            onChange={(e) => onNewDomainChange(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && onAdd()}
-            className="flex-1"
-          />
-          <Button onClick={onAdd} disabled={isAdding || !newDomain.trim()}>
-            {isAdding ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-            Add
-          </Button>
-        </div>
+        {notAvailable ? (
+          <p className="text-sm text-muted-foreground">
+            Custom domains are not available on your current plan. Upgrade to Pro or higher to add a custom domain.
+          </p>
+        ) : (
+          <div className="flex gap-2">
+            <Label htmlFor="new-custom-domain" className="sr-only">Custom domain</Label>
+            <Input
+              id="new-custom-domain"
+              placeholder="e.g. docs.acme.com or acme.com"
+              value={newDomain}
+              onChange={(e) => onNewDomainChange(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && !addDisabled && onAdd()}
+              className="flex-1"
+              disabled={atCap}
+            />
+            <Button onClick={onAdd} disabled={addDisabled}>
+              {isAdding ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+              Add
+            </Button>
+          </div>
+        )}
+
+        {atCap && !notAvailable && (
+          <p className="text-xs text-muted-foreground">
+            Domain limit reached ({domains.length} / {limit}). Remove a domain to add another, or upgrade your plan.
+          </p>
+        )}
 
         {domains.length > 0 ? (
           <div className="space-y-3">
@@ -500,7 +533,7 @@ function CustomDomainsCard({ domains, newDomain, onNewDomainChange, onAdd, onRem
             ))}
           </div>
         ) : (
-          <p className="text-sm text-muted-foreground">No custom domains yet</p>
+          !notAvailable && <p className="text-sm text-muted-foreground">No custom domains yet</p>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/lib/canvas/__tests__/custom-domain-mirror.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/custom-domain-mirror.test.ts
@@ -29,6 +29,7 @@ vi.mock('../published-storage', () => ({
     path ? `published/${prefix}/${path}/index.html` : `published/${prefix}/index.html`,
   ),
   copyPublishedArtifact: vi.fn().mockResolvedValue(undefined),
+  copyPublishedSiteFileArtifact: vi.fn().mockResolvedValue(undefined),
   deletePublishedArtifact: vi.fn().mockResolvedValue(undefined),
   clearPublishedPrefix: vi.fn().mockResolvedValue(undefined),
   publishedArtifactExists: vi.fn().mockResolvedValue(false),
@@ -42,6 +43,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 import { db } from '@pagespace/db/db';
 import {
   copyPublishedArtifact,
+  copyPublishedSiteFileArtifact,
   deletePublishedArtifact,
   clearPublishedPrefix,
   publishedArtifactExists,
@@ -209,17 +211,18 @@ describe('mirror404ToHosts', () => {
 
     await mirror404ToHosts('drive-1', 'acme');
 
-    // 3 site files × 2 hosts = 6
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(6);
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    // 3 site files × 2 hosts = 6 — all use copyPublishedSiteFileArtifact (preserves content-type)
+    expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledTimes(6);
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/404.html',
       'published/a.example.com/404.html',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/robots.txt',
       'published/a.example.com/robots.txt',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/sitemap.xml',
       'published/a.example.com/sitemap.xml',
     );
@@ -231,6 +234,7 @@ describe('mirror404ToHosts', () => {
     await mirror404ToHosts('drive-1', 'acme');
 
     expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(copyPublishedSiteFileArtifact).not.toHaveBeenCalled();
   });
 
   it('is a no-op when publishing is not configured', async () => {
@@ -239,11 +243,12 @@ describe('mirror404ToHosts', () => {
     await mirror404ToHosts('drive-1', 'acme');
 
     expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(copyPublishedSiteFileArtifact).not.toHaveBeenCalled();
   });
 
   it('swallows failures (best-effort)', async () => {
     mockSelect([{ hostname: 'a.example.com', status: 'active', createdAt: new Date() }]);
-    vi.mocked(copyPublishedArtifact).mockRejectedValueOnce(new Error('S3 down'));
+    vi.mocked(copyPublishedSiteFileArtifact).mockRejectedValueOnce(new Error('S3 down'));
 
     await expect(mirror404ToHosts('drive-1', 'acme')).resolves.toBeUndefined();
   });
@@ -339,8 +344,9 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    // 2 page artifacts + 404.html + robots.txt + sitemap.xml = 5 copies
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(5);
+    // Page artifacts use copyPublishedArtifact (html content-type); site files use
+    // copyPublishedSiteFileArtifact (MetadataDirective=COPY to preserve their content-type).
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(2);
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/about/index.html',
       'published/www.example.com/about/index.html',
@@ -349,15 +355,16 @@ describe('mirrorDriveToCustomHost', () => {
       'published/acme/team/index.html',
       'published/www.example.com/team/index.html',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledTimes(3);
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/404.html',
       'published/www.example.com/404.html',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/robots.txt',
       'published/www.example.com/robots.txt',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/sitemap.xml',
       'published/www.example.com/sitemap.xml',
     );
@@ -375,12 +382,13 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    // 1 page + root + 404 + robots.txt + sitemap.xml = 5 copies
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(5);
+    // 1 page + root = 2 page artifact copies; 3 site files via copyPublishedSiteFileArtifact
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(2);
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/index.html',
       'published/www.example.com/index.html',
     );
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledTimes(3);
   });
 
   it('does NOT include root when home page exists but root mirror does not', async () => {
@@ -395,10 +403,11 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    // 1 page + 404 + robots.txt + sitemap.xml (no root) = 4
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(4);
+    // 1 page (no root) via copyPublishedArtifact; 3 site files via copyPublishedSiteFileArtifact
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(1);
     const calls = vi.mocked(copyPublishedArtifact).mock.calls.map(([, to]) => to);
     expect(calls).not.toContain('published/www.example.com/index.html');
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledTimes(3);
   });
 
   it('copies only site files (404.html + robots.txt + sitemap.xml) when the drive has no published pages', async () => {
@@ -410,16 +419,17 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(3);
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledTimes(3);
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/404.html',
       'published/www.example.com/404.html',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/robots.txt',
       'published/www.example.com/robots.txt',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledWith(
       'published/acme/sitemap.xml',
       'published/www.example.com/sitemap.xml',
     );
@@ -434,6 +444,7 @@ describe('mirrorDriveToCustomHost', () => {
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
     expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(copyPublishedSiteFileArtifact).not.toHaveBeenCalled();
   });
 
   it('is a no-op when publishing is not configured', async () => {
@@ -442,6 +453,7 @@ describe('mirrorDriveToCustomHost', () => {
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
     expect(copyPublishedArtifact).not.toHaveBeenCalled();
+    expect(copyPublishedSiteFileArtifact).not.toHaveBeenCalled();
   });
 
   it('swallows per-copy failures and continues the backfill', async () => {
@@ -453,12 +465,13 @@ describe('mirrorDriveToCustomHost', () => {
       { pageId: 'p1', path: 'about' },
       { pageId: 'p2', path: 'team' },
     ]));
-    // First copy fails, rest succeed
+    // First page-artifact copy fails, rest succeed
     vi.mocked(copyPublishedArtifact).mockRejectedValueOnce(new Error('S3 error'));
 
     await expect(mirrorDriveToCustomHost('drive-1', 'www.example.com')).resolves.toBeUndefined();
-    // Despite the failure, the remaining copies were still attempted
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(5); // 2 pages + 404 + robots.txt + sitemap.xml
+    // Despite the failure, remaining page copies and all site file copies were still attempted
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(2); // 2 page artifacts
+    expect(copyPublishedSiteFileArtifact).toHaveBeenCalledTimes(3); // 3 site files
   });
 });
 

--- a/apps/web/src/lib/canvas/__tests__/custom-domain-mirror.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/custom-domain-mirror.test.ts
@@ -13,7 +13,7 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
 
 vi.mock('@pagespace/db/schema/custom-domains', () => ({
-  customDomains: { driveId: 'customDomains.driveId', hostname: 'customDomains.hostname', status: 'customDomains.status' },
+  customDomains: { driveId: 'customDomains.driveId', hostname: 'customDomains.hostname', status: 'customDomains.status', createdAt: 'customDomains.createdAt' },
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -53,6 +53,7 @@ import {
   deletePageFromCustomHosts,
   mirrorDriveToCustomHost,
   clearCustomHost,
+  getActiveDomainRecords,
 } from '../custom-domain-mirror';
 
 // Cast helpers (same approach as publish-page.test.ts)
@@ -200,23 +201,28 @@ describe('mirror404ToHosts', () => {
     vi.mocked(isPublishConfigured).mockReturnValue(true);
   });
 
-  it('copies 404.html to each active host', async () => {
+  it('copies 404.html, robots.txt, and sitemap.xml to each active host', async () => {
     mockSelect([
-      { hostname: 'a.example.com', status: 'active' },
-      { hostname: 'b.example.com', status: 'active' },
+      { hostname: 'a.example.com', status: 'active', createdAt: new Date() },
+      { hostname: 'b.example.com', status: 'active', createdAt: new Date() },
     ]);
 
     await mirror404ToHosts('drive-1', 'acme');
 
+    // 3 site files × 2 hosts = 6
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(6);
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/404.html',
       'published/a.example.com/404.html',
     );
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
-      'published/acme/404.html',
-      'published/b.example.com/404.html',
+      'published/acme/robots.txt',
+      'published/a.example.com/robots.txt',
     );
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(2);
+    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+      'published/acme/sitemap.xml',
+      'published/a.example.com/sitemap.xml',
+    );
   });
 
   it('is a no-op when no active hosts', async () => {
@@ -236,7 +242,7 @@ describe('mirror404ToHosts', () => {
   });
 
   it('swallows failures (best-effort)', async () => {
-    mockSelect([{ hostname: 'a.example.com', status: 'active' }]);
+    mockSelect([{ hostname: 'a.example.com', status: 'active', createdAt: new Date() }]);
     vi.mocked(copyPublishedArtifact).mockRejectedValueOnce(new Error('S3 down'));
 
     await expect(mirror404ToHosts('drive-1', 'acme')).resolves.toBeUndefined();
@@ -321,7 +327,7 @@ describe('mirrorDriveToCustomHost', () => {
     vi.mocked(publishedArtifactExists).mockResolvedValue(false);
   });
 
-  it('copies every published page + 404.html to the host', async () => {
+  it('copies every published page + 404.html + robots.txt + sitemap.xml to the host', async () => {
     vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
       publishSubdomain: 'acme',
       homePageId: null,
@@ -333,8 +339,8 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    // 2 page artifacts + 404.html = 3 copies
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(3);
+    // 2 page artifacts + 404.html + robots.txt + sitemap.xml = 5 copies
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(5);
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/about/index.html',
       'published/www.example.com/about/index.html',
@@ -346,6 +352,14 @@ describe('mirrorDriveToCustomHost', () => {
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/404.html',
       'published/www.example.com/404.html',
+    );
+    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+      'published/acme/robots.txt',
+      'published/www.example.com/robots.txt',
+    );
+    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+      'published/acme/sitemap.xml',
+      'published/www.example.com/sitemap.xml',
     );
   });
 
@@ -361,8 +375,8 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    // 1 page + root + 404 = 3 copies
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(3);
+    // 1 page + root + 404 + robots.txt + sitemap.xml = 5 copies
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(5);
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/index.html',
       'published/www.example.com/index.html',
@@ -381,13 +395,13 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    // 1 page + 404 only (no root) = 2
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(2);
+    // 1 page + 404 + robots.txt + sitemap.xml (no root) = 4
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(4);
     const calls = vi.mocked(copyPublishedArtifact).mock.calls.map(([, to]) => to);
     expect(calls).not.toContain('published/www.example.com/index.html');
   });
 
-  it('copies only 404.html when the drive has no published pages', async () => {
+  it('copies only site files (404.html + robots.txt + sitemap.xml) when the drive has no published pages', async () => {
     vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
       publishSubdomain: 'acme',
       homePageId: null,
@@ -396,10 +410,18 @@ describe('mirrorDriveToCustomHost', () => {
 
     await mirrorDriveToCustomHost('drive-1', 'www.example.com');
 
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(1);
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(3);
     expect(copyPublishedArtifact).toHaveBeenCalledWith(
       'published/acme/404.html',
       'published/www.example.com/404.html',
+    );
+    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+      'published/acme/robots.txt',
+      'published/www.example.com/robots.txt',
+    );
+    expect(copyPublishedArtifact).toHaveBeenCalledWith(
+      'published/acme/sitemap.xml',
+      'published/www.example.com/sitemap.xml',
     );
   });
 
@@ -436,7 +458,36 @@ describe('mirrorDriveToCustomHost', () => {
 
     await expect(mirrorDriveToCustomHost('drive-1', 'www.example.com')).resolves.toBeUndefined();
     // Despite the failure, the remaining copies were still attempted
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(3); // 2 pages + 404
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(5); // 2 pages + 404 + robots.txt + sitemap.xml
+  });
+});
+
+describe('getActiveDomainRecords', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isPublishConfigured).mockReturnValue(true);
+  });
+
+  it('returns hostname and createdAt for active domains only', async () => {
+    const createdAt = new Date('2026-01-01T00:00:00.000Z');
+    mockSelect([
+      { hostname: 'active.example.com', status: 'active', createdAt },
+      { hostname: 'pending.example.com', status: 'pending', createdAt },
+    ]);
+
+    const records = await getActiveDomainRecords('drive-1');
+
+    expect(records).toHaveLength(1);
+    expect(records[0].hostname).toBe('active.example.com');
+    expect(records[0].createdAt).toEqual(createdAt);
+  });
+
+  it('returns empty array when no active domains', async () => {
+    mockSelect([{ hostname: 'pending.example.com', status: 'pending', createdAt: new Date() }]);
+
+    const records = await getActiveDomainRecords('drive-1');
+
+    expect(records).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -283,7 +283,7 @@ describe('publishCanvasPage', () => {
     expect(PublishError).toBeDefined();
   });
 
-  it('uses the active custom domain as the canonical host when one exists', async () => {
+  it('response url is always the subdomain (not the custom domain) regardless of active custom domains', async () => {
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
       id: 'page-1', type: 'CANVAS', title: 'About', content: '<div/>', driveId: 'drive-1',
     }));
@@ -297,11 +297,12 @@ describe('publishCanvasPage', () => {
 
     const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
 
-    // The returned URL still reflects the primary public address (custom domain)
-    expect(result.url).toBe('https://www.acme.com/about');
+    // Response URL uses the subdomain (guaranteed write) so the caller always gets a working link.
+    // The canonical/OG tags baked into the HTML still use the custom domain.
+    expect(result.url).toBe('https://acme.pagespace.site/about');
   });
 
-  it('uses the subdomain as canonical host when no active custom domain exists', async () => {
+  it('uses the subdomain as response URL when no active custom domain exists', async () => {
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
       id: 'page-1', type: 'CANVAS', title: 'About', content: '<div/>', driveId: 'drive-1',
     }));
@@ -309,7 +310,6 @@ describe('publishCanvasPage', () => {
       id: 'drive-1', slug: 'acme', publishSubdomain: 'acme', kind: 'STANDARD', homePageId: null,
     }));
     vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
-    // Default mock already returns []
     vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
 
     const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
@@ -317,7 +317,7 @@ describe('publishCanvasPage', () => {
     expect(result.url).toBe('https://acme.pagespace.site/about');
   });
 
-  it('home page canonical is the custom domain root when active custom domain exists', async () => {
+  it('home page response URL is the subdomain root even when a custom domain is active', async () => {
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
       id: 'page-1', type: 'CANVAS', title: 'Home', content: '<div/>', driveId: 'drive-1',
     }));
@@ -332,7 +332,7 @@ describe('publishCanvasPage', () => {
     const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
 
     expect(result.isHomePage).toBe(true);
-    expect(result.url).toBe('https://www.acme.com/');
+    expect(result.url).toBe('https://acme.pagespace.site/');
   });
 });
 

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -69,6 +69,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 vi.mock('../custom-domain-mirror', () => ({
   mirrorPublishedPageToHosts: vi.fn().mockResolvedValue(undefined),
   mirror404ToHosts: vi.fn().mockResolvedValue(undefined),
+  getActiveDomainRecords: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@pagespace/lib/services/drive-guards', () => ({
@@ -100,6 +101,7 @@ vi.mock('@pagespace/lib/utils/utils', () => ({
 import { db } from '@pagespace/db/db';
 import { putPublishedArtifact, putPublishedSiteFile, publishedArtifactExists, deletePublishedArtifact, copyPublishedArtifact, isPublishConfigured } from '../published-storage';
 import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, syncPublishedHomeRoot, PublishError } from '../publish-page';
+import { getActiveDomainRecords } from '../custom-domain-mirror';
 
 // The mocked `db` keeps the real relational-query return types, so partial test
 // fixtures are cast through `unknown` to the row shape (never `any`).
@@ -280,12 +282,65 @@ describe('publishCanvasPage', () => {
       .rejects.toMatchObject({ statusCode: 400 });
     expect(PublishError).toBeDefined();
   });
+
+  it('uses the active custom domain as the canonical host when one exists', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CANVAS', title: 'About', content: '<div/>', driveId: 'drive-1',
+    }));
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      id: 'drive-1', slug: 'acme', publishSubdomain: 'acme', kind: 'STANDARD', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([
+      { hostname: 'www.acme.com', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+    ]);
+
+    const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    // The returned URL still reflects the primary public address (custom domain)
+    expect(result.url).toBe('https://www.acme.com/about');
+  });
+
+  it('uses the subdomain as canonical host when no active custom domain exists', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CANVAS', title: 'About', content: '<div/>', driveId: 'drive-1',
+    }));
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      id: 'drive-1', slug: 'acme', publishSubdomain: 'acme', kind: 'STANDARD', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+    // Default mock already returns []
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
+
+    const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(result.url).toBe('https://acme.pagespace.site/about');
+  });
+
+  it('home page canonical is the custom domain root when active custom domain exists', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CANVAS', title: 'Home', content: '<div/>', driveId: 'drive-1',
+    }));
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      id: 'drive-1', slug: 'acme', publishSubdomain: 'acme', kind: 'STANDARD', homePageId: 'page-1',
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([
+      { hostname: 'www.acme.com', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+    ]);
+
+    const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(result.isHomePage).toBe(true);
+    expect(result.url).toBe('https://www.acme.com/');
+  });
 });
 
 describe('publishHomePageAtRoot', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(isPublishConfigured).mockReturnValue(true);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
   });
 
   it('returns null when the drive has no home page', async () => {
@@ -334,6 +389,7 @@ describe('clearPublishedHomeRoot', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(isPublishConfigured).mockReturnValue(true);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
   });
 
   it('deletes the root mirror artifact for the drive subdomain', async () => {
@@ -405,6 +461,44 @@ describe('regeneratePublishedSiteFiles', () => {
     vi.mocked(isPublishConfigured).mockReturnValue(true);
     vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([]));
     vi.mocked(publishedArtifactExists).mockResolvedValue(true);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
+  });
+
+  it('uses the active custom domain as origin for sitemap/robots URLs', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([
+      { pageId: 'p1', path: 'about', updatedAt: new Date('2026-06-22T00:00:00.000Z') },
+    ]));
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([
+      { hostname: 'www.acme.com', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+    ]);
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    const sitemapCall = vi.mocked(putPublishedSiteFile).mock.calls.find((c) => c[0].file === 'sitemap.xml');
+    // Sitemap <loc> uses the custom domain, not the subdomain
+    expect(sitemapCall?.[0].body).toContain('https://www.acme.com/about');
+    expect(sitemapCall?.[0].body).not.toContain('pagespace.site');
+
+    const robotsCall = vi.mocked(putPublishedSiteFile).mock.calls.find((c) => c[0].file === 'robots.txt');
+    expect(robotsCall?.[0].body).toContain('https://www.acme.com/sitemap.xml');
+  });
+
+  it('falls back to subdomain origin when no active custom domain', async () => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      name: 'Acme', publishSubdomain: 'acme', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findMany).mockResolvedValue(publishedRows([
+      { pageId: 'p1', path: 'about', updatedAt: new Date('2026-06-22T00:00:00.000Z') },
+    ]));
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
+
+    await regeneratePublishedSiteFiles('drive-1');
+
+    const sitemapCall = vi.mocked(putPublishedSiteFile).mock.calls.find((c) => c[0].file === 'sitemap.xml');
+    expect(sitemapCall?.[0].body).toContain('https://acme.pagespace.site/about');
   });
 
   it('canonicalizes the home page to root when its root mirror exists', async () => {
@@ -507,6 +601,7 @@ describe('syncPublishedHomeRoot', () => {
     vi.clearAllMocks();
     vi.mocked(isPublishConfigured).mockReturnValue(true);
     vi.mocked(db.query.publishedPages.findMany).mockResolvedValue([]);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
   });
 
   it('is a no-op when publishing is not configured', async () => {

--- a/apps/web/src/lib/canvas/custom-domain-mirror.ts
+++ b/apps/web/src/lib/canvas/custom-domain-mirror.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { planCustomDomainMirror } from '@pagespace/lib/canvas/custom-domain-mirror';
+import type { ActiveDomainRecord } from '@pagespace/lib/canvas/primary-host';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
@@ -17,16 +18,24 @@ import {
 } from './published-storage';
 
 /**
- * Return the active custom hostnames for a drive. Only domains with
- * `status = 'active'` (DNS-verified + cert provisioned) are mirrored.
+ * Return all active custom domain records for a drive. Only domains with
+ * `status = 'active'` (DNS-verified + cert provisioned) are included.
+ * Exported so publish-page.ts can resolve the primary host without a
+ * duplicate DB query.
  */
-async function getActiveDriveHosts(driveId: string): Promise<string[]> {
+export async function getActiveDomainRecords(driveId: string): Promise<ActiveDomainRecord[]> {
   const rows = await db
-    .select({ hostname: customDomains.hostname, status: customDomains.status })
+    .select({ hostname: customDomains.hostname, status: customDomains.status, createdAt: customDomains.createdAt })
     .from(customDomains)
     .where(eq(customDomains.driveId, driveId));
 
-  return rows.filter((r) => r.status === 'active').map((r) => r.hostname);
+  return rows.filter((r) => r.status === 'active').map((r) => ({ hostname: r.hostname, createdAt: r.createdAt }));
+}
+
+/** Return only the active custom hostnames for a drive (legacy internal helper). */
+async function getActiveDriveHosts(driveId: string): Promise<string[]> {
+  const records = await getActiveDomainRecords(driveId);
+  return records.map((r) => r.hostname);
 }
 
 /**
@@ -80,9 +89,9 @@ export async function mirrorPublishedPageToHosts(params: {
 }
 
 /**
- * Mirror the drive's 404.html site file to every active custom-domain host.
- * Called after `regeneratePublishedSiteFiles` writes the 404 to the subdomain
- * prefix so the branded not-found page is always in sync across hosts.
+ * Mirror all drive site files (robots.txt, sitemap.xml, 404.html) to every
+ * active custom-domain host. Called after `regeneratePublishedSiteFiles` so
+ * every copy of the site carries the same canonical site-level documents.
  * Best-effort.
  */
 export async function mirror404ToHosts(driveId: string, subdomain: string): Promise<void> {
@@ -97,12 +106,13 @@ export async function mirror404ToHosts(driveId: string, subdomain: string): Prom
       paths: [],
       hosts,
       include404: true,
+      includeSiteFiles: true,
     });
 
     await Promise.allSettled(
       copies.map(({ from, to }) =>
         copyPublishedArtifact(from, to).catch((err) => {
-          loggers.api.warn('Failed to mirror 404.html to custom host', {
+          loggers.api.warn('Failed to mirror site file to custom host', {
             from,
             to,
             error: err instanceof Error ? err.message : String(err),
@@ -111,7 +121,7 @@ export async function mirror404ToHosts(driveId: string, subdomain: string): Prom
       ),
     );
   } catch (err) {
-    loggers.api.warn('Failed to mirror 404.html to custom hosts', {
+    loggers.api.warn('Failed to mirror site files to custom hosts', {
       driveId,
       error: err instanceof Error ? err.message : String(err),
     });
@@ -211,6 +221,7 @@ export async function mirrorDriveToCustomHost(driveId: string, host: string): Pr
     hosts: [host],
     includeRoot: rootExists,
     include404: true,
+    includeSiteFiles: true,
   });
 
   await Promise.allSettled(

--- a/apps/web/src/lib/canvas/custom-domain-mirror.ts
+++ b/apps/web/src/lib/canvas/custom-domain-mirror.ts
@@ -11,11 +11,17 @@ import { publishedPages } from '@pagespace/db/schema/published-pages';
 import {
   buildPublishedKey,
   copyPublishedArtifact,
+  copyPublishedSiteFileArtifact,
   deletePublishedArtifact,
   clearPublishedPrefix,
   publishedArtifactExists,
   isPublishConfigured,
 } from './published-storage';
+
+/** True for the three drive-level site files that must preserve their content type on copy. */
+function isSiteFileKey(key: string): boolean {
+  return key.endsWith('/robots.txt') || key.endsWith('/sitemap.xml') || key.endsWith('/404.html');
+}
 
 /**
  * Return all active custom domain records for a drive. Only domains with
@@ -110,15 +116,16 @@ export async function mirror404ToHosts(driveId: string, subdomain: string): Prom
     });
 
     await Promise.allSettled(
-      copies.map(({ from, to }) =>
-        copyPublishedArtifact(from, to).catch((err) => {
+      copies.map(({ from, to }) => {
+        const copy = isSiteFileKey(to) ? copyPublishedSiteFileArtifact(from, to) : copyPublishedArtifact(from, to);
+        return copy.catch((err) => {
           loggers.api.warn('Failed to mirror site file to custom host', {
             from,
             to,
             error: err instanceof Error ? err.message : String(err),
           });
-        }),
-      ),
+        });
+      }),
     );
   } catch (err) {
     loggers.api.warn('Failed to mirror site files to custom hosts', {
@@ -225,8 +232,9 @@ export async function mirrorDriveToCustomHost(driveId: string, host: string): Pr
   });
 
   await Promise.allSettled(
-    copies.map(({ from, to }) =>
-      copyPublishedArtifact(from, to).catch((err) => {
+    copies.map(({ from, to }) => {
+      const copy = isSiteFileKey(to) ? copyPublishedSiteFileArtifact(from, to) : copyPublishedArtifact(from, to);
+      return copy.catch((err) => {
         loggers.api.warn('Failed to copy artifact during drive mirror to custom host', {
           driveId,
           host,
@@ -234,8 +242,8 @@ export async function mirrorDriveToCustomHost(driveId: string, host: string): Pr
           to,
           error: err instanceof Error ? err.message : String(err),
         });
-      }),
-    ),
+      });
+    }),
   );
 }
 

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -23,7 +23,8 @@ import {
 } from './published-storage';
 import { rewriteCanvasAssets, rewriteInterPageLinksForDrive, extractAndStripOgMeta } from './asset-pipeline';
 import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml } from '@pagespace/lib/canvas/site-files';
-import { mirrorPublishedPageToHosts, mirror404ToHosts } from './custom-domain-mirror';
+import { resolvePrimaryPublishedHost } from '@pagespace/lib/canvas/primary-host';
+import { mirrorPublishedPageToHosts, mirror404ToHosts, getActiveDomainRecords } from './custom-domain-mirror';
 
 export const PUBLISH_HOST = 'pagespace.site';
 const FAVICON_BASE_URL = 'https://pagespace.ai';
@@ -212,10 +213,19 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   });
   const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
   const assetBaseUrl = getPublishAssetBaseUrl();
-  const rootUrl = `https://${subdomain}.${PUBLISH_HOST}/`;
-  const publishedUrl = `https://${subdomain}.${PUBLISH_HOST}/${path}`;
+
+  // Resolve the drive's primary published host. When an active custom domain
+  // exists it is the primary; otherwise we fall back to the subdomain. All
+  // copies (subdomain + every custom host mirror) embed the same canonical URL
+  // pointing at the primary host, so search-engine ranking signals converge on
+  // the customer's own domain.
+  const activeDomains = await getActiveDomainRecords(driveId);
+  const primaryHost = resolvePrimaryPublishedHost({ subdomain, publishHost: PUBLISH_HOST, activeDomains });
+
+  const rootUrl = `https://${primaryHost}/`;
+  const publishedUrl = `https://${primaryHost}/${path}`;
   // The canonical/OG/JSON-LD URL is the page's PRIMARY public URL. For the home
-  // page that is the subdomain root (the same artifact is also mirrored there),
+  // page that is the site root (the same artifact is also mirrored there),
   // not the secondary slug path — using the slug would make the root page
   // canonicalize itself away to `/<slug>`. Other pages are canonical at their
   // slug. The SEO description prefers the author's og:description, falling back
@@ -355,7 +365,12 @@ export async function regeneratePublishedSiteFiles(driveId: string): Promise<voi
     const subdomain = drive?.publishSubdomain;
     if (!subdomain) return;
 
-    const origin = `https://${subdomain}.${PUBLISH_HOST}`;
+    // Resolve primary host: custom domain (if active) or subdomain fallback.
+    // Loading domains here means sitemap/robots URLs point at the customer's
+    // domain on every copy — subdomain and custom-host alike.
+    const activeDomains = await getActiveDomainRecords(driveId);
+    const primaryHost = resolvePrimaryPublishedHost({ subdomain, publishHost: PUBLISH_HOST, activeDomains });
+    const origin = `https://${primaryHost}`;
 
     const published = await db.query.publishedPages.findMany({
       where: eq(publishedPages.driveId, driveId),

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -333,10 +333,14 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   // prefix so Caddy can serve them there immediately.
   await mirrorPublishedPageToHosts({ driveId, subdomain, path, isHomePage });
 
-  // The home page's primary public URL is the subdomain root (matching the
-  // canonical tag baked above); it is also reachable at its slug. Other pages
-  // live only at their slug.
-  return { url: isHomePage ? rootUrl : publishedUrl, subdomain, path, isHomePage };
+  // Return the subdomain URL (guaranteed write target, always available) so the
+  // caller gets a reliable link. The canonical/OG/sitemap URLs still point at
+  // the primary host (custom domain when active), but those are baked into the
+  // rendered HTML — the response URL is for the UI to display/copy.
+  const responseUrl = isHomePage
+    ? `https://${subdomain}.${PUBLISH_HOST}/`
+    : `https://${subdomain}.${PUBLISH_HOST}/${path}`;
+  return { url: responseUrl, subdomain, path, isHomePage };
 }
 
 /**

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -277,6 +277,25 @@ export async function copyPublishedArtifact(fromKey: string, toKey: string): Pro
   );
 }
 
+/**
+ * Copy a site-level file artifact (robots.txt, sitemap.xml, 404.html) to
+ * another key within the same publish bucket. Unlike `copyPublishedArtifact`,
+ * this uses `MetadataDirective=COPY` so the source object's stored ContentType
+ * is preserved — robots.txt must be `text/plain`, sitemap.xml must be
+ * `application/xml`, and 404.html must be `text/html`.
+ */
+export async function copyPublishedSiteFileArtifact(fromKey: string, toKey: string): Promise<void> {
+  const bucket = getPublishBucket();
+  await getPublishClient().send(
+    new CopyObjectCommand({
+      Bucket: bucket,
+      CopySource: `${bucket}/${fromKey}`,
+      Key: toKey,
+      MetadataDirective: 'COPY',
+    }),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Asset pipeline helpers (CDN copy of embedded PageSpace files)
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/subscription/plans.ts
+++ b/apps/web/src/lib/subscription/plans.ts
@@ -49,6 +49,11 @@ export interface PlanDefinition {
       bytes: number;
       formatted: string;
     };
+    /**
+     * Maximum custom domains per drive. 0 = custom domains not available on
+     * this tier. The add-domain endpoint enforces this at request time.
+     */
+    maxCustomDomains: number;
   };
   features: PlanFeature[];
   highlighted?: boolean;
@@ -90,6 +95,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         bytes: 50 * 1024 * 1024, // 50MB
         formatted: '50MB',
       },
+      maxCustomDomains: 0,
     },
     features: [
       { name: monthlyCreditsPhrase('free'), included: true },
@@ -136,6 +142,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         bytes: 250 * 1024 * 1024, // 250MB
         formatted: '250MB',
       },
+      maxCustomDomains: 1,
     },
     features: [
       { name: monthlyCreditsPhrase('pro'), included: true, description: '3x more than Free' },
@@ -179,6 +186,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         bytes: 500 * 1024 * 1024, // 500MB
         formatted: '500MB',
       },
+      maxCustomDomains: 3,
     },
     features: [
       { name: monthlyCreditsPhrase('founder'), included: true, description: '10x more than Free' },
@@ -217,6 +225,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         bytes: 1024 * 1024 * 1024, // 1GB
         formatted: '1GB',
       },
+      maxCustomDomains: 10,
     },
     features: [
       { name: monthlyCreditsPhrase('business'), included: true, description: '20x more than Free' },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -652,6 +652,11 @@
       "import": "./dist/canvas/custom-domain-mirror.js",
       "require": "./dist/canvas/custom-domain-mirror.js"
     },
+    "./canvas/primary-host": {
+      "types": "./dist/canvas/primary-host.d.ts",
+      "import": "./dist/canvas/primary-host.js",
+      "require": "./dist/canvas/primary-host.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -1348,6 +1353,9 @@
       ],
       "canvas/custom-domain-mirror": [
         "./dist/canvas/custom-domain-mirror.d.ts"
+      ],
+      "canvas/primary-host": [
+        "./dist/canvas/primary-host.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/src/canvas/__tests__/custom-domain-mirror.test.ts
+++ b/packages/lib/src/canvas/__tests__/custom-domain-mirror.test.ts
@@ -133,6 +133,75 @@ describe('planCustomDomainMirror', () => {
     expect(copies).toHaveLength(8);
   });
 
+  it('includeSiteFiles adds robots.txt and sitemap.xml for each host', () => {
+    const { copies } = planCustomDomainMirror({
+      subdomain: 'acme',
+      paths: [],
+      hosts: ['www.example.com'],
+      includeSiteFiles: true,
+    });
+
+    expect(copies).toHaveLength(2);
+    expect(copies).toContainEqual({
+      from: 'published/acme/robots.txt',
+      to: 'published/www.example.com/robots.txt',
+    });
+    expect(copies).toContainEqual({
+      from: 'published/acme/sitemap.xml',
+      to: 'published/www.example.com/sitemap.xml',
+    });
+  });
+
+  it('includeSiteFiles × M hosts → 2×M copies', () => {
+    const { copies } = planCustomDomainMirror({
+      subdomain: 'acme',
+      paths: [],
+      hosts: ['a.example.com', 'b.example.com'],
+      includeSiteFiles: true,
+    });
+
+    // 2 site files × 2 hosts = 4
+    expect(copies).toHaveLength(4);
+  });
+
+  it('includeSiteFiles does NOT include 404.html (that is include404)', () => {
+    const { copies } = planCustomDomainMirror({
+      subdomain: 'acme',
+      paths: [],
+      hosts: ['www.example.com'],
+      includeSiteFiles: true,
+    });
+
+    const tos = copies.map((c) => c.to);
+    expect(tos).not.toContain('published/www.example.com/404.html');
+  });
+
+  it('includeRoot + include404 + includeSiteFiles + N paths × M hosts → correct total', () => {
+    const { copies } = planCustomDomainMirror({
+      subdomain: 'acme',
+      paths: ['about', 'team'],
+      hosts: ['a.example.com', 'b.example.com'],
+      includeRoot: true,
+      include404: true,
+      includeSiteFiles: true,
+    });
+
+    // (2 paths + 1 root + 1 404 + 2 site files) × 2 hosts = 12
+    expect(copies).toHaveLength(12);
+  });
+
+  it('does not include site files by default', () => {
+    const { copies } = planCustomDomainMirror({
+      subdomain: 'acme',
+      paths: ['about'],
+      hosts: ['www.example.com'],
+    });
+
+    const tos = copies.map((c) => c.to);
+    expect(tos).not.toContain('published/www.example.com/robots.txt');
+    expect(tos).not.toContain('published/www.example.com/sitemap.xml');
+  });
+
   it('page key uses subdomain as source prefix verbatim', () => {
     const { copies } = planCustomDomainMirror({
       subdomain: 'my-drive',

--- a/packages/lib/src/canvas/__tests__/primary-host.test.ts
+++ b/packages/lib/src/canvas/__tests__/primary-host.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePrimaryPublishedHost } from '../primary-host';
+
+describe('resolvePrimaryPublishedHost', () => {
+  const PUBLISH_HOST = 'pagespace.site';
+
+  it('returns the subdomain fallback when there are no active domains', () => {
+    const host = resolvePrimaryPublishedHost({
+      subdomain: 'acme',
+      publishHost: PUBLISH_HOST,
+      activeDomains: [],
+    });
+    expect(host).toBe('acme.pagespace.site');
+  });
+
+  it('returns the single active domain hostname when only one exists', () => {
+    const host = resolvePrimaryPublishedHost({
+      subdomain: 'acme',
+      publishHost: PUBLISH_HOST,
+      activeDomains: [{ hostname: 'www.acme.com', createdAt: new Date('2026-01-01T00:00:00.000Z') }],
+    });
+    expect(host).toBe('www.acme.com');
+  });
+
+  it('picks the earliest createdAt domain when multiple are active', () => {
+    const host = resolvePrimaryPublishedHost({
+      subdomain: 'acme',
+      publishHost: PUBLISH_HOST,
+      activeDomains: [
+        { hostname: 'docs.acme.com', createdAt: new Date('2026-03-01T00:00:00.000Z') },
+        { hostname: 'www.acme.com',  createdAt: new Date('2026-01-01T00:00:00.000Z') },
+        { hostname: 'blog.acme.com', createdAt: new Date('2026-06-01T00:00:00.000Z') },
+      ],
+    });
+    expect(host).toBe('www.acme.com');
+  });
+
+  it('breaks createdAt ties by hostname lexicographic order (deterministic)', () => {
+    const sameTime = new Date('2026-01-01T00:00:00.000Z');
+    const host = resolvePrimaryPublishedHost({
+      subdomain: 'acme',
+      publishHost: PUBLISH_HOST,
+      activeDomains: [
+        { hostname: 'z.acme.com', createdAt: sameTime },
+        { hostname: 'a.acme.com', createdAt: sameTime },
+        { hostname: 'm.acme.com', createdAt: sameTime },
+      ],
+    });
+    expect(host).toBe('a.acme.com');
+  });
+
+  it('does not mutate the input array when sorting', () => {
+    const input = [
+      { hostname: 'b.acme.com', createdAt: new Date('2026-01-02T00:00:00.000Z') },
+      { hostname: 'a.acme.com', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+    ];
+    const originalOrder = input.map((d) => d.hostname);
+
+    resolvePrimaryPublishedHost({ subdomain: 'acme', publishHost: PUBLISH_HOST, activeDomains: input });
+
+    expect(input.map((d) => d.hostname)).toEqual(originalOrder);
+  });
+
+  it('is deterministic: same inputs always yield the same output', () => {
+    const domains = [
+      { hostname: 'c.example.com', createdAt: new Date('2026-02-01T00:00:00.000Z') },
+      { hostname: 'a.example.com', createdAt: new Date('2026-01-01T00:00:00.000Z') },
+    ];
+    const first  = resolvePrimaryPublishedHost({ subdomain: 's', publishHost: PUBLISH_HOST, activeDomains: domains });
+    const second = resolvePrimaryPublishedHost({ subdomain: 's', publishHost: PUBLISH_HOST, activeDomains: domains });
+    expect(first).toBe(second);
+    expect(first).toBe('a.example.com');
+  });
+
+  it('prefers the custom domain over the subdomain fallback regardless of subdomain value', () => {
+    const host = resolvePrimaryPublishedHost({
+      subdomain: 'my-drive',
+      publishHost: PUBLISH_HOST,
+      activeDomains: [{ hostname: 'custom.example.com', createdAt: new Date('2026-06-01T00:00:00.000Z') }],
+    });
+    expect(host).not.toBe('my-drive.pagespace.site');
+    expect(host).toBe('custom.example.com');
+  });
+});

--- a/packages/lib/src/canvas/custom-domain-mirror.ts
+++ b/packages/lib/src/canvas/custom-domain-mirror.ts
@@ -45,6 +45,14 @@ export interface PlanCustomDomainMirrorInput {
    * paths under each custom host render the branded not-found page.
    */
   include404?: boolean;
+  /**
+   * When true, plan copies for `robots.txt` and `sitemap.xml` so every
+   * custom-domain host serves the same canonical site-file inventory. When
+   * the primary published host is a custom domain, the URLs in these files
+   * already point at the custom domain, so the files are identical across
+   * all copies and can be mirrored byte-for-byte without re-generation.
+   */
+  includeSiteFiles?: boolean;
 }
 
 /**
@@ -69,7 +77,7 @@ function pageKey(prefix: string, path: string): string {
  * Returns an empty copy set when `hosts` is empty (no-op).
  */
 export function planCustomDomainMirror(input: PlanCustomDomainMirrorInput): { copies: CopyOp[] } {
-  const { subdomain, paths, hosts, includeRoot = false, include404 = false } = input;
+  const { subdomain, paths, hosts, includeRoot = false, include404 = false, includeSiteFiles = false } = input;
 
   if (hosts.length === 0) {
     return { copies: [] };
@@ -90,6 +98,17 @@ export function planCustomDomainMirror(input: PlanCustomDomainMirrorInput): { co
       copies.push({
         from: `published/${subdomain}/404.html`,
         to: `published/${host}/404.html`,
+      });
+    }
+
+    if (includeSiteFiles) {
+      copies.push({
+        from: `published/${subdomain}/robots.txt`,
+        to: `published/${host}/robots.txt`,
+      });
+      copies.push({
+        from: `published/${subdomain}/sitemap.xml`,
+        to: `published/${host}/sitemap.xml`,
       });
     }
   }

--- a/packages/lib/src/canvas/primary-host.ts
+++ b/packages/lib/src/canvas/primary-host.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure resolver for a drive's "primary published host".
+ *
+ * Every custom-domain mirror is byte-for-byte identical to the subdomain copy
+ * (no re-render). To consolidate SEO we pick ONE host as canonical — the same
+ * value baked into `<link rel=canonical>`, `og:url`, `sitemap.xml <loc>`, and
+ * `robots.txt Sitemap:` across ALL copies. When multiple copies point at the
+ * same primary host, search engines consolidate ranking signals on that one URL.
+ *
+ * Primary-host selection rule (deterministic — no DB flag needed):
+ *   - If the drive has ≥1 active custom domain, the PRIMARY is the active domain
+ *     with the earliest `createdAt`. Ties (same timestamp) are broken by
+ *     hostname lexicographic order so the result is always predictable.
+ *   - Otherwise fall back to `<subdomain>.<publishHost>` (the pagespace.site
+ *     subdomain, which is always authoritative when no custom domain is active).
+ *
+ * Keeping this function pure (no I/O, no env reads) means the non-trivial part
+ * — sorting + fallback — is fully unit-testable without a DB or network call.
+ * The thin shell that fetches the active domains from the DB calls this.
+ */
+
+/** Minimal shape of an active custom domain needed for primary-host resolution. */
+export interface ActiveDomainRecord {
+  hostname: string;
+  createdAt: Date;
+}
+
+/**
+ * Resolve the primary published host for a drive.
+ *
+ * @param subdomain    - Drive's allocated pagespace.site subdomain.
+ * @param publishHost  - The root publish hostname (e.g. `pagespace.site`).
+ * @param activeDomains - Active custom domains for the drive (any order).
+ * @returns The hostname that should be used for canonical/og:url/sitemap URLs.
+ */
+export function resolvePrimaryPublishedHost({
+  subdomain,
+  publishHost,
+  activeDomains,
+}: {
+  subdomain: string;
+  publishHost: string;
+  activeDomains: ActiveDomainRecord[];
+}): string {
+  if (activeDomains.length === 0) {
+    return `${subdomain}.${publishHost}`;
+  }
+
+  const sorted = [...activeDomains].sort((a, b) => {
+    const dt = a.createdAt.getTime() - b.createdAt.getTime();
+    if (dt !== 0) return dt;
+    return a.hostname < b.hostname ? -1 : a.hostname > b.hostname ? 1 : 0;
+  });
+
+  return sorted[0].hostname;
+}

--- a/packages/lib/src/canvas/primary-host.ts
+++ b/packages/lib/src/canvas/primary-host.ts
@@ -9,8 +9,10 @@
  *
  * Primary-host selection rule (deterministic — no DB flag needed):
  *   - If the drive has ≥1 active custom domain, the PRIMARY is the active domain
- *     with the earliest `createdAt`. Ties (same timestamp) are broken by
- *     hostname lexicographic order so the result is always predictable.
+ *     with the earliest `createdAt` (earliest-registered, not earliest-activated,
+ *     because the schema has no separate activation timestamp). Ties (same
+ *     timestamp) are broken by hostname lexicographic order so the result is
+ *     always predictable.
  *   - Otherwise fall back to `<subdomain>.<publishHost>` (the pagespace.site
  *     subdomain, which is always authoritative when no custom domain is active).
  *
@@ -19,7 +21,12 @@
  * The thin shell that fetches the active domains from the DB calls this.
  */
 
-/** Minimal shape of an active custom domain needed for primary-host resolution. */
+/**
+ * Minimal shape of an active custom domain needed for primary-host resolution.
+ * `createdAt` is the row creation timestamp (earliest-registered), used as a
+ * stable deterministic tie-breaker. There is no separate activation timestamp
+ * in the schema.
+ */
 export interface ActiveDomainRecord {
   hostname: string;
   createdAt: Date;


### PR DESCRIPTION
## Summary

- **Primary published host**: Pure \`resolvePrimaryPublishedHost()\` function picks earliest-registered custom domain (\`createdAt\` = registration time, schema has no activation timestamp; hostname lexicographic tiebreaker), falling back to \`<subdomain>.pagespace.site\`. Exported as \`@pagespace/lib/canvas/primary-host\`.
- **Canonical/OG/JSON-LD host**: \`publishCanvasPage\` and \`regeneratePublishedSiteFiles\` now load active custom domains and use the primary host for og:url, canonical tags, sitemap \`<loc>\`, and robots.txt \`Sitemap:\` directive. Response URL (what the UI shows) uses the subdomain (guaranteed write target) — the canonical URLs in the rendered HTML use the primary host.
- **Site file mirroring**: \`planCustomDomainMirror\` gains an \`includeSiteFiles\` flag; \`mirror404ToHosts\` and \`mirrorDriveToCustomHost\` mirror \`robots.txt\` + \`sitemap.xml\` to every active custom-domain prefix (alongside 404.html and page artifacts). \`copyPublishedSiteFileArtifact\` (new) uses \`MetadataDirective: 'COPY'\` to preserve source content-type; page artifacts keep \`MetadataDirective: 'REPLACE'\`.
- **Tier caps (atomic)**: \`maxCustomDomains\` added to \`PlanDefinition.limits\` (free=0, pro=1, founder=3, business=10). \`POST /api/drives/[driveId]/domains\` enforces the cap atomically — \`SELECT drives.id FOR UPDATE\` + count-check + insert run in a single transaction to prevent over-cap inserts under concurrent load. \`GET\` returns \`limit\` for the UI.
- **Mirror cleanup (retryable)**: \`cert/refresh\` route calls \`clearCustomHost\` whenever \`nextStatus === 'cert_failed'\` (not just \`active → cert_failed\`), so retries after a failed \`clearCustomHost()\` still attempt cleanup — the prefix delete is idempotent/no-op when nothing remains. Errors caught+logged so a storage failure does not return 500 when the DB status is already committed.
- **Cert activation ordering**: \`regeneratePublishedSiteFiles\` is called BEFORE \`mirrorDriveToCustomHost\` on cert activation — so site files embed the custom domain as primary host before being copied.
- **UI**: \`CustomDomainsCard\` shows \`X / N\` counter, disables Add at cap, shows upgrade nudge for free tier, surfaces 403 plan errors in toast.

## Files changed

| Layer | File | What changed |
|-------|------|-------------|
| lib (pure) | \`packages/lib/src/canvas/primary-host.ts\` | NEW — \`resolvePrimaryPublishedHost\` |
| lib (pure) | \`packages/lib/src/canvas/custom-domain-mirror.ts\` | \`includeSiteFiles\` flag in planner |
| lib | \`packages/lib/package.json\` | \`canvas/primary-host\` export entry |
| web lib | \`apps/web/src/lib/canvas/published-storage.ts\` | \`copyPublishedSiteFileArtifact\` (MetadataDirective: COPY) |
| web lib | \`apps/web/src/lib/canvas/custom-domain-mirror.ts\` | \`getActiveDomainRecords()\` export; \`isSiteFileKey()\` dispatch; pass \`includeSiteFiles\` |
| web lib | \`apps/web/src/lib/canvas/publish-page.ts\` | Primary host threading; subdomain response URL |
| web API | \`apps/web/src/app/api/drives/[driveId]/domains/route.ts\` | Atomic transaction cap enforcement; \`limit\` in GET |
| web API | \`apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts\` | Retryable \`clearCustomHost\`; regen before mirror |
| web UI | \`apps/web/src/lib/subscription/plans.ts\` | \`maxCustomDomains\` per plan |
| web UI | \`apps/web/src/app/dashboard/[driveId]/settings/general/page.tsx\` | Domain count/limit display; 403 error handling |

## Test plan

- [x] \`packages/lib\` canvas tests: \`primary-host.test.ts\` (7 pure tests), \`custom-domain-mirror.test.ts\` (updated)
- [x] \`apps/web\` tests: \`publish-page.test.ts\`, \`custom-domain-mirror.test.ts\`, \`domains/route.test.ts\`, \`cert/refresh/route.test.ts\`, \`pages/publish/route.test.ts\` — all pass
- [x] Web typecheck: \`bun run --filter 'web' typecheck\` exits 0
- [x] \`@pagespace/lib\` typecheck: exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWbcqFFxPncD7Xpu6XRdSY