### PR TITLE
test(ci): exercise tests on Node 24 (match prod) + fix jsdom/undici AbortSignal mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          # Node 24 matches the version `web` and `realtime` run in production.
+          # Keep CI on the same major so version-specific behavior (e.g. undici's
+          # native AbortSignal instanceof check) is exercised before we ship.
+          node-version: '24'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -1,3 +1,14 @@
+// @vitest-environment node
+//
+// This is an API route-handler test: it exercises server code only and has no
+// reason to run under jsdom. It MUST run in the `node` environment because the
+// tests construct `new Request(url, { signal })` with an `AbortSignal`. Under
+// jsdom, `AbortController`/`AbortSignal` are jsdom's implementations, but the
+// global `Request` is Node's (undici). On Node >=24 undici's `Request` does a
+// strict `instanceof` brand check against the *native* AbortSignal and rejects
+// the jsdom signal ("Expected signal to be an instance of AbortSignal"). The
+// node environment uses native AbortSignal throughout, so the check passes on
+// every Node version. See PR: jsdom AbortSignal vs undici Request on Node >=24.
 import { describe, test, beforeEach, vi } from 'vitest';
 import { assert } from '@/lib/ai/openai-api/__tests__/riteway';
 


### PR DESCRIPTION
## Root cause

The chat-completions API route test constructs `new Request(url, { signal })` with an `AbortSignal`. The web vitest config sets `environment: 'jsdom'` for ALL tests. Under jsdom, the global `AbortController`/`AbortSignal` are jsdom's implementations, but the global `Request` is Node's (undici). On **Node >=24** (newer bundled undici), undici's `Request` does a strict `instanceof` brand check against the *native* `AbortSignal` and rejects the jsdom signal:

```
TypeError: RequestInit: Expected signal ("AbortSignal {}") to be an instance of AbortSignal.
```

On **Node 22** the check passes. Production (`web`/`realtime`) runs Node 24, but CI ran tests on Node 22 — so the version that ships was never exercised. Exactly two tests failed on Node 24:
- `consumer disconnect settles billing once as aborted and releases the hold`
- `request already aborted before streaming trips the model abort signal`

(both in `apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts`)

## What changed

**1. Test env fix (Option A — minimal, per-file).** Added a `// @vitest-environment node` docblock to `route.test.ts` with a comment explaining the jsdom-AbortSignal-vs-undici-Request mismatch. This is a server-only route-handler test with no need for jsdom; the `node` env uses native `AbortSignal` throughout, so the undici check passes on every Node version. A sweep of `src/app/api/**` confirmed this is the **only** api route test that passes a `signal` into `new Request`, so no other files needed the change.

**2. CI test job bumped to Node 24.** `.github/workflows/ci.yml` `unit-tests` job: `node-version: '22'` → `'24'` to match the version web/realtime actually run in production. Only the `unit-tests` job had a `node-version` pin. The `lint` job uses bun directly (no node pin). `build-desktop.yml` (Node 20, intentional) and `fix-migrations.yml` were left untouched.

## Verification

- Target file: **42/42 pass on Node 24 AND Node 22** (was 2 failed / 42 on Node 24, 42 passed on Node 22).
- `bun run --filter 'web' typecheck` — green on Node 24.
- `bun run --filter 'web' lint` — green on Node 24 (only pre-existing warnings).
- Full `apps/web` suite on Node 24: `16 failed | 10471 passed`. The 16 failures are **pre-existing and unrelated** — `admin-role-version.test.ts` (×14) and `activity-tools.test.ts` (×1) need a real DB (this worktree has none; stack traces show drizzle/pg-pool connections), and `grouping.test.ts` (×1) is timezone-dependent. They pass in CI (which provisions Postgres). The two AbortSignal tests are no longer among the failures — the only delta this PR set out to eliminate is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test environment for API route tests to run in Node, improving compatibility with the runtime used in production.

* **Chores**
  * Bumped the CI Node.js version to 24 for the unit test job so checks better match the production runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->