### PR TITLE
fix: stable useChat id architecture with pure config functions

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -56,6 +56,7 @@ import {
   useChatTransport,
   useStreamingRegistration,
   useSendHandoff,
+  buildChatConfig,
   AgentConfig,
 } from '@/lib/ai/shared';
 import {
@@ -271,10 +272,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   }, []);
 
   const chatConfig = useMemo(
-    () => !transport ? null : ({
+    () => !transport ? null : buildChatConfig({
       id: page.id,
       transport,
-      experimental_throttle: 100,
       onError: handleChatError,
     }),
     [page.id, transport, handleChatError]

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -82,7 +82,6 @@ type ConversationListResponse = { conversations?: Array<{ id: string }> };
 type ConversationMessagesResponse = { messages: UIMessage[] };
 
 const VOICE_OWNER: VoiceModeOwner = 'ai-page';
-const EMPTY_MESSAGES: UIMessage[] = [];
 
 const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const params = useParams();
@@ -259,10 +258,13 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // ============================================
   // CHAT CONFIGURATION
   // ============================================
-  // Use conversation ID for stream tracking (falls back to page.id before conversation is created)
-  const streamTrackingId = currentConversationId || page.id;
-
-  const transport = useChatTransport(streamTrackingId, '/api/ai/chat');
+  // Stable transport: uses page.id so the transport (and therefore chatConfig)
+  // never changes across conversation switches within the same page. Changing
+  // the transport on every switch caused useChat to reset its internal store,
+  // which clobbered the messages written by loadMessagesForConversation — the
+  // root cause of conversations not loading when clicked from History.
+  const transport = useChatTransport(page.id, '/api/ai/chat');
+  const streamTrackingId = page.id;
 
   const handleChatError = useCallback((error: Error) => {
     console.error('AiChatView: Chat error:', error);
@@ -271,7 +273,6 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const chatConfig = useMemo(
     () => !transport ? null : ({
       id: page.id,
-      messages: EMPTY_MESSAGES,
       transport,
       experimental_throttle: 100,
       onError: handleChatError,

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -149,6 +149,12 @@ vi.mock('@/lib/ai/shared', () => ({
   useStreamingRegistration: vi.fn(),
   useChatStop: vi.fn(() => mockLocalStop),
   useSendHandoff: vi.fn(() => ({ wrapSend: vi.fn((cb: () => void) => cb()) })),
+  buildChatConfig: vi.fn((params: { id: string; transport: unknown; onError?: (error: Error) => void }) => ({
+    id: params.id,
+    transport: params.transport,
+    experimental_throttle: 100,
+    onError: params.onError ?? vi.fn(),
+  })),
 }));
 
 vi.mock('@/lib/ai/shared/hooks/useImageAttachments', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -720,6 +720,18 @@ const GlobalAssistantView: React.FC = () => {
     }
   }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, setAgentMessages]);
 
+  // Global-mode load-on-select guarantee: same pattern, different signal.
+  // When globalConversationLoadSignal changes (loadConversation or
+  // createNewConversation ran in GlobalChatContext), re-apply messages.
+  const prevGlobalLoadSignalRef = useRef(globalConversationLoadSignal);
+  useEffect(() => {
+    if (globalConversationLoadSignal === prevGlobalLoadSignalRef.current) return;
+    prevGlobalLoadSignalRef.current = globalConversationLoadSignal;
+    if (!selectedAgent && globalIsInitialized && globalConversationId) {
+      handlePullUpRefresh();
+    }
+  }, [globalConversationLoadSignal, selectedAgent, globalIsInitialized, globalConversationId, handlePullUpRefresh]);
+
   // Agent-mode multiplayer wiring (Tasks 2 + 5 + 6). No-op when selectedAgent
   // is null. Encapsulates page-room subscription, stream bootstrap/socket
   // events, dashboard-store stop-slot single-writer claim, channel-id-keyed

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -65,6 +65,8 @@ import {
   useChatStop,
   useSendHandoff,
   useStreamRecovery,
+  buildChatConfig,
+  AGENT_CHAT_ID,
   LocationContext,
 } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
@@ -285,14 +287,13 @@ const GlobalAssistantView: React.FC = () => {
   const agentChatConfig = useMemo(() => {
     if (!selectedAgent || !agentConversationId || !agentTransport) return null;
 
-    return {
-      id: selectedAgent.id,
+    return buildChatConfig({
+      id: AGENT_CHAT_ID,
       transport: agentTransport,
-      experimental_throttle: 100,
       onError: (error: Error) => {
         console.error('Agent Chat error:', error);
       },
-    };
+    });
   }, [selectedAgent, agentConversationId, agentTransport]);
 
   // Global mode chat

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -103,7 +103,7 @@ const GlobalAssistantView: React.FC = () => {
   // ============================================
   const { chatConfig: globalChatConfig, setIsStreaming: setGlobalIsStreaming, setStopStreaming: setGlobalStopStreaming } = useGlobalChatConfig();
   const { isStreaming: contextIsStreaming, stopStreaming: contextStopStreaming } = useGlobalChatStream();
-  const { currentConversationId: globalConversationId, isInitialized: globalIsInitialized, createNewConversation, refreshSignal, rejoinGlobalStream } = useGlobalChatConversation();
+  const { currentConversationId: globalConversationId, isInitialized: globalIsInitialized, initialMessages: globalInitialMessages, createNewConversation, refreshSignal, rejoinGlobalStream } = useGlobalChatConversation();
 
   // ============================================
   // AGENT STORE - for agent selection and conversation management
@@ -286,15 +286,14 @@ const GlobalAssistantView: React.FC = () => {
     if (!selectedAgent || !agentConversationId || !agentTransport) return null;
 
     return {
-      id: agentConversationId,
-      messages: agentInitialMessages,
+      id: selectedAgent.id,
       transport: agentTransport,
       experimental_throttle: 100,
       onError: (error: Error) => {
         console.error('Agent Chat error:', error);
       },
     };
-  }, [selectedAgent, agentConversationId, agentTransport, agentInitialMessages]);
+  }, [selectedAgent, agentConversationId, agentTransport]);
 
   // Global mode chat
   const {
@@ -705,12 +704,12 @@ const GlobalAssistantView: React.FC = () => {
     };
   }, [selectedAgent, agentStatus, agentStop, agentConversationId, setAgentStopStreaming]);
 
-  // Agent-mode load-on-select guarantee: when the dashboard store's
-  // conversationLoadSignal changes (loadConversation or createNewConversation
-  // ran), re-apply the store's messages via setAgentMessages. This is needed
-  // because useChat ignores the messages prop when the id (conversationId)
-  // hasn't changed — so clicking the same conversation from history would show
-  // stale messages without this direct write.
+  // Agent-mode load-on-select guarantee: the store's conversationLoadSignal
+  // fires on explicit load/create (not on streaming updates). We use it rather
+  // than watching conversationMessages directly because the store receives
+  // bidirectional writes during streaming — watching the array would clobber
+  // in-progress parts. With stable useChat id, setMessages has no competing
+  // store recreation, so this is the sole message writer on load.
   const prevAgentLoadSignalRef = useRef(agentConversationLoadSignal);
   useEffect(() => {
     if (agentConversationLoadSignal === prevAgentLoadSignalRef.current) return;
@@ -720,17 +719,14 @@ const GlobalAssistantView: React.FC = () => {
     }
   }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, setAgentMessages]);
 
-  // Global-mode load-on-select guarantee: same pattern, different signal.
-  // When globalConversationLoadSignal changes (loadConversation or
-  // createNewConversation ran in GlobalChatContext), re-apply messages.
-  const prevGlobalLoadSignalRef = useRef(globalConversationLoadSignal);
+  // Global-mode load-on-select guarantee: apply messages from context whenever
+  // they change (loadConversation or createNewConversation ran). With a stable
+  // useChat id, setMessages is the sole writer — no race with store recreation.
   useEffect(() => {
-    if (globalConversationLoadSignal === prevGlobalLoadSignalRef.current) return;
-    prevGlobalLoadSignalRef.current = globalConversationLoadSignal;
-    if (!selectedAgent && globalIsInitialized && globalConversationId) {
-      handlePullUpRefresh();
-    }
-  }, [globalConversationLoadSignal, selectedAgent, globalIsInitialized, globalConversationId, handlePullUpRefresh]);
+    if (selectedAgent) return;
+    if (!globalIsInitialized || !globalConversationId) return;
+    setGlobalLocalMessages(globalInitialMessages);
+  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, setGlobalLocalMessages]);
 
   // Agent-mode multiplayer wiring (Tasks 2 + 5 + 6). No-op when selectedAgent
   // is null. Encapsulates page-room subscription, stream bootstrap/socket

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -114,6 +114,7 @@ const GlobalAssistantView: React.FC = () => {
   const agentConversationId = usePageAgentDashboardStore((state) => state.conversationId);
   const agentInitialMessages = usePageAgentDashboardStore((state) => state.conversationMessages);
   const agentIsLoading = usePageAgentDashboardStore((state) => state.isConversationLoading);
+  const agentConversationLoadSignal = usePageAgentDashboardStore((state) => state.conversationLoadSignal);
   const setAgentStoreMessages = usePageAgentDashboardStore((state) => state.setConversationMessages);
   const createAgentConversation = usePageAgentDashboardStore((state) => state.createNewConversation);
   const loadMostRecentConversation = usePageAgentDashboardStore((state) => state.loadMostRecentConversation);
@@ -703,6 +704,21 @@ const GlobalAssistantView: React.FC = () => {
       setAgentStopStreaming(null);
     };
   }, [selectedAgent, agentStatus, agentStop, agentConversationId, setAgentStopStreaming]);
+
+  // Agent-mode load-on-select guarantee: when the dashboard store's
+  // conversationLoadSignal changes (loadConversation or createNewConversation
+  // ran), re-apply the store's messages via setAgentMessages. This is needed
+  // because useChat ignores the messages prop when the id (conversationId)
+  // hasn't changed — so clicking the same conversation from history would show
+  // stale messages without this direct write.
+  const prevAgentLoadSignalRef = useRef(agentConversationLoadSignal);
+  useEffect(() => {
+    if (agentConversationLoadSignal === prevAgentLoadSignalRef.current) return;
+    prevAgentLoadSignalRef.current = agentConversationLoadSignal;
+    if (selectedAgent && agentConversationId) {
+      setAgentMessages(agentInitialMessages);
+    }
+  }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, setAgentMessages]);
 
   // Agent-mode multiplayer wiring (Tasks 2 + 5 + 6). No-op when selectedAgent
   // is null. Encapsulates page-room subscription, stream bootstrap/socket

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -711,7 +711,14 @@ const GlobalAssistantView: React.FC = () => {
   // bidirectional writes during streaming — watching the array would clobber
   // in-progress parts. With stable useChat id, setMessages has no competing
   // store recreation, so this is the sole message writer on load.
-  const prevAgentLoadSignalRef = useRef(agentConversationLoadSignal);
+  //
+  // Seeded to `null` (not the current signal value) so a remount with an
+  // already-selected agent/conversation still applies messages to the fresh
+  // useChat instance. usePageAgentDashboardStore is a module-level singleton
+  // that outlives this component's mount — seeding to the live value would
+  // make the effect wrongly believe "nothing changed" on first render after
+  // navigating away and back, leaving the freshly mounted chat blank.
+  const prevAgentLoadSignalRef = useRef<number | null>(null);
   useEffect(() => {
     if (agentConversationLoadSignal === prevAgentLoadSignalRef.current) return;
     prevAgentLoadSignalRef.current = agentConversationLoadSignal;

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -35,7 +35,7 @@ import { LocationContext } from '@/lib/ai/shared';
 import { parseTabPath, getStaticTabMeta } from '@/lib/tabs/tab-title';
 import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId } from '@/lib/ai/core/client';
 import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
-import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery } from '@/lib/ai/shared';
+import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery, buildChatConfig, SIDEBAR_AGENT_CHAT_ID } from '@/lib/ai/shared';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
@@ -225,15 +225,14 @@ const SidebarChatTab: React.FC = () => {
   const agentChatConfig = useMemo(() => {
     if (!selectedAgent || !agentConversationId || !agentTransport) return null;
 
-    return {
-      id: selectedAgent.id,
+    return buildChatConfig({
+      id: SIDEBAR_AGENT_CHAT_ID,
       transport: agentTransport,
-      experimental_throttle: 100,
       onError: (error: Error) => {
         console.error('Sidebar Agent Chat error:', error);
         toast.error('Chat error. Please try again.');
       },
-    };
+    });
   }, [selectedAgent, agentConversationId, agentTransport]);
 
   // ============================================

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -207,6 +207,7 @@ const SidebarChatTab: React.FC = () => {
   const {
     selectedAgent,
     conversationId: agentConversationId,
+    initialMessages: agentInitialMessages,
     isInitialized: agentIsInitialized,
     selectAgent,
     createNewConversation: createAgentConversation,
@@ -717,6 +718,20 @@ const SidebarChatTab: React.FC = () => {
       loadGlobalMessages(globalConversationId);
     }
   }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, loadGlobalMessages]);
+
+  // Load-on-select guarantee for agent mode: with a stable useChat id, the
+  // sidebar's agent Chat instance is never recreated on conversation switch,
+  // so usePageAgentSidebarState's fetched messages must be explicitly applied
+  // via setMessages. Seeded to `null` so the initial-mount/agent-select load
+  // is also covered by this effect.
+  const prevSidebarAgentMessagesRef = useRef<UIMessage[] | null>(null);
+  useEffect(() => {
+    if (agentInitialMessages === prevSidebarAgentMessagesRef.current) return;
+    prevSidebarAgentMessagesRef.current = agentInitialMessages;
+    if (selectedAgent) {
+      setMessages(agentInitialMessages);
+    }
+  }, [agentInitialMessages, selectedAgent, setMessages]);
 
   const handleNewConversation = useCallback(async () => {
     try {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -207,7 +207,6 @@ const SidebarChatTab: React.FC = () => {
   const {
     selectedAgent,
     conversationId: agentConversationId,
-    initialMessages: agentInitialMessages,
     isInitialized: agentIsInitialized,
     selectAgent,
     createNewConversation: createAgentConversation,
@@ -595,20 +594,6 @@ const SidebarChatTab: React.FC = () => {
     }
   }, [refreshSignal, selectedAgent, globalConversationId, displayIsStreaming, loadGlobalMessages]);
 
-  // Load-on-select guarantee for global mode (1B).
-  //
-  // Whenever the active global conversation changes (or the context finishes
-  // initialising), explicitly fetch the latest DB messages and write them
-  // directly to the useChat instance via setGlobalMessages. This does NOT rely
-  // on GlobalChatContext seeding useChat via chatConfig.messages (which only
-  // fires on the useChat `id` prop changing — a path prone to timing gaps when
-  // the conversation id is the same across refreshes).
-  useEffect(() => {
-    if (selectedAgent) return; // agent mode handled by useAgentChannelMultiplayer
-    if (!globalIsInitialized || !globalConversationId) return;
-    loadGlobalMessages(globalConversationId);
-  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, loadGlobalMessages]);
-
   // ============================================
   // Effects: UI State
   // ============================================
@@ -719,10 +704,12 @@ const SidebarChatTab: React.FC = () => {
     loadGlobalMessages(globalConversationId);
   }, [selectedAgent, globalConversationId, globalIsInitialized, loadGlobalMessages]);
 
-  // Global-mode load-on-select guarantee: with a stable useChat id, surfaces
-  // must re-apply messages on conversation load. The sidebar re-fetches via
-  // loadGlobalMessages (includes stale-request guard + own-stream reconciliation).
-  const prevSidebarGlobalMessagesRef = useRef(globalInitialMessages);
+  // Load-on-select guarantee for global mode: with a stable useChat id,
+  // surfaces must explicitly re-apply messages on conversation load/reselect.
+  // The sidebar re-fetches via loadGlobalMessages (includes stale-request
+  // guard + own-stream reconciliation). Seeded to `null` so the initial-mount
+  // load is also covered by this effect (avoids a second, redundant effect).
+  const prevSidebarGlobalMessagesRef = useRef<UIMessage[] | null>(null);
   useEffect(() => {
     if (globalInitialMessages === prevSidebarGlobalMessagesRef.current) return;
     prevSidebarGlobalMessagesRef.current = globalInitialMessages;

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -188,6 +188,7 @@ const SidebarChatTab: React.FC = () => {
     isInitialized: globalIsInitialized,
     createNewConversation: createGlobalConversation,
     refreshSignal,
+    conversationLoadSignal: globalConversationLoadSignal,
     rejoinGlobalStream,
   } = useGlobalChatConversation();
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -186,9 +186,9 @@ const SidebarChatTab: React.FC = () => {
   const {
     currentConversationId: globalConversationId,
     isInitialized: globalIsInitialized,
+    initialMessages: globalInitialMessages,
     createNewConversation: createGlobalConversation,
     refreshSignal,
-    conversationLoadSignal: globalConversationLoadSignal,
     rejoinGlobalStream,
   } = useGlobalChatConversation();
 
@@ -226,8 +226,7 @@ const SidebarChatTab: React.FC = () => {
     if (!selectedAgent || !agentConversationId || !agentTransport) return null;
 
     return {
-      id: agentConversationId,
-      messages: agentInitialMessages,
+      id: selectedAgent.id,
       transport: agentTransport,
       experimental_throttle: 100,
       onError: (error: Error) => {
@@ -235,7 +234,7 @@ const SidebarChatTab: React.FC = () => {
         toast.error('Chat error. Please try again.');
       },
     };
-  }, [selectedAgent, agentConversationId, agentTransport, agentInitialMessages]);
+  }, [selectedAgent, agentConversationId, agentTransport]);
 
   // ============================================
   // Sidebar Chat (custom hook - unified interface)
@@ -609,7 +608,7 @@ const SidebarChatTab: React.FC = () => {
     if (selectedAgent) return; // agent mode handled by useAgentChannelMultiplayer
     if (!globalIsInitialized || !globalConversationId) return;
     loadGlobalMessages(globalConversationId);
-  }, [globalConversationId, globalIsInitialized, selectedAgent, loadGlobalMessages]);
+  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, loadGlobalMessages]);
 
   // ============================================
   // Effects: UI State
@@ -720,6 +719,18 @@ const SidebarChatTab: React.FC = () => {
     if (selectedAgent || !globalConversationId || !globalIsInitialized) return;
     loadGlobalMessages(globalConversationId);
   }, [selectedAgent, globalConversationId, globalIsInitialized, loadGlobalMessages]);
+
+  // Global-mode load-on-select guarantee: with a stable useChat id, surfaces
+  // must re-apply messages on conversation load. The sidebar re-fetches via
+  // loadGlobalMessages (includes stale-request guard + own-stream reconciliation).
+  const prevSidebarGlobalMessagesRef = useRef(globalInitialMessages);
+  useEffect(() => {
+    if (globalInitialMessages === prevSidebarGlobalMessagesRef.current) return;
+    prevSidebarGlobalMessagesRef.current = globalInitialMessages;
+    if (!selectedAgent && globalIsInitialized && globalConversationId) {
+      loadGlobalMessages(globalConversationId);
+    }
+  }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, loadGlobalMessages]);
 
   const handleNewConversation = useCallback(async () => {
     try {
@@ -1006,9 +1017,8 @@ const SidebarChatTab: React.FC = () => {
   // ============================================
 
   // Use messages from the useChat hook directly for both modes.
-  // Previously used contextMessages for global mode, but this added an extra layer of
-  // indirection through sync effects that could cause race conditions and state snapping.
-  // The useChat hook with the same ID shares state via SWR, so all components see the same messages.
+  // useChat instances are independent (no shared state). GlobalAssistantView and
+  // SidebarChatTab each manage their own useChat and sync via explicit fetch + setMessages.
   const displayMessages = messages;
 
   // ============================================

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -46,6 +46,22 @@ function getStopFunction(
   return stop;
 }
 
+/**
+ * Pure function that mirrors the agent-mode load-on-select effect in
+ * SidebarChatTab: with a stable useChat id, the agent Chat instance is never
+ * recreated on conversation switch, so usePageAgentSidebarState's fetched
+ * messages must be explicitly applied via setMessages whenever the reference
+ * changes — but only while in agent mode.
+ */
+function shouldApplySidebarAgentMessages<T>(
+  selectedAgent: { id: string } | null,
+  agentInitialMessages: T[],
+  prevAgentInitialMessages: T[] | null
+): boolean {
+  if (agentInitialMessages === prevAgentInitialMessages) return false;
+  return Boolean(selectedAgent);
+}
+
 // ============================================
 // Test Data
 // ============================================
@@ -295,6 +311,40 @@ describe('SidebarChatTab Display Logic', () => {
       const result = getDisplayMessages(null, [], manyMessages);
       // Should return the same reference, not a copy
       expect(result).toBe(manyMessages);
+    });
+  });
+
+  // ============================================
+  // Agent-mode load-on-select regression tests
+  //
+  // Regression coverage for: with a stable useChat id, the sidebar's agent
+  // Chat instance is never recreated on conversation switch/select/create, so
+  // fetched messages must be explicitly applied via setMessages. Without this,
+  // agent-mode conversations never load in the sidebar (the exact class of bug
+  // this PR fixes, reintroduced for this one surface).
+  // ============================================
+
+  describe('shouldApplySidebarAgentMessages (agent-mode load-on-select)', () => {
+    it('given an agent selected and a new messages reference, should apply', () => {
+      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, null)).toBe(true);
+    });
+
+    it('given an agent selected and conversation switch fetches a new reference, should apply', () => {
+      const firstConversation = [mockUserMessage] as never[];
+      const secondConversation = [mockAssistantMessage] as never[];
+      expect(shouldApplySidebarAgentMessages(mockAgent, secondConversation, firstConversation)).toBe(true);
+    });
+
+    it('given an agent selected but the messages reference is unchanged, should NOT re-apply (no-op)', () => {
+      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, mockAgentMessages)).toBe(false);
+    });
+
+    it('given global mode (no agent selected), should never apply agent messages even on a new reference', () => {
+      expect(shouldApplySidebarAgentMessages(null, mockAgentMessages, null)).toBe(false);
+    });
+
+    it('given a new empty-array reference (new conversation created), should still apply', () => {
+      expect(shouldApplySidebarAgentMessages(mockAgent, [], null)).toBe(true);
     });
   });
 });

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -84,6 +84,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const [initialMessages, setInitialMessages] = useState<UIMessage[]>([]);
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const [refreshSignal, setRefreshSignal] = useState(0);
+  const [conversationLoadSignal, setConversationLoadSignal] = useState(0);
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [stopStreaming, setStopStreaming] = useState<(() => void) | null>(null);
   const [latestGlobalConversationAdded, setLatestGlobalConversationAdded] = useState<ChatGlobalConversationAddedPayload | null>(null);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -107,6 +107,12 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
         setCurrentConversationId(conversationId);
         conversationState.setActiveConversationId(conversationId);
         setIsInitialized(true);
+        // Always signal surfaces to re-fetch. When the conversation ID is the
+        // same as before, useChat ignores the new initialMessages (its SWR
+        // cache key hasn't changed), so without this signal the messages
+        // would go stale. When the ID is different, this is a harmless
+        // redundant fetch that guarantees the UI matches the DB.
+        setRefreshSignal((n) => n + 1);
       } else {
         console.error('Failed to load conversation:', conversationId);
         setIsInitialized(true);
@@ -131,6 +137,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
           setConversationId(newConversation.id, 'push');
         }
         setIsInitialized(true);
+        setRefreshSignal((n) => n + 1);
       }
     } catch (error) {
       console.error('Failed to create new conversation:', error);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -37,7 +37,9 @@ import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 
 interface GlobalChatConversationContextValue {
   currentConversationId: string | null;
-  /** Seed messages for useChat — set by loadConversation on conversation switch. */
+  /** Fetched messages from the last loadConversation/createNewConversation.
+   *  Surfaces watch this reference and apply via setMessages (not via useChat
+   *  config, which ignores the messages prop after construction). */
   initialMessages: UIMessage[];
   isInitialized: boolean;
   /** Increments when remote events require surfaces to re-fetch messages from DB. */
@@ -58,8 +60,7 @@ interface GlobalChatStreamContextValue {
 
 interface GlobalChatConfigContextValue {
   chatConfig: {
-    id: string | undefined;
-    messages: UIMessage[];
+    id: string;
     transport: DefaultChatTransport<UIMessage>;
     onError: (error: Error) => void;
   } | null;
@@ -84,7 +85,6 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const [initialMessages, setInitialMessages] = useState<UIMessage[]>([]);
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
   const [refreshSignal, setRefreshSignal] = useState(0);
-  const [conversationLoadSignal, setConversationLoadSignal] = useState(0);
   const [isStreaming, setIsStreaming] = useState<boolean>(false);
   const [stopStreaming, setStopStreaming] = useState<(() => void) | null>(null);
   const [latestGlobalConversationAdded, setLatestGlobalConversationAdded] = useState<ChatGlobalConversationAddedPayload | null>(null);
@@ -108,12 +108,6 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
         setCurrentConversationId(conversationId);
         conversationState.setActiveConversationId(conversationId);
         setIsInitialized(true);
-        // Always signal surfaces to re-fetch. When the conversation ID is the
-        // same as before, useChat ignores the new initialMessages (its SWR
-        // cache key hasn't changed), so without this signal the messages
-        // would go stale. When the ID is different, this is a harmless
-        // redundant fetch that guarantees the UI matches the DB.
-        setRefreshSignal((n) => n + 1);
       } else {
         console.error('Failed to load conversation:', conversationId);
         setIsInitialized(true);
@@ -138,7 +132,6 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
           setConversationId(newConversation.id, 'push');
         }
         setIsInitialized(true);
-        setRefreshSignal((n) => n + 1);
       }
     } catch (error) {
       console.error('Failed to create new conversation:', error);
@@ -286,8 +279,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const chatConfig = useMemo(() => {
     if (!currentConversationId || !transport) return null;
     return {
-      id: currentConversationId,
-      messages: initialMessages,
+      id: 'global-assistant',
       transport,
       experimental_throttle: 100,
       onError: (error: Error) => {
@@ -297,7 +289,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
         }
       },
     };
-  }, [currentConversationId, transport, initialMessages]);
+  }, [currentConversationId, transport]);
 
   // ============================================
   // Context Values

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -5,7 +5,7 @@ import { DefaultChatTransport, UIMessage } from 'ai';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
-import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
+import { useChatTransport, useStreamingRegistration, buildChatConfig, GLOBAL_CHAT_ID } from '@/lib/ai/shared';
 import { shouldRefreshOnReconnect } from '@/lib/ai/streams/shouldRefreshOnReconnect';
 import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
@@ -278,17 +278,16 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
 
   const chatConfig = useMemo(() => {
     if (!currentConversationId || !transport) return null;
-    return {
-      id: 'global-assistant',
+    return buildChatConfig({
+      id: GLOBAL_CHAT_ID,
       transport,
-      experimental_throttle: 100,
       onError: (error: Error) => {
         console.error('Global Chat Error:', error);
         if (error.message?.includes('Unauthorized') || error.message?.includes('401')) {
           console.error('Authentication failed - user may need to log in again');
         }
       },
-    };
+    });
   }, [currentConversationId, transport]);
 
   // ============================================

--- a/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
@@ -10,7 +10,6 @@ import {
   AGENT_CHAT_ID,
   SIDEBAR_AGENT_CHAT_ID,
   buildChatConfig,
-  shouldApplyMessages,
 } from '../chat-config';
 
 describe('chat-config pure functions', () => {
@@ -63,33 +62,6 @@ describe('chat-config pure functions', () => {
       expect(a.id).toBe(b.id);
       expect(a.transport).toBe(b.transport);
       expect(a.experimental_throttle).toBe(b.experimental_throttle);
-    });
-  });
-
-  describe('shouldApplyMessages', () => {
-    const mockMessages: UIMessage[] = [
-      { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
-    ];
-    const mockMessages2: UIMessage[] = [
-      { id: 'msg-2', role: 'assistant', parts: [{ type: 'text', text: 'Hi!' }] },
-    ];
-
-    it('given a new message array and active conversation, should return true', () => {
-      expect(shouldApplyMessages(null, mockMessages, 'conv-1')).toBe(true);
-    });
-
-    it('given a different message array reference, should return true', () => {
-      expect(shouldApplyMessages(mockMessages, mockMessages2, 'conv-1')).toBe(true);
-    });
-
-    it('given the same message array reference, should return false (no-op)', () => {
-      expect(shouldApplyMessages(mockMessages, mockMessages, 'conv-1')).toBe(false);
-    });
-
-    it('given no conversation ID, should return false even if messages changed', () => {
-      expect(shouldApplyMessages(null, mockMessages, null)).toBe(false);
-      expect(shouldApplyMessages(null, mockMessages, undefined)).toBe(false);
-      expect(shouldApplyMessages(null, mockMessages, '')).toBe(false);
     });
   });
 });

--- a/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for pure chat-config functions.
+ * RITE tests: Readable, Isolated, Thorough, Explicit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { DefaultChatTransport, type UIMessage } from 'ai';
+import {
+  GLOBAL_CHAT_ID,
+  AGENT_CHAT_ID,
+  SIDEBAR_AGENT_CHAT_ID,
+  buildChatConfig,
+  shouldApplyMessages,
+} from '../chat-config';
+
+describe('chat-config pure functions', () => {
+  describe('stable chat ID constants', () => {
+    it('given the module loads, should export stable ID constants for each surface', () => {
+      expect(GLOBAL_CHAT_ID).toBe('global-assistant');
+      expect(AGENT_CHAT_ID).toBe('agent-chat');
+      expect(SIDEBAR_AGENT_CHAT_ID).toBe('sidebar-agent');
+    });
+  });
+
+  describe('buildChatConfig', () => {
+    const mockTransport = new DefaultChatTransport<UIMessage>({ api: '/api/ai/chat' });
+
+    it('given valid params, should return a config with the provided id', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
+      expect(config.id).toBe(GLOBAL_CHAT_ID);
+    });
+
+    it('given no throttleMs, should default to 100ms', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
+      expect(config.experimental_throttle).toBe(100);
+    });
+
+    it('given a custom throttleMs, should use it', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport, throttleMs: 50 });
+      expect(config.experimental_throttle).toBe(50);
+    });
+
+    it('given a custom onError handler, should use it', () => {
+      const handler = vi.fn();
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport, onError: handler });
+      expect(config.onError).toBe(handler);
+    });
+
+    it('given no onError handler, should provide a default', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
+      expect(typeof config.onError).toBe('function');
+    });
+
+    it('given the same inputs, should NOT include a messages property', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
+      expect(config).not.toHaveProperty('messages');
+    });
+
+    it('given the same inputs, should produce deterministic output (purity)', () => {
+      const params = { id: GLOBAL_CHAT_ID, transport: mockTransport };
+      const a = buildChatConfig(params);
+      const b = buildChatConfig(params);
+      expect(a.id).toBe(b.id);
+      expect(a.transport).toBe(b.transport);
+      expect(a.experimental_throttle).toBe(b.experimental_throttle);
+    });
+  });
+
+  describe('shouldApplyMessages', () => {
+    const mockMessages: UIMessage[] = [
+      { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+    ];
+    const mockMessages2: UIMessage[] = [
+      { id: 'msg-2', role: 'assistant', parts: [{ type: 'text', text: 'Hi!' }] },
+    ];
+
+    it('given a new message array and active conversation, should return true', () => {
+      expect(shouldApplyMessages(null, mockMessages, 'conv-1')).toBe(true);
+    });
+
+    it('given a different message array reference, should return true', () => {
+      expect(shouldApplyMessages(mockMessages, mockMessages2, 'conv-1')).toBe(true);
+    });
+
+    it('given the same message array reference, should return false (no-op)', () => {
+      expect(shouldApplyMessages(mockMessages, mockMessages, 'conv-1')).toBe(false);
+    });
+
+    it('given no conversation ID, should return false even if messages changed', () => {
+      expect(shouldApplyMessages(null, mockMessages, null)).toBe(false);
+      expect(shouldApplyMessages(null, mockMessages, undefined)).toBe(false);
+      expect(shouldApplyMessages(null, mockMessages, '')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/lib/ai/shared/chat-config.ts
+++ b/apps/web/src/lib/ai/shared/chat-config.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure functions for building stable useChat configurations.
+ *
+ * The AI SDK's useChat hook recreates its internal Chat instance when the `id`
+ * prop changes (chat.react.ts → shouldRecreateChat). Recreation clobbers any
+ * messages written by setMessages, producing blank screens and stale history.
+ *
+ * The fix: give every useChat a stable `id` tied to the surface, not the
+ * conversation. Messages flow through setMessages exclusively — the `messages`
+ * prop is construction-only and silently ignored after the first render.
+ *
+ * @see https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat — id: "A unique identifier for the chat."
+ * @see vercel/ai packages/react/src/use-chat.ts — shouldRecreateChat checks id only
+ */
+
+import type { DefaultChatTransport, UIMessage } from 'ai';
+
+/**
+ * Stable chat IDs per surface. These never change across conversation switches
+ * within the same surface, preventing Chat instance recreation.
+ */
+export const GLOBAL_CHAT_ID = 'global-assistant';
+export const AGENT_CHAT_ID = 'agent-chat';
+export const SIDEBAR_AGENT_CHAT_ID = 'sidebar-agent';
+
+/**
+ * Parameters for building a useChat config object.
+ */
+export interface ChatConfigParams {
+  /** Stable surface ID (use constants above or page.id for AiChatView). */
+  id: string;
+  /** Transport instance from useChatTransport. */
+  transport: DefaultChatTransport<UIMessage>;
+  /** Throttle in ms for UI updates. Defaults to 100. */
+  throttleMs?: number;
+  /** Error handler. */
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Build a useChat config object with a stable id and no messages prop.
+ *
+ * Pure: same inputs always produce the same output. No side effects.
+ *
+ * The messages prop is intentionally omitted — useChat only reads it during
+ * Chat construction (first render). After that, setMessages is the sole writer.
+ * Including messages in the config creates a false dependency that useChat
+ * silently ignores, making the code harder to reason about.
+ */
+export function buildChatConfig(params: ChatConfigParams): {
+  id: string;
+  transport: DefaultChatTransport<UIMessage>;
+  experimental_throttle: number;
+  onError: (error: Error) => void;
+} {
+  return {
+    id: params.id,
+    transport: params.transport,
+    experimental_throttle: params.throttleMs ?? 100,
+    onError: params.onError ?? defaultOnError,
+  };
+}
+
+const defaultOnError = (error: Error): void => {
+  console.error('Chat error:', error);
+};
+
+/**
+ * Determine whether messages should be applied to useChat via setMessages.
+ *
+ * Pure: given the same inputs, always returns the same boolean.
+ * Used by surface effects that watch reference changes from the message source
+ * (context initialMessages, store conversationMessages).
+ *
+ * Returns false when:
+ * - No conversation is active (conversationId is null/empty)
+ * - The message array reference hasn't changed (same fetch result, no-op)
+ */
+export function shouldApplyMessages(
+  prevMessages: UIMessage[] | null,
+  currentMessages: UIMessage[],
+  conversationId: string | null | undefined,
+): boolean {
+  if (!conversationId) return false;
+  if (prevMessages === currentMessages) return false;
+  return true;
+}

--- a/apps/web/src/lib/ai/shared/chat-config.ts
+++ b/apps/web/src/lib/ai/shared/chat-config.ts
@@ -64,24 +64,3 @@ export function buildChatConfig(params: ChatConfigParams): {
 const defaultOnError = (error: Error): void => {
   console.error('Chat error:', error);
 };
-
-/**
- * Determine whether messages should be applied to useChat via setMessages.
- *
- * Pure: given the same inputs, always returns the same boolean.
- * Used by surface effects that watch reference changes from the message source
- * (context initialMessages, store conversationMessages).
- *
- * Returns false when:
- * - No conversation is active (conversationId is null/empty)
- * - The message array reference hasn't changed (same fetch result, no-op)
- */
-export function shouldApplyMessages(
-  prevMessages: UIMessage[] | null,
-  currentMessages: UIMessage[],
-  conversationId: string | null | undefined,
-): boolean {
-  if (!conversationId) return false;
-  if (prevMessages === currentMessages) return false;
-  return true;
-}

--- a/apps/web/src/lib/ai/shared/hooks/index.ts
+++ b/apps/web/src/lib/ai/shared/hooks/index.ts
@@ -11,3 +11,12 @@ export { useStreamingRegistration } from './useStreamingRegistration';
 export { useChatStop } from './useChatStop';
 export { useSendHandoff } from './useSendHandoff';
 export { useStreamRecovery } from './useStreamRecovery';
+
+// Pure functions (no hooks, no side effects)
+export {
+  GLOBAL_CHAT_ID,
+  AGENT_CHAT_ID,
+  SIDEBAR_AGENT_CHAT_ID,
+  buildChatConfig,
+  shouldApplyMessages,
+} from '../chat-config';

--- a/apps/web/src/lib/ai/shared/hooks/index.ts
+++ b/apps/web/src/lib/ai/shared/hooks/index.ts
@@ -18,5 +18,4 @@ export {
   AGENT_CHAT_ID,
   SIDEBAR_AGENT_CHAT_ID,
   buildChatConfig,
-  shouldApplyMessages,
 } from '../chat-config';

--- a/apps/web/src/stores/page-agents/__tests__/usePageAgentDashboardStore.test.ts
+++ b/apps/web/src/stores/page-agents/__tests__/usePageAgentDashboardStore.test.ts
@@ -61,6 +61,7 @@ describe('usePageAgentDashboardStore', () => {
       conversationMessages: [],
       isConversationLoading: false,
       conversationAgentId: null,
+      conversationLoadSignal: 0,
       activeTab: 'history',
     });
 

--- a/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
+++ b/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
@@ -29,6 +29,10 @@ interface AgentState {
   conversationMessages: UIMessage[];
   isConversationLoading: boolean;
   conversationAgentId: string | null; // Track which agent the conversation belongs to
+  /** Increments every time loadConversation or createNewConversation runs.
+   *  GlobalAssistantView watches this to re-apply messages via setAgentMessages
+   *  even when the conversation ID doesn't change (clicking the same conversation). */
+  conversationLoadSignal: number;
 
   // Streaming state (for agent mode sync between GlobalAssistantView and sidebar)
   isAgentStreaming: boolean;
@@ -61,6 +65,7 @@ export const usePageAgentDashboardStore = create<AgentState>()((set, get) => ({
   conversationMessages: [],
   isConversationLoading: false,
   conversationAgentId: null,
+  conversationLoadSignal: 0,
   isAgentStreaming: false,
   agentStopStreaming: null,
   activeTab: 'history', // Default for dashboard (no chat tab in dashboard context)
@@ -190,6 +195,7 @@ export const usePageAgentDashboardStore = create<AgentState>()((set, get) => ({
         conversationMessages: result.messages,
         conversationAgentId: agent.id,
         isConversationLoading: false,
+        conversationLoadSignal: get().conversationLoadSignal + 1,
       });
 
       // Update URL for bookmarkability
@@ -218,6 +224,7 @@ export const usePageAgentDashboardStore = create<AgentState>()((set, get) => ({
         conversationMessages: [],
         conversationAgentId: agent.id,
         isConversationLoading: false,
+        conversationLoadSignal: get().conversationLoadSignal + 1,
       });
 
       // Update URL for bookmarkability

--- a/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
+++ b/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
@@ -285,6 +285,7 @@ export const usePageAgentDashboardStore = create<AgentState>()((set, get) => ({
           conversationMessages: result.messages,
           conversationAgentId: agent.id,
           isConversationLoading: false,
+          conversationLoadSignal: get().conversationLoadSignal + 1,
         });
         return;
       }
@@ -298,6 +299,7 @@ export const usePageAgentDashboardStore = create<AgentState>()((set, get) => ({
           conversationMessages: result.messages,
           conversationAgentId: agent.id,
           isConversationLoading: false,
+          conversationLoadSignal: get().conversationLoadSignal + 1,
         });
 
         // Update URL (use 'replace' for auto-loading to avoid polluting history)

--- a/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
+++ b/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
@@ -29,7 +29,8 @@ interface AgentState {
   conversationMessages: UIMessage[];
   isConversationLoading: boolean;
   conversationAgentId: string | null; // Track which agent the conversation belongs to
-  /** Increments every time loadConversation or createNewConversation runs.
+  /** Increments every time conversation state is set by loadConversation,
+   *  createNewConversation, or loadMostRecentConversation.
    *  GlobalAssistantView watches this to re-apply messages via setAgentMessages
    *  even when the conversation ID doesn't change (clicking the same conversation). */
   conversationLoadSignal: number;


### PR DESCRIPTION
## Problem

Clicking conversations from history was broken across two surfaces:

1. **Page AI (AiChatView)**: Older conversations don't load when clicked from History. The view shows the empty/new conversation screen.
2. **Global Assistant**: Conversations go stale. Clicking the same conversation doesn't re-fetch new messages.

## Root Cause

The AI SDK's `useChat` hook recreates its internal `Chat` instance when the `id` prop changes ([vercel/ai `chat.react.ts` → `shouldRecreateChat`](https://github.com/vercel/ai/blob/main/packages/react/src/use-chat.ts)). Recreation clobbers messages written by `setMessages`, producing blank screens and stale history.

All three chat surfaces used the **conversation ID** as the `useChat` `id` prop. Every conversation switch triggered recreation.

Additionally, the `messages` prop was included in all configs. This prop is construction-only — silently ignored after the first render. Including it created a false dependency that made the code harder to reason about.

## Solution

**Stable `id` per surface, no `messages` prop, `setMessages` is the sole writer.**

### Pure functions module (`chat-config.ts`)

Extracted `buildChatConfig` as a pure function with unit tests (all passing). Stable ID constants per surface.

### Changes per surface

| Surface | Stable `id` | Transport key |
|---|---|---|
| AiChatView | `page.id` | `page.id` |
| GlobalChatContext | `GLOBAL_CHAT_ID` (`"global-assistant"`) | `conversationId` |
| GlobalAssistantView agent | `AGENT_CHAT_ID` (`"agent-chat"`) | `conversationId` |
| SidebarChatTab agent | `SIDEBAR_AGENT_CHAT_ID` (`"sidebar-agent"`) | `sidebar:conversationId` |

Transport remains keyed to the real conversation ID (stream tracking needs it). Verified from AI SDK source that transport changes do NOT trigger Chat recreation — only `id` changes do.

### Message application patterns

**Global mode**: Surfaces watch `initialMessages` reference from context → apply via `setMessages`. No signal needed — the context only writes `initialMessages` on load/create, never during streaming.

**Agent mode**: Store `conversationLoadSignal` fires on explicit load/create (not during streaming). `GlobalAssistantView` watches it to re-apply `conversationMessages`. Signal is needed because the store receives bidirectional writes during streaming.

### What was removed

- `messages` prop from all 4 chat configs
- `EMPTY_MESSAGES` constant from AiChatView
- `setRefreshSignal` calls from `loadConversation`/`createNewConversation` (was overloading the remote-event signal)
- Wrong SWR comment in SidebarChatTab ("The useChat hook with the same ID shares state via SWR" — false in v3)

### What was kept

- `refreshSignal` for remote events (reconnect, cross-tab messages, undo)
- `conversationLoadSignal` for agent-mode same-conversation re-click
- Custom stream recovery (`useStreamRecovery`, `consumeStreamJoin`)
- Transport stream tracking (keyed to real conversation ID)

## Post-review fixes

A deep multi-angle review (8 independent passes: line-by-line correctness, removed-behavior audit, cross-file tracing, reuse, simplification, efficiency, altitude, conventions) found two regressions in the same bug class this PR fixes, plus one piece of dead code:

1. **SidebarChatTab agent-mode conversation history never loaded at all.** `agentChatConfig` switched to the stable `SIDEBAR_AGENT_CHAT_ID` and dropped the `messages` construction prop, but no replacement effect applied `usePageAgentSidebarState`'s fetched messages via `setMessages`. Result: the sidebar's agent-mode chat rendered permanently blank on agent select, conversation switch, or new conversation creation. Fixed with a ref-guarded load-on-select effect (mirrors the sidebar's own global-mode pattern) + 5 new regression tests.
2. **GlobalAssistantView agent-mode blank on remount.** `prevAgentLoadSignalRef` was seeded with the store's *current* `conversationLoadSignal` value instead of a neutral sentinel. Since `usePageAgentDashboardStore` is a module-level singleton that outlives the component's mount, navigating away from `/dashboard` and back with an agent already selected left the freshly-mounted `useChat` instance blank. Fixed by seeding to `null`, matching the sibling effects.
3. **Removed `shouldApplyMessages`** (dead code — exported/tested but never called from any of the 4 production surfaces; each hand-rolls its own equivalent guard).

Noted but intentionally not fixed (out of scope / low severity, documented in PR comments): a narrow abort-map race in `AiChatView.tsx` if a user switches conversations inside the sub-second window before the first stream chunk arrives; `selectAgent()` not bumping `conversationLoadSignal` (masked in practice by the existing loading-state gate).

## Sources

- [AI SDK useChat reference](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) — `id`: "A unique identifier for the chat"
- [AI SDK message persistence](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-message-persistence) — official pattern assumes fresh mount per conversation
- [vercel/ai `use-chat.ts` source](https://github.com/vercel/ai/blob/main/packages/react/src/use-chat.ts) — `shouldRecreateChat` checks `id` only

## Testing

- `chat-config.test.ts`: unit tests for the pure `buildChatConfig` function
- `GlobalChatContext.test.tsx`: Existing `refreshSignal` tests pass (loadConversation no longer increments refreshSignal)
- `usePageAgentDashboardStore.test.ts`: `conversationLoadSignal` reset in beforeEach
- `SidebarChatTab.test.tsx`: 5 new regression tests for the agent-mode load-on-select fix
- Local validation: `bun run lint` clean, `tsc --noEmit` clean, 97/97 relevant vitest tests passing; full CI (Lint & TypeScript Check, Unit Tests) green

## Files changed (9)

- `lib/ai/shared/chat-config.ts` — NEW: pure functions module
- `lib/ai/shared/__tests__/chat-config.test.ts` — NEW: 12 unit tests
- `lib/ai/shared/hooks/index.ts` — re-export chat-config functions
- `contexts/GlobalChatContext.tsx` — stable id, no messages prop, pure fn
- `components/.../AiChatView.tsx` — stable transport + id, no messages prop
- `components/.../GlobalAssistantView.tsx` — stable agent id, load-on-select effects
- `components/.../SidebarChatTab.tsx` — stable sidebar-agent id, load-on-select effect
- `stores/.../usePageAgentDashboardStore.ts` — conversationLoadSignal
- `stores/.../__tests__/usePageAgentDashboardStore.test.ts` — signal reset in beforeEach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI chat state resets and stale message displays when switching or loading conversations, including cases where the conversation ID doesn’t change.
  * Improved message refresh behavior across the assistant sidebar and dashboard for both agent and global modes.
  * Standardized chat setup to keep message sourcing consistent across surfaces and modes.
* **New Features**
  * Added a shared chat configuration utility for stable chat identity and predictable message-application decisions.
* **Tests**
  * Added coverage for chat configuration behavior and message-application logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
