### PR TITLE
Make legacy task-list status-config backfill best-effort

### DIFF
--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -297,6 +297,26 @@ describe('MCP Documents API — TASK_LIST read', () => {
     expect(inserted.every((c: { taskListId: string }) => c.taskListId === EXISTING_TASK_LIST.id)).toBe(true);
   });
 
+  it('still returns 200 with the DEFAULT_TASK_STATUSES fallback when the legacy backfill insert fails', async () => {
+    // The backfill is best-effort: this branch used to be a pure read (no write)
+    // that could never fail. A transient DB error on the backfill insert must
+    // not turn a previously-safe display fallback into a failed request.
+    mockFindFirstTaskList.mockResolvedValue(EXISTING_TASK_LIST);
+    mockFindManyStatusConfigs.mockResolvedValue([]);
+    mockInsertStatusConfigValues.mockImplementationOnce(() => {
+      throw new Error('connection reset');
+    });
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.availableStatuses.map((s: { slug: string }) => s.slug)).toEqual([
+      'pending', 'in_progress', 'blocked', 'completed',
+    ]);
+  });
+
   it('uses custom status configs when present', async () => {
     const customConfigs = [
       { slug: 'backlog', name: 'Backlog', group: 'todo', position: 0, color: '#aaa' },

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -215,8 +215,15 @@ export async function POST(req: NextRequest) {
 
           // Legacy task_lists row (e.g. seeded by a pre-fix lazy-init path) with no
           // configs — backfill now instead of leaving it half-initialized forever.
+          // Best-effort: this read already has a correct in-memory fallback
+          // (DEFAULT_TASK_STATUSES below), so a transient backfill failure must not
+          // fail the whole read — it'll simply retry on the next read of this page.
           if (statusConfigs.length === 0) {
-            await seedDefaultTaskStatusConfigs(db, taskList.id);
+            try {
+              await seedDefaultTaskStatusConfigs(db, taskList.id);
+            } catch (error) {
+              loggers.api.error('Failed to backfill default task status configs', error as Error);
+            }
           }
 
           const availableStatuses = statusConfigs.length > 0

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -863,6 +863,30 @@ describe('page-read-tools', () => {
           expected: true,
         });
       });
+
+      it('still returns the DEFAULT_TASK_STATUSES fallback when the legacy backfill insert fails', async () => {
+        // The backfill is best-effort: this branch used to be a pure read (no
+        // write) that could never fail. A transient DB error on the backfill
+        // insert must not turn a previously-safe display fallback into a
+        // failed tool call -- it should log and let the read still succeed.
+        setupTaskListMocks({ tasks: [{ id: 't1', status: 'pending' }], statusConfigs: [] });
+
+        mockDb.insert = vi.fn(() => ({
+          values: () => Promise.reject(new Error('connection reset')),
+        })) as unknown as typeof mockDb.insert;
+
+        const result = await pageReadTools.read_page.execute!(
+          { title: 'My Tasks', pageId: 'page-1' },
+          createAuthContext()
+        ) as { availableStatuses: Array<{ slug: string }> };
+
+        assert({
+          given: 'a legacy list whose backfill insert fails with an unrelated error',
+          should: 'still return the documented default statuses instead of throwing',
+          actual: result.availableStatuses.map(s => s.slug).sort(),
+          expected: ['blocked', 'completed', 'in_progress', 'pending'],
+        });
+      });
     });
 
   });

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -13,6 +13,9 @@ import type { ToolExecutionContext } from '../core/types';
 import { getSuggestedVisionModels } from '../core/model-capabilities';
 import { serializePageContentForAI } from '../core/page-serializer';
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const pageReadLogger = loggers.ai.child({ module: 'page-read-tools' });
 
 export const pageReadTools = {
   /**
@@ -308,8 +311,15 @@ export const pageReadTools = {
 
           // Legacy task_lists row (e.g. seeded by a pre-fix lazy-init path) with no
           // configs — backfill now instead of leaving it half-initialized forever.
+          // Best-effort: this read already has a correct in-memory fallback
+          // (DEFAULT_TASK_STATUSES below), so a transient backfill failure must not
+          // fail the whole read — it'll simply retry on the next read of this page.
           if (statusConfigs.length === 0) {
-            await seedDefaultTaskStatusConfigs(db, taskList.id);
+            try {
+              await seedDefaultTaskStatusConfigs(db, taskList.id);
+            } catch (error) {
+              pageReadLogger.error('Failed to backfill default task status configs', error as Error);
+            }
           }
 
           const availableStatuses = statusConfigs.length > 0


### PR DESCRIPTION
## Summary

Follow-up to #1751. That PR (merged) fixed TASK_LIST pages crashing the Kanban UI when created via AI/MCP, including a fix — flagged in review (chatgpt-codex-connector, P2) — for a gap where a `task_lists` row that already exists but has zero `task_status_configs` (a legacy state) was never backfilled.

This PR was written as a follow-up commit to that same fix, addressing a regression my own proactive review caught in the backfill itself: adding the backfill insert turned a previously side-effect-free read branch (existing task list, empty configs → just render `DEFAULT_TASK_STATUSES`) into one that could throw. A transient DB error during the backfill insert (lock contention, connection reset — anything other than the unique-violation it already swallows) would propagate out and fail the whole read with a 500, which is worse than before this fix existed, where the same request could never fail this way.

It landed on the `pu/fix-tasklist-api-crash` branch one commit after the last one that made it into #1751 — #1751 was merged before this commit was pushed, so it never got its own review/CI cycle as part of that PR. Cherry-picked cleanly onto current `master`.

- `apps/web/src/app/api/mcp/documents/route.ts` (`read` op) and `apps/web/src/lib/ai/tools/page-read-tools.ts` (`read_page`): wrap the `seedDefaultTaskStatusConfigs` backfill call in a try/catch that logs and lets the read continue with the `DEFAULT_TASK_STATUSES` fallback regardless — the backfill simply retries on the next read of that page.
- Added `page-read-tools.ts`'s missing module-level logger, following the `loggers.ai.child({ module })` convention already used by its sibling `page-write-tools.ts`.
- Added a resilience test to both affected test files asserting the read still succeeds with the documented defaults when the backfill insert fails for an unrelated reason.

No schema changes, no behavior change to the happy path — only makes an already-best-effort operation actually best-effort under failure.

## Test plan

- [x] `bun run typecheck` (apps/web) — clean (one pre-existing, unrelated error on master itself in `apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts` from #1745, not touched by this PR)
- [x] Targeted test suite (20 files / 354 tests) passing, including the 2 new resilience tests
- [x] `eslint` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULXXknuDewVGwJju41CWPd