### PR TITLE
fix(sandbox): persist interactive terminals across WebSocket keepalive drops

### DIFF
--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { openPtyShell } from '../sprites-shell';
-import type { SpriteInstanceLike, SpriteCommandLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import type {
+  SpriteInstanceLike,
+  SpriteCommandLike,
+  SpriteSessionInfo,
+} from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 
-function buildFakeCommand(): SpriteCommandLike & { _stdout: EventEmitter; _stderr: EventEmitter; _emitter: EventEmitter } {
+type FakeCommand = SpriteCommandLike & { _stdout: EventEmitter; _stderr: EventEmitter; _emitter: EventEmitter };
+
+function buildFakeCommand(): FakeCommand {
   const _stdout = new EventEmitter();
   const _stderr = new EventEmitter();
   const _emitter = new EventEmitter();
@@ -11,7 +17,7 @@ function buildFakeCommand(): SpriteCommandLike & { _stdout: EventEmitter; _stder
   const resizeFn = vi.fn();
   const killFn = vi.fn();
 
-  const cmd: SpriteCommandLike & { _stdout: EventEmitter; _stderr: EventEmitter; _emitter: EventEmitter } = {
+  const cmd: FakeCommand = {
     _stdout,
     _stderr,
     _emitter,
@@ -25,31 +31,44 @@ function buildFakeCommand(): SpriteCommandLike & { _stdout: EventEmitter; _stder
   return cmd;
 }
 
-function buildFakeSprite(cmd: SpriteCommandLike): SpriteInstanceLike & { spawnCalls: { file: string; args: string[]; options: unknown }[] } {
-  const spawnCalls: { file: string; args: string[]; options: unknown }[] = [];
+type FakeSprite = SpriteInstanceLike & {
+  createSession: ReturnType<typeof vi.fn>;
+  attachSession: ReturnType<typeof vi.fn>;
+  listSessions: ReturnType<typeof vi.fn>;
+};
+
+function buildFakeSprite(
+  cmd: SpriteCommandLike,
+  opts: { sessions?: SpriteSessionInfo[]; attachCmd?: SpriteCommandLike; listRejects?: boolean } = {},
+): FakeSprite {
   return {
     name: 'fake-sprite',
-    spawnCalls,
-    spawn: vi.fn((file, args = [], options = {}) => {
-      spawnCalls.push({ file, args, options });
-      return cmd;
+    spawn: vi.fn(),
+    createSession: vi.fn(() => cmd),
+    attachSession: vi.fn(() => opts.attachCmd ?? cmd),
+    listSessions: vi.fn(async () => {
+      if (opts.listRejects) throw new Error('list failed');
+      return opts.sessions ?? [];
     }),
     filesystem: vi.fn(),
     updateNetworkPolicy: vi.fn(),
     destroy: vi.fn(),
-  } as unknown as SpriteInstanceLike & { spawnCalls: { file: string; args: string[]; options: unknown }[] };
+  } as unknown as FakeSprite;
 }
 
+const liveSession: SpriteSessionInfo = { id: 'sess-1', command: 'bash', isActive: true, tty: true };
+
 describe('openPtyShell', () => {
-  it('given a sprite and dimensions, should call spawn with bash + tty:true + correct dims + cwd + terminal env', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('given a sprite and dimensions, should create a detachable session with bash + tty + dims + cwd + terminal env', () => {
     const cmd = buildFakeCommand();
     const sprite = buildFakeSprite(cmd);
-    const onOutput = vi.fn();
-    const onExit = vi.fn();
 
-    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
 
-    expect(sprite.spawn).toHaveBeenCalledWith('bash', [], {
+    expect(sprite.createSession).toHaveBeenCalledWith('bash', [], {
       tty: true,
       cols: 80,
       rows: 24,
@@ -58,13 +77,22 @@ describe('openPtyShell', () => {
     });
   });
 
+  it('given a sessionId, should attach to the existing session instead of creating one', () => {
+    const cmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd);
+
+    openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-1', onOutput: vi.fn(), onExit: vi.fn() });
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+    expect(sprite.createSession).not.toHaveBeenCalled();
+  });
+
   it('given sprite emits stdout data, should call onOutput with the string', () => {
     const cmd = buildFakeCommand();
     const sprite = buildFakeSprite(cmd);
     const onOutput = vi.fn();
-    const onExit = vi.fn();
 
-    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
     cmd._stdout.emit('data', 'hello\r\n');
 
     expect(onOutput).toHaveBeenCalledWith('hello\r\n');
@@ -74,9 +102,8 @@ describe('openPtyShell', () => {
     const cmd = buildFakeCommand();
     const sprite = buildFakeSprite(cmd);
     const onOutput = vi.fn();
-    const onExit = vi.fn();
 
-    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
     cmd._stderr.emit('data', Buffer.from('err msg'));
 
     expect(onOutput).toHaveBeenCalledWith('err msg');
@@ -85,10 +112,9 @@ describe('openPtyShell', () => {
   it('given sprite emits exit, should call onExit with the exit code', () => {
     const cmd = buildFakeCommand();
     const sprite = buildFakeSprite(cmd);
-    const onOutput = vi.fn();
     const onExit = vi.fn();
 
-    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
     cmd._emitter.emit('exit', 0);
 
     expect(onExit).toHaveBeenCalledWith(0);
@@ -124,19 +150,6 @@ describe('openPtyShell', () => {
     expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
   });
 
-  it('given sprite emits an error event, should call onOutput with error text and onExit with -1', () => {
-    const cmd = buildFakeCommand();
-    const sprite = buildFakeSprite(cmd);
-    const onOutput = vi.fn();
-    const onExit = vi.fn();
-
-    openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
-    cmd._emitter.emit('error', new Error('connection lost'));
-
-    expect(onOutput).toHaveBeenCalledWith(expect.stringContaining('connection lost'));
-    expect(onExit).toHaveBeenCalledWith(-1);
-  });
-
   it('given stdin is null, shell.write should be a no-op', () => {
     const cmd = buildFakeCommand();
     (cmd as Record<string, unknown>).stdin = null;
@@ -155,5 +168,75 @@ describe('openPtyShell', () => {
     cmd._emitter.emit('exit', null);
 
     expect(onExit).toHaveBeenCalledWith(-1);
+  });
+
+  describe('reconnect on transient WebSocket drop', () => {
+    it('given an error and a live session exists, should reattach and NOT call onExit', async () => {
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+      expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('given a reattached session, output flows from the new command', async () => {
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+      const onOutput = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      attachCmd._stdout.emit('data', 'back\r\n');
+      expect(onOutput).toHaveBeenCalledWith('back\r\n');
+    });
+
+    it('given an error and NO live session, should call onExit(-1) without an error banner', async () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [] });
+      const onOutput = vi.fn();
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(onExit).toHaveBeenCalledWith(-1);
+      expect(onOutput).not.toHaveBeenCalledWith(expect.stringContaining('Shell error'));
+    });
+
+    it('given reattach repeatedly fails, should give up after the bounded budget and surface onExit(-1)', async () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { listRejects: true });
+      const onOutput = vi.fn();
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(onExit).toHaveBeenCalledWith(-1);
+      expect(onOutput).toHaveBeenCalledWith(expect.stringContaining('lost connection'));
+    });
+
+    it('given a genuine exit (not an error), should call onExit immediately without reattaching', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+      cmd._emitter.emit('exit', 0);
+
+      expect(onExit).toHaveBeenCalledWith(0);
+      expect(sprite.attachSession).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -288,5 +288,65 @@ describe('openPtyShell', () => {
       expect(onExit).not.toHaveBeenCalled();
       expect(sprite.attachSession.mock.calls.length).toBeGreaterThan(5);
     });
+
+    it('given the shell was killed, a trailing exit does not double-fire onExit', () => {
+      // kill() sets closed=true; a subsequent exit hits the `closed` guard in fatal().
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+      const onExit = vi.fn();
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+      shell.kill();
+      cmd._emitter.emit('exit', 0);
+
+      expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('given a second error while a reconnect is already in flight, ignores the duplicate', async () => {
+      // The second error hits the `reconnecting` guard in reconnect() — only one reattach.
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd: buildFakeCommand() });
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('error', new Error('keepalive'));
+      cmd._emitter.emit('error', new Error('keepalive again'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.attachSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('given the shell is killed during the reconnect backoff, aborts the pending reattach', async () => {
+      // kill() sets closed=true mid-delay; reconnect resumes, sees `closed`, and bails before attaching.
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd: buildFakeCommand() });
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('error', new Error('keepalive'));
+      shell.kill();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.attachSession).not.toHaveBeenCalled();
+    });
+
+    it('given the session id is unknown at reconnect, resolves the live session via listSessions and attaches', async () => {
+      // Background id-capture returns [] (id stays undefined); reconnect's own
+      // listSessions returns the live session → the pickShellSession()?.id branch.
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+      sprite.listSessions
+        .mockResolvedValueOnce([])             // create-path background capture
+        .mockResolvedValueOnce([liveSession]); // reconnect resolution
+      sprite.attachSession.mockImplementation(() => attachCmd);
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+      await vi.advanceTimersByTimeAsync(0); // flush background listSessions ([])
+      cmd._emitter.emit('error', new Error('keepalive'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+      expect(onExit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -238,5 +238,55 @@ describe('openPtyShell', () => {
       expect(onExit).toHaveBeenCalledWith(0);
       expect(sprite.attachSession).not.toHaveBeenCalled();
     });
+
+    it('given a command that errored, should IGNORE its trailing stale exit and reattach instead', async () => {
+      // A keepalive timeout in the SDK emits 'error' AND THEN closes the socket,
+      // which makes the same dead transport emit a spurious 'exit' (code 0). That
+      // stale exit must not tear the session down while reconnect() is in flight.
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      cmd._emitter.emit('exit', 0); // trailing stale exit from the SAME dead command
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(onExit).not.toHaveBeenCalled();
+      expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+    });
+
+    it('given repeated idle keepalive cycles that each reattach successfully, should NOT trip the bounded budget', async () => {
+      // Each cycle: the live command errors (keepalive drop) → reconnect →
+      // attachSession returns a fresh command that confirms open via 'spawn' but
+      // emits NO stdout. The 'spawn' reset must keep the budget from climbing, so
+      // a healthy-but-quiet shell survives indefinitely. Without it, the failure
+      // counter would reach the fatal budget (> 5) and close the terminal.
+      const initial = buildFakeCommand();
+      const attached: FakeCommand[] = [];
+      const sprite = buildFakeSprite(initial, { sessions: [liveSession] });
+      // A successful reattach: fresh command, emits 'spawn' once wired (next tick).
+      sprite.attachSession.mockImplementation(() => {
+        const next = buildFakeCommand();
+        attached.push(next);
+        setTimeout(() => next._emitter.emit('spawn'), 0);
+        return next;
+      });
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+
+      // Run more cycles than MAX_RECONNECT_ATTEMPTS (5) would otherwise allow.
+      let currentCmd: FakeCommand = initial;
+      for (let i = 0; i < 8; i += 1) {
+        currentCmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+        await vi.advanceTimersByTimeAsync(2000); // cover backoff delay + spawn tick
+        currentCmd = attached[attached.length - 1];
+      }
+
+      expect(onExit).not.toHaveBeenCalled();
+      expect(sprite.attachSession.mock.calls.length).toBeGreaterThan(5);
+    });
   });
 });

--- a/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
@@ -137,7 +137,7 @@ describe('buildTerminalHandlers', () => {
       expect(socket.emit).toHaveBeenCalledWith('terminal:closed', { exitCode: -2 });
     });
 
-    it('given a live tmux session already on the Sprite (e.g. after a realtime restart), should reattach to it via listSessions', async () => {
+    it('given a live session already on the Sprite (e.g. after a realtime restart), should reattach to it via listSessions', async () => {
       const auth = makeAuthSuccess('key1', [{ id: 'sess-9', command: 'bash', isActive: true, tty: true }]);
       checkAuth.mockResolvedValue(auth);
       const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });

--- a/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
@@ -12,12 +12,21 @@ function makeShell(): PtyShell & { write: ReturnType<typeof vi.fn>; resize: Retu
   return { write: vi.fn(), resize: vi.fn(), kill: vi.fn() };
 }
 
-function makeSprite() {
-  return { name: 'sbx1', spawn: vi.fn(), filesystem: vi.fn(), updateNetworkPolicy: vi.fn(), destroy: vi.fn() };
+function makeSprite(sessions: Array<{ id: string; command: string; isActive: boolean; tty: boolean }> = []) {
+  return {
+    name: 'sbx1',
+    spawn: vi.fn(),
+    createSession: vi.fn(),
+    attachSession: vi.fn(),
+    listSessions: vi.fn(async () => sessions),
+    filesystem: vi.fn(),
+    updateNetworkPolicy: vi.fn(),
+    destroy: vi.fn(),
+  };
 }
 
-function makeAuthSuccess(sessionKey = 'key1') {
-  return { ok: true as const, sandboxId: 'sbx1', sessionKey, sprite: makeSprite(), releaseSlot: vi.fn() };
+function makeAuthSuccess(sessionKey = 'key1', sessions: Array<{ id: string; command: string; isActive: boolean; tty: boolean }> = []) {
+  return { ok: true as const, sandboxId: 'sbx1', sessionKey, sprite: makeSprite(sessions), releaseSlot: vi.fn() };
 }
 
 const validPayload = { pageId: 'page1', cols: 80, rows: 24 };
@@ -126,6 +135,44 @@ describe('buildTerminalHandlers', () => {
       expect(shell.kill).toHaveBeenCalledWith();
       expect(sessionMap.getByKey('key1')).toBeUndefined();
       expect(socket.emit).toHaveBeenCalledWith('terminal:closed', { exitCode: -2 });
+    });
+
+    it('given a live tmux session already on the Sprite (e.g. after a realtime restart), should reattach to it via listSessions', async () => {
+      const auth = makeAuthSuccess('key1', [{ id: 'sess-9', command: 'bash', isActive: true, tty: true }]);
+      checkAuth.mockResolvedValue(auth);
+      const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      expect(auth.sprite.listSessions).toHaveBeenCalled();
+      expect(openShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-9' }));
+      expect(sessionMap.getByKey('key1')?.sessionId).toBe('sess-9');
+    });
+
+    it('given a detached TTY shell reporting isActive:false, should still discover and reattach to it', async () => {
+      // The API's is_active semantics are undocumented; a running-but-detached
+      // shell may report false. Discovery must match on tty, not isActive.
+      const auth = makeAuthSuccess('key1', [{ id: 'sess-detached', command: 'bash', isActive: false, tty: true }]);
+      checkAuth.mockResolvedValue(auth);
+      const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      expect(openShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-detached' }));
+    });
+
+    it('given only a non-TTY session on the Sprite, should NOT reattach (opens a fresh shell)', async () => {
+      const auth = makeAuthSuccess('key1', [{ id: 'sess-batch', command: 'npm test', isActive: true, tty: false }]);
+      checkAuth.mockResolvedValue(auth);
+      const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      expect(openShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }));
+    });
+
+    it('given no live session on the Sprite, should open a fresh shell with no sessionId', async () => {
+      const { onConnect } = buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket });
+      await onConnect(validPayload);
+
+      expect(openShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }));
     });
 
     it('given an existing live session for the same pageId, should reattach rather than spawn a new shell', async () => {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -75,14 +75,31 @@ export function openPtyShell({ sprite, cols, rows, sessionId, onOutput, onExit }
   }
 
   function wire(cmd: SpriteCommandLike): void {
+    // Per-command staleness. A keepalive timeout in the SDK emits 'error' and
+    // then closes the socket, which makes the SAME dead command also emit a
+    // spurious 'exit' (code 0 or 1). A genuine shell exit (user typed `exit`)
+    // emits ONLY 'exit', no preceding 'error'. We mark a command stale the
+    // instant it errors so the trailing close/exit it produces can't tear the
+    // session down while reconnect() is replacing it.
+    let stale = false;
     cmd.stdout.on('data', (chunk) => {
       // Any inbound data proves the connection recovered; reset the failure budget.
       consecutiveFailures = 0;
       onOutput(toStr(chunk));
     });
     cmd.stderr.on('data', (chunk) => onOutput(toStr(chunk)));
-    cmd.on('exit', (code) => fatal(code ?? -1));
-    cmd.on('error', () => { void reconnect(); });
+    // The SDK emits 'spawn' only AFTER the WebSocket actually opens. A confirmed
+    // open is the authoritative signal the connection is healthy — reset the
+    // bounded reconnect budget here so an idle shell that reattaches cleanly but
+    // stays quiet (no stdout) doesn't slowly exhaust the budget and get killed.
+    cmd.on('spawn', () => { consecutiveFailures = 0; });
+    cmd.on('exit', (code) => {
+      // Ignore the stale exit that trails a keepalive 'error' on the same dead
+      // command — only an exit WITHOUT a preceding error is a real shell exit.
+      if (stale) return;
+      fatal(code ?? -1);
+    });
+    cmd.on('error', () => { stale = true; void reconnect(); });
   }
 
   async function reconnect(): Promise<void> {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -57,7 +57,7 @@ export function openPtyShell({ sprite, cols, rows, sessionId, onOutput, onExit }
   const toStr = (chunk: unknown) => (typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8'));
 
   let current: SpriteCommandLike;
-  // The live tmux session id to reattach to. Known immediately when attaching;
+  // The live session id to reattach to. Known immediately when attaching;
   // for a freshly created session it is resolved in the background via
   // listSessions() (and again at reconnect time as a fallback).
   let currentSessionId: string | undefined = sessionId;

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -1,5 +1,21 @@
-import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import type {
+  SpriteInstanceLike,
+  SpriteCommandLike,
+  SpriteSessionInfo,
+} from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
+
+/**
+ * Pick the live interactive shell to reattach to from a Sprite's exec sessions.
+ * A terminal owns exactly one TTY shell per Sprite (one page = one Sprite), so
+ * match on `tty` rather than on `isActive` — the API's `is_active` semantics
+ * (process-alive vs client-attached) are undocumented, and a detached-but-running
+ * shell may report `is_active: false`. `isActive` is used only as a tiebreaker.
+ */
+export function pickShellSession(sessions: SpriteSessionInfo[]): SpriteSessionInfo | undefined {
+  const shells = sessions.filter((s) => s.tty);
+  return shells.find((s) => s.isActive) ?? shells[0];
+}
 
 export type PtyShell = {
   write(data: string): void;
@@ -11,32 +27,124 @@ export type OpenPtyShellArgs = {
   sprite: SpriteInstanceLike;
   cols: number;
   rows: number;
+  /**
+   * When set, attach to this existing detachable session instead of creating a
+   * fresh shell — used to reattach to a shell that survived a navigation away or
+   * a realtime-process restart, replaying its scrollback.
+   */
+  sessionId?: string;
   onOutput(data: string): void;
   onExit(exitCode: number): void;
 };
 
-export function openPtyShell({ sprite, cols, rows, onOutput, onExit }: OpenPtyShellArgs): PtyShell {
-  const cmd = sprite.spawn('bash', [], {
-    tty: true,
-    cols,
-    rows,
-    cwd: SANDBOX_ROOT,
-    env: { TERM: 'xterm-256color', COLORTERM: 'truecolor', LANG: 'en_US.UTF-8' },
-  });
+// The @fly/sprites WSCommand keepalive is output-driven: it declares the socket
+// dead after 45s with no INBOUND frame (see websocket.js WS_PONG_WAIT), even
+// though the shell is still alive server-side — a TTY session has
+// max_run_after_disconnect:0, so it keeps running after the client drops, and
+// the docs specify no server ping / idle timeout. An idle prompt therefore trips
+// the CLIENT watchdog on a fixed cadence. We treat that (and any mid-session WS
+// drop) as a transient disconnect and transparently reattach to the live session
+// rather than tearing the terminal down. Consecutive FAILED reattaches are
+// bounded so a genuinely dead Sprite still surfaces an exit.
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 200;
 
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const TERMINAL_ENV = { TERM: 'xterm-256color', COLORTERM: 'truecolor', LANG: 'en_US.UTF-8' };
+
+export function openPtyShell({ sprite, cols, rows, sessionId, onOutput, onExit }: OpenPtyShellArgs): PtyShell {
   const toStr = (chunk: unknown) => (typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8'));
-  cmd.stdout.on('data', (chunk) => onOutput(toStr(chunk)));
-  cmd.stderr.on('data', (chunk) => onOutput(toStr(chunk)));
-  cmd.on('error', (err: unknown) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    onOutput(`\r\n\x1b[31mShell error: ${msg}\x1b[0m\r\n`);
-    onExit(-1);
-  });
-  cmd.on('exit', (code) => onExit(code ?? -1));
+
+  let current: SpriteCommandLike;
+  // The live tmux session id to reattach to. Known immediately when attaching;
+  // for a freshly created session it is resolved in the background via
+  // listSessions() (and again at reconnect time as a fallback).
+  let currentSessionId: string | undefined = sessionId;
+  let lastCols = cols;
+  let lastRows = rows;
+  let closed = false; // a real exit (or exhausted reconnects) — stop everything
+  let reconnecting = false;
+  let consecutiveFailures = 0;
+
+  function fatal(exitCode: number, message?: string): void {
+    if (closed) return;
+    closed = true;
+    if (message !== undefined) onOutput(`\r\n\x1b[31mShell error: ${message}\x1b[0m\r\n`);
+    onExit(exitCode);
+  }
+
+  function wire(cmd: SpriteCommandLike): void {
+    cmd.stdout.on('data', (chunk) => {
+      // Any inbound data proves the connection recovered; reset the failure budget.
+      consecutiveFailures = 0;
+      onOutput(toStr(chunk));
+    });
+    cmd.stderr.on('data', (chunk) => onOutput(toStr(chunk)));
+    cmd.on('exit', (code) => fatal(code ?? -1));
+    cmd.on('error', () => { void reconnect(); });
+  }
+
+  async function reconnect(): Promise<void> {
+    if (closed || reconnecting) return;
+    reconnecting = true;
+    consecutiveFailures += 1;
+    if (consecutiveFailures > MAX_RECONNECT_ATTEMPTS) {
+      reconnecting = false;
+      fatal(-1, 'lost connection to shell');
+      return;
+    }
+    try {
+      await delay(RECONNECT_BASE_DELAY_MS * consecutiveFailures);
+      if (closed) { reconnecting = false; return; }
+
+      let id = currentSessionId;
+      if (id === undefined) {
+        id = pickShellSession(await sprite.listSessions())?.id;
+      }
+      if (id === undefined) {
+        // No live session to reattach to — the shell is genuinely gone.
+        reconnecting = false;
+        fatal(-1);
+        return;
+      }
+      currentSessionId = id;
+      current = sprite.attachSession(id, { cols: lastCols, rows: lastRows });
+      wire(current);
+      reconnecting = false;
+    } catch {
+      reconnecting = false;
+      // Reattach itself failed; retry until the bounded budget is exhausted.
+      void reconnect();
+    }
+  }
+
+  if (currentSessionId !== undefined) {
+    current = sprite.attachSession(currentSessionId, { cols, rows });
+  } else {
+    current = sprite.createSession('bash', [], {
+      tty: true,
+      cols,
+      rows,
+      cwd: SANDBOX_ROOT,
+      env: TERMINAL_ENV,
+    });
+    // Resolve our own session id so a keepalive drop can reattach to it. Best
+    // effort: reconnect() also resolves it on demand if this hasn't landed yet.
+    void sprite
+      .listSessions()
+      .then((sessions) => {
+        if (currentSessionId === undefined) {
+          currentSessionId = pickShellSession(sessions)?.id;
+        }
+      })
+      .catch(() => {});
+  }
+  wire(current);
 
   return {
-    write: (data) => { cmd.stdin?.write(data); },
-    resize: (c, r) => cmd.resize?.(c, r),
-    kill: () => cmd.kill('SIGKILL'),
+    write: (data) => { if (!closed) current.stdin?.write(data); },
+    resize: (c, r) => { lastCols = c; lastRows = r; if (!closed) current.resize?.(c, r); },
+    kill: () => { closed = true; current.kill('SIGKILL'); },
   };
 }

--- a/apps/realtime/src/terminal/terminal-handler.ts
+++ b/apps/realtime/src/terminal/terminal-handler.ts
@@ -1,6 +1,7 @@
 import type { TerminalSessionMap, TerminalSession } from './terminal-session-map';
 import { MAX_SCROLLBACK_BYTES, DETACHED_IDLE_MS } from './terminal-session-map';
 import type { OpenPtyShellArgs, PtyShell } from './sprites-shell';
+import { pickShellSession } from './sprites-shell';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { validateTerminalConnectPayload, clampTerminalDimensions } from './validation';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -81,13 +82,25 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
         return;
       }
 
-      // New session: spawn a fresh shell.
+      // No in-memory session in THIS process. The TTY shell may still be alive on
+      // the Sprite (max_run_after_disconnect:0 outlives both socket drops and
+      // realtime restarts), so discover it and reattach — the Sprite is the source
+      // of truth. Falls back to a fresh shell on any lookup failure or when none
+      // is found.
       const { sandboxId } = authResult;
+
+      let existingSessionId: string | undefined;
+      try {
+        existingSessionId = pickShellSession(await authResult.sprite.listSessions())?.id;
+      } catch {
+        existingSessionId = undefined;
+      }
 
       const session: TerminalSession = {
         command: null as unknown as PtyShell, // assigned below before any async
         sandboxId,
         sessionKey,
+        sessionId: existingSessionId,
         releaseSlot: authResult.releaseSlot,
         outputFn: (data) => socket.emit('terminal:output', { data }),
         closedFn: (exitCode) => socket.emit('terminal:closed', { exitCode }),
@@ -103,6 +116,7 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
           sprite: authResult.sprite,
           cols: clampedCols,
           rows: clampedRows,
+          sessionId: existingSessionId,
           onOutput: (data) => {
             appendScrollback(session, data);
             session.outputFn(data);

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -7,6 +7,8 @@ export type TerminalSession = {
   command: PtyShell;
   sandboxId: string;
   sessionKey: string;
+  /** Detachable tmux session id on the Sprite, used to reattach after a WS drop. */
+  sessionId?: string;
   reAuthInterval?: ReturnType<typeof setInterval>;
   idleTimer?: ReturnType<typeof setTimeout>;
   releaseSlot(): void;

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -7,7 +7,7 @@ export type TerminalSession = {
   command: PtyShell;
   sandboxId: string;
   sessionKey: string;
-  /** Detachable tmux session id on the Sprite, used to reattach after a WS drop. */
+  /** Detachable exec session id on the Sprite, used to reattach after a WS drop. */
   sessionId?: string;
   reAuthInterval?: ReturnType<typeof setInterval>;
   idleTimer?: ReturnType<typeof setTimeout>;

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -77,6 +77,9 @@ function fakeSprite(
   return {
     name: 'session-key',
     spawn: () => fakeCommand({ stdout: ['out'], exitCode: 0 }),
+    createSession: () => fakeCommand({ stdout: ['out'], exitCode: 0 }),
+    attachSession: () => fakeCommand({ stdout: ['out'], exitCode: 0 }),
+    listSessions: async () => [],
     filesystem: () => fs,
     updateNetworkPolicy: async () => {},
     destroy: async () => {},

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -104,6 +104,12 @@ export interface SpriteCommandLike {
   readonly stdin?: { write(data: string | Buffer): void };
   on(event: 'exit', listener: (code: number) => void): unknown;
   on(event: 'error', listener: (error: unknown) => void): unknown;
+  // Emitted by the SDK's WSCommand AFTER the WebSocket actually opens
+  // (`cmd.start().then(() => cmd.emit('spawn'))`). A failed/flapping attach
+  // rejects and emits 'error' instead, never 'spawn' — so 'spawn' is the
+  // authoritative, flap-safe "connection established" signal the terminal uses
+  // to reset its bounded reconnect budget.
+  on(event: 'spawn', listener: () => void): unknown;
   kill(signal?: string): void;
   resize?(cols: number, rows: number): void;
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -117,6 +117,21 @@ export interface SpriteSpawnOptions {
   cols?: number;
 }
 
+/**
+ * An exec session as reported by `listSessions()` (GET `/v1/sprites/{name}/exec`).
+ * The `id` is the handle passed to `attachSession` (WSS `/v1/sprites/{name}/exec/{id}`)
+ * to transparently reconnect to a shell that survived a WebSocket keepalive drop.
+ * `isActive` is the SDK's mapping of the API's `is_active`; its exact meaning
+ * (process-alive vs client-attached) is not specified by the docs, so callers
+ * select a shell to reattach by `tty` and use `isActive` only as a tiebreaker.
+ */
+export interface SpriteSessionInfo {
+  id: string;
+  command: string;
+  isActive: boolean;
+  tty: boolean;
+}
+
 /** The Sprite instance subset the driver consumes. */
 export interface SpriteInstanceLike {
   readonly name: string;
@@ -125,6 +140,24 @@ export interface SpriteInstanceLike {
     args?: string[],
     options?: SpriteSpawnOptions,
   ): SpriteCommandLike;
+  /**
+   * Start a detachable session (the SDK forces `tty: true`). A TTY session has
+   * `max_run_after_disconnect: 0` server-side — it keeps running indefinitely
+   * after the client WebSocket drops — which is the basis for a persistent
+   * interactive terminal that survives keepalive timeouts and reconnects.
+   */
+  createSession(
+    command: string,
+    args?: string[],
+    options?: SpriteSpawnOptions,
+  ): SpriteCommandLike;
+  /**
+   * Reattach to an existing session by id (connects to WSS `/exec/{id}`); the
+   * server immediately replays the session's scrollback buffer as stdout.
+   */
+  attachSession(sessionId: string, options?: SpriteSpawnOptions): SpriteCommandLike;
+  /** List the Sprite's exec sessions (the source of truth for reattach). */
+  listSessions(): Promise<SpriteSessionInfo[]>;
   filesystem(workingDir?: string): SpriteFsLike;
   updateNetworkPolicy(policy: NetworkPolicy): Promise<void>;
   destroy(): Promise<void>;


### PR DESCRIPTION
## Problem

Opening an interactive terminal into a sandbox and sitting idle for ~45s killed the shell:

```
Shell error: WebSocket keepalive timeout
Process exited with code -1
```

**Root cause (verified against the Sprites API docs + installed SDK `@fly/sprites@0.0.1-rc37`):** the SDK's `WSCommand` keepalive is a **client-side, output-driven watchdog** — it declares the socket dead after 45s with no *inbound* frame (`WS_PONG_WAIT`), even though the shell is still alive server-side. The docs confirm a TTY exec session has `max_run_after_disconnect: 0` (runs forever after the client disconnects) and specify **no** server ping / idle timeout. So an idle prompt produced no output → no inbound frames → the watchdog tripped ~every 45s. The old code (`sprites-shell.ts`) surfaced that error as `onExit(-1)`, which tore down the whole session in `terminal-handler.ts` — abandoning a still-alive shell it had no session id to reconnect to.

## Fix

Make the terminal a persistent, self-healing **view** onto a survivable shell:

- **Detachable shell** — open via `createSession` (detachable TTY) instead of plain `spawn`, and capture the session id.
- **Transparent reattach** — a keepalive timeout / transient WS drop now reattaches to the live session (`attachSession` → `WSS /exec/{id}`, which replays the scrollback buffer) instead of exiting. A bounded consecutive-failure budget still surfaces a real exit if the Sprite is genuinely dead.
- **Restart-survivable discovery** — on connect, `listSessions()` discovers an existing shell on the Sprite and reattaches, so the terminal survives a realtime-process restart, not just a socket blip. Discovery matches on `tty` (one shell per Sprite) rather than the API's **undocumented** `is_active` (a detached-but-running shell may report `false`); `isActive` is only a tiebreaker.

Widens `SpriteInstanceLike` with `createSession`/`attachSession`/`listSessions` (type-only — the real SDK `Sprite` already implements them).

## Scope

**Terminal only.** No behavioral change to the agent `bash` tool: agent commands are short, hard-capped at 120s, and never sit idle at a prompt, so they don't hit the keepalive window. The only shared change is the type-only interface widening, which the agent path ignores.

## API alignment (no guessing)

Cross-checked the full terminal path end-to-end against `https://sprites.dev/api/` and the SDK source:

| Behavior | Source | Verdict |
|---|---|---|
| TTY session survives disconnect (`max_run_after_disconnect:0`) | `/api/sprites/exec` | ✅ |
| Attach replays scrollback + `session_info` | `/api/sprites/exec` | ✅ |
| `listSessions` → `{id,command,is_active,tty,...}` | `/api/sprites/exec` + SDK | ✅ |
| Keepalive is client-only (no server ping/idle timeout) | `/api/sprites/exec` | ✅ root cause |
| FS persists indefinitely; sleep/wake; stable name | `/api/sprites` | ✅ |
| Network policy `{rules:[{domain,action}]}` → `POST /policy/network` | `/api/sprites/policies` + SDK | ✅ (pre-existing) |

Corrected two earlier guesses: dropped a "tmux-backed" claim (mechanism is TTY + `max_run_after_disconnect:0`; the SDK's `tmux attach` args are dead code, skipped by the `sessionId` guard), and stopped depending on `is_active` semantics.

## Tests

- 44 terminal tests (`sprites-shell`, `terminal-handler`) — new cases: attach-on-connect discovery, reattach-on-keepalive (no `onExit`), `isActive:false` TTY discovery, non-TTY-only → fresh shell, no-session → exit, exhausted-reconnect → exit.
- 33 lib sandbox-client driver tests.
- `realtime` typecheck passes.

## Manual verification (live sprite)

Open a terminal, sit idle >60s → stays alive (no `keepalive timeout` teardown); navigate away/back or restart realtime → reconnect lands on the same shell (cwd + scrollback) via `listSessions()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKu8skiyvc559bimMQ6jpP

## Review follow-ups

- **P1 (stale exit on reconnect)** — a keepalive timeout emits `error` then a spurious `exit` (0/1) on the same dead transport; `wire()` now marks a command `stale` on `error` so its trailing `exit` cannot tear down the session mid-reconnect. Only an exit *without* a preceding error is a real shell exit.
- **P2 (reconnect budget)** — the bounded reconnect budget now resets on the SDK `spawn` event (confirmed WS open), so a successful-but-quiet reattach no longer slowly exhausts the budget; a flapping attach emits `error` (never `spawn`), so the budget still bounds genuinely dead reconnects.
- Dropped unsubstantiated "tmux" comments — the documented mechanism is a TTY exec session (`max_run_after_disconnect:0`) reattached via WSS `/exec/{id}`.

All local validation green: realtime suite (424), lib sandbox suite (292), lint, typecheck.
