### PR TITLE
feat(ai-chat): multiplayer (share) toggle in the conversation header

### DIFF
--- a/apps/web/src/components/ai/page-agents/ConversationShareToggle.tsx
+++ b/apps/web/src/components/ai/page-agents/ConversationShareToggle.tsx
@@ -1,0 +1,62 @@
+import { Lock, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ConversationShareToggleProps {
+  /** Whether the conversation is shared (multiplayer) with everyone on the page. */
+  isShared: boolean;
+  /** Whether the current user owns the conversation (only owners may change sharing). */
+  isOwner: boolean;
+  /** Flip the share state. Only called for owners. */
+  onToggle: () => void;
+}
+
+/**
+ * The "Private" / "Shared" pill for an AI conversation.
+ *
+ * Owners get an interactive Lock/Users toggle; non-owners viewing a shared
+ * conversation get a read-only "Shared" indicator. Used in both the chat-screen
+ * header and the History tab's conversation cards so the two stay in lockstep.
+ */
+export function ConversationShareToggle({
+  isShared,
+  isOwner,
+  onToggle,
+}: ConversationShareToggleProps) {
+  if (isOwner) {
+    return (
+      <Button
+        variant={isShared ? 'secondary' : 'ghost'}
+        size="sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle();
+        }}
+        title={isShared ? 'Make private' : 'Share with everyone on this page'}
+        className="h-7 px-2 gap-1 text-xs"
+      >
+        {isShared ? (
+          <>
+            <Users className="h-3 w-3" />
+            Shared
+          </>
+        ) : (
+          <>
+            <Lock className="h-3 w-3" />
+            Private
+          </>
+        )}
+      </Button>
+    );
+  }
+
+  if (isShared) {
+    return (
+      <span className="flex items-center gap-1 text-xs text-muted-foreground px-1">
+        <Users className="h-3 w-3" />
+        Shared
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/components/ai/page-agents/PageAgentHistoryTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentHistoryTab.tsx
@@ -8,12 +8,11 @@ import {
   MessageSquare,
   Clock,
   Hash,
-  Lock,
-  Users,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatDistanceToNow } from 'date-fns';
 import { VirtualizedConversationList } from '@/components/ai/shared/chat';
+import { ConversationShareToggle } from './ConversationShareToggle';
 
 // Threshold for enabling virtualization
 const VIRTUALIZATION_THRESHOLD = 20;
@@ -90,28 +89,12 @@ const ConversationCard = memo(function ConversationCard({
           </div>
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          {conversation.isShared && !conversation.isOwner && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground px-1">
-              <Users className="h-3 w-3" />
-              Shared
-            </span>
-          )}
-          {conversation.isOwner && onToggleShare && (
-            <Button
-              variant={conversation.isShared ? 'secondary' : 'ghost'}
-              size="sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggleShare();
-              }}
-              title={conversation.isShared ? 'Make private' : 'Share with everyone on this page'}
-              className="h-7 px-2 gap-1 text-xs"
-            >
-              {conversation.isShared
-                ? <><Users className="h-3 w-3" />Shared</>
-                : <><Lock className="h-3 w-3" />Private</>
-              }
-            </Button>
+          {onToggleShare && (
+            <ConversationShareToggle
+              isShared={conversation.isShared ?? false}
+              isOwner={conversation.isOwner ?? false}
+              onToggle={onToggleShare}
+            />
           )}
           <Button
             variant="ghost"

--- a/apps/web/src/components/ai/page-agents/index.ts
+++ b/apps/web/src/components/ai/page-agents/index.ts
@@ -7,3 +7,4 @@
 export { default as PageAgentHistoryTab } from './PageAgentHistoryTab';
 export { default as PageAgentSettingsTab, type PageAgentSettingsTabRef } from './PageAgentSettingsTab';
 export { PageAgentConversationRenderer } from './PageAgentConversationRenderer';
+export { ConversationShareToggle } from './ConversationShareToggle';

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -239,6 +239,23 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     [conversations, currentConversationId],
   );
 
+  // A real conversation can become active without ever entering the cached list:
+  // the first message on a fresh page creates it, but private conversations are
+  // not broadcast and the stream-completion path doesn't refresh the list. Since
+  // the list is now fetched on the chat tab, a fresh page caches [] up-front;
+  // without this, the header share toggle never appears and opening History
+  // reuses that stale empty cache. Pull the list once per id that's missing from
+  // it so both the header and History reflect the just-created conversation.
+  const syncedConversationRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!currentConversationId) return;
+    if (currentConversationId === `${page.id}-default`) return;
+    if (conversations.some((c) => c.id === currentConversationId)) return;
+    if (syncedConversationRef.current === currentConversationId) return;
+    syncedConversationRef.current = currentConversationId;
+    refreshConversations();
+  }, [currentConversationId, conversations, page.id, refreshConversations]);
+
   // ============================================
   // CHAT CONFIGURATION
   // ============================================

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -20,7 +20,7 @@ import { useDriveStore } from '@/hooks/useDrive';
 import { buildPageContext } from '@/lib/ai/shared/buildPageContext';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
-import { PageAgentSettingsTab, PageAgentHistoryTab, type PageAgentSettingsTabRef } from '@/components/ai/page-agents';
+import { PageAgentSettingsTab, PageAgentHistoryTab, ConversationShareToggle, type PageAgentSettingsTabRef } from '@/components/ai/page-agents';
 import { AgentIntegrationsPanel } from '@/components/ai/page-agents/AgentIntegrationsPanel';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
@@ -181,7 +181,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   } = useConversations({
     agentId: page.id,
     currentConversationId,
-    enabled: activeTab === 'history',
+    // Enabled on the chat tab too (not just history) so the header can show the
+    // active conversation's share state and let the owner toggle it in place.
+    enabled: activeTab === 'history' || activeTab === 'chat',
     onConversationLoad: (conversationId, messages) => {
       // Use the pre-fetched messages directly (no re-fetch) and suppress the
       // load-on-select effect for this id so we don't double-request the server.
@@ -228,6 +230,14 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       toast.error('Failed to update conversation sharing');
     }
   }, [page.id, refreshConversations]);
+
+  // The active conversation's metadata (share state, ownership), derived from the
+  // conversation list. Null for the page-scoped placeholder id (no persisted
+  // conversation yet) — the header toggle is hidden until the first message lands.
+  const currentConversation = useMemo(
+    () => conversations.find((c) => c.id === currentConversationId) ?? null,
+    [conversations, currentConversationId],
+  );
 
   // ============================================
   // CHAT CONFIGURATION
@@ -886,6 +896,19 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                 )}
 
                 <TasksDropdown messages={messages} driveId={driveId} />
+
+                {currentConversation && (
+                  <ConversationShareToggle
+                    isShared={currentConversation.isShared}
+                    isOwner={currentConversation.isOwner}
+                    onToggle={() =>
+                      toggleConversationShare(
+                        currentConversation.id,
+                        !currentConversation.isShared,
+                      )
+                    }
+                  />
+                )}
 
                 <Button
                   variant="outline"

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -102,8 +102,9 @@ vi.mock('@/lib/ai/core/stream-abort-client', () => ({
 }));
 vi.mock('@/lib/ai/core/vision-models', () => ({ hasVisionCapability: vi.fn(() => false) }));
 
-const { mockCreateConversation } = vi.hoisted(() => ({
+const { mockCreateConversation, mockRefreshConversations } = vi.hoisted(() => ({
   mockCreateConversation: vi.fn(),
+  mockRefreshConversations: vi.fn(),
 }));
 
 vi.mock('@/lib/ai/shared', () => ({
@@ -141,6 +142,8 @@ vi.mock('@/lib/ai/shared', () => ({
     loadConversation: vi.fn(),
     createConversation: mockCreateConversation,
     deleteConversation: vi.fn(),
+    refreshConversations: mockRefreshConversations,
+    prependConversationOptimistic: vi.fn(),
   })),
   useChatTransport: vi.fn(() => ({})),
   useStreamingRegistration: vi.fn(),
@@ -534,6 +537,56 @@ describe('AiChatView late-joiner conversation sync', () => {
         given: 'stream.conversationId matches the persisted conversation while holding page-scoped default',
         should: 'append the completed AI message',
         actual: mockSetMessages.mock.calls.some((args) => typeof args[0] === 'function'),
+        expected: true,
+      });
+    });
+  });
+
+  test('given the late-joiner sync resolves currentConversationId to a conversation absent from the cached list, should refresh the conversation list so the header toggle and History reflect the new conversation', async () => {
+    let capturedCallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      capturedCallback = opts?.onStreamComplete;
+      return { rejoinActiveStreams: vi.fn() };
+    });
+
+    setupNoConversationsInit();
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with no existing conversations',
+        should: 'fetch conversations list',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    // The page-scoped placeholder id must not trigger a refresh (nothing persisted yet).
+    assert({
+      given: 'only the page-scoped placeholder conversation is active',
+      should: 'not refresh the conversation list',
+      actual: mockRefreshConversations.mock.calls.length,
+      expected: 0,
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) {
+        return makeOkResponse({ conversations: [{ id: REAL_CONV_ID }] });
+      }
+      return makeErrorResponse();
+    });
+
+    capturedCallback?.(MESSAGE_ID);
+
+    await waitFor(() => {
+      assert({
+        given: 'a freshly-created conversation became active but is absent from the cached (empty) list',
+        should: 'refresh the conversation list',
+        actual: mockRefreshConversations.mock.calls.length > 0,
         expected: true,
       });
     });


### PR DESCRIPTION
## What

AI Page conversations are **private by default**. Making one "multiplayer" (shared with everyone who has access to the page) was only possible from the **History tab**, inside each conversation card — so users had to leave the conversation they were in, find it in the list, and toggle it there.

This surfaces the same toggle in the **main chat screen header**, next to **New Chat**, so the owner can flip the active conversation between Private and Shared without leaving it.

## How

The entire backend already existed (`conversations.isShared` column, owner-only PATCH endpoint, real-time broadcasts, and a working `toggleConversationShare` in `AiChatView`). This is **pure frontend wiring**:

- **New `ConversationShareToggle`** — extracts the existing `🔒 Private` ⇄ `👥 Shared` pill. Owners get the interactive toggle; non-owners on a shared conversation get the read-only "Shared" indicator; otherwise it renders nothing.
- **`PageAgentHistoryTab`** — refactored `ConversationCard` to use the shared component (removes duplicated inline markup) so the History tab and chat header can't drift apart.
- **`AiChatView`** — enables the conversation list on the chat tab so the header knows the active conversation's share state; derives `currentConversation` from it. After a toggle, the existing `refreshConversations()` revalidates the list, so the pill flips reactively — no new local state.

The header toggle is hidden until a real conversation exists (the page-scoped placeholder id has nothing to share yet).

## Regression fix (cache freshness)

Enabling the SWR fetch on the chat tab means a new/empty AI page caches `[]` before the first prompt is saved. Private conversations aren't broadcast and the stream-completion path doesn't refresh the list, so without mitigation the header toggle would never appear and opening History would reuse the stale empty cache. Fixed with a small effect that refreshes the list once per **real conversation id that is missing from the cached list** (ref-guarded against refetch loops). Since History and the header share the same SWR `cacheKey`, this fixes both symptoms at once.

## Notes

- No backend / schema / API changes. Owner-only enforcement (403) and real-time `conversation_added`/`deleted` broadcasts already exist server-side.

## Validation

- `bun run --filter web typecheck` ✅
- `bun run --filter web lint` ✅ (no new warnings)
- `AiChatView.test.tsx` ✅ (21 tests) — includes a new test asserting the list refreshes when a fresh conversation becomes active but is absent from the cached list, and does NOT refresh for the placeholder id. The `useConversations` test mock was completed to match `UseConversationsResult`.
- Manual: open an AI Chat page → send a message → `Private` pill appears in the header → click toggles to `Shared` → reflected in History tab; a second user with page access sees the shared conversation and a read-only `Shared` indicator (no toggle, since they're not the owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)