### PR TITLE
fix(publish): mirror custom-domain content at verify (decouple from cert) + lazy cert reconcile

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/__tests__/route.test.ts
@@ -129,13 +129,37 @@ describe('DELETE /api/drives/[driveId]/domains/[domainId]', () => {
     expect(clearCustomHost).toHaveBeenCalledWith('acme.com');
   });
 
-  it('does NOT trigger clearCustomHost for a non-active domain', async () => {
-    const deleted = { id: DOMAIN_ID, driveId: DRIVE_ID, hostname: 'pending.com', status: 'pending', createdAt: new Date() };
+  it('triggers clearCustomHost when deleted domain is verified (serving, mirrored at verify time)', async () => {
+    const deleted = { id: DOMAIN_ID, driveId: DRIVE_ID, hostname: 'verified.com', status: 'verified', createdAt: new Date() };
+    dbDelete.mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([deleted]) }) });
+
+    const res = await DELETE(makeReq(), ctx());
+    await Promise.resolve();
+
+    expect(res.status).toBe(200);
+    expect(clearCustomHost).toHaveBeenCalledWith('verified.com');
+  });
+
+  it('triggers clearCustomHost when deleted domain is provisioning (serving)', async () => {
+    const deleted = { id: DOMAIN_ID, driveId: DRIVE_ID, hostname: 'prov.com', status: 'provisioning', createdAt: new Date() };
     dbDelete.mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([deleted]) }) });
 
     await DELETE(makeReq(), ctx());
     await Promise.resolve();
 
-    expect(clearCustomHost).not.toHaveBeenCalled();
+    expect(clearCustomHost).toHaveBeenCalledWith('prov.com');
+  });
+
+  it('does NOT trigger clearCustomHost for a non-serving domain (pending/dns_failed)', async () => {
+    for (const status of ['pending', 'dns_failed', 'cert_failed']) {
+      clearCustomHost.mockClear();
+      const deleted = { id: DOMAIN_ID, driveId: DRIVE_ID, hostname: `${status}.com`, status, createdAt: new Date() };
+      dbDelete.mockReturnValue({ where: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([deleted]) }) });
+
+      await DELETE(makeReq(), ctx());
+      await Promise.resolve();
+
+      expect(clearCustomHost).not.toHaveBeenCalled();
+    }
   });
 });

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/cert/refresh/route.ts
@@ -7,18 +7,13 @@ import {
 } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { nextCertAction, certActionToDbStatus, isCertEligible } from '@pagespace/lib/canvas/cert-action';
-import type { CertEligibleStatus } from '@pagespace/lib/canvas/cert-action';
-import { addCertificate } from '@/lib/fly/certs';
+import { isCertEligible } from '@pagespace/lib/canvas/cert-action';
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
-import { mirrorDriveToCustomHost, clearCustomHost } from '@/lib/canvas/custom-domain-mirror';
-import { regeneratePublishedSiteFiles } from '@/lib/canvas/publish-page';
+import { reconcileCustomDomainCert } from '@/lib/canvas/reconcile-cert';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
-
-const FLY_APP_NAME = process.env.FLY_PROXY_APP_NAME ?? 'pagespace-proxy';
 
 export async function POST(
   request: Request,
@@ -57,48 +52,15 @@ export async function POST(
       return NextResponse.json({ error: 'SSL provisioning is not configured (ops: set FLY_API_TOKEN)' }, { status: 503 });
     }
 
-    const flyCert = await addCertificate(FLY_APP_NAME, domain.hostname);
-
-    const action = nextCertAction(domain.status as CertEligibleStatus, flyCert);
-    const nextStatus = certActionToDbStatus(action);
-
-    await db
-      .update(customDomains)
-      .set({ status: nextStatus })
-      .where(eq(customDomains.id, domainId));
-
-    // When the cert is freshly provisioned and the domain just became active,
-    // regenerate site files first (so sitemap/robots embed the custom domain as
-    // primary host), then backfill all currently-published artifacts to the
-    // custom-host prefix. Best-effort: failure does not roll back the status update.
-    if (nextStatus === 'active' && domain.status !== 'active') {
-      await regeneratePublishedSiteFiles(driveId);
-      mirrorDriveToCustomHost(driveId, domain.hostname).catch((err) => {
-        loggers.api.warn('Failed to backfill artifacts after cert activation', {
-          driveId,
-          hostname: domain.hostname,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
-    }
-
-    // When a domain transitions to cert_failed, purge its mirrored prefix so
-    // stale content is not served until the cert is recovered. Run on every
-    // cert_failed outcome (not just active → cert_failed) so that retries
-    // after a failed clearCustomHost() still clean up — the delete is
-    // idempotent/no-op when nothing remains.
-    // Awaited with errors caught and logged so a storage failure doesn't return
-    // 500 when the DB status has already been committed.
-    if (nextStatus === 'cert_failed') {
-      try {
-        await clearCustomHost(domain.hostname);
-      } catch (err) {
-        loggers.api.warn('Failed to clear custom host artifacts after cert failure', {
-          hostname: domain.hostname,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+    // Advance the cert one step via the shared service (also used by the lazy
+    // reconcile on the domains-list GET). It commits the status, then runs the
+    // active/cert_failed side effects best-effort.
+    const { status: nextStatus, action } = await reconcileCustomDomainCert({
+      id: domain.id,
+      driveId,
+      hostname: domain.hostname,
+      status: domain.status,
+    });
 
     auditRequest(request, {
       eventType: 'data.write',
@@ -108,12 +70,12 @@ export async function POST(
       details: {
         operation: 'cert-refresh',
         hostname: domain.hostname,
-        action: action.action,
+        action,
         status: nextStatus,
       },
     });
 
-    return NextResponse.json({ status: nextStatus, action: action.action });
+    return NextResponse.json({ status: nextStatus, action });
   } catch (error) {
     loggers.api.error('Error refreshing cert:', error as Error);
     return NextResponse.json({ error: 'Failed to refresh cert' }, { status: 500 });

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/route.ts
@@ -11,6 +11,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
 import { clearCustomHost } from '@/lib/canvas/custom-domain-mirror';
+import { isServingStatus } from '@pagespace/lib/canvas/cert-action';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -40,9 +41,12 @@ export async function DELETE(
     }
 
     // Wipe all artifacts under this host's prefix so stale content is not
-    // served if the domain is re-added later or pointed elsewhere. Best-effort:
-    // a storage failure does not block the successful domain removal.
-    if (deleted.status === 'active') {
+    // served if the domain is re-added later or pointed elsewhere. Keyed off the
+    // serving predicate (verified | provisioning | active) — content is mirrored
+    // at verify time, so a verified/provisioning domain removed before SSL goes
+    // active still has a populated prefix that must be cleared. Best-effort: a
+    // storage failure does not block the successful domain removal.
+    if (isServingStatus(deleted.status)) {
       clearCustomHost(deleted.hostname).catch((err) => {
         loggers.api.warn('Failed to clear custom host artifacts after domain removal', {
           hostname: deleted.hostname,

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/verify/__tests__/route.test.ts
@@ -36,6 +36,13 @@ vi.mock('@/lib/publish/dns-resolver', () => ({
   resolveHostname: (...args: unknown[]) => resolveHostname(...args),
 }));
 
+const mirrorDriveToCustomHost = vi.fn().mockResolvedValue(undefined);
+const clearCustomHost = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/canvas/custom-domain-mirror', () => ({
+  mirrorDriveToCustomHost: (...args: unknown[]) => mirrorDriveToCustomHost(...args),
+  clearCustomHost: (...args: unknown[]) => clearCustomHost(...args),
+}));
+
 const dbSelect = vi.fn();
 const dbUpdate = vi.fn();
 vi.mock('@pagespace/db/db', () => ({
@@ -193,5 +200,49 @@ describe('POST /api/drives/[driveId]/domains/[domainId]/verify', () => {
     });
     const res = await POST(makeReq(), ctx());
     expect(res.status).toBe(500);
+  });
+
+  describe('content mirror decoupled from cert (mirror at verify)', () => {
+    it('mirrors the drive to the host when DNS verifies (→ verified)', async () => {
+      setupSelectReturning([APEX_DOMAIN]);
+      verifyDnsRecords.mockReturnValue({ verified: true });
+
+      await POST(makeReq(), ctx());
+
+      expect(mirrorDriveToCustomHost).toHaveBeenCalledWith(DRIVE_ID, 'acme.com');
+      expect(clearCustomHost).not.toHaveBeenCalled();
+    });
+
+    it('clears the host when DNS fails (→ dns_failed)', async () => {
+      setupSelectReturning([APEX_DOMAIN]);
+      verifyDnsRecords.mockReturnValue({ verified: false, reason: 'No A records' });
+
+      await POST(makeReq(), ctx());
+
+      expect(clearCustomHost).toHaveBeenCalledWith('acme.com');
+      expect(mirrorDriveToCustomHost).not.toHaveBeenCalled();
+    });
+
+    it('still returns 200 when the verify-time mirror throws (best-effort)', async () => {
+      setupSelectReturning([APEX_DOMAIN]);
+      verifyDnsRecords.mockReturnValue({ verified: true });
+      mirrorDriveToCustomHost.mockRejectedValueOnce(new Error('S3 down'));
+
+      const res = await POST(makeReq(), ctx());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('verified');
+    });
+
+    it('still returns 200 when the DNS-failure clear throws (best-effort)', async () => {
+      setupSelectReturning([APEX_DOMAIN]);
+      verifyDnsRecords.mockReturnValue({ verified: false, reason: 'No A records' });
+      clearCustomHost.mockRejectedValueOnce(new Error('S3 down'));
+
+      const res = await POST(makeReq(), ctx());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe('dns_failed');
+    });
   });
 });

--- a/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/verify/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/[domainId]/verify/route.ts
@@ -12,6 +12,7 @@ import { resolveHostname } from '@/lib/publish/dns-resolver';
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { customDomains } from '@pagespace/db/schema/custom-domains';
+import { mirrorDriveToCustomHost, clearCustomHost } from '@/lib/canvas/custom-domain-mirror';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -59,6 +60,29 @@ export async function POST(
       .update(customDomains)
       .set({ status: nextStatus })
       .where(eq(customDomains.id, domainId));
+
+    // Content mirroring is decoupled from cert activation: the moment DNS is
+    // confirmed, mirror the drive's published artifacts to `published/<host>/`
+    // so the custom-domain prefix is populated immediately — serving no longer
+    // waits on the async Fly cert. When DNS breaks, clear the prefix so stale
+    // content stops being served. Both best-effort and fire-and-forget: a
+    // storage failure must never fail the verify response.
+    if (nextStatus === 'verified') {
+      mirrorDriveToCustomHost(driveId, domain.hostname).catch((err) => {
+        loggers.api.warn('Failed to mirror drive to custom host on verify', {
+          driveId,
+          hostname: domain.hostname,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    } else {
+      clearCustomHost(domain.hostname).catch((err) => {
+        loggers.api.warn('Failed to clear custom host on DNS failure', {
+          hostname: domain.hostname,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
 
     auditRequest(request, {
       eventType: 'data.write',

--- a/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
@@ -214,6 +214,19 @@ describe('GET /api/drives/[driveId]/domains', () => {
     expect(body.domains.find((d: { hostname: string }) => d.hostname === 'prov.com').status).toBe('active');
   });
 
+  it('reconciles non-destructively on reads (allowFailureTransition: false)', async () => {
+    mockGetSelects([
+      { id: 'd1', driveId: DRIVE_ID, hostname: 'verified.com', status: 'verified', createdAt: new Date() },
+    ]);
+
+    await GET(makeReq(), ctx());
+
+    expect(reconcileCustomDomainCert).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: 'verified.com' }),
+      { allowFailureTransition: false },
+    );
+  });
+
   it('does NOT reconcile terminal rows (pending/active/dns_failed/cert_failed)', async () => {
     mockGetSelects([
       { id: 'd1', driveId: DRIVE_ID, hostname: 'pending.com', status: 'pending', createdAt: new Date() },

--- a/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
@@ -63,6 +63,11 @@ vi.mock('@/lib/subscription/plans', () => ({
   })),
 }));
 
+const reconcileCustomDomainCert = vi.fn();
+vi.mock('@/lib/canvas/reconcile-cert', () => ({
+  reconcileCustomDomainCert: (...args: unknown[]) => reconcileCustomDomainCert(...args),
+}));
+
 const DRIVE_ID = 'drive-1';
 const USER_ID = 'user-1';
 const mockAuth = { userId: USER_ID };
@@ -112,6 +117,8 @@ beforeEach(() => {
   authenticateRequestWithOptions.mockResolvedValue(mockAuth);
   checkMCPDriveScope.mockReturnValue(null);
   isPrincipalDriveOwnerOrAdmin.mockResolvedValue(true);
+  // Default reconcile: no-op echoing the input status (overridden per-test).
+  reconcileCustomDomainCert.mockImplementation(async (d: { status: string }) => ({ status: d.status, action: null }));
   // Default transaction: pass a tx stub that delegates to the same dbSelect/dbInsert mocks.
   dbTransaction.mockImplementation(async (cb: (tx: unknown) => unknown) =>
     cb({
@@ -174,6 +181,65 @@ describe('GET /api/drives/[driveId]/domains', () => {
     }));
     const res = await GET(makeReq(), ctx());
     expect(res.status).toBe(500);
+  });
+
+  // ── lazy cert reconcile ──────────────────────────────────────────────────
+  /** Stub a GET where the domain list is `domains` and tier lookup is `pro`. */
+  function mockGetSelects(domains: unknown[]) {
+    let callIndex = 0;
+    dbSelect.mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) {
+        return { from: vi.fn().mockReturnThis(), where: vi.fn().mockResolvedValue(domains) };
+      }
+      return { from: vi.fn().mockReturnThis(), innerJoin: vi.fn().mockReturnThis(), where: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue([{ tier: 'pro' }]) };
+    });
+  }
+
+  it('reconciles verified and provisioning rows and returns the advanced status', async () => {
+    mockGetSelects([
+      { id: 'd1', driveId: DRIVE_ID, hostname: 'verified.com', status: 'verified', createdAt: new Date() },
+      { id: 'd2', driveId: DRIVE_ID, hostname: 'prov.com', status: 'provisioning', createdAt: new Date() },
+    ]);
+    reconcileCustomDomainCert.mockImplementation(async (d: { hostname: string }) => ({
+      status: d.hostname === 'verified.com' ? 'provisioning' : 'active',
+      action: 'mark-active',
+    }));
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(reconcileCustomDomainCert).toHaveBeenCalledTimes(2);
+    expect(body.domains.find((d: { hostname: string }) => d.hostname === 'verified.com').status).toBe('provisioning');
+    expect(body.domains.find((d: { hostname: string }) => d.hostname === 'prov.com').status).toBe('active');
+  });
+
+  it('does NOT reconcile terminal rows (pending/active/dns_failed/cert_failed)', async () => {
+    mockGetSelects([
+      { id: 'd1', driveId: DRIVE_ID, hostname: 'pending.com', status: 'pending', createdAt: new Date() },
+      { id: 'd2', driveId: DRIVE_ID, hostname: 'active.com', status: 'active', createdAt: new Date() },
+      { id: 'd3', driveId: DRIVE_ID, hostname: 'dnsfail.com', status: 'dns_failed', createdAt: new Date() },
+      { id: 'd4', driveId: DRIVE_ID, hostname: 'certfail.com', status: 'cert_failed', createdAt: new Date() },
+    ]);
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(reconcileCustomDomainCert).not.toHaveBeenCalled();
+    expect(body.domains).toHaveLength(4);
+  });
+
+  it('never 500s when reconcile throws (Fly outage) — returns the un-advanced row', async () => {
+    mockGetSelects([
+      { id: 'd1', driveId: DRIVE_ID, hostname: 'verified.com', status: 'verified', createdAt: new Date() },
+    ]);
+    reconcileCustomDomainCert.mockRejectedValueOnce(new Error('Fly is down'));
+
+    const res = await GET(makeReq(), ctx());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.domains[0].status).toBe('verified');
   });
 });
 

--- a/apps/web/src/app/api/drives/[driveId]/domains/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/route.ts
@@ -16,6 +16,10 @@ import { drives } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
 import { getPlan } from '@/lib/subscription/plans';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { reconcileCustomDomainCert } from '@/lib/canvas/reconcile-cert';
+
+/** Statuses whose cert is still advancing — worth a lazy reconcile on read. */
+const CERT_NON_TERMINAL = new Set(['verified', 'provisioning']);
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -58,7 +62,29 @@ export async function GET(
       getMaxCustomDomainsForDrive(driveId),
     ]);
 
-    return NextResponse.json({ domains, limit });
+    // Lazy cert reconcile (no cron): for each row whose cert is still advancing
+    // (verified | provisioning), advance it one step so the badge + canonical
+    // self-heal on any settings visit. Best-effort and bounded — typically 0–1
+    // rows, run concurrently; a Fly outage must NOT break the list response.
+    // Content already serves without this (mirrored at verify time).
+    const reconciled = await Promise.all(
+      domains.map(async (domain) => {
+        if (!CERT_NON_TERMINAL.has(domain.status)) return domain;
+        try {
+          const { status } = await reconcileCustomDomainCert(domain);
+          return { ...domain, status };
+        } catch (err) {
+          loggers.api.warn('Lazy cert reconcile failed during domains list', {
+            driveId,
+            hostname: domain.hostname,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return domain;
+        }
+      }),
+    );
+
+    return NextResponse.json({ domains: reconciled, limit });
   } catch (error) {
     loggers.api.error('Error listing custom domains:', error as Error);
     return NextResponse.json({ error: 'Failed to list domains' }, { status: 500 });

--- a/apps/web/src/app/api/drives/[driveId]/domains/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/route.ts
@@ -66,12 +66,15 @@ export async function GET(
     // (verified | provisioning), advance it one step so the badge + canonical
     // self-heal on any settings visit. Best-effort and bounded — typically 0–1
     // rows, run concurrently; a Fly outage must NOT break the list response.
-    // Content already serves without this (mirrored at verify time).
+    // `allowFailureTransition: false` keeps a read non-destructive — a transient
+    // Fly error never flips a DNS-valid domain to cert_failed or wipes its
+    // content; that is reserved for the explicit "Check SSL" action. Content
+    // already serves without this (mirrored at verify time).
     const reconciled = await Promise.all(
       domains.map(async (domain) => {
         if (!CERT_NON_TERMINAL.has(domain.status)) return domain;
         try {
-          const { status } = await reconcileCustomDomainCert(domain);
+          const { status } = await reconcileCustomDomainCert(domain, { allowFailureTransition: false });
           return { ...domain, status };
         } catch (err) {
           loggers.api.warn('Lazy cert reconcile failed during domains list', {

--- a/apps/web/src/lib/canvas/__tests__/custom-domain-mirror.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/custom-domain-mirror.test.ts
@@ -134,11 +134,13 @@ describe('mirrorPublishedPageToHosts', () => {
     expect(copyPublishedArtifact).toHaveBeenCalledTimes(2);
   });
 
-  it('does NOT mirror to pending or verified (not-active) domains', async () => {
+  it('mirrors to serving (verified/provisioning/active) hosts but NOT pending/dns_failed', async () => {
     mockSelect([
       { hostname: 'pending.example.com', status: 'pending' },
       { hostname: 'verified.example.com', status: 'verified' },
+      { hostname: 'provisioning.example.com', status: 'provisioning' },
       { hostname: 'active.example.com', status: 'active' },
+      { hostname: 'dnsfailed.example.com', status: 'dns_failed' },
     ]);
 
     await mirrorPublishedPageToHosts({
@@ -148,16 +150,25 @@ describe('mirrorPublishedPageToHosts', () => {
       isHomePage: false,
     });
 
-    // Only the active domain receives a copy
-    expect(copyPublishedArtifact).toHaveBeenCalledTimes(1);
-    expect(copyPublishedArtifact).toHaveBeenCalledWith(
-      'published/acme/about/index.html',
-      'published/active.example.com/about/index.html',
+    // verified + provisioning + active each receive a copy; pending/dns_failed do not.
+    expect(copyPublishedArtifact).toHaveBeenCalledTimes(3);
+    const targets = vi.mocked(copyPublishedArtifact).mock.calls.map(([, to]) => to);
+    expect(targets).toEqual(
+      expect.arrayContaining([
+        'published/verified.example.com/about/index.html',
+        'published/provisioning.example.com/about/index.html',
+        'published/active.example.com/about/index.html',
+      ]),
     );
+    expect(targets).not.toContain('published/pending.example.com/about/index.html');
+    expect(targets).not.toContain('published/dnsfailed.example.com/about/index.html');
   });
 
-  it('is a no-op when there are no active custom domains', async () => {
-    mockSelect([{ hostname: 'pending.example.com', status: 'pending' }]);
+  it('is a no-op when there are no serving custom domains', async () => {
+    mockSelect([
+      { hostname: 'pending.example.com', status: 'pending' },
+      { hostname: 'dnsfailed.example.com', status: 'dns_failed' },
+    ]);
 
     await mirrorPublishedPageToHosts({
       driveId: 'drive-1',
@@ -285,21 +296,29 @@ describe('deletePageFromCustomHosts', () => {
     );
   });
 
-  it('does NOT delete from pending/verified domains', async () => {
+  it('deletes from serving (verified/active) hosts but NOT pending/dns_failed', async () => {
     mockSelect([
       { hostname: 'pending.example.com', status: 'pending' },
+      { hostname: 'verified.example.com', status: 'verified' },
       { hostname: 'active.example.com', status: 'active' },
+      { hostname: 'dnsfailed.example.com', status: 'dns_failed' },
     ]);
 
     await deletePageFromCustomHosts({ driveId: 'drive-1', path: 'about', isHomePage: false });
 
-    expect(deletePublishedArtifact).toHaveBeenCalledTimes(1);
-    expect(deletePublishedArtifact).toHaveBeenCalledWith(
-      'published/active.example.com/about/index.html',
+    expect(deletePublishedArtifact).toHaveBeenCalledTimes(2);
+    const targets = vi.mocked(deletePublishedArtifact).mock.calls.map(([key]) => key);
+    expect(targets).toEqual(
+      expect.arrayContaining([
+        'published/verified.example.com/about/index.html',
+        'published/active.example.com/about/index.html',
+      ]),
     );
+    expect(targets).not.toContain('published/pending.example.com/about/index.html');
+    expect(targets).not.toContain('published/dnsfailed.example.com/about/index.html');
   });
 
-  it('is a no-op when no active hosts', async () => {
+  it('is a no-op when no serving hosts', async () => {
     mockSelect([]);
 
     await deletePageFromCustomHosts({ driveId: 'drive-1', path: 'about', isHomePage: false });

--- a/apps/web/src/lib/canvas/__tests__/reconcile-cert.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/reconcile-cert.test.ts
@@ -154,6 +154,45 @@ describe('reconcileCustomDomainCert — cert advance', () => {
   });
 });
 
+describe('reconcileCustomDomainCert — non-destructive read path (allowFailureTransition: false)', () => {
+  it('Fly error is a no-op: does NOT flip to cert_failed, does NOT update the DB, does NOT clear', async () => {
+    addCertificate.mockResolvedValue({ ok: false, error: 'Fly API timeout' });
+
+    const result = await reconcileCustomDomainCert(domain('verified'), { allowFailureTransition: false });
+
+    expect(result).toEqual({ status: 'verified', action: null });
+    expect(dbUpdate).not.toHaveBeenCalled();
+    expect(clearCustomHost).not.toHaveBeenCalled();
+  });
+
+  it('still advances forward on success (verified + Ready → active) even with failures suppressed', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: true });
+
+    const result = await reconcileCustomDomainCert(domain('verified'), { allowFailureTransition: false });
+
+    expect(result.status).toBe('active');
+    expect(setMock).toHaveBeenCalledWith({ status: 'active' });
+    expect(mirrorDriveToCustomHost).toHaveBeenCalledWith(DRIVE_ID, 'docs.acme.com');
+  });
+
+  it('still advances provisioning → provisioning (poll) with failures suppressed', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: false });
+
+    const result = await reconcileCustomDomainCert(domain('provisioning'), { allowFailureTransition: false });
+
+    expect(result.status).toBe('provisioning');
+  });
+
+  it('the default (no opts) STILL flips a Fly error to cert_failed + clears — explicit refresh path', async () => {
+    addCertificate.mockResolvedValue({ ok: false, error: 'Fly API timeout' });
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(result.status).toBe('cert_failed');
+    expect(clearCustomHost).toHaveBeenCalledWith('docs.acme.com');
+  });
+});
+
 describe('reconcileCustomDomainCert — side effects never throw', () => {
   it('does not throw when clearCustomHost fails on cert_failed', async () => {
     addCertificate.mockResolvedValue({ ok: false, error: 'Fly down' });

--- a/apps/web/src/lib/canvas/__tests__/reconcile-cert.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/reconcile-cert.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Shell tests for reconcileCustomDomainCert — the cert-advance flow shared by
+ * the "Check SSL" route and the lazy reconcile on the domains-list GET. Fly, DB,
+ * storage and site-file regeneration are all mocked; cert-action stays real
+ * (pure decision).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { warn: vi.fn(), error: vi.fn() } },
+}));
+
+const addCertificate = vi.fn();
+vi.mock('@/lib/fly/certs', () => ({
+  addCertificate: (...args: unknown[]) => addCertificate(...args),
+}));
+
+const dbUpdate = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: { update: (...args: unknown[]) => dbUpdate(...args) },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
+}));
+vi.mock('@pagespace/db/schema/custom-domains', () => ({
+  customDomains: { id: 'col_id', status: 'col_status' },
+}));
+
+const mirrorDriveToCustomHost = vi.fn().mockResolvedValue(undefined);
+const clearCustomHost = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/canvas/custom-domain-mirror', () => ({
+  mirrorDriveToCustomHost: (...args: unknown[]) => mirrorDriveToCustomHost(...args),
+  clearCustomHost: (...args: unknown[]) => clearCustomHost(...args),
+}));
+
+const regeneratePublishedSiteFiles = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/canvas/publish-page', () => ({
+  regeneratePublishedSiteFiles: (...args: unknown[]) => regeneratePublishedSiteFiles(...args),
+}));
+
+import { reconcileCustomDomainCert } from '../reconcile-cert';
+
+const DRIVE_ID = 'drive-1';
+const setMock = vi.fn();
+
+function domain(status: string) {
+  return { id: 'dom-1', driveId: DRIVE_ID, hostname: 'docs.acme.com', status };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.FLY_API_TOKEN = 'test-token';
+  process.env.FLY_PROXY_APP_NAME = 'pagespace-proxy';
+  setMock.mockReturnValue({ where: vi.fn().mockResolvedValue([]) });
+  dbUpdate.mockReturnValue({ set: setMock });
+  mirrorDriveToCustomHost.mockResolvedValue(undefined);
+  clearCustomHost.mockResolvedValue(undefined);
+  regeneratePublishedSiteFiles.mockResolvedValue(undefined);
+});
+
+describe('reconcileCustomDomainCert — no-op guards', () => {
+  it('is a no-op when FLY_API_TOKEN is unset (never flips to cert_failed)', async () => {
+    delete process.env.FLY_API_TOKEN;
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(result).toEqual({ status: 'verified', action: null });
+    expect(addCertificate).not.toHaveBeenCalled();
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the status is not cert-eligible (e.g. pending)', async () => {
+    const result = await reconcileCustomDomainCert(domain('pending'));
+
+    expect(result).toEqual({ status: 'pending', action: null });
+    expect(addCertificate).not.toHaveBeenCalled();
+    expect(dbUpdate).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for dns_failed (DNS not confirmed)', async () => {
+    const result = await reconcileCustomDomainCert(domain('dns_failed'));
+
+    expect(result).toEqual({ status: 'dns_failed', action: null });
+    expect(addCertificate).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcileCustomDomainCert — cert advance', () => {
+  it('verified + cert Ready → active, regenerates site files + re-mirrors', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: true });
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(addCertificate).toHaveBeenCalledWith('pagespace-proxy', 'docs.acme.com');
+    expect(result).toEqual({ status: 'active', action: 'mark-active' });
+    expect(setMock).toHaveBeenCalledWith({ status: 'active' });
+    expect(regeneratePublishedSiteFiles).toHaveBeenCalledWith(DRIVE_ID);
+    expect(mirrorDriveToCustomHost).toHaveBeenCalledWith(DRIVE_ID, 'docs.acme.com');
+    expect(clearCustomHost).not.toHaveBeenCalled();
+  });
+
+  it('verified + cert not yet Ready → provisioning, no mirror/regenerate', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: false });
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(result).toEqual({ status: 'provisioning', action: 'provision' });
+    expect(setMock).toHaveBeenCalledWith({ status: 'provisioning' });
+    expect(regeneratePublishedSiteFiles).not.toHaveBeenCalled();
+    expect(mirrorDriveToCustomHost).not.toHaveBeenCalled();
+  });
+
+  it('provisioning + still issuing → stays provisioning', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: false });
+
+    const result = await reconcileCustomDomainCert(domain('provisioning'));
+
+    expect(result).toEqual({ status: 'provisioning', action: 'poll-again' });
+    expect(mirrorDriveToCustomHost).not.toHaveBeenCalled();
+  });
+
+  it('provisioning + cert Ready → active, regenerates + re-mirrors', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: true });
+
+    const result = await reconcileCustomDomainCert(domain('provisioning'));
+
+    expect(result.status).toBe('active');
+    expect(regeneratePublishedSiteFiles).toHaveBeenCalledWith(DRIVE_ID);
+    expect(mirrorDriveToCustomHost).toHaveBeenCalledWith(DRIVE_ID, 'docs.acme.com');
+  });
+
+  it('Fly error → cert_failed, clears the host prefix', async () => {
+    addCertificate.mockResolvedValue({ ok: false, error: 'Fly API timeout' });
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(result).toEqual({ status: 'cert_failed', action: 'mark-failed' });
+    expect(setMock).toHaveBeenCalledWith({ status: 'cert_failed' });
+    expect(clearCustomHost).toHaveBeenCalledWith('docs.acme.com');
+    expect(mirrorDriveToCustomHost).not.toHaveBeenCalled();
+  });
+
+  it('already-active re-check that stays active does NOT re-mirror or clear', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: true });
+
+    const result = await reconcileCustomDomainCert(domain('active'));
+
+    expect(result.status).toBe('active');
+    expect(regeneratePublishedSiteFiles).not.toHaveBeenCalled();
+    expect(mirrorDriveToCustomHost).not.toHaveBeenCalled();
+    expect(clearCustomHost).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcileCustomDomainCert — side effects never throw', () => {
+  it('does not throw when clearCustomHost fails on cert_failed', async () => {
+    addCertificate.mockResolvedValue({ ok: false, error: 'Fly down' });
+    clearCustomHost.mockRejectedValueOnce(new Error('S3 down'));
+
+    const result = await reconcileCustomDomainCert(domain('active'));
+
+    expect(result.status).toBe('cert_failed');
+  });
+
+  it('does not throw when regenerate fails on activation (still re-mirrors)', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: true });
+    regeneratePublishedSiteFiles.mockRejectedValueOnce(new Error('regen boom'));
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(result.status).toBe('active');
+    expect(mirrorDriveToCustomHost).toHaveBeenCalledWith(DRIVE_ID, 'docs.acme.com');
+  });
+
+  it('does not throw when the fire-and-forget re-mirror rejects', async () => {
+    addCertificate.mockResolvedValue({ ok: true, configured: true });
+    mirrorDriveToCustomHost.mockRejectedValueOnce(new Error('mirror boom'));
+
+    const result = await reconcileCustomDomainCert(domain('verified'));
+
+    expect(result.status).toBe('active');
+  });
+});

--- a/apps/web/src/lib/canvas/custom-domain-mirror.ts
+++ b/apps/web/src/lib/canvas/custom-domain-mirror.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { planCustomDomainMirror } from '@pagespace/lib/canvas/custom-domain-mirror';
+import { isServingStatus } from '@pagespace/lib/canvas/cert-action';
 import type { ActiveDomainRecord } from '@pagespace/lib/canvas/primary-host';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
@@ -38,16 +39,29 @@ export async function getActiveDomainRecords(driveId: string): Promise<ActiveDom
   return rows.filter((r) => r.status === 'active').map((r) => ({ hostname: r.hostname, createdAt: r.createdAt }));
 }
 
-/** Return only the active custom hostnames for a drive (legacy internal helper). */
-async function getActiveDriveHosts(driveId: string): Promise<string[]> {
-  const records = await getActiveDomainRecords(driveId);
-  return records.map((r) => r.hostname);
+/**
+ * Return the custom hostnames for a drive that should hold mirrored content —
+ * the "serving" hosts (status verified | provisioning | active), independent of
+ * cert state. This is the CONTENT-mirror target: a host serves the drive's
+ * artifacts the moment DNS is verified, so content no longer waits on the
+ * async Fly cert.
+ *
+ * Distinct from `getActiveDomainRecords`, which stays ACTIVE-only because the
+ * canonical/primary host must never point at a not-yet-live host.
+ */
+async function getServingDriveHosts(driveId: string): Promise<string[]> {
+  const rows = await db
+    .select({ hostname: customDomains.hostname, status: customDomains.status })
+    .from(customDomains)
+    .where(eq(customDomains.driveId, driveId));
+
+  return rows.filter((r) => isServingStatus(r.status)).map((r) => r.hostname);
 }
 
 /**
- * Mirror a single published page artifact to every active custom-domain host
- * for the drive. When the page is the drive's home page the root mirror is
- * copied too (`published/<host>/index.html`).
+ * Mirror a single published page artifact to every serving custom-domain host
+ * for the drive (verified | provisioning | active). When the page is the drive's
+ * home page the root mirror is copied too (`published/<host>/index.html`).
  *
  * Best-effort: individual copy failures are logged but never thrown — the
  * primary publish has already succeeded and will be retried by the next
@@ -65,7 +79,7 @@ export async function mirrorPublishedPageToHosts(params: {
   try {
     if (!isPublishConfigured()) return;
 
-    const hosts = await getActiveDriveHosts(driveId);
+    const hosts = await getServingDriveHosts(driveId);
     if (hosts.length === 0) return;
 
     const { copies } = planCustomDomainMirror({
@@ -96,15 +110,15 @@ export async function mirrorPublishedPageToHosts(params: {
 
 /**
  * Mirror all drive site files (robots.txt, sitemap.xml, 404.html) to every
- * active custom-domain host. Called after `regeneratePublishedSiteFiles` so
- * every copy of the site carries the same canonical site-level documents.
- * Best-effort.
+ * serving custom-domain host (verified | provisioning | active). Called after
+ * `regeneratePublishedSiteFiles` so every copy of the site carries the same
+ * canonical site-level documents. Best-effort.
  */
 export async function mirror404ToHosts(driveId: string, subdomain: string): Promise<void> {
   try {
     if (!isPublishConfigured()) return;
 
-    const hosts = await getActiveDriveHosts(driveId);
+    const hosts = await getServingDriveHosts(driveId);
     if (hosts.length === 0) return;
 
     const { copies } = planCustomDomainMirror({
@@ -137,8 +151,9 @@ export async function mirror404ToHosts(driveId: string, subdomain: string): Prom
 
 /**
  * Delete a page's artifact (and its root mirror when it is the home page) from
- * every active custom-domain host for the drive. Called during unpublish so the
- * page stops being served at custom domains.
+ * every serving custom-domain host for the drive (verified | provisioning |
+ * active). Called during unpublish so the page stops being served at custom
+ * domains.
  *
  * Best-effort: individual delete failures are logged but never thrown.
  */
@@ -152,7 +167,7 @@ export async function deletePageFromCustomHosts(params: {
   try {
     if (!isPublishConfigured()) return;
 
-    const hosts = await getActiveDriveHosts(driveId);
+    const hosts = await getServingDriveHosts(driveId);
     if (hosts.length === 0) return;
 
     const deleteOps: Array<() => Promise<void>> = [];
@@ -184,8 +199,10 @@ export async function deletePageFromCustomHosts(params: {
 
 /**
  * Copy ALL currently-published artifacts for a drive to a single custom-domain
- * host prefix. Called when a domain transitions to `active` (cert provisioned +
- * DNS verified) so the host is immediately ready to serve the full published site.
+ * host prefix. Called when a domain transitions to `verified` (DNS confirmed) so
+ * the host prefix is populated the moment DNS is confirmed — serving no longer
+ * waits on the async Fly cert. Also re-run on `→ active` so site files adopt the
+ * now-active canonical host.
  *
  * Backfills:
  *  - every page artifact (`published_pages` rows)

--- a/apps/web/src/lib/canvas/reconcile-cert.ts
+++ b/apps/web/src/lib/canvas/reconcile-cert.ts
@@ -1,0 +1,105 @@
+import 'server-only';
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { nextCertAction, certActionToDbStatus, isCertEligible } from '@pagespace/lib/canvas/cert-action';
+import type { CertAction, CertEligibleStatus } from '@pagespace/lib/canvas/cert-action';
+import { addCertificate } from '@/lib/fly/certs';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { customDomains } from '@pagespace/db/schema/custom-domains';
+import { mirrorDriveToCustomHost, clearCustomHost } from '@/lib/canvas/custom-domain-mirror';
+import { regeneratePublishedSiteFiles } from '@/lib/canvas/publish-page';
+
+const FLY_APP_NAME = process.env.FLY_PROXY_APP_NAME ?? 'pagespace-proxy';
+
+/** The minimal domain shape `reconcileCustomDomainCert` needs. */
+export interface CertReconcileDomain {
+  id: string;
+  driveId: string;
+  hostname: string;
+  status: string;
+}
+
+export interface CertReconcileResult {
+  /** The resulting DB status (equals the input status when no work was done). */
+  status: string;
+  /** The cert action taken, or `null` when reconcile was a no-op. */
+  action: CertAction['action'] | null;
+}
+
+/**
+ * Advance a custom domain's TLS cert state by one step, shared by the explicit
+ * "Check SSL" route and the lazy reconcile on the domains-list GET.
+ *
+ * Flow (pure decision in `@pagespace/lib/canvas/cert-action`):
+ *   addCertificate (idempotent) → nextCertAction(status, flyCert) → persist status.
+ *   - `→ active` (and was not already active): regenerate the drive's site files
+ *     so sitemap/robots/canonical adopt the now-active custom host. (Content is
+ *     already mirrored at verify time; this only refreshes the canonical-bearing
+ *     site files.)
+ *   - `→ cert_failed`: clear the host prefix so stale content is not served.
+ *
+ * No-op (returns the unchanged status, action `null`) when:
+ *   - `FLY_API_TOKEN` is unset — never flip a verified domain to cert_failed just
+ *     because ops creds are missing (important for the best-effort GET path).
+ *   - the status is not cert-eligible (e.g. pending / dns_failed).
+ *
+ * This function NEVER throws on Fly/storage failure of the side effects: the
+ * cert decision is committed first, then mirror/clear run best-effort. A Fly
+ * error surfaces as a `cert_failed` status (via `nextCertAction`), not an
+ * exception — so callers can run it concurrently across rows without a single
+ * outage breaking the batch.
+ */
+export async function reconcileCustomDomainCert(
+  domain: CertReconcileDomain,
+): Promise<CertReconcileResult> {
+  if (!process.env.FLY_API_TOKEN) {
+    return { status: domain.status, action: null };
+  }
+  if (!isCertEligible(domain.status)) {
+    return { status: domain.status, action: null };
+  }
+
+  const flyCert = await addCertificate(FLY_APP_NAME, domain.hostname);
+  const action = nextCertAction(domain.status as CertEligibleStatus, flyCert);
+  const nextStatus = certActionToDbStatus(action);
+
+  await db.update(customDomains).set({ status: nextStatus }).where(eq(customDomains.id, domain.id));
+
+  // On the freshly-active transition, regenerate site files so the now-active
+  // custom host is adopted as canonical/primary. Best-effort: a failure here
+  // does not roll back the committed status.
+  if (nextStatus === 'active' && domain.status !== 'active') {
+    try {
+      await regeneratePublishedSiteFiles(domain.driveId);
+    } catch (err) {
+      loggers.api.warn('Failed to regenerate site files after cert activation', {
+        driveId: domain.driveId,
+        hostname: domain.hostname,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    mirrorDriveToCustomHost(domain.driveId, domain.hostname).catch((err) => {
+      loggers.api.warn('Failed to re-mirror artifacts after cert activation', {
+        driveId: domain.driveId,
+        hostname: domain.hostname,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
+  // On any → cert_failed outcome, purge the mirrored prefix so stale content is
+  // not served until the cert recovers. Idempotent: a no-op when nothing remains.
+  if (nextStatus === 'cert_failed') {
+    try {
+      await clearCustomHost(domain.hostname);
+    } catch (err) {
+      loggers.api.warn('Failed to clear custom host artifacts after cert failure', {
+        hostname: domain.hostname,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { status: nextStatus, action: action.action };
+}

--- a/apps/web/src/lib/canvas/reconcile-cert.ts
+++ b/apps/web/src/lib/canvas/reconcile-cert.ts
@@ -27,6 +27,18 @@ export interface CertReconcileResult {
   action: CertAction['action'] | null;
 }
 
+export interface CertReconcileOptions {
+  /**
+   * Whether a Fly API error may transition the domain to `cert_failed` (and
+   * clear its mirrored prefix). Defaults to `true` for the explicit "Check SSL"
+   * action. The lazy domains-list GET passes `false`: a transient Fly
+   * error/timeout on a mere read must NOT flip a DNS-valid domain to
+   * `cert_failed` or wipe its content — that destructive transition is reserved
+   * for the user-initiated refresh.
+   */
+  allowFailureTransition?: boolean;
+}
+
 /**
  * Advance a custom domain's TLS cert state by one step, shared by the explicit
  * "Check SSL" route and the lazy reconcile on the domains-list GET.
@@ -48,11 +60,16 @@ export interface CertReconcileResult {
  * cert decision is committed first, then mirror/clear run best-effort. A Fly
  * error surfaces as a `cert_failed` status (via `nextCertAction`), not an
  * exception — so callers can run it concurrently across rows without a single
- * outage breaking the batch.
+ * outage breaking the batch. On the lazy GET path (`allowFailureTransition:
+ * false`) a Fly error is instead swallowed as a no-op, so a read never destroys
+ * a DNS-valid domain's content.
  */
 export async function reconcileCustomDomainCert(
   domain: CertReconcileDomain,
+  opts: CertReconcileOptions = {},
 ): Promise<CertReconcileResult> {
+  const { allowFailureTransition = true } = opts;
+
   if (!process.env.FLY_API_TOKEN) {
     return { status: domain.status, action: null };
   }
@@ -62,6 +79,15 @@ export async function reconcileCustomDomainCert(
 
   const flyCert = await addCertificate(FLY_APP_NAME, domain.hostname);
   const action = nextCertAction(domain.status as CertEligibleStatus, flyCert);
+
+  // Non-destructive read path: a Fly error/timeout maps to `mark-failed`, which
+  // would flip the domain to `cert_failed` and wipe its mirrored prefix. On the
+  // lazy GET we refuse that — only ever advance forward; a DNS-valid domain must
+  // not lose its content because a list read hit a transient Fly blip.
+  if (action.action === 'mark-failed' && !allowFailureTransition) {
+    return { status: domain.status, action: null };
+  }
+
   const nextStatus = certActionToDbStatus(action);
 
   await db.update(customDomains).set({ status: nextStatus }).where(eq(customDomains.id, domain.id));

--- a/apps/web/src/lib/fly/__tests__/certs.test.ts
+++ b/apps/web/src/lib/fly/__tests__/certs.test.ts
@@ -63,6 +63,26 @@ describe('addCertificate', () => {
     expect(init.method).toBe('POST');
   });
 
+  it('passes a bounded AbortSignal (timeout) to fetch so a hung Fly response cannot block the caller', async () => {
+    mockFetchOk(addCertOk('Awaiting certificates'));
+
+    await addCertificate(APP_NAME, HOSTNAME);
+
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('returns ok:false when the Fly request times out (aborted)', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' }),
+    );
+
+    const result = await addCertificate(APP_NAME, HOSTNAME);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/timed out/i);
+  });
+
   it('sends the mutation with appId (not appName) and hostname variables', async () => {
     mockFetchOk(addCertOk('Awaiting certificates'));
 

--- a/apps/web/src/lib/fly/certs.ts
+++ b/apps/web/src/lib/fly/certs.ts
@@ -2,6 +2,12 @@ import type { FlyCertResponse } from '@pagespace/lib/canvas/cert-action';
 
 const FLY_API_URL = 'https://api.fly.io/graphql';
 
+// Bound the Fly request so a hung response can't block the caller indefinitely.
+// addCertificate is invoked from the domains-list GET (lazy cert reconcile), so
+// an unbounded fetch would stall the settings UI. On timeout the AbortSignal
+// rejects the fetch and we degrade to an ok:false error response.
+const FLY_API_TIMEOUT_MS = 10_000;
+
 // Fly's GraphQL `addCertificate` takes `appId` (an ID! whose value is the app
 // NAME), NOT `appName` — passing `appName` is rejected with a schema error, so
 // this mutation never succeeded until this was corrected.
@@ -57,6 +63,7 @@ async function flyGraphQL<T>(
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(FLY_API_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/packages/lib/src/canvas/__tests__/cert-action.test.ts
+++ b/packages/lib/src/canvas/__tests__/cert-action.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { nextCertAction, certActionToDbStatus, isCertEligible } from '../cert-action';
+import { nextCertAction, certActionToDbStatus, isCertEligible, isServingStatus } from '../cert-action';
 import type { FlyCertResponse } from '../cert-action';
 
 const ok = (configured: boolean): FlyCertResponse => ({ ok: true, configured });
@@ -107,4 +107,17 @@ describe('isCertEligible', () => {
   it('returns false for pending', () => expect(isCertEligible('pending')).toBe(false));
   it('returns false for dns_failed', () => expect(isCertEligible('dns_failed')).toBe(false));
   it('returns false for failed (legacy)', () => expect(isCertEligible('failed')).toBe(false));
+});
+
+describe('isServingStatus', () => {
+  // Serving = DNS-confirmed host that should hold mirrored content, independent
+  // of cert state. Asserted for EVERY status value in the enum.
+  it('returns true for verified', () => expect(isServingStatus('verified')).toBe(true));
+  it('returns true for provisioning', () => expect(isServingStatus('provisioning')).toBe(true));
+  it('returns true for active', () => expect(isServingStatus('active')).toBe(true));
+  it('returns false for pending', () => expect(isServingStatus('pending')).toBe(false));
+  it('returns false for dns_failed', () => expect(isServingStatus('dns_failed')).toBe(false));
+  it('returns false for cert_failed', () => expect(isServingStatus('cert_failed')).toBe(false));
+  it('returns false for failed (legacy)', () => expect(isServingStatus('failed')).toBe(false));
+  it('returns false for an unknown status', () => expect(isServingStatus('bogus')).toBe(false));
 });

--- a/packages/lib/src/canvas/cert-action.ts
+++ b/packages/lib/src/canvas/cert-action.ts
@@ -16,6 +16,20 @@ export function isCertEligible(status: string): status is CertEligibleStatus {
 }
 
 /**
+ * "Serving" statuses = DNS-confirmed hosts that should hold mirrored content,
+ * independent of TLS cert state. A host serves content the moment DNS is
+ * verified; the cert only controls whether Fly TLS-terminates the host at the
+ * edge. Content mirroring keys off this predicate; canonical/primary-host
+ * resolution keys off `active` only.
+ *
+ * True for: verified | provisioning | active.
+ * False for: pending | failed | dns_failed | cert_failed (and anything else).
+ */
+export function isServingStatus(status: string): boolean {
+  return status === 'verified' || status === 'provisioning' || status === 'active';
+}
+
+/**
  * Pure decision function: given the domain's current status and a Fly cert API
  * response, return the next action to take.
  *


### PR DESCRIPTION
## Why (real production bug, paying customer)

Custom domains publish a drive's canvas site at the customer's hostname. A paying customer added a domain **after** the cert fix (#1713) deployed and their site still 404'd with raw S3 errors.

**Root cause: content mirroring was coupled to cert-activation.** The flow is `pending → verified → provisioning → active`, and the drive's content was only mirrored to `published/<host>/…` on the `provisioning → active` transition. But **Fly issues certs asynchronously with no webhook**, so after `verify` the status sits at `provisioning` until the user clicks "Check SSL" *again* once the cert finishes. If they walk away (they did), it never flips → the mirror never runs → the custom-domain prefix is empty → every path 404s. This broke **every** new custom domain unless the customer babysat the button.

## The fix: serving-vs-active

**The cert and the content are independent.** The cert only controls whether Fly TLS-terminates the host at the edge; the `published/<host>/` objects in Tigris don't need the cert to exist. So we mirror content the moment DNS is **`verified`** — then once Fly issues the cert on its own, `https://<host>/` just works with zero further app action. The `provisioning → active` flip becomes cosmetic (badge + canonical + which hosts future publishes target) and is reconciled lazily.

Define **"serving hosts" = DNS-confirmed hosts that should hold content** = status in `{verified, provisioning, active}`. **Content mirroring keys off serving; canonical keys off active only.**

## What changed

1. **Pure predicate** `isServingStatus(status)` in `packages/lib/canvas/cert-action.ts` — true for `verified | provisioning | active`. Unit-tested for every enum value.
2. **Content mirror targets serving hosts:** `getActiveDriveHosts → getServingDriveHosts`, re-filtered with `isServingStatus`. All three callers (`mirrorPublishedPageToHosts`, `mirror404ToHosts`, `deletePageFromCustomHosts`) now keep verified/provisioning hosts in sync on every publish/unpublish. **`getActiveDomainRecords` stays ACTIVE-only** so the canonical/primary host never points at a not-yet-live host.
3. **Mirror at verify:** the verify route mirrors the drive to the host on `→ verified` and clears the prefix on `→ dns_failed`. Best-effort, fire-and-forget — a storage failure never fails the verify response. The prefix is now populated the moment DNS is confirmed.
4. **Lazy cert reconcile (no cron):** cert-advance logic extracted into a shared `reconcileCustomDomainCert(domain)` service (`apps/web/src/lib/canvas/reconcile-cert.ts`). Both the cert/refresh route **and** the domains-list GET use it. The GET reconciles non-terminal rows (`verified`/`provisioning`) best-effort — per-row try/catch, run concurrently, no-op without `FLY_API_TOKEN`, a Fly outage never breaks the list response. This self-heals the badge + canonical on any settings visit. **Content already works without it.**
5. The explicit "Check SSL" button + verify→cert chain keep working (both now go through the shared `reconcileCustomDomainCert`).

## Tests

TDD, pure-core-first. Fly/DB/storage are mocked shells (never real Fly/S3/DB).

- `isServingStatus` — true for verified/provisioning/active, false otherwise (every enum value).
- `getServingDriveHosts` includes verified+provisioning+active; `getActiveDomainRecords` still active-only.
- Verify route: `→ verified` mirrors (asserts the call); `→ dns_failed` clears; both best-effort (still 200 on storage failure).
- `reconcileCustomDomainCert`: verified+Ready → active (+regenerate +re-mirror); provisioning+still-issuing → stays provisioning; Fly error → cert_failed (+clear); no-op without token / non-eligible; side effects never throw.
- Domains-list GET reconciles non-terminal rows, leaves terminal rows untouched, never 500s on a Fly error.

`bun run lint` ✅ · `bun run typecheck` (incl. `web:build`) ✅ · affected vitest suites ✅ (203 canvas tests green).

## Out of scope

- A cron/background scheduler (lazy-on-read is the chosen mechanism; cron noted as a future option only).
- Re-rendering page artifacts with the custom-domain canonical on activation (republish territory / PR5).
- Any change to the host-as-prefix serving model or the Caddy edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GRzkowHNebMzyiCDogP9J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom domain certificates now advance automatically during domain listing and verification, helping domains reach a usable state sooner.
  * Published site content is now mirrored or cleared for custom hosts based on domain serving status.

* **Bug Fixes**
  * Improved handling for certificate and DNS status changes so failed background steps no longer block successful responses.
  * Updated domain content serving behavior to include all active serving states, reducing cases where content appeared unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review fixes (commit 4812f84db)

- **P1 (Codex) — destructive reconcile on reads:** lazy GET reconcile is now non-destructive. `reconcileCustomDomainCert` takes `{ allowFailureTransition }` (default `true`); the GET passes `false`, so a transient Fly error/timeout on a read is a no-op (no `cert_failed`, no `clearCustomHost`) — reads only advance forward. Failure transitions stay with the explicit "Check SSL" action.
- **P2 (Codex) — orphaned mirrors on delete:** the DELETE route now clears the host prefix for any serving status (`isServingStatus`: verified | provisioning | active), not just `active`, so verified/provisioning domains removed before SSL goes live are cleaned up.
- **Minor (CodeRabbit) — unbounded Fly fetch:** `flyGraphQL` now uses `AbortSignal.timeout(10s)`; a hung Fly response degrades to `ok:false` instead of blocking the settings UI.

All three covered by new unit tests (135 affected tests green); lint + typecheck (incl. web:build) green.