### PR TITLE
test(ci): exercise tests on Node 24 (match prod) + fix jsdom/undici AbortSignal mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - name: Setup Node.js
+      # Test on the Node version we ship. apps/web and apps/realtime run Node 24
+      # in production (see their Dockerfiles), so the bulk of the suite runs here.
+      # apps/processor is the exception: it ships on Node 22 and its Magika
+      # (onnxruntime) content detection fails to load on Node 24 — so it is
+      # excluded here and run separately below on its own Node 22 runtime.
+      - name: Setup Node.js (24 — web/realtime runtime)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
@@ -58,10 +63,23 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pagespace_test
         run: bun run --filter '@pagespace/db' db:migrate
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage (Node 24)
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pagespace_test
-        run: bun run test:coverage
+        run: bunx turbo run test:coverage --filter='!@pagespace/processor'
+
+      # apps/processor ships on Node 22 (apps/processor/Dockerfile). Magika's
+      # onnxruntime native bindings fail to initialize on Node 24, so test the
+      # processor on the runtime it actually deploys to.
+      - name: Setup Node.js (22 — processor runtime)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22'
+
+      - name: Run processor tests with coverage (Node 22)
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pagespace_test
+        run: bunx turbo run test:coverage --filter='@pagespace/processor'
 
       # Backfill scripts have their own vitest context (scripts/vitest.config.ts)
       # and are not part of any workspace package, so the turbo test pipeline

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -1,3 +1,9 @@
+// @vitest-environment node
+// These are API route-handler tests with no DOM needs. The default jsdom env
+// makes AbortController/AbortSignal jsdom globals while Request stays Node's
+// undici, so on Node >=24 `new Request(url, { signal })` throws because the
+// jsdom AbortSignal fails undici's `instanceof AbortSignal` check. Running this
+// file under the node env keeps both on the same (undici) implementation.
 import { describe, test, beforeEach, vi } from 'vitest';
 import { assert } from '@/lib/ai/openai-api/__tests__/riteway';
 


### PR DESCRIPTION
## Root cause

Production runs **Node 24** for `apps/web` and `apps/realtime` (see their Dockerfiles), but CI tested on **Node 22** (`.github/workflows/ci.yml`). The suite was never exercised on the runtime we ship — and that skew was hiding real breakage: two route-handler tests already **failed on Node 24** while **passing on Node 22**.

`apps/web/vitest.config.ts` sets the `jsdom` environment for ALL tests. Under jsdom, `AbortController`/`AbortSignal` are jsdom globals, but `Request` stays Node's undici. On Node >=24, `new Request(url, { signal })` throws:

```
TypeError: RequestInit: Expected signal ("AbortSignal {}") to be an instance of AbortSignal.
```

because the jsdom `AbortSignal` fails undici's `instanceof AbortSignal` check. Both failing tests construct a `new Request(...)` with an `AbortSignal` in the test body.

## What changed

**1. Test env fix** — added a `// @vitest-environment node` docblock (plus a WHY comment) to the top of `apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts`. These are API route-handler tests with no DOM needs; the `node` env keeps `AbortSignal` and `Request` on the same (undici) implementation. Version-agnostic — no Node-version conditionals.

**2. CI now tests each app on its shipped Node version** (`.github/workflows/ci.yml`, `unit-tests` job — the only job that pins a Node version; the `lint` job runs purely under bun with no `setup-node` step):

- **Node 24** (web + realtime production runtime): full suite **minus** processor — `turbo run test:coverage --filter='!@pagespace/processor'`.
- **Node 22** (processor production runtime): processor only — `turbo run test:coverage --filter='@pagespace/processor'`.

Both runs happen in the same job/checkout, so coverage aggregation (which globs `apps/*/coverage`) is unchanged.

Why the split: bumping the whole job to Node 24 surfaced failures in `apps/processor` (`content-detector.test.ts`, `processing-pipeline.test.ts`) — Magika's onnxruntime native bindings fail to initialize on Node 24 (`'magika'`->`'fallback'`, `pdf`/`elf`->`'unknown'`). But the processor **ships on Node 22** (`apps/processor/Dockerfile`), so that is a runtime mismatch, not a production bug. Testing it on Node 24 would test a runtime it never deploys to. `build-desktop.yml` (Node 20) and `fix-migrations.yml` were intentionally **not** touched.

## Verification

Target file `chat/completions/route.test.ts`:

| | Node 22 | Node 24 |
|---|---|---|
| before fix | 42/42 passed | 2 failed / 40 passed |
| after fix | **42/42 passed** | **42/42 passed** |

Processor tests (`content-detector` + `processing-pipeline`): **23/23 on Node 22**, 2 failed on Node 24 — hence run on Node 22.

- `bun run --filter 'web' typecheck` → green on Node 24
- `bun run --filter 'web' lint` → green on Node 24 (pre-existing warnings only)

The ~16 other failures in a DB-less local worktree (`admin-role-version.test.ts` ×14, `activity-tools.test.ts` ×1, `grouping.test.ts` ×1) are pre-existing, require a real Postgres / are a timezone test, pass in CI (which has a DB), and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run on the appropriate Node.js versions for different parts of the project.
  * Improved CI coverage execution so each app is tested in a more compatible environment.

* **Tests**
  * Adjusted one test suite to use the Node.js environment, preventing runtime compatibility issues and reducing flaky failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->