### PR TITLE
fix(ai-sidebar): correct context-aware help label for all routes

### DIFF
--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -450,7 +450,7 @@ const SidebarChatTab: React.FC = () => {
             if (parsed.pageId) {
               currentPage = await fetchPageContext(parsed.pageId, currentDrive);
             }
-            label = currentPage?.title ?? getStaticTabMeta(parsed)?.title ?? null;
+            label = currentPage?.title ?? null;
             break;
           }
 
@@ -481,8 +481,10 @@ const SidebarChatTab: React.FC = () => {
 
           // Everything else with a known static title (dms, channels, tasks,
           // calendar, files/drives, activity, drive-scoped variants, …).
+          // 'unknown' routes have no meaningful label (getStaticTabMeta would
+          // echo the raw path), so fall back to the generic prompt.
           default: {
-            label = getStaticTabMeta(parsed)?.title ?? null;
+            label = parsed.type === 'unknown' ? null : getStaticTabMeta(parsed)?.title ?? null;
             break;
           }
         }

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -32,6 +32,7 @@ import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { toast } from 'sonner';
 import { LocationContext } from '@/lib/ai/shared';
+import { parseTabPath, getStaticTabMeta } from '@/lib/tabs/tab-title';
 import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId } from '@/lib/ai/core/client';
 import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
 import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery } from '@/lib/ai/shared';
@@ -56,7 +57,8 @@ const SIDEBAR_VIRTUALIZATION_THRESHOLD = 30;
 export interface SidebarMessagesContentProps {
   messages: UIMessage[];
   assistantName: string;
-  locationContext: LocationContext | null;
+  /** Human-readable label for the current location, shown in the empty state. */
+  contextLabel: string | null;
   handleEdit: (messageId: string, newContent: string) => Promise<void>;
   handleDelete: (messageId: string) => Promise<void>;
   handleRetry: () => Promise<void>;
@@ -71,7 +73,7 @@ export interface SidebarMessagesContentProps {
 export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
   messages,
   assistantName,
-  locationContext,
+  contextLabel,
   handleEdit,
   handleDelete,
   handleRetry,
@@ -122,8 +124,8 @@ export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
           <div className="max-w-full px-2">
             <p className="font-medium truncate">{assistantName}</p>
             <p className="text-xs truncate">
-              {locationContext
-                ? `Context-aware help for ${locationContext.currentPage?.title || locationContext.currentDrive?.name}`
+              {contextLabel
+                ? `Context-aware help for ${contextLabel}`
                 : 'Ask me anything about your workspace'}
             </p>
           </div>
@@ -337,6 +339,7 @@ const SidebarChatTab: React.FC = () => {
   const [input, setInput] = useState<string>('');
   const [showError, setShowError] = useState(true);
   const [locationContext, setLocationContext] = useState<LocationContext | null>(null);
+  const [contextLabel, setContextLabel] = useState<string | null>(null);
   const [undoDialogMessageId, setUndoDialogMessageId] = useState<string | null>(null);
   const [lastAIResponse, setLastAIResponse] = useState<{ id: string; text: string } | null>(null);
   // undefined = uninitialized, null = initialized with no baseline message, string = baseline message ID
@@ -386,102 +389,126 @@ const SidebarChatTab: React.FC = () => {
   // Effects: Location Context Extraction
   // ============================================
   useEffect(() => {
-    const extractLocationContext = async () => {
-      const pathParts = pathname.split('/').filter(Boolean);
+    // Capture the pathname this run is resolving for, so async branches can
+    // bail if the user navigated away before they completed.
+    const activePathname = pathname;
+    let ignore = false;
 
-      if (pathParts.length >= 2 && pathParts[0] === 'dashboard') {
-        const driveId = pathParts[1];
+    const resolveDrive = (driveId: string | undefined) => {
+      if (!driveId) return null;
+      const driveData = useDriveStore.getState().drives.find(d => d.id === driveId);
+      return driveData
+        ? { id: driveData.id, slug: driveData.slug, name: driveData.name }
+        : null;
+    };
 
+    const fetchPageContext = async (
+      pageId: string,
+      currentDrive: { id: string; slug: string; name: string } | null
+    ) => {
+      try {
+        const pageResponse = await fetchWithAuth(`/api/pages/${pageId}`);
+        if (!pageResponse.ok) return null;
+        const pageData = await pageResponse.json();
+
+        let path = `/${currentDrive?.slug}/${pageData.title}`;
         try {
-          let currentPage = null;
-          let currentDrive = null;
-
-          if (driveId) {
-            const currentDrives = useDriveStore.getState().drives;
-            const driveData = currentDrives.find(d => d.id === driveId);
-            if (driveData) {
-              currentDrive = {
-                id: driveData.id,
-                slug: driveData.slug,
-                name: driveData.name
-              };
-            }
+          const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
+          if (breadcrumbsResponse.ok) {
+            const breadcrumbsData = await breadcrumbsResponse.json();
+            const pathSegments = breadcrumbsData.map((crumb: { title: string }) => crumb.title);
+            path = `/${currentDrive?.slug}/${pathSegments.join('/')}`;
           }
-
-          if (pathParts.length > 2) {
-            const pageId = pathParts[2];
-
-            try {
-              const pageResponse = await fetchWithAuth(`/api/pages/${pageId}`);
-              if (pageResponse.ok) {
-                const pageData = await pageResponse.json();
-
-                try {
-                  const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
-                  if (breadcrumbsResponse.ok) {
-                    const breadcrumbsData = await breadcrumbsResponse.json();
-                    const pathSegments = breadcrumbsData.map((crumb: { title: string }) => crumb.title);
-                    const fullPath = `/${currentDrive?.slug}/${pathSegments.join('/')}`;
-
-                    currentPage = {
-                      id: pageData.id,
-                      title: pageData.title,
-                      type: pageData.type,
-                      path: fullPath
-                    };
-                  } else {
-                    currentPage = {
-                      id: pageData.id,
-                      title: pageData.title,
-                      type: pageData.type,
-                      path: `/${currentDrive?.slug}/${pageData.title}`
-                    };
-                  }
-                } catch {
-                  currentPage = {
-                    id: pageData.id,
-                    title: pageData.title,
-                    type: pageData.type,
-                    path: `/${currentDrive?.slug}/${pageData.title}`
-                  };
-                }
-              } else {
-                currentPage = {
-                  id: pageId,
-                  title: pathParts[pathParts.length - 1].replace(/-/g, ' '),
-                  type: 'DOCUMENT',
-                  path: `/${currentDrive?.slug}/${pathParts[pathParts.length - 1].replace(/-/g, ' ')}`
-                };
-              }
-            } catch {
-              currentPage = {
-                id: pageId,
-                title: pathParts[pathParts.length - 1].replace(/-/g, ' '),
-                type: 'DOCUMENT',
-                path: `/${currentDrive?.slug}/${pathParts[pathParts.length - 1].replace(/-/g, ' ')}`
-              };
-            }
-          }
-
-          const breadcrumbs = [];
-          if (currentDrive) {
-            breadcrumbs.push(currentDrive.name);
-          }
-          if (currentPage && currentPage.path) {
-            const pathParts = currentPage.path.split('/').filter(Boolean);
-            breadcrumbs.push(...pathParts.slice(1));
-          }
-
-          setLocationContext({ currentPage, currentDrive, breadcrumbs });
         } catch {
-          setLocationContext(null);
+          // Keep the simple path fallback.
         }
-      } else {
-        setLocationContext(null);
+
+        return {
+          id: pageData.id,
+          title: pageData.title,
+          type: pageData.type,
+          path,
+        };
+      } catch {
+        return null;
       }
     };
 
+    const extractLocationContext = async () => {
+      const parsed = parseTabPath(activePathname);
+
+      let label: string | null = null;
+      let currentPage: LocationContext['currentPage'] = null;
+      let currentDrive: LocationContext['currentDrive'] = null;
+
+      try {
+        switch (parsed.type) {
+          // Real page routes — fetch the page so the AI keeps page context.
+          case 'page':
+          case 'channel': {
+            currentDrive = parsed.type === 'page' ? resolveDrive(parsed.driveId) : null;
+            if (parsed.pageId) {
+              currentPage = await fetchPageContext(parsed.pageId, currentDrive);
+            }
+            label = currentPage?.title ?? getStaticTabMeta(parsed)?.title ?? null;
+            break;
+          }
+
+          // A whole drive — use the drive name from the store.
+          case 'drive': {
+            currentDrive = resolveDrive(parsed.driveId);
+            label = currentDrive?.name ?? null;
+            break;
+          }
+
+          // A specific DM — show the other person's name (DMs are not pages).
+          case 'dm': {
+            if (parsed.conversationId) {
+              try {
+                const res = await fetchWithAuth(`/api/messages/conversations/${parsed.conversationId}`);
+                if (res.ok) {
+                  const data = await res.json();
+                  const otherUser = data?.conversation?.otherUser;
+                  label = otherUser?.displayName || otherUser?.name || null;
+                }
+              } catch {
+                // Fall through to the generic DM label below.
+              }
+            }
+            if (!label) label = 'Direct Message';
+            break;
+          }
+
+          // Everything else with a known static title (dms, channels, tasks,
+          // calendar, files/drives, activity, drive-scoped variants, …).
+          default: {
+            label = getStaticTabMeta(parsed)?.title ?? null;
+            break;
+          }
+        }
+      } catch {
+        label = null;
+      }
+
+      if (ignore) return;
+
+      const breadcrumbs: string[] = [];
+      if (currentDrive) breadcrumbs.push(currentDrive.name);
+      if (currentPage?.path) {
+        breadcrumbs.push(...currentPage.path.split('/').filter(Boolean).slice(1));
+      }
+
+      setContextLabel(label);
+      setLocationContext(
+        currentPage || currentDrive ? { currentPage, currentDrive, breadcrumbs } : null
+      );
+    };
+
     extractLocationContext();
+
+    return () => {
+      ignore = true;
+    };
   }, [pathname]);
 
   // ============================================
@@ -1050,7 +1077,7 @@ const SidebarChatTab: React.FC = () => {
             <SidebarMessagesContent
               messages={displayMessages}
               assistantName={assistantName}
-              locationContext={locationContext}
+              contextLabel={contextLabel}
               handleEdit={handleEdit}
               handleDelete={handleDelete}
               handleRetry={handleRetry}
@@ -1106,9 +1133,7 @@ const SidebarChatTab: React.FC = () => {
           onSend={handleSendMessage}
           onStop={handleStop}
           isStreaming={displayIsStreaming}
-          placeholder={locationContext
-            ? `Ask about ${locationContext.currentPage?.title || 'this page'}...`
-            : 'Ask about your workspace...'}
+          placeholder={`Ask about ${contextLabel ?? 'your workspace'}...`}
           driveId={locationContext?.currentDrive?.id}
           crossDrive={true}
           hideModelSelector={true}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -380,6 +380,9 @@ const SidebarChatTab: React.FC = () => {
   // Effects: Drive Loading
   // ============================================
   const fetchDrives = useDriveStore((state) => state.fetchDrives);
+  // Subscribe to drives so the location-context effect re-runs once the store
+  // populates (drive labels would otherwise stay null until the next nav).
+  const drives = useDriveStore((state) => state.drives);
 
   useEffect(() => {
     fetchDrives();
@@ -396,7 +399,7 @@ const SidebarChatTab: React.FC = () => {
 
     const resolveDrive = (driveId: string | undefined) => {
       if (!driveId) return null;
-      const driveData = useDriveStore.getState().drives.find(d => d.id === driveId);
+      const driveData = drives.find(d => d.id === driveId);
       return driveData
         ? { id: driveData.id, slug: driveData.slug, name: driveData.name }
         : null;
@@ -411,13 +414,17 @@ const SidebarChatTab: React.FC = () => {
         if (!pageResponse.ok) return null;
         const pageData = (await pageResponse.json()) as { id: string; title: string; type: string };
 
-        let path = `/${currentDrive?.slug}/${pageData.title}`;
+        // Only prefix the drive slug when we actually have one — channel routes
+        // resolve no drive, so a bare `/${slug}` would bake "/undefined/..." into
+        // the path that gets sent to the AI.
+        const slugPrefix = currentDrive?.slug ? `/${currentDrive.slug}` : '';
+        let path = `${slugPrefix}/${pageData.title}`;
         try {
           const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
           if (breadcrumbsResponse.ok) {
             const breadcrumbsData = (await breadcrumbsResponse.json()) as Array<{ title: string }>;
             const pathSegments = breadcrumbsData.map((crumb) => crumb.title);
-            path = `/${currentDrive?.slug}/${pathSegments.join('/')}`;
+            path = `${slugPrefix}/${pathSegments.join('/')}`;
           }
         } catch {
           // Keep the simple path fallback.
@@ -513,7 +520,7 @@ const SidebarChatTab: React.FC = () => {
     return () => {
       ignore = true;
     };
-  }, [pathname]);
+  }, [pathname, drives]);
 
   // ============================================
   // Effects: Global Mode Sync to Context

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -409,14 +409,14 @@ const SidebarChatTab: React.FC = () => {
       try {
         const pageResponse = await fetchWithAuth(`/api/pages/${pageId}`);
         if (!pageResponse.ok) return null;
-        const pageData = await pageResponse.json();
+        const pageData = (await pageResponse.json()) as { id: string; title: string; type: string };
 
         let path = `/${currentDrive?.slug}/${pageData.title}`;
         try {
           const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
           if (breadcrumbsResponse.ok) {
-            const breadcrumbsData = await breadcrumbsResponse.json();
-            const pathSegments = breadcrumbsData.map((crumb: { title: string }) => crumb.title);
+            const breadcrumbsData = (await breadcrumbsResponse.json()) as Array<{ title: string }>;
+            const pathSegments = breadcrumbsData.map((crumb) => crumb.title);
             path = `/${currentDrive?.slug}/${pathSegments.join('/')}`;
           }
         } catch {
@@ -467,7 +467,9 @@ const SidebarChatTab: React.FC = () => {
               try {
                 const res = await fetchWithAuth(`/api/messages/conversations/${parsed.conversationId}`);
                 if (res.ok) {
-                  const data = await res.json();
+                  const data = (await res.json()) as {
+                    conversation?: { otherUser?: { displayName?: string | null; name?: string | null } };
+                  };
                   const otherUser = data?.conversation?.otherUser;
                   label = otherUser?.displayName || otherUser?.name || null;
                 }

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarMessagesContent.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarMessagesContent.test.tsx
@@ -87,7 +87,7 @@ const noopHandlers = {
 const baseProps = {
   ...noopHandlers,
   assistantName: 'Global Assistant',
-  locationContext: null,
+  contextLabel: null,
   lastAssistantMessageId: undefined,
   lastUserMessageId: undefined,
   displayIsStreaming: false,

--- a/apps/web/src/components/layout/tabs/TabItem.tsx
+++ b/apps/web/src/components/layout/tabs/TabItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useCallback, useMemo, type CSSProperties } from 'react';
-import { X, Pin, File, FileText, LayoutDashboard, CheckSquare, Activity, Users, Settings, Trash2, MessageSquare, Layout, Folder, Table, Inbox, Calendar, HardDrive, Link, UserPlus, User, Bell, Shield, LifeBuoy, PenSquare, Hash, MessageCircle } from 'lucide-react';
+import { X, Pin, File, FileText, LayoutDashboard, CheckSquare, Activity, Users, Settings, Trash2, MessageSquare, Layout, Folder, Table, Inbox, Calendar, HardDrive, Link, UserPlus, User, Bell, Shield, LifeBuoy, PenSquare, Hash, MessageCircle, Workflow } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
@@ -57,6 +57,7 @@ const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   LifeBuoy,
   PenSquare,
   Hash,
+  Workflow,
 };
 
 export const TabItem = memo(function TabItem({

--- a/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
+++ b/apps/web/src/lib/tabs/__tests__/tab-title.test.ts
@@ -70,6 +70,22 @@ describe('tab-title', () => {
       expect(result.driveId).toBe('drive-123');
     });
 
+    it('given drive files path, should return drive-files type', () => {
+      const result = parseTabPath('/dashboard/drive-123/files');
+
+      expect(result.type).toBe('drive-files');
+      expect(result.driveId).toBe('drive-123');
+      expect(result.pageId).toBeUndefined();
+    });
+
+    it('given drive workflows path, should return drive-workflows type', () => {
+      const result = parseTabPath('/dashboard/drive-123/workflows');
+
+      expect(result.type).toBe('drive-workflows');
+      expect(result.driveId).toBe('drive-123');
+      expect(result.pageId).toBeUndefined();
+    });
+
     it('given dms root, should return dms type', () => {
       const result = parseTabPath('/dashboard/dms');
 
@@ -432,6 +448,20 @@ describe('tab-title', () => {
 
       expect(meta!.title).toBe('Channels');
       expect(meta!.iconName).toBe('Hash');
+    });
+
+    it('given drive-files type, should return Files title', () => {
+      const meta = getStaticTabMeta({ type: 'drive-files', driveId: 'drive-123' });
+
+      expect(meta!.title).toBe('Files');
+      expect(meta!.iconName).toBe('Folder');
+    });
+
+    it('given drive-workflows type, should return Workflows title', () => {
+      const meta = getStaticTabMeta({ type: 'drive-workflows', driveId: 'drive-123' });
+
+      expect(meta!.title).toBe('Workflows');
+      expect(meta!.iconName).toBe('Workflow');
     });
 
     // Members sub-routes

--- a/apps/web/src/lib/tabs/tab-title.ts
+++ b/apps/web/src/lib/tabs/tab-title.ts
@@ -18,6 +18,8 @@ export type PathType =
   | 'drive-trash'
   | 'drive-calendar'
   | 'drive-channels'
+  | 'drive-files'
+  | 'drive-workflows'
   // Global dashboard routes
   | 'dashboard-tasks'
   | 'dashboard-activity'
@@ -68,7 +70,7 @@ export interface TabMeta {
 const GLOBAL_DASHBOARD_ROUTES = ['tasks', 'activity', 'storage', 'trash', 'connections', 'calendar', 'dms', 'channels', 'drives'] as const;
 
 // Drive-specific special routes
-const DRIVE_SPECIAL_ROUTES = ['tasks', 'activity', 'members', 'settings', 'trash', 'calendar', 'channels'] as const;
+const DRIVE_SPECIAL_ROUTES = ['tasks', 'activity', 'members', 'settings', 'trash', 'calendar', 'channels', 'files', 'workflows'] as const;
 
 export const parseTabPath = (path: string): ParsedPath => {
   const segments = path.split('/').filter(Boolean);
@@ -221,6 +223,8 @@ export const parseTabPath = (path: string): ParsedPath => {
       trash: 'drive-trash',
       calendar: 'drive-calendar',
       channels: 'drive-channels',
+      files: 'drive-files',
+      workflows: 'drive-workflows',
     };
     return {
       type: typeMap[thirdSegment],
@@ -311,6 +315,12 @@ export const getStaticTabMeta = (parsed: ParsedPath): TabMeta | null => {
 
     case 'drive-channels':
       return { title: 'Channels', iconName: 'Hash' };
+
+    case 'drive-files':
+      return { title: 'Files', iconName: 'Folder' };
+
+    case 'drive-workflows':
+      return { title: 'Workflows', iconName: 'Workflow' };
 
     // Direct Messages + Channels routes
     case 'dms':


### PR DESCRIPTION
## Problem

The right-sidebar AI assistant's context line showed broken text:
- **"Context-aware help for undefined"** on every top-level route — Direct Messages, Channels, Tasks, Calendar, Files, Activity, Drives, etc.
- **"Ask about <conversation-id>…"** for a selected DM (raw id instead of the person's name).
- Channels happened to work only because a channel *is* a real page.

**Root cause:** `extractLocationContext` in `SidebarChatTab.tsx` assumed every path was `/dashboard/<driveId>/<pageId>`. Section/list routes resolved to no drive **and** no page (→ `undefined`), and a selected DM tried to fetch `/api/pages/<conversationId>` — DMs aren't pages — and fell back to the raw id.

## Fix

- **Rewrote `extractLocationContext`** to drive off the existing `parseTabPath()` route parser and derive a proper label per route type:
  - DM selected → the other person's name (`/api/messages/conversations/<id>`, reusing the `displayName || name` precedence from `useTabMeta`)
  - DMs list → "Direct Messages", Channels list → "Channels", Tasks/Calendar/Files/Activity/etc. → their static titles (`getStaticTabMeta`)
  - Real page/channel → fetched page title (preserved, including the AI `currentPage`/`currentDrive` payload)
  - Unknown routes → generic prompt (never echoes a raw path)
  - Added a stale-navigation guard so an in-flight fetch can't clobber the label after the user navigates away.
- **Decoupled display from the AI payload** via a new `contextLabel`; the request body still carries only real drive/page data (no synthetic page ids).
- **Typed the page/breadcrumbs/DM fetch responses** (no implicit `any`), matching the typed fetcher pattern in `useTabMeta`.
- **Closed a shared-util gap** in `tab-title.ts`: `/dashboard/[driveId]/files` and `/workflows` were mis-classified as pages. Added `drive-files`/`drive-workflows` path types, route mappings, and static meta — this also corrects tab titles app-wide.
- **Mapped the `Workflow` icon** in `TabItem`'s `ICON_MAP` so the new `drive-workflows` tab gets the right icon instead of a document fallback.

## Files

- `components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx` — label rewrite + `contextLabel`
- `lib/tabs/tab-title.ts` — `drive-files` / `drive-workflows` route types + static meta
- `components/layout/tabs/TabItem.tsx` — `Workflow` icon mapping
- Tests: `tab-title.test.ts`, `SidebarMessagesContent.test.tsx`

## Testing

- `web` typecheck clean, lint clean (no new warnings)
- Unit tests pass: `tab-title.test.ts` (new drive-files/workflows cases) + `SidebarMessagesContent.test.tsx`
- Manual: open the sidebar and navigate `/dashboard/dms`, a DM, `/dashboard/channels`, a channel, `/dashboard/tasks`, `/dashboard/calendar`, `/dashboard/drives`, drive-scoped `/files` and `/workflows`, and a normal page — both the empty-state header and the input placeholder show the right label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)