### PR TITLE
fix(security): resolve remaining CodeQL code-scanning alerts

### DIFF
--- a/apps/processor/src/services/__tests__/content-detector.test.ts
+++ b/apps/processor/src/services/__tests__/content-detector.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import path from 'path';
 import os from 'os';
 import fs from 'fs/promises';
+import { mkdtempSync } from 'fs';
 
 import {
   detectContentType,
@@ -9,7 +10,8 @@ import {
   __resetContentDetectorForTests,
 } from '../content-detector';
 
-const FIXTURE_DIR = path.join(os.tmpdir(), `pagespace-magika-${process.pid}`);
+// mkdtempSync creates a uniquely-named temp dir (avoids predictable, attacker-guessable paths).
+const FIXTURE_DIR = mkdtempSync(path.join(os.tmpdir(), 'pagespace-magika-'));
 
 const PNG_BYTES = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -374,12 +374,11 @@ Returns the page content converted to readable markdown.`,
         for (const chunk of chunks) { allBytes.set(chunk, offset); offset += chunk.length; }
         const html = new TextDecoder().decode(allBytes);
 
-        const cleaned = html
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<style[\s\S]*?<\/style>/gi, '');
-
         const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
-        const fullMarkdown = td.turndown(cleaned);
+        // Drop <script>/<style> via Turndown's HTML parser rather than regex, so
+        // malformed/nested tags can't smuggle content into the markdown.
+        td.remove(['script', 'style']);
+        const fullMarkdown = td.turndown(html);
         const markdown = fullMarkdown.slice(0, maxLength);
 
         webSearchLogger.info('URL fetch complete', {

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -591,4 +591,27 @@ describe('renderCanvasDocument — Twitter Card', () => {
     const out = renderCanvasDocument({ html: '<p>x</p>', title: 'My Page' });
     expect(out).not.toContain('twitter:');
   });
+
+  // Hardened closing-tag matching: junk/whitespace/bogus attributes before `>`
+  // must not let style/script content escape the alternation (CodeQL 204-205).
+  it('given a <style> closed with junk before `>` (`</style\\n foo>`), should still hoist+sanitize and drop it from the body', () => {
+    const out = renderCanvasDocument({
+      html: '<style>body { background: url("https://evil.com/pixel.png"); }</style\n foo><p>x</p>',
+    });
+    // External url() was routed through sanitizeCSS (hoisted to <head>), not leaked.
+    expect(out).not.toContain('https://evil.com');
+    expect(out).toContain('url("")');
+    // The whole <style>…</style\n foo> block was consumed — no <style> survives in the body.
+    expect(out).toContain('</head><body><p>x</p></body>');
+  });
+
+  it('given a <script> closed with a bogus attribute (`</script bar>`), should PRESERVE the script verbatim', () => {
+    const out = renderCanvasDocument({
+      html: '<div id="app"></div><script>document.getElementById("app").textContent = "hi";</script bar>',
+    });
+    // Scripts are preserved by design (sandboxed iframe + strict CSP); the junk
+    // close must not cause the script body to be mistaken for a <style>.
+    expect(out).toContain('<script>');
+    expect(out).toContain('document.getElementById("app")');
+  });
 });

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -614,4 +614,33 @@ describe('renderCanvasDocument — Twitter Card', () => {
     expect(out).toContain('<script>');
     expect(out).toContain('document.getElementById("app")');
   });
+
+  // A hyphen/colon after the tag name is NOT a valid end-tag delimiter, so a
+  // hyphenated token like `</script-template>` must NOT terminate the <script>.
+  // Otherwise the parser would resume outside the script and wrongly hoist a
+  // later inner <style>, corrupting an author script that should stay verbatim.
+  it('given `</script-template>` text inside a <script>, should PRESERVE the whole script and NOT hoist a <style> that follows inside it', () => {
+    const out = renderCanvasDocument({
+      html: '<script>const t = "</script-template>"; const css = "<style>.x{color:red}</style>";</script><p>x</p>',
+    });
+    // The entire script (including the inner <style> text) is preserved verbatim.
+    expect(out).toContain('const t = "</script-template>"');
+    expect(out).toContain('const css = "<style>.x{color:red}</style>"');
+    // The inner <style> was script text, not a real stylesheet — it must NOT be
+    // sanitized/hoisted into <head>. There is no real author stylesheet here, so
+    // the (single, baseline) <style> in <head> carries no author `.x` rule.
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).not.toContain('.x{color:red}');
+  });
+
+  it('given a custom element `<script-template>`, should NOT treat it as a <script> open', () => {
+    const out = renderCanvasDocument({
+      html: '<script-template><style>.y{color:blue}</style></script-template>',
+    });
+    // `<script-template>` is a normal (custom) element, so the <style> inside it
+    // IS a real stylesheet — it should be sanitized + hoisted, not preserved raw.
+    const head = out.slice(0, out.indexOf('</head>'));
+    expect(head).toContain('.y');
+    expect(out).not.toContain('<style>.y{color:blue}</style>');
+  });
 });

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -137,7 +137,11 @@ export function escapeHtml(value: string): string {
  * stylesheet — the script is preserved verbatim.
  */
 function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[]): { css: string; body: string } {
-  const scriptOrStyle = /<script\b[^>]*>[\s\S]*?<\/script\s*>|<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
+  // Closing tags tolerate arbitrary junk before `>` (whitespace, newlines, bogus
+  // attributes) so a tag like `</style\n foo>` or `</script bar>` can't smuggle
+  // content past the match. The `\b` after the tag name keeps `</styled>` /
+  // `</scripted>` from being mistaken for a close.
+  const scriptOrStyle = /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>|<style\b[^>]*>([\s\S]*?)<\/style\b[^>]*>/gi;
   const cssParts: string[] = [];
   const body = html.replace(scriptOrStyle, (match, styleContent: string | undefined) => {
     // styleContent is the capture group; defined only when a real <style>

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -137,11 +137,14 @@ export function escapeHtml(value: string): string {
  * stylesheet — the script is preserved verbatim.
  */
 function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[]): { css: string; body: string } {
-  // Closing tags tolerate arbitrary junk before `>` (whitespace, newlines, bogus
-  // attributes) so a tag like `</style\n foo>` or `</script bar>` can't smuggle
-  // content past the match. The `\b` after the tag name keeps `</styled>` /
-  // `</scripted>` from being mistaken for a close.
-  const scriptOrStyle = /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>|<style\b[^>]*>([\s\S]*?)<\/style\b[^>]*>/gi;
+  // Tag names require a genuine delimiter — whitespace, `/`, or `>` — immediately
+  // after the name (the `(?=[\s/>])` lookahead), mirroring the HTML tokenizer.
+  // Only after that delimiter is arbitrary junk/attributes tolerated up to `>`,
+  // so `</style\n foo>` / `</script bar>` can't smuggle content past the match,
+  // while hyphenated names like `<script-template>` / `</script-template>` are
+  // NOT mistaken for a real script/style tag (a `\b` alone would match before
+  // `-`/`:` and could truncate an author script mid-block, corrupting it).
+  const scriptOrStyle = /<script(?=[\s/>])[^>]*>[\s\S]*?<\/script(?=[\s/>])[^>]*>|<style(?=[\s/>])[^>]*>([\s\S]*?)<\/style(?=[\s/>])[^>]*>/gi;
   const cssParts: string[] = [];
   const body = html.replace(scriptOrStyle, (match, styleContent: string | undefined) => {
     // styleContent is the capture group; defined only when a real <style>


### PR DESCRIPTION
## Summary
Closes the remaining 9 open CodeQL code-scanning alerts via three surgical code changes. The repo had 17 open alerts; 8 confirmed false-positives were already dismissed via the API, and this PR addresses the 9 genuine (or defense-in-depth) findings.

## Changes

### EDIT 1 — `apps/processor/src/services/__tests__/content-detector.test.ts`
**Closes alerts 170-173 (`js/insecure-temporary-file`)**
Replaced the predictable PID-based fixture path with `mkdtempSync(path.join(os.tmpdir(), 'pagespace-magika-'))`, which atomically creates a uniquely-named temp dir. The existing `beforeAll` `fs.mkdir(..., { recursive: true })` stays idempotent; `afterAll` cleanup is unchanged.

### EDIT 2 — `apps/web/src/lib/ai/tools/web-search-tools.ts`
**Closes alerts 187-189 (`js/bad-tag-filter` + `js/incomplete-multi-character-sanitization`)**
Replaced the regex strip of `<script>`/`<style>` with Turndown's parser-based node removal: `td.remove(['script', 'style'])` (turndown 7.2.4 exposes `.remove()`). Output behavior is equivalent — script/style content is dropped from the markdown fed to the LLM — but malformed/nested tags can no longer smuggle content through. The regex is removed entirely.

### EDIT 3 — `packages/lib/src/canvas/render-document.ts`
**Closes alerts 204-205 (defense-in-depth)**
Hardened the closing-tag matching in `extractAndSanitizeStyles`. This is intentionally regex-by-design (must run identically in Node and the browser, no DOM parser) and still preserves `<script>` verbatim (rendered in a sandboxed iframe + strict CSP; CSS routed through `sanitizeCSS`).

The tag-name match now requires a genuine end-tag delimiter — whitespace, `/`, or `>` — via a `(?=[\s/>])` lookahead on both opening and closing tag names, mirroring the HTML tokenizer. Only after that delimiter is arbitrary junk/attribute tail tolerated up to `>`. This:
- keeps the hardening goal — `</style\n foo>` / `</script bar>` can no longer smuggle content past the match;
- fixes a Codex-flagged regression in the initial `\b` approach: `\b` also matches before `-`/`:`, so `</script-template>` inside an author script could falsely close the `<script>` and let a following inner `<style>` be hoisted, corrupting a script that must stay verbatim. The lookahead no longer mistakes hyphenated custom-element names for script/style tags.

Added colocated tests: `</style\n foo>` is consumed (style hoisted+sanitized, dropped from body); `</script bar>` preserves the script; `</script-template>` text inside a `<script>` preserves the whole script and does NOT hoist an inner `<style>`; a real `<script-template>` custom element is treated as a normal element (its inner `<style>` IS sanitized + hoisted).

> Note: CodeQL's `bad-tag-filter`/incomplete-sanitization queries may still flag any regex-based HTML handling. If alerts 204-205 persist after this hardening, they are acceptable to dismiss as won't-fix/by-design.

## Verification
- `bun run typecheck` — ✅ pass (local + CI Lint & TypeScript Check green)
- `bun run lint` — ✅ pass
- `render-document` tests — ✅ 79 passed (incl. 4 closing-tag / delimiter tests)
- `web-search-tools` tests — ✅ 35 passed
- `content-detector` tests — 3 passed / 2 pre-existing Magika ML-model failures (identical on the unmodified branch; environmental, unrelated to this change)
- CI — ✅ Lint & TypeScript Check pass, Unit Tests pass, CodeRabbit pass

The remaining 8 alerts were dismissed as false-positives via the CodeQL API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)