### PR TITLE
feat(mcp): add include=content option to list_pages

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -338,6 +338,155 @@ describe('page-read-tools', () => {
       });
     });
 
+    describe('include=content', () => {
+      const driveSlug = 'my-drive';
+      const driveId = 'drive-1';
+
+      const docPage = { id: 'doc-1', title: 'README', type: 'DOCUMENT', parentId: null, position: 1, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+      const codePage = { id: 'code-1', title: 'index.ts', type: 'CODE', parentId: null, position: 2, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+      const taskListPage = { id: 'tasks-1', title: 'Sprint Tasks', type: 'TASK_LIST', parentId: null, position: 3, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+      const channelPage = { id: 'channel-1', title: 'General', type: 'CHANNEL', parentId: null, position: 4, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+      const filePage = { id: 'file-1', title: 'report.pdf', type: 'FILE', parentId: null, position: 5, driveId, isTrashed: false, permissions: { canView: true, canEdit: true, canShare: false, canDelete: false } };
+
+      const setupDriveAccessWithContent = (
+        visiblePages: unknown[],
+        contentRows: Array<{ id: string; content: string; contentMode: string; type: string }>,
+      ) => {
+        mockGetUserDriveAccess.mockResolvedValue(true as unknown as never);
+        mockGetUserAccessiblePagesInDrive.mockResolvedValue(visiblePages as unknown as never);
+        (mockDb.selectDistinct as ReturnType<typeof vi.fn>).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        });
+        (mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(contentRows),
+          }),
+        });
+      };
+
+      it('returns content for a DOCUMENT and CODE page', async () => {
+        setupDriveAccessWithContent(
+          [docPage, codePage],
+          [
+            { id: 'doc-1', content: 'Hello world', contentMode: 'html', type: 'DOCUMENT' },
+            { id: 'code-1', content: 'export const x = 1;', contentMode: 'markdown', type: 'CODE' },
+          ],
+        );
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as { pages: Array<{ id: string; content?: string; contentOmitted?: string }> };
+
+        const doc = result.pages.find(p => p.id === 'doc-1');
+        const code = result.pages.find(p => p.id === 'code-1');
+
+        assert({
+          given: 'include=content with a DOCUMENT page',
+          should: 'attach serialized content',
+          actual: doc?.content,
+          expected: 'Hello world',
+        });
+
+        assert({
+          given: 'include=content with a CODE page',
+          should: 'attach raw content untouched',
+          actual: code?.content,
+          expected: 'export const x = 1;',
+        });
+
+        assert({
+          given: 'text-serializable pages',
+          should: 'not set contentOmitted',
+          actual: [doc?.contentOmitted, code?.contentOmitted],
+          expected: [undefined, undefined],
+        });
+      });
+
+      it('omits content with a reason for TASK_LIST, CHANNEL, and FILE pages', async () => {
+        setupDriveAccessWithContent(
+          [taskListPage, channelPage, filePage],
+          [
+            { id: 'tasks-1', content: '', contentMode: 'html', type: 'TASK_LIST' },
+            { id: 'channel-1', content: '', contentMode: 'html', type: 'CHANNEL' },
+            { id: 'file-1', content: '', contentMode: 'html', type: 'FILE' },
+          ],
+        );
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as { pages: Array<{ id: string; content?: string; contentOmitted?: string }> };
+
+        for (const id of ['tasks-1', 'channel-1', 'file-1']) {
+          const entry = result.pages.find(p => p.id === id);
+          assert({
+            given: `a structured page type (${id})`,
+            should: 'not include a content field',
+            actual: entry?.content,
+            expected: undefined,
+          });
+          assert({
+            given: `a structured page type (${id})`,
+            should: 'include a contentOmitted explanation',
+            actual: typeof entry?.contentOmitted,
+            expected: 'string',
+          });
+        }
+      });
+
+      it('reports the guardrail when the page count exceeds the content cap', async () => {
+        const manyPages = Array.from({ length: 60 }, (_, i) => ({
+          id: `page-${i}`,
+          title: `Page ${i}`,
+          type: 'DOCUMENT',
+          parentId: null,
+          position: i,
+          driveId,
+          isTrashed: false,
+          permissions: { canView: true, canEdit: true, canShare: false, canDelete: false },
+        }));
+        const contentRows = manyPages
+          .slice(0, 50)
+          .map(p => ({ id: p.id, content: 'x', contentMode: 'html', type: 'DOCUMENT' }));
+
+        setupDriveAccessWithContent(manyPages, contentRows);
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as {
+          pages: Array<{ id: string; content?: string }>;
+          contentTruncated: boolean;
+          contentPageCap: number;
+          nextSteps: string[];
+        };
+
+        assert({
+          given: '60 pages with include=content and a cap of 50',
+          should: 'flag contentTruncated as true',
+          actual: result.contentTruncated,
+          expected: true,
+        });
+
+        assert({
+          given: '60 pages with include=content',
+          should: 'only attach content to the first 50 pages',
+          actual: result.pages.filter(p => p.content !== undefined).length,
+          expected: 50,
+        });
+
+        assert({
+          given: 'truncated content batch',
+          should: 'report what was dropped in nextSteps rather than staying silent',
+          actual: result.nextSteps.some(s => s.includes('50') && s.includes('60')),
+          expected: true,
+        });
+      });
+    });
+
   });
 
   describe('read_page', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -485,6 +485,54 @@ describe('page-read-tools', () => {
           expected: true,
         });
       });
+
+      it('clips a single page whose content exceeds the per-page character cap', async () => {
+        const hugeContent = 'x'.repeat(10000);
+        setupDriveAccessWithContent(
+          [docPage],
+          [{ id: 'doc-1', content: hugeContent, contentMode: 'html', type: 'DOCUMENT' }],
+        );
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as {
+          pages: Array<{ id: string; content?: string; contentClipped?: boolean }>;
+          contentClippedCount: number;
+          contentCharCapPerPage: number;
+          nextSteps: string[];
+        };
+
+        const doc = result.pages.find(p => p.id === 'doc-1');
+
+        assert({
+          given: 'a page whose content exceeds the per-page char cap',
+          should: 'clip content to the cap length',
+          actual: doc?.content?.length,
+          expected: result.contentCharCapPerPage,
+        });
+
+        assert({
+          given: 'a clipped page',
+          should: 'flag contentClipped: true on that entry',
+          actual: doc?.contentClipped,
+          expected: true,
+        });
+
+        assert({
+          given: 'a batch with one clipped page',
+          should: 'report contentClippedCount',
+          actual: result.contentClippedCount,
+          expected: 1,
+        });
+
+        assert({
+          given: 'a batch with a clipped page',
+          should: 'mention the clip in nextSteps rather than staying silent',
+          actual: result.nextSteps.some(s => s.includes('clipped')),
+          expected: true,
+        });
+      });
     });
 
   });

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -497,7 +497,7 @@ describe('page-read-tools', () => {
           { driveId, driveSlug, include: 'content' },
           createAuthContext()
         ) as {
-          pages: Array<{ id: string; content?: string; contentClipped?: boolean }>;
+          pages: Array<{ id: string; content?: string; contentClipped?: boolean; contentClippedAfterLine?: number }>;
           contentClippedCount: number;
           contentCharCapPerPage: number;
           nextSteps: string[];
@@ -506,8 +506,8 @@ describe('page-read-tools', () => {
         const doc = result.pages.find(p => p.id === 'doc-1');
 
         assert({
-          given: 'a page whose content exceeds the per-page char cap',
-          should: 'clip content to the cap length',
+          given: 'a page whose content exceeds the per-page char cap with no newlines to cut at',
+          should: 'fall back to a hard clip at the cap length',
           actual: doc?.content?.length,
           expected: result.contentCharCapPerPage,
         });
@@ -517,6 +517,13 @@ describe('page-read-tools', () => {
           should: 'flag contentClipped: true on that entry',
           actual: doc?.contentClipped,
           expected: true,
+        });
+
+        assert({
+          given: 'a clipped page with no newlines',
+          should: 'report a single-line contentClippedAfterLine',
+          actual: doc?.contentClippedAfterLine,
+          expected: 1,
         });
 
         assert({
@@ -531,6 +538,133 @@ describe('page-read-tools', () => {
           should: 'mention the clip in nextSteps rather than staying silent',
           actual: result.nextSteps.some(s => s.includes('clipped')),
           expected: true,
+        });
+      });
+
+      it('cuts a clipped page at the last newline instead of mid-line', async () => {
+        // 900 lines of 10 chars + newline = 9900 chars, over the 8000 cap.
+        // The clip should land on a line boundary, not mid-line.
+        const lines = Array.from({ length: 900 }, (_, i) => `line${String(i).padStart(5, '0')}`);
+        const longContent = lines.join('\n');
+
+        setupDriveAccessWithContent(
+          [docPage],
+          [{ id: 'doc-1', content: longContent, contentMode: 'html', type: 'DOCUMENT' }],
+        );
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as {
+          pages: Array<{ id: string; content?: string; contentClipped?: boolean; contentClippedAfterLine?: number }>;
+        };
+
+        const doc = result.pages.find(p => p.id === 'doc-1');
+        const clippedLines = doc?.content?.split('\n') ?? [];
+
+        assert({
+          given: 'clipped content cut at a newline boundary',
+          should: 'not end mid-line (every line is a full "lineNNNNN" token)',
+          actual: clippedLines.every(l => /^line\d{5}$/.test(l)),
+          expected: true,
+        });
+
+        assert({
+          given: 'clipped content cut at a newline boundary',
+          should: 'stay under the char cap',
+          actual: (doc?.content?.length ?? Infinity) <= 8000,
+          expected: true,
+        });
+
+        assert({
+          given: '900 ten-char lines clipped at an 8000-char cap (800 full lines fit exactly)',
+          should: 'keep exactly 800 complete lines',
+          actual: clippedLines.length,
+          expected: 800,
+        });
+
+        assert({
+          given: 'clipped content cut at a newline boundary',
+          should: 'report contentClippedAfterLine matching the number of lines kept',
+          actual: doc?.contentClippedAfterLine,
+          expected: clippedLines.length,
+        });
+      });
+
+      it('does not clip content exactly at the per-page character cap', async () => {
+        const exactContent = 'x'.repeat(8000);
+        setupDriveAccessWithContent(
+          [docPage],
+          [{ id: 'doc-1', content: exactContent, contentMode: 'html', type: 'DOCUMENT' }],
+        );
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as {
+          pages: Array<{ id: string; content?: string; contentClipped?: boolean }>;
+          contentClippedCount: number;
+        };
+
+        const doc = result.pages.find(p => p.id === 'doc-1');
+
+        assert({
+          given: 'content exactly at the per-page char cap (not exceeding it)',
+          should: 'not be clipped',
+          actual: doc?.contentClipped,
+          expected: undefined,
+        });
+
+        assert({
+          given: 'content exactly at the per-page char cap',
+          should: 'keep the full content',
+          actual: doc?.content?.length,
+          expected: 8000,
+        });
+
+        assert({
+          given: 'content exactly at the per-page char cap',
+          should: 'report contentClippedCount of 0',
+          actual: result.contentClippedCount,
+          expected: 0,
+        });
+      });
+
+      it('does not truncate content when exactly at the page-count cap (50 pages)', async () => {
+        const exactlyFiftyPages = Array.from({ length: 50 }, (_, i) => ({
+          id: `page-${i}`,
+          title: `Page ${i}`,
+          type: 'DOCUMENT',
+          parentId: null,
+          position: i,
+          driveId,
+          isTrashed: false,
+          permissions: { canView: true, canEdit: true, canShare: false, canDelete: false },
+        }));
+        const contentRows = exactlyFiftyPages.map(p => ({ id: p.id, content: 'x', contentMode: 'html', type: 'DOCUMENT' }));
+
+        setupDriveAccessWithContent(exactlyFiftyPages, contentRows);
+
+        const result = await pageReadTools.list_pages.execute!(
+          { driveId, driveSlug, include: 'content' },
+          createAuthContext()
+        ) as {
+          pages: Array<{ id: string; content?: string }>;
+          contentTruncated: boolean;
+        };
+
+        assert({
+          given: 'exactly 50 pages (the page-count cap) with include=content',
+          should: 'not flag contentTruncated',
+          actual: result.contentTruncated,
+          expected: false,
+        });
+
+        assert({
+          given: 'exactly 50 pages with include=content',
+          should: 'attach content to all 50 pages',
+          actual: result.pages.filter(p => p.content !== undefined).length,
+          expected: 50,
         });
       });
     });

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -19,6 +19,14 @@ import { serializePageContentForAI, isTextSerializablePageType } from '../core/p
 // folder/audit pass while keeping the batched content query and payload size bounded.
 const MAX_CONTENT_INCLUDE_PAGES = 50;
 
+// The page-count cap above bounds how many pages get content, but not how
+// large any single page is — a folder of 50 long CODE/DOCUMENT pages could
+// still return a multi-megabyte response. Cap each page's content the same
+// way read_conversation already truncates long messages, so one huge page
+// can't blow up the whole batch; callers needing the rest can page through it
+// with read_page's lineStart/lineEnd.
+const MAX_CONTENT_CHARS_PER_PAGE = 8000;
+
 export const pageReadTools = {
   /**
    * Explore the folder structure and find content within a workspace
@@ -30,7 +38,7 @@ export const pageReadTools = {
       driveId: z.string().describe('The unique ID of the drive (used for operations)'),
       parentId: z.string().optional().describe('Page ID to list children of. Omit for drive root.'),
       recursive: z.boolean().optional().describe('Set true to return the full subtree instead of direct children only. Default: false.'),
-      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response, avoiding N+1 read_page calls. Capped at ${MAX_CONTENT_INCLUDE_PAGES} pages per call — CHANNEL/TASK_LIST/FILE pages get a short summary instead of full content (same as read_page).`),
+      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response, avoiding N+1 read_page calls. Capped at ${MAX_CONTENT_INCLUDE_PAGES} pages per call, and each page's content is clipped to ${MAX_CONTENT_CHARS_PER_PAGE} characters (contentClipped: true when clipped) — use read_page with lineStart/lineEnd for the rest. CHANNEL/TASK_LIST/FILE pages get a short summary instead of full content (same as read_page).`),
     }),
     execute: async ({ driveSlug, driveId, parentId, recursive = false, include }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
@@ -89,6 +97,7 @@ export const pageReadTools = {
           path: string;
           content?: string;
           contentOmitted?: string;
+          contentClipped?: boolean;
         }
 
         let resultPages: PageEntry[];
@@ -131,6 +140,7 @@ export const pageReadTools = {
         // this endpoint to lean on for a size limit, so cap explicitly here and
         // report what was dropped instead of silently truncating.
         let contentTruncated = false;
+        let contentClippedCount = 0;
         if (include === 'content' && resultPages.length > 0) {
           const pagesForContent = resultPages.slice(0, MAX_CONTENT_INCLUDE_PAGES);
           contentTruncated = resultPages.length > MAX_CONTENT_INCLUDE_PAGES;
@@ -148,7 +158,14 @@ export const pageReadTools = {
               entry.contentOmitted = `${row.type} pages return structured data, not inline text — use read_page with this page's ID instead.`;
               continue;
             }
-            entry.content = serializePageContentForAI(row);
+            const fullContent = serializePageContentForAI(row);
+            if (fullContent.length > MAX_CONTENT_CHARS_PER_PAGE) {
+              entry.content = fullContent.slice(0, MAX_CONTENT_CHARS_PER_PAGE);
+              entry.contentClipped = true;
+              contentClippedCount++;
+            } else {
+              entry.content = fullContent;
+            }
           }
         }
 
@@ -169,6 +186,8 @@ export const pageReadTools = {
             contentIncluded: true,
             contentPageCap: MAX_CONTENT_INCLUDE_PAGES,
             contentTruncated,
+            contentCharCapPerPage: MAX_CONTENT_CHARS_PER_PAGE,
+            contentClippedCount,
           }),
           summary: recursive
             ? `Found ${resultPages.length} page${resultPages.length === 1 ? '' : 's'} in "${driveLabel}" (full tree)`
@@ -179,6 +198,9 @@ export const pageReadTools = {
             'Use create_page to add new content',
             ...(contentTruncated ? [
               `Content was only included for the first ${MAX_CONTENT_INCLUDE_PAGES} of ${resultPages.length} pages — the rest have no "content" field. Narrow with parentId or call read_page directly for the remaining pages.`,
+            ] : []),
+            ...(contentClippedCount > 0 ? [
+              `${contentClippedCount} page${contentClippedCount === 1 ? '' : 's'} had content clipped to the first ${MAX_CONTENT_CHARS_PER_PAGE} characters (contentClipped: true) — use read_page with lineStart/lineEnd on those pages to read the rest.`,
             ] : []),
           ] : [`"${locationLabel}" is empty — use create_page to add content`],
         };

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -21,10 +21,11 @@ const MAX_CONTENT_INCLUDE_PAGES = 50;
 
 // The page-count cap above bounds how many pages get content, but not how
 // large any single page is — a folder of 50 long CODE/DOCUMENT pages could
-// still return a multi-megabyte response. Cap each page's content the same
-// way read_conversation already truncates long messages, so one huge page
-// can't blow up the whole batch; callers needing the rest can page through it
-// with read_page's lineStart/lineEnd.
+// still return a multi-megabyte response. Clip each page's content (in the
+// same truncate-and-report spirit as read_conversation's message truncation,
+// though the mechanics differ — see the newline-boundary cut below) so one
+// huge page can't blow up the whole batch; callers needing the rest can
+// resume with read_page's lineStart/lineEnd.
 const MAX_CONTENT_CHARS_PER_PAGE = 8000;
 
 export const pageReadTools = {
@@ -38,7 +39,7 @@ export const pageReadTools = {
       driveId: z.string().describe('The unique ID of the drive (used for operations)'),
       parentId: z.string().optional().describe('Page ID to list children of. Omit for drive root.'),
       recursive: z.boolean().optional().describe('Set true to return the full subtree instead of direct children only. Default: false.'),
-      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response, avoiding N+1 read_page calls. Capped at ${MAX_CONTENT_INCLUDE_PAGES} pages per call, and each page's content is clipped near ${MAX_CONTENT_CHARS_PER_PAGE} characters (contentClipped: true, contentClippedAfterLine gives the resume line) — use read_page with lineStart: contentClippedAfterLine + 1 for the rest. CHANNEL/TASK_LIST/FILE pages get a short summary instead of full content (same as read_page).`),
+      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response instead of calling read_page per page. Content over ${MAX_CONTENT_CHARS_PER_PAGE} characters is clipped (contentClipped: true) — resume with read_page's lineStart at contentClippedAfterLine + 1. CHANNEL/TASK_LIST/FILE pages get a short summary instead of content.`),
     }),
     execute: async ({ driveSlug, driveId, parentId, recursive = false, include }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
@@ -146,34 +147,41 @@ export const pageReadTools = {
           const pagesForContent = resultPages.slice(0, MAX_CONTENT_INCLUDE_PAGES);
           contentTruncated = resultPages.length > MAX_CONTENT_INCLUDE_PAGES;
 
-          const contentRows = await db
-            .select({ id: pages.id, content: pages.content, contentMode: pages.contentMode, type: pages.type })
-            .from(pages)
-            .where(inArray(pages.id, pagesForContent.map(p => p.id)));
-          const contentMap = new Map(contentRows.map(r => [r.id, r]));
+          // Type is already known from resultPages, so split up front: structured
+          // types (CHANNEL/TASK_LIST/FILE) never need their content column fetched
+          // at all, and the query below only runs for the text-serializable subset.
+          const textEntries = pagesForContent.filter(entry => {
+            if (isTextSerializablePageType(entry.type)) return true;
+            entry.contentOmitted = `${entry.type} pages return structured data, not inline text — use read_page with this page's ID instead.`;
+            return false;
+          });
 
-          for (const entry of pagesForContent) {
-            const row = contentMap.get(entry.id);
-            if (!row) continue;
-            if (!isTextSerializablePageType(row.type)) {
-              entry.contentOmitted = `${row.type} pages return structured data, not inline text — use read_page with this page's ID instead.`;
-              continue;
-            }
-            const fullContent = serializePageContentForAI(row);
-            if (fullContent.length > MAX_CONTENT_CHARS_PER_PAGE) {
-              // Cut at the last newline within the budget rather than an arbitrary
-              // character offset, so we don't split a UTF-16 surrogate pair or sever
-              // an HTML tag mid-way. Falls back to a hard cut only when the window
-              // has no newline at all (e.g. one huge minified line).
-              const hardCut = fullContent.slice(0, MAX_CONTENT_CHARS_PER_PAGE);
-              const lastNewline = hardCut.lastIndexOf('\n');
-              const clipped = lastNewline > 0 ? hardCut.slice(0, lastNewline) : hardCut;
-              entry.content = clipped;
-              entry.contentClipped = true;
-              entry.contentClippedAfterLine = clipped.split('\n').length;
-              contentClippedCount++;
-            } else {
-              entry.content = fullContent;
+          if (textEntries.length > 0) {
+            const contentRows = await db
+              .select({ id: pages.id, content: pages.content, contentMode: pages.contentMode })
+              .from(pages)
+              .where(inArray(pages.id, textEntries.map(p => p.id)));
+            const contentMap = new Map(contentRows.map(r => [r.id, r]));
+
+            for (const entry of textEntries) {
+              const row = contentMap.get(entry.id);
+              if (!row) continue;
+              const fullContent = serializePageContentForAI({ type: entry.type, ...row });
+              if (fullContent.length > MAX_CONTENT_CHARS_PER_PAGE) {
+                // Cut at the last newline within the budget rather than an arbitrary
+                // character offset, so we don't split a UTF-16 surrogate pair or sever
+                // an HTML tag mid-way. Falls back to a hard cut only when the window
+                // has no newline at all (e.g. one huge minified line).
+                const hardCut = fullContent.slice(0, MAX_CONTENT_CHARS_PER_PAGE);
+                const lastNewline = hardCut.lastIndexOf('\n');
+                const clipped = lastNewline > 0 ? hardCut.slice(0, lastNewline) : hardCut;
+                entry.content = clipped;
+                entry.contentClipped = true;
+                entry.contentClippedAfterLine = clipped.split('\n').length;
+                contentClippedCount++;
+              } else {
+                entry.content = fullContent;
+              }
             }
           }
         }

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -11,21 +11,28 @@ import { getPageTypeEmoji, isFolderPage } from '@pagespace/lib/content/page-type
 import { PageType } from '@pagespace/lib/utils/enums';
 import type { ToolExecutionContext } from '../core/types';
 import { getSuggestedVisionModels } from '../core/model-capabilities';
-import { serializePageContentForAI } from '../core/page-serializer';
+import { serializePageContentForAI, isTextSerializablePageType } from '../core/page-serializer';
+
+// Batching raw content onto list_pages has no pagination to lean on (recursive
+// listing is already unbounded), so this caps how many pages can have content
+// fetched in one call. Chosen to comfortably cover a single small-to-medium
+// folder/audit pass while keeping the batched content query and payload size bounded.
+const MAX_CONTENT_INCLUDE_PAGES = 50;
 
 export const pageReadTools = {
   /**
    * Explore the folder structure and find content within a workspace
    */
   list_pages: tool({
-    description: 'List pages at a location in a workspace. Defaults to direct children of the drive root (ls-style). Pass parentId to navigate into a folder. Set recursive: true to return the full subtree. Each result includes hasChildren so you know whether to drill in further.',
+    description: 'List pages at a location in a workspace. Defaults to direct children of the drive root (ls-style). Pass parentId to navigate into a folder. Set recursive: true to return the full subtree. Each result includes hasChildren so you know whether to drill in further. Pass include: "content" to batch each page\'s content into the response instead of calling read_page per page — capped at ' + MAX_CONTENT_INCLUDE_PAGES + ' pages per call.',
     inputSchema: z.object({
       driveSlug: z.string().optional().describe('The human-readable slug of the drive (for semantic understanding)'),
       driveId: z.string().describe('The unique ID of the drive (used for operations)'),
       parentId: z.string().optional().describe('Page ID to list children of. Omit for drive root.'),
       recursive: z.boolean().optional().describe('Set true to return the full subtree instead of direct children only. Default: false.'),
+      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response, avoiding N+1 read_page calls. Capped at ${MAX_CONTENT_INCLUDE_PAGES} pages per call — CHANNEL/TASK_LIST/FILE pages get a short summary instead of full content (same as read_page).`),
     }),
-    execute: async ({ driveSlug, driveId, parentId, recursive = false }, { experimental_context: context }) => {
+    execute: async ({ driveSlug, driveId, parentId, recursive = false, include }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
@@ -80,6 +87,8 @@ export const pageReadTools = {
           hasChildren: boolean;
           isTaskLinked: boolean;
           path: string;
+          content?: string;
+          contentOmitted?: string;
         }
 
         let resultPages: PageEntry[];
@@ -117,6 +126,32 @@ export const pageReadTools = {
           resultPages = collectSubtree(parentId ?? null);
         }
 
+        // Batch content onto the result set in one additional query, rather than
+        // making callers do N read_page calls. There's no pagination anywhere on
+        // this endpoint to lean on for a size limit, so cap explicitly here and
+        // report what was dropped instead of silently truncating.
+        let contentTruncated = false;
+        if (include === 'content' && resultPages.length > 0) {
+          const pagesForContent = resultPages.slice(0, MAX_CONTENT_INCLUDE_PAGES);
+          contentTruncated = resultPages.length > MAX_CONTENT_INCLUDE_PAGES;
+
+          const contentRows = await db
+            .select({ id: pages.id, content: pages.content, contentMode: pages.contentMode, type: pages.type })
+            .from(pages)
+            .where(inArray(pages.id, pagesForContent.map(p => p.id)));
+          const contentMap = new Map(contentRows.map(r => [r.id, r]));
+
+          for (const entry of pagesForContent) {
+            const row = contentMap.get(entry.id);
+            if (!row) continue;
+            if (!isTextSerializablePageType(row.type)) {
+              entry.contentOmitted = `${row.type} pages return structured data, not inline text — use read_page with this page's ID instead.`;
+              continue;
+            }
+            entry.content = serializePageContentForAI(row);
+          }
+        }
+
         const driveLabel = driveSlug || driveId;
         const breadcrumb = buildBreadcrumb(parentId);
         const location = parentId ? buildPath(parentId) : `/${driveLabel}`;
@@ -130,13 +165,21 @@ export const pageReadTools = {
           pages: resultPages,
           count: resultPages.length,
           totalInDrive: visiblePages.length,
+          ...(include === 'content' && {
+            contentIncluded: true,
+            contentPageCap: MAX_CONTENT_INCLUDE_PAGES,
+            contentTruncated,
+          }),
           summary: recursive
             ? `Found ${resultPages.length} page${resultPages.length === 1 ? '' : 's'} in "${driveLabel}" (full tree)`
             : `Found ${resultPages.length} page${resultPages.length === 1 ? '' : 's'} in "${locationLabel}"`,
           nextSteps: resultPages.length > 0 ? [
-            'Use read_page with a page ID to read its content',
+            ...(include === 'content' ? [] : ['Use read_page with a page ID to read its content']),
             'Pass parentId with a folder ID to navigate into it',
             'Use create_page to add new content',
+            ...(contentTruncated ? [
+              `Content was only included for the first ${MAX_CONTENT_INCLUDE_PAGES} of ${resultPages.length} pages — the rest have no "content" field. Narrow with parentId or call read_page directly for the remaining pages.`,
+            ] : []),
           ] : [`"${locationLabel}" is empty — use create_page to add content`],
         };
       } catch (error) {

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -38,7 +38,7 @@ export const pageReadTools = {
       driveId: z.string().describe('The unique ID of the drive (used for operations)'),
       parentId: z.string().optional().describe('Page ID to list children of. Omit for drive root.'),
       recursive: z.boolean().optional().describe('Set true to return the full subtree instead of direct children only. Default: false.'),
-      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response, avoiding N+1 read_page calls. Capped at ${MAX_CONTENT_INCLUDE_PAGES} pages per call, and each page's content is clipped to ${MAX_CONTENT_CHARS_PER_PAGE} characters (contentClipped: true when clipped) — use read_page with lineStart/lineEnd for the rest. CHANNEL/TASK_LIST/FILE pages get a short summary instead of full content (same as read_page).`),
+      include: z.enum(['content']).optional().describe(`Set to "content" to batch each page's content into the response, avoiding N+1 read_page calls. Capped at ${MAX_CONTENT_INCLUDE_PAGES} pages per call, and each page's content is clipped near ${MAX_CONTENT_CHARS_PER_PAGE} characters (contentClipped: true, contentClippedAfterLine gives the resume line) — use read_page with lineStart: contentClippedAfterLine + 1 for the rest. CHANNEL/TASK_LIST/FILE pages get a short summary instead of full content (same as read_page).`),
     }),
     execute: async ({ driveSlug, driveId, parentId, recursive = false, include }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
@@ -98,6 +98,7 @@ export const pageReadTools = {
           content?: string;
           contentOmitted?: string;
           contentClipped?: boolean;
+          contentClippedAfterLine?: number;
         }
 
         let resultPages: PageEntry[];
@@ -160,8 +161,16 @@ export const pageReadTools = {
             }
             const fullContent = serializePageContentForAI(row);
             if (fullContent.length > MAX_CONTENT_CHARS_PER_PAGE) {
-              entry.content = fullContent.slice(0, MAX_CONTENT_CHARS_PER_PAGE);
+              // Cut at the last newline within the budget rather than an arbitrary
+              // character offset, so we don't split a UTF-16 surrogate pair or sever
+              // an HTML tag mid-way. Falls back to a hard cut only when the window
+              // has no newline at all (e.g. one huge minified line).
+              const hardCut = fullContent.slice(0, MAX_CONTENT_CHARS_PER_PAGE);
+              const lastNewline = hardCut.lastIndexOf('\n');
+              const clipped = lastNewline > 0 ? hardCut.slice(0, lastNewline) : hardCut;
+              entry.content = clipped;
               entry.contentClipped = true;
+              entry.contentClippedAfterLine = clipped.split('\n').length;
               contentClippedCount++;
             } else {
               entry.content = fullContent;
@@ -200,7 +209,7 @@ export const pageReadTools = {
               `Content was only included for the first ${MAX_CONTENT_INCLUDE_PAGES} of ${resultPages.length} pages — the rest have no "content" field. Narrow with parentId or call read_page directly for the remaining pages.`,
             ] : []),
             ...(contentClippedCount > 0 ? [
-              `${contentClippedCount} page${contentClippedCount === 1 ? '' : 's'} had content clipped to the first ${MAX_CONTENT_CHARS_PER_PAGE} characters (contentClipped: true) — use read_page with lineStart/lineEnd on those pages to read the rest.`,
+              `${contentClippedCount} page${contentClippedCount === 1 ? '' : 's'} had content clipped near the ${MAX_CONTENT_CHARS_PER_PAGE}-character mark (contentClipped: true) — each clipped entry's contentClippedAfterLine tells you where it stopped, so call read_page with lineStart: contentClippedAfterLine + 1 on that page to continue.`,
             ] : []),
           ] : [`"${locationLabel}" is empty — use create_page to add content`],
         };


### PR DESCRIPTION
## Summary
- Adds an `include: z.enum(['content']).optional()` option to the `list_pages` MCP tool so callers can batch page content into the response instead of issuing a separate `read_page` call per page (fixes an N+1 pattern for content auditing).
- After computing the result page list, issues one additional batched query (`inArray(pages.id, resultPageIds)`, scoped to text-serializable types only — see guardrails below) and runs each row through the same serialization `read_page` already uses (`serializePageContentForAI` + `isTextSerializablePageType` from `page-serializer.ts`), so DOCUMENT/CODE/etc. pages get inline text content.
- CHANNEL/TASK_LIST/FILE pages (which `read_page` already returns as structured data, not text) get a `contentOmitted` reason instead of content, so callers know to use `read_page` for those instead of getting empty/wrong data. These are filtered out before the DB query even runs, so a batch of all-structured pages costs zero extra DB round trips.
- Scoped entirely to `page-read-tools.ts` — the shared permission-resolution functions (`agent-permissions.ts`, `permissions.ts`) are untouched, since they're reused by many unrelated callers and widening their column selects would bloat every one of those call sites. Verified (independently, twice) that every page ID reaching the new content query already passed view-permission filtering upstream, for both the user and agent/MCP-scoped-token actor paths — no new authorization surface.
- The REST route `GET /api/drives/[driveId]/pages` is untouched — out of scope.

## Guardrails (two axes — page count and per-page size)
There's no existing pagination on this endpoint to lean on (`recursive: true` is already unbounded), so `include=content` needed its own safety net on two independent axes:
1. **Page count** — capped at **50 pages** per call (`MAX_CONTENT_INCLUDE_PAGES`). Chosen to comfortably cover a single small-to-medium folder or audit pass while keeping the extra batched query and response payload bounded. When exceeded, `contentTruncated: true` and `nextSteps` explicitly states how many of how many pages got content — never silently looks complete.
2. **Per-page size** — a single huge document/code page could still blow up the response even under the page-count cap, so each page's content is clipped at **8000 characters** (`MAX_CONTENT_CHARS_PER_PAGE`). The clip lands on the last newline within the budget (not an arbitrary character offset), so it never splits a UTF-16 surrogate pair or severs an HTML tag mid-way. Clipped entries get `contentClipped: true` and `contentClippedAfterLine` (the exact line to resume from via `read_page`'s `lineStart`), aggregated as `contentClippedCount` at the top level.

## Review history
- `chatgpt-codex-connector` flagged the per-page-size gap (thread on `page-read-tools.ts:151`, anchored to the first commit) — this was independently caught and fixed in the same review pass before the comment was seen; replied with details and left the thread open for human verification since the fix landed mid-review.
- A self-driven adversarial review pass (independent subagents, not just self-review) confirmed: no permission bypass (traced both `getUserAccessiblePagesInDriveWithDetails` and `getAgentAccessiblePagesInDrive`, plus the MCP-token ceiling intersection), no downstream UI/consumer breakage (`registry.tsx`/`CompactToolCallRenderer.tsx` only read `count`/`tree`/`path`, ignore new fields), and no persistence/size-limit issue (tool results are `jsonb`, no app-level cap). Also caught and fixed: a redundant DB fetch of `type` (already known from the page list) and an unconditional content query even for all-structured-type batches — both eliminated in the last commit.

## Test plan
- [x] `bunx tsc --noEmit` in `apps/web` — clean
- [x] `bunx vitest run apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts` — 55/55 passing, including 7 new tests under `include=content`:
  - returns serialized content for DOCUMENT/CODE pages
  - omits content with a `contentOmitted` reason for TASK_LIST/CHANNEL/FILE pages
  - the 50-page cap triggers and is reported (not silent) when exceeded
  - a single page over the char cap is clipped, flagged, and counted
  - the clip lands on a line boundary, not mid-line (900-line fixture)
  - content exactly at the char cap is NOT clipped (boundary test)
  - exactly 50 pages (page-count cap boundary) does NOT trigger truncation
- [x] Full `apps/web/src/lib/ai/tools` + `core` test suite run clean except one pre-existing, unrelated failure (`activity-tools.test.ts`, DB-role error) confirmed present on the pre-change tree via `git stash`.

Note: this repo currently has no `CHANGELOG.md` / `docs/*/changelog.md` file (the `docs/` tree was removed in a prior "chore: remove stale docs" commit, and `scripts/changelog/` referenced by `package.json`'s `changelog:generate` script doesn't exist in the tree). No changelog entry was added since there's no live changelog artifact to update — flagging this rather than inventing a new file/convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPMD4zxLAw3ckEmtaAtu81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include page content in page listings, so results can now return both page metadata and readable content together.
  * Large content responses are automatically capped to keep results manageable.

* **Bug Fixes**
  * Improved handling for long pages by clipping content more safely, including better line-boundary trimming.
  * Non-text page types now return a clear note when content can’t be included instead of failing or showing incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->