### PR TITLE
fix(read_page): show page body AND task descriptions on TASK_LIST pages

### DIFF
--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -174,7 +174,9 @@ describe('MCP Documents API — TASK_LIST read', () => {
     mockSerializeTaskItem.mockImplementation((t: unknown) => t);
   });
 
-  it('returns structured task list data (not numberedLines) for TASK_LIST pages', async () => {
+  it('returns structured task list data AND the page body for TASK_LIST pages', async () => {
+    mockFindFirstPage.mockResolvedValue({ ...TASK_LIST_PAGE, content: 'task body line 1\ntask body line 2' });
+
     const { POST } = await import('../route');
     const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
 
@@ -186,8 +188,10 @@ describe('MCP Documents API — TASK_LIST read', () => {
     expect(data.tasks).toBeDefined();
     expect(data.availableStatuses).toBeDefined();
     expect(data.progress).toBeDefined();
-    expect(data.numberedLines).toBeUndefined();
-    expect(data.content).toBeUndefined();
+    // The page's own content body is rendered alongside the task view.
+    expect(data.numberedLines).toBeDefined();
+    expect(data.content).toBe('task body line 1\ntask body line 2');
+    expect(data.totalLines).toBe(2);
   });
 
   it('returns numberedLines for non-TASK_LIST pages (regression guard)', async () => {
@@ -323,8 +327,8 @@ describe('MCP Documents API — TASK_LIST read', () => {
     expect(mockBackfillMissingTaskItems).not.toHaveBeenCalled();
   });
 
-  it('maps enriched tasks through serializeTaskItem', async () => {
-    const raw = [{ id: 't1', status: 'pending', completedAt: null }];
+  it('maps enriched tasks through serializeTaskItem and adds each task description', async () => {
+    const raw = [{ id: 't1', status: 'pending', completedAt: null, page: { title: 'Task 1', content: 'do the thing' } }];
     const serialized = { id: 't1', title: 'Task 1', status: 'pending' };
     mockFetchEnrichedTasks.mockResolvedValue(raw);
     mockSerializeTaskItem.mockReturnValue(serialized);
@@ -334,6 +338,20 @@ describe('MCP Documents API — TASK_LIST read', () => {
 
     const data = await response.json();
     expect(mockSerializeTaskItem).toHaveBeenCalledWith(raw[0]);
-    expect(data.tasks[0]).toEqual(serialized);
+    // Description comes from the task's own linked page content.
+    expect(data.tasks[0]).toEqual({ ...serialized, description: 'do the thing' });
+  });
+
+  it('defaults task description to empty string when the linked page has no content', async () => {
+    const raw = [{ id: 't1', status: 'pending', completedAt: null }];
+    const serialized = { id: 't1', title: 'Task 1', status: 'pending' };
+    mockFetchEnrichedTasks.mockResolvedValue(raw);
+    mockSerializeTaskItem.mockReturnValue(serialized);
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(data.tasks[0]).toEqual({ ...serialized, description: '' });
   });
 });

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -327,7 +327,7 @@ describe('MCP Documents API — TASK_LIST read', () => {
     expect(mockBackfillMissingTaskItems).not.toHaveBeenCalled();
   });
 
-  it('maps enriched tasks through serializeTaskItem and adds each task description', async () => {
+  it('maps enriched tasks through serializeTaskItem and flags tasks that have a description', async () => {
     const raw = [{ id: 't1', status: 'pending', completedAt: null, page: { title: 'Task 1', content: 'do the thing' } }];
     const serialized = { id: 't1', title: 'Task 1', status: 'pending' };
     mockFetchEnrichedTasks.mockResolvedValue(raw);
@@ -338,11 +338,12 @@ describe('MCP Documents API — TASK_LIST read', () => {
 
     const data = await response.json();
     expect(mockSerializeTaskItem).toHaveBeenCalledWith(raw[0]);
-    // Description comes from the task's own linked page content.
-    expect(data.tasks[0]).toEqual({ ...serialized, description: 'do the thing' });
+    // Only a boolean flag is exposed — never the child page body, which belongs
+    // to a page this principal may not be authorized to read.
+    expect(data.tasks[0]).toEqual({ ...serialized, hasContent: true });
   });
 
-  it('defaults task description to empty string when the linked page has no content', async () => {
+  it('reports hasContent false when the linked task page has no description', async () => {
     const raw = [{ id: 't1', status: 'pending', completedAt: null }];
     const serialized = { id: 't1', title: 'Task 1', status: 'pending' };
     mockFetchEnrichedTasks.mockResolvedValue(raw);
@@ -352,6 +353,22 @@ describe('MCP Documents API — TASK_LIST read', () => {
     const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
 
     const data = await response.json();
-    expect(data.tasks[0]).toEqual({ ...serialized, description: '' });
+    expect(data.tasks[0]).toEqual({ ...serialized, hasContent: false });
+  });
+
+  it('never returns child task page bodies (no inheritance: parent grant must not leak child content)', async () => {
+    const secret = 'SECRET child task body that the caller is not authorized to read';
+    const raw = [{ id: 't1', status: 'pending', completedAt: null, page: { title: 'Task 1', content: `<p>${secret}</p>` } }];
+    mockFetchEnrichedTasks.mockResolvedValue(raw);
+    mockSerializeTaskItem.mockImplementation((t: { id: string; status: string }) => ({ id: t.id, status: t.status }));
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    const data = await response.json();
+    expect(data.tasks[0].hasContent).toBe(true);
+    expect(data.tasks[0].description).toBeUndefined();
+    // The child body must not appear anywhere in the serialized response.
+    expect(JSON.stringify(data)).not.toContain(secret);
   });
 });

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -5,6 +5,7 @@ import { pages } from '@pagespace/db/schema/core';
 import { taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';
 import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
+import { computeHasContent } from '@/app/api/pages/[pageId]/tasks/task-utils';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
 import { z } from 'zod/v4';
@@ -240,9 +241,15 @@ export async function POST(req: NextRequest) {
 
           // A TASK_LIST page also has its own content body (e.g. an
           // individual task page whose body holds the description / sub-tasks).
-          // Render both the body and the structured task view.
+          // This body belongs to `pageId` itself — already authorized above —
+          // so it is safe to return. Render both the body and the task view.
           const numberedLines = getNumberedLines(currentContent);
 
+          // Each task is a child TASK_LIST page. Page permissions do NOT inherit
+          // to children, and this route only authorizes `pageId`, so we must NOT
+          // return child page bodies here. Mirror the canonical task-list API
+          // (GET /api/pages/[pageId]/tasks) which exposes only a `hasContent`
+          // boolean — read_page the individual task to view its description.
           return NextResponse.json({
             pageId,
             pageTitle: page.title,
@@ -251,7 +258,7 @@ export async function POST(req: NextRequest) {
             totalLines: lines.length,
             numberedLines,
             content: currentContent,
-            tasks: tasks.map(t => ({ ...serializeTaskItem(t), description: t.page?.content ?? '' })),
+            tasks: tasks.map(t => ({ ...serializeTaskItem(t), hasContent: computeHasContent(t.page?.content) })),
             availableStatuses,
             progress: {
               total: totalTasks,

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -238,12 +238,20 @@ export async function POST(req: NextRequest) {
           const completedCount = byGroup.done || 0;
           const progressPercentage = totalTasks > 0 ? Math.round((completedCount / totalTasks) * 100) : 0;
 
+          // A TASK_LIST page also has its own content body (e.g. an
+          // individual task page whose body holds the description / sub-tasks).
+          // Render both the body and the structured task view.
+          const numberedLines = getNumberedLines(currentContent);
+
           return NextResponse.json({
             pageId,
             pageTitle: page.title,
             pageType: 'TASK_LIST',
             taskListId: taskList.id,
-            tasks: tasks.map(t => serializeTaskItem(t)),
+            totalLines: lines.length,
+            numberedLines,
+            content: currentContent,
+            tasks: tasks.map(t => ({ ...serializeTaskItem(t), description: t.page?.content ?? '' })),
             availableStatuses,
             progress: {
               total: totalTasks,

--- a/apps/web/src/lib/ai/tools/task-helpers.ts
+++ b/apps/web/src/lib/ai/tools/task-helpers.ts
@@ -182,7 +182,7 @@ export async function fetchEnrichedTasks(parentPageId: string) {
     with: {
       assignee: { columns: { id: true, name: true, image: true } },
       assigneeAgent: { columns: { id: true, title: true, type: true } },
-      page: { columns: { title: true } },
+      page: { columns: { title: true, content: true } },
       assignees: {
         with: {
           user: { columns: { id: true, name: true } },


### PR DESCRIPTION
## Problem

`read_page` on a `TASK_LIST` page stopped showing task descriptions. Commit da29b05 added a dedicated TASK_LIST render path that returns/renders **only** the structured task list (tasks, statuses, progress) and dropped everything else that used to render:

1. **The page's own body is gone.** Before da29b05 every page (TASK_LIST included) rendered its content as `numberedLines`. Since each task page is itself `TASK_LIST`-typed, reading an individual task hit the new branch and its description body vanished.
2. **No signal of per-task descriptions.** The list view only showed title/status/assignee/dueDate.

## Changes

- **`task-helpers.ts`** — `fetchEnrichedTasks` selects each task's linked-page `content` (used server-side only, to derive a boolean — never returned raw).
- **`api/mcp/documents/route.ts`** — the `TASK_LIST` read branch now returns:
  - The page's **own** body (`totalLines`, `numberedLines`, `content`). This belongs to the authorized `pageId` itself, so it is safe.
  - A per-task **`hasContent`** boolean (via `computeHasContent`) so callers know a description exists.
- **Tests** — updated expectations + added a security regression test asserting child bodies never appear in the response.

## Security note (addressed in this PR)

An earlier revision returned each child task's raw page `content` as `description`. That **leaked child task page bodies**: this route authorizes only `pageId` via `getPrincipalAccessLevel`, the tasks are child `TASK_LIST` pages fetched by `parentId`, and **page permissions do not inherit to children** (`packages/lib` `permissions.test.ts`). A principal with only a page-level grant on the parent could read child bodies they cannot access directly.

The fix mirrors the canonical task-list API (`GET /api/pages/[pageId]/tasks`, used by the web UI), which deliberately exposes only a `hasContent` boolean per task and never the child body. To read a task's description, `read_page` its individual `pageId` (which authorizes that page).

## Companion change (separate repo)

The MCP renderer fix lands in **pagespace-mcp** (2witstudios/pagespace-mcp#7): adds a `## Page Content` section, renders a "has description (read_page …)" marker per task, and fixes a secondary bug where `@${t.assignee}` interpolated the assignee object (`@[object Object]`) instead of `@${t.assignee.name}`.

## Verification

- MCP documents tests: 27/27 pass (incl. new no-leak regression test)
- task / page-read tool tests: 71/71 pass
- `web` typecheck: clean · `web` lint: clean (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `TASK_LIST` read responses now include the page body plus `totalLines` and `numberedLines`.
  * Serialized task entries now include a `hasContent` flag based on linked page content.
* **Bug Fixes**
  * Tasks with missing linked page content correctly report `hasContent: false`, and linked child page bodies are not exposed in the response.
* **Tests**
  * Updated/expanded assertions for `TASK_LIST` read responses and enriched task serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->