### PR TITLE
feat(api): edit MCP token drive scopes after creation (PATCH endpoint)

### DIFF
--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -54,12 +54,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 }));
 
 vi.mock('@pagespace/lib/services/drive-service', () => ({
-  getDriveAccess: vi.fn(),
-}));
-
-vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
-  customRoleBelongsToDrive: vi.fn().mockResolvedValue(true),
-  getMemberCustomRoleId: vi.fn().mockResolvedValue(null),
+  validateDriveScopeAccess: vi.fn(),
 }));
 
 import { DELETE, PATCH } from '../route';
@@ -67,7 +62,7 @@ import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
-import { getDriveAccess } from '@pagespace/lib/services/drive-service';
+import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
 
 const createContext = (tokenId = 'token-123') => ({
   params: Promise.resolve({ tokenId }),
@@ -205,11 +200,12 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
     vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([
       { id: 'drive-1', name: 'My Drive' },
     ]);
-    vi.mocked(getDriveAccess).mockResolvedValue({
-      isOwner: true,
-      isMember: true,
-      isAdmin: true,
-    } as never);
+    vi.mocked(validateDriveScopeAccess).mockResolvedValue({
+      invalidDriveIds: [],
+      unauthorizedRoles: [],
+      invalidCustomRoles: [],
+      unauthorizedCustomRoles: [],
+    });
   });
 
   it('returns 404 when token not found', async () => {
@@ -265,11 +261,12 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
   });
 
   it('returns 403 when user lacks access to a drive', async () => {
-    vi.mocked(getDriveAccess).mockResolvedValueOnce({
-      isOwner: false,
-      isMember: false,
-      isAdmin: false,
-    } as never);
+    vi.mocked(validateDriveScopeAccess).mockResolvedValueOnce({
+      invalidDriveIds: ['forbidden-drive'],
+      unauthorizedRoles: [],
+      invalidCustomRoles: [],
+      unauthorizedCustomRoles: [],
+    });
 
     const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
       method: 'PATCH',
@@ -285,11 +282,12 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
   });
 
   it('returns 403 when member tries to grant ADMIN', async () => {
-    vi.mocked(getDriveAccess).mockResolvedValueOnce({
-      isOwner: false,
-      isMember: true,
-      isAdmin: false,
-    } as never);
+    vi.mocked(validateDriveScopeAccess).mockResolvedValueOnce({
+      invalidDriveIds: [],
+      unauthorizedRoles: ['drive-1'],
+      invalidCustomRoles: [],
+      unauthorizedCustomRoles: [],
+    });
 
     const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
       method: 'PATCH',

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -127,7 +127,10 @@ describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
     });
 
     const response = await DELETE(request, createContext('nonexistent'));
+    const body = await response.json();
+
     expect(response.status).toBe(404);
+    expect(body.error).toBe('Token not found');
   });
 
   it('returns 200 on successful revocation', async () => {
@@ -222,7 +225,26 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
     });
 
     const response = await PATCH(request, createContext());
+    const body = await response.json();
+
     expect(response.status).toBe(404);
+    expect(body.error).toBe('Token not found');
+  });
+
+  it('returns 400 when neither drives nor driveIds is provided', async () => {
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ name: 'renamed' }),
+    });
+
+    const response = await PATCH(request, createContext());
+
+    expect(response.status).toBe(400);
+    expect(sessionRepository.updateMcpTokenDriveScopes).not.toHaveBeenCalled();
   });
 
   it('returns 400 when both drives and driveIds are provided', async () => {

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
     findUserMcpTokensWithDrives: vi.fn(),
     findMcpTokenByIdAndUser: vi.fn(),
     revokeMcpToken: vi.fn(),
+    updateMcpTokenDriveScopes: vi.fn(),
   },
 }));
 
@@ -52,11 +53,21 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   logTokenActivity: vi.fn(),
 }));
 
-import { DELETE } from '../route';
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getDriveAccess: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
+  customRoleBelongsToDrive: vi.fn().mockResolvedValue(true),
+  getMemberCustomRoleId: vi.fn().mockResolvedValue(null),
+}));
+
+import { DELETE, PATCH } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 
 const createContext = (tokenId = 'token-123') => ({
   params: Promise.resolve({ tokenId }),
@@ -158,5 +169,177 @@ describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
       'Error revoking MCP token:',
       new Error('DB connection error')
     );
+  });
+});
+
+describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      userId: 'test-user-id',
+      role: 'user',
+      tokenVersion: 0,
+      tokenType: 'session',
+      sessionId: 'test-session-id',
+    } as never);
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockResolvedValue({
+      id: 'token-123',
+      name: 'My Token',
+    });
+    vi.mocked(sessionRepository.updateMcpTokenDriveScopes).mockResolvedValue({
+      id: 'token-123',
+      userId: 'test-user-id',
+      tokenHash: 'hash',
+      tokenPrefix: 'mcp_test',
+      name: 'My Token',
+      isScoped: true,
+      lastUsed: null,
+      createdAt: new Date(),
+      revokedAt: null,
+    } as never);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([
+      { id: 'drive-1', name: 'My Drive' },
+    ]);
+    vi.mocked(getDriveAccess).mockResolvedValue({
+      isOwner: true,
+      isMember: true,
+      isAdmin: true,
+    } as never);
+  });
+
+  it('returns 404 when token not found', async () => {
+    vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockResolvedValueOnce(null);
+
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [{ id: 'drive-1' }] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 400 when both drives and driveIds are provided', async () => {
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({
+        drives: [{ id: 'drive-1' }],
+        driveIds: ['drive-2'],
+      }),
+    });
+
+    const response = await PATCH(request, createContext());
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 403 when user lacks access to a drive', async () => {
+    vi.mocked(getDriveAccess).mockResolvedValueOnce({
+      isOwner: false,
+      isMember: false,
+      isAdmin: false,
+    } as never);
+
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [{ id: 'forbidden-drive' }] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 403 when member tries to grant ADMIN', async () => {
+    vi.mocked(getDriveAccess).mockResolvedValueOnce({
+      isOwner: false,
+      isMember: true,
+      isAdmin: false,
+    } as never);
+
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [{ id: 'drive-1', role: 'ADMIN' }] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    expect(response.status).toBe(403);
+  });
+
+  it('updates scopes and returns 200 on valid input', async () => {
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [{ id: 'drive-1', role: 'ADMIN' }] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe('token-123');
+    expect(body.name).toBe('My Token');
+    expect(body.driveScopes).toEqual([{ id: 'drive-1', name: 'My Drive' }]);
+    expect(sessionRepository.updateMcpTokenDriveScopes).toHaveBeenCalledWith(
+      'token-123',
+      'test-user-id',
+      [{ id: 'drive-1', role: 'ADMIN', customRoleId: undefined }]
+    );
+  });
+
+  it('handles legacy driveIds format', async () => {
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ driveIds: ['drive-1'] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    expect(response.status).toBe(200);
+    expect(sessionRepository.updateMcpTokenDriveScopes).toHaveBeenCalledWith(
+      'token-123',
+      'test-user-id',
+      [{ id: 'drive-1', role: null, customRoleId: undefined }]
+    );
+  });
+
+  it('returns 500 when db throws', async () => {
+    vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockRejectedValueOnce(
+      new Error('DB error')
+    );
+
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [{ id: 'drive-1' }] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    expect(response.status).toBe(500);
   });
 });

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -347,6 +347,50 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
     );
   });
 
+  it('clears all scopes when drives is explicitly an empty array', async () => {
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.driveScopes).toEqual([]);
+    expect(sessionRepository.updateMcpTokenDriveScopes).toHaveBeenCalledWith(
+      'token-123',
+      'test-user-id',
+      []
+    );
+  });
+
+  it('clears all scopes when driveIds is explicitly an empty array', async () => {
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ driveIds: [] }),
+    });
+
+    const response = await PATCH(request, createContext());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.driveScopes).toEqual([]);
+    expect(sessionRepository.updateMcpTokenDriveScopes).toHaveBeenCalledWith(
+      'token-123',
+      'test-user-id',
+      []
+    );
+  });
+
   it('returns 500 when db throws', async () => {
     vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockRejectedValueOnce(
       new Error('DB error')

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -1,11 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { normalizeDriveScopes } from '@pagespace/lib/auth/mcp-token-scopes';
+import { getDriveAccess } from '@pagespace/lib/services/drive-service';
+import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+// Schema for PATCH (editing drive scopes on an existing token)
+const updateTokenScopesSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  // Legacy: plain drive IDs — scope only, role inherits from owner
+  driveIds: z.array(z.string()).optional(),
+  // Preferred: per-drive scope with optional role downgrade
+  drives: z.array(z.object({
+    id: z.string(),
+    role: z.enum(['ADMIN', 'MEMBER']).nullish(),
+    customRoleId: z.string().optional(),
+  })).optional(),
+}).refine(d => !(d.drives && d.driveIds), {
+  message: 'Provide drives or driveIds, not both',
+});
 
 // DELETE: Revoke an MCP token
 export async function DELETE(
@@ -42,5 +61,119 @@ export async function DELETE(
   } catch (error) {
     loggers.auth.error('Error revoking MCP token:', error as Error);
     return NextResponse.json({ error: 'Failed to revoke MCP token' }, { status: 500 });
+  }
+}
+
+// PATCH: Update drive scopes on an existing MCP token
+export async function PATCH(
+  req: NextRequest,
+  context: { params: Promise<{ tokenId: string }> }
+) {
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const { tokenId } = await context.params;
+
+  try {
+    const body = await req.json();
+    const parsed = updateTokenScopesSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+    const { drives: rawDrives, driveIds: rawDriveIds } = parsed.data;
+
+    // Normalize using pure function
+    const driveScopes = normalizeDriveScopes(rawDrives, rawDriveIds);
+
+    // Ownership check — token must belong to the requesting user
+    const existingToken = await sessionRepository.findMcpTokenByIdAndUser(tokenId, userId);
+    if (!existingToken) {
+      return new NextResponse('Token not found', { status: 404 });
+    }
+
+    // Validate drive access for each scope (same logic as POST /create)
+    if (driveScopes.length > 0) {
+      const invalidDriveIds: string[] = [];
+      const unauthorizedRoles: string[] = [];
+      const invalidCustomRoles: string[] = [];
+      const unauthorizedCustomRoles: string[] = [];
+
+      for (const scope of driveScopes) {
+        const access = await getDriveAccess(scope.id, userId);
+        if (!access.isOwner && !access.isMember) {
+          invalidDriveIds.push(scope.id);
+          continue;
+        }
+        if (scope.role === 'ADMIN' && !access.isAdmin) {
+          unauthorizedRoles.push(scope.id);
+        }
+        if (scope.customRoleId && !await customRoleBelongsToDrive(scope.customRoleId, scope.id)) {
+          invalidCustomRoles.push(scope.id);
+          continue;
+        }
+        if (scope.customRoleId && !access.isAdmin && !access.isOwner) {
+          const callerCustomRoleId = await getMemberCustomRoleId(scope.id, userId);
+          if (scope.customRoleId !== callerCustomRoleId) {
+            unauthorizedCustomRoles.push(scope.id);
+          }
+        }
+      }
+
+      if (invalidDriveIds.length > 0) {
+        return NextResponse.json(
+          { error: 'You do not have access to these drives: ' + invalidDriveIds.join(', ') },
+          { status: 403 }
+        );
+      }
+      if (unauthorizedRoles.length > 0) {
+        return NextResponse.json(
+          { error: 'You do not have permission to grant ADMIN role in these drives: ' + unauthorizedRoles.join(', ') },
+          { status: 403 }
+        );
+      }
+      if (invalidCustomRoles.length > 0) {
+        return NextResponse.json(
+          { error: 'Custom role does not belong to the specified drive: ' + invalidCustomRoles.join(', ') },
+          { status: 400 }
+        );
+      }
+      if (unauthorizedCustomRoles.length > 0) {
+        return NextResponse.json(
+          { error: 'You may only use your own assigned custom role in these drives: ' + unauthorizedCustomRoles.join(', ') },
+          { status: 403 }
+        );
+      }
+    }
+
+    // Update drive scopes transactionally
+    await sessionRepository.updateMcpTokenDriveScopes(tokenId, userId, driveScopes);
+
+    // Fetch drive names for response
+    let driveScopeNames: { id: string; name: string }[] = [];
+    if (driveScopes.length > 0) {
+      driveScopeNames = await sessionRepository.findDrivesByIds(driveScopes.map(d => d.id));
+    }
+
+    // Log activity for audit trail
+    const actorInfo = await getActorInfo(userId);
+    logTokenActivity(userId, 'token_update', {
+      tokenId,
+      tokenType: 'mcp',
+      tokenName: existingToken.name,
+    }, actorInfo);
+    auditRequest(req, { eventType: 'auth.token.updated', userId, details: { tokenType: 'mcp', driveCount: driveScopes.length } });
+
+    return NextResponse.json({
+      id: tokenId,
+      name: existingToken.name,
+      driveScopes: driveScopeNames,
+    });
+  } catch (error) {
+    loggers.auth.error('Error updating MCP token:', error as Error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: error.issues }, { status: 400 });
+    }
+    return NextResponse.json({ error: 'Failed to update MCP token' }, { status: 500 });
   }
 }

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -6,8 +6,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { normalizeDriveScopes } from '@pagespace/lib/auth/mcp-token-scopes';
-import { getDriveAccess } from '@pagespace/lib/services/drive-service';
-import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
+import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -95,31 +94,8 @@ export async function PATCH(
 
     // Validate drive access for each scope (same logic as POST /create)
     if (driveScopes.length > 0) {
-      const invalidDriveIds: string[] = [];
-      const unauthorizedRoles: string[] = [];
-      const invalidCustomRoles: string[] = [];
-      const unauthorizedCustomRoles: string[] = [];
-
-      for (const scope of driveScopes) {
-        const access = await getDriveAccess(scope.id, userId);
-        if (!access.isOwner && !access.isMember) {
-          invalidDriveIds.push(scope.id);
-          continue;
-        }
-        if (scope.role === 'ADMIN' && !access.isAdmin) {
-          unauthorizedRoles.push(scope.id);
-        }
-        if (scope.customRoleId && !await customRoleBelongsToDrive(scope.customRoleId, scope.id)) {
-          invalidCustomRoles.push(scope.id);
-          continue;
-        }
-        if (scope.customRoleId && !access.isAdmin && !access.isOwner) {
-          const callerCustomRoleId = await getMemberCustomRoleId(scope.id, userId);
-          if (scope.customRoleId !== callerCustomRoleId) {
-            unauthorizedCustomRoles.push(scope.id);
-          }
-        }
-      }
+      const { invalidDriveIds, unauthorizedRoles, invalidCustomRoles, unauthorizedCustomRoles } =
+        await validateDriveScopeAccess(driveScopes, userId);
 
       if (invalidDriveIds.length > 0) {
         return NextResponse.json(

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -13,7 +13,6 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
 // Schema for PATCH (editing drive scopes on an existing token)
 const updateTokenScopesSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
   // Legacy: plain drive IDs — scope only, role inherits from owner
   driveIds: z.array(z.string()).optional(),
   // Preferred: per-drive scope with optional role downgrade
@@ -24,6 +23,8 @@ const updateTokenScopesSchema = z.object({
   })).optional(),
 }).refine(d => !(d.drives && d.driveIds), {
   message: 'Provide drives or driveIds, not both',
+}).refine(d => d.drives !== undefined || d.driveIds !== undefined, {
+  message: 'Provide drives or driveIds',
 });
 
 // DELETE: Revoke an MCP token
@@ -42,7 +43,7 @@ export async function DELETE(
     const existingToken = await sessionRepository.findMcpTokenByIdAndUser(tokenId, userId);
 
     if (!existingToken) {
-      return new NextResponse('Token not found', { status: 404 });
+      return NextResponse.json({ error: 'Token not found' }, { status: 404 });
     }
 
     // Verify the token belongs to the user and revoke it
@@ -89,7 +90,7 @@ export async function PATCH(
     // Ownership check — token must belong to the requesting user
     const existingToken = await sessionRepository.findMcpTokenByIdAndUser(tokenId, userId);
     if (!existingToken) {
-      return new NextResponse('Token not found', { status: 404 });
+      return NextResponse.json({ error: 'Token not found' }, { status: 404 });
     }
 
     // Validate drive access for each scope (same logic as POST /create)

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -68,20 +68,14 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 }));
 
 vi.mock('@pagespace/lib/services/drive-service', () => ({
-  getDriveAccess: vi.fn(),
-}));
-
-vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
-  customRoleBelongsToDrive: vi.fn().mockResolvedValue(true),
-  getMemberCustomRoleId: vi.fn().mockResolvedValue(null),
+  validateDriveScopeAccess: vi.fn(),
 }));
 
 import { POST, GET } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { getDriveAccess } from '@pagespace/lib/services/drive-service';
-import { getMemberCustomRoleId, customRoleBelongsToDrive } from '@pagespace/lib/permissions/membership-queries';
+import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
 
@@ -118,17 +112,13 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
     vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([]);
     vi.mocked(sessionRepository.findUserMcpTokensWithDrives).mockResolvedValue([]);
 
-    // Default drive access mock
-    vi.mocked(getDriveAccess).mockResolvedValue({
-      isOwner: true,
-      isAdmin: true,
-      isMember: true,
-      role: 'OWNER',
-    } as never);
-
-    // Default: custom role belongs to drive, caller has no custom role assigned
-    vi.mocked(customRoleBelongsToDrive).mockResolvedValue(true);
-    vi.mocked(getMemberCustomRoleId).mockResolvedValue(null);
+    // Default: drive scope validation succeeds
+    vi.mocked(validateDriveScopeAccess).mockResolvedValue({
+      invalidDriveIds: [],
+      unauthorizedRoles: [],
+      invalidCustomRoles: [],
+      unauthorizedCustomRoles: [],
+    });
   });
 
   describe('POST /api/auth/mcp-tokens', () => {
@@ -152,12 +142,12 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
 
     describe('drive scope validation', () => {
       it('returns 403 when user lacks access to specified drives', async () => {
-        vi.mocked(getDriveAccess).mockResolvedValue({
-          isOwner: false,
-          isAdmin: false,
-          isMember: false,
-          role: null,
-        } as never);
+        vi.mocked(validateDriveScopeAccess).mockResolvedValue({
+          invalidDriveIds: ['drive-1', 'drive-2'],
+          unauthorizedRoles: [],
+          invalidCustomRoles: [],
+          unauthorizedCustomRoles: [],
+        });
 
         const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
           method: 'POST',
@@ -180,13 +170,6 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
       });
 
       it('allows scoping to drives where user is member but not owner', async () => {
-        vi.mocked(getDriveAccess).mockResolvedValue({
-          isOwner: false,
-          isAdmin: false,
-          isMember: true,
-          role: 'MEMBER',
-        } as never);
-
         vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([
           { id: 'drive-1', name: 'Shared Drive' },
         ]);
@@ -206,13 +189,6 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
       });
 
       it('deduplicates drive IDs', async () => {
-        vi.mocked(getDriveAccess).mockResolvedValue({
-          isOwner: true,
-          isAdmin: true,
-          isMember: true,
-          role: 'OWNER',
-        } as never);
-
         vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([
           { id: 'drive-1', name: 'My Drive' },
         ]);
@@ -230,8 +206,12 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
         const response = await POST(request);
         expect(response.status).toBe(200);
 
-        // getDriveAccess should only be called once (deduplication)
-        expect(getDriveAccess).toHaveBeenCalledTimes(1);
+        // Validation should run once on the deduplicated set, not once per raw ID
+        expect(validateDriveScopeAccess).toHaveBeenCalledTimes(1);
+        expect(validateDriveScopeAccess).toHaveBeenCalledWith(
+          [{ id: 'drive-1', role: null, customRoleId: undefined }],
+          'test-user-id'
+        );
 
         // Repository should be called with deduplicated drives.
         // Legacy driveIds carry no role: stored role is null (inherit owner).
@@ -264,10 +244,12 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
 
     describe('custom role privilege escalation', () => {
       it('returns 403 when a MEMBER specifies a custom role not assigned to them', async () => {
-        vi.mocked(getDriveAccess).mockResolvedValue({
-          isOwner: false, isAdmin: false, isMember: true, role: 'MEMBER',
-        } as never);
-        vi.mocked(getMemberCustomRoleId).mockResolvedValue('role-assigned');
+        vi.mocked(validateDriveScopeAccess).mockResolvedValue({
+          invalidDriveIds: [],
+          unauthorizedRoles: [],
+          invalidCustomRoles: [],
+          unauthorizedCustomRoles: ['drive-1'],
+        });
 
         const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
           method: 'POST',
@@ -283,10 +265,6 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
       });
 
       it('allows a MEMBER to mint a token with their own assigned custom role', async () => {
-        vi.mocked(getDriveAccess).mockResolvedValue({
-          isOwner: false, isAdmin: false, isMember: true, role: 'MEMBER',
-        } as never);
-        vi.mocked(getMemberCustomRoleId).mockResolvedValue('role-xyz');
         vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([{ id: 'drive-1', name: 'Drive' }] as never);
 
         const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
@@ -299,10 +277,11 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
         expect(response.status).toBe(200);
       });
 
-      it('allows an ADMIN to mint a token with any custom role without checking their own role', async () => {
-        vi.mocked(getDriveAccess).mockResolvedValue({
-          isOwner: false, isAdmin: true, isMember: true, role: 'ADMIN',
-        } as never);
+      it('allows an ADMIN to mint a token with any custom role', async () => {
+        // Whether the admin-bypass rule (no ownership check on the caller's
+        // own custom role) is applied correctly is unit-tested directly on
+        // validateDriveScopeAccess in drive-service.test.ts; at the route
+        // level we just confirm a successful validation results in 200.
         vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([{ id: 'drive-1', name: 'Drive' }] as never);
 
         const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
@@ -313,7 +292,6 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
 
         const response = await POST(request);
         expect(response.status).toBe(200);
-        expect(getMemberCustomRoleId).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/web/src/app/api/auth/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/route.ts
@@ -6,8 +6,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
-import { getDriveAccess } from '@pagespace/lib/services/drive-service';
-import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
+import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -42,34 +41,8 @@ export async function POST(req: NextRequest) {
     const uniqueDriveScopes = [...new Map(driveScopes.map(d => [d.id, d])).values()];
 
     if (uniqueDriveScopes.length > 0) {
-      const invalidDriveIds: string[] = [];
-      const unauthorizedRoles: string[] = [];
-      const invalidCustomRoles: string[] = [];
-      const unauthorizedCustomRoles: string[] = [];
-
-      for (const scope of uniqueDriveScopes) {
-        const access = await getDriveAccess(scope.id, userId);
-        if (!access.isOwner && !access.isMember) {
-          invalidDriveIds.push(scope.id);
-          continue;
-        }
-        // A MEMBER cannot grant ADMIN — cap to caller's actual authority
-        if (scope.role === 'ADMIN' && !access.isAdmin) {
-          unauthorizedRoles.push(scope.id);
-        }
-        // Prevent using a custom role that belongs to a different drive
-        if (scope.customRoleId && !await customRoleBelongsToDrive(scope.customRoleId, scope.id)) {
-          invalidCustomRoles.push(scope.id);
-          continue;
-        }
-        // Non-admins can only mint tokens with their own assigned custom role
-        if (scope.customRoleId && !access.isAdmin && !access.isOwner) {
-          const callerCustomRoleId = await getMemberCustomRoleId(scope.id, userId);
-          if (scope.customRoleId !== callerCustomRoleId) {
-            unauthorizedCustomRoles.push(scope.id);
-          }
-        }
-      }
+      const { invalidDriveIds, unauthorizedRoles, invalidCustomRoles, unauthorizedCustomRoles } =
+        await validateDriveScopeAccess(uniqueDriveScopes, userId);
 
       if (invalidDriveIds.length > 0) {
         return NextResponse.json(

--- a/apps/web/src/lib/repositories/session-repository.ts
+++ b/apps/web/src/lib/repositories/session-repository.ts
@@ -159,6 +159,56 @@ export const sessionRepository = {
       .set({ revokedAt: new Date() })
       .where(and(eq(mcpTokens.id, tokenId), eq(mcpTokens.userId, userId)));
   },
+
+  /**
+   * Replace all drive scopes on an existing MCP token transactionally.
+   *
+   * Once a token is scoped, it stays scoped (isScoped is never set to false).
+   * If drives is empty, all existing scopes are removed but the token remains
+   * scoped (fail-closed: scoped + no drives = deny all access).
+   *
+   * Returns the updated token record, or null if the token doesn't belong
+   * to the given user.
+   */
+  async updateMcpTokenDriveScopes(
+    tokenId: string,
+    userId: string,
+    drives: { id: string; role: 'ADMIN' | 'MEMBER' | null; customRoleId?: string }[]
+  ): Promise<McpToken | null> {
+    // Ownership check — must match both tokenId AND userId
+    const existing = await db.query.mcpTokens.findFirst({
+      where: and(eq(mcpTokens.id, tokenId), eq(mcpTokens.userId, userId)),
+      columns: { id: true },
+    });
+    if (!existing) return null;
+
+    return db.transaction(async (tx) => {
+      // Delete all existing drive scopes for this token
+      await tx.delete(mcpTokenDrives).where(eq(mcpTokenDrives.tokenId, tokenId));
+
+      // Insert new scopes
+      if (drives.length > 0) {
+        await tx.insert(mcpTokenDrives).values(
+          drives.map(({ id: driveId, role, customRoleId }) => ({
+            tokenId,
+            driveId,
+            role,
+            customRoleId: customRoleId ?? null,
+            addedBy: userId,
+          }))
+        );
+      }
+
+      // Ensure token stays scoped (once scoped, always scoped)
+      const [updated] = await tx
+        .update(mcpTokens)
+        .set({ isScoped: true })
+        .where(eq(mcpTokens.id, tokenId))
+        .returning();
+
+      return updated;
+    });
+  },
 };
 
 export type SessionRepository = typeof sessionRepository;

--- a/packages/db/src/schema/security-audit.ts
+++ b/packages/db/src/schema/security-audit.ts
@@ -38,6 +38,7 @@ export type SecurityEventType =
   | 'auth.token.created'
   | 'auth.token.revoked'
   | 'auth.token.refreshed'
+  | 'auth.token.updated'
   | 'auth.mfa.enabled'
   | 'auth.mfa.disabled'
   | 'auth.mfa.challenged'

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -972,6 +972,11 @@
       "import": "./dist/auth/token-utils.js",
       "require": "./dist/auth/token-utils.js"
     },
+    "./auth/mcp-token-scopes": {
+      "types": "./dist/auth/mcp-token-scopes.d.ts",
+      "import": "./dist/auth/mcp-token-scopes.js",
+      "require": "./dist/auth/mcp-token-scopes.js"
+    },
     "./auth/exchange-codes": {
       "types": "./dist/auth/exchange-codes.d.ts",
       "import": "./dist/auth/exchange-codes.js",

--- a/packages/lib/src/auth/__tests__/mcp-token-scopes.test.ts
+++ b/packages/lib/src/auth/__tests__/mcp-token-scopes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeDriveScopes, type DriveScopeInput } from '../mcp-token-scopes';
+
+describe('normalizeDriveScopes', () => {
+ it('returns empty array when both inputs are undefined', () => {
+   expect(normalizeDriveScopes()).toEqual([]);
+ });
+
+ it('returns empty array when both inputs are empty arrays', () => {
+   expect(normalizeDriveScopes([], [])).toEqual([]);
+ });
+
+ it('throws when both drives and driveIds are provided', () => {
+   expect(() =>
+     normalizeDriveScopes(
+       [{ id: 'drive-1', role: 'ADMIN' }],
+       ['drive-2']
+     )
+   ).toThrow(/mutually exclusive/i);
+ });
+
+ it('maps driveIds to scopes with null role (inherit)', () => {
+   const result = normalizeDriveScopes(undefined, ['drive-1', 'drive-2']);
+   expect(result).toEqual([
+     { id: 'drive-1', role: null, customRoleId: undefined },
+     { id: 'drive-2', role: null, customRoleId: undefined },
+   ]);
+ });
+
+ it('passes drives through with defaults for missing fields', () => {
+   const result = normalizeDriveScopes([
+     { id: 'drive-1', role: 'ADMIN' },
+     { id: 'drive-2', role: null, customRoleId: 'role-1' },
+   ]);
+   expect(result).toEqual([
+     { id: 'drive-1', role: 'ADMIN', customRoleId: undefined },
+     { id: 'drive-2', role: null, customRoleId: 'role-1' },
+   ]);
+ });
+
+ it('deduplicates drive IDs (last wins)', () => {
+   const result = normalizeDriveScopes([
+     { id: 'drive-1', role: 'MEMBER' },
+     { id: 'drive-1', role: 'ADMIN' },
+   ]);
+   expect(result).toEqual([
+     { id: 'drive-1', role: 'ADMIN', customRoleId: undefined },
+   ]);
+ });
+
+ it('deduplicates driveIds (last wins)', () => {
+   const result = normalizeDriveScopes(undefined, ['drive-1', 'drive-1']);
+   expect(result).toEqual([
+     { id: 'drive-1', role: null, customRoleId: undefined },
+   ]);
+ });
+
+ it('handles mixed role + customRoleId from drives input', () => {
+   const result = normalizeDriveScopes([
+     { id: 'd1', role: 'ADMIN', customRoleId: undefined },
+     { id: 'd2', role: 'MEMBER', customRoleId: 'cr-1' },
+     { id: 'd3', role: null, customRoleId: 'cr-2' },
+   ]);
+   expect(result).toHaveLength(3);
+   expect(result[0]).toEqual({ id: 'd1', role: 'ADMIN', customRoleId: undefined });
+   expect(result[1]).toEqual({ id: 'd2', role: 'MEMBER', customRoleId: 'cr-1' });
+   expect(result[2]).toEqual({ id: 'd3', role: null, customRoleId: 'cr-2' });
+ });
+});

--- a/packages/lib/src/auth/mcp-token-scopes.ts
+++ b/packages/lib/src/auth/mcp-token-scopes.ts
@@ -11,6 +11,12 @@ export interface DriveScopeInput {
   customRoleId?: string;
 }
 
+export interface NormalizedDriveScope {
+  id: string;
+  role: 'ADMIN' | 'MEMBER' | null;
+  customRoleId?: string;
+}
+
 /**
  * Normalize drive scope inputs from either the `drives` (preferred) or
  * `driveIds` (legacy) request body shape into a canonical array.
@@ -25,14 +31,14 @@ export interface DriveScopeInput {
 export function normalizeDriveScopes(
   drives?: DriveScopeInput[],
   driveIds?: string[]
-): DriveScopeInput[] {
+): NormalizedDriveScope[] {
   if (drives && driveIds && drives.length > 0 && driveIds.length > 0) {
     throw new Error('Provide drives or driveIds, not both — they are mutually exclusive');
   }
 
   // Legacy: plain drive ID array → scopes with null role (inherit)
   if (driveIds && driveIds.length > 0) {
-    const map = new Map<string, DriveScopeInput>();
+    const map = new Map<string, NormalizedDriveScope>();
     for (const id of driveIds) {
       map.set(id, { id, role: null });
     }
@@ -41,7 +47,7 @@ export function normalizeDriveScopes(
 
   // Preferred: per-drive scope with optional role + customRoleId
   if (drives && drives.length > 0) {
-    const map = new Map<string, DriveScopeInput>();
+    const map = new Map<string, NormalizedDriveScope>();
     for (const scope of drives) {
       map.set(scope.id, {
         id: scope.id,

--- a/packages/lib/src/auth/mcp-token-scopes.ts
+++ b/packages/lib/src/auth/mcp-token-scopes.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure functions for MCP token drive scope normalization.
+ *
+ * These functions have NO side effects — they transform input data into a
+ * canonical shape that the repository and route handlers can consume.
+ */
+
+export interface DriveScopeInput {
+  id: string;
+  role?: 'ADMIN' | 'MEMBER' | null;
+  customRoleId?: string;
+}
+
+/**
+ * Normalize drive scope inputs from either the `drives` (preferred) or
+ * `driveIds` (legacy) request body shape into a canonical array.
+ *
+ * Rules:
+ * - `drives` and `driveIds` are mutually exclusive — throws if both are provided.
+ * - `driveIds` maps to scopes with `role: null` (inherit owner's access).
+ * - Duplicate drive IDs are deduplicated (last definition wins).
+ *
+ * @returns Canonical DriveScopeInput[] — never throws (except mutual-exclusivity violation).
+ */
+export function normalizeDriveScopes(
+  drives?: DriveScopeInput[],
+  driveIds?: string[]
+): DriveScopeInput[] {
+  if (drives && driveIds && drives.length > 0 && driveIds.length > 0) {
+    throw new Error('Provide drives or driveIds, not both — they are mutually exclusive');
+  }
+
+  // Legacy: plain drive ID array → scopes with null role (inherit)
+  if (driveIds && driveIds.length > 0) {
+    const map = new Map<string, DriveScopeInput>();
+    for (const id of driveIds) {
+      map.set(id, { id, role: null });
+    }
+    return [...map.values()];
+  }
+
+  // Preferred: per-drive scope with optional role + customRoleId
+  if (drives && drives.length > 0) {
+    const map = new Map<string, DriveScopeInput>();
+    for (const scope of drives) {
+      map.set(scope.id, {
+        id: scope.id,
+        role: scope.role ?? null,
+        customRoleId: scope.customRoleId,
+      });
+    }
+    return [...map.values()];
+  }
+
+  return [];
+}

--- a/packages/lib/src/auth/mcp-token-scopes.ts
+++ b/packages/lib/src/auth/mcp-token-scopes.ts
@@ -26,7 +26,7 @@ export interface NormalizedDriveScope {
  * - `driveIds` maps to scopes with `role: null` (inherit owner's access).
  * - Duplicate drive IDs are deduplicated (last definition wins).
  *
- * @returns Canonical DriveScopeInput[] — never throws (except mutual-exclusivity violation).
+ * @returns Canonical NormalizedDriveScope[] — never throws (except mutual-exclusivity violation).
  */
 export function normalizeDriveScopes(
   drives?: DriveScopeInput[],

--- a/packages/lib/src/compliance/art30/classify-processing.ts
+++ b/packages/lib/src/compliance/art30/classify-processing.ts
@@ -85,6 +85,7 @@ const SECURITY_OPERATIONS = new Set<string>([
   'email_change',
   'token_create',
   'token_revoke',
+  'token_update',
   'account_delete',
 ]);
 

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -255,6 +255,7 @@ export type ActivityOperation =
   | 'email_change'
   | 'token_create'
   | 'token_revoke'
+  | 'token_update'
   // File operations
   | 'upload'
   | 'convert'
@@ -1051,7 +1052,7 @@ export function logUserActivity(
  */
 export function logTokenActivity(
   userId: string,
-  operation: 'token_create' | 'token_revoke',
+  operation: 'token_create' | 'token_revoke' | 'token_update',
   data: {
     tokenId: string;
     tokenType: 'device' | 'mcp' | 'api';

--- a/packages/lib/src/services/__tests__/drive-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-service.test.ts
@@ -48,9 +48,14 @@ vi.mock('@pagespace/db/operators', () => ({
   gt: vi.fn((a, b) => ({ op: 'gt', a, b })),
   asc: vi.fn(() => ({ op: 'asc' })),
 }));
+vi.mock('../../permissions/membership-queries', () => ({
+  customRoleBelongsToDrive: vi.fn().mockResolvedValue(true),
+  getMemberCustomRoleId: vi.fn().mockResolvedValue(null),
+}));
 
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
+import { customRoleBelongsToDrive, getMemberCustomRoleId } from '../../permissions/membership-queries';
 
 // Drizzle transaction callback receives a tx whose type is the inner parameter of db.transaction.
 type MockTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -65,6 +70,7 @@ import {
   trashDrive,
   restoreDrive,
   isValidDriveHomePage,
+  validateDriveScopeAccess,
 } from '../drive-service';
 
 // ============================================================================
@@ -376,6 +382,121 @@ describe('getDriveAccess', () => {
       isMember: false,
       role: null,
     });
+  });
+});
+
+// ============================================================================
+// validateDriveScopeAccess
+// ============================================================================
+
+describe('validateDriveScopeAccess', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(customRoleBelongsToDrive).mockResolvedValue(true);
+    vi.mocked(getMemberCustomRoleId).mockResolvedValue(null);
+  });
+
+  const mockOwnerAccess = (driveId: string, userId: string) => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(
+      createMockDrive({ id: driveId, name: 'Test', ownerId: userId })
+    );
+  };
+
+  const mockMemberAccess = (driveId: string, role: 'ADMIN' | 'MEMBER') => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(
+      createMockDrive({ id: driveId, name: 'Test', ownerId: 'other_user' })
+    );
+    const limitMock = vi.fn().mockResolvedValue([{ role }]);
+    const whereMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  const mockNoAccess = (driveId: string) => {
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(
+      createMockDrive({ id: driveId, name: 'Test', ownerId: 'other_user' })
+    );
+    const limitMock = vi.fn().mockResolvedValue([]);
+    const whereMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  it('returns all-empty for a valid owner-scoped drive', async () => {
+    mockOwnerAccess('drive_123', 'user_123');
+
+    const result = await validateDriveScopeAccess([{ id: 'drive_123', role: null }], 'user_123');
+
+    expect(result).toEqual({
+      invalidDriveIds: [],
+      unauthorizedRoles: [],
+      invalidCustomRoles: [],
+      unauthorizedCustomRoles: [],
+    });
+  });
+
+  it('flags drives the user has no access to', async () => {
+    mockNoAccess('forbidden-drive');
+
+    const result = await validateDriveScopeAccess([{ id: 'forbidden-drive', role: null }], 'user_123');
+
+    expect(result.invalidDriveIds).toEqual(['forbidden-drive']);
+  });
+
+  it('flags a MEMBER attempting to grant ADMIN', async () => {
+    mockMemberAccess('drive_123', 'MEMBER');
+
+    const result = await validateDriveScopeAccess([{ id: 'drive_123', role: 'ADMIN' }], 'user_123');
+
+    expect(result.unauthorizedRoles).toEqual(['drive_123']);
+  });
+
+  it('flags a custom role that does not belong to the drive', async () => {
+    mockOwnerAccess('drive_123', 'user_123');
+    vi.mocked(customRoleBelongsToDrive).mockResolvedValue(false);
+
+    const result = await validateDriveScopeAccess(
+      [{ id: 'drive_123', role: 'MEMBER', customRoleId: 'role-other-drive' }],
+      'user_123'
+    );
+
+    expect(result.invalidCustomRoles).toEqual(['drive_123']);
+  });
+
+  it('flags a MEMBER using a custom role not assigned to them', async () => {
+    mockMemberAccess('drive_123', 'MEMBER');
+    vi.mocked(getMemberCustomRoleId).mockResolvedValue('role-assigned');
+
+    const result = await validateDriveScopeAccess(
+      [{ id: 'drive_123', role: 'MEMBER', customRoleId: 'role-other' }],
+      'user_123'
+    );
+
+    expect(result.unauthorizedCustomRoles).toEqual(['drive_123']);
+  });
+
+  it('allows a MEMBER to use their own assigned custom role', async () => {
+    mockMemberAccess('drive_123', 'MEMBER');
+    vi.mocked(getMemberCustomRoleId).mockResolvedValue('role-xyz');
+
+    const result = await validateDriveScopeAccess(
+      [{ id: 'drive_123', role: 'MEMBER', customRoleId: 'role-xyz' }],
+      'user_123'
+    );
+
+    expect(result.unauthorizedCustomRoles).toEqual([]);
+  });
+
+  it('allows an ADMIN to use any custom role without checking assignment', async () => {
+    mockMemberAccess('drive_123', 'ADMIN');
+
+    const result = await validateDriveScopeAccess(
+      [{ id: 'drive_123', role: 'MEMBER', customRoleId: 'any-role' }],
+      'user_123'
+    );
+
+    expect(result.unauthorizedCustomRoles).toEqual([]);
+    expect(getMemberCustomRoleId).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/lib/src/services/drive-service.ts
+++ b/packages/lib/src/services/drive-service.ts
@@ -12,6 +12,7 @@ import { drives, pages } from '@pagespace/db/schema/core';
 import { allocateUniqueSubdomainWithRetry } from './subdomain-allocation';
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 import { slugify } from '../utils/utils';
+import { customRoleBelongsToDrive, getMemberCustomRoleId } from '../permissions/membership-queries';
 
 // ============================================================================
 // Types
@@ -244,6 +245,62 @@ export async function getDriveAccess(
   }
 
   return { isOwner: false, isAdmin: false, isMember: false, role: null };
+}
+
+export interface DriveScopeToValidate {
+  id: string;
+  role?: 'ADMIN' | 'MEMBER' | null;
+  customRoleId?: string;
+}
+
+export interface DriveScopeValidationResult {
+  invalidDriveIds: string[];
+  unauthorizedRoles: string[];
+  invalidCustomRoles: string[];
+  unauthorizedCustomRoles: string[];
+}
+
+/**
+ * Validate that `userId` may grant each of the given drive scopes: drive
+ * membership/ownership, role authority (a MEMBER can't grant ADMIN), and
+ * custom role ownership/assignment. Shared by the MCP token create (POST)
+ * and edit (PATCH) routes, which each format their own error responses from
+ * the returned categorized ID lists.
+ */
+export async function validateDriveScopeAccess(
+  scopes: DriveScopeToValidate[],
+  userId: string
+): Promise<DriveScopeValidationResult> {
+  const invalidDriveIds: string[] = [];
+  const unauthorizedRoles: string[] = [];
+  const invalidCustomRoles: string[] = [];
+  const unauthorizedCustomRoles: string[] = [];
+
+  for (const scope of scopes) {
+    const access = await getDriveAccess(scope.id, userId);
+    if (!access.isOwner && !access.isMember) {
+      invalidDriveIds.push(scope.id);
+      continue;
+    }
+    // A MEMBER cannot grant ADMIN — cap to caller's actual authority
+    if (scope.role === 'ADMIN' && !access.isAdmin) {
+      unauthorizedRoles.push(scope.id);
+    }
+    // Prevent using a custom role that belongs to a different drive
+    if (scope.customRoleId && !await customRoleBelongsToDrive(scope.customRoleId, scope.id)) {
+      invalidCustomRoles.push(scope.id);
+      continue;
+    }
+    // Non-admins can only use their own assigned custom role
+    if (scope.customRoleId && !access.isAdmin && !access.isOwner) {
+      const callerCustomRoleId = await getMemberCustomRoleId(scope.id, userId);
+      if (scope.customRoleId !== callerCustomRoleId) {
+        unauthorizedCustomRoles.push(scope.id);
+      }
+    }
+  }
+
+  return { invalidDriveIds, unauthorizedRoles, invalidCustomRoles, unauthorizedCustomRoles };
 }
 
 export interface DriveAccessWithDrive {


### PR DESCRIPTION
## Problem

Users create scoped MCP tokens for specific drives, but when they create new drives, those drives aren't accessible via the existing token. The only workaround was a God key (all drives). No way to edit scopes without rotating the key.

## Solution

`PATCH /api/auth/mcp-tokens/[tokenId]` replaces drive scopes on an existing token transactionally. The auth system already reads scopes dynamically at request time (no caching), so updating the join table takes effect immediately without token rotation.

### Security Properties
- **Once scoped, always scoped.** `isScoped` is never set to false.
- **Fail-closed.** If all drives are removed from a scoped token, access is denied entirely.
- **Same validation as POST.** Drive access checks, role authority checks, custom role ownership checks.
- **Ownership enforced.** Token must belong to the requesting user.

## Architecture (AIDD / TDD)

### Pure Functions
- `normalizeDriveScopes(drives?, driveIds?)` — pure function in `packages/lib/src/auth/mcp-token-scopes.ts`. Normalizes both legacy `driveIds` and preferred `drives` shapes into canonical format (`NormalizedDriveScope[]`, role always defined). Deduplicates. Throws on mutual exclusivity violation.

### Repository
- `updateMcpTokenDriveScopes(tokenId, userId, drives)` — transactional delete + insert in `session-repository.ts`. Ownership check before mutation.

### Route
- `PATCH /api/auth/mcp-tokens/[tokenId]` — ownership check, drive access validation (same as POST), normalizeDriveScopes, repository call, audit log. Requires `drives` or `driveIds` to be explicitly present (omitting both is rejected with 400, rather than treated as clear-all); an explicit empty array on either field still intentionally clears all scopes.

## Review Feedback Addressed

Three follow-up commits after the initial implementation, in response to review from chatgpt-codex-connector and coderabbitai, plus one self-initiated pass:

1. **`6edb72d`** — a PATCH body omitting both `drives` and `driveIds` (e.g. a name-only body) used to silently wipe every existing drive scope, since `normalizeDriveScopes(undefined, undefined)` returns `[]` and the handler unconditionally applied it. Removed the unused/unwired `name` field (no rename capability exists) and added a schema refine requiring `drives` or `driveIds` to be explicitly present — now rejected with 400. Also changed both PATCH/DELETE 404 responses from plain-text to `NextResponse.json`, matching this path's JSON-response convention.
2. **`9d365579f`** — fixed 3 pre-existing `web:typecheck` failures in this same route (blocking CI's Static Security Analysis / Lint & TypeScript Check): added `token_update`/`auth.token.updated` to the shared `ActivityOperation`/`SecurityEventType` unions (purely additive, no migration), and tightened `normalizeDriveScopes`'s return type (`NormalizedDriveScope`, role required) to match what the repository already expected.
3. **`5c7428771`** — an independent adversarial review pass found the "explicit empty array intentionally clears all scopes" path (as distinct from "omitted = rejected") had no test coverage — added it, plus fixed a stale docstring.
4. **`a10984865`** — a `/simplify` pass (4 independent angles: reuse, simplification, efficiency, altitude) unanimously flagged that PATCH's drive-access/role/custom-role validation loop was copy-pasted verbatim from POST's handler (~50 lines, only the last error message's wording had drifted). Extracted into a shared `validateDriveScopeAccess(scopes, userId)` in `packages/lib/src/services/drive-service.ts`, used by both routes — zero behavior change, each route still formats its own error text from the returned categorized ID lists. Test coverage for the extracted logic (including the admin-bypass and MEMBER-owns-custom-role cases) moved to `drive-service.test.ts`, co-located with the function. Other findings from that pass (a repo-level ownership recheck, two near-duplicate scope types, sequential per-scope awaits, double mutual-exclusivity enforcement) were reviewed and intentionally left as-is — each is either deliberate defense-in-depth/API-boundary design or a lower-value change with real risk to a rarely-hit endpoint; reasoning is in the commit message.

All 3 original review threads are now resolved; CI (10 checks: unit tests, lint/typecheck, security scans, CodeQL, etc.) is fully green.

## Test Coverage

| Area | Tests |
|---|---|
| `normalizeDriveScopes` pure function | 8 tests |
| `validateDriveScopeAccess` (shared, drive-service) | 7 tests |
| PATCH route | 9 tests |
| DELETE route | 5 tests |
| POST route | 13 tests (existing, updated for the shared helper) |

## Files Changed

```
 packages/lib/src/auth/mcp-token-scopes.ts                       (new, pure function + NormalizedDriveScope type)
 packages/lib/src/auth/__tests__/mcp-token-scopes.test.ts         (new, 8 tests)
 packages/lib/package.json                                        (export entry)
 packages/lib/src/monitoring/activity-logger.ts                   (+token_update operation)
 packages/lib/src/compliance/art30/classify-processing.ts         (+token_update security classification)
 packages/db/src/schema/security-audit.ts                         (+auth.token.updated event type)
 packages/lib/src/services/drive-service.ts                       (+validateDriveScopeAccess, shared by POST+PATCH)
 packages/lib/src/services/__tests__/drive-service.test.ts        (+7 tests for validateDriveScopeAccess)
 apps/web/src/lib/repositories/session-repository.ts               (+50 lines)
 apps/web/src/app/api/auth/mcp-tokens/route.ts                     (POST now calls validateDriveScopeAccess)
 apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts      (updated mocks for the shared helper)
 apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts           (PATCH handler + 404/schema fixes)
 apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts  (14 tests total)
```

## What's NOT in this PR
- Frontend UI (T4) — separate PR. The API is ready for the frontend team to wire up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - MCP token drive permissions can now be updated via a dedicated update endpoint.
  - Supports both the newer drives-based input (with role/custom role options) and the legacy drive ID format.

- **Bug Fixes**
  - Improved request validation for missing/conflicting scope inputs.
  - Enhanced authorization checks, and standardized error responses when a token is not found.

- **Tests**
  - Expanded MCP token scope update test coverage for validation, permission/role scenarios, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

