### PR TITLE
Trim CLAUDE.md: remove stale info and derivable content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,118 +1,60 @@
 # PageSpace
 
-PageSpace is an AI-native knowledge management and collaboration platform. Humans and AI agents work together in shared workspaces using 33+ real tools — AI can create, edit, organize, and search content directly, not just answer questions. The platform supports 9 page types (Document, Code, Sheet, Canvas, Task List, Channel, AI Chat, File, Folder), 100+ AI models across multiple providers, and MCP protocol integration. Available as cloud SaaS (pagespace.ai), self-hosted, desktop (Electron), and mobile (Capacitor).
+AI-native knowledge management platform. bun workspace + Turbo monorepo.
 
-## Monorepo Structure
-
-bun workspace + Turbo build system.
+## Monorepo Layout
 
 ```
-apps/
-  web/              # Next.js 15 main app (frontend + API routes)
-  realtime/         # Socket.IO real-time collaboration server
-  processor/        # File processing (uploads, images, OCR, PDF extraction)
-  control-plane/    # Fastify tenant provisioning, Stripe billing, lifecycle mgmt
-  desktop/          # Electron wrapper (macOS, Windows, Linux)
-  ios/              # Capacitor iOS wrapper
-  android/          # Capacitor Android wrapper
-  marketing/        # Marketing site (pagespace.ai landing pages)
-  atlas/            # Internal architecture visualization (React Flow)
-
-packages/
-  db/               # Drizzle ORM schema + migrations (PostgreSQL)
-  lib/              # Shared auth, permissions, services, integrations, utilities
+apps/       web (Next.js 15), realtime (Socket.IO), processor (file processing),
+            control-plane (billing/provisioning), admin, marketing, atlas,
+            desktop (Electron), ios/android (Capacitor), e2e
+packages/   db (Drizzle/Postgres), lib (auth, permissions, services, integrations)
 ```
-
-## Tech Stack
-
-- **Full-stack**: Next.js 15 App Router + TypeScript + Tailwind + shadcn/ui
-- **Database**: PostgreSQL + Drizzle ORM
-- **AI**: Vercel AI SDK + multi-provider (Anthropic, OpenAI, Google, xAI, OpenRouter, Ollama)
-- **Auth**: Passwordless — passkeys (WebAuthn) + magic links. Opaque session tokens, SHA3-256 hashed at rest.
-- **Real-time**: Socket.IO (single-process fanout; no external broker)
-- **Editors**: TipTap (rich text), Monaco (code), custom sheet + canvas
-- **State**: Zustand (client) + SWR (server cache)
-- **Build**: bun + Turbo + Docker Compose
-- **Deployment**: Docker images on GHCR (`ghcr.io/2witstudios/`), Caddy reverse proxy
-- **Deploy repo**: Compose file, Caddyfile, deploy scripts at `/Users/jono/production/PageSpace-Deploy/`
-
-## Deployment Modes
-
-Three modes via `DEPLOYMENT_MODE` env var (see `packages/lib/src/deployment-mode.ts`):
-
-- **`cloud`** (default) — SaaS at pagespace.ai. Stripe billing, OAuth, self-registration enabled.
-- **`onprem`** — Self-hosted. Disables Stripe, OAuth, self-registration. Password auth, local AI, admin-managed accounts.
-- **`tenant`** — Managed multi-tenant. Billing at the control plane. All users get business-tier features. Cloud-only routes blocked.
 
 ## Critical Rules
 
-**Package manager**: Always use `bun`. Never `npm` or `pnpm`. This is a bun workspace — everything breaks otherwise.
+- **bun only**. Never npm/pnpm. Bun workspace breaks otherwise.
+- **Next.js 15 async params**: `params` in dynamic routes are Promises. Always `await context.params`. Destructuring without await = silent runtime bug.
+- **Migrations**: Never edit SQL in `packages/db/drizzle/`. Run `bun run db:generate` from schema changes.
+- **No `any` types**. TypeScript strict mode.
+- **Message content**: Use `parts` array structure. See `packages/lib/src/types.ts`.
+- **Permissions**: Use centralized functions from `packages/lib/src/permissions/`. Never roll your own.
+- **UI refresh protection**: Components editing/streaming content must register with `useEditingStore` (`apps/web/src/stores/useEditingStore.ts`) to prevent SWR clobbering.
 
-**Next.js 15 async params**: `params` in dynamic routes are Promises. You MUST await them:
-```typescript
-export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
-  const { id } = await context.params;
-}
-```
-Destructuring params directly without await is a silent runtime bug.
+## Deployment Modes
 
-**Database migrations**: Never manually create or edit SQL files in `packages/db/drizzle/`. Always use `bun run db:generate` from schema changes in `packages/db/src/schema/`.
+`DEPLOYMENT_MODE` env var controls feature gating (`packages/lib/src/deployment-mode.ts`):
 
-**No `any` types**: Always use proper TypeScript types.
+- `cloud` (default) — SaaS. Full features, Stripe billing.
+- `tenant` — Dedicated-image cloud. Same feature set as cloud; different infra topology and billing path (control plane, not Stripe).
+- `onprem` — Self-hosted. No external integrations (OAuth, Google Calendar, external AI). Password auth, local AI only.
 
-**Message content**: Always use the `parts` array structure for message content. Read the message types in `packages/lib/src/types.ts` for the canonical shape.
-
-**Permissions**: Always use the centralized permission functions from `packages/lib/src/permissions/`. Never roll your own access checks.
-
-**UI refresh protection**: Any component that edits content or streams AI must register state with `useEditingStore` to prevent SWR from clobbering in-progress work. Read `apps/web/src/stores/useEditingStore.ts` for the API.
-
-**Changelog**: When changes land, update the changelog and any user-visible notes.
+Guard selection: use `isOnPrem()` to gate integrations. `isBillingEnabled()` gates billing (false for onprem + tenant). Never use `!isCloud()` to gate integrations — it incorrectly restricts tenant.
 
 ## Key Source Locations
-
-When you need to understand a subsystem, read these canonical sources (not docs that may be stale):
 
 | Area | Path |
 |------|------|
 | Page types enum | `packages/lib/src/utils/enums.ts` |
 | Permissions | `packages/lib/src/permissions/` |
-| Auth (opaque tokens, sessions) | `packages/lib/src/auth/` |
+| Auth (tokens, sessions) | `packages/lib/src/auth/` |
 | UI refresh protection | `apps/web/src/stores/useEditingStore.ts` |
-| Integrations (GitHub, Calendar, OAuth) | `packages/lib/src/integrations/` |
-| DB schema (all tables) | `packages/db/src/schema/` |
-| Services (billing, search, calendar sync) | `packages/lib/src/services/` |
-| Deployment mode detection | `packages/lib/src/deployment-mode.ts` |
+| Integrations | `packages/lib/src/integrations/` |
+| DB schema | `packages/db/src/schema/` |
+| Services | `packages/lib/src/services/` |
+| Deployment mode | `packages/lib/src/deployment-mode.ts` |
 | AI provider setup | `apps/web/src/lib/ai/` |
 | Real-time events | `apps/realtime/src/` |
 
 ## Commands
 
 ```bash
-# Development
-bun run dev                          # Start all services (web, realtime, processor — excludes control-plane)
-bun run dev:services                 # Start Postgres, processor, realtime via Docker
-bun run --filter 'web' dev           # Start web app only
-bun run --filter 'realtime' dev      # Start realtime service only
-bun run --filter 'processor' dev     # Start processor service only
-bun run dev:desktop                  # Start Electron desktop app
-
-# Build
-bun run build                        # Build all apps (Turbo)
-bun run --filter 'web' build         # Build web app only
-
-# Database
-bun run db:generate                  # Generate Drizzle migrations from schema changes
-bun run db:migrate                   # Run database migrations
-bun run --filter '@pagespace/db' db:studio  # Open Drizzle Studio
-
-# Testing
-bun run test                         # Run all tests (with DB setup)
-bun run test:unit                    # Run unit tests (packages/lib + apps/web)
-bun run test:watch                   # Run tests in watch mode
-bun run test:coverage                # Run tests with coverage report
-bun run test:security                # Run security tests
-
-# Quality
-bun run lint                         # Lint all apps
-bun run typecheck                    # TypeScript checks across monorepo
+bun run dev          # All services (excludes control-plane)
+bun run build        # All apps (Turbo)
+bun run typecheck    # TypeScript across monorepo
+bun run lint         # All apps
+bun run test         # All tests (with DB setup)
+bun run test:unit    # Unit tests only
+bun run db:generate  # Generate Drizzle migrations
+bun run db:migrate   # Run migrations
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,13 @@ AI-native knowledge management platform. bun workspace + Turbo monorepo.
 ## Monorepo Layout
 
 ```
-apps/       web (Next.js 15), realtime (Socket.IO), processor (file processing),
-            control-plane (billing/provisioning), admin, marketing, atlas,
-            desktop (Electron), ios/android (Capacitor), e2e
-packages/   db (Drizzle/Postgres), lib (auth, permissions, services, integrations)
+apps/            web (Next.js 15), realtime (Socket.IO), processor (file processing),
+                 control-plane (billing/provisioning), admin (Next.js, port 3005),
+                 marketing, atlas (React Flow viz), desktop (Electron),
+                 ios/android (Capacitor), e2e (Playwright)
+packages/        db (Drizzle/Postgres), lib (auth, permissions, services, integrations)
+infrastructure/  Tenant deployment scripts, Docker Compose configs, Traefik
+scripts/          Backfill scripts, changelog generator, coverage tools
 ```
 
 ## Critical Rules
@@ -19,7 +22,8 @@ packages/   db (Drizzle/Postgres), lib (auth, permissions, services, integration
 - **No `any` types**. TypeScript strict mode.
 - **Message content**: Use `parts` array structure. See `packages/lib/src/types.ts`.
 - **Permissions**: Use centralized functions from `packages/lib/src/permissions/`. Never roll your own.
-- **UI refresh protection**: Components editing/streaming content must register with `useEditingStore` (`apps/web/src/stores/useEditingStore.ts`) to prevent SWR clobbering.
+- **UI refresh protection**: Components editing/streaming content must register with `useEditingStore` (`apps/web/src/stores/useEditingStore.ts`) to prevent SWR clobbering and auth refresh interruption.
+- **Changelog**: Run `bun run changelog:generate` when changes land. Update any user-visible notes.
 
 ## Deployment Modes
 
@@ -38,8 +42,10 @@ Guard selection: use `isOnPrem()` to gate integrations. `isBillingEnabled()` gat
 | Page types enum | `packages/lib/src/utils/enums.ts` |
 | Permissions | `packages/lib/src/permissions/` |
 | Auth (tokens, sessions) | `packages/lib/src/auth/` |
+| Compliance (GDPR, PII, retention) | `packages/lib/src/compliance/` |
+| Encryption (field-level, blind index) | `packages/lib/src/encryption/` |
 | UI refresh protection | `apps/web/src/stores/useEditingStore.ts` |
-| Integrations | `packages/lib/src/integrations/` |
+| Integrations (GitHub, Calendar, OAuth) | `packages/lib/src/integrations/` |
 | DB schema | `packages/db/src/schema/` |
 | Services | `packages/lib/src/services/` |
 | Deployment mode | `packages/lib/src/deployment-mode.ts` |
@@ -49,12 +55,14 @@ Guard selection: use `isOnPrem()` to gate integrations. `isBillingEnabled()` gat
 ## Commands
 
 ```bash
-bun run dev          # All services (excludes control-plane)
-bun run build        # All apps (Turbo)
-bun run typecheck    # TypeScript across monorepo
-bun run lint         # All apps
-bun run test         # All tests (with DB setup)
-bun run test:unit    # Unit tests only
-bun run db:generate  # Generate Drizzle migrations
-bun run db:migrate   # Run migrations
+bun run dev                # All services (excludes control-plane)
+bun run build              # All apps (Turbo)
+bun run typecheck          # TypeScript across monorepo
+bun run lint               # All apps
+bun run test               # All tests (with DB setup)
+bun run test:unit          # Unit tests only
+bun run test:security      # Security tests
+bun run db:generate        # Generate Drizzle migrations
+bun run db:migrate         # Run migrations
+bun run changelog:generate # Generate changelog from merged PRs
 ```


### PR DESCRIPTION
Cut CLAUDE.md from ~120 lines to ~50.

Removed: marketing copy (stale tool/model counts), full tech stack (derivable from package.json), exhaustive commands (derivable from package.json scripts), machine-specific deploy path, redundant monorepo comments.

Fixed: page type count (10 not 9), tenant mode description (same feature set as cloud), added !isCloud() guard warning, added missing apps/admin and apps/e2e.

Kept: critical gotchas, deployment mode guard selection, key source locations table, essential commands.

Net: 32 insertions, 90 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined the project guide into a shorter, easier-to-scan reference.
  * Clarified key development rules and deployment guidance.
  * Simplified the list of important source locations and commonly used commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->