### PR TITLE
fix(drives): reject publishSubdomain in generic PATCH instead of silently dropping it

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
@@ -539,6 +539,47 @@ describe('PATCH /api/drives/[driveId]', () => {
     });
   });
 
+  describe('publishSubdomain', () => {
+    const ownerFixtures = () => {
+      vi.mocked(getDriveById).mockResolvedValue(createRawDriveFixture({ id: mockDriveId, name: 'Test' }));
+      vi.mocked(getDriveAccess).mockResolvedValue(createAccessFixture({ isOwner: true, role: 'OWNER' }));
+    };
+
+    it('rejects publishSubdomain with a clear 400 instead of silently dropping it', async () => {
+      ownerFixtures();
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ publishSubdomain: 'my-new-subdomain' }),
+      });
+      const response = await PATCH(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe(
+        'publishSubdomain cannot be changed via this endpoint. Use PATCH /api/drives/[driveId]/subdomain instead.'
+      );
+      expect(updateDrive).not.toHaveBeenCalled();
+    });
+
+    it('rejects a mixed body containing publishSubdomain alongside a valid field', async () => {
+      ownerFixtures();
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'New Name', publishSubdomain: 'my-new-subdomain' }),
+      });
+      const response = await PATCH(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe(
+        'publishSubdomain cannot be changed via this endpoint. Use PATCH /api/drives/[driveId]/subdomain instead.'
+      );
+      expect(updateDrive).not.toHaveBeenCalled();
+    });
+  });
+
   describe('homePageId', () => {
     const ownerFixtures = () => {
       vi.mocked(getDriveById).mockResolvedValue(createRawDriveFixture({ id: mockDriveId, name: 'Test' }));

--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -114,6 +114,18 @@ export async function PATCH(
     const userId = auth.userId;
 
     const body = await request.json();
+
+    // publishSubdomain lives on this schema's reject-list, not its allow-list:
+    // it has its own dedicated endpoint (tier-gating, conflict checks, and
+    // republish/rollback via changePublishSubdomain()) that this generic route
+    // must not bypass or duplicate.
+    if (typeof body === 'object' && body !== null && 'publishSubdomain' in body) {
+      return NextResponse.json(
+        { error: 'publishSubdomain cannot be changed via this endpoint. Use PATCH /api/drives/[driveId]/subdomain instead.' },
+        { status: 400 }
+      );
+    }
+
     const validatedBody = patchSchema.parse(body);
 
     // Check drive exists
@@ -230,15 +242,6 @@ export async function PATCH(
     return NextResponse.json(updatedDrive);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      const unrecognizedKeys = error.issues
-        .filter((issue) => issue.code === 'unrecognized_keys')
-        .flatMap((issue) => issue.keys);
-      if (unrecognizedKeys.includes('publishSubdomain')) {
-        return NextResponse.json(
-          { error: 'publishSubdomain cannot be changed via this endpoint. Use PATCH /api/drives/[driveId]/subdomain instead.' },
-          { status: 400 }
-        );
-      }
       return NextResponse.json(
         { error: 'Invalid request body', details: error.issues },
         { status: 400 }

--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -25,7 +25,7 @@ const patchSchema = z.object({
   // Drive-wide default OG/share image. "" or null clears it; a non-empty value
   // must be a valid URL.
   publishDefaultOgImageUrl: z.union([z.literal(''), z.string().url()]).nullable().optional(),
-});
+}).strict();
 
 /**
  * GET /api/drives/[driveId]
@@ -230,6 +230,15 @@ export async function PATCH(
     return NextResponse.json(updatedDrive);
   } catch (error) {
     if (error instanceof z.ZodError) {
+      const unrecognizedKeys = error.issues
+        .filter((issue) => issue.code === 'unrecognized_keys')
+        .flatMap((issue) => issue.keys);
+      if (unrecognizedKeys.includes('publishSubdomain')) {
+        return NextResponse.json(
+          { error: 'publishSubdomain cannot be changed via this endpoint. Use PATCH /api/drives/[driveId]/subdomain instead.' },
+          { status: 400 }
+        );
+      }
       return NextResponse.json(
         { error: 'Invalid request body', details: error.issues },
         { status: 400 }

--- a/apps/web/src/app/api/drives/[driveId]/subdomain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/subdomain/__tests__/route.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET, PATCH } from '../route';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+// ============================================================================
+// Contract tests for the dedicated PATCH /api/drives/[driveId]/subdomain
+// endpoint — the one true way to change publishSubdomain. These guard the
+// existing behavior stays intact while the generic drive PATCH route now
+// rejects publishSubdomain instead of silently dropping it.
+// ============================================================================
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn() },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_col, val) => ({ __eq: val })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  drives: { id: 'drives.id', ownerId: 'drives.ownerId', publishSubdomain: 'drives.publishSubdomain' },
+}));
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'users.id', subscriptionTier: 'users.subscriptionTier' },
+}));
+
+vi.mock('@/lib/subscription/plans', () => ({
+  getPlan: vi.fn(),
+}));
+
+const { MockPublishError } = vi.hoisted(() => {
+  class MockPublishError extends Error {
+    statusCode: number;
+    constructor(message: string, statusCode: number) {
+      super(message);
+      this.name = 'PublishError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { MockPublishError };
+});
+
+vi.mock('@/lib/canvas/publish-page', () => ({
+  changePublishSubdomain: vi.fn(),
+  PublishError: MockPublishError,
+  PUBLISH_HOST: 'pagespace.site',
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+  checkMCPDriveScope: vi.fn().mockReturnValue(null),
+  isPrincipalDriveOwnerOrAdmin: vi.fn(),
+}));
+
+import { db } from '@pagespace/db/db';
+import { getPlan } from '@/lib/subscription/plans';
+import { changePublishSubdomain } from '@/lib/canvas/publish-page';
+import { authenticateRequestWithOptions, isAuthError, isPrincipalDriveOwnerOrAdmin } from '@/lib/auth';
+
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const createContext = (driveId: string) => ({
+  params: Promise.resolve({ driveId }),
+});
+
+// Chainable db.select() mock: supports the innerJoin()+limit() shape used by
+// canChooseSubdomain() and the plain where()+limit() shape used by GET.
+function mockSelectChain(result: unknown[]) {
+  const chain = {
+    from: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(result)),
+  };
+  return chain;
+}
+
+describe('PATCH /api/drives/[driveId]/subdomain', () => {
+  const mockUserId = 'user_123';
+  const mockDriveId = 'drive_abc';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(true);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`, {
+      method: 'PATCH',
+      body: JSON.stringify({ subdomain: 'new-name' }),
+    });
+    const response = await PATCH(request, createContext(mockDriveId));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when the principal is not owner/admin', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`, {
+      method: 'PATCH',
+      body: JSON.stringify({ subdomain: 'new-name' }),
+    });
+    const response = await PATCH(request, createContext(mockDriveId));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(changePublishSubdomain).not.toHaveBeenCalled();
+    expect(body.error).toBe('Only drive owners and admins can change the subdomain');
+  });
+
+  it('returns 403 when the tier does not allow choosing a subdomain', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{ tier: 'free' }]) as never);
+    vi.mocked(getPlan).mockReturnValue({ limits: { canChooseSubdomain: false } } as ReturnType<typeof getPlan>);
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`, {
+      method: 'PATCH',
+      body: JSON.stringify({ subdomain: 'new-name' }),
+    });
+    const response = await PATCH(request, createContext(mockDriveId));
+
+    expect(response.status).toBe(403);
+    expect(changePublishSubdomain).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid subdomain without calling the service', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{ tier: 'pro' }]) as never);
+    vi.mocked(getPlan).mockReturnValue({ limits: { canChooseSubdomain: true } } as ReturnType<typeof getPlan>);
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`, {
+      method: 'PATCH',
+      body: JSON.stringify({ subdomain: '' }),
+    });
+    const response = await PATCH(request, createContext(mockDriveId));
+
+    expect(response.status).toBe(400);
+    expect(changePublishSubdomain).not.toHaveBeenCalled();
+  });
+
+  it('persists the new subdomain via changePublishSubdomain and returns it', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{ tier: 'pro' }]) as never);
+    vi.mocked(getPlan).mockReturnValue({ limits: { canChooseSubdomain: true } } as ReturnType<typeof getPlan>);
+    vi.mocked(changePublishSubdomain).mockResolvedValue({ oldSubdomain: 'old-name', newSubdomain: 'new-name' });
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`, {
+      method: 'PATCH',
+      body: JSON.stringify({ subdomain: 'new-name' }),
+    });
+    const response = await PATCH(request, createContext(mockDriveId));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(changePublishSubdomain).toHaveBeenCalledWith(mockDriveId, 'new-name', mockUserId);
+    expect(body.subdomain).toBe('new-name');
+    expect(body.url).toBe('https://new-name.pagespace.site');
+  });
+
+  it('maps a PublishError from the service to its status code', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(mockSelectChain([{ tier: 'pro' }]) as never);
+    vi.mocked(getPlan).mockReturnValue({ limits: { canChooseSubdomain: true } } as ReturnType<typeof getPlan>);
+    vi.mocked(changePublishSubdomain).mockRejectedValue(new MockPublishError('Subdomain "new-name" is already taken', 409));
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`, {
+      method: 'PATCH',
+      body: JSON.stringify({ subdomain: 'new-name' }),
+    });
+    const response = await PATCH(request, createContext(mockDriveId));
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toBe('Subdomain "new-name" is already taken');
+  });
+});
+
+describe('GET /api/drives/[driveId]/subdomain', () => {
+  const mockUserId = 'user_123';
+  const mockDriveId = 'drive_abc';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(true);
+  });
+
+  it('returns the current subdomain and change eligibility', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChain([{ publishSubdomain: 'current-name' }]) as never)
+      .mockReturnValueOnce(mockSelectChain([{ tier: 'pro' }]) as never);
+    vi.mocked(getPlan).mockReturnValue({ limits: { canChooseSubdomain: true } } as ReturnType<typeof getPlan>);
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`);
+    const response = await GET(request, createContext(mockDriveId));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      subdomain: 'current-name',
+      canChange: true,
+      publishHost: 'pagespace.site',
+    });
+  });
+
+  it('returns 403 when the principal is not owner/admin', async () => {
+    vi.mocked(isPrincipalDriveOwnerOrAdmin).mockResolvedValue(false);
+
+    const request = new Request(`https://example.com/api/drives/${mockDriveId}/subdomain`);
+    const response = await GET(request, createContext(mockDriveId));
+
+    expect(response.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

`PATCH /api/drives/[driveId]/subdomain` is the correct, dedicated endpoint for changing a drive's `publishSubdomain` (Canvas Publishing / `pagespace.site`). It handles tier-gating, conflict checks, and republish/rollback via `changePublishSubdomain()`.

The **generic** `PATCH /api/drives/[driveId]` route had a silent no-op bug: its `patchSchema` is a plain `z.object({...})` that never lists `publishSubdomain`. Zod's default behavior for `z.object()` silently strips unknown keys, so a body containing `publishSubdomain` parsed fine, the field was discarded before reaching `updateDrive()`, and the response came back `200 OK` with no indication the value never changed.

## Approach taken

Went with the **recommended approach**: reject `publishSubdomain` on the generic route with a clear `400`, rather than wiring it through to `changePublishSubdomain()` here.

- `patchSchema` is now `.strict()` — any unrecognized/typo'd field now produces a real Zod validation error instead of being silently stripped. This closes the same silent-no-op bug class for any future field, not just this one.
- Before `patchSchema.parse()` runs, the route checks the raw body for `publishSubdomain` by name and returns a targeted `400`:
  `{ error: "publishSubdomain cannot be changed via this endpoint. Use PATCH /api/drives/[driveId]/subdomain instead." }`

This check was originally implemented inside the `ZodError` catch block (by decoding `.strict()`'s `unrecognized_keys` issue shape), but self-review flagged that as the wrong altitude — it would've been the first field-specific special case in any route's generic error handling in this codebase, an awkward place to extend if another field ever needs the same treatment. Moved it to an explicit, readable pre-check right where the body is parsed instead; `.strict()` still stands as generic defense-in-depth for any other unrecognized field.

Rejected the alternative (wiring `publishSubdomain` through to `changePublishSubdomain()` inline) because that would duplicate non-trivial logic — tier-gating, conflict detection, republish, and rollback — that already lives correctly in `apps/web/src/lib/canvas/publish-page.ts`. Nothing in the codebase suggests clients rely on setting `publishSubdomain` via the generic route (verified: no frontend call site or MCP tool sends it here); the dedicated `/subdomain` endpoint is the only caller-facing path today.

## Changes

- `apps/web/src/app/api/drives/[driveId]/route.ts` — `.strict()` schema + explicit pre-parse rejection of `publishSubdomain`.
- `apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts` — new tests proving `publishSubdomain` (alone or mixed with valid fields) now 400s instead of silently no-op'ing 200.
- `apps/web/src/app/api/drives/[driveId]/subdomain/__tests__/route.test.ts` — **new** contract test file (this route previously had none) proving the dedicated endpoint's GET/PATCH behavior is unchanged: auth, tier-gating, validation, success path, and `PublishError` → status code mapping.

No `CHANGELOG.md` exists in this repo to update (only an unrelated orphaned test referencing an unbuilt `scripts/changelog/` module) — confirmed via repo-wide search before skipping that step.

## Test plan

- [x] `bun run --filter 'web' typecheck` — passes
- [x] `bunx vitest run src/app/api/drives` (apps/web) — 40 files / 806 tests passing, including the new coverage
- [x] Verified the bug reproduces on `master` (silent strip via plain `z.object()`) and is fixed on this branch (explicit 400)
- [x] Self-reviewed via independent correctness + cleanup/altitude finder passes; the one actionable finding (field-specific logic living in a generic catch block) was applied as a follow-up simplification commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAbzVKGuFKC1dbSiTkmxEx