### PR TITLE
fix(publish): auto-slug reserved/taken subdomains instead of erroring

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -28,11 +28,12 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserEditPage: (...args: unknown[]) => canUserEditPage(...args),
 }));
 
-const validatePublishSubdomain = vi.fn();
-vi.mock('@pagespace/lib/validators/subdomain', () => ({
-  normalizeSubdomain: (input: string) =>
-    input.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-+/, '').replace(/-+$/, ''),
-  validatePublishSubdomain: (...args: unknown[]) => validatePublishSubdomain(...args),
+// First-publish subdomain allocation is delegated to the shared, race-safe
+// allocator (the same one drive creation uses). It auto-resolves reserved /
+// taken / malformed candidates to a unique slug instead of erroring.
+const allocatePublishSubdomain = vi.fn();
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  allocatePublishSubdomain: (...args: unknown[]) => allocatePublishSubdomain(...args),
 }));
 
 vi.mock('@pagespace/lib/utils/utils', () => ({
@@ -129,7 +130,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   authenticateRequestWithOptions.mockResolvedValue({ userId: 'user-1' });
   canUserEditPage.mockResolvedValue(true);
-  validatePublishSubdomain.mockReturnValue({ valid: true });
+  allocatePublishSubdomain.mockResolvedValue('acme');
   isPublishConfigured.mockReturnValue(true);
   getPublishAssetBaseUrl.mockReturnValue('https://test-publish.t3.tigrisfiles.io');
   rewriteCanvasAssets.mockImplementation(async ({ html }: { html: string }) => ({ html }));
@@ -213,10 +214,12 @@ describe('POST /api/pages/[pageId]/publish', () => {
     const res = await POST(makeReq({}), { params });
     expect(res.status).toBe(200);
 
-    // validates and persists the NORMALIZED candidate derived from the slug
-    expect(validatePublishSubdomain).toHaveBeenCalledWith('acme');
-    // 2 updates: subdomain allocation + post-upload updatedAt advancement
-    expect(updateWhere).toHaveBeenCalledTimes(2);
+    // Delegates allocation to the shared allocator with the drive id + raw slug
+    // base (the allocator normalizes/dedupes internally).
+    expect(allocatePublishSubdomain).toHaveBeenCalledWith('drive-1', 'Acme');
+    // 1 update: post-upload updatedAt advancement (subdomain allocation no longer
+    // writes through this mocked `update` path — it's owned by the allocator).
+    expect(updateWhere).toHaveBeenCalledTimes(1);
 
     expect(rewriteCanvasAssets).toHaveBeenCalledWith({ html: '<p>hi</p>', userId: 'user-1', db: expect.any(Object) });
     expect(renderPublishedPage).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>hi</p>', title: 'Welcome', assetBaseUrl: 'https://test-publish.t3.tigrisfiles.io', faviconBaseUrl: 'https://pagespace.ai', pageUrl: 'https://acme.pagespace.site/welcome', description: 'hi' }));
@@ -230,6 +233,25 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(json).toEqual({
       url: 'https://acme.pagespace.site/welcome',
       subdomain: 'acme',
+      path: 'welcome',
+      isHomePage: false,
+    });
+  });
+
+  it('first-publish with a reserved slug auto-slugs to a unique subdomain (no 4xx)', async () => {
+    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CANVAS', title: 'Welcome', content: '<p>hi</p>', driveId: 'drive-1' });
+    findFirstDrive.mockResolvedValue({ id: 'drive-1', slug: 'pagespace', publishSubdomain: null });
+    // 'pagespace' is reserved — the allocator resolves it to a suffixed slug.
+    allocatePublishSubdomain.mockResolvedValue('pagespace-2');
+
+    const res = await POST(makeReq({}), { params });
+    expect(res.status).toBe(200);
+
+    expect(allocatePublishSubdomain).toHaveBeenCalledWith('drive-1', 'pagespace');
+    const json = await res.json();
+    expect(json).toEqual({
+      url: 'https://pagespace-2.pagespace.site/welcome',
+      subdomain: 'pagespace-2',
       path: 'welcome',
       isHomePage: false,
     });
@@ -350,26 +372,19 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(res.status).toBe(200);
   });
 
-  it('returns 400 when the requested subdomain is invalid/reserved', async () => {
+  it('auto-slugs a caller-supplied reserved subdomain instead of erroring', async () => {
     findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CANVAS', title: 'Welcome', content: 'x', driveId: 'drive-1' });
     findFirstDrive.mockResolvedValue({ id: 'drive-1', slug: 'acme', publishSubdomain: null });
-    validatePublishSubdomain.mockReturnValue({ valid: false, reason: 'Subdomain "admin" is reserved' });
+    // The caller asks for the reserved 'admin'; the allocator resolves it.
+    allocatePublishSubdomain.mockResolvedValue('admin-2');
 
     const res = await POST(makeReq({ subdomain: 'admin' }), { params });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    // The caller-supplied value is forwarded as the base candidate.
+    expect(allocatePublishSubdomain).toHaveBeenCalledWith('drive-1', 'admin');
     const json = await res.json();
-    expect(json.error).toMatch(/reserved/i);
-    expect(updateWhere).not.toHaveBeenCalled();
-    expect(putPublishedArtifact).not.toHaveBeenCalled();
-  });
-
-  it('returns 409 when the chosen subdomain is already taken', async () => {
-    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CANVAS', title: 'Welcome', content: 'x', driveId: 'drive-1' });
-    findFirstDrive.mockResolvedValue({ id: 'drive-1', slug: 'acme', publishSubdomain: null });
-    updateWhere.mockRejectedValue(Object.assign(new Error('dup'), { code: '23505' }));
-
-    const res = await POST(makeReq({}), { params });
-    expect(res.status).toBe(409);
+    expect(json.subdomain).toBe('admin-2');
+    expect(json.url).toBe('https://admin-2.pagespace.site/welcome');
   });
 
   it('republish: reuses the existing subdomain, re-uploads, updates the row', async () => {
@@ -380,7 +395,7 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(res.status).toBe(200);
 
     // no new allocation when the drive already owns a subdomain
-    expect(validatePublishSubdomain).not.toHaveBeenCalled();
+    expect(allocatePublishSubdomain).not.toHaveBeenCalled();
     // 1 update: post-upload updatedAt advancement only (no subdomain allocation)
     expect(updateWhere).toHaveBeenCalledTimes(1);
 

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -76,13 +76,16 @@ vi.mock('@pagespace/lib/services/drive-guards', () => ({
   isHomeDrive: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock('@pagespace/lib/validators/subdomain', () => ({
-  normalizeSubdomain: vi.fn((s: string) => s.toLowerCase()),
-  validatePublishSubdomain: vi.fn().mockReturnValue({ valid: true }),
-}));
-
 vi.mock('@pagespace/lib/services/subdomain-allocation', () => ({
   isUniqueViolation: vi.fn().mockReturnValue(false),
+}));
+
+// First-publish subdomain allocation is delegated to the shared, race-safe
+// allocator (the same one drive creation uses). It normalizes the candidate and
+// auto-resolves reserved / taken / malformed values to a unique slug. The stub
+// mirrors the normalize step so candidate-derived assertions stay faithful.
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  allocatePublishSubdomain: vi.fn((_driveId: string, base: string) => Promise.resolve(base.toLowerCase())),
 }));
 
 vi.mock('@pagespace/lib/utils/utils', () => ({
@@ -101,6 +104,7 @@ vi.mock('@pagespace/lib/utils/utils', () => ({
 import { db } from '@pagespace/db/db';
 import { putPublishedArtifact, putPublishedSiteFile, publishedArtifactExists, deletePublishedArtifact, copyPublishedArtifact, isPublishConfigured } from '../published-storage';
 import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, syncPublishedHomeRoot, republishDriveCanonical, PublishError } from '../publish-page';
+import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service';
 import { getActiveDomainRecords } from '../custom-domain-mirror';
 import { renderPublishedPage } from '../render-published';
 import { extractAndStripOgMeta } from '../asset-pipeline';
@@ -213,8 +217,28 @@ describe('publishCanvasPage', () => {
       pageId: 'page-1', driveId: 'drive-1', userId: 'user-1', subdomain: 'Chosen-Sub',
     });
 
-    // normalizeSubdomain lowercases the candidate before allocation.
+    // The caller-supplied value is only a candidate base: it is forwarded to the
+    // shared allocator (which normalizes + dedupes), never written verbatim.
+    expect(allocatePublishSubdomain).toHaveBeenCalledWith('drive-1', 'Chosen-Sub');
     expect(result.subdomain).toBe('chosen-sub');
+  });
+
+  it('given no existing subdomain and a reserved candidate, auto-slugs instead of erroring', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CANVAS', title: 'Welcome', content: '<div>hi</div>', driveId: 'drive-1',
+    }));
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      id: 'drive-1', slug: 'pagespace', publishSubdomain: null, kind: 'STANDARD', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+    // The allocator resolves the reserved slug to a suffixed, unique subdomain.
+    vi.mocked(allocatePublishSubdomain).mockResolvedValueOnce('pagespace-2');
+
+    const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(allocatePublishSubdomain).toHaveBeenCalledWith('drive-1', 'pagespace');
+    expect(result.subdomain).toBe('pagespace-2');
+    expect(result.url).toBe('https://pagespace-2.pagespace.site/welcome');
   });
 
   it('given an explicit non-empty path, normalizes it (Foo -> foo)', async () => {

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -1,11 +1,11 @@
 import 'server-only';
 
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { normalizeSubdomain, validatePublishSubdomain } from '@pagespace/lib/validators/subdomain';
 import { isUniqueViolation } from '@pagespace/lib/services/subdomain-allocation';
+import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service';
 import { slugify } from '@pagespace/lib/utils/utils';
 import { db } from '@pagespace/db/db';
-import { eq, and, isNull } from '@pagespace/db/operators';
+import { eq } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
 import { isHomeDrive } from '@pagespace/lib/services/drive-guards';
@@ -161,38 +161,15 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   // Resolve the drive's publish subdomain. The subdomain is a property of the
   // DRIVE, never of an individual publish request: once allocated it is always
   // reused. A caller-supplied `subdomain` is only a *candidate* for the drive's
-  // first allocation — it must pass validation and win the unique constraint.
-  // Using `input.subdomain` directly would let a caller publish under another
-  // drive's subdomain (or a reserved/invalid one), overwriting that public site.
+  // first allocation. `allocatePublishSubdomain` normalizes the candidate and
+  // auto-resolves reserved / already-taken / malformed values to a unique slug
+  // (pagespace -> pagespace-2, acme -> acme-3, …) rather than erroring — the same
+  // race-safe allocator used by drive creation. It is idempotent (returns the
+  // existing subdomain when one is set), so a caller can never overwrite another
+  // drive's subdomain or publish under a reserved one.
   let subdomain = drive.publishSubdomain;
   if (!subdomain) {
-    const candidate = normalizeSubdomain(input.subdomain ?? drive.slug);
-    const validation = validatePublishSubdomain(candidate);
-    if (!validation.valid) {
-      throw new PublishError(`Invalid subdomain: ${validation.reason}`, 400);
-    }
-
-    try {
-      // Compare-and-set: only the first publisher (publishSubdomain still NULL)
-      // wins the allocation. A concurrent loser's update matches no rows, so we
-      // re-read and adopt the winner's subdomain instead of returning a URL for
-      // a subdomain the drive no longer owns.
-      await db
-        .update(drives)
-        .set({ publishSubdomain: candidate })
-        .where(and(eq(drives.id, drive.id), isNull(drives.publishSubdomain)));
-    } catch (err) {
-      if (isUniqueViolation(err)) {
-        throw new PublishError('Subdomain taken, choose another', 409);
-      }
-      throw err;
-    }
-
-    const allocated = await db.query.drives.findFirst({
-      where: eq(drives.id, drive.id),
-      columns: { publishSubdomain: true },
-    });
-    subdomain = allocated?.publishSubdomain ?? candidate;
+    subdomain = await allocatePublishSubdomain(drive.id, input.subdomain ?? drive.slug);
   }
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Publishing a Canvas page from a drive whose subdomain candidate is **reserved** (e.g. a drive slugged `pagespace`) or **already taken** threw a hard error instead of just working:

- `Invalid subdomain: Subdomain "pagespace" is reserved` → HTTP 400
- `Subdomain taken, choose another` → HTTP 409

## Fix

This auto-slug pattern already exists and is used everywhere else — drive creation, the MCP drive route, AI drive tools, and home-drive provisioning all go through the shared, race-safe `allocatePublishSubdomain` helper, which normalizes the candidate and de-duplicates against reserved/taken names with a numeric suffix (`pagespace` → `pagespace-2`, `acme` → `acme-3`, …).

The **canvas publish flow was the one place that bypassed it** and rejected instead. This PR routes that path through the same helper.

- `allocatePublishSubdomain` is **idempotent** (reuses an already-allocated subdomain) and **race-safe**, so it fully replaces the hand-rolled validate + compare-and-set block.
- A caller-supplied subdomain is now a *candidate* that auto-resolves rather than a hard requirement. Reserved names are still **never used verbatim** — they're suffixed, not rejected.
- The publish response already returns the actual allocated `subdomain` + `url`, so the UI silently reflects the corrected value.
- **No** migration, **no** schema change, **no** UI change (there is no client-side subdomain validation — the publish UI just POSTs and shows the returned URL).

## Changes

- `apps/web/src/lib/canvas/publish-page.ts` — replace the bespoke 400/409 validate-and-reject + compare-and-set with a single `allocatePublishSubdomain(drive.id, input.subdomain ?? drive.slug)` call; drop now-unused imports.
- `apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts` — mock the allocator instead of the validator; replace the old "400 reserved" / "409 taken" tests with auto-slug cases (drive slug `pagespace` → `pagespace-2`; caller-supplied `admin` → `admin-2`).

## Verification

- Publish route suite: **35 passed**
- Resolver/allocator suites: **22 passed** (`subdomain-allocator`, `drive-subdomain-allocation`)
- `tsc` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publishing now automatically assigns a unique subdomain on first publish, even when the requested value is reserved or already taken.
  * Republish flows continue using the existing subdomain without reallocating it.

* **Bug Fixes**
  * Improved publish behavior so valid slugs are accepted more consistently and no longer fail with avoidable errors during subdomain setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->