### PR TITLE
fix(voice): eliminate TTS word dropping (.tsx) + awkward pauses between chunks

### DIFF
--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -726,15 +726,24 @@ export function useVoiceMode({
               const { isEnabled: sEnabled, interactionMode: sMode } =
                 useVoiceModeStore.getState();
               if (sEnabled && sMode === 'conversation') {
-                playbackRefs.current.autoListenTimer = setTimeout(() => {
+                // Re-arming safety timer: checks every 500ms whether the stream
+                // has ended. If stream is still active, re-arms and waits again.
+                // This prevents voice from getting stuck in 'speaking' when the
+                // stream ends after the gap but no new text was delivered.
+                const recheck = () => {
                   playbackRefs.current.autoListenTimer = null;
-                  if (!isAIStreamingRef.current && !playbackRefs.current.audioSource) {
+                  if (playbackRefs.current.audioSource) return; // new audio started
+                  if (!isAIStreamingRef.current) {
                     stopSpeakingStore();
                     const { isEnabled: en, interactionMode: md } =
                       useVoiceModeStore.getState();
                     if (en && md === 'conversation') void startListening();
+                  } else {
+                    // Stream still active, re-arm
+                    playbackRefs.current.autoListenTimer = setTimeout(recheck, 500);
                   }
-                }, 500);
+                };
+                playbackRefs.current.autoListenTimer = setTimeout(recheck, 500);
               }
               return;
             }

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -641,6 +641,12 @@ export function useVoiceMode({
         const audioId = createId();
         startSpeakingStore(audioId);
 
+        // Clear any pending transition timer from a previous gap-between-chunks
+        if (playbackRefs.current.autoListenTimer) {
+          clearTimeout(playbackRefs.current.autoListenTimer);
+          playbackRefs.current.autoListenTimer = null;
+        }
+
         const audioContext = getAudioContext();
         let audioBuffer: AudioBuffer;
 
@@ -707,6 +713,32 @@ export function useVoiceMode({
               return;
             }
 
+            // If the AI stream is still active, keep 'speaking' state so the UI
+            // doesn't flicker to idle between chunks. Clear the audio ID so
+            // queueSentence knows to trigger playback directly when the next
+            // chunk arrives (no onended will fire to drain the queue).
+            if (isAIStreamingRef.current) {
+              setCurrentAudioId(null);
+              callbacksRef.current.onSpeakComplete?.();
+              // Safety net: if the stream ends without delivering more text,
+              // this timer transitions out of speaking. The isAIStreamingRef
+              // check at fire time makes it a no-op if chunks are still flowing.
+              const { isEnabled: sEnabled, interactionMode: sMode } =
+                useVoiceModeStore.getState();
+              if (sEnabled && sMode === 'conversation') {
+                playbackRefs.current.autoListenTimer = setTimeout(() => {
+                  playbackRefs.current.autoListenTimer = null;
+                  if (!isAIStreamingRef.current && !playbackRefs.current.audioSource) {
+                    stopSpeakingStore();
+                    const { isEnabled: en, interactionMode: md } =
+                      useVoiceModeStore.getState();
+                    if (en && md === 'conversation') void startListening();
+                  }
+                }, 500);
+              }
+              return;
+            }
+
             stopSpeakingStore();
             callbacksRef.current.onSpeakComplete?.();
 
@@ -714,12 +746,12 @@ export function useVoiceMode({
             // but only when the AI stream has fully finished (not mid-tool-call).
             const { isEnabled: liveEnabled, interactionMode: liveMode } =
               useVoiceModeStore.getState();
-            if (liveEnabled && liveMode === 'conversation' && !isAIStreamingRef.current) {
+            if (liveEnabled && liveMode === 'conversation') {
               playbackRefs.current.autoListenTimer = setTimeout(() => {
                 playbackRefs.current.autoListenTimer = null;
                 const { isEnabled: enabledNow, interactionMode: modeNow } =
                   useVoiceModeStore.getState();
-                if (enabledNow && modeNow === 'conversation' && !isAIStreamingRef.current) {
+                if (enabledNow && modeNow === 'conversation') {
                   void startListening();
                 }
               }, 300);
@@ -780,7 +812,14 @@ export function useVoiceMode({
       if (currentState === 'listening' || currentState === 'processing') return;
       if (currentState === 'speaking') {
         speechQueueRef.current.push(text);
-        if (!prefetchedAudioRef.current) {
+        const { currentAudioId } = useVoiceModeStore.getState();
+        if (!currentAudioId) {
+          // Between chunks during streaming — onended fired but we kept
+          // 'speaking' state. No audio is playing or being fetched, so
+          // start playback immediately to minimize the gap.
+          const nextText = speechQueueRef.current.shift()!;
+          void speak(nextText);
+        } else if (!prefetchedAudioRef.current) {
           // Pre-fetch the queue head (index 0), not the just-pushed tail
           prefetchedAudioRef.current = prefetchAudio(speechQueueRef.current[0]);
         }

--- a/apps/web/src/lib/voice/__tests__/chunkForTts.test.ts
+++ b/apps/web/src/lib/voice/__tests__/chunkForTts.test.ts
@@ -7,6 +7,13 @@ import {
 } from '../chunkForTts';
 
 describe('normalizeForSpeech', () => {
+  it('preserves file extensions like .tsx without mangling the period', () => {
+    // normalizeForSpeech should pass Button.tsx through unchanged.
+    // The period in a file extension is NOT a sentence terminator.
+    const out = normalizeForSpeech('Look at Button.tsx for the component.');
+    expect(out).toContain('Button.tsx');
+  });
+
   it('extracts code block body for speaking (strips only fence markers)', () => {
     const input = 'Hello.\n```js\nconst x = 1;\n```\nWorld.';
     const out = normalizeForSpeech(input);
@@ -134,6 +141,57 @@ describe('normalizeForSpeech', () => {
 });
 
 describe('chunkStreamingForTts', () => {
+  it('does not drop content before a file extension period (Button.tsx)', () => {
+    // Regression test: the old regex [^.!?]+[.!?]+(?:\s+|$)|[^.!?]+$ would
+    // match the . in Button.tsx as a sentence boundary, then lose everything
+    // before it. The result would be only "tsx" spoken.
+    const result = chunkStreamingForTts('Let me check Button.tsx more text.');
+    const all = result.ready.join(' ');
+    expect(all).toContain('Button');
+    expect(all).toContain('tsx');
+    // Should NOT be split into "Button." + "tsx more text."
+    expect(all).toContain('Button.tsx');
+  });
+
+  it('preserves a standalone filename at end of text via flush', () => {
+    // "something Button.tsx" with no trailing sentence — the old regex
+    // would return only ["tsx"], silently dropping "something Button"
+    const result = flushForTts('something Button.tsx');
+    const all = result.join(' ');
+    expect(all).toContain('something');
+    expect(all).toContain('Button');
+    expect(all).toContain('tsx');
+  });
+
+  it('preserves multiple file extensions in one sentence', () => {
+    const result = flushForTts('We changed App.tsx, index.ts, and config.json in this PR.');
+    const all = result.join(' ');
+    expect(all).toContain('App.tsx');
+    expect(all).toContain('index.ts');
+    expect(all).toContain('config.json');
+  });
+
+  it('preserves decimal numbers like 3.14', () => {
+    const result = flushForTts('The value is exactly 3.14 in this case.');
+    const all = result.join(' ');
+    expect(all).toContain('3.14');
+  });
+
+  it('preserves version numbers like v1.2.3', () => {
+    const result = flushForTts('We upgraded to v1.2.3 last week.');
+    const all = result.join(' ');
+    expect(all).toContain('v1.2.3');
+  });
+
+  it('preserves a filename at the very end of a complete sentence', () => {
+    const result = chunkStreamingForTts('Look at Button.tsx. Next thing.');
+    const all = result.ready.join(' ');
+    expect(all).toContain('Button.tsx');
+    expect(all).toContain('Next thing');
+    // Button.tsx should NOT be split into separate chunks
+    expect(all).not.toMatch(/Button\.\s+tsx/);
+  });
+
   it('returns the buffer as pending when no terminator is present', () => {
     const result = chunkStreamingForTts('Hello world without a period');
     expect(result.ready).toEqual([]);
@@ -322,6 +380,26 @@ describe('splitOversizedForTts', () => {
 });
 
 describe('streaming end-to-end simulation', () => {
+  it('preserves file extensions across streaming token boundaries', () => {
+    // Simulate tokens arriving: "Check the file " + "Button.tsx" + " for details."
+    let buffer = '';
+    const tokens = ['Check the file ', 'Button.tsx', ' for details. '];
+    const allReady: string[] = [];
+    for (const t of tokens) {
+      buffer += t;
+      const r = chunkStreamingForTts(buffer);
+      allReady.push(...r.ready);
+      buffer = r.pending;
+    }
+    allReady.push(...flushForTts(buffer));
+    const combined = allReady.join(' ');
+    expect(combined).toContain('Button');
+    expect(combined).toContain('tsx');
+    expect(combined).toContain('details');
+    // Button.tsx should not be split into "Button." and "tsx"
+    expect(combined).not.toMatch(/Button\.\s+tsx/);
+  });
+
   it('handles a markdown response with a code block without dropping content', () => {
     let buffer = '';
     const tokens = [
@@ -344,7 +422,10 @@ describe('streaming end-to-end simulation', () => {
     expect(combined).toContain('Here is some code');
     expect(combined).toContain('Done');
     expect(combined).not.toContain('```');
-    expect(combined).not.toContain('const x');
+    // Code body IS spoken — normalizeForSpeech intentionally extracts it.
+    // The old packSentences regex would silently drop content before the
+    // period in "console.log", which is the same bug as the .tsx issue.
+    expect(combined).toContain('const x');
   });
 
   it('handles a long unpunctuated paragraph by flushing it at end', () => {

--- a/apps/web/src/lib/voice/chunkForTts.ts
+++ b/apps/web/src/lib/voice/chunkForTts.ts
@@ -119,7 +119,14 @@ function findLastSafeBoundary(buffer: string): number {
 
 function packSentences(text: string, maxChars: number): string[] {
   const sentences: string[] = [];
-  const re = /[^.!?]+[.!?]+(?:\s+|$)|[^.!?]+$/g;
+  // Lazy quantifier (\S*?) naturally skips past periods that are NOT sentence
+  // terminators — file extensions (Button.tsx), decimals (3.14), version
+  // numbers (v1.2.3) — because [\s\S]*? expands until it finds a [.!?] that
+  // IS followed by whitespace or end-of-string.
+  // The previous regex /[^.!?]+[.!?]+(?:\s+|$)|[^.!?]+$/g used [^.!?]+ which
+  // could only match non-punctuation runs, so a period inside an identifier
+  // (like .tsx) caused everything before it to be silently DROPPED.
+  const re = /[\s\S]*?[.!?]+(?:\s|$)|[\s\S]+$/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
     const s = m[0].trim();


### PR DESCRIPTION
## Problem

Two distinct voice mode bugs:

1. **Word dropping** — The `packSentences` regex used `[^.!?]+` which can only match non-punctuation runs. When it hit a period inside an identifier like `Button.tsx`, it failed to match and silently dropped everything before the period. TTS would speak only "tsx" instead of "Button.tsx".

2. **Awkward pauses** — When the speech queue emptied between chunks during AI streaming, `onended` called `stopSpeakingStore()` which flickered voice state to `idle`. The next chunk required a full synthesis round-trip with no pre-fetch benefit, plus a visible UI state change.

## Root Causes

### Word dropping (commit 1: `ac707f8`)

`packSentences` in `chunkForTts.ts` regex changed from:
```
/[^.!?]+[.!?]+(?:\s+|$)|[^.!?]+$/g
```
to:
```
/[\s\S]*?[.!?]+(?:\s|$)|[\s\S]+$/g
```

The lazy quantifier naturally skips non-terminal periods (file extensions, decimals, version numbers) because it expands until it finds a `[.!?]` that IS followed by whitespace or end-of-string.

### Awkward pauses (commit 2: `c516316`)

Three changes to `useVoiceMode.ts`:

1. **`onended` handler**: When queue is empty but AI is still streaming, keep `'speaking'` state and clear `currentAudioId`. A 500ms safety timer handles the edge case where the stream ends without delivering more text.

2. **`queueSentence`**: When voice is `'speaking'` but `currentAudioId` is null (between chunks), start playback immediately instead of pushing to a queue that no `onended` will drain.

3. **`speak()`**: Clear any pending transition timer when starting a new chunk to prevent stale timers from firing during playback.

The three changes form a closed state machine: `onended` sets timer + clears audioId → `queueSentence` detects null audioId → `speak()` clears timer before async fetch. No race conditions.

## Testing

- All 53 `chunkForTts` tests pass
- TypeScript clean
- Includes 9 regression tests for `.tsx`, decimals, version numbers, and streaming token boundaries
- AIDD 8-lens review: clean (see PR review comment)