### PR TITLE
fix(publish): verify custom domains against authoritative DNS (no stale local resolver)

### DIFF
--- a/apps/web/src/lib/publish/__tests__/dns-resolver.test.ts
+++ b/apps/web/src/lib/publish/__tests__/dns-resolver.test.ts
@@ -140,9 +140,9 @@ describe('resolveHostname — authoritative DNS', () => {
       domain === 'example.com' ? ['ns1.example.com'] : [],
     );
     resolve4Impl.mockImplementation(async (servers, host) => {
-      if (host === 'ns1.example.com') return ['10.0.0.1']; // example.com authoritative NS
+      if (host === 'ns1.example.com') return ['93.184.216.34']; // example.com authoritative NS (public)
       if (host === 'app.example.com') {
-        const isParentZone = servers.includes('10.0.0.1');
+        const isParentZone = servers.includes('93.184.216.34');
         if (isParentZone) return []; // referral to the delegated sub-zone
         if (isPublic(servers)) return ['137.66.4.209']; // recursive resolver follows the delegation
       }
@@ -154,8 +154,31 @@ describe('resolveHostname — authoritative DNS', () => {
     const result = await resolveHostname('app.example.com');
 
     expect(result.a).toEqual(['137.66.4.209']);
-    expect(resolve4Impl).toHaveBeenCalledWith(['10.0.0.1'], 'app.example.com');
+    expect(resolve4Impl).toHaveBeenCalledWith(['93.184.216.34'], 'app.example.com');
     expect(resolve4Impl).toHaveBeenCalledWith(PUBLIC_DNS, 'app.example.com');
+  });
+
+  it('drops private/reserved nameserver IPs (SSRF guard) and falls back to the public resolver', async () => {
+    // A customer controls their domain's NS records; point them at internal IPs.
+    resolveNsImpl.mockResolvedValue(['ns1.attacker.example']);
+    resolve4Impl.mockImplementation(async (servers, host) => {
+      if (host === 'ns1.attacker.example') return ['169.254.169.254', '10.0.0.5']; // metadata + private
+      if (host === 'attacker.example' && isPublic(servers)) return ['137.66.4.209'];
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue([]);
+
+    const result = await resolveHostname('attacker.example');
+
+    // No resolver was ever pointed at the private/metadata IPs.
+    const queriedInternal = instances.some(
+      (r) => r.servers.includes('169.254.169.254') || r.servers.includes('10.0.0.5'),
+    );
+    expect(queriedInternal).toBe(false);
+    // Resolution came from the public resolver instead.
+    expect(result.a).toEqual(['137.66.4.209']);
+    expect(resolve4Impl).toHaveBeenCalledWith(PUBLIC_DNS, 'attacker.example');
   });
 
   it('derives the registrable domain for a subdomain when looking up nameservers', async () => {

--- a/apps/web/src/lib/publish/__tests__/dns-resolver.test.ts
+++ b/apps/web/src/lib/publish/__tests__/dns-resolver.test.ts
@@ -100,6 +100,62 @@ describe('resolveHostname — authoritative DNS', () => {
 
     // The NS lookup itself went through the public resolver (never the local one).
     expect(resolveNsImpl).toHaveBeenCalledWith(PUBLIC_DNS, 'jonowoodall.com');
+
+    // A non-empty authoritative answer is trusted directly — no redundant
+    // public-resolver query for the target.
+    expect(resolve4Impl).not.toHaveBeenCalledWith(PUBLIC_DNS, 'jonowoodall.com');
+  });
+
+  it('falls back to the public recursive resolver when the heuristic picks a multi-segment public suffix', async () => {
+    // registrableDomain('www.example.co.uk') === 'co.uk' — the parent zone, not
+    // the customer's zone. The .co.uk registry NS only hold a delegation.
+    resolveNsImpl.mockImplementation(async (_servers, domain) =>
+      domain === 'co.uk' ? ['ns1.nic.uk'] : [],
+    );
+    resolve4Impl.mockImplementation(async (servers, host) => {
+      if (host === 'ns1.nic.uk') return ['1.2.3.4']; // co.uk registry NS IP
+      if (host === 'www.example.co.uk') {
+        const isCoUkRegistry = servers.includes('1.2.3.4');
+        if (isCoUkRegistry) return []; // referral — not authoritative for example.co.uk
+        if (isPublic(servers)) return ['137.66.4.209']; // recursive resolver follows the delegation
+      }
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue([]);
+
+    const result = await resolveHostname('www.example.co.uk');
+
+    expect(result.a).toEqual(['137.66.4.209']);
+    // We tried the (wrong) authoritative zone, got a referral, then resolved via
+    // the public recursive resolver.
+    expect(resolve4Impl).toHaveBeenCalledWith(['1.2.3.4'], 'www.example.co.uk');
+    expect(resolve4Impl).toHaveBeenCalledWith(PUBLIC_DNS, 'www.example.co.uk');
+  });
+
+  it('falls back to the public recursive resolver when the target is in a deeper delegated zone', async () => {
+    // registrableDomain('app.example.com') === 'example.com', but app.example.com
+    // is delegated to a separate provider: example.com's NS return only a referral.
+    resolveNsImpl.mockImplementation(async (_servers, domain) =>
+      domain === 'example.com' ? ['ns1.example.com'] : [],
+    );
+    resolve4Impl.mockImplementation(async (servers, host) => {
+      if (host === 'ns1.example.com') return ['10.0.0.1']; // example.com authoritative NS
+      if (host === 'app.example.com') {
+        const isParentZone = servers.includes('10.0.0.1');
+        if (isParentZone) return []; // referral to the delegated sub-zone
+        if (isPublic(servers)) return ['137.66.4.209']; // recursive resolver follows the delegation
+      }
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue([]);
+
+    const result = await resolveHostname('app.example.com');
+
+    expect(result.a).toEqual(['137.66.4.209']);
+    expect(resolve4Impl).toHaveBeenCalledWith(['10.0.0.1'], 'app.example.com');
+    expect(resolve4Impl).toHaveBeenCalledWith(PUBLIC_DNS, 'app.example.com');
   });
 
   it('derives the registrable domain for a subdomain when looking up nameservers', async () => {

--- a/apps/web/src/lib/publish/__tests__/dns-resolver.test.ts
+++ b/apps/web/src/lib/publish/__tests__/dns-resolver.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Mock dns/promises.Resolver ───────────────────────────────────────────────
+// Every method delegates to a module-level spy that receives the resolver's
+// configured `servers`, so a test can branch on which resolver (public vs
+// authoritative) issued each query and assert the authoritative path is used.
+
+const PUBLIC_DNS = ['1.1.1.1', '8.8.8.8', '9.9.9.9'];
+
+interface MockResolver {
+  servers: string[];
+  setServers(servers: string[]): void;
+  resolveNs(domain: string): Promise<string[]>;
+  resolve4(host: string): Promise<string[]>;
+  resolve6(host: string): Promise<string[]>;
+  resolveCname(host: string): Promise<string[]>;
+}
+
+// vi.mock is hoisted above the module body, so the spies and the mock class
+// must be created in a hoisted block they can both reference.
+const { resolveNsImpl, resolve4Impl, resolve6Impl, resolveCnameImpl, instances, MockResolverCtor } =
+  vi.hoisted(() => {
+    const resolveNsImpl = vi.fn<(servers: string[], domain: string) => Promise<string[]>>();
+    const resolve4Impl = vi.fn<(servers: string[], host: string) => Promise<string[]>>();
+    const resolve6Impl = vi.fn<(servers: string[], host: string) => Promise<string[]>>();
+    const resolveCnameImpl = vi.fn<(servers: string[], host: string) => Promise<string[]>>();
+    const instances: MockResolver[] = [];
+
+    class MockResolverCtor implements MockResolver {
+      servers: string[] = [];
+      constructor() {
+        instances.push(this);
+      }
+      setServers(servers: string[]) {
+        this.servers = servers;
+      }
+      getServers() {
+        return this.servers;
+      }
+      resolveNs(domain: string) {
+        return resolveNsImpl(this.servers, domain);
+      }
+      resolve4(host: string) {
+        return resolve4Impl(this.servers, host);
+      }
+      resolve6(host: string) {
+        return resolve6Impl(this.servers, host);
+      }
+      resolveCname(host: string) {
+        return resolveCnameImpl(this.servers, host);
+      }
+    }
+
+    return { resolveNsImpl, resolve4Impl, resolve6Impl, resolveCnameImpl, instances, MockResolverCtor };
+  });
+
+vi.mock('dns/promises', () => ({
+  Resolver: MockResolverCtor,
+  default: { Resolver: MockResolverCtor },
+}));
+
+import { resolveHostname } from '../dns-resolver';
+
+const isPublic = (servers: string[]) => PUBLIC_DNS.every((s) => servers.includes(s)) && servers.length === PUBLIC_DNS.length;
+
+beforeEach(() => {
+  instances.length = 0;
+  resolveNsImpl.mockReset();
+  resolve4Impl.mockReset();
+  resolve6Impl.mockReset();
+  resolveCnameImpl.mockReset();
+});
+
+describe('resolveHostname — authoritative DNS', () => {
+  it('queries the authoritative nameservers (not the public resolver) for the target', async () => {
+    const NS_IPS = ['9.9.9.1', '9.9.9.2'];
+    resolveNsImpl.mockResolvedValue(['ns1.registrar-servers.com', 'ns2.registrar-servers.com']);
+    resolve4Impl.mockImplementation(async (servers, host) => {
+      if (host === 'ns1.registrar-servers.com') return ['9.9.9.1'];
+      if (host === 'ns2.registrar-servers.com') return ['9.9.9.2'];
+      if (host === 'jonowoodall.com') {
+        // The bug: the public/stale resolver still returns the OLD parking IP,
+        // while the authoritative NS already serve the correct new edge IP.
+        return isPublic(servers) ? ['192.64.119.23'] : ['137.66.4.209'];
+      }
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue([]);
+
+    const result = await resolveHostname('jonowoodall.com');
+
+    // Source of truth — the authoritative answer, not the stale parking IP.
+    expect(result.a).toEqual(['137.66.4.209']);
+
+    // A resolver was pointed at the authoritative NS IPs and used for the target.
+    const authResolver = instances.find((r) => r.servers.length === 2 && r.servers.includes('9.9.9.1') && r.servers.includes('9.9.9.2'));
+    expect(authResolver).toBeDefined();
+    expect(resolve4Impl).toHaveBeenCalledWith(NS_IPS, 'jonowoodall.com');
+
+    // The NS lookup itself went through the public resolver (never the local one).
+    expect(resolveNsImpl).toHaveBeenCalledWith(PUBLIC_DNS, 'jonowoodall.com');
+  });
+
+  it('derives the registrable domain for a subdomain when looking up nameservers', async () => {
+    resolveNsImpl.mockResolvedValue(['ns1.acme.com']);
+    resolve4Impl.mockImplementation(async (_servers, host) => {
+      if (host === 'ns1.acme.com') return ['5.5.5.5'];
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue(['drive.pagespace.site']);
+
+    const result = await resolveHostname('www.acme.com');
+
+    expect(resolveNsImpl).toHaveBeenCalledWith(PUBLIC_DNS, 'acme.com');
+    expect(result.cname).toEqual(['drive.pagespace.site']);
+    // Target queried through the authoritative resolver.
+    expect(resolveCnameImpl).toHaveBeenCalledWith(['5.5.5.5'], 'www.acme.com');
+  });
+
+  it('falls back to the public resolver when the NS lookup fails', async () => {
+    resolveNsImpl.mockRejectedValue(new Error('NXDOMAIN'));
+    resolve4Impl.mockImplementation(async (servers, host) => {
+      if (host === 'jonowoodall.com' && isPublic(servers)) return ['137.66.4.209'];
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue([]);
+
+    const result = await resolveHostname('jonowoodall.com');
+
+    expect(result.a).toEqual(['137.66.4.209']);
+    // No authoritative resolver was usable, so the public resolver answered.
+    expect(resolve4Impl).toHaveBeenCalledWith(PUBLIC_DNS, 'jonowoodall.com');
+  });
+
+  it('falls back to the public resolver when NS records resolve to no IPs', async () => {
+    resolveNsImpl.mockResolvedValue(['ns1.registrar-servers.com']);
+    resolve4Impl.mockImplementation(async (servers, host) => {
+      if (host === 'ns1.registrar-servers.com') return []; // NS host has no A glue
+      if (host === 'jonowoodall.com' && isPublic(servers)) return ['137.66.4.209'];
+      return [];
+    });
+    resolve6Impl.mockResolvedValue([]);
+    resolveCnameImpl.mockResolvedValue([]);
+
+    const result = await resolveHostname('jonowoodall.com');
+
+    expect(result.a).toEqual(['137.66.4.209']);
+    expect(resolve4Impl).toHaveBeenCalledWith(PUBLIC_DNS, 'jonowoodall.com');
+  });
+
+  it('returns empty arrays when every lookup fails (never throws)', async () => {
+    resolveNsImpl.mockRejectedValue(new Error('NXDOMAIN'));
+    resolve4Impl.mockRejectedValue(new Error('timeout'));
+    resolve6Impl.mockRejectedValue(new Error('timeout'));
+    resolveCnameImpl.mockRejectedValue(new Error('timeout'));
+
+    const result = await resolveHostname('broken.example.com');
+
+    expect(result).toEqual({ a: [], aaaa: [], cname: [] });
+  });
+
+  it('a failure of one record type does not break the others', async () => {
+    resolveNsImpl.mockResolvedValue(['ns1.registrar-servers.com']);
+    resolve4Impl.mockImplementation(async (_servers, host) => {
+      if (host === 'ns1.registrar-servers.com') return ['9.9.9.1'];
+      if (host === 'jonowoodall.com') return ['137.66.4.209'];
+      return [];
+    });
+    resolve6Impl.mockRejectedValue(new Error('no AAAA')); // AAAA fails
+    resolveCnameImpl.mockResolvedValue(['drive.pagespace.site']);
+
+    const result = await resolveHostname('jonowoodall.com');
+
+    expect(result.a).toEqual(['137.66.4.209']);
+    expect(result.aaaa).toEqual([]);
+    expect(result.cname).toEqual(['drive.pagespace.site']);
+  });
+});

--- a/apps/web/src/lib/publish/dns-resolver.ts
+++ b/apps/web/src/lib/publish/dns-resolver.ts
@@ -1,16 +1,88 @@
-import { resolve4, resolve6, resolveCname } from 'dns/promises';
+import { Resolver } from 'dns/promises';
+import { registrableDomain } from '@pagespace/lib/validators/custom-domain';
 import type { ResolvedRecords } from '@pagespace/lib/validators/custom-domain';
 
 /**
- * Resolve a hostname's DNS records using the system resolver.
- * NXDOMAIN, ENODATA, ENOTFOUND, and timeouts all return empty arrays for
- * that record type — the caller treats them as "not yet set".
+ * Custom-domain DNS verification must reflect source-of-truth DNS immediately,
+ * never a caching local resolver. Node's default `dns/promises` queries the app
+ * server's system resolver (on Fly), which caches and lags authoritative DNS —
+ * a false-negative at onboarding when a customer has just set the right record.
+ *
+ * So we resolve the target against its own authoritative nameservers:
+ *   1. Find the registrable domain's NS records, via a fast PUBLIC resolver
+ *      (so even the NS lookup doesn't hit the stale local resolver).
+ *   2. Resolve those NS hostnames to IPs (public resolver too).
+ *   3. Point a second resolver at those authoritative NS IPs and query the
+ *      target there — no cache lag, the records as the domain owner published them.
+ *
+ * Fallbacks: if the NS lookup or its IP resolution fails/empty, query the target
+ * via the public resolver — still far better than the local one. If everything
+ * fails, return empty arrays per record type (the "not yet set" semantics) — this
+ * function never throws.
  */
-export async function resolveHostname(hostname: string): Promise<ResolvedRecords> {
+
+/** Fast public resolvers: Cloudflare, Google, Quad9. */
+const PUBLIC_DNS_SERVERS = ['1.1.1.1', '8.8.8.8', '9.9.9.9'];
+
+/** Per-lookup timeout so a dead/slow NS can't hang the verify request. */
+const DNS_TIMEOUT_MS = 5000;
+const DNS_TRIES = 2;
+
+function makeResolver(servers: string[]): Resolver {
+  const resolver = new Resolver({ timeout: DNS_TIMEOUT_MS, tries: DNS_TRIES });
+  resolver.setServers(servers);
+  return resolver;
+}
+
+/**
+ * Resolve the authoritative nameserver IPs for a hostname's registrable domain,
+ * using the public resolver. Returns `[]` if the NS lookup fails, finds no NS
+ * records, or none of them resolve to an IP — the caller then falls back.
+ */
+async function resolveAuthoritativeNsIps(hostname: string, publicResolver: Resolver): Promise<string[]> {
+  const domain = registrableDomain(hostname);
+  if (!domain) return [];
+
+  const nsHosts = await publicResolver.resolveNs(domain).catch(() => [] as string[]);
+  if (nsHosts.length === 0) return [];
+
+  const ipLists = await Promise.all(
+    nsHosts.map((ns) => publicResolver.resolve4(ns).catch(() => [] as string[])),
+  );
+  // De-dupe so we don't hand the same IP to setServers twice.
+  return [...new Set(ipLists.flat())];
+}
+
+/**
+ * Query a single hostname's A / AAAA / CNAME records through the given resolver.
+ * Each record type is independent: a failure of one (no AAAA, no CNAME, timeout)
+ * yields `[]` for that type and never breaks the others. Never throws.
+ */
+async function queryRecords(resolver: Resolver, hostname: string): Promise<ResolvedRecords> {
   const [a, aaaa, cname] = await Promise.all([
-    resolve4(hostname).catch(() => [] as string[]),
-    resolve6(hostname).catch(() => [] as string[]),
-    resolveCname(hostname).catch(() => [] as string[]),
+    resolver.resolve4(hostname).catch(() => [] as string[]),
+    resolver.resolve6(hostname).catch(() => [] as string[]),
+    resolver.resolveCname(hostname).catch(() => [] as string[]),
   ]);
   return { a, aaaa, cname };
+}
+
+/**
+ * Resolve a hostname's DNS records against its authoritative nameservers,
+ * falling back to a public resolver, then to empty arrays. NXDOMAIN, ENODATA,
+ * ENOTFOUND, and timeouts all surface as empty arrays for that record type —
+ * the caller treats them as "not yet set".
+ */
+export async function resolveHostname(hostname: string): Promise<ResolvedRecords> {
+  const publicResolver = makeResolver(PUBLIC_DNS_SERVERS);
+
+  // 1. Authoritative path — the source of truth, no local cache lag.
+  const nsIps = await resolveAuthoritativeNsIps(hostname, publicResolver).catch(() => [] as string[]);
+  if (nsIps.length > 0) {
+    const authoritativeResolver = makeResolver(nsIps);
+    return queryRecords(authoritativeResolver, hostname);
+  }
+
+  // 2. Fallback — public resolver (still bypasses the stale local resolver).
+  return queryRecords(publicResolver, hostname);
 }

--- a/apps/web/src/lib/publish/dns-resolver.ts
+++ b/apps/web/src/lib/publish/dns-resolver.ts
@@ -15,10 +15,18 @@ import type { ResolvedRecords } from '@pagespace/lib/validators/custom-domain';
  *   3. Point a second resolver at those authoritative NS IPs and query the
  *      target there — no cache lag, the records as the domain owner published them.
  *
- * Fallbacks: if the NS lookup or its IP resolution fails/empty, query the target
- * via the public resolver — still far better than the local one. If everything
- * fails, return empty arrays per record type (the "not yet set" semantics) — this
- * function never throws.
+ * Fallbacks: query the target via the public *recursive* resolver when either
+ *   - the NS lookup or its IP resolution fails/empty, OR
+ *   - the authoritative query returns NO records at all.
+ * The second case matters because the registrable-domain heuristic ("last 2
+ * labels") picks the parent zone for a multi-segment public suffix
+ * (`www.example.co.uk` → `co.uk`), and the target may also live in a deeper
+ * delegated zone — in both cases the queried nameservers are authoritative only
+ * for the parent and answer with a referral (no records). A public recursive
+ * resolver performs full iterative resolution (follows referrals), so it
+ * resolves those names correctly while still honoring TTLs and bypassing the
+ * stale local Fly resolver. If everything fails, return empty arrays per record
+ * type (the "not yet set" semantics) — this function never throws.
  */
 
 /** Fast public resolvers: Cloudflare, Google, Quad9. */
@@ -67,11 +75,16 @@ async function queryRecords(resolver: Resolver, hostname: string): Promise<Resol
   return { a, aaaa, cname };
 }
 
+/** Whether a resolution produced any A / AAAA / CNAME record. */
+function hasAnyRecord(records: ResolvedRecords): boolean {
+  return records.a.length > 0 || records.aaaa.length > 0 || records.cname.length > 0;
+}
+
 /**
  * Resolve a hostname's DNS records against its authoritative nameservers,
- * falling back to a public resolver, then to empty arrays. NXDOMAIN, ENODATA,
- * ENOTFOUND, and timeouts all surface as empty arrays for that record type —
- * the caller treats them as "not yet set".
+ * falling back to a public recursive resolver, then to empty arrays. NXDOMAIN,
+ * ENODATA, ENOTFOUND, and timeouts all surface as empty arrays for that record
+ * type — the caller treats them as "not yet set".
  */
 export async function resolveHostname(hostname: string): Promise<ResolvedRecords> {
   const publicResolver = makeResolver(PUBLIC_DNS_SERVERS);
@@ -80,9 +93,15 @@ export async function resolveHostname(hostname: string): Promise<ResolvedRecords
   const nsIps = await resolveAuthoritativeNsIps(hostname, publicResolver).catch(() => [] as string[]);
   if (nsIps.length > 0) {
     const authoritativeResolver = makeResolver(nsIps);
-    return queryRecords(authoritativeResolver, hostname);
+    const records = await queryRecords(authoritativeResolver, hostname);
+    // A non-empty answer is authoritative — trust it. An all-empty answer means
+    // the heuristic's zone wasn't authoritative for the target (a multi-segment
+    // public suffix, or a deeper delegation that returns only a referral), so
+    // fall through to the recursive resolver, which follows the referral chain.
+    if (hasAnyRecord(records)) return records;
   }
 
-  // 2. Fallback — public resolver (still bypasses the stale local resolver).
+  // 2. Fallback — public recursive resolver: follows referrals, honors TTLs, and
+  //    still bypasses the stale local Fly resolver.
   return queryRecords(publicResolver, hostname);
 }

--- a/apps/web/src/lib/publish/dns-resolver.ts
+++ b/apps/web/src/lib/publish/dns-resolver.ts
@@ -1,6 +1,7 @@
 import { Resolver } from 'dns/promises';
 import { registrableDomain } from '@pagespace/lib/validators/custom-domain';
 import type { ResolvedRecords } from '@pagespace/lib/validators/custom-domain';
+import { isPublicIp } from '@/lib/ai/tools/web-fetch-ssrf';
 
 /**
  * Custom-domain DNS verification must reflect source-of-truth DNS immediately,
@@ -45,7 +46,16 @@ function makeResolver(servers: string[]): Resolver {
 /**
  * Resolve the authoritative nameserver IPs for a hostname's registrable domain,
  * using the public resolver. Returns `[]` if the NS lookup fails, finds no NS
- * records, or none of them resolve to an IP — the caller then falls back.
+ * records, or none of them resolve to a public IP — the caller then falls back.
+ *
+ * The registrable domain (and thus its NS records) is attacker-controlled — a
+ * customer registers any domain and points its NS wherever they like. So every
+ * resolved IP is filtered through {@link isPublicIp} before it reaches
+ * `setServers`: an NS record pointing at a private/loopback/link-local/reserved
+ * address (e.g. `169.254.169.254` cloud metadata, `127.0.0.1`, `10.0.0.0/8`)
+ * would otherwise turn this verifier into an SSRF vector that fires DNS queries
+ * at internal hosts. Filtered-out IPs simply drop us to the public-resolver
+ * fallback.
  */
 async function resolveAuthoritativeNsIps(hostname: string, publicResolver: Resolver): Promise<string[]> {
   const domain = registrableDomain(hostname);
@@ -57,8 +67,8 @@ async function resolveAuthoritativeNsIps(hostname: string, publicResolver: Resol
   const ipLists = await Promise.all(
     nsHosts.map((ns) => publicResolver.resolve4(ns).catch(() => [] as string[])),
   );
-  // De-dupe so we don't hand the same IP to setServers twice.
-  return [...new Set(ipLists.flat())];
+  // De-dupe, and only ever hand globally-routable public IPs to setServers.
+  return [...new Set(ipLists.flat())].filter(isPublicIp);
 }
 
 /**

--- a/packages/lib/src/validators/__tests__/custom-domain.test.ts
+++ b/packages/lib/src/validators/__tests__/custom-domain.test.ts
@@ -4,6 +4,7 @@ import {
   validateCustomDomain,
   buildDnsInstructions,
   isApexDomain,
+  registrableDomain,
   verifyDnsRecords,
 } from '../custom-domain';
 import type { DnsInstructions, ResolvedRecords } from '../custom-domain';
@@ -134,6 +135,40 @@ describe('isApexDomain', () => {
     expect(isApexDomain('www.acme.com')).toBe(false);
     expect(isApexDomain('blog.acme.com')).toBe(false);
     expect(isApexDomain('a.b.c.com')).toBe(false);
+  });
+});
+
+describe('registrableDomain', () => {
+  it('returns an apex domain unchanged', () => {
+    expect(registrableDomain('jonowoodall.com')).toBe('jonowoodall.com');
+    expect(registrableDomain('acme.io')).toBe('acme.io');
+  });
+
+  it('reduces a subdomain to its last two labels', () => {
+    expect(registrableDomain('www.acme.com')).toBe('acme.com');
+    expect(registrableDomain('blog.acme.com')).toBe('acme.com');
+  });
+
+  it('reduces a deep subdomain to its last two labels', () => {
+    expect(registrableDomain('docs.blog.acme.io')).toBe('acme.io');
+    expect(registrableDomain('a.b.c.d.example.com')).toBe('example.com');
+  });
+
+  it('strips a trailing dot', () => {
+    expect(registrableDomain('www.acme.com.')).toBe('acme.com');
+    expect(registrableDomain('acme.com.')).toBe('acme.com');
+  });
+
+  it('lowercases the result', () => {
+    expect(registrableDomain('WWW.ACME.COM')).toBe('acme.com');
+  });
+
+  it('returns a single label unchanged', () => {
+    expect(registrableDomain('localhost')).toBe('localhost');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(registrableDomain('')).toBe('');
   });
 });
 

--- a/packages/lib/src/validators/custom-domain.ts
+++ b/packages/lib/src/validators/custom-domain.ts
@@ -109,11 +109,19 @@ export function isApexDomain(hostname: string): boolean {
  * `www.acme.com` → `acme.com`, `docs.blog.acme.io` → `acme.io`,
  * `jonowoodall.com` → `jonowoodall.com`. Lowercased and trailing-dot-stripped.
  *
- * Like {@link isApexDomain}, this uses the simple "last 2 labels" heuristic,
- * which is accurate for single-segment TLDs (.com, .io, .dev) and a documented
- * limitation for multi-segment TLDs like .co.uk. Authoritative-NS lookups work
- * regardless: the registrar's NS for `example.co.uk` is reachable from the NS
- * of `co.uk`, so an over-broad registrable domain still resolves correctly.
+ * Like {@link isApexDomain}, this uses the simple "last 2 labels" heuristic.
+ * It is correct for single-segment TLDs (.com, .io, .dev) — the overwhelming
+ * majority of custom domains — but, for a multi-segment public suffix like
+ * .co.uk, it picks the parent zone (`www.example.co.uk` → `co.uk`) rather than
+ * the customer's zone (`example.co.uk`). The `.co.uk` registry's nameservers
+ * are NOT authoritative for `example.co.uk`; they only hold a delegation, so an
+ * authoritative query against them returns a referral (no answer records).
+ *
+ * The DNS resolver in `apps/web/src/lib/publish/dns-resolver.ts` accounts for
+ * this: when the authoritative query against the heuristic's zone returns no
+ * records, it falls back to a public *recursive* resolver, which performs full
+ * iterative resolution (following referrals) and so resolves multi-segment
+ * public suffixes and deeper delegations correctly.
  */
 export function registrableDomain(hostname: string): string {
   let h = hostname.trim().toLowerCase();

--- a/packages/lib/src/validators/custom-domain.ts
+++ b/packages/lib/src/validators/custom-domain.ts
@@ -102,6 +102,28 @@ export function isApexDomain(hostname: string): boolean {
   return hostname.split('.').length === 2;
 }
 
+/**
+ * The registrable domain — the last two labels of a hostname — used to look up
+ * a domain's authoritative nameservers.
+ *
+ * `www.acme.com` → `acme.com`, `docs.blog.acme.io` → `acme.io`,
+ * `jonowoodall.com` → `jonowoodall.com`. Lowercased and trailing-dot-stripped.
+ *
+ * Like {@link isApexDomain}, this uses the simple "last 2 labels" heuristic,
+ * which is accurate for single-segment TLDs (.com, .io, .dev) and a documented
+ * limitation for multi-segment TLDs like .co.uk. Authoritative-NS lookups work
+ * regardless: the registrar's NS for `example.co.uk` is reachable from the NS
+ * of `co.uk`, so an over-broad registrable domain still resolves correctly.
+ */
+export function registrableDomain(hostname: string): string {
+  let h = hostname.trim().toLowerCase();
+  if (h.endsWith('.')) h = h.slice(0, -1);
+  if (!h) return '';
+  const labels = h.split('.');
+  if (labels.length <= 2) return h;
+  return labels.slice(-2).join('.');
+}
+
 export interface DnsRecord {
   type: 'A' | 'AAAA' | 'CNAME';
   name: string;


### PR DESCRIPTION
## Why (production bug, paying customer)

Custom-domain verification (`POST /api/drives/[driveId]/domains/[domainId]/verify`) resolves the customer's A/AAAA/CNAME and checks they point at our edge. It used Node's default `dns/promises` (`resolve4/resolve6/resolveCname`), which queries the **app server's local resolver on Fly** — and that resolver **caches and lags authoritative DNS**.

### Repro — jonowoodall.com
The customer set the correct apex A record (`137.66.4.209`) — confirmed at the **authoritative Namecheap NS** (`dns1/dns2.registrar-servers.com`) **and** at public resolvers `1.1.1.1` / `8.8.8.8`. But PageSpace verify kept returning the customer's **old Namecheap parking IP** `192.64.119.23` for ~30 minutes. Clicking **Retry** couldn't fix it — every retry hit the same stale Fly-resolver cache. It only passed once the local cache's TTL finally expired.

That's a false-negative verification at the worst moment: onboarding.

## What

Resolve the target against **its own authoritative nameservers** instead of trusting the local/system resolver, with a recursive-resolver safety net:

1. **New pure helper** `registrableDomain(hostname)` in `packages/lib` — last 2 labels (`www.acme.com` → `acme.com`, `jonowoodall.com` → `jonowoodall.com`). Unit-tested: apex, subdomain, deep subdomain, trailing dot, case, single label, empty.
2. **`resolveHostname` rewrite** (`apps/web/src/lib/publish/dns-resolver.ts`):
   - Look up the registrable domain's **NS records** via a `dns.promises.Resolver` pointed at a fast **public** resolver (`1.1.1.1`/`8.8.8.8`/`9.9.9.9`) — so even the NS lookup bypasses the stale Fly resolver.
   - Resolve those NS hostnames to IPs (public resolver too).
   - Point a **second `Resolver`** at those authoritative NS IPs (`setServers`) and query the target there — the source of truth, no cache lag.
3. **Fallback to a public _recursive_ resolver** when:
   - the NS lookup / IP resolution fails or is empty, **OR**
   - the authoritative query returns **no records at all**.

   A recursive resolver performs full iterative resolution (follows the referral chain), honors TTLs, and still bypasses the stale local Fly resolver. A non-empty authoritative answer is trusted directly (no redundant public query).
4. If everything fails → empty arrays per record type (existing "not yet set" semantics). **Never throws.** Per-lookup timeout (5s, 2 tries) so a dead NS can't hang the request; a failure of one record type never breaks the others.

### Why the recursive-resolver fallback (multi-segment suffixes & delegated zones)

The "last 2 labels" heuristic picks the **parent** zone for a multi-segment public suffix (`www.example.co.uk` → `co.uk`) and for a target in a **deeper delegated** zone (`app.example.com` delegated to a separate provider → `example.com`). Those nameservers are authoritative only for the parent and answer with a **referral** (no records), which Node's stub resolver surfaces as empty. The public recursive resolver follows the referral and resolves these correctly — so verification succeeds even for `.co.uk`-style domains and delegated subdomains, without a public-suffix-list dependency. (A non-empty authoritative answer is still trusted directly, keeping the no-lag path for the common single-segment apex/subdomain case.)

`resolveHostname`'s name and the `ResolvedRecords` return shape are **unchanged**, so the verify route, `verifyDnsRecords`, and `buildDnsInstructions` are untouched.

## Tests (TDD, pure-core-first; no real DNS)

- `registrableDomain` — pure unit tests in `packages/lib`.
- `dns-resolver.test.ts` — fully mocked `dns.promises.Resolver`:
  - **Authoritative path used**: asserts `setServers` with the NS IPs + the target queried through that resolver, returning the **new edge IP** `137.66.4.209` over the **stale parking IP** `192.64.119.23` (the exact repro); asserts **no redundant public query**.
  - Registrable-domain derivation for a subdomain (`www.acme.com` → NS for `acme.com`).
  - **Public-recursive fallback** for a multi-segment public suffix (`www.example.co.uk`): authoritative `co.uk` zone returns a referral → resolved via the public resolver.
  - **Public-recursive fallback** for a deeper delegated zone (`app.example.com`): parent `example.com` returns a referral → resolved via the public resolver.
  - **Public-resolver fallback** when the NS lookup fails / resolves to no IPs.
  - **Empty arrays** when every lookup fails (no throw).
  - **Per-record-type isolation** (AAAA fails, A/CNAME still returned).

## Verification
- `bun run lint` ✅ (only pre-existing warnings)
- `bun run typecheck` ✅ (lib + web)
- tests ✅ — lib `custom-domain` 63, web `dns-resolver` 8, verify-route 113
- `bun run build` (web) ✅

## Out of scope
The verify route / decision logic (already correct), the mirror/cert flow (#1720, merged), any caching layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostname lookups to better return current DNS records, especially for domains with delegated name servers.
  * Added a safer fallback path when authoritative DNS queries don’t return usable results.
  * Made DNS resolution more resilient, so failures for one record type won’t block other results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->