### PR TITLE
fix(publish): custom-domain cert provisioning (appId + already-exists handling)

### DIFF
--- a/apps/web/src/lib/fly/__tests__/certs.test.ts
+++ b/apps/web/src/lib/fly/__tests__/certs.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.stubGlobal('fetch', vi.fn());
 
-import { addCertificate } from '../certs';
+import { addCertificate, getCertificate } from '../certs';
 
 const FLY_API_URL = 'https://api.fly.io/graphql';
 const TOKEN = 'fly-test-token';
@@ -28,6 +28,18 @@ function mockFetchHttpError(status: number) {
   } as unknown as Response);
 }
 
+function addCertOk(clientStatus: string) {
+  return {
+    data: { addCertificate: { certificate: { configured: true, clientStatus, hostname: HOSTNAME } } },
+  };
+}
+
+function getCertOk(clientStatus: string) {
+  return {
+    data: { app: { certificate: { configured: true, clientStatus, hostname: HOSTNAME } } },
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.FLY_API_TOKEN = TOKEN;
@@ -39,9 +51,7 @@ afterEach(() => {
 
 describe('addCertificate', () => {
   it('sends POST to Fly GraphQL with correct Authorization header', async () => {
-    mockFetchOk({
-      data: { addCertificate: { certificate: { configured: false, hostname: HOSTNAME } } },
-    });
+    mockFetchOk(addCertOk('Awaiting certificates'));
 
     await addCertificate(APP_NAME, HOSTNAME);
 
@@ -53,35 +63,45 @@ describe('addCertificate', () => {
     expect(init.method).toBe('POST');
   });
 
-  it('sends mutation with appName and hostname variables', async () => {
-    mockFetchOk({
-      data: { addCertificate: { certificate: { configured: false, hostname: HOSTNAME } } },
-    });
+  it('sends the mutation with appId (not appName) and hostname variables', async () => {
+    mockFetchOk(addCertOk('Awaiting certificates'));
 
     await addCertificate(APP_NAME, HOSTNAME);
 
     const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
-    const body = JSON.parse(init.body as string) as { variables: Record<string, string> };
-    expect(body.variables.appName).toBe(APP_NAME);
+    const body = JSON.parse(init.body as string) as { query: string; variables: Record<string, string> };
+    expect(body.variables.appId).toBe(APP_NAME);
     expect(body.variables.hostname).toBe(HOSTNAME);
+    expect(body.variables.appName).toBeUndefined();
+    expect(body.query).toContain('addCertificate(appId: $appId');
   });
 
-  it('returns ok:true with configured:false when cert is provisioning', async () => {
-    mockFetchOk({
-      data: { addCertificate: { certificate: { configured: false, hostname: HOSTNAME } } },
-    });
-
+  it('returns ok:true configured:false while the cert is not yet Ready', async () => {
+    mockFetchOk(addCertOk('Awaiting configuration'));
     const result = await addCertificate(APP_NAME, HOSTNAME);
     expect(result).toEqual({ ok: true, configured: false });
   });
 
-  it('returns ok:true with configured:true when cert is already ready', async () => {
-    mockFetchOk({
-      data: { addCertificate: { certificate: { configured: true, hostname: HOSTNAME } } },
-    });
-
+  it('returns ok:true configured:true when clientStatus is Ready', async () => {
+    mockFetchOk(addCertOk('Ready'));
     const result = await addCertificate(APP_NAME, HOSTNAME);
     expect(result).toEqual({ ok: true, configured: true });
+  });
+
+  it('treats "Hostname already exists" as non-fatal and reads the existing cert status', async () => {
+    // 1st call: addCertificate → "already exists" error
+    mockFetchOk({ data: null, errors: [{ message: 'Hostname already exists on app' }] });
+    // 2nd call: getCertificate → Ready
+    mockFetchOk(getCertOk('Ready'));
+
+    const result = await addCertificate(APP_NAME, HOSTNAME);
+
+    expect(result).toEqual({ ok: true, configured: true });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const [, secondInit] = (fetch as ReturnType<typeof vi.fn>).mock.calls[1] as [string, RequestInit];
+    const secondBody = JSON.parse(secondInit.body as string) as { query: string; variables: Record<string, string> };
+    expect(secondBody.query).toContain('app(name: $appName)');
+    expect(secondBody.variables.appName).toBe(APP_NAME);
   });
 
   it('returns ok:false when FLY_API_TOKEN is absent', async () => {
@@ -104,7 +124,7 @@ describe('addCertificate', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('returns ok:false when GraphQL response has errors', async () => {
+  it('returns ok:false on a non-"already exists" GraphQL error', async () => {
     mockFetchOk({ data: null, errors: [{ message: 'app not found' }] });
     const result = await addCertificate(APP_NAME, HOSTNAME);
     expect(result.ok).toBe(false);
@@ -112,3 +132,26 @@ describe('addCertificate', () => {
   });
 });
 
+describe('getCertificate', () => {
+  it('queries app(name:) and maps Ready → configured:true', async () => {
+    mockFetchOk(getCertOk('Ready'));
+    const result = await getCertificate(APP_NAME, HOSTNAME);
+    expect(result).toEqual({ ok: true, configured: true });
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as { variables: Record<string, string> };
+    expect(body.variables.appName).toBe(APP_NAME);
+    expect(body.variables.hostname).toBe(HOSTNAME);
+  });
+
+  it('maps a non-Ready status to configured:false', async () => {
+    mockFetchOk(getCertOk('Awaiting configuration'));
+    const result = await getCertificate(APP_NAME, HOSTNAME);
+    expect(result).toEqual({ ok: true, configured: false });
+  });
+
+  it('returns ok:false when the app/cert is missing', async () => {
+    mockFetchOk({ data: { app: { certificate: null } } });
+    const result = await getCertificate(APP_NAME, HOSTNAME);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/web/src/lib/fly/certs.ts
+++ b/apps/web/src/lib/fly/certs.ts
@@ -2,16 +2,43 @@ import type { FlyCertResponse } from '@pagespace/lib/canvas/cert-action';
 
 const FLY_API_URL = 'https://api.fly.io/graphql';
 
+// Fly's GraphQL `addCertificate` takes `appId` (an ID! whose value is the app
+// NAME), NOT `appName` — passing `appName` is rejected with a schema error, so
+// this mutation never succeeded until this was corrected.
 const ADD_CERTIFICATE_MUTATION = `
-  mutation AddCertificate($appName: ID!, $hostname: String!) {
-    addCertificate(appName: $appName, hostname: $hostname) {
+  mutation AddCertificate($appId: ID!, $hostname: String!) {
+    addCertificate(appId: $appId, hostname: $hostname) {
       certificate {
         configured
+        clientStatus
         hostname
       }
     }
   }
 `;
+
+// Reading an existing cert's status uses `app(name:)` (a String!, not the ID!
+// that addCertificate wants). Used when a cert already exists on the app.
+const GET_CERTIFICATE_QUERY = `
+  query GetCertificate($appName: String!, $hostname: String!) {
+    app(name: $appName) {
+      certificate(hostname: $hostname) {
+        configured
+        clientStatus
+        hostname
+      }
+    }
+  }
+`;
+
+// A Fly cert is live/servable when its clientStatus is "Ready". The boolean
+// `configured` field only reflects DNS configuration, not issuance, so we key
+// "active" off clientStatus.
+const CERT_READY_STATUS = 'Ready';
+
+type CertNode = { configured: boolean; clientStatus: string; hostname: string } | null;
+type AddCertData = { addCertificate: { certificate: CertNode } | null };
+type GetCertData = { app: { certificate: CertNode } | null };
 
 async function flyGraphQL<T>(
   query: string,
@@ -54,16 +81,33 @@ async function flyGraphQL<T>(
   }
 }
 
-type AddCertData = {
-  addCertificate: { certificate: { configured: boolean; hostname: string } };
-};
-
-/** Request a TLS certificate from Fly for the given hostname on the given app. Idempotent. */
-export async function addCertificate(appName: string, hostname: string): Promise<FlyCertResponse> {
-  const result = await flyGraphQL<AddCertData>(ADD_CERTIFICATE_MUTATION, { appName, hostname });
-  if ('error' in result) return { ok: false, error: result.error };
-  const cert = result.data.addCertificate?.certificate;
+/** Map a Fly cert node to our response; `configured` means "Ready/live". */
+function certToResponse(cert: CertNode): FlyCertResponse {
   if (!cert) return { ok: false, error: 'Fly did not return a certificate' };
-  return { ok: true, configured: cert.configured };
+  return { ok: true, configured: cert.clientStatus === CERT_READY_STATUS };
 }
 
+/**
+ * Request a TLS certificate from Fly for the given hostname on the given app.
+ *
+ * Idempotent: if the cert already exists (Fly returns "Hostname already exists
+ * on app"), that is NOT a failure — we read the existing cert's status instead,
+ * so re-provision / poll cycles converge to active.
+ */
+export async function addCertificate(appName: string, hostname: string): Promise<FlyCertResponse> {
+  const result = await flyGraphQL<AddCertData>(ADD_CERTIFICATE_MUTATION, { appId: appName, hostname });
+  if ('error' in result) {
+    if (/already exists/i.test(result.error)) {
+      return getCertificate(appName, hostname);
+    }
+    return { ok: false, error: result.error };
+  }
+  return certToResponse(result.data.addCertificate?.certificate ?? null);
+}
+
+/** Read the status of an existing cert for a hostname on the given app. */
+export async function getCertificate(appName: string, hostname: string): Promise<FlyCertResponse> {
+  const result = await flyGraphQL<GetCertData>(GET_CERTIFICATE_QUERY, { appName, hostname });
+  if ('error' in result) return { ok: false, error: result.error };
+  return certToResponse(result.data.app?.certificate ?? null);
+}


### PR DESCRIPTION
## Summary
Custom-domain SSL provisioning **never worked**. Found while debugging a real domain (`viewswitcher.app`) stuck at "SSL provisioning failed". Two bugs in the Fly cert client (`apps/web/src/lib/fly/certs.ts`):

### Bug 1 — wrong GraphQL argument (`appName` → `appId`)
`addCertificate` was called with `appName: $appName`, but Fly's schema requires **`appId`** (an `ID!` whose value is the app name). Fly rejected every call with a schema error, so the domain always became `cert_failed` — **regardless of `FLY_API_TOKEN`**. Confirmed against the live Fly GraphQL API:
- `appName` → `Field 'addCertificate' doesn't accept argument 'appName'` / `missing required arguments: appId`
- `appId` → accepted

### Bug 2 — "already exists" treated as failure
Once a cert exists, `addCertificate` returns `"Hostname already exists on app"`. The client mapped **any** error to a failure, so a re-provision/poll on an existing cert could never reach `active`. Now "already exists" falls back to reading the cert's status via `app(name:){ certificate(hostname:) }` and converges to active.

### Also
- "Active" now keys off `clientStatus === "Ready"` (true issuance signal) instead of the `configured` boolean (DNS-configured only).
- Adds `getCertificate()`.
- The `(appName, hostname)` signature and `FlyCertResponse` contract are unchanged → the `cert/refresh` route and `nextCertAction` need no changes.

## Tests
`apps/web/src/lib/fly/__tests__/certs.test.ts`: appId variable, `clientStatus → configured` mapping, already-exists → status-read fallback, `getCertificate` happy/missing paths. **41 cert tests green** (12 client + 29 route), lint clean.

## Ops note
Custom-domain certs are added to `pagespace-proxy`, so `FLY_API_TOKEN` on `pagespace-web` must be scoped to manage `pagespace-proxy` (a `pagespace-proxy` deploy token or org token), not a `pagespace-web`-only token. The prod secret has been updated to a `pagespace-proxy`-scoped deploy token.

## Manual unblock already applied
`viewswitcher.app`'s cert was provisioned manually via `flyctl` (issued + active) to restore HTTPS immediately while this fix lands. After deploy, clicking **Retry SSL** will mark the domain `active` and mirror its content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)