### PR TITLE
chore(deps): raise node engines to >=22 and zod floor to ^4.1.8 (AI SDK 7 prep)

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -40,7 +40,7 @@
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
     "stripe": "^20.1.0",
-    "zod": "^4.0.16"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,7 +26,7 @@
     "electron-updater": "^6.6.2",
     "node-machine-id": "^1.1.12",
     "ws": "^8.18.3",
-    "zod": "^4.0.16"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.17.12",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -124,7 +124,7 @@
     "use-debounce": "^10.0.5",
     "use-stick-to-bottom": "^1.1.1",
     "ws": "^8.18.3",
-    "zod": "^4.0.16",
+    "zod": "^4.1.8",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "recharts": "^3.1.2",
         "stripe": "^20.1.0",
         "tailwind-merge": "^3.3.1",
-        "zod": "^4.0.16",
+        "zod": "^4.1.8",
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -154,7 +154,7 @@
         "electron-updater": "^6.6.2",
         "node-machine-id": "^1.1.12",
         "ws": "^8.18.3",
-        "zod": "^4.0.16",
+        "zod": "^4.1.8",
       },
       "devDependencies": {
         "@types/node": "^20.17.12",
@@ -431,7 +431,7 @@
         "use-debounce": "^10.0.5",
         "use-stick-to-bottom": "^1.1.1",
         "ws": "^8.18.3",
-        "zod": "^4.0.16",
+        "zod": "^4.1.8",
         "zustand": "^5.0.6",
       },
       "devDependencies": {
@@ -501,7 +501,7 @@
         "server-only": "^0.0.1",
         "xlsx": "^0.18.5",
         "yaml": "^2.8.2",
-        "zod": "^4.0.16",
+        "zod": "^4.1.8",
       },
       "devDependencies": {
         "@react-email/preview-server": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "UNLICENSED",
   "engines": {
-    "node": ">=20.3.0"
+    "node": ">=22"
   },
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1775,7 +1775,7 @@
     "server-only": "^0.0.1",
     "xlsx": "^0.18.5",
     "yaml": "^2.8.2",
-    "zod": "^4.0.16"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@react-email/preview-server": "5.1.1",


### PR DESCRIPTION
## What

Phase 0 of the **AI SDK 7 Migration & Durable Execution** epic — a tiny, standalone, safe floor bump that lands on `master` ahead of the version PRs.

- Root `package.json`: `engines.node` `">=20.3.0"` → `">=22"`
- `zod` `^4.0.16` → `^4.1.8` in `packages/lib`, `apps/web`, `apps/admin`, `apps/desktop`
- `apps/marketing` was already at `^4.1.11` — left untouched

## Why

`ai@7` requires `node >=22` and `zod ^3.25.76 || ^4.1.8`. Prod Dockerfiles already run node 22/24, but root `engines.node` was stale (`>=20.3.0`) and `zod` was pinned just below ai@7's floor (`^4.0.16`). Bumping now de-risks the later version PRs.

## Scope guardrails

- **No** `ai` / `@ai-sdk/*` / `@openrouter/*` version changes — that's Phase 1+. Still on `ai@5`; this is only the floor bump.
- `bun install` clean; zod resolves to a single `4.3.6` across the workspace (no split).
- `bun run typecheck` ✅ (13/13) and `bun run lint` ✅ (13/13, only pre-existing warnings) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)