### PR TITLE
Fix sandbox git_clone narrow refspec breaking branch tracking (#1746)

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -81,7 +81,7 @@ describe('git_clone', () => {
     const calls = getRunCalls(deps);
     expect(calls[0].cmd).toBe('git');
     expect(calls[0].args).toEqual([
-      'clone', '--depth', '1', 'https://github.com/owner/repo.git', '/workspace',
+      'clone', '--no-single-branch', '--depth', '1', 'https://github.com/owner/repo.git', '/workspace',
     ]);
   });
 
@@ -441,6 +441,24 @@ describe('gh_pr_create', () => {
     const calls = getRunCalls(deps);
     expect(calls[0].cmd).toBe('gh');
     expect(calls[0].args).toContain('--draft');
+  });
+
+  it('passes --head <branch> when head is given', async () => {
+    const deps = makeDeps();
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    await gh_pr_create.execute!({ title: 'PR', body: 'b', head: 'feat/x' }, {} as never);
+    const calls = getRunCalls(deps);
+    const headIdx = calls[0].args.indexOf('--head');
+    expect(headIdx).toBeGreaterThan(-1);
+    expect(calls[0].args[headIdx + 1]).toBe('feat/x');
+  });
+
+  it('omits --head when head is not given', async () => {
+    const deps = makeDeps();
+    const { gh_pr_create } = createSandboxGitTools(deps);
+    await gh_pr_create.execute!({ title: 'PR', body: 'b' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).not.toContain('--head');
   });
 
   it('joins labels with comma in --label arg', async () => {

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -131,7 +131,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   // ── Repo + config ───────────────────────────────────────────────────────
 
   const gitClone = tool({
-    description: 'Clone a GitHub repository into the sandbox. Use HTTPS URLs only.',
+    description:
+      'Clone a GitHub repository into the sandbox. Use HTTPS URLs only. Fetches all branch refs (even with depth) so later-created branches get proper origin tracking refs — required for git_push -u and gh_pr_create to work.',
     inputSchema: z.object({
       repo_url: z
         .string()
@@ -152,7 +153,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       if (!resolved.ok) return resolved.error;
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      const args = ['clone', ...(depth ? ['--depth', String(depth)] : []), repo_url, resolved.path];
+      // `--depth` implies `--single-branch`, which writes a narrow fetch refspec
+      // (`+refs/heads/<branch>:...`) into .git/config — that leaves later-created
+      // branches without an origin tracking ref, breaking `push -u` and PR creation.
+      // `--no-single-branch` keeps the wildcard `+refs/heads/*:refs/remotes/origin/*`.
+      const args = [
+        'clone',
+        ...(depth ? ['--no-single-branch', '--depth', String(depth)] : []),
+        repo_url,
+        resolved.path,
+      ];
       return git('git', args, opened.ctx);
     },
   });
@@ -487,17 +497,19 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   // ── GitHub PRs (token required) ─────────────────────────────────────────
 
   const ghPrCreate = tool({
-    description: 'Create a pull request. Requires a connected GitHub account.',
+    description:
+      'Create a pull request. Requires a connected GitHub account. head defaults to the current branch; pass it to name the PR head branch explicitly (bypasses the local upstream-tracking check).',
     inputSchema: z.object({
       title: z.string().min(1),
       body: z.string(),
       base: z.string().optional(),
+      head: z.string().optional(),
       draft: z.boolean().optional(),
       labels: z.array(z.string()).optional(),
       cwd: cwdField,
     })
       .strict(),
-    execute: async ({ title, body, base, draft, labels, cwd }, options) => {
+    execute: async ({ title, body, base, head, draft, labels, cwd }, options) => {
       if (!title) {
         return { success: false as const, error: 'title is required' };
       }
@@ -509,6 +521,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
             '--title', title,
             '--body', body,
             ...(base ? ['--base', base] : []),
+            ...(head ? ['--head', head] : []),
             ...(draft ? ['--draft'] : []),
             ...(labels?.length ? ['--label', labels.join(',')] : []),
           ],


### PR DESCRIPTION
## Problem

When an AI agent uses the sandbox git tools (`git_clone`, `git_push`, `gh_pr_create`) to make a change and open a PR, the branch-tracking chain silently breaks and `gh_pr_create` fails with a misleading `"you must first push the current branch to a remote"` — even though the branch was already pushed successfully.

## Root cause

`git_clone` passed `--depth N` (when a `depth` is given) without `--no-single-branch`. Git treats `--depth` as implying `--single-branch`, which writes a **narrow** fetch refspec into `.git/config`:

```
fetch = +refs/heads/master:refs/remotes/origin/master
```

instead of the wildcard `+refs/heads/*:refs/remotes/origin/*`. With a narrow refspec, newly-created feature branches never get an `origin/<branch>` tracking ref — so `git push -u` reports success without setting real upstream config, and `gh pr create` can't resolve the head branch. Agents were burning 3–4 extra tool calls on a manual workaround (rewrite `remote.origin.fetch`, re-fetch, re-clone).

## Changes

Both in `apps/web/src/lib/ai/tools/sandbox-git-tools.ts` (approach A + C from the issue):

- **`git_clone` (root-cause fix):** add `--no-single-branch` when `depth` is set, so a shallow clone still writes the wildcard `+refs/heads/*:refs/remotes/origin/*` refspec — the exact config the manual workaround set by hand. The non-depth path is unchanged.
- **`gh_pr_create` (escape hatch):** add an optional `head` param, forwarded as `gh pr create --head <branch>`, which bypasses the local upstream-tracking check entirely for resilience.
- Updated both tool descriptions and the unit tests.

## Verification

- Unit tests: `56 passed` (`sandbox-git-tools` suite, +2 new `gh_pr_create` head tests).
- `bun run --filter 'web' typecheck` → exit 0.
- `bun run --filter 'web' lint` → exit 0 (only pre-existing warnings in unrelated files).
- Reasoning check: a depth clone now emits `git clone --no-single-branch --depth N <url> <path>`, which per git docs writes the wildcard fetch refspec.

Closes #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkExVeZE97rBnPnrc7Hv6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkExVeZE97rBnPnrc7Hv6b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository cloning for depth-based fetches so later remote actions and PR creation work more reliably.
  * When creating pull requests, the branch name is now included when provided, and omitted when not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->