### PR TITLE
feat(gdpr): configurable retention, activity-log archival tier, export manifest + portable format

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,15 @@ RETENTION_API_METRICS_DAYS=90
 RETENTION_SYSTEM_LOGS_DAYS=30
 RETENTION_ERROR_LOGS_DAYS=90
 RETENTION_USER_ACTIVITIES_DAYS=180
+# AI usage log purge window (days). Used by the purge-ai-usage-logs cron.
+RETENTION_AI_USAGE_LOGS_DAYS=90
+
+# activity_logs hot→cold archival (isArchived flip job, archive-activity-logs cron).
+# Rows older than ACTIVITY_LOGS_ARCHIVE_DAYS are flagged isArchived=true in batches.
+# This NEVER deletes rows or touches the tamper-evident hash chain.
+ACTIVITY_LOGS_ARCHIVE_DAYS=365
+ACTIVITY_LOGS_ARCHIVE_BATCH_SIZE=1000
+ACTIVITY_LOGS_ARCHIVE_MAX_RUN_MS=25000
 
 # Socket.IO Realtime Service Security
 REALTIME_BROADCAST_SECRET=your_realtime_broadcast_secret_here_generate_a_secure_random_string

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -190,8 +190,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      // Should append 11 JSON files (sessions, notifications, displayPreferences added; personalization omitted when null)
-      expect(mockArchive.append).toHaveBeenCalledTimes(11);
+      // 11 data files (personalization omitted when null) + manifest.json
+      expect(mockArchive.append).toHaveBeenCalledTimes(12);
       // Verify each data category name pattern
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
@@ -207,6 +207,44 @@ describe('GET /api/account/export', () => {
       expect(appendCalls.some((n: string) => n.includes('sessions.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('notifications.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('display-preferences.json'))).toBe(true);
+      // manifest.json is always present (Art 20 self-describing bundle)
+      expect(appendCalls.some((n: string) => n.includes('manifest.json'))).toBe(true);
+    });
+
+    it('manifest.json documents the schema version and file inventory', async () => {
+      vi.mocked(collectAllUserData).mockResolvedValue(mockUserData as never);
+
+      await GET(createRequest());
+
+      const manifestCall = mockArchive.append.mock.calls.find(
+        (call: unknown[]) => (call[1] as { name: string }).name.includes('manifest.json')
+      );
+      expect(manifestCall).toBeDefined();
+      const manifest = JSON.parse(manifestCall![0] as string);
+      expect(manifest.schemaVersion).toBe('1.0.0');
+      expect(manifest.format).toBe('native');
+      expect(Array.isArray(manifest.files)).toBe(true);
+      expect(manifest.files.some((f: { name: string }) => f.name === 'pages.json')).toBe(true);
+    });
+
+    it('format=portable emits a single schema.org data.json plus manifest', async () => {
+      vi.mocked(collectAllUserData).mockResolvedValue(mockUserData as never);
+
+      await GET(new Request('http://localhost/api/account/export?format=portable'));
+
+      const appendCalls = mockArchive.append.mock.calls.map(
+        (call: unknown[]) => (call[1] as { name: string }).name
+      );
+      // portable = data.json + manifest.json only
+      expect(mockArchive.append).toHaveBeenCalledTimes(2);
+      expect(appendCalls.some((n: string) => n.includes('data.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('manifest.json'))).toBe(true);
+
+      const dataCall = mockArchive.append.mock.calls.find(
+        (call: unknown[]) => (call[1] as { name: string }).name.includes('data.json')
+      );
+      const portable = JSON.parse(dataCall![0] as string);
+      expect(portable['@context']).toBe('https://schema.org');
     });
 
     it('appends personalization.json when personalization data exists', async () => {
@@ -217,7 +255,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      expect(mockArchive.append).toHaveBeenCalledTimes(12);
+      // 12 data files + manifest.json
+      expect(mockArchive.append).toHaveBeenCalledTimes(13);
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
       );

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -1,4 +1,10 @@
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
+import {
+  parseExportFormat,
+  buildNativeExportFiles,
+  buildPortableExportFiles,
+  buildExportManifest,
+} from '@pagespace/lib/compliance/export/export-format';
 import { db } from '@pagespace/db/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { checkDistributedRateLimit, resetDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
@@ -22,6 +28,10 @@ export async function GET(request: Request) {
     return auth.error;
   }
   const userId = auth.userId;
+
+  // Portability format selection (Art 20). `native` = per-section JSON (default);
+  // `portable` = a single documented schema.org bundle. Unknown values → native.
+  const format = parseExportFormat(new URL(request.url).searchParams.get('format'));
 
   // Rate limiting (distributed via Postgres rate_limit_buckets)
   const rateLimitKey = `export:user:${userId}`;
@@ -72,21 +82,16 @@ export async function GET(request: Request) {
       },
     });
 
-    // Add JSON files to archive
-    archive.append(JSON.stringify(data.profile, null, 2), { name: `pagespace-export-${dateStr}/profile.json` });
-    archive.append(JSON.stringify(data.drives, null, 2), { name: `pagespace-export-${dateStr}/drives.json` });
-    archive.append(JSON.stringify(data.pages, null, 2), { name: `pagespace-export-${dateStr}/pages.json` });
-    archive.append(JSON.stringify(data.messages, null, 2), { name: `pagespace-export-${dateStr}/messages.json` });
-    archive.append(JSON.stringify(data.files, null, 2), { name: `pagespace-export-${dateStr}/files-metadata.json` });
-    archive.append(JSON.stringify(data.activity, null, 2), { name: `pagespace-export-${dateStr}/activity.json` });
-    archive.append(JSON.stringify(data.aiUsage, null, 2), { name: `pagespace-export-${dateStr}/ai-usage.json` });
-    archive.append(JSON.stringify(data.tasks, null, 2), { name: `pagespace-export-${dateStr}/tasks.json` });
-    archive.append(JSON.stringify(data.sessions, null, 2), { name: `pagespace-export-${dateStr}/sessions.json` });
-    archive.append(JSON.stringify(data.notifications, null, 2), { name: `pagespace-export-${dateStr}/notifications.json` });
-    archive.append(JSON.stringify(data.displayPreferences, null, 2), { name: `pagespace-export-${dateStr}/display-preferences.json` });
-    if (data.personalization) {
-      archive.append(JSON.stringify(data.personalization, null, 2), { name: `pagespace-export-${dateStr}/personalization.json` });
+    // Build the file set for the requested format and append each as JSON.
+    const files = format === 'portable' ? buildPortableExportFiles(data) : buildNativeExportFiles(data);
+    for (const file of files) {
+      archive.append(JSON.stringify(file.data, null, 2), { name: `pagespace-export-${dateStr}/${file.name}` });
     }
+
+    // manifest.json documents the schema version + file inventory so the bundle
+    // is self-describing (GDPR Art 20 portability).
+    const manifest = buildExportManifest(files, { exportedAt: new Date(), format });
+    archive.append(JSON.stringify(manifest, null, 2), { name: `pagespace-export-${dateStr}/manifest.json` });
 
     // Finalize the archive (must be called after all data is appended)
     archive.finalize();

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -65,7 +65,8 @@ export async function GET(request: Request) {
 
     // Build ZIP archive
     const archive = archiver('zip', { zlib: { level: 6 } });
-    const dateStr = new Date().toISOString().split('T')[0];
+    const exportedAt = new Date();
+    const dateStr = exportedAt.toISOString().split('T')[0];
 
     // Bridge Node Readable → Web ReadableStream
     const readable = new ReadableStream({
@@ -90,7 +91,7 @@ export async function GET(request: Request) {
 
     // manifest.json documents the schema version + file inventory so the bundle
     // is self-describing (GDPR Art 20 portability).
-    const manifest = buildExportManifest(files, { exportedAt: new Date(), format });
+    const manifest = buildExportManifest(files, { exportedAt, format });
     archive.append(JSON.stringify(manifest, null, 2), { name: `pagespace-export-${dateStr}/manifest.json` });
 
     // Finalize the archive (must be called after all data is appended)

--- a/apps/web/src/app/api/cron/archive-activity-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/archive-activity-logs/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Contract tests for /api/cron/archive-activity-logs
+ * Verifies HMAC gating, audit logging, and before/after chain integrity reporting
+ * for the activity_logs hot→cold archival (isArchived flip) cron.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockArchive, mockConfig, mockQuickCheck, mockAudit } = vi.hoisted(() => ({
+  mockArchive: vi.fn(),
+  mockConfig: vi.fn(),
+  mockQuickCheck: vi.fn(),
+  mockAudit: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/cron-auth', () => ({
+  validateSignedCronRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/compliance/retention/activity-log-archival', () => ({
+  archiveActivityLogs: mockArchive,
+  getActivityLogArchivalConfig: mockConfig,
+}));
+
+vi.mock('@pagespace/lib/monitoring/hash-chain-verifier', () => ({
+  quickIntegrityCheck: mockQuickCheck,
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: mockAudit,
+}));
+
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        status: init?.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  },
+}));
+
+import { GET } from '../route';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+function makeRequest(): Request {
+  return new Request('http://localhost:3000/api/cron/archive-activity-logs');
+}
+
+describe('/api/cron/archive-activity-logs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateSignedCronRequest).mockReturnValue(null);
+    mockConfig.mockReturnValue({ archiveDays: 365, batchSize: 1000, maxRunMs: 25000 });
+    mockArchive.mockResolvedValue({ table: 'activity_logs', archived: 7, batches: 1 });
+    mockQuickCheck.mockResolvedValue({
+      isLikelyValid: true,
+      hasChainSeed: true,
+      lastEntriesValid: true,
+      sampleValid: true,
+      details: 'ok',
+    });
+  });
+
+  it('returns the auth error and never archives when auth fails', async () => {
+    const authResponse = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+    vi.mocked(validateSignedCronRequest).mockReturnValue(authResponse as never);
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(403);
+    expect(mockArchive).not.toHaveBeenCalled();
+    expect(mockAudit).not.toHaveBeenCalled();
+  });
+
+  it('archives and emits a data.write audit event with the archived count', async () => {
+    await GET(makeRequest());
+
+    expect(mockArchive).toHaveBeenCalledTimes(1);
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'data.write',
+        resourceType: 'cron_job',
+        resourceId: 'archive_activity_logs',
+        details: expect.objectContaining({ archived: 7 }),
+      }),
+    );
+  });
+
+  it('reports quickIntegrityCheck before and after the run', async () => {
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(mockQuickCheck).toHaveBeenCalledTimes(2);
+    expect(body.chainIntegrity.before.isLikelyValid).toBe(true);
+    expect(body.chainIntegrity.after.isLikelyValid).toBe(true);
+    expect(body.archived).toBe(7);
+  });
+});

--- a/apps/web/src/app/api/cron/archive-activity-logs/route.ts
+++ b/apps/web/src/app/api/cron/archive-activity-logs/route.ts
@@ -1,0 +1,80 @@
+import {
+  archiveActivityLogs,
+  getActivityLogArchivalConfig,
+} from '@pagespace/lib/compliance/retention/activity-log-archival';
+import { quickIntegrityCheck } from '@pagespace/lib/monitoring/hash-chain-verifier';
+import { db } from '@pagespace/db/db';
+import { audit } from '@pagespace/lib/audit/audit-log';
+import { NextResponse } from 'next/server';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+/**
+ * Cron endpoint to archive (hot→cold tier) old activity_logs rows.
+ *
+ * Flips `isArchived = true` on rows older than ACTIVITY_LOGS_ARCHIVE_DAYS
+ * (default 365), batched and bounded by a per-run wall-clock budget. This is a
+ * flag flip ONLY: it never deletes rows and never touches the tamper-evident
+ * hash chain, so chain verification is unaffected.
+ *
+ * Defense in depth: runs the hash-chain quick integrity check before and after
+ * the run and reports both in the response. `isArchived` is not a hash input,
+ * so a difference here would indicate a bug, not normal operation.
+ *
+ * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce, X-Cron-Signature headers.
+ */
+export async function GET(request: Request) {
+  const authError = validateSignedCronRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const before = await quickIntegrityCheck();
+
+    const config = getActivityLogArchivalConfig();
+    const result = await archiveActivityLogs(
+      db as Parameters<typeof archiveActivityLogs>[0],
+      config,
+    );
+
+    const after = await quickIntegrityCheck();
+
+    console.log(
+      `[Cron] activity_logs archival: ${result.archived} rows flipped across ${result.batches} batch(es)`,
+    );
+
+    audit({
+      eventType: 'data.write',
+      resourceType: 'cron_job',
+      resourceId: 'archive_activity_logs',
+      details: {
+        archived: result.archived,
+        batches: result.batches,
+        archiveDays: config.archiveDays,
+        chainIntegrityBefore: before.isLikelyValid,
+        chainIntegrityAfter: after.isLikelyValid,
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      archived: result.archived,
+      batches: result.batches,
+      chainIntegrity: { before, after },
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('[Cron] Error archiving activity logs:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  return GET(request);
+}

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -69,4 +69,24 @@ describe('/api/cron/purge-ai-usage-logs', () => {
 
     expect(mockAudit).not.toHaveBeenCalled();
   });
+
+  it('purges using the env-configured retention window, not a hardcoded 90', async () => {
+    const original = process.env.RETENTION_AI_USAGE_LOGS_DAYS;
+    process.env.RETENTION_AI_USAGE_LOGS_DAYS = '30';
+    try {
+      const before = Date.now();
+      await GET(makeRequest());
+      const after = Date.now();
+
+      expect(mockPurge).toHaveBeenCalledTimes(1);
+      const cutoff = mockPurge.mock.calls[0][0] as Date;
+      const expectedMs = 30 * 24 * 60 * 60 * 1000;
+      // cutoff ≈ now - 30d; bounded by the test's wall-clock window
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - expectedMs - 5);
+      expect(cutoff.getTime()).toBeLessThanOrEqual(after - expectedMs + 5);
+    } finally {
+      if (original === undefined) delete process.env.RETENTION_AI_USAGE_LOGS_DAYS;
+      else process.env.RETENTION_AI_USAGE_LOGS_DAYS = original;
+    }
+  });
 });

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
@@ -1,4 +1,5 @@
 import { purgeAiUsageLogs } from '@pagespace/lib/logging/ai-usage-purge';
+import { getAiUsageLogsRetentionDays, getRetentionCutoff } from '@pagespace/lib/compliance/retention/monitoring-retention';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
@@ -6,7 +7,9 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 /**
  * Cron endpoint to purge old AI usage logs.
  *
- * Deletes entire rows older than 90 days to enforce data retention limits.
+ * Deletes entire rows older than RETENTION_AI_USAGE_LOGS_DAYS (default 90) to
+ * enforce data retention limits. The window is env-configurable so tenant
+ * deployments can tune it without a code change.
  *
  * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce, X-Cron-Signature headers.
  */
@@ -18,9 +21,9 @@ export async function GET(request: Request) {
 
   try {
     const now = new Date();
-    const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+    const cutoff = getRetentionCutoff(getAiUsageLogsRetentionDays());
 
-    const purged = await purgeAiUsageLogs(ninetyDaysAgo);
+    const purged = await purgeAiUsageLogs(cutoff);
 
     console.log(`[Cron] AI usage logs: purged ${purged}`);
 

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -27,6 +27,11 @@
 # Verifies hash chain integrity of security audit log
 0 2 * * * cron-curl GET __WEB_URL__/api/cron/verify-audit-chain >> /var/log/cron/audit-chain.log 2>&1
 
+# Activity log archival (hot→cold tier) - Daily at 2:30am UTC
+# Flips isArchived=true on activity_logs older than ACTIVITY_LOGS_ARCHIVE_DAYS (default 365)
+# so the active-view stays bounded. Flag-flip only: never deletes rows or touches the hash chain.
+30 2 * * * cron-curl GET __WEB_URL__/api/cron/archive-activity-logs >> /var/log/cron/archive-activity-logs.log 2>&1
+
 # AI usage log purge - Daily at 3am UTC
 # Anonymizes prompt/completion text >30 days, purges rows >90 days
 0 3 * * * cron-curl POST __WEB_URL__/api/cron/purge-ai-usage-logs >> /var/log/cron/purge-ai-usage.log 2>&1

--- a/docs/security/audit-log-retention-policy.md
+++ b/docs/security/audit-log-retention-policy.md
@@ -33,7 +33,8 @@ hot-path routes) narrows over time and query cost stays bounded as the table
 grows.
 
 **Job.** `apps/web/src/app/api/cron/archive-activity-logs/route.ts`, HMAC-validated
-via `validateSignedCronRequest` on the same cadence as the other retention crons.
+via `validateSignedCronRequest`, registered in `docker/cron/crontab` (daily at
+02:30 UTC, alongside the other retention/purge jobs).
 
 **Engine.** `packages/lib/src/compliance/retention/activity-log-archival.ts`:
 

--- a/docs/security/audit-log-retention-policy.md
+++ b/docs/security/audit-log-retention-policy.md
@@ -1,0 +1,65 @@
+# Audit & Activity Log Retention Policy
+
+This document describes retention for the audit/activity logging tables and the
+configurable retention windows for monitoring data.
+
+## Tables and their retention model
+
+| Table | Retention | Mechanism |
+|-------|-----------|-----------|
+| `security_audit_log` | **Infinite** | Never deleted — tamper-evident hash chain requires an uninterrupted chain (GDPR Art 17(3)(b) legal-obligation justification). |
+| `activity_logs` | **Infinite (rows), tiered visibility** | Never deleted (hash chain + rollback provenance). Old rows are flagged `isArchived = true` to keep the hot/active view bounded — see **Archival** below. |
+| `api_metrics` | `RETENTION_API_METRICS_DAYS` (default 90) | Time-based delete. |
+| `system_logs` | `RETENTION_SYSTEM_LOGS_DAYS` (default 30) | Time-based delete. |
+| `error_logs` | `RETENTION_ERROR_LOGS_DAYS` (default 90) | Time-based delete. |
+| `user_activities` | `RETENTION_USER_ACTIVITIES_DAYS` (default 180) | Time-based delete. |
+| `ai_usage_logs` | `RETENTION_AI_USAGE_LOGS_DAYS` (default 90) | Time-based delete (purge-ai-usage-logs cron). |
+
+All windows are positive integers (days). Unset, zero, negative, or non-numeric
+values fall back to the defaults above. This makes retention tunable per
+deployment (including tenant deployments) without a code change. See
+`packages/lib/src/compliance/retention/monitoring-retention.ts`.
+
+## Archival (`activity_logs` hot→cold tier)
+
+`activity_logs` rows are **never deleted** — the tamper-evident hash chain
+(`previousLogHash`, `logHash`, `chainSeed`, `chainSeq`) and rollback provenance
+(`contentSnapshot`, `contentRef`, `previousValues`, `newValues`,
+`rollbackFromActivityId`) must survive for chain verification and rollback.
+
+Instead, a writer flips `isArchived = true` on rows older than a threshold so
+the active-view filter (`isArchived = false`, used by the `/api/activities/**`
+hot-path routes) narrows over time and query cost stays bounded as the table
+grows.
+
+**Job.** `apps/web/src/app/api/cron/archive-activity-logs/route.ts`, HMAC-validated
+via `validateSignedCronRequest` on the same cadence as the other retention crons.
+
+**Engine.** `packages/lib/src/compliance/retention/activity-log-archival.ts`:
+
+- Selects up to `batchSize` not-yet-archived rows older than the cutoff
+  (oldest first by `chainSeq`) and sets `isArchived = true` on exactly those ids.
+- Batched and bounded by a per-run wall-clock budget to avoid long-held locks on
+  a large table. The next batch re-filters on `isArchived = false`, so the window
+  self-advances without an offset and cannot loop forever.
+- **Flag flip ONLY.** The update payload is exactly `{ isArchived: true }`; it
+  never touches any hash-chain or rollback-provenance field. `isArchived` is not
+  a hash input (see `computeLogHash` / `hash-chain-verifier`), so chain
+  verification is unaffected. The cron runs `quickIntegrityCheck` before and
+  after each run and reports both as defense in depth.
+
+**Configuration:**
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `ACTIVITY_LOGS_ARCHIVE_DAYS` | 365 | Rows older than this are archived. |
+| `ACTIVITY_LOGS_ARCHIVE_BATCH_SIZE` | 1000 | Rows flipped per batch. |
+| `ACTIVITY_LOGS_ARCHIVE_MAX_RUN_MS` | 25000 | Per-run wall-clock budget. |
+
+### Out of scope
+
+- Cold storage / external sink (S3, Parquet, Snowflake) — separate epic.
+- Time-based **deletion** of `activity_logs` — would break the hash chain and
+  rollback provenance; we deliberately don't delete.
+- Analogous treatment for `security_audit_log` — no `isArchived` field, different
+  query profile; handle separately if ever needed.

--- a/docs/security/gdpr-export-format.md
+++ b/docs/security/gdpr-export-format.md
@@ -56,6 +56,15 @@ it can be ingested by other tools without bespoke parsers:
   = page type, `isPartOf` = drive id, `dateCreated`/`dateModified`).
 - Messages → [`Message`](https://schema.org/Message) under `message` (`text`,
   `dateSent`, `messageAttachment` = source surface).
+- Files → [`MediaObject`](https://schema.org/MediaObject) under `subjectOf`
+  (`encodingFormat`, `contentSize`, `contentUrl`, `isPartOf`, `dateCreated`).
+
+The portable format is **lossless**: categories without a natural schema.org
+type (activity, AI usage, tasks, sessions, notifications, display preferences,
+personalization) are carried verbatim as
+[`PropertyValue`](https://schema.org/PropertyValue) entries under
+`additionalProperty`, so the portable bundle contains exactly the same data as
+the native export.
 
 All dates are ISO-8601 strings. Empty sections are emitted as empty arrays.
 

--- a/docs/security/gdpr-export-format.md
+++ b/docs/security/gdpr-export-format.md
@@ -1,0 +1,64 @@
+# GDPR Data Export Format
+
+`GET /api/account/export` returns a ZIP archive of all data held about the
+authenticated user (GDPR Art 15 access / Art 20 portability). Every bundle is
+self-describing via a `manifest.json` at its root.
+
+## Choosing a format — `?format=`
+
+| `format` | Contents |
+|----------|----------|
+| `native` (default, or any unrecognized value) | One JSON file per data category, mirroring PageSpace's internal structure. |
+| `portable` | A single `data.json` in the documented, interoperable [schema.org](https://schema.org) vocabulary. |
+
+Example: `GET /api/account/export?format=portable`
+
+## `manifest.json`
+
+Present in every export. Lets a recipient interpret the bundle without
+out-of-band knowledge.
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "generator": "PageSpace GDPR export",
+  "exportedAt": "2026-06-24T00:00:00.000Z",
+  "format": "native",
+  "files": [
+    { "name": "pages.json", "description": "Pages across your drives", "recordCount": 42 }
+  ]
+}
+```
+
+- `schemaVersion` — bumped when the bundle structure/inventory changes.
+- `files[]` — the inventory: each file's name, a human description, and its record
+  count (array length; `1` for the singular profile / personalization).
+
+## Native format
+
+Per-category JSON files: `profile.json`, `drives.json`, `pages.json`,
+`messages.json`, `files-metadata.json`, `activity.json`, `ai-usage.json`,
+`tasks.json`, `sessions.json`, `notifications.json`, `display-preferences.json`,
+and `personalization.json` (only when the user has personalization). Shapes are
+the `*Export` interfaces in
+`packages/lib/src/compliance/export/gdpr-export.ts`.
+
+## Portable format (schema.org)
+
+A single `data.json` mapping the data onto widely-supported schema.org types so
+it can be ingested by other tools without bespoke parsers:
+
+- The data subject → [`Person`](https://schema.org/Person) (`@context:
+  "https://schema.org"`), with `identifier`, `name`, `email`, `image`,
+  `dateCreated`, `dateModified`.
+- Drives → [`CreativeWork`](https://schema.org/CreativeWork) under `owns`.
+- Pages → `CreativeWork` under `creativeWork` (`name`, `text`, `additionalType`
+  = page type, `isPartOf` = drive id, `dateCreated`/`dateModified`).
+- Messages → [`Message`](https://schema.org/Message) under `message` (`text`,
+  `dateSent`, `messageAttachment` = source surface).
+
+All dates are ISO-8601 strings. Empty sections are emitted as empty arrays.
+
+The mapping is a pure transform (`toPortableExport` in
+`packages/lib/src/compliance/export/export-format.ts`), so the format is stable
+and testable independent of the database.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -987,6 +987,11 @@
       "import": "./dist/compliance/retention/monitoring-retention.js",
       "require": "./dist/compliance/retention/monitoring-retention.js"
     },
+    "./compliance/retention/activity-log-archival": {
+      "types": "./dist/compliance/retention/activity-log-archival.d.ts",
+      "import": "./dist/compliance/retention/activity-log-archival.js",
+      "require": "./dist/compliance/retention/activity-log-archival.js"
+    },
     "./compliance/file-cleanup/orphan-detector": {
       "types": "./dist/compliance/file-cleanup/orphan-detector.d.ts",
       "import": "./dist/compliance/file-cleanup/orphan-detector.js",
@@ -996,6 +1001,11 @@
       "types": "./dist/compliance/export/gdpr-export.d.ts",
       "import": "./dist/compliance/export/gdpr-export.js",
       "require": "./dist/compliance/export/gdpr-export.js"
+    },
+    "./compliance/export/export-format": {
+      "types": "./dist/compliance/export/export-format.d.ts",
+      "import": "./dist/compliance/export/export-format.js",
+      "require": "./dist/compliance/export/export-format.js"
     },
     "./compliance/anonymize": {
       "types": "./dist/compliance/anonymize.d.ts",
@@ -1555,11 +1565,17 @@
       "compliance/retention/monitoring-retention": [
         "./dist/compliance/retention/monitoring-retention.d.ts"
       ],
+      "compliance/retention/activity-log-archival": [
+        "./dist/compliance/retention/activity-log-archival.d.ts"
+      ],
       "compliance/file-cleanup/orphan-detector": [
         "./dist/compliance/file-cleanup/orphan-detector.d.ts"
       ],
       "compliance/export/gdpr-export": [
         "./dist/compliance/export/gdpr-export.d.ts"
+      ],
+      "compliance/export/export-format": [
+        "./dist/compliance/export/export-format.d.ts"
       ],
       "compliance/anonymize": [
         "./dist/compliance/anonymize.d.ts"

--- a/packages/lib/src/compliance/export/export-format.test.ts
+++ b/packages/lib/src/compliance/export/export-format.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import type { AllUserData } from './gdpr-export';
+import {
+  EXPORT_SCHEMA_VERSION,
+  parseExportFormat,
+  buildNativeExportFiles,
+  buildExportManifest,
+  buildPortableExportFiles,
+  toPortableExport,
+} from './export-format';
+
+const D1 = new Date('2024-01-02T03:04:05.000Z');
+const D2 = new Date('2024-02-03T04:05:06.000Z');
+
+function makeData(overrides: Partial<AllUserData> = {}): AllUserData {
+  return {
+    profile: {
+      id: 'u1',
+      name: 'Ada',
+      email: 'ada@example.com',
+      image: null,
+      timezone: 'UTC',
+      createdAt: D1,
+      updatedAt: D2,
+    },
+    drives: [{ id: 'd1', name: 'Drive One', slug: 'drive-one', role: 'OWNER', createdAt: D1 }],
+    pages: [
+      { id: 'p1', title: 'Page One', type: 'DOCUMENT', content: 'hello', driveId: 'd1', createdAt: D1, updatedAt: D2 },
+      { id: 'p2', title: 'Page Two', type: 'CANVAS', content: '{}', driveId: 'd1', createdAt: D1, updatedAt: D2 },
+    ],
+    messages: [{ id: 'm1', source: 'channel', content: 'hi', createdAt: D1 }],
+    files: [],
+    activity: [],
+    aiUsage: [],
+    tasks: [],
+    sessions: [],
+    notifications: [],
+    displayPreferences: [],
+    personalization: null,
+    ...overrides,
+  };
+}
+
+describe('parseExportFormat', () => {
+  it('given_noOrUnknownOrNative_resolvesToNative', () => {
+    expect(parseExportFormat(undefined)).toBe('native');
+    expect(parseExportFormat(null)).toBe('native');
+    expect(parseExportFormat('native')).toBe('native');
+    expect(parseExportFormat('weird')).toBe('native');
+  });
+
+  it('given_portable_resolvesToPortable', () => {
+    expect(parseExportFormat('portable')).toBe('portable');
+  });
+});
+
+describe('buildNativeExportFiles', () => {
+  it('given_collections_reportsArrayLengthsAndSingularProfileAsOne', () => {
+    const files = buildNativeExportFiles(makeData());
+    const byName = Object.fromEntries(files.map((f) => [f.name, f.recordCount]));
+
+    expect(byName['profile.json']).toBe(1);
+    expect(byName['pages.json']).toBe(2);
+    expect(byName['drives.json']).toBe(1);
+    expect(byName['messages.json']).toBe(1);
+    expect(byName['files-metadata.json']).toBe(0);
+  });
+
+  it('given_nullPersonalization_omitsItFromInventory', () => {
+    const files = buildNativeExportFiles(makeData({ personalization: null }));
+    expect(files.some((f) => f.name === 'personalization.json')).toBe(false);
+  });
+
+  it('given_presentPersonalization_includesItWithCountOne', () => {
+    const files = buildNativeExportFiles(
+      makeData({
+        personalization: {
+          bio: 'b',
+          writingStyle: null,
+          rules: null,
+          enabled: true,
+          createdAt: D1,
+          updatedAt: D2,
+        },
+      }),
+    );
+    const entry = files.find((f) => f.name === 'personalization.json');
+    expect(entry?.recordCount).toBe(1);
+  });
+});
+
+describe('buildExportManifest', () => {
+  it('given_filesAndDate_returnsVersionedManifestWithInventory', () => {
+    const files = buildNativeExportFiles(makeData());
+    const manifest = buildExportManifest(files, { exportedAt: D1, format: 'native' });
+
+    expect(manifest.schemaVersion).toBe(EXPORT_SCHEMA_VERSION);
+    expect(manifest.exportedAt).toBe('2024-01-02T03:04:05.000Z');
+    expect(manifest.format).toBe('native');
+    expect(manifest.generator).toContain('PageSpace');
+    const pages = manifest.files.find((f) => f.name === 'pages.json');
+    expect(pages).toEqual({ name: 'pages.json', description: expect.any(String), recordCount: 2 });
+    // inventory does not leak the raw data payload
+    expect(JSON.stringify(manifest)).not.toContain('hello');
+  });
+});
+
+describe('toPortableExport', () => {
+  it('given_data_mapsProfileToPersonPagesToCreativeWorkMessagesToMessage', () => {
+    const portable = toPortableExport(makeData());
+
+    expect(portable['@context']).toBe('https://schema.org');
+    expect(portable['@type']).toBe('Person');
+    expect(portable.email).toBe('ada@example.com');
+
+    const creativeWork = portable.creativeWork as Array<Record<string, unknown>>;
+    expect(creativeWork).toHaveLength(2);
+    expect(creativeWork[0]['@type']).toBe('CreativeWork');
+    expect(creativeWork[0].name).toBe('Page One');
+
+    const messages = portable.message as Array<Record<string, unknown>>;
+    expect(messages[0]['@type']).toBe('Message');
+    expect(messages[0].text).toBe('hi');
+  });
+
+  it('given_dates_serializesAsIso8601Strings', () => {
+    const portable = toPortableExport(makeData());
+    expect(portable.dateCreated).toBe('2024-01-02T03:04:05.000Z');
+    const creativeWork = portable.creativeWork as Array<Record<string, unknown>>;
+    expect(creativeWork[0].dateModified).toBe('2024-02-03T04:05:06.000Z');
+  });
+
+  it('given_emptySections_producesEmptyArraysNotThrows', () => {
+    const portable = toPortableExport(makeData({ pages: [], messages: [], drives: [] }));
+    expect(portable.creativeWork).toEqual([]);
+    expect(portable.message).toEqual([]);
+    expect(portable.owns).toEqual([]);
+  });
+});
+
+describe('buildPortableExportFiles', () => {
+  it('given_data_returnsSingleSchemaOrgDataJson', () => {
+    const files = buildPortableExportFiles(makeData());
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe('data.json');
+    expect((files[0].data as Record<string, unknown>)['@context']).toBe('https://schema.org');
+  });
+});

--- a/packages/lib/src/compliance/export/export-format.test.ts
+++ b/packages/lib/src/compliance/export/export-format.test.ts
@@ -152,6 +152,40 @@ describe('toPortableExport', () => {
     expect(media[0].contentSize).toBe(1234);
   });
 
+  it('is field-level lossless: native fields without a schema.org slot are preserved', () => {
+    const portable = toPortableExport(
+      makeData({
+        messages: [
+          {
+            id: 'm1',
+            source: 'direct_message',
+            content: 'hi',
+            direction: 'sent',
+            role: 'user',
+            pageId: 'pg1',
+            conversationId: 'c1',
+            isActive: true,
+            deletedAt: D2,
+            createdAt: D1,
+          },
+        ],
+      }),
+    );
+
+    // profile.timezone and drive.slug have no schema.org equivalent but must survive
+    expect(portable.timezone).toBe('UTC');
+    const owns = portable.owns as Array<Record<string, unknown>>;
+    expect(owns[0].slug).toBe('drive-one');
+
+    const msg = (portable.message as Array<Record<string, unknown>>)[0];
+    expect(msg.direction).toBe('sent');
+    expect(msg.sender).toBe('user');
+    expect(msg.pageId).toBe('pg1');
+    expect(msg.conversationId).toBe('c1');
+    expect(msg.isActive).toBe(true);
+    expect(msg.dateDeleted).toBe('2024-02-03T04:05:06.000Z');
+  });
+
   it('is lossless: every native data category is represented (GDPR Art 20)', () => {
     const full = makeData({
       files: [{ id: 'f1', driveId: 'd1', sizeBytes: 1, mimeType: null, storagePath: null, createdAt: D1 }],

--- a/packages/lib/src/compliance/export/export-format.test.ts
+++ b/packages/lib/src/compliance/export/export-format.test.ts
@@ -136,6 +136,51 @@ describe('toPortableExport', () => {
     expect(portable.message).toEqual([]);
     expect(portable.owns).toEqual([]);
   });
+
+  it('given_files_mapsToMediaObject', () => {
+    const portable = toPortableExport(
+      makeData({
+        files: [
+          { id: 'f1', driveId: 'd1', sizeBytes: 1234, mimeType: 'image/png', storagePath: 'path/f1', createdAt: D1 },
+        ],
+      }),
+    );
+    const media = portable.subjectOf as Array<Record<string, unknown>>;
+    expect(media).toHaveLength(1);
+    expect(media[0]['@type']).toBe('MediaObject');
+    expect(media[0].encodingFormat).toBe('image/png');
+    expect(media[0].contentSize).toBe(1234);
+  });
+
+  it('is lossless: every native data category is represented (GDPR Art 20)', () => {
+    const full = makeData({
+      files: [{ id: 'f1', driveId: 'd1', sizeBytes: 1, mimeType: null, storagePath: null, createdAt: D1 }],
+      activity: [{ id: 'a1', operation: 'create', resourceType: 'page', resourceId: 'p1', timestamp: D1, metadata: null }],
+      aiUsage: [{ id: 'ai1', provider: 'openrouter', model: 'm', inputTokens: 1, outputTokens: 2, cost: 0.1, timestamp: D1 }],
+      tasks: [{ listId: 'l1', listTitle: 'L', items: [] }],
+      sessions: [{ id: 's1', type: 'session', deviceId: null, scopes: [], createdByIp: null, lastUsedAt: null, lastUsedIp: null, expiresAt: D2, revokedAt: null, revokedReason: null, createdAt: D1 }],
+      notifications: [{ id: 'n1', type: 't', title: 'T', message: 'M', metadata: null, isRead: false, createdAt: D1, readAt: null }],
+      displayPreferences: [{ preferenceType: 'theme', enabled: true, updatedAt: D2 }],
+      personalization: { bio: 'b', writingStyle: null, rules: null, enabled: true, createdAt: D1, updatedAt: D2 },
+    });
+    const portable = toPortableExport(full);
+
+    // schema.org-typed categories
+    expect((portable.owns as unknown[]).length).toBe(1);
+    expect((portable.creativeWork as unknown[]).length).toBe(2);
+    expect((portable.message as unknown[]).length).toBe(1);
+    expect((portable.subjectOf as unknown[]).length).toBe(1);
+
+    // everything else carried verbatim under additionalProperty
+    const props = portable.additionalProperty as Array<{ name: string; value: unknown }>;
+    const byName = Object.fromEntries(props.map((p) => [p.name, p.value]));
+    for (const key of ['activity', 'aiUsage', 'tasks', 'sessions', 'notifications', 'displayPreferences', 'personalization']) {
+      expect(byName).toHaveProperty(key);
+    }
+    expect((byName.activity as unknown[]).length).toBe(1);
+    expect((byName.sessions as unknown[]).length).toBe(1);
+    expect(byName.personalization).not.toBeNull();
+  });
 });
 
 describe('buildPortableExportFiles', () => {

--- a/packages/lib/src/compliance/export/export-format.ts
+++ b/packages/lib/src/compliance/export/export-format.ts
@@ -97,9 +97,14 @@ function toIso(value: Date | null | undefined): string | null {
 
 /**
  * Map the collected data onto a documented, interoperable schema.org structure
- * (https://schema.org): the data subject as a `Person`, pages as `CreativeWork`,
- * and messages as `Message`. Dates are ISO-8601 strings. Empty sections become
- * empty arrays rather than throwing.
+ * (https://schema.org): the data subject as a `Person`, with drives/pages as
+ * `CreativeWork`, messages as `Message`, and files as `MediaObject`. The
+ * remaining operational categories (activity, AI usage, tasks, sessions,
+ * notifications, display preferences, personalization) are carried verbatim as
+ * `PropertyValue` entries so the portable bundle is **complete** — no data
+ * category is dropped (GDPR Art 20). Dates are ISO-8601 strings (mapped fields
+ * explicitly; values inside `additionalProperty` serialize to ISO-8601 via
+ * JSON). Empty sections become empty arrays rather than throwing.
  */
 export function toPortableExport(data: AllUserData): Record<string, unknown> {
   return {
@@ -135,6 +140,26 @@ export function toPortableExport(data: AllUserData): Record<string, unknown> {
       messageAttachment: m.source,
       dateSent: toIso(m.createdAt),
     })),
+    subjectOf: data.files.map((f) => ({
+      '@type': 'MediaObject',
+      identifier: f.id,
+      encodingFormat: f.mimeType,
+      contentSize: f.sizeBytes,
+      contentUrl: f.storagePath,
+      isPartOf: f.driveId,
+      dateCreated: toIso(f.createdAt),
+    })),
+    // Complete-but-not-natively-typed categories, kept verbatim so the portable
+    // bundle loses nothing relative to the native export.
+    additionalProperty: [
+      { '@type': 'PropertyValue', name: 'activity', value: data.activity },
+      { '@type': 'PropertyValue', name: 'aiUsage', value: data.aiUsage },
+      { '@type': 'PropertyValue', name: 'tasks', value: data.tasks },
+      { '@type': 'PropertyValue', name: 'sessions', value: data.sessions },
+      { '@type': 'PropertyValue', name: 'notifications', value: data.notifications },
+      { '@type': 'PropertyValue', name: 'displayPreferences', value: data.displayPreferences },
+      { '@type': 'PropertyValue', name: 'personalization', value: data.personalization },
+    ],
   };
 }
 

--- a/packages/lib/src/compliance/export/export-format.ts
+++ b/packages/lib/src/compliance/export/export-format.ts
@@ -1,0 +1,153 @@
+/**
+ * GDPR export formatting — pure transforms over collected user data.
+ *
+ * No I/O. Given an in-memory `AllUserData` snapshot, these functions build:
+ *  - the native per-section file inventory,
+ *  - a versioned `manifest.json` documenting the bundle (schema version + files),
+ *  - a documented, interoperable portable representation (schema.org), and
+ *  - the format selector for the `?format=` switch.
+ *
+ * The export route is a thin edge: it collects data, calls these, and streams
+ * the result into a ZIP via `archiver`.
+ */
+
+import type { AllUserData } from './gdpr-export';
+
+/** Bump when the export bundle's structure/inventory changes. */
+export const EXPORT_SCHEMA_VERSION = '1.0.0';
+
+export type ExportFormat = 'native' | 'portable';
+
+/** One serializable file in the export bundle. */
+export interface ExportFile {
+  name: string;
+  description: string;
+  recordCount: number;
+  data: unknown;
+}
+
+export interface ExportManifestFileEntry {
+  name: string;
+  description: string;
+  recordCount: number;
+}
+
+export interface ExportManifest {
+  schemaVersion: string;
+  generator: string;
+  exportedAt: string;
+  format: ExportFormat;
+  files: ExportManifestFileEntry[];
+}
+
+/**
+ * Resolve the requested export format. Anything other than the documented
+ * `portable` value (including null/unknown) resolves to `native`.
+ */
+export function parseExportFormat(param: string | null | undefined): ExportFormat {
+  return param === 'portable' ? 'portable' : 'native';
+}
+
+/**
+ * The native bundle: one JSON file per data category. `recordCount` is the
+ * array length for collections and 1 for the singular profile/personalization.
+ * `personalization.json` is omitted entirely when the user has none.
+ */
+export function buildNativeExportFiles(data: AllUserData): ExportFile[] {
+  const files: ExportFile[] = [
+    { name: 'profile.json', description: 'User account profile', recordCount: 1, data: data.profile },
+    { name: 'drives.json', description: 'Drives owned or joined', recordCount: data.drives.length, data: data.drives },
+    { name: 'pages.json', description: 'Pages across your drives', recordCount: data.pages.length, data: data.pages },
+    { name: 'messages.json', description: 'Chat, channel, conversation and direct messages', recordCount: data.messages.length, data: data.messages },
+    { name: 'files-metadata.json', description: 'Uploaded file metadata', recordCount: data.files.length, data: data.files },
+    { name: 'activity.json', description: 'Activity / audit trail entries', recordCount: data.activity.length, data: data.activity },
+    { name: 'ai-usage.json', description: 'AI usage records', recordCount: data.aiUsage.length, data: data.aiUsage },
+    { name: 'tasks.json', description: 'Task lists and items', recordCount: data.tasks.length, data: data.tasks },
+    { name: 'sessions.json', description: 'Authentication sessions', recordCount: data.sessions.length, data: data.sessions },
+    { name: 'notifications.json', description: 'Notifications', recordCount: data.notifications.length, data: data.notifications },
+    { name: 'display-preferences.json', description: 'Display preferences', recordCount: data.displayPreferences.length, data: data.displayPreferences },
+  ];
+  if (data.personalization) {
+    files.push({ name: 'personalization.json', description: 'Personalization settings', recordCount: 1, data: data.personalization });
+  }
+  return files;
+}
+
+/**
+ * Build the manifest from the actual file set being shipped. The manifest
+ * documents the schema version and the inventory so the recipient can interpret
+ * the bundle without out-of-band knowledge (GDPR Art 20 portability).
+ */
+export function buildExportManifest(
+  files: ExportFile[],
+  opts: { exportedAt: Date; format: ExportFormat },
+): ExportManifest {
+  return {
+    schemaVersion: EXPORT_SCHEMA_VERSION,
+    generator: 'PageSpace GDPR export',
+    exportedAt: opts.exportedAt.toISOString(),
+    format: opts.format,
+    files: files.map((f) => ({ name: f.name, description: f.description, recordCount: f.recordCount })),
+  };
+}
+
+function toIso(value: Date | null | undefined): string | null {
+  return value ? value.toISOString() : null;
+}
+
+/**
+ * Map the collected data onto a documented, interoperable schema.org structure
+ * (https://schema.org): the data subject as a `Person`, pages as `CreativeWork`,
+ * and messages as `Message`. Dates are ISO-8601 strings. Empty sections become
+ * empty arrays rather than throwing.
+ */
+export function toPortableExport(data: AllUserData): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    identifier: data.profile.id,
+    name: data.profile.name,
+    email: data.profile.email,
+    image: data.profile.image ?? null,
+    dateCreated: toIso(data.profile.createdAt),
+    dateModified: toIso(data.profile.updatedAt),
+    owns: data.drives.map((d) => ({
+      '@type': 'CreativeWork',
+      identifier: d.id,
+      name: d.name,
+      roleName: d.role,
+      dateCreated: toIso(d.createdAt),
+    })),
+    creativeWork: data.pages.map((p) => ({
+      '@type': 'CreativeWork',
+      identifier: p.id,
+      name: p.title,
+      additionalType: p.type,
+      text: p.content,
+      isPartOf: p.driveId,
+      dateCreated: toIso(p.createdAt),
+      dateModified: toIso(p.updatedAt),
+    })),
+    message: data.messages.map((m) => ({
+      '@type': 'Message',
+      identifier: m.id,
+      text: m.content,
+      messageAttachment: m.source,
+      dateSent: toIso(m.createdAt),
+    })),
+  };
+}
+
+/**
+ * The portable bundle: a single self-describing `data.json` plus its manifest.
+ */
+export function buildPortableExportFiles(data: AllUserData): ExportFile[] {
+  return [
+    {
+      name: 'data.json',
+      description: 'All user data in schema.org portable format (https://schema.org)',
+      recordCount: 1,
+      data: toPortableExport(data),
+    },
+  ];
+}

--- a/packages/lib/src/compliance/export/export-format.ts
+++ b/packages/lib/src/compliance/export/export-format.ts
@@ -114,6 +114,9 @@ export function toPortableExport(data: AllUserData): Record<string, unknown> {
     name: data.profile.name,
     email: data.profile.email,
     image: data.profile.image ?? null,
+    // Native field kept (no schema.org equivalent) so the portable export is
+    // field-for-field complete with the native export (GDPR Art 20).
+    timezone: data.profile.timezone ?? null,
     dateCreated: toIso(data.profile.createdAt),
     dateModified: toIso(data.profile.updatedAt),
     owns: data.drives.map((d) => ({
@@ -121,6 +124,7 @@ export function toPortableExport(data: AllUserData): Record<string, unknown> {
       identifier: d.id,
       name: d.name,
       roleName: d.role,
+      slug: d.slug,
       dateCreated: toIso(d.createdAt),
     })),
     creativeWork: data.pages.map((p) => ({
@@ -138,6 +142,13 @@ export function toPortableExport(data: AllUserData): Record<string, unknown> {
       identifier: m.id,
       text: m.content,
       messageAttachment: m.source,
+      // Native fields kept verbatim (no schema.org equivalents) for completeness.
+      direction: m.direction ?? null,
+      sender: m.role ?? null,
+      pageId: m.pageId ?? null,
+      conversationId: m.conversationId ?? null,
+      isActive: m.isActive ?? null,
+      dateDeleted: toIso(m.deletedAt ?? null),
       dateSent: toIso(m.createdAt),
     })),
     subjectOf: data.files.map((f) => ({

--- a/packages/lib/src/compliance/retention/activity-log-archival.test.ts
+++ b/packages/lib/src/compliance/retention/activity-log-archival.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import {
+  getActivityLogArchivalConfig,
+  shouldContinueArchiving,
+  archiveActivityLogs,
+} from './activity-log-archival';
+
+type DB = NodePgDatabase<Record<string, unknown>>;
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  delete process.env.ACTIVITY_LOGS_ARCHIVE_DAYS;
+  delete process.env.ACTIVITY_LOGS_ARCHIVE_BATCH_SIZE;
+  delete process.env.ACTIVITY_LOGS_ARCHIVE_MAX_RUN_MS;
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+/**
+ * Fake db that returns a scripted sequence of id batches from the select chain
+ * and records every payload passed to `.set()` on the update chain. No real DB.
+ */
+function makeDb(batches: string[][]) {
+  let call = 0;
+  const setPayloads: unknown[] = [];
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: async () => (batches[call++] ?? []).map((id) => ({ id })),
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (payload: unknown) => {
+        setPayloads.push(payload);
+        return { where: async () => undefined };
+      },
+    }),
+  };
+  return { db: db as unknown as DB, setPayloads };
+}
+
+describe('getActivityLogArchivalConfig', () => {
+  it('given_noEnvVars_returnsDefaults', () => {
+    expect(getActivityLogArchivalConfig()).toEqual({
+      archiveDays: 365,
+      batchSize: 1000,
+      maxRunMs: 25000,
+    });
+  });
+
+  it('given_validEnvVars_usesThem', () => {
+    process.env.ACTIVITY_LOGS_ARCHIVE_DAYS = '180';
+    process.env.ACTIVITY_LOGS_ARCHIVE_BATCH_SIZE = '500';
+    process.env.ACTIVITY_LOGS_ARCHIVE_MAX_RUN_MS = '10000';
+    expect(getActivityLogArchivalConfig()).toEqual({
+      archiveDays: 180,
+      batchSize: 500,
+      maxRunMs: 10000,
+    });
+  });
+
+  it('given_invalidOrEmptyEnvVars_fallsBackPerField', () => {
+    process.env.ACTIVITY_LOGS_ARCHIVE_DAYS = '0';
+    process.env.ACTIVITY_LOGS_ARCHIVE_BATCH_SIZE = '-1';
+    process.env.ACTIVITY_LOGS_ARCHIVE_MAX_RUN_MS = 'nope';
+    expect(getActivityLogArchivalConfig()).toEqual({
+      archiveDays: 365,
+      batchSize: 1000,
+      maxRunMs: 25000,
+    });
+  });
+});
+
+describe('shouldContinueArchiving', () => {
+  it('given_drainedBatch_stops', () => {
+    expect(
+      shouldContinueArchiving({ lastBatchSize: 3, batchSize: 1000, elapsedMs: 0, maxRunMs: 25000 }),
+    ).toBe(false);
+  });
+
+  it('given_wallClockExhausted_stops', () => {
+    expect(
+      shouldContinueArchiving({ lastBatchSize: 1000, batchSize: 1000, elapsedMs: 25000, maxRunMs: 25000 }),
+    ).toBe(false);
+  });
+
+  it('given_fullBatchAndTimeRemaining_continues', () => {
+    expect(
+      shouldContinueArchiving({ lastBatchSize: 1000, batchSize: 1000, elapsedMs: 10, maxRunMs: 25000 }),
+    ).toBe(true);
+  });
+});
+
+describe('archiveActivityLogs', () => {
+  it('given_agedUnarchivedRows_flipsIsArchivedInBatches', async () => {
+    // Two full batches then a partial batch drains the loop.
+    const { db, setPayloads } = makeDb([['a', 'b'], ['c', 'd'], ['e']]);
+
+    const result = await archiveActivityLogs(db, {
+      archiveDays: 365,
+      batchSize: 2,
+      maxRunMs: 60_000,
+    });
+
+    expect(result).toEqual({ table: 'activity_logs', archived: 5, batches: 3 });
+    expect(setPayloads).toHaveLength(3);
+  });
+
+  it('given_anyBatch_updatePayloadContainsOnlyIsArchived_neverHashChainFields', async () => {
+    const { db, setPayloads } = makeDb([['a']]);
+
+    await archiveActivityLogs(db, { archiveDays: 365, batchSize: 1000, maxRunMs: 60_000 });
+
+    for (const payload of setPayloads) {
+      expect(payload).toEqual({ isArchived: true });
+      const keys = Object.keys(payload as object);
+      expect(keys).toEqual(['isArchived']);
+      for (const forbidden of ['previousLogHash', 'logHash', 'chainSeed', 'chainSeq']) {
+        expect(keys).not.toContain(forbidden);
+      }
+    }
+  });
+
+  it('given_emptyFirstBatch_performsZeroUpdates', async () => {
+    const { db, setPayloads } = makeDb([[]]);
+
+    const result = await archiveActivityLogs(db, { archiveDays: 365, batchSize: 1000, maxRunMs: 60_000 });
+
+    expect(result).toEqual({ table: 'activity_logs', archived: 0, batches: 0 });
+    expect(setPayloads).toHaveLength(0);
+  });
+
+  it('given_wallClockBudgetExhaustedMidRun_stopsEarlyKeepingCount', async () => {
+    // Full batches available, but the injected clock jumps past maxRunMs after batch 1.
+    const { db } = makeDb([['a', 'b'], ['c', 'd'], ['e', 'f']]);
+    let t = 0;
+    const clock = () => {
+      const v = t;
+      t += 30_000; // each read advances 30s
+      return v;
+    };
+
+    const result = await archiveActivityLogs(db, {
+      archiveDays: 365,
+      batchSize: 2,
+      maxRunMs: 25_000,
+      clock,
+    });
+
+    expect(result.archived).toBe(2);
+    expect(result.batches).toBe(1);
+  });
+});

--- a/packages/lib/src/compliance/retention/activity-log-archival.ts
+++ b/packages/lib/src/compliance/retention/activity-log-archival.ts
@@ -1,0 +1,134 @@
+/**
+ * activity_logs hot→cold tiering writer.
+ *
+ * Flips `isArchived = true` on activity_logs rows older than a configurable
+ * threshold so the active-view filter (`isArchived = false`) narrows over time
+ * and hot-path query cost stays bounded as the table grows.
+ *
+ * This is a flag flip ONLY. It never deletes rows and never touches the
+ * tamper-evident hash chain (`previousLogHash`, `logHash`, `chainSeed`,
+ * `chainSeq`) or rollback provenance — so chain verification is unaffected
+ * (`isArchived` is not a hash input; see hash-chain-verifier / computeLogHash).
+ *
+ * Pure core (config parsing + loop control) is exhaustively testable; the only
+ * side effect is the batched DB read/update at the `archiveActivityLogs` edge,
+ * which takes an injected `database` handle.
+ */
+
+import { and, lt, eq, inArray, asc } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { activityLogs } from '@pagespace/db/schema/monitoring';
+
+const DEFAULT_ARCHIVE_DAYS = 365;
+const DEFAULT_BATCH_SIZE = 1000;
+const DEFAULT_MAX_RUN_MS = 25000;
+
+type DB = NodePgDatabase<Record<string, unknown>>;
+
+export interface ActivityLogArchivalConfig {
+  archiveDays: number;
+  batchSize: number;
+  maxRunMs: number;
+}
+
+export interface ArchiveActivityLogsResult {
+  table: 'activity_logs';
+  archived: number;
+  batches: number;
+}
+
+export interface ArchiveActivityLogsOptions {
+  archiveDays: number;
+  batchSize: number;
+  maxRunMs: number;
+  /** Reference "now" for cutoff computation. Defaults to the wall clock. */
+  now?: Date;
+  /** Monotonic millisecond source for the per-run wall-clock budget. Injected for tests. */
+  clock?: () => number;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = parseInt(value, 10);
+  if (isNaN(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+/**
+ * Read the archival config from the environment. Each field falls back to its
+ * default for unset / zero / negative / non-numeric values.
+ */
+export function getActivityLogArchivalConfig(): ActivityLogArchivalConfig {
+  return {
+    archiveDays: parsePositiveInt(process.env.ACTIVITY_LOGS_ARCHIVE_DAYS, DEFAULT_ARCHIVE_DAYS),
+    batchSize: parsePositiveInt(process.env.ACTIVITY_LOGS_ARCHIVE_BATCH_SIZE, DEFAULT_BATCH_SIZE),
+    maxRunMs: parsePositiveInt(process.env.ACTIVITY_LOGS_ARCHIVE_MAX_RUN_MS, DEFAULT_MAX_RUN_MS),
+  };
+}
+
+/**
+ * Pure loop-control predicate: stop when the last batch drained the eligible
+ * set (`lastBatchSize < batchSize`) or the per-run wall-clock budget is spent.
+ */
+export function shouldContinueArchiving(params: {
+  lastBatchSize: number;
+  batchSize: number;
+  elapsedMs: number;
+  maxRunMs: number;
+}): boolean {
+  if (params.lastBatchSize < params.batchSize) return false;
+  if (params.elapsedMs >= params.maxRunMs) return false;
+  return true;
+}
+
+/**
+ * Archive (flag-flip) eligible activity_logs rows in batches.
+ *
+ * Each batch selects up to `batchSize` not-yet-archived rows older than the
+ * cutoff (oldest first by chainSeq) and sets `isArchived = true` on exactly
+ * those ids. Because the next select re-filters on `isArchived = false`, the
+ * window self-advances without an offset and cannot loop forever.
+ */
+export async function archiveActivityLogs(
+  database: DB,
+  opts: ArchiveActivityLogsOptions,
+): Promise<ArchiveActivityLogsResult> {
+  const now = opts.now ?? new Date();
+  const clock = opts.clock ?? (() => Date.now());
+  const cutoff = new Date(now.getTime() - opts.archiveDays * 24 * 60 * 60 * 1000);
+  const start = clock();
+
+  let archived = 0;
+  let batches = 0;
+
+  for (;;) {
+    const rows = await database
+      .select({ id: activityLogs.id })
+      .from(activityLogs)
+      .where(and(lt(activityLogs.timestamp, cutoff), eq(activityLogs.isArchived, false)))
+      .orderBy(asc(activityLogs.chainSeq))
+      .limit(opts.batchSize);
+
+    if (rows.length === 0) break;
+
+    const ids = rows.map((r) => r.id);
+    // Flag flip ONLY — never any hash-chain or rollback-provenance field.
+    await database.update(activityLogs).set({ isArchived: true }).where(inArray(activityLogs.id, ids));
+
+    archived += ids.length;
+    batches += 1;
+
+    if (
+      !shouldContinueArchiving({
+        lastBatchSize: ids.length,
+        batchSize: opts.batchSize,
+        elapsedMs: clock() - start,
+        maxRunMs: opts.maxRunMs,
+      })
+    ) {
+      break;
+    }
+  }
+
+  return { table: 'activity_logs', archived, batches };
+}

--- a/packages/lib/src/compliance/retention/monitoring-retention.test.ts
+++ b/packages/lib/src/compliance/retention/monitoring-retention.test.ts
@@ -38,6 +38,7 @@ vi.mock('@pagespace/db/schema/monitoring', () => ({
 import {
   getRetentionConfig,
   getRetentionCutoff,
+  getAiUsageLogsRetentionDays,
   cleanupApiMetrics,
   cleanupSystemLogs,
   cleanupErrorLogs,
@@ -54,6 +55,7 @@ beforeEach(() => {
   delete process.env.RETENTION_SYSTEM_LOGS_DAYS;
   delete process.env.RETENTION_ERROR_LOGS_DAYS;
   delete process.env.RETENTION_USER_ACTIVITIES_DAYS;
+  delete process.env.RETENTION_AI_USAGE_LOGS_DAYS;
   vi.clearAllMocks();
   mockReturning.mockResolvedValue([]);
 });
@@ -114,6 +116,31 @@ describe('getRetentionConfig', () => {
 
     expect(config.apiMetricsDays).toBe(90);
     expect(config.errorLogsDays).toBe(90);
+  });
+});
+
+describe('getAiUsageLogsRetentionDays', () => {
+  it('given_noEnvVar_returnsDefaultOf90', () => {
+    expect(getAiUsageLogsRetentionDays()).toBe(90);
+  });
+
+  it('given_validPositiveInt_returnsThatValue', () => {
+    process.env.RETENTION_AI_USAGE_LOGS_DAYS = '30';
+    expect(getAiUsageLogsRetentionDays()).toBe(30);
+  });
+
+  it('given_zeroNegativeOrNonNumeric_fallsBackTo90', () => {
+    process.env.RETENTION_AI_USAGE_LOGS_DAYS = '0';
+    expect(getAiUsageLogsRetentionDays()).toBe(90);
+    process.env.RETENTION_AI_USAGE_LOGS_DAYS = '-7';
+    expect(getAiUsageLogsRetentionDays()).toBe(90);
+    process.env.RETENTION_AI_USAGE_LOGS_DAYS = 'nope';
+    expect(getAiUsageLogsRetentionDays()).toBe(90);
+  });
+
+  it('given_emptyString_fallsBackTo90', () => {
+    process.env.RETENTION_AI_USAGE_LOGS_DAYS = '';
+    expect(getAiUsageLogsRetentionDays()).toBe(90);
   });
 });
 

--- a/packages/lib/src/compliance/retention/monitoring-retention.ts
+++ b/packages/lib/src/compliance/retention/monitoring-retention.ts
@@ -7,6 +7,7 @@ const DEFAULT_API_METRICS_DAYS = 90;
 const DEFAULT_SYSTEM_LOGS_DAYS = 30;
 const DEFAULT_ERROR_LOGS_DAYS = 90;
 const DEFAULT_USER_ACTIVITIES_DAYS = 180;
+const DEFAULT_AI_USAGE_LOGS_DAYS = 90;
 
 export interface RetentionConfig {
   apiMetricsDays: number;
@@ -29,6 +30,16 @@ export function getRetentionConfig(): RetentionConfig {
     errorLogsDays: parsePositiveInt(process.env.RETENTION_ERROR_LOGS_DAYS, DEFAULT_ERROR_LOGS_DAYS),
     userActivitiesDays: parsePositiveInt(process.env.RETENTION_USER_ACTIVITIES_DAYS, DEFAULT_USER_ACTIVITIES_DAYS),
   };
+}
+
+/**
+ * Retention window (in days) for AI usage logs, used by the purge-ai-usage-logs
+ * cron. Configurable via RETENTION_AI_USAGE_LOGS_DAYS so tenant deployments can
+ * tune storage limits without a code change (mirrors the RETENTION_* pattern
+ * above). Falls back to 90 days for unset/invalid values.
+ */
+export function getAiUsageLogsRetentionDays(): number {
+  return parsePositiveInt(process.env.RETENTION_AI_USAGE_LOGS_DAYS, DEFAULT_AI_USAGE_LOGS_DAYS);
 }
 
 export function getRetentionCutoff(days: number): Date {

--- a/tasks/gdpr-retention-export-epic.md
+++ b/tasks/gdpr-retention-export-epic.md
@@ -1,0 +1,110 @@
+# GDPR Retention & Export Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Close GDPR storage-limitation (Art 5(1)(e)) and portability (Art 20) gaps — make retention windows configurable, add the activity_logs hot→cold tiering writer, and give the data export a manifest + a documented portable format.
+
+## Overview
+
+Because tenant deployments cannot currently configure retention (windows are hardcoded in route handlers), the activity_logs hot/cold tier is designed but has no writer (so the active view never narrows and query cost grows forever), and the export bundle ships raw JSON with no manifest or standard format (hurting portability), this epic makes every retention window env-driven, ships the `isArchived` flip job (chain-safe, batched, HMAC-validated), and adds an export `manifest.json` plus a documented schema.org-based portable format. Every leaf is satisfiable only by a failing test written first and business logic living in a pure function; side effects (DB/Drizzle, archiver) sit at thin imperative edges.
+
+---
+
+## Phase 1 — Configurable AI-usage retention (#918)
+
+### AI-usage retention window helper
+
+Add a pure, env-driven helper for the AI-usage-log purge window, mirroring the existing `RETENTION_*` config pattern.
+
+**Requirements**:
+- Given no `RETENTION_AI_USAGE_LOGS_DAYS` env var, should return the default of 90 days from a pure `getAiUsageLogsRetentionDays()` function (proven by a test written first).
+- Given a valid positive integer in `RETENTION_AI_USAGE_LOGS_DAYS`, should return that value.
+- Given a zero, negative, non-numeric, or empty `RETENTION_AI_USAGE_LOGS_DAYS`, should fall back to 90.
+
+### Wire purge cron to the configurable window
+
+Replace the hardcoded 90-day literal in the purge-ai-usage-logs route with the pure helper + `getRetentionCutoff`.
+
+**Requirements**:
+- Given the route runs, should derive the cutoff from `getAiUsageLogsRetentionDays()` (not a hardcoded literal), verified by a route test that overrides the env var and asserts `purgeAiUsageLogs` is called with the matching cutoff.
+- Given `RETENTION_AI_USAGE_LOGS_DAYS` is documented in `.env.example`, should sit alongside the other monitoring-table retention vars.
+
+---
+
+## Phase 2 — activity_logs hot→cold tiering writer (#984)
+
+### Archival config + loop-control pure functions
+
+Add pure config parsing and a pure loop-control predicate for the archival job.
+
+**Requirements**:
+- Given no env vars, should return defaults `{ archiveDays: 365, batchSize: 1000, maxRunMs: 25000 }` from a pure `getActivityLogArchivalConfig()` (test first).
+- Given valid `ACTIVITY_LOGS_ARCHIVE_DAYS` / `_BATCH_SIZE` / `_MAX_RUN_MS`, should use them; given invalid/zero/negative/empty values, should fall back to each default.
+- Given a drained batch (`lastBatchSize < batchSize`), should stop via a pure `shouldContinueArchiving` predicate.
+- Given elapsed wall-clock `>= maxRunMs`, should stop; otherwise should continue.
+
+### Archival edge (isArchived flip, batched, chain-safe)
+
+Add the thin imperative `archiveActivityLogs(database, opts)` that selects aged unarchived rows in batches and flips only `isArchived`.
+
+**Requirements**:
+- Given rows older than the cutoff with `isArchived = false`, should set `isArchived = true` in batches bounded by `batchSize`, returning `{ table: 'activity_logs', archived, batches }`.
+- Given the update payload, should contain ONLY `{ isArchived: true }` and never any hash-chain field (`previousLogHash`, `logHash`, `chainSeed`, `chainSeq`) — asserted by a test inspecting the `set()` argument.
+- Given an empty first batch, should perform zero updates and return `archived: 0`.
+- Given the per-run wall-clock budget is exhausted mid-run, should stop early without losing the already-archived count.
+
+### Archive cron route (HMAC + before/after chain check)
+
+Add `apps/web/src/app/api/cron/archive-activity-logs/route.ts`, HMAC-validated, calling the edge and doing a defense-in-depth chain integrity check.
+
+**Requirements**:
+- Given a request failing `validateSignedCronRequest`, should return that auth error and never archive (test first).
+- Given a successful run, should call `archiveActivityLogs` and emit a `data.update` audit event with the archived count.
+- Given the run completes, should report `quickIntegrityCheck` before/after results in the JSON response.
+
+### Retention policy doc
+
+Document the archival tier and its env vars.
+
+**Requirements**:
+- Given `docs/security/audit-log-retention-policy.md`, should contain an "Archival" section describing the `isArchived` flip job, its defaults, that it never deletes rows or touches the hash chain, and the `ACTIVITY_LOGS_ARCHIVE_*` env vars (also added to `.env.example`).
+
+---
+
+## Phase 3 — Export manifest (#915)
+
+### Pure manifest builder
+
+Add a pure `buildExportManifest(data, opts)` deriving a versioned schema + file inventory from `AllUserData`.
+
+**Requirements**:
+- Given `AllUserData` and an export date, should return a manifest object with `schemaVersion`, `exportedAt`, `generator`, and a `files` inventory listing each export file name, description, and record count (test first, no I/O).
+- Given a collection section (e.g. `pages`), should report its exact array length as `recordCount`; given the singular `profile`, should report `recordCount: 1`; given a null `personalization`, should omit it from the inventory.
+
+### Wire manifest into the export ZIP
+
+Append `manifest.json` to the archive in the export route.
+
+**Requirements**:
+- Given an export is generated, should include `manifest.json` built by `buildExportManifest`, verified by a pure test on the builder (route is a thin edge appending the serialized result).
+
+---
+
+## Phase 4 — Documented portable format (#916)
+
+### Pure portable transformer
+
+Add a pure `toPortableExport(data)` mapping `AllUserData` onto a documented schema.org-aligned structure.
+
+**Requirements**:
+- Given `AllUserData`, should return an object with `@context: "https://schema.org"` and a `Person` mapping the profile, with pages mapped to `CreativeWork` and messages to `Message` (test first, deterministic, no I/O).
+- Given any date field, should serialize as an ISO-8601 string for interoperability.
+- Given an unknown/empty section, should produce an empty array rather than throwing.
+
+### Format selection + wiring
+
+Add a pure `parseExportFormat(param)` and wire a `?format=` switch into the route.
+
+**Requirements**:
+- Given no/`native`/unknown `format`, should resolve to `native` from pure `parseExportFormat`; given `portable`, should resolve to `portable` (test first).
+- Given `format=portable`, the route should emit the schema.org `data.json` (plus manifest) instead of the native per-section files; given native, should keep current behavior.
+- Given the portable format, should be documented in `docs/security/gdpr-export-format.md`.


### PR DESCRIPTION
## Workstream C — GDPR Retention & Export

Closes storage-limitation (Art 5(1)(e)) and portability (Art 20) gaps. Pure-core-first + TDD throughout; every business rule lives in a pure, exhaustively-tested function, with side effects (Drizzle, archiver) at thin imperative edges.

### #918 — Retention windows hardcoded in route handlers
- New pure `getAiUsageLogsRetentionDays()` reading `RETENTION_AI_USAGE_LOGS_DAYS` (default 90), mirroring the existing `RETENTION_*` pattern.
- `purge-ai-usage-logs` cron now derives its cutoff from it instead of a hardcoded `90 * 24 * 60 * 60 * 1000` literal, so tenant deployments can tune it. Documented in `.env.example`.

### #984 — activity_logs hot→cold tiering writer (isArchived flip)
- `packages/lib/src/compliance/retention/activity-log-archival.ts`: pure config (`getActivityLogArchivalConfig`) + pure loop control (`shouldContinueArchiving`) + a thin batched edge (`archiveActivityLogs`) that flips **only** `isArchived` — never any hash-chain (`previousLogHash`/`logHash`/`chainSeed`/`chainSeq`) or rollback-provenance field. A test asserts the update payload is exactly `{ isArchived: true }`; `isArchived` is not a `computeLogHash` input, so the chain is provably unaffected.
- New HMAC-validated cron `apps/web/src/app/api/cron/archive-activity-logs/route.ts` (batched, per-run wall-clock budget) that runs `quickIntegrityCheck` **before and after** as defense-in-depth and emits a `data.write` audit event.
- **Registered in `docker/cron/crontab`** (daily 02:30 UTC) so the in-repo scheduler actually invokes it.
- `ACTIVITY_LOGS_ARCHIVE_{DAYS,BATCH_SIZE,MAX_RUN_MS}` in `.env.example`; documented in `docs/security/audit-log-retention-policy.md`. Never deletes rows.

### #915 — Export ZIP+JSON had no manifest
- Every export now includes a `manifest.json` (schema version + file inventory with record counts), built by the pure `buildExportManifest` over the actual file set shipped.

### #916 — No standard-format export
- `?format=portable` emits a single documented [schema.org](https://schema.org) `data.json` via the pure `toPortableExport`, alongside the native per-section format (default). The portable format is **lossless** — profile→`Person`, drives/pages→`CreativeWork`, messages→`Message`, files→`MediaObject`, and all remaining categories carried verbatim as `PropertyValue` under `additionalProperty`, so no data is dropped. Documented in `docs/security/gdpr-export-format.md`.

## Verification
- `bun run typecheck` — green (13/13 packages)
- `@pagespace/lib` unit — green (incl. new archival + export-format suites, with lossless-completeness test)
- Touched route tests — green (archive-activity-logs, purge-ai-usage-logs, account/export)
- Security **Audit Route Coverage** suite passes (new cron route is audited). The 7 failing `test:security` suites (auth/session/permissions/login) are pre-existing worktree/env failures — confirmed identical with these changes stashed.

## Review-driven changes
- **Codex P2 (lossy portable export):** made `toPortableExport` lossless (commit `844da4bc6`), then a follow-up adversarial self-review made it **field-for-field** lossless — restoring `profile.timezone`, `drive.slug`, and message `direction`/`role`/`pageId`/`conversationId`/`isActive`/`deletedAt` on the mapped schema.org objects, with a field-level losslessness test (commit `327ad31d5`).
- **Codex P2 (cron not scheduled):** registered the archival cron in `docker/cron/crontab` (commit `568bcf3f8`).

Both Codex P2 threads have been verified fixed and resolved.

Closes #918
Closes #984
Closes #915
Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V55s9vp3RfkF9fNPz1osX1
