### PR TITLE
Fix TASK_LIST pages crashing the Kanban UI when created via AI/MCP

### DIFF
--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -7,6 +7,7 @@ const mockFindFirstPage = vi.fn();
 const mockFindFirstTaskList = vi.fn();
 const mockFindManyStatusConfigs = vi.fn();
 const mockInsertReturning = vi.fn();
+const mockInsertStatusConfigValues = vi.fn();
 const mockSelectChildPages = vi.fn();
 const mockBackfillMissingTaskItems = vi.fn();
 const mockFetchEnrichedTasks = vi.fn();
@@ -71,10 +72,14 @@ vi.mock('@pagespace/db/db', () => ({
       taskLists: { findFirst: (...args: unknown[]) => mockFindFirstTaskList(...args) },
       taskStatusConfigs: { findMany: (...args: unknown[]) => mockFindManyStatusConfigs(...args) },
     },
-    insert: () => ({
-      values: () => ({
-        returning: (...args: unknown[]) => mockInsertReturning(...args),
-      }),
+    insert: (table: { pageId?: string }) => ({
+      values: (vals: Record<string, unknown> | Record<string, unknown>[]) => {
+        if (table?.pageId === 'taskLists.pageId') {
+          return { returning: (...args: unknown[]) => mockInsertReturning(...args) };
+        }
+        mockInsertStatusConfigValues(vals);
+        return Promise.resolve(undefined);
+      },
     }),
     select: () => ({
       from: () => ({
@@ -84,9 +89,15 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 
-vi.mock('@/services/api/task-sync-service', () => ({
-  backfillMissingTaskItems: (...args: unknown[]) => mockBackfillMissingTaskItems(...args),
-}));
+// ensureTaskListForPage is real (not mocked) — it's the fix under test, exercised
+// against the mocked `db` above so we can assert the status configs actually persist.
+vi.mock('@/services/api/task-sync-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/api/task-sync-service')>();
+  return {
+    ...actual,
+    backfillMissingTaskItems: (...args: unknown[]) => mockBackfillMissingTaskItems(...args),
+  };
+});
 
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
@@ -227,6 +238,29 @@ describe('MCP Documents API — TASK_LIST read', () => {
     await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
 
     expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it('persists the default task_status_configs (not just the response fallback) when auto-creating', async () => {
+    mockFindFirstTaskList.mockResolvedValue(null);
+    mockInsertReturning.mockResolvedValue([{ ...EXISTING_TASK_LIST, id: 'tl_new' }]);
+
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockInsertStatusConfigValues).toHaveBeenCalledTimes(1);
+    const inserted = mockInsertStatusConfigValues.mock.calls[0][0];
+    expect(inserted).toHaveLength(4);
+    expect(inserted.map((c: { slug: string }) => c.slug)).toEqual([
+      'pending', 'in_progress', 'blocked', 'completed',
+    ]);
+    expect(inserted.every((c: { taskListId: string }) => c.taskListId === 'tl_new')).toBe(true);
+  });
+
+  it('does not insert status configs when taskLists record already exists', async () => {
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockInsertStatusConfigValues).not.toHaveBeenCalled();
   });
 
   it('uses custom status configs when present', async () => {

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -99,10 +99,15 @@ vi.mock('@/services/api/task-sync-service', async (importOriginal) => {
   };
 });
 
+// task-sync-service (real, unmocked below) also imports `desc`/`inArray` for its
+// other exports (addTaskItemUnderParent, backfillMissingTaskItems); include them
+// even though the code paths under test here don't call them.
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   asc: vi.fn(),
   and: vi.fn(),
+  desc: vi.fn(),
+  inArray: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -111,6 +116,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 
 vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: { pageId: 'taskLists.pageId' },
+  taskItems: { pageId: 'taskItems.pageId' },
   taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
   DEFAULT_TASK_STATUSES: [
     { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300' },
@@ -243,6 +249,12 @@ describe('MCP Documents API — TASK_LIST read', () => {
   it('persists the default task_status_configs (not just the response fallback) when auto-creating', async () => {
     mockFindFirstTaskList.mockResolvedValue(null);
     mockInsertReturning.mockResolvedValue([{ ...EXISTING_TASK_LIST, id: 'tl_new' }]);
+    // Simulates the findMany the route runs right after creation seeing the rows
+    // ensureTaskListForPage just inserted, so the separate empty-configs backfill
+    // check below doesn't also fire and double-insert.
+    mockFindManyStatusConfigs.mockResolvedValue([
+      { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#gray' },
+    ]);
 
     const { POST } = await import('../route');
     await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
@@ -256,11 +268,33 @@ describe('MCP Documents API — TASK_LIST read', () => {
     expect(inserted.every((c: { taskListId: string }) => c.taskListId === 'tl_new')).toBe(true);
   });
 
-  it('does not insert status configs when taskLists record already exists', async () => {
+  it('does not insert status configs when the task list already has configs', async () => {
+    mockFindManyStatusConfigs.mockResolvedValue([
+      { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#gray' },
+    ]);
+
     const { POST } = await import('../route');
     await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
 
     expect(mockInsertStatusConfigValues).not.toHaveBeenCalled();
+  });
+
+  it('backfills status configs for a legacy task_lists row that exists but has none', async () => {
+    // Reproduces the gap flagged in review: a task_lists row created by a pre-fix
+    // lazy-init path (or one seeded before this fix shipped) has zero configs.
+    // ensureTaskListForPage no-ops since the row already exists, so the read path
+    // itself must backfill once it observes the empty configs, instead of leaving
+    // that row permanently half-initialized.
+    mockFindFirstTaskList.mockResolvedValue(EXISTING_TASK_LIST);
+    mockFindManyStatusConfigs.mockResolvedValue([]);
+
+    const { POST } = await import('../route');
+    await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(mockInsertStatusConfigValues).toHaveBeenCalledTimes(1);
+    const inserted = mockInsertStatusConfigValues.mock.calls[0][0];
+    expect(inserted).toHaveLength(4);
+    expect(inserted.every((c: { taskListId: string }) => c.taskListId === EXISTING_TASK_LIST.id)).toBe(true);
   });
 
   it('uses custom status configs when present', async () => {

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
 import { eq, asc, and } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
-import { taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
+import { taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';
-import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
+import { backfillMissingTaskItems, ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { computeHasContent } from '@/app/api/pages/[pageId]/tasks/task-utils';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
@@ -180,23 +180,15 @@ export async function POST(req: NextRequest) {
         auditRequest(req, { eventType: 'data.read', userId, resourceType: 'page', resourceId: pageId, details: { source: 'mcp', operation: 'read' } });
 
         if (page.type === PageType.TASK_LIST) {
-          let taskList = await db.query.taskLists.findFirst({
-            where: eq(taskLists.pageId, pageId),
+          const taskList = await ensureTaskListForPage(db, {
+            pageId,
+            title: page.title,
+            userId,
+            metadata: {
+              createdAt: new Date().toISOString(),
+              autoCreated: true,
+            },
           });
-
-          if (!taskList) {
-            const [newTaskList] = await db.insert(taskLists).values({
-              userId,
-              pageId,
-              title: page.title,
-              status: 'pending',
-              metadata: {
-                createdAt: new Date().toISOString(),
-                autoCreated: true,
-              },
-            }).returning();
-            taskList = newTaskList;
-          }
 
           // Self-heal: ensure every child TASK_LIST page has a task_items row.
           // Mirrors the same call in /api/pages/[pageId]/tasks/route.ts:143.

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -4,7 +4,7 @@ import { eq, asc, and } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
 import { taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';
-import { backfillMissingTaskItems, ensureTaskListForPage } from '@/services/api/task-sync-service';
+import { backfillMissingTaskItems, ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { computeHasContent } from '@/app/api/pages/[pageId]/tasks/task-utils';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
@@ -212,6 +212,12 @@ export async function POST(req: NextRequest) {
               orderBy: [asc(taskStatusConfigs.position)],
             }),
           ]);
+
+          // Legacy task_lists row (e.g. seeded by a pre-fix lazy-init path) with no
+          // configs — backfill now instead of leaving it half-initialized forever.
+          if (statusConfigs.length === 0) {
+            await seedDefaultTaskStatusConfigs(db, taskList.id);
+          }
 
           const availableStatuses = statusConfigs.length > 0
             ? statusConfigs.map(c => ({ slug: c.slug, label: c.name, group: c.group, position: c.position, color: c.color }))

--- a/apps/web/src/components/tasks/TaskKanbanComponents.tsx
+++ b/apps/web/src/components/tasks/TaskKanbanComponents.tsx
@@ -33,6 +33,14 @@ export const STATUS_GROUP_CONFIG: Record<TaskStatusGroup, { label: string; color
   done: { label: 'Done', color: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300' },
 };
 
+/**
+ * Groups that aren't one of the 3 known keys (e.g. a task list whose
+ * taskStatusConfigs never got seeded) must not crash the Kanban board.
+ */
+export function getStatusGroupConfig(group: string): { label: string; color: string } {
+  return STATUS_GROUP_CONFIG[group as TaskStatusGroup] ?? STATUS_GROUP_CONFIG.todo;
+}
+
 export interface KanbanCardProps {
   task: Task;
   isDragging?: boolean;
@@ -224,7 +232,7 @@ export function KanbanColumn({
   onCancelEdit,
 }: KanbanColumnProps) {
   const { setNodeRef } = useDroppable({ id: statusGroup });
-  const config = STATUS_GROUP_CONFIG[statusGroup];
+  const config = getStatusGroupConfig(statusGroup);
 
   return (
     <div className="flex-shrink-0 w-72 flex flex-col">

--- a/apps/web/src/components/tasks/__tests__/TaskKanbanComponents.test.ts
+++ b/apps/web/src/components/tasks/__tests__/TaskKanbanComponents.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { STATUS_GROUP_CONFIG, getStatusGroupConfig } from '../TaskKanbanComponents';
+
+describe('getStatusGroupConfig', () => {
+  it('returns the matching config for each known group', () => {
+    expect(getStatusGroupConfig('todo')).toEqual(STATUS_GROUP_CONFIG.todo);
+    expect(getStatusGroupConfig('in_progress')).toEqual(STATUS_GROUP_CONFIG.in_progress);
+    expect(getStatusGroupConfig('done')).toEqual(STATUS_GROUP_CONFIG.done);
+  });
+
+  it('falls back to the todo config for a group with no seeded status config', () => {
+    // Reproduces the crash: a TASK_LIST page whose taskStatusConfigs were never
+    // seeded (or a status whose group isn't one of the 3 known keys) previously
+    // hit `STATUS_GROUP_CONFIG[undefined].color` -> "Cannot read properties of
+    // undefined (reading 'color')".
+    expect(getStatusGroupConfig('unknown_group')).toEqual(STATUS_GROUP_CONFIG.todo);
+    expect(getStatusGroupConfig(undefined as unknown as string)).toEqual(STATUS_GROUP_CONFIG.todo);
+    expect(getStatusGroupConfig('')).toEqual(STATUS_GROUP_CONFIG.todo);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -642,6 +642,12 @@ describe('page-read-tools', () => {
         mockDb.query.taskStatusConfigs = {
           findMany: vi.fn().mockResolvedValue(opts.statusConfigs ?? []),
         } as unknown as typeof mockDb.query.taskStatusConfigs;
+        // Default no-op insert: most of these tests aren't asserting on the
+        // legacy-backfill insert this triggers when statusConfigs is empty
+        // (see the dedicated backfill test below, which overrides this).
+        mockDb.insert = vi.fn(() => ({
+          values: () => Promise.resolve(undefined),
+        })) as unknown as typeof mockDb.insert;
 
         // db.select().from().innerJoin().where().orderBy() for tasks (title joined from pages)
         // db.select().from().innerJoin().where().groupBy() for sub-task count aggregates
@@ -776,6 +782,14 @@ describe('page-read-tools', () => {
         mockDb.query.taskLists = {
           findFirst: vi.fn().mockResolvedValue(undefined),
         } as unknown as typeof mockDb.query.taskLists;
+        // Simulates the findMany the tool runs right after creation seeing the rows
+        // ensureTaskListForPage just inserted, so the separate empty-configs backfill
+        // check doesn't also fire and double-insert.
+        mockDb.query.taskStatusConfigs = {
+          findMany: vi.fn().mockResolvedValue([
+            { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#gray' },
+          ]),
+        } as unknown as typeof mockDb.query.taskStatusConfigs;
 
         const taskListInserts: Array<Record<string, unknown>> = [];
         const statusConfigInserts: Array<Record<string, unknown>> = [];
@@ -811,6 +825,41 @@ describe('page-read-tools', () => {
           given: 'the persisted status configs',
           should: 'link each row to the new task_lists id',
           actual: statusConfigInserts.every(c => c.taskListId === 'list-new'),
+          expected: true,
+        });
+      });
+
+      it('backfills status configs for a legacy task_lists row that exists but has none', async () => {
+        // Reproduces the gap flagged in review: a task_lists row created by a pre-fix
+        // lazy-init path (or one seeded before this fix shipped) has zero configs.
+        // ensureTaskListForPage no-ops since the row already exists, so read_page
+        // itself must backfill once it observes the empty configs, instead of
+        // leaving that row permanently half-initialized.
+        setupTaskListMocks({ tasks: [{ id: 't1', status: 'pending' }], statusConfigs: [] });
+
+        const statusConfigInserts: Array<Record<string, unknown>> = [];
+        mockDb.insert = vi.fn(() => ({
+          values: (vals: Record<string, unknown> | Record<string, unknown>[]) => {
+            statusConfigInserts.push(...(Array.isArray(vals) ? vals : [vals]));
+            return Promise.resolve(undefined);
+          },
+        })) as unknown as typeof mockDb.insert;
+
+        await pageReadTools.read_page.execute!(
+          { title: 'My Tasks', pageId: 'page-1' },
+          createAuthContext()
+        );
+
+        assert({
+          given: 'a task_lists row that already exists but has zero status configs',
+          should: 'backfill the 4 default status configs',
+          actual: statusConfigInserts.map(c => c.slug),
+          expected: ['pending', 'in_progress', 'blocked', 'completed'],
+        });
+        assert({
+          given: 'the backfilled status configs',
+          should: 'link each row to the existing task_lists id',
+          actual: statusConfigInserts.every(c => c.taskListId === 'list-1'),
           expected: true,
         });
       });

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -10,6 +10,7 @@ vi.mock('@pagespace/db/db', () => ({
     where: vi.fn(),
     orderBy: vi.fn().mockReturnThis(),
     groupBy: vi.fn().mockReturnThis(),
+    insert: vi.fn(),
     query: {
       pages: { findFirst: vi.fn(), findMany: vi.fn().mockResolvedValue([]) },
       drives: { findFirst: vi.fn() },
@@ -765,6 +766,52 @@ describe('page-read-tools', () => {
           should: 'compute percentage from the done group',
           actual: result.progress.percentage,
           expected: 67,
+        });
+      });
+
+      it('persists a task_lists row AND seeds task_status_configs when auto-creating (not just the response fallback)', async () => {
+        setupTaskListMocks({ tasks: [{ id: 't1', status: 'pending' }] });
+
+        // No taskLists row exists yet for this page.
+        mockDb.query.taskLists = {
+          findFirst: vi.fn().mockResolvedValue(undefined),
+        } as unknown as typeof mockDb.query.taskLists;
+
+        const taskListInserts: Array<Record<string, unknown>> = [];
+        const statusConfigInserts: Array<Record<string, unknown>> = [];
+        mockDb.insert = vi.fn((table: { pageId?: string }) => ({
+          values: (vals: Record<string, unknown> | Record<string, unknown>[]) => {
+            if (table?.pageId === 'pageId') {
+              taskListInserts.push(vals as Record<string, unknown>);
+              return { returning: () => Promise.resolve([{ id: 'list-new', pageId: 'page-1', title: 'My Tasks' }]) };
+            }
+            statusConfigInserts.push(...(Array.isArray(vals) ? vals : [vals]));
+            return Promise.resolve(undefined);
+          },
+        })) as unknown as typeof mockDb.insert;
+
+        await pageReadTools.read_page.execute!(
+          { title: 'My Tasks', pageId: 'page-1' },
+          createAuthContext()
+        );
+
+        assert({
+          given: 'a TASK_LIST page with no task_lists row yet',
+          should: 'insert exactly one task_lists row',
+          actual: taskListInserts.length,
+          expected: 1,
+        });
+        assert({
+          given: 'a newly auto-created task_lists row',
+          should: 'persist the 4 default task_status_configs (not just return them in the response)',
+          actual: statusConfigInserts.map(c => c.slug),
+          expected: ['pending', 'in_progress', 'blocked', 'completed'],
+        });
+        assert({
+          given: 'the persisted status configs',
+          should: 'link each row to the new task_lists id',
+          actual: statusConfigInserts.every(c => c.taskListId === 'list-new'),
+          expected: true,
         });
       });
     });

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -120,7 +120,12 @@ vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   getDriveRecipientUserIds: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock('@/services/api/task-sync-service', () => ({
+  ensureTaskListForPage: vi.fn().mockResolvedValue({ id: 'tasklist-1' }),
+}));
+
 import { pageWriteTools } from '../page-write-tools';
+import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { getAgentAccessLevel } from '@pagespace/lib/permissions/agent-permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
@@ -134,6 +139,7 @@ const mockGetAgentAccessLevel = vi.mocked(getAgentAccessLevel);
 const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
+const mockEnsureTaskListForPage = vi.mocked(ensureTaskListForPage);
 
 describe('page-write-tools', () => {
   beforeEach(() => {
@@ -475,6 +481,56 @@ describe('page-write-tools', () => {
           context
         )
       ).rejects.toThrow('Insufficient permissions to create pages in this drive');
+    });
+
+    it('seeds task_lists + default task_status_configs when creating a TASK_LIST page', async () => {
+      // Reproduces the bug: create_page uses pageRepository.create() directly (not
+      // pageService.createPage()), so without an explicit TASK_LIST branch the new
+      // page has no taskLists/taskStatusConfigs rows and the Kanban UI crashes on
+      // first load with "Cannot read properties of undefined (reading 'color')".
+      mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-999' });
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockPageRepo.getNextPosition.mockResolvedValue(1);
+      mockPageRepo.create.mockResolvedValue({
+        id: 'new-tasklist-1',
+        title: 'New Task List',
+        type: 'TASK_LIST',
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.create_page.execute!(
+        { driveId: 'drive-1', title: 'New Task List', type: 'TASK_LIST' },
+        context
+      );
+
+      if ('error' in result) throw new Error('Expected success');
+      expect(mockEnsureTaskListForPage).toHaveBeenCalledWith(
+        expect.anything(),
+        { pageId: 'new-tasklist-1', title: 'New Task List', userId: 'user-123' }
+      );
+    });
+
+    it('does not seed task_lists for non-TASK_LIST page types', async () => {
+      mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-999' });
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockPageRepo.getNextPosition.mockResolvedValue(1);
+      mockPageRepo.create.mockResolvedValue({ id: 'new-page-1', title: 'New Page', type: 'DOCUMENT' });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await pageWriteTools.create_page.execute!(
+        { driveId: 'drive-1', title: 'New Page', type: 'DOCUMENT' },
+        context
+      );
+
+      expect(mockEnsureTaskListForPage).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -12,6 +12,7 @@ import { PageType } from '@pagespace/lib/utils/enums';
 import type { ToolExecutionContext } from '../core/types';
 import { getSuggestedVisionModels } from '../core/model-capabilities';
 import { serializePageContentForAI } from '../core/page-serializer';
+import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 
 export const pageReadTools = {
   /**
@@ -264,25 +265,17 @@ export const pageReadTools = {
 
         // Handle TASK_LIST pages - return structured task data
         if (page.type === 'TASK_LIST') {
-          // Find or create task_list record for this page
-          let taskList = await db.query.taskLists.findFirst({
-            where: eq(taskLists.pageId, page.id),
+          // Find or create task_list record for this page, seeding default status
+          // configs alongside it so the DB is never left half-initialized.
+          const taskList = await ensureTaskListForPage(db, {
+            pageId: page.id,
+            title: page.title,
+            userId,
+            metadata: {
+              createdAt: new Date().toISOString(),
+              autoCreated: true,
+            },
           });
-
-          if (!taskList) {
-            // Auto-create task_list record
-            const [newTaskList] = await db.insert(taskLists).values({
-              userId,
-              pageId: page.id,
-              title: page.title,
-              status: 'pending',
-              metadata: {
-                createdAt: new Date().toISOString(),
-                autoCreated: true,
-              },
-            }).returning();
-            taskList = newTaskList;
-          }
 
           // Get all non-trashed tasks ordered by position. Title lives on the linked page.
           const tasks = await db

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -12,7 +12,7 @@ import { PageType } from '@pagespace/lib/utils/enums';
 import type { ToolExecutionContext } from '../core/types';
 import { getSuggestedVisionModels } from '../core/model-capabilities';
 import { serializePageContentForAI } from '../core/page-serializer';
-import { ensureTaskListForPage } from '@/services/api/task-sync-service';
+import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 
 export const pageReadTools = {
   /**
@@ -305,6 +305,12 @@ export const pageReadTools = {
             where: eq(taskStatusConfigs.taskListId, taskList.id),
             orderBy: [asc(taskStatusConfigs.position)],
           });
+
+          // Legacy task_lists row (e.g. seeded by a pre-fix lazy-init path) with no
+          // configs — backfill now instead of leaving it half-initialized forever.
+          if (statusConfigs.length === 0) {
+            await seedDefaultTaskStatusConfigs(db, taskList.id);
+          }
 
           const availableStatuses = statusConfigs.length > 0
             ? statusConfigs.map(c => ({

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -20,6 +20,7 @@ import { broadcastPageEvent, createPageEventPayload, broadcastDriveEvent, create
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import type { ToolExecutionContext } from '../core/types';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { replaceLines } from '@/lib/editor/line-edit';
 import { insertAtAnchor } from '@/lib/editor/text-edit';
 
@@ -623,6 +624,18 @@ export const pageWriteTools = {
             agentPageId: newPage.id,
             role: 'MEMBER',
             addedBy: userId,
+          });
+        }
+
+        // TASK_LIST pages need their `task_lists` + default status configs seeded
+        // immediately — unlike the browser's page-creation flow, this repository-level
+        // create() bypasses pageService.createPage()'s seeding, so without this the
+        // Kanban UI crashes on first load with no status-group config to render.
+        if (type === 'TASK_LIST') {
+          await ensureTaskListForPage(db, {
+            pageId: newPage.id,
+            title: newPage.title,
+            userId,
           });
         }
 

--- a/apps/web/src/services/api/__tests__/page-service.test.ts
+++ b/apps/web/src/services/api/__tests__/page-service.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * pageService.createPage() — TASK_LIST seeding coverage.
+ *
+ * Mocks every dependency at its architectural boundary so the transaction body
+ * actually runs, letting these tests assert on the exact `ensureTaskListForPage`
+ * call `createPage()` makes for a TASK_LIST page — the fix that guarantees the
+ * browser page-creation flow seeds `taskStatusConfigs` immediately instead of
+ * relying on lazy self-heal on first UI load.
+ */
+
+const mockFindFirstDrive = vi.fn();
+const mockFindFirstPage = vi.fn();
+const mockTxInsertReturning = vi.fn();
+const mockEnsureTaskItemForPage = vi.fn();
+const mockEnsureTaskListForPage = vi.fn();
+const mockCreatePageVersion = vi.fn();
+const mockLogActivityWithTx = vi.fn();
+
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  DEFAULT_PROVIDER: 'anthropic',
+  DEFAULT_MODEL: 'test-model',
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      drives: { findFirst: (...args: unknown[]) => mockFindFirstDrive(...args) },
+      pages: { findFirst: (...args: unknown[]) => mockFindFirstPage(...args) },
+      users: { findFirst: vi.fn() },
+    },
+    transaction: (cb: (tx: unknown) => Promise<unknown>) => cb({
+      insert: () => ({
+        values: () => ({
+          returning: (...args: unknown[]) => mockTxInsertReturning(...args),
+        }),
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  desc: vi.fn(),
+  isNull: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: {} }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {}, drives: {}, chatMessages: {} }));
+vi.mock('@pagespace/db/schema/members', () => ({ driveAgentMembers: {} }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+  canUserEditPage: vi.fn().mockResolvedValue(true),
+  canUserDeletePage: vi.fn(),
+  isDriveOwnerOrAdmin: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com', actorDisplayName: 'Test User' }),
+  logActivityWithTx: (...args: unknown[]) => mockLogActivityWithTx(...args),
+}));
+vi.mock('@pagespace/lib/content/page-content-format', () => ({
+  detectPageContentFormat: vi.fn(() => 'text'),
+}));
+vi.mock('@pagespace/lib/utils/hash-utils', () => ({
+  hashWithPrefix: vi.fn(() => 'content-ref'),
+}));
+vi.mock('@pagespace/lib/services/page-version-service', () => ({
+  computePageStateHash: vi.fn(() => 'state-hash'),
+  createPageVersion: (...args: unknown[]) => mockCreatePageVersion(...args),
+}));
+vi.mock('@pagespace/lib/pages/circular-reference-guard', () => ({
+  validatePageMove: vi.fn(),
+}));
+vi.mock('@pagespace/lib/content/page-type-validators', () => ({
+  validatePageCreation: vi.fn(() => ({ valid: true, errors: [] })),
+  validateAIChatTools: vi.fn(() => ({ valid: true, errors: [] })),
+}));
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+  getDefaultContent: vi.fn(() => ''),
+  isAIChatPage: vi.fn((type: string) => type === 'AI_CHAT'),
+}));
+vi.mock('@pagespace/lib/utils/enums', () => ({
+  PageType: { TASK_LIST: 'TASK_LIST', DOCUMENT: 'DOCUMENT', AI_CHAT: 'AI_CHAT' },
+}));
+vi.mock('@pagespace/lib/monitoring/change-group', () => ({
+  createChangeGroupId: vi.fn(() => 'change-group-1'),
+  inferChangeGroupType: vi.fn(() => 'user'),
+}));
+vi.mock('../page-mutation-service', () => ({
+  applyPageMutation: vi.fn(),
+  PageRevisionMismatchError: class PageRevisionMismatchError extends Error {},
+}));
+vi.mock('../task-sync-service', () => ({
+  ensureTaskItemForPage: (...args: unknown[]) => mockEnsureTaskItemForPage(...args),
+  ensureTaskListForPage: (...args: unknown[]) => mockEnsureTaskListForPage(...args),
+}));
+
+import { pageService } from '../page-service';
+
+describe('pageService.createPage — TASK_LIST seeding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirstDrive.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-1' });
+    mockFindFirstPage.mockResolvedValue(undefined); // no sibling pages -> position 1
+    mockEnsureTaskItemForPage.mockResolvedValue(undefined);
+    mockEnsureTaskListForPage.mockResolvedValue({ id: 'tasklist-1' });
+    mockCreatePageVersion.mockResolvedValue(undefined);
+    mockLogActivityWithTx.mockResolvedValue(undefined);
+  });
+
+  it('seeds task_lists + default task_status_configs for a root TASK_LIST page (no TASK_LIST parent)', async () => {
+    mockTxInsertReturning.mockResolvedValue([{
+      id: 'new-tasklist-page',
+      title: 'My Tasks',
+      type: 'TASK_LIST',
+      parentId: null,
+      driveId: 'drive-1',
+      content: '',
+      contentMode: 'html',
+      position: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      revision: 0,
+      stateHash: 'state-hash',
+      isTrashed: false,
+      trashedAt: null,
+      aiProvider: null,
+      aiModel: null,
+      systemPrompt: null,
+      enabledTools: null,
+      isPaginated: null,
+    }]);
+
+    const result = await pageService.createPage('user-123', {
+      title: 'My Tasks',
+      type: 'TASK_LIST',
+      driveId: 'drive-1',
+    });
+
+    expect(result.success).toBe(true);
+    // This is the crux of the fix: a bare top-level TASK_LIST page (parentId
+    // null, so ensureTaskItemForPage's TASK_LIST-under-TASK_LIST check never
+    // fires) must still get its own task_lists/task_status_configs seeded here,
+    // immediately, rather than relying on lazy self-heal on first UI load.
+    expect(mockEnsureTaskListForPage).toHaveBeenCalledWith(
+      expect.anything(),
+      { pageId: 'new-tasklist-page', title: 'My Tasks', userId: 'user-123' }
+    );
+  });
+
+  it('does not seed task_lists for non-TASK_LIST page types', async () => {
+    mockTxInsertReturning.mockResolvedValue([{
+      id: 'new-doc-page',
+      title: 'My Doc',
+      type: 'DOCUMENT',
+      parentId: null,
+      driveId: 'drive-1',
+      content: '',
+      contentMode: 'html',
+      position: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      revision: 0,
+      stateHash: 'state-hash',
+      isTrashed: false,
+      trashedAt: null,
+      aiProvider: null,
+      aiModel: null,
+      systemPrompt: null,
+      enabledTools: null,
+      isPaginated: null,
+    }]);
+
+    const result = await pageService.createPage('user-123', {
+      title: 'My Doc',
+      type: 'DOCUMENT',
+      driveId: 'drive-1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockEnsureTaskListForPage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -23,6 +23,7 @@ vi.mock('@pagespace/db/db', () => ({ db: {} }));
 import {
   ensureTaskItemForPage,
   ensureTaskListForPage,
+  seedDefaultTaskStatusConfigs,
   syncTaskItemOnMove,
   backfillMissingTaskItems,
 } from '../task-sync-service';
@@ -88,6 +89,36 @@ function makeTx(config: {
 
   return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds };
 }
+
+describe('seedDefaultTaskStatusConfigs', () => {
+  it('inserts the 4 default status configs linked to the given task_lists id', async () => {
+    const { tx, taskStatusConfigInserts } = makeTx();
+    await seedDefaultTaskStatusConfigs(tx as never, 'list-1');
+    expect(taskStatusConfigInserts).toEqual([
+      { taskListId: 'list-1', slug: 'pending', name: 'To Do', color: 'c', group: 'todo', position: 0 },
+    ]);
+  });
+
+  it('swallows a unique-constraint violation (concurrent caller already seeded this list)', async () => {
+    const { taskStatusConfigInserts } = makeTx();
+    const tx = {
+      insert: vi.fn(() => ({
+        values: () => Promise.reject(new Error('duplicate key value violates unique constraint "task_status_configs_task_list_slug"')),
+      })),
+    };
+    await expect(seedDefaultTaskStatusConfigs(tx as never, 'list-1')).resolves.toBeUndefined();
+    expect(taskStatusConfigInserts).toHaveLength(0);
+  });
+
+  it('rethrows an unrelated error', async () => {
+    const tx = {
+      insert: vi.fn(() => ({
+        values: () => Promise.reject(new Error('connection reset')),
+      })),
+    };
+    await expect(seedDefaultTaskStatusConfigs(tx as never, 'list-1')).rejects.toThrow('connection reset');
+  });
+});
 
 describe('ensureTaskListForPage', () => {
   it('is a no-op when a task_lists row already exists for the page', async () => {

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -22,6 +22,7 @@ vi.mock('@pagespace/db/db', () => ({ db: {} }));
 
 import {
   ensureTaskItemForPage,
+  ensureTaskListForPage,
   syncTaskItemOnMove,
   backfillMissingTaskItems,
 } from '../task-sync-service';
@@ -49,6 +50,7 @@ function makeTx(config: {
 
   const taskItemInserts: Array<Record<string, unknown>> = [];
   const taskListInserts: Array<Record<string, unknown>> = [];
+  const taskStatusConfigInserts: Array<Record<string, unknown>> = [];
   const deletedPageIds: string[] = [];
 
   // getPageType: tx.select(...).from(pages).where(eq(pages.id, X)).limit(1)
@@ -69,6 +71,7 @@ function makeTx(config: {
         const isTaskItems = table?.pageId === 'taskItems.pageId';
         if (isTaskItems) taskItemInserts.push(vals as Record<string, unknown>);
         else if (table?.pageId === 'taskLists.pageId') taskListInserts.push(vals as Record<string, unknown>);
+        else taskStatusConfigInserts.push(...(Array.isArray(vals) ? vals : [vals]));
         // taskItems insert is awaited via .onConflictDoNothing(); taskLists via .returning().
         return { onConflictDoNothing: () => Promise.resolve(), returning: () => Promise.resolve([{ id: 'tasklist-1' }]) };
       },
@@ -83,8 +86,44 @@ function makeTx(config: {
     },
   };
 
-  return { tx, taskItemInserts, taskListInserts, deletedPageIds };
+  return { tx, taskItemInserts, taskListInserts, taskStatusConfigInserts, deletedPageIds };
 }
+
+describe('ensureTaskListForPage', () => {
+  it('is a no-op when a task_lists row already exists for the page', async () => {
+    const { tx, taskListInserts, taskStatusConfigInserts } = makeTx({ existingTaskList: true });
+    const result = await ensureTaskListForPage(tx as never, { pageId: 'page-1', title: 'My List', userId: 'u' });
+    expect(result).toEqual({ id: 'tasklist-1' });
+    expect(taskListInserts).toHaveLength(0);
+    expect(taskStatusConfigInserts).toHaveLength(0);
+  });
+
+  it('seeds task_lists AND the default task_status_configs when none exist', async () => {
+    const { tx, taskListInserts, taskStatusConfigInserts } = makeTx({ existingTaskList: false });
+    const result = await ensureTaskListForPage(tx as never, { pageId: 'page-1', title: 'My List', userId: 'u' });
+
+    expect(result).toEqual({ id: 'tasklist-1' });
+    expect(taskListInserts).toEqual([
+      { userId: 'u', pageId: 'page-1', title: 'My List', status: 'pending' },
+    ]);
+    // This is the crux of the bug fix: previously only task_lists was seeded and
+    // task_status_configs was left empty, which is what crashes the Kanban UI.
+    expect(taskStatusConfigInserts).toEqual([
+      { taskListId: 'tasklist-1', slug: 'pending', name: 'To Do', color: 'c', group: 'todo', position: 0 },
+    ]);
+  });
+
+  it('passes through optional metadata on the new task_lists row', async () => {
+    const { tx, taskListInserts } = makeTx({ existingTaskList: false });
+    await ensureTaskListForPage(tx as never, {
+      pageId: 'page-1',
+      title: 'My List',
+      userId: 'u',
+      metadata: { autoCreated: true },
+    });
+    expect(taskListInserts[0]).toMatchObject({ metadata: { autoCreated: true } });
+  });
+});
 
 describe('ensureTaskItemForPage', () => {
   it('does nothing for a non-TASK_LIST page (no parent lookup, no insert)', async () => {

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -18,7 +18,7 @@ import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monito
 import { logActivityWithTx, type DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createId } from '@paralleldrive/cuid2';
 import { applyPageMutation, PageRevisionMismatchError, type PageMutationContext } from './page-mutation-service';
-import { ensureTaskItemForPage } from './task-sync-service';
+import { ensureTaskItemForPage, ensureTaskListForPage } from './task-sync-service';
 
 /**
  * Helper to convert DB page result to PageData type
@@ -801,6 +801,17 @@ export const pageService = {
         parentId: page.parentId,
         userId,
       });
+
+      // Every TASK_LIST page needs its own `task_lists` + default status configs
+      // seeded immediately, not lazily on first UI load — a bare top-level TASK_LIST
+      // (no TASK_LIST parent) isn't covered by ensureTaskItemForPage above.
+      if (page.type === PageTypeEnum.TASK_LIST) {
+        await ensureTaskListForPage(tx, {
+          pageId: page.id,
+          title: page.title ?? 'Task List',
+          userId,
+        });
+      }
 
       if (isAIChatPage(params.type as PageTypeEnum)) {
         await tx.insert(driveAgentMembers).values({

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -78,7 +78,7 @@ async function addTaskItemUnderParent(
 ): Promise<void> {
   const { pageId, parentId, userId } = params
 
-  const taskList = await ensureTaskListForPage(tx, { pageId: parentId, title: 'Task List', userId })
+  await ensureTaskListForPage(tx, { pageId: parentId, title: 'Task List', userId })
 
   const existing = await tx.query.taskItems.findFirst({
     where: eq(taskItems.pageId, pageId),

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -30,12 +30,28 @@ async function getPageType(tx: Tx, pageId: string): Promise<string | null> {
 }
 
 /**
+ * Seed the default `task_status_configs` for a `task_lists` row. Swallows a
+ * unique-constraint violation on `(taskListId, slug)` — a concurrent caller may have
+ * seeded the same list a moment earlier; the caller only needed the configs to exist.
+ */
+export async function seedDefaultTaskStatusConfigs(tx: Tx, taskListId: string): Promise<void> {
+  try {
+    await tx.insert(taskStatusConfigs).values(
+      DEFAULT_TASK_STATUSES.map(s => ({ taskListId, ...s }))
+    )
+  } catch (err) {
+    const message = err instanceof Error ? err.message : ''
+    if (!message.includes('unique') && !message.includes('duplicate')) throw err
+  }
+}
+
+/**
  * Ensure a TASK_LIST page has its `task_lists` row and default `task_status_configs`
- * seeded. Idempotent — a no-op if the `task_lists` row already exists (status configs
- * are only ever seeded alongside a *new* `task_lists` row here; a legacy `task_lists`
- * row with zero configs — e.g. one created by a pre-fix lazy-init path — is not
- * backfilled by this function. The browser Kanban route's `getOrCreateTaskListForPage`
- * in `app/api/pages/[pageId]/tasks/route.ts` already handles that migration case.
+ * seeded. Idempotent — a no-op if the `task_lists` row already exists. Callers that
+ * separately look up `task_status_configs` for display (the MCP documents `read` route,
+ * `page-read-tools.ts`'s `read_page`) also call `seedDefaultTaskStatusConfigs` when that
+ * lookup comes back empty, so a legacy `task_lists` row missed by a pre-fix lazy-init
+ * path gets backfilled on next read instead of staying half-initialized forever.
  *
  * Called from every page-creation and lazy-init entry point that seeds a TASK_LIST
  * page's *own* task list (`page-service.ts`, `page-write-tools.ts`'s `create_page`,
@@ -63,9 +79,7 @@ export async function ensureTaskListForPage(
     }).returning()
     taskList = created
 
-    await tx.insert(taskStatusConfigs).values(
-      DEFAULT_TASK_STATUSES.map(s => ({ taskListId: created.id, ...s }))
-    )
+    await seedDefaultTaskStatusConfigs(tx, created.id)
   }
 
   return taskList

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -32,12 +32,16 @@ async function getPageType(tx: Tx, pageId: string): Promise<string | null> {
 /**
  * Ensure a TASK_LIST page has its `task_lists` row and default `task_status_configs`
  * seeded. Idempotent — a no-op if the `task_lists` row already exists (status configs
- * are only ever seeded alongside a *new* `task_lists` row, never backfilled onto an
- * existing one here).
+ * are only ever seeded alongside a *new* `task_lists` row here; a legacy `task_lists`
+ * row with zero configs — e.g. one created by a pre-fix lazy-init path — is not
+ * backfilled by this function. The browser Kanban route's `getOrCreateTaskListForPage`
+ * in `app/api/pages/[pageId]/tasks/route.ts` already handles that migration case.
  *
- * This is the single seeding path every page-creation and lazy-init entry point must
- * call for a TASK_LIST page — skipping it is what leaves `taskStatusConfigs` empty and
- * crashes the Kanban UI (`STATUS_GROUP_CONFIG[group]` lookup with no matching group).
+ * Called from every page-creation and lazy-init entry point that seeds a TASK_LIST
+ * page's *own* task list (`page-service.ts`, `page-write-tools.ts`'s `create_page`,
+ * the MCP documents `read` route, and `page-read-tools.ts`'s `read_page`) — skipping
+ * it is what leaves `taskStatusConfigs` empty and crashes the Kanban UI
+ * (`STATUS_GROUP_CONFIG[group]` lookup with no matching group).
  */
 export async function ensureTaskListForPage(
   tx: Tx,

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -30,6 +30,44 @@ async function getPageType(tx: Tx, pageId: string): Promise<string | null> {
 }
 
 /**
+ * Ensure a TASK_LIST page has its `task_lists` row and default `task_status_configs`
+ * seeded. Idempotent — a no-op if the `task_lists` row already exists (status configs
+ * are only ever seeded alongside a *new* `task_lists` row, never backfilled onto an
+ * existing one here).
+ *
+ * This is the single seeding path every page-creation and lazy-init entry point must
+ * call for a TASK_LIST page — skipping it is what leaves `taskStatusConfigs` empty and
+ * crashes the Kanban UI (`STATUS_GROUP_CONFIG[group]` lookup with no matching group).
+ */
+export async function ensureTaskListForPage(
+  tx: Tx,
+  params: { pageId: string; title: string; userId: string; metadata?: Record<string, unknown> },
+): Promise<typeof taskLists.$inferSelect> {
+  const { pageId, title, userId, metadata } = params
+
+  let taskList = await tx.query.taskLists.findFirst({
+    where: eq(taskLists.pageId, pageId),
+  })
+
+  if (!taskList) {
+    const [created] = await tx.insert(taskLists).values({
+      userId,
+      pageId,
+      title,
+      status: 'pending',
+      ...(metadata ? { metadata } : {}),
+    }).returning()
+    taskList = created
+
+    await tx.insert(taskStatusConfigs).values(
+      DEFAULT_TASK_STATUSES.map(s => ({ taskListId: created.id, ...s }))
+    )
+  }
+
+  return taskList
+}
+
+/**
  * Create the `task_items` row for a page under a known TASK_LIST parent.
  * Idempotent — does nothing if the row already exists. Ensures the parent's
  * `task_lists` row and default status configs exist first.
@@ -40,23 +78,7 @@ async function addTaskItemUnderParent(
 ): Promise<void> {
   const { pageId, parentId, userId } = params
 
-  let taskList = await tx.query.taskLists.findFirst({
-    where: eq(taskLists.pageId, parentId),
-  })
-
-  if (!taskList) {
-    const [created] = await tx.insert(taskLists).values({
-      userId,
-      pageId: parentId,
-      title: 'Task List',
-      status: 'pending',
-    }).returning()
-    taskList = created
-
-    await tx.insert(taskStatusConfigs).values(
-      DEFAULT_TASK_STATUSES.map(s => ({ taskListId: created.id, ...s }))
-    )
-  }
+  const taskList = await ensureTaskListForPage(tx, { pageId: parentId, title: 'Task List', userId })
 
   const existing = await tx.query.taskItems.findFirst({
     where: eq(taskItems.pageId, pageId),


### PR DESCRIPTION
## Summary

TASK_LIST pages created through the AI/MCP `create_page` tool crashed the UI with `Cannot read properties of undefined (reading 'color')`. Root cause: the MCP-facing creation path never seeded `taskLists` / `taskStatusConfigs`, so the Kanban board had no status-group config to render against (`STATUS_GROUP_CONFIG[statusGroup]` was `undefined`).

- **`task-sync-service.ts`**: extracted `ensureTaskListForPage()` — the single seeding path for a TASK_LIST's `task_lists` row + default `task_status_configs`. `addTaskItemUnderParent` now delegates to it instead of duplicating the logic.
- **`page-write-tools.ts` (`create_page` tool)**: seeds `taskLists`/`taskStatusConfigs` unconditionally for `TASK_LIST` pages — this path uses `pageRepository.create()` directly and never went through `pageService.createPage()`'s seeding hook.
- **`page-service.ts` (`createPage()`)**: now unconditionally seeds a TASK_LIST page's own `task_lists` row. Previously only `ensureTaskItemForPage` ran, which seeds the *parent's* task list and only fires for a TASK_LIST nested under another TASK_LIST — a bare top-level TASK_LIST page relied on lazy self-heal on first UI load.
- **`mcp/documents/route.ts`** (`read` op) and **`page-read-tools.ts`** (`read_page`): both lazily created a `taskLists` row on read but only ever returned `DEFAULT_TASK_STATUSES` as a JSON response fallback — never persisting `taskStatusConfigs`. Now they persist via `ensureTaskListForPage`, so the DB is never left half-initialized.
- **`TaskKanbanComponents.tsx`**: defense-in-depth — falls back to `STATUS_GROUP_CONFIG.todo` when a status group isn't one of the 3 known keys, matching the defensive pattern already used everywhere else this data is read in the codebase.

No schema changes — the `taskLists`/`taskStatusConfigs` tables already existed; this fixes the seeding gap across all page-creation/read entry points so none of them depend on the others' side effects.

## Test plan

- [x] `bun run typecheck` (apps/web) — clean
- [x] New/updated unit tests, all passing (347 tests across touched files):
  - `task-sync-service.test.ts` — `ensureTaskListForPage` seeds both tables, idempotent, metadata pass-through
  - `page-write-tools.test.ts` — `create_page` seeds for TASK_LIST, skips for other types
  - `page-service.test.ts` (new) — `createPage()` seeds a root TASK_LIST page
  - `page-read-tools.test.ts` — `read_page` persists status configs on auto-create (not just the response fallback)
  - `route.task-list.test.ts` (MCP documents) — same persistence assertion for the MCP read path
  - `TaskKanbanComponents.test.ts` (new) — fallback config for unrecognized status groups
- [ ] Manual verification: create a TASK_LIST page via the `create_page` MCP tool and open it in the browser Kanban view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULXXknuDewVGwJju41CWPd