### PR TITLE
fix(sandbox): unify path handling, fix stale-remote and slow-install gotchas

### DIFF
--- a/apps/web/src/lib/ai/core/run-agent-with-retry.ts
+++ b/apps/web/src/lib/ai/core/run-agent-with-retry.ts
@@ -51,7 +51,12 @@ export interface RunAgentWithRetryParams {
   maxRetries?: number;
   /** `Date.now()` at request start, for the wall-clock budget. */
   startTimeMs: number;
-  /** Stop retrying once elapsed exceeds this (keeps us under the 300s function cap). */
+  /**
+   * Stop retrying once elapsed exceeds this (keeps us under the 300s function cap).
+   * If you change this default (or any route's `maxDuration`), also check
+   * `SANDBOX_MAX_TIMEOUT_MS` (packages/lib/src/services/sandbox/execution-policy.ts)
+   * — its cap is sized to leave headroom under this budget for a single bash call.
+   */
   maxDurationMs?: number;
   /** Backoff before retry attempt N (0-indexed). Default 0.5s then 1.5s. Injectable for tests. */
   backoffMs?: (attempt: number) => number;

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -89,11 +89,12 @@ const READ_ONLY_CONSTRAINT = `READ-ONLY MODE:
 // request (same gate as ai-tools.ts). Deliberately short — the basics that make
 // the sandbox smooth to use, not a wall of instructions.
 const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
-• Working dir is /workspace; writeFile/readFile/editFile paths are relative to it.
+• Paths always resolve from /workspace, relative or absolute (e.g. "repo/src/x.ts" and "/workspace/repo/src/x.ts" are the same file) — one rule for every tool. Most tools take path (file tools, and git_clone/git_init for their destination); bash and the rest of the git_*/gh_* tools take cwd for their working directory instead. A field from the wrong family (e.g. cwd on writeFile) is rejected, not silently ignored.
 • The /workspace filesystem persists across turns and tool calls in this conversation — your clone, branch checkout, and commits are still there next turn. Check state before recreating it: git_status / git_branch before re-cloning or branching; gh_pr_list / gh_pr_view before opening a PR. To update an open PR, push more commits to its branch (force-push is fine for your PR branch, never to main/master) — don't open a second PR.
-• Each tool call is a fresh process — cd does NOT persist between calls (the filesystem persists, the shell does not). Pass cwd to operate inside a subdirectory (e.g. a cloned repo).
+• Each tool call is a fresh process — cd does NOT persist between calls (the filesystem persists, the shell does not).
 • bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
 • Use editFile for targeted string edits; writeFile rewrites the whole file.
+• Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs if a command needs more than the 120s default.
 • Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view.`;
 
 /**

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -94,7 +94,7 @@ const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
 • Each tool call is a fresh process — cd does NOT persist between calls (the filesystem persists, the shell does not).
 • bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
 • Use editFile for targeted string edits; writeFile rewrites the whole file.
-• Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs if a command needs more than the 120s default.
+• Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs (up to 200000ms) if a command needs more than the 120s default.
 • Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view.`;
 
 /**

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -80,18 +80,20 @@ describe('git_clone', () => {
     );
     const calls = getRunCalls(deps);
     expect(calls[0].cmd).toBe('git');
-    expect(calls[0].args).toEqual(['clone', '--depth', '1', 'https://github.com/owner/repo.git', '.']);
+    expect(calls[0].args).toEqual([
+      'clone', '--depth', '1', 'https://github.com/owner/repo.git', '/workspace',
+    ]);
   });
 
-  it('clones into the default working directory when no path is given', async () => {
+  it('clones into the sandbox root when no path is given', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
     await git_clone.execute!({ repo_url: 'https://github.com/owner/repo.git' }, {} as never);
     const calls = getRunCalls(deps);
-    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git', '.']);
+    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git', '/workspace']);
   });
 
-  it('uses the explicit clone path when provided', async () => {
+  it('resolves the explicit clone path under the sandbox root', async () => {
     const deps = makeDeps();
     const { git_clone } = createSandboxGitTools(deps);
     await git_clone.execute!(
@@ -99,19 +101,38 @@ describe('git_clone', () => {
       {} as never,
     );
     const calls = getRunCalls(deps);
-    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git', 'repo']);
+    expect(calls[0].args).toEqual(['clone', 'https://github.com/owner/repo.git', '/workspace/repo']);
+  });
+
+  it('rejects a clone destination that escapes the sandbox root', async () => {
+    const deps = makeDeps();
+    const { git_clone } = createSandboxGitTools(deps);
+    const result = await git_clone.execute!(
+      { repo_url: 'https://github.com/owner/repo.git', path: '../../escaped-outside-workspace' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false, reason: 'path_escape' });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
 });
 
 // ── git_init ───────────────────────────────────────────────────────────────
 
 describe('git_init', () => {
-  it('defaults to "." when no path given', async () => {
+  it('defaults to the sandbox root when no path given', async () => {
     const deps = makeDeps();
     const { git_init } = createSandboxGitTools(deps);
     await git_init.execute!({}, {} as never);
     const calls = getRunCalls(deps);
-    expect(calls[0].args).toEqual(['init', '.']);
+    expect(calls[0].args).toEqual(['init', '/workspace']);
+  });
+
+  it('rejects an init path that escapes the sandbox root', async () => {
+    const deps = makeDeps();
+    const { git_init } = createSandboxGitTools(deps);
+    const result = await git_init.execute!({ path: '/etc/foo' }, {} as never);
+    expect(result).toMatchObject({ success: false, reason: 'path_escape' });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
 });
 
@@ -358,6 +379,22 @@ describe('git_push', () => {
     expect(calls[0].args).toContain('-u');
   });
 
+  it('includes -u by default when set_upstream is omitted', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute!({ branch: 'feature' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('-u');
+  });
+
+  it('omits -u when set_upstream: false is explicit', async () => {
+    const deps = makeDeps();
+    const { git_push } = createSandboxGitTools(deps);
+    await git_push.execute!({ branch: 'feature', set_upstream: false }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).not.toContain('-u');
+  });
+
   it('returns no-connection error without opening sandbox when token is null', async () => {
     const deps = makeDeps(null);
     const { git_push } = createSandboxGitTools(deps);
@@ -476,6 +513,40 @@ describe('cwd threading', () => {
     await git_status.execute!({}, {} as never);
     const calls = getRunCalls(deps);
     expect((calls[0] as unknown as { cwd: string }).cwd).toBe('/workspace');
+  });
+});
+
+// ── schema strictness ────────────────────────────────────────────────────
+
+describe('schema strictness', () => {
+  function safeParse(schema: unknown, value: unknown) {
+    return (schema as { safeParse: (v: unknown) => { success: boolean } }).safeParse(value);
+  }
+
+  it('git_status: given an unrecognized field, should reject instead of silently dropping it', () => {
+    const { git_status } = createSandboxGitTools(makeDeps());
+    expect(safeParse(git_status.inputSchema, { cwd: 'repo', bogus: true }).success).toBe(false);
+    expect(safeParse(git_status.inputSchema, { cwd: 'repo' }).success).toBe(true);
+  });
+
+  it('git_add (refine-wrapped schema): given an unrecognized field, should reject instead of silently dropping it', () => {
+    const { git_add } = createSandboxGitTools(makeDeps());
+    expect(safeParse(git_add.inputSchema, { all: true, bogus: true }).success).toBe(false);
+    expect(safeParse(git_add.inputSchema, { all: true }).success).toBe(true);
+  });
+
+  it('git_clone (field-level refine on repo_url): given an unrecognized field, should reject; a valid HTTPS url still passes', () => {
+    const { git_clone } = createSandboxGitTools(makeDeps());
+    expect(
+      safeParse(git_clone.inputSchema, { repo_url: 'https://github.com/o/r.git', bogus: true }).success,
+    ).toBe(false);
+    expect(safeParse(git_clone.inputSchema, { repo_url: 'https://github.com/o/r.git' }).success).toBe(true);
+  });
+
+  it('gh_pr_create: given an unrecognized field, should reject instead of silently dropping it', () => {
+    const { gh_pr_create } = createSandboxGitTools(makeDeps());
+    expect(safeParse(gh_pr_create.inputSchema, { title: 't', body: 'b', bogus: true }).success).toBe(false);
+    expect(safeParse(gh_pr_create.inputSchema, { title: 't', body: 'b' }).success).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -124,6 +124,40 @@ describe('createSandboxTools', () => {
     expect(schema.safeParse({ command: 'ls' }).success).toBe(true);
   });
 
+  describe('schema strictness', () => {
+    function schemaOf(tools: ReturnType<typeof createSandboxTools>, name: keyof ReturnType<typeof createSandboxTools>) {
+      return tools[name].inputSchema as { safeParse: (v: unknown) => { success: boolean } };
+    }
+
+    it('writeFile inputSchema: given an unrecognized cwd field, should reject instead of silently dropping it', () => {
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
+      const schema = schemaOf(tools, 'writeFile');
+      expect(schema.safeParse({ path: 'a.txt', content: 'x', cwd: 'PageSpace' }).success).toBe(false);
+      expect(schema.safeParse({ path: 'a.txt', content: 'x' }).success).toBe(true);
+    });
+
+    it('readFile inputSchema: given an unrecognized cwd field, should reject instead of silently dropping it', () => {
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
+      const schema = schemaOf(tools, 'readFile');
+      expect(schema.safeParse({ path: 'a.txt', cwd: 'PageSpace' }).success).toBe(false);
+      expect(schema.safeParse({ path: 'a.txt' }).success).toBe(true);
+    });
+
+    it('editFile inputSchema: given an unrecognized cwd field, should reject instead of silently dropping it', () => {
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
+      const schema = schemaOf(tools, 'editFile');
+      expect(schema.safeParse({ path: 'a.txt', oldString: 'x', newString: 'y', cwd: 'PageSpace' }).success).toBe(false);
+      expect(schema.safeParse({ path: 'a.txt', oldString: 'x', newString: 'y' }).success).toBe(true);
+    });
+
+    it('bash inputSchema: given a legitimate extra-looking but unknown field, should reject it', () => {
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
+      const schema = schemaOf(tools, 'bash');
+      expect(schema.safeParse({ command: 'ls', bogus: true }).success).toBe(false);
+      expect(schema.safeParse({ command: 'ls', cwd: 'PageSpace' }).success).toBe(true);
+    });
+  });
+
   it('editFile: should delegate and report replacements', async () => {
     const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
     const result = await exec(tools.editFile, { path: 'a.txt', oldString: 'data', newString: 'X' }, {});

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -87,6 +87,24 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     runGitInSandbox({ cmd, args, cwd, ctx, deps: gitRunDeps });
 
   /**
+   * Resolves `git_clone`/`git_init`'s optional destination `path` (defaulting to
+   * `SANDBOX_ROOT`), returning a ready-made `path_escape` denial on failure —
+   * the only two tools here that take a destination `path` rather than a `cwd`.
+   */
+  const resolveDestinationPath = (
+    path: string | undefined,
+  ): { ok: true; path: string } | { ok: false; error: { success: false; error: string; reason: 'path_escape' } } => {
+    const resolved = path !== undefined ? resolveSandboxPath(path) : SANDBOX_ROOT;
+    if (!resolved) {
+      return {
+        ok: false,
+        error: { success: false, error: 'The path is invalid or escapes the sandbox root.', reason: 'path_escape' },
+      };
+    }
+    return { ok: true, path: resolved };
+  };
+
+  /**
    * For remote/gh tools: pre-checks the GitHub token before opening a sandbox.
    * Passes the already-resolved token to `runGitInSandbox` to avoid a second DB fetch.
    */
@@ -130,17 +148,11 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       if (!repo_url.startsWith('https://')) {
         return { success: false as const, error: 'Only HTTPS URLs are supported for git clone.' };
       }
-      const resolvedPath = path !== undefined ? resolveSandboxPath(path) : SANDBOX_ROOT;
-      if (!resolvedPath) {
-        return {
-          success: false as const,
-          error: 'The path is invalid or escapes the sandbox root.',
-          reason: 'path_escape' as const,
-        };
-      }
+      const resolved = resolveDestinationPath(path);
+      if (!resolved.ok) return resolved.error;
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      const args = ['clone', ...(depth ? ['--depth', String(depth)] : []), repo_url, resolvedPath];
+      const args = ['clone', ...(depth ? ['--depth', String(depth)] : []), repo_url, resolved.path];
       return git('git', args, opened.ctx);
     },
   });
@@ -149,17 +161,11 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     description: 'Initialize a new git repository in the sandbox.',
     inputSchema: z.object({ path: z.string().optional() }).strict(),
     execute: async ({ path }, options) => {
-      const resolvedPath = path !== undefined ? resolveSandboxPath(path) : SANDBOX_ROOT;
-      if (!resolvedPath) {
-        return {
-          success: false as const,
-          error: 'The path is invalid or escapes the sandbox root.',
-          reason: 'path_escape' as const,
-        };
-      }
+      const resolved = resolveDestinationPath(path);
+      if (!resolved.ok) return resolved.error;
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['init', resolvedPath], opened.ctx);
+      return git('git', ['init', resolved.path], opened.ctx);
     },
   });
 

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -19,6 +19,7 @@ import { z } from 'zod';
 import type { SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
 import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
 import { runGitInSandbox } from '@pagespace/lib/services/sandbox/git-tool-runners';
+import { resolveSandboxPath, SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { MAX_PATH_LENGTH, type ResolveSandboxContext, type SandboxGate } from './sandbox-tools';
 import type { ToolExecutionContext } from '../core/types';
 
@@ -123,25 +124,42 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         ),
       path: z.string().optional(),
       depth: z.number().int().positive().optional(),
-    }),
+    })
+      .strict(),
     execute: async ({ repo_url, path, depth }, options) => {
       if (!repo_url.startsWith('https://')) {
         return { success: false as const, error: 'Only HTTPS URLs are supported for git clone.' };
       }
+      const resolvedPath = path !== undefined ? resolveSandboxPath(path) : SANDBOX_ROOT;
+      if (!resolvedPath) {
+        return {
+          success: false as const,
+          error: 'The path is invalid or escapes the sandbox root.',
+          reason: 'path_escape' as const,
+        };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      const args = ['clone', ...(depth ? ['--depth', String(depth)] : []), repo_url, path ?? '.'];
+      const args = ['clone', ...(depth ? ['--depth', String(depth)] : []), repo_url, resolvedPath];
       return git('git', args, opened.ctx);
     },
   });
 
   const gitInit = tool({
     description: 'Initialize a new git repository in the sandbox.',
-    inputSchema: z.object({ path: z.string().optional() }),
+    inputSchema: z.object({ path: z.string().optional() }).strict(),
     execute: async ({ path }, options) => {
+      const resolvedPath = path !== undefined ? resolveSandboxPath(path) : SANDBOX_ROOT;
+      if (!resolvedPath) {
+        return {
+          success: false as const,
+          error: 'The path is invalid or escapes the sandbox root.',
+          reason: 'path_escape' as const,
+        };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['init', path ?? '.'], opened.ctx);
+      return git('git', ['init', resolvedPath], opened.ctx);
     },
   });
 
@@ -152,7 +170,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       value: z.string(),
       global: z.boolean().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ key, value, global: isGlobal, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -169,7 +188,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         .url()
         .refine((u) => u.startsWith('https://'), 'Only HTTPS remote URLs are supported'),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ name, url, cwd }, options) => {
       if (!url.startsWith('https://')) {
         return { success: false as const, error: 'Only HTTPS URLs are supported for git remote add.' };
@@ -184,7 +204,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitStatus = tool({
     description: 'Show the working tree status in porcelain format.',
-    inputSchema: z.object({ path: z.string().optional(), cwd: cwdField }),
+    inputSchema: z.object({ path: z.string().optional(), cwd: cwdField }).strict(),
     execute: async ({ path, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -194,7 +214,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitDiff = tool({
     description: 'Show changes in the working tree or staged changes.',
-    inputSchema: z.object({ staged: z.boolean().optional(), path: z.string().optional(), cwd: cwdField }),
+    inputSchema: z
+      .object({ staged: z.boolean().optional(), path: z.string().optional(), cwd: cwdField })
+      .strict(),
     execute: async ({ staged, path, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -211,6 +233,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     description: 'Stage files for commit.',
     inputSchema: z
       .object({ paths: z.array(z.string()).optional(), all: z.boolean().optional(), cwd: cwdField })
+      .strict()
       .refine((d) => d.all || (d.paths && d.paths.length > 0), {
         message: 'Provide paths or set all: true',
       }),
@@ -230,7 +253,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       mode: z.enum(['soft', 'mixed', 'hard']),
       ref: z.string().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ mode, ref, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -244,7 +268,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       action: z.enum(['push', 'pop', 'list', 'drop']),
       message: z.string().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ action, message, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -264,7 +289,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       message: z.string().min(1),
       amend: z.boolean().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ message, amend, cwd }, options) => {
       if (!message) {
         return { success: false as const, error: 'commit message is required' };
@@ -287,7 +313,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       path: z.string().optional(),
       oneline: z.boolean().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ n, path, oneline, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -312,7 +339,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       branch: z.string().min(1),
       strategy: z.enum(['merge', 'squash', 'ff-only']).optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ branch, strategy, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -324,7 +352,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitRebase = tool({
     description: 'Rebase onto a branch or ref. Non-interactive only.',
-    inputSchema: z.object({ branch_or_ref: z.string().min(1), cwd: cwdField }),
+    inputSchema: z.object({ branch_or_ref: z.string().min(1), cwd: cwdField }).strict(),
     execute: async ({ branch_or_ref, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -334,7 +362,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitCheckout = tool({
     description: 'Switch branches or create a new one.',
-    inputSchema: z.object({ ref: z.string().min(1), create: z.boolean().optional(), cwd: cwdField }),
+    inputSchema: z
+      .object({ ref: z.string().min(1), create: z.boolean().optional(), cwd: cwdField })
+      .strict(),
     execute: async ({ ref, create, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
@@ -346,6 +376,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     description: 'List, create, or delete branches.',
     inputSchema: z
       .object({ action: z.enum(['list', 'create', 'delete']), name: z.string().optional(), cwd: cwdField })
+      .strict()
       .refine((d) => d.action === 'list' || !!d.name, { message: 'name required for create/delete' }),
     execute: async ({ action, name, cwd }, options) => {
       if ((action === 'create' || action === 'delete') && !name) {
@@ -363,7 +394,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitFetch = tool({
     description: 'Fetch from a remote. Requires a connected GitHub account.',
-    inputSchema: z.object({ remote: z.string().optional(), branch: z.string().optional(), cwd: cwdField }),
+    inputSchema: z
+      .object({ remote: z.string().optional(), branch: z.string().optional(), cwd: cwdField })
+      .strict(),
     execute: async ({ remote, branch, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR('git', ['fetch', remote ?? 'origin', ...(branch ? [branch] : [])], ctx, token, cwd),
@@ -377,7 +410,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       branch: z.string().optional(),
       rebase: z.boolean().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ remote, branch, rebase, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
@@ -399,7 +433,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       force: z.boolean().optional(),
       set_upstream: z.boolean().optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ remote, branch, force, set_upstream, cwd }, options) => {
       // Force-push is fine for a feature/PR branch, but never the default branch.
       // A push forces when the `force` flag is set OR the refspec is `+`-prefixed
@@ -431,7 +466,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           [
             'push',
             ...(force ? ['--force-with-lease'] : []),
-            ...(set_upstream ? ['-u'] : []),
+            ...(set_upstream !== false ? ['-u'] : []),
             remote ?? 'origin',
             ...(branch ? [branch] : []),
           ],
@@ -454,7 +489,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       draft: z.boolean().optional(),
       labels: z.array(z.string()).optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ title, body, base, draft, labels, cwd }, options) => {
       if (!title) {
         return { success: false as const, error: 'title is required' };
@@ -484,7 +520,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       state: z.enum(['open', 'closed', 'merged', 'all']).optional(),
       limit: z.number().int().positive().max(100).optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ state, limit, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
@@ -504,7 +541,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const ghPrView = tool({
     description: 'View a pull request. Requires a connected GitHub account.',
-    inputSchema: z.object({ number: z.number().int().positive().optional(), cwd: cwdField }),
+    inputSchema: z
+      .object({ number: z.number().int().positive().optional(), cwd: cwdField })
+      .strict(),
     execute: async ({ number, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
@@ -527,7 +566,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       number: z.number().int().positive().optional(),
       strategy: z.enum(['merge', 'squash', 'rebase']),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ number, strategy, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
@@ -547,7 +587,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const ghPrCheckout = tool({
     description: 'Check out a pull request locally. Requires a connected GitHub account.',
-    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }),
+    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }).strict(),
     execute: async ({ number, cwd }, options) =>
       withToken(options, (ctx, token) => gitR('gh', ['pr', 'checkout', String(number)], ctx, token, cwd)),
   });
@@ -561,7 +601,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       body: z.string(),
       labels: z.array(z.string()).optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ title, body, labels, cwd }, options) => {
       if (!title) {
         return { success: false as const, error: 'title is required' };
@@ -589,7 +630,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       state: z.enum(['open', 'closed', 'all']).optional(),
       limit: z.number().int().positive().max(100).optional(),
       cwd: cwdField,
-    }),
+    })
+      .strict(),
     execute: async ({ state, limit, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(
@@ -609,7 +651,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const ghIssueView = tool({
     description: 'View an issue. Requires a connected GitHub account.',
-    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }),
+    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }).strict(),
     execute: async ({ number, cwd }, options) =>
       withToken(options, (ctx, token) =>
         gitR(

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -34,29 +34,40 @@ import type { ToolExecutionContext } from '../core/types';
 
 export const MAX_PATH_LENGTH = 1024;
 
-export const bashInputSchema = z.object({
-  command: z
-    .string()
-    .min(1, 'command is required')
-    .max(MAX_COMMAND_BYTES, 'command is too large'),
-  cwd: z.string().max(MAX_PATH_LENGTH).optional(),
-});
+export const bashInputSchema = z
+  .object({
+    command: z
+      .string()
+      .min(1, 'command is required')
+      .max(MAX_COMMAND_BYTES, 'command is too large'),
+    cwd: z.string().max(MAX_PATH_LENGTH).optional(),
+    // Opt-in override for long-running commands (e.g. `bun install`), clamped
+    // to SANDBOX_MAX_TIMEOUT_MS by the runner. Omit for the default (120s).
+    timeoutMs: z.number().int().positive().optional(),
+  })
+  .strict();
 
-export const writeFileInputSchema = z.object({
-  path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
-  content: z.string().max(MAX_WRITE_BYTES, 'content is too large'),
-});
+export const writeFileInputSchema = z
+  .object({
+    path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
+    content: z.string().max(MAX_WRITE_BYTES, 'content is too large'),
+  })
+  .strict();
 
-export const readFileInputSchema = z.object({
-  path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
-});
+export const readFileInputSchema = z
+  .object({
+    path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
+  })
+  .strict();
 
-export const editFileInputSchema = z.object({
-  path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
-  oldString: z.string().min(1, 'oldString is required'),
-  newString: z.string(),
-  replaceAll: z.boolean().optional(),
-});
+export const editFileInputSchema = z
+  .object({
+    path: z.string().min(1, 'path is required').max(MAX_PATH_LENGTH),
+    oldString: z.string().min(1, 'oldString is required'),
+    newString: z.string(),
+    replaceAll: z.boolean().optional(),
+  })
+  .strict();
 
 /** Resolves the actor context for a turn, or an error to surface to the model. */
 export type ResolveSandboxContext = (
@@ -113,10 +124,10 @@ export function createSandboxTools({ runDeps, resolveContext, gate }: SandboxToo
       description:
         'Run a shell command in this conversation\'s isolated sandbox. Returns stdout, stderr, and the exit code. The filesystem is scoped to the sandbox.',
       inputSchema: bashInputSchema,
-      execute: async ({ command, cwd }, options) => {
+      execute: async ({ command, cwd, timeoutMs }, options) => {
         const opened = await open(options);
         if (!opened.ok) return opened.error;
-        return runBashInSandbox({ command, cwd, ctx: opened.ctx, deps: runDeps });
+        return runBashInSandbox({ command, cwd, timeoutMs, ctx: opened.ctx, deps: runDeps });
       },
     }),
 

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-paths.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-paths.test.ts
@@ -26,4 +26,33 @@ describe('resolveSandboxPath', () => {
     expect(resolveSandboxPath('')).toBeNull();
     expect(resolveSandboxPath(undefined as unknown as string)).toBeNull();
   });
+
+  it('given an absolute path under /workspace, should resolve the same as the equivalent relative path', () => {
+    expect(resolveSandboxPath('/workspace/PageSpace/apps/web/foo.ts')).toBe(
+      resolveSandboxPath('PageSpace/apps/web/foo.ts'),
+    );
+  });
+
+  it('given the bare sandbox root with no trailing content, should resolve to the root', () => {
+    expect(resolveSandboxPath('/workspace')).toBe(SANDBOX_ROOT);
+  });
+
+  it('given an absolute path NOT prefixed with /workspace, should still reject it', () => {
+    expect(resolveSandboxPath('/etc/passwd')).toBeNull();
+    expect(resolveSandboxPath('/workspace-evil/foo.ts')).toBeNull();
+  });
+
+  it('given a traversal attempt appended after the /workspace prefix, should still reject it', () => {
+    expect(resolveSandboxPath('/workspace/../../etc/passwd')).toBeNull();
+  });
+
+  it('given a URL-encoded attempt to smuggle the /workspace prefix, should still reject it', () => {
+    expect(resolveSandboxPath('%2Fworkspace%2F..%2F..%2Fetc%2Fpasswd')).toBeNull();
+  });
+
+  it('given a doubled separator right after the /workspace prefix, should still resolve (not misread the extra slash as a fresh absolute segment)', () => {
+    expect(resolveSandboxPath('/workspace//PageSpace/foo.ts')).toBe(
+      resolveSandboxPath('PageSpace/foo.ts'),
+    );
+  });
 });

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -304,6 +304,51 @@ describe('runBashInSandbox', () => {
     await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
     expect(seen).toEqual({ timeoutMs: 120_000, maxBytes: 256 * 1024 });
   });
+
+  it('given an explicit timeoutMs, should forward it to the driver instead of the default', async () => {
+    let seenTimeout: number | undefined;
+    const { deps } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          runCommand: async (a) => {
+            seenTimeout = a.timeoutMs;
+            return { exitCode: 0, stdout: '', stderr: '' };
+          },
+        }),
+    });
+    await runBashInSandbox({ command: 'bun install', timeoutMs: 180_000, ctx: makeCtx(), deps });
+    expect(seenTimeout).toBe(180_000);
+  });
+
+  it('given a timeoutMs above the max, should clamp it down instead of passing it through raw', async () => {
+    let seenTimeout: number | undefined;
+    const { deps } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          runCommand: async (a) => {
+            seenTimeout = a.timeoutMs;
+            return { exitCode: 0, stdout: '', stderr: '' };
+          },
+        }),
+    });
+    await runBashInSandbox({ command: 'bun install', timeoutMs: 10_000_000, ctx: makeCtx(), deps });
+    expect(seenTimeout).toBe(200_000);
+  });
+
+  it('given no timeoutMs, should default to SANDBOX_TIMEOUT_MS unchanged', async () => {
+    let seenTimeout: number | undefined;
+    const { deps } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          runCommand: async (a) => {
+            seenTimeout = a.timeoutMs;
+            return { exitCode: 0, stdout: '', stderr: '' };
+          },
+        }),
+    });
+    await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+    expect(seenTimeout).toBe(120_000);
+  });
 });
 
 describe('writeSandboxFile', () => {

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -349,6 +349,21 @@ describe('runBashInSandbox', () => {
     await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
     expect(seenTimeout).toBe(120_000);
   });
+
+  it('given a non-positive timeoutMs (bypassing the zod schema at this exported layer), should clamp to a floor of 1 instead of passing it through raw', async () => {
+    let seenTimeout: number | undefined;
+    const { deps } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          runCommand: async (a) => {
+            seenTimeout = a.timeoutMs;
+            return { exitCode: 0, stdout: '', stderr: '' };
+          },
+        }),
+    });
+    await runBashInSandbox({ command: 'echo hi', timeoutMs: 0, ctx: makeCtx(), deps });
+    expect(seenTimeout).toBe(1);
+  });
 });
 
 describe('writeSandboxFile', () => {

--- a/packages/lib/src/services/sandbox/execution-policy.ts
+++ b/packages/lib/src/services/sandbox/execution-policy.ts
@@ -14,6 +14,14 @@ export const SANDBOX_EGRESS_ALLOWLIST = Object.freeze([
 ] as const);
 
 export const SANDBOX_TIMEOUT_MS = 120_000;
+// Opt-in ceiling for the `bash` tool's per-call `timeoutMs` override — long
+// installs/typechecks can ask for headroom above the default without lifting
+// the cap for every command. Kept well under the AI route's own budget
+// (runAgentWithRetry's maxDurationMs defaults to 285_000, itself under the
+// platform's hard maxDuration=300 route ceiling) — a single tool call must
+// leave room for the rest of the turn (model latency, other tool calls), not
+// consume the entire per-request budget by itself.
+export const SANDBOX_MAX_TIMEOUT_MS = 200_000;
 export const SANDBOX_MAX_OUTPUT_BYTES = 256 * 1024;
 
 // Resource caps set explicitly per sandbox at creation, rather than relying on

--- a/packages/lib/src/services/sandbox/sandbox-paths.ts
+++ b/packages/lib/src/services/sandbox/sandbox-paths.ts
@@ -20,12 +20,39 @@ import { resolvePathWithinSync } from '../../security/path-validator';
 export const SANDBOX_ROOT = '/workspace';
 
 /**
+ * Strip a literal, undecoded `/workspace` prefix from `userPath`, tolerating
+ * any number of separating slashes (e.g. a doubled `/workspace//x`), and
+ * return the root-relative remainder. Returns `userPath` unchanged if it
+ * isn't actually rooted at the sandbox root — `/workspace-evil/x` shares a
+ * textual prefix but is a different path, not a prefix match, and must still
+ * fall through to `resolvePathWithinSync`'s absolute-path rejection.
+ */
+function stripSandboxRootPrefix(userPath: string): string {
+  if (!userPath.startsWith(SANDBOX_ROOT)) {
+    return userPath;
+  }
+  const rest = userPath.slice(SANDBOX_ROOT.length);
+  if (rest.length > 0 && !rest.startsWith('/')) {
+    return userPath;
+  }
+  let i = 0;
+  while (rest[i] === '/') i++;
+  return rest.slice(i);
+}
+
+/**
  * Resolve an agent-supplied, sandbox-root-relative path to an absolute path
  * inside the sandbox, or `null` if it escapes the root or is otherwise invalid.
+ *
+ * A literal, undecoded `/workspace` prefix is treated as equivalent to the
+ * same relative path — the sandbox root isn't something an absolute path can
+ * "escape". Only that exact prefix is special-cased; any other absolute path
+ * (or an attempt to smuggle the prefix via encoding) falls through unchanged
+ * to `resolvePathWithinSync`, which still rejects it.
  */
 export function resolveSandboxPath(userPath: string): string | null {
   if (typeof userPath !== 'string' || userPath.length === 0) {
     return null;
   }
-  return resolvePathWithinSync(SANDBOX_ROOT, userPath);
+  return resolvePathWithinSync(SANDBOX_ROOT, stripSandboxRootPrefix(userPath));
 }

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -25,7 +25,7 @@
  */
 
 import type { SubscriptionTier } from '../subscription-utils';
-import { SANDBOX_TIMEOUT_MS, SANDBOX_MAX_OUTPUT_BYTES } from './execution-policy';
+import { SANDBOX_TIMEOUT_MS, SANDBOX_MAX_TIMEOUT_MS, SANDBOX_MAX_OUTPUT_BYTES } from './execution-policy';
 import { evaluateCommandPolicy } from './command-policy';
 import { truncateToBytes } from './output-limit';
 import { resolveSandboxPath, SANDBOX_ROOT } from './sandbox-paths';
@@ -312,11 +312,14 @@ async function openSession(
 export async function runBashInSandbox({
   command,
   cwd,
+  timeoutMs,
   ctx,
   deps,
 }: {
   command: string;
   cwd?: string;
+  /** Opt-in override for long-running commands (e.g. `bun install`), clamped to `SANDBOX_MAX_TIMEOUT_MS`. Defaults to `SANDBOX_TIMEOUT_MS`. */
+  timeoutMs?: number;
   ctx: SandboxActorContext;
   deps: SandboxRunDeps;
 }): Promise<BashToolResult> {
@@ -363,7 +366,7 @@ export async function runBashInSandbox({
         args: ['-c', command],
         cwd: resolvedCwd,
         env: deps.buildEnv(),
-        timeoutMs: SANDBOX_TIMEOUT_MS,
+        timeoutMs: Math.min(timeoutMs ?? SANDBOX_TIMEOUT_MS, SANDBOX_MAX_TIMEOUT_MS),
         maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
       });
     } catch (error) {

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -366,7 +366,7 @@ export async function runBashInSandbox({
         args: ['-c', command],
         cwd: resolvedCwd,
         env: deps.buildEnv(),
-        timeoutMs: Math.min(timeoutMs ?? SANDBOX_TIMEOUT_MS, SANDBOX_MAX_TIMEOUT_MS),
+        timeoutMs: Math.min(Math.max(timeoutMs ?? SANDBOX_TIMEOUT_MS, 1), SANDBOX_MAX_TIMEOUT_MS),
         maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary

Closes #1740, #1741. Collapses the agent code-execution sandbox's two path conventions into one, and closes the friction gaps a real agent session hit: file tools (`readFile`/`writeFile`/`editFile`) always resolved paths relative to `/workspace`, while `bash`/git tools required an explicit `cwd` — two different mental models for the same location, plus valid `/workspace`-absolute paths being wrongly rejected as `path_escape`. A PageSpace skill page existed purely to teach agents to memorize and switch between the two; the goal here is to make that skill unnecessary by fixing the tooling itself, not documenting the workaround.

- **One path rule, not two**: `resolveSandboxPath` now accepts `/workspace`-prefixed absolute paths as equivalent to the relative form (including a doubled-separator edge case caught in review — `/workspace//foo.ts`). File tools keep their existing single `path` param unchanged; `bash`/git tools keep their existing `cwd` unchanged.
- **`.strict()` on every sandbox tool schema** (4 file/bash + 26 git/gh tools): a field from the wrong tool family (e.g. `cwd` on `writeFile`) is now rejected immediately with a clear error instead of silently dropped (previously a silent wrong-location write, or a confusing "file not found").
- **`git_clone`/`git_init` path validation** (pre-existing gap, closed in-theme): their destination `path` now goes through `resolveSandboxPath` — previously a traversal path (`../../escaped`) could clone/init outside `/workspace` entirely.
- **`git_push` stale-remote fix**: defaults to `-u`/`--set-upstream` unless explicitly disabled, closing the documented `gh_pr_create` "branch isn't pushed" gotcha (root cause: missing local upstream-tracking config after a first push).
- **`bash` `timeoutMs` override**: opt-in, capped at 200s — kept comfortably under the AI route's own 285s/300s execution budget (`runAgentWithRetry`'s `maxDurationMs` default / the route's `maxDuration = 300`), so a single long-running tool call (`bun install`) can't consume the whole turn's budget. Includes a defensive lower-bound floor (1ms) per CodeRabbit review.
- **`SANDBOX_INSTRUCTIONS` rewritten**: one accurate paragraph on path resolution instead of the old two-convention framing, plus terse static reminders (branch discipline, check `AGENTS.md`/`CLAUDE.md`, install deps before tests/typecheck, mentions the `timeoutMs` ceiling) — static and hardcoded per explicit decision, not sourced from the PageSpace skill page.

Design reasoning and the full plan: `~/.claude/plans/https-github-com-2witstudios-pagespace-i-optimized-harp.md`. Tracked as a PageSpace epic: `Features/AI Orchestration/Coding Sandbox/Sandbox Path Unification` (`jiqncgpg5eyhzsgl9w9a0x7k`).

**Follow-up (not in this PR, PageSpace content only):** `AI Agent Hub > Skills > code > SKILL.md` documents the old two-convention split and two now-resolved gotchas — needs a content edit once this merges.

## Review

Ran an 8-angle `/code-review` pass on the diff before opening this PR. Two real bugs surfaced and were fixed pre-PR:
- The `/workspace`-prefix strip broke on a doubled separator (`/workspace//foo.ts`) — fixed with a small helper, regression test added.
- `SANDBOX_MAX_TIMEOUT_MS` was initially set to 300s, sitting at/above the AI route's own 285s/300s execution budget with zero headroom — reduced to 200s with a comment explaining the constraint.

Also fixed in the same pass: the `git_clone`/`git_init` path-validation gap, an inaccurate blanket claim in the rewritten prompt text, and an undocumented `timeoutMs`.

**Post-open**: addressed both CodeRabbit nitpicks (defensive `timeoutMs` lower-bound clamp; explicit mention of the timeout ceiling in the prompt text). Rebased onto `master` after it moved 8 commits ahead (including PR #1736, which also touched `tool-runners.ts`/`git-tool-runners.ts`, and #1732's AI SDK v5→v6 upgrade) — rebase applied cleanly with no conflicts, all validation re-run and green on the new base.

## Test plan
- [x] `bun run typecheck` — clean across `@pagespace/lib` and `web` (including through the AI SDK v6 upgrade)
- [x] `bun run --filter '@pagespace/lib' test` — 5951/5951 passing
- [x] `bun run --filter 'web' test` — 10485/10501 passing; the 16 pre-existing failures (3 files: `admin-role-version.test.ts`, `grouping.test.ts`, `activity-tools.test.ts`) are unrelated to this diff — no test DB in this worktree + an unrelated message-grouping bug; none touch the changed files
- [x] `bun run lint` — clean (includes `web:build`)
- [x] CI green: all 10 required/optional checks passing (Lint & TypeScript, Unit Tests, CodeQL, Security Test Suite, Static Security Analysis, Dependency Audit, Secret Scanning, CodeRabbit)
- [ ] Manual: drive one sandbox session end-to-end behind `CODE_EXECUTION_ENABLED` (clone → edit via a `/workspace`-absolute path → commit/push without `set_upstream` → `gh_pr_create` succeeds first try; confirm passing `cwd` to `writeFile` now fails fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdKbMZsQyb9qFvYkavDKNX