### PR TITLE
feat(canvas): custom subdomain selection (Pro+)

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
@@ -1,0 +1,132 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  checkMCPDriveScope,
+  isPrincipalDriveOwnerOrAdmin,
+} from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@/lib/audit/audit-log';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { drives } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { getPlan } from '@/lib/subscription/plans';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { changePublishSubdomain, PublishError } from '@/lib/canvas/publish-page';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+const schema = z.object({
+  subdomain: z.string().min(1).max(63),
+});
+
+async function canChooseSubdomain(driveId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ tier: users.subscriptionTier })
+    .from(drives)
+    .innerJoin(users, eq(drives.ownerId, users.id))
+    .where(eq(drives.id, driveId))
+    .limit(1);
+  const tier = ((row?.tier ?? 'free') as SubscriptionTier);
+  return getPlan(tier).limits.canChooseSubdomain;
+}
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ driveId: string }> }
+) {
+  try {
+    const { driveId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, { allow: ['session', 'mcp'] as const, requireCSRF: false });
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      return NextResponse.json({ error: 'Only drive owners and admins can view subdomain settings' }, { status: 403 });
+    }
+
+    const [driveRow] = await db
+      .select({ publishSubdomain: drives.publishSubdomain })
+      .from(drives)
+      .where(eq(drives.id, driveId))
+      .limit(1);
+
+    const canChange = await canChooseSubdomain(driveId);
+
+    return NextResponse.json({
+      subdomain: driveRow?.publishSubdomain ?? null,
+      canChange,
+    });
+  } catch (error) {
+    loggers.api.error('Error reading subdomain:', error as Error);
+    return NextResponse.json({ error: 'Failed to read subdomain' }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ driveId: string }> }
+) {
+  try {
+    const { driveId } = await context.params;
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+
+    const scopeError = checkMCPDriveScope(auth, driveId);
+    if (scopeError) return scopeError;
+
+    const userId = auth.userId!;
+
+    if (!(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
+      return NextResponse.json({ error: 'Only drive owners and admins can change the subdomain' }, { status: 403 });
+    }
+
+    if (!(await canChooseSubdomain(driveId))) {
+      return NextResponse.json(
+        { error: 'Custom subdomain selection is a Pro feature. Upgrade to choose your own subdomain.' },
+        { status: 403 }
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+    }
+
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues[0]?.message ?? 'Invalid subdomain' }, { status: 400 });
+    }
+
+    const result = await changePublishSubdomain(driveId, parsed.data.subdomain, userId);
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: {
+        operation: 'change_publish_subdomain',
+        oldSubdomain: result.oldSubdomain,
+        newSubdomain: result.newSubdomain,
+      },
+    });
+
+    return NextResponse.json({
+      subdomain: result.newSubdomain,
+      url: `https://${result.newSubdomain}.pagespace.site`,
+    });
+  } catch (error) {
+    loggers.api.error('Error changing subdomain:', error as Error);
+    if (error instanceof PublishError) {
+      return NextResponse.json({ error: error.message }, { status: error.statusCode });
+    }
+    return NextResponse.json({ error: 'Failed to change subdomain' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
@@ -7,7 +7,7 @@ import {
   isPrincipalDriveOwnerOrAdmin,
 } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { auditRequest } from '@/lib/audit/audit-log';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';

--- a/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
@@ -14,7 +14,7 @@ import { drives } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
 import { getPlan } from '@/lib/subscription/plans';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
-import { changePublishSubdomain, PublishError } from '@/lib/canvas/publish-page';
+import { changePublishSubdomain, PublishError, PUBLISH_HOST } from '@/lib/canvas/publish-page';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true }; // keep PATCH CSRF-protected
 
@@ -60,6 +60,7 @@ export async function GET(
     return NextResponse.json({
       subdomain: driveRow?.publishSubdomain ?? null,
       canChange,
+      publishHost: PUBLISH_HOST,
     });
   } catch (error) {
     loggers.api.error('Error reading subdomain:', error as Error);
@@ -120,7 +121,8 @@ export async function PATCH(
 
     return NextResponse.json({
       subdomain: result.newSubdomain,
-      url: `https://${result.newSubdomain}.pagespace.site`,
+      publishHost: PUBLISH_HOST,
+      url: `https://${result.newSubdomain}.${PUBLISH_HOST}`,
     });
   } catch (error) {
     loggers.api.error('Error changing subdomain:', error as Error);

--- a/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/subdomain/route.ts
@@ -16,7 +16,7 @@ import { getPlan } from '@/lib/subscription/plans';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { changePublishSubdomain, PublishError } from '@/lib/canvas/publish-page';
 
-const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true }; // keep PATCH CSRF-protected
 
 const schema = z.object({
   subdomain: z.string().min(1).max(63),

--- a/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ChevronLeft, Shield, Globe, Trash2, Plus, RefreshCw, CheckCircle2, XCircle, Lock, Loader2, Star, Image as ImageIcon } from 'lucide-react';
+import Link from 'next/link';
 import { useDriveStore } from '@/hooks/useDrive';
 import { toast } from 'sonner';
 import { fetchWithAuth, del, patch } from '@/lib/auth/auth-fetch';
@@ -29,6 +30,11 @@ interface DomainsResponse {
   domains: CustomDomain[];
   /** Maximum custom domains allowed by the drive owner's plan (0 = not available). */
   limit: number;
+}
+
+interface SubdomainResponse {
+  subdomain: string | null;
+  canChange: boolean;
 }
 
 const fetcher = (url: string) => fetchWithAuth(url).then((r) => r.json());
@@ -52,6 +58,8 @@ export default function DomainsSettingsPage() {
   const [verifyReasons, setVerifyReasons] = useState<Record<string, string | undefined>>({});
   const [refreshingCertId, setRefreshingCertId] = useState<string | null>(null);
   const [settingPrimaryId, setSettingPrimaryId] = useState<string | null>(null);
+  const [subdomainInput, setSubdomainInput] = useState('');
+  const [isSavingSubdomain, setIsSavingSubdomain] = useState(false);
 
   useEffect(() => {
     fetchDrives();
@@ -90,6 +98,40 @@ export default function DomainsSettingsPage() {
     drive && canManage ? `/api/drives/${driveId}/domains` : null,
     fetcher
   );
+
+  const { data: subdomainData, mutate: mutateSubdomain } = useSWR<SubdomainResponse>(
+    drive && canManage ? `/api/drives/${driveId}/subdomain` : null,
+    fetcher
+  );
+
+  useEffect(() => {
+    if (subdomainData?.subdomain) setSubdomainInput(subdomainData.subdomain);
+  }, [subdomainData?.subdomain]);
+
+  const handleChangeSubdomain = async () => {
+    const trimmed = subdomainInput.trim().toLowerCase();
+    if (!trimmed || isSavingSubdomain) return;
+    if (trimmed === subdomainData?.subdomain) return;
+    setIsSavingSubdomain(true);
+    try {
+      const res = await fetchWithAuth(`/api/drives/${driveId}/subdomain`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ subdomain: trimmed }),
+      });
+      const data = await res.json().catch(() => ({})) as { subdomain?: string; error?: string };
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to update subdomain');
+        return;
+      }
+      await mutateSubdomain();
+      toast.success('Subdomain updated');
+    } catch {
+      toast.error('Failed to update subdomain');
+    } finally {
+      setIsSavingSubdomain(false);
+    }
+  };
 
   const handleAddDomain = async () => {
     const hostname = normalizeHostname(newDomain.trim());
@@ -266,6 +308,15 @@ export default function DomainsSettingsPage() {
         <p className="text-muted-foreground">Custom domains and share defaults for this drive&apos;s published canvas site</p>
       </div>
 
+      <SubdomainCard
+        subdomain={subdomainData?.subdomain ?? null}
+        canChange={subdomainData?.canChange ?? false}
+        inputValue={subdomainInput}
+        onInputChange={setSubdomainInput}
+        onSave={handleChangeSubdomain}
+        isSaving={isSavingSubdomain}
+      />
+
       <CustomDomainsCard
         domains={domainsData?.domains ?? []}
         limit={domainsData?.limit ?? null}
@@ -335,6 +386,84 @@ export default function DomainsSettingsPage() {
         </CardContent>
       </Card>
     </div>
+  );
+}
+
+// ── Subdomain Card ──────────────────────────────────────────────────────────
+
+interface SubdomainCardProps {
+  subdomain: string | null;
+  canChange: boolean;
+  inputValue: string;
+  onInputChange: (v: string) => void;
+  onSave: () => void;
+  isSaving: boolean;
+}
+
+function SubdomainCard({ subdomain, canChange, inputValue, onInputChange, onSave, isSaving }: SubdomainCardProps) {
+  const preview = inputValue.trim().toLowerCase() || subdomain || 'your-subdomain';
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Globe className="h-4 w-4" />
+          Subdomain
+        </CardTitle>
+        <CardDescription>
+          Your published site URL on pagespace.site
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {subdomain && (
+          <a
+            href={`https://${subdomain}.pagespace.site`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-block text-sm text-blue-500 hover:underline"
+          >
+            {subdomain}.pagespace.site
+          </a>
+        )}
+        {canChange ? (
+          <>
+            <div className="flex gap-2 items-end">
+              <div className="flex-1 space-y-1.5">
+                <Label htmlFor="subdomain-input">Custom subdomain</Label>
+                <div className="flex items-center">
+                  <Input
+                    id="subdomain-input"
+                    value={inputValue}
+                    onChange={(e) => onInputChange(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && !isSaving && inputValue.trim().toLowerCase() !== subdomain && onSave()}
+                    placeholder="my-brand"
+                    className="rounded-r-none"
+                    disabled={isSaving}
+                  />
+                  <span className="inline-flex items-center px-3 h-9 rounded-r-md border border-l-0 bg-muted text-sm text-muted-foreground">
+                    .pagespace.site
+                  </span>
+                </div>
+              </div>
+              <Button
+                onClick={onSave}
+                disabled={isSaving || !inputValue.trim() || inputValue.trim().toLowerCase() === subdomain}
+              >
+                {isSaving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Save
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Preview: https://{preview}.pagespace.site
+            </p>
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Custom subdomain selection is a Pro feature. <Link href="/dashboard/settings/billing" className="text-blue-500 hover:underline">Upgrade</Link> to choose your own subdomain.
+          </p>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
@@ -35,6 +35,7 @@ interface DomainsResponse {
 interface SubdomainResponse {
   subdomain: string | null;
   canChange: boolean;
+  publishHost: string;
 }
 
 const fetcher = (url: string) => fetchWithAuth(url).then((r) => r.json());
@@ -310,6 +311,7 @@ export default function DomainsSettingsPage() {
 
       <SubdomainCard
         subdomain={subdomainData?.subdomain ?? null}
+        publishHost={subdomainData?.publishHost ?? 'pagespace.site'}
         canChange={subdomainData?.canChange ?? false}
         inputValue={subdomainInput}
         onInputChange={setSubdomainInput}
@@ -393,6 +395,7 @@ export default function DomainsSettingsPage() {
 
 interface SubdomainCardProps {
   subdomain: string | null;
+  publishHost: string;
   canChange: boolean;
   inputValue: string;
   onInputChange: (v: string) => void;
@@ -400,7 +403,7 @@ interface SubdomainCardProps {
   isSaving: boolean;
 }
 
-function SubdomainCard({ subdomain, canChange, inputValue, onInputChange, onSave, isSaving }: SubdomainCardProps) {
+function SubdomainCard({ subdomain, publishHost, canChange, inputValue, onInputChange, onSave, isSaving }: SubdomainCardProps) {
   const preview = inputValue.trim().toLowerCase() || subdomain || 'your-subdomain';
 
   return (
@@ -411,18 +414,18 @@ function SubdomainCard({ subdomain, canChange, inputValue, onInputChange, onSave
           Subdomain
         </CardTitle>
         <CardDescription>
-          Your published site URL on pagespace.site
+          Your published site URL on {publishHost}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {subdomain && (
           <a
-            href={`https://${subdomain}.pagespace.site`}
+            href={`https://${subdomain}.${publishHost}`}
             target="_blank"
             rel="noreferrer"
             className="inline-block text-sm text-blue-500 hover:underline"
           >
-            {subdomain}.pagespace.site
+            {subdomain}.{publishHost}
           </a>
         )}
         {canChange ? (
@@ -441,7 +444,7 @@ function SubdomainCard({ subdomain, canChange, inputValue, onInputChange, onSave
                     disabled={isSaving}
                   />
                   <span className="inline-flex items-center px-3 h-9 rounded-r-md border border-l-0 bg-muted text-sm text-muted-foreground">
-                    .pagespace.site
+                    .{publishHost}
                   </span>
                 </div>
               </div>
@@ -454,7 +457,7 @@ function SubdomainCard({ subdomain, canChange, inputValue, onInputChange, onSave
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Preview: https://{preview}.pagespace.site
+              Preview: https://{preview}.{publishHost}
             </p>
           </>
         ) : (

--- a/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
@@ -459,7 +459,7 @@ function SubdomainCard({ subdomain, canChange, inputValue, onInputChange, onSave
           </>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Custom subdomain selection is a Pro feature. <Link href="/dashboard/settings/billing" className="text-blue-500 hover:underline">Upgrade</Link> to choose your own subdomain.
+            Custom subdomain selection is a Pro feature. <Link href="/settings/billing" className="text-blue-500 hover:underline">Upgrade</Link> to choose your own subdomain.
           </p>
         )}
       </CardContent>

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -6,7 +6,7 @@ import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service'
 import { slugify } from '@pagespace/lib/utils/utils';
 import { validatePublishSubdomain, normalizeSubdomain } from '@pagespace/lib/validators/subdomain';
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { eq, and, ne } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
 import { isHomeDrive } from '@pagespace/lib/services/drive-guards';
@@ -21,6 +21,7 @@ import {
   copyPublishedArtifact,
   isPublishConfigured,
   getPublishAssetBaseUrl,
+  clearPublishedPrefix,
 } from './published-storage';
 import { rewriteCanvasAssets, rewriteInterPageLinksForDrive, extractAndStripOgMeta } from './asset-pipeline';
 import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml } from '@pagespace/lib/canvas/site-files';
@@ -473,10 +474,27 @@ export async function changePublishSubdomain(
     throw new PublishError(`Subdomain "${normalized}" is already taken`, 409);
   }
 
-  await db.update(drives).set({ publishSubdomain: normalized }).where(eq(drives.id, driveId));
+  try {
+    await db.update(drives).set({ publishSubdomain: normalized }).where(eq(drives.id, driveId));
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      throw new PublishError(`Subdomain "${normalized}" is already taken`, 409);
+    }
+    throw err;
+  }
 
   // Re-render all published pages under the new subdomain prefix.
-  await republishDriveCanonical(driveId, userId);
+  const publishedRows = await db.query.publishedPages.findMany({
+    where: eq(publishedPages.driveId, driveId),
+    columns: { pageId: true },
+  });
+  const refreshedCount = await republishDriveCanonical(driveId, userId);
+  if (refreshedCount !== publishedRows.length) {
+    throw new PublishError(
+      `Subdomain migration incomplete: refreshed ${refreshedCount}/${publishedRows.length} published pages`,
+      500,
+    );
+  }
 
   // Regenerate robots/sitemap/404 under the new prefix.
   await regeneratePublishedSiteFiles(driveId);

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -4,6 +4,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { isUniqueViolation } from '@pagespace/lib/services/subdomain-allocation';
 import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service';
 import { slugify } from '@pagespace/lib/utils/utils';
+import { validatePublishSubdomain, normalizeSubdomain } from '@pagespace/lib/validators/subdomain';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
@@ -432,6 +433,70 @@ export async function republishDriveCanonical(driveId: string, userId: string): 
  * lifecycle event will rebuild the files. No-op when publishing is unconfigured
  * or the drive has not yet been allocated a subdomain.
  */
+/**
+ * Change a drive's publish subdomain and migrate all published artifacts.
+ *
+ * Validates the new subdomain, checks global uniqueness, updates the DB, then
+ * re-renders every published page under the new prefix and regenerates site
+ * files. Old artifacts are deleted last (best-effort). The caller is responsible
+ * for auth and tier-gating.
+ */
+export async function changePublishSubdomain(
+  driveId: string,
+  candidate: string,
+  userId: string,
+): Promise<{ oldSubdomain: string | null; newSubdomain: string }> {
+  const drive = await db.query.drives.findFirst({
+    where: eq(drives.id, driveId),
+    columns: { id: true, publishSubdomain: true, kind: true },
+  });
+  if (!drive) throw new PublishError('Drive not found', 404);
+  if (isHomeDrive(drive)) throw new PublishError('Cannot change subdomain of a Home drive', 403);
+
+  const oldSubdomain = drive.publishSubdomain;
+
+  const normalized = normalizeSubdomain(candidate);
+  const validation = validatePublishSubdomain(normalized);
+  if (!validation.valid) {
+    throw new PublishError(validation.reason, 400);
+  }
+
+  if (normalized === oldSubdomain) {
+    return { oldSubdomain, newSubdomain: normalized };
+  }
+
+  const conflict = await db.query.drives.findFirst({
+    where: and(eq(drives.publishSubdomain, normalized), ne(drives.id, driveId)),
+    columns: { id: true },
+  });
+  if (conflict) {
+    throw new PublishError(`Subdomain "${normalized}" is already taken`, 409);
+  }
+
+  await db.update(drives).set({ publishSubdomain: normalized }).where(eq(drives.id, driveId));
+
+  // Re-render all published pages under the new subdomain prefix.
+  await republishDriveCanonical(driveId, userId);
+
+  // Regenerate robots/sitemap/404 under the new prefix.
+  await regeneratePublishedSiteFiles(driveId);
+
+  // Delete old artifacts (best-effort — pages already serve from new prefix).
+  if (oldSubdomain) {
+    try {
+      await clearPublishedPrefix(oldSubdomain);
+    } catch (err) {
+      loggers.api.warn('Failed to clear old subdomain prefix after change', {
+        driveId,
+        oldSubdomain,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { oldSubdomain, newSubdomain: normalized };
+}
+
 export async function regeneratePublishedSiteFiles(driveId: string): Promise<void> {
   try {
     if (!isPublishConfigured()) return;

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -21,7 +21,6 @@ import {
   copyPublishedArtifact,
   isPublishConfigured,
   getPublishAssetBaseUrl,
-  clearPublishedPrefix,
 } from './published-storage';
 import { rewriteCanvasAssets, rewriteInterPageLinksForDrive, extractAndStripOgMeta } from './asset-pipeline';
 import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml } from '@pagespace/lib/canvas/site-files';
@@ -483,35 +482,43 @@ export async function changePublishSubdomain(
     throw err;
   }
 
-  // Re-render all published pages under the new subdomain prefix.
-  const publishedRows = await db.query.publishedPages.findMany({
-    where: eq(publishedPages.driveId, driveId),
-    columns: { pageId: true },
-  });
-  const refreshedCount = await republishDriveCanonical(driveId, userId);
-  if (refreshedCount !== publishedRows.length) {
-    throw new PublishError(
-      `Subdomain migration incomplete: refreshed ${refreshedCount}/${publishedRows.length} published pages`,
-      500,
-    );
-  }
+  try {
+    // Re-render all published pages under the new subdomain prefix.
+    const publishedRows = await db.query.publishedPages.findMany({
+      where: eq(publishedPages.driveId, driveId),
+      columns: { pageId: true },
+    });
+    const refreshedCount = await republishDriveCanonical(driveId, userId);
+    if (refreshedCount !== publishedRows.length) {
+      throw new PublishError(
+        `Subdomain migration incomplete: refreshed ${refreshedCount}/${publishedRows.length} published pages`,
+        500,
+      );
+    }
 
-  // Regenerate robots/sitemap/404 under the new prefix.
-  await regeneratePublishedSiteFiles(driveId);
-
-  // Delete old artifacts (best-effort — pages already serve from new prefix).
-  if (oldSubdomain) {
+    // Regenerate robots/sitemap/404 under the new prefix.
+    await regeneratePublishedSiteFiles(driveId);
+  } catch (err) {
+    // Roll back subdomain pointer so the drive keeps serving from the previous
+    // host when migration doesn't fully complete.
     try {
-      await clearPublishedPrefix(oldSubdomain);
-    } catch (err) {
-      loggers.api.warn('Failed to clear old subdomain prefix after change', {
+      await db.update(drives).set({ publishSubdomain: oldSubdomain }).where(eq(drives.id, driveId));
+    } catch (rollbackErr) {
+      loggers.api.error('Failed to roll back publish subdomain after migration error', {
         driveId,
         oldSubdomain,
-        error: err instanceof Error ? err.message : String(err),
+        attemptedSubdomain: normalized,
+        error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
       });
     }
+
+    if (err instanceof PublishError) throw err;
+    throw new PublishError('Failed to migrate published artifacts to new subdomain', 500);
   }
 
+  // Do not clear the old prefix here. Once the DB pointer changes, the old
+  // subdomain can be claimed by another drive; prefix-wide deletion could remove
+  // artifacts that no longer belong to this drive.
   return { oldSubdomain, newSubdomain: normalized };
 }
 

--- a/apps/web/src/lib/subscription/__tests__/plans.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/plans.test.ts
@@ -218,5 +218,13 @@ describe('Subscription Plans', () => {
         expect(plans[i].limits.monthlyCreditsCents).toBeGreaterThan(plans[i - 1].limits.monthlyCreditsCents);
       }
     });
+    });
+
+    it('should gate canChooseSubdomain to Pro and above', () => {
+      expect(PLANS.free.limits.canChooseSubdomain).toBe(false);
+      expect(PLANS.pro.limits.canChooseSubdomain).toBe(true);
+      expect(PLANS.founder.limits.canChooseSubdomain).toBe(true);
+      expect(PLANS.business.limits.canChooseSubdomain).toBe(true);
+    });
   });
 });

--- a/apps/web/src/lib/subscription/__tests__/plans.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/plans.test.ts
@@ -218,7 +218,6 @@ describe('Subscription Plans', () => {
         expect(plans[i].limits.monthlyCreditsCents).toBeGreaterThan(plans[i - 1].limits.monthlyCreditsCents);
       }
     });
-    });
 
     it('should gate canChooseSubdomain to Pro and above', () => {
       expect(PLANS.free.limits.canChooseSubdomain).toBe(false);

--- a/apps/web/src/lib/subscription/plans.ts
+++ b/apps/web/src/lib/subscription/plans.ts
@@ -101,6 +101,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         formatted: '50MB',
       },
       maxCustomDomains: 0,
+      canChooseSubdomain: false,
     },
     features: [
       { name: monthlyCreditsPhrase('free'), included: true },
@@ -148,6 +149,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         formatted: '250MB',
       },
       maxCustomDomains: 1,
+      canChooseSubdomain: true,
     },
     features: [
       { name: monthlyCreditsPhrase('pro'), included: true, description: '3x more than Free' },
@@ -192,6 +194,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         formatted: '500MB',
       },
       maxCustomDomains: 3,
+      canChooseSubdomain: true,
     },
     features: [
       { name: monthlyCreditsPhrase('founder'), included: true, description: '10x more than Free' },

--- a/apps/web/src/lib/subscription/plans.ts
+++ b/apps/web/src/lib/subscription/plans.ts
@@ -54,6 +54,11 @@ export interface PlanDefinition {
      * this tier. The add-domain endpoint enforces this at request time.
      */
     maxCustomDomains: number;
+    /**
+     * Whether the user can choose a custom subdomain for their published
+     * canvas site. Free users get the auto-allocated slug; Pro+ can change it.
+     */
+    canChooseSubdomain: boolean;
   };
   features: PlanFeature[];
   highlighted?: boolean;
@@ -226,6 +231,7 @@ export const PLANS: Record<SubscriptionTier, PlanDefinition> = {
         formatted: '1GB',
       },
       maxCustomDomains: 10,
+      canChooseSubdomain: true,
     },
     features: [
       { name: monthlyCreditsPhrase('business'), included: true, description: '20x more than Free' },


### PR DESCRIPTION
## What

Pro+ users can now change their published canvas site's subdomain from the auto-allocated slug to a custom one via **Drive Settings -> Domains & Publishing**.

## Changes

| Area | File | Change |
|------|------|--------|
| Plans | `plans.ts` | Added `canChooseSubdomain` to `PlanDefinition.limits` (false: free, true: pro/founder/business) |
| Backend | `publish-page.ts` | New `changePublishSubdomain()`: validates subdomain, checks uniqueness, updates `drives.publishSubdomain`, re-renders all published pages under new prefix, regenerates site files, cleans up old artifacts |
| API | `api/drives/[driveId]/subdomain/route.ts` | New endpoint: GET (status + canChange flag), PATCH (change subdomain with tier-gating) |
| UI | `domains/page.tsx` | New Subdomain card with live URL preview, Pro+ gating, upgrade CTA for free users |
| Test | `plans.test.ts` | Verify `canChooseSubdomain` gating across all tiers |

## Tier gating

- **Free**: subdomain auto-allocated from drive slug, read-only display with upgrade CTA
- **Pro/Founder/Business**: editable subdomain input with validation, live preview, and instant migration

## Migration behavior

When a user changes their subdomain:
1. New subdomain validated and checked for global uniqueness
2. `drives.publishSubdomain` updated in DB
3. All published pages re-rendered under the new prefix (reuses `republishDriveCanonical`)
4. Site files (robots.txt, sitemap.xml, 404.html) regenerated
5. Old artifacts deleted via `clearPublishedPrefix` (best-effort)

## Security
- Owner/admin only (both API and UI)
- CSRF protected
- Reserved subdomains blocked by existing validator

## Notes
- Could not run `tsc --noEmit` or tests in sandbox (no node_modules). CI should catch any type errors.
- SKILL.md in PageSpace workspace updated separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and changing a published site’s custom subdomain.
  * The settings page now shows the current subdomain, a live preview URL, and upgrade messaging for unavailable tiers.

* **Bug Fixes**
  * Improved validation and error handling when updating subdomains.
  * Ensures subdomain changes update published pages and related site files consistently.

* **Tests**
  * Added coverage for tier-based subdomain availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->