### PR TITLE
fix(ai-tools): dedupe MCP-scope helper + close agent-config listing gap

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: any) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
+  isScopedMcpAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: any) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
-  isScopedMcpAuth: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { POST } from '../route';
 import type { SessionAuthResult, MCPAuthResult } from '@/lib/auth';
@@ -16,10 +15,11 @@ import type { SessionAuthResult, MCPAuthResult } from '@/lib/auth';
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
-  isAuthError: vi.fn((result: any) => 'error' in result),
-  isMCPAuthResult: vi.fn((result: any) => result.tokenType === 'mcp'),
+  isAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
+  isMCPAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
-  getAllowedDriveIds: vi.fn((auth: any) => auth.allowedDriveIds ?? []),
+  getAllowedDriveIds: vi.fn((auth: { allowedDriveIds?: string[] }) => auth.allowedDriveIds ?? []),
+  isScopedMcpAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -19,7 +19,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((result: { tokenType?: string }) => result?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn((auth: { allowedDriveIds?: string[] }) => auth.allowedDriveIds ?? []),
-  isScopedMcpAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
+  isScopedMCPAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -17,6 +17,8 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: any) => 'error' in result),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  isScopedMcpAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn((result: any) => 'error' in result),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
-  isScopedMcpAuth: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -57,6 +57,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: { tokenType?: string }) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
+  isScopedMcpAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -57,7 +57,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: { tokenType?: string }) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
-  isScopedMcpAuth: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -27,7 +27,7 @@ import { broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
-import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMcpAuth, canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMCPAuth, canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -611,7 +611,7 @@ export async function POST(request: Request) {
     // (e.g. create_drive) from drive-scoped MCP tokens' tool list.
     const baseTools = filterToolsForMcpScope(
       filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
-      isScopedMcpAuth(authResult)
+      isScopedMCPAuth(authResult)
     );
 
     // Step 2: Extract web_search so it can be handled as a runtime-toggle override

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -27,7 +27,7 @@ import { broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
-import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMcpAuth, canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -611,7 +611,7 @@ export async function POST(request: Request) {
     // (e.g. create_drive) from drive-scoped MCP tokens' tool list.
     const baseTools = filterToolsForMcpScope(
       filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
-      getAllowedDriveIds(authResult).length > 0
+      isScopedMcpAuth(authResult)
     );
 
     // Step 2: Extract web_search so it can be handled as a runtime-toggle override

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
@@ -23,6 +23,8 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
   checkMCPDriveScope: vi.fn(),
+  isScopedMCPAuth: (auth: { tokenType?: string; allowedDriveIds?: string[] }) =>
+    auth?.tokenType === 'mcp' && (auth.allowedDriveIds?.length ?? 0) > 0,
   canPrincipalEditPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserEditPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserEditPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, canPrincipalEditPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, canPrincipalEditPage, isScopedMCPAuth } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
+import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentConfigUpdate } from '@/lib/repositories/page-agent-repository';
@@ -127,9 +128,11 @@ export async function PUT(
       parseEnabledToolsInput(agent.enabledTools).value
     );
 
-    // Validate enabled tools if provided
+    // Validate enabled tools if provided. A drive-scoped MCP token cannot
+    // newly enable an account-level-only tool (e.g. create_drive) — mirrors
+    // the runtime chat/consult tool-list filtering.
     if (Array.isArray(requestedEnabledTools.sanitized) && requestedEnabledTools.sanitized.length > 0) {
-      const availableToolNames = Object.keys(pageSpaceTools);
+      const availableToolNames = Object.keys(filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(auth)));
       const invalidTools = requestedEnabledTools.sanitized.filter(
         (toolName: string) => !availableToolNames.includes(toolName)
       );

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: { tokenType?: string }) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
+  isScopedMcpAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: { tokenType?: string }) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
-  isScopedMcpAuth: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: { tokenType?: string }) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn((auth: { allowedDriveIds?: string[] }) => auth.allowedDriveIds ?? []),
+  isScopedMcpAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: { tokenType?: string }) => r?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn((auth: { allowedDriveIds?: string[] }) => auth.allowedDriveIds ?? []),
-  isScopedMcpAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
+  isScopedMCPAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
     const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
     return canUserViewPage(auth.userId, pageId);

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -3,7 +3,7 @@ import { convertToModelMessages, generateText, stepCountIs, hasToolCall } from '
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
-import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, canPrincipalViewPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMcpAuth, canPrincipalViewPage } from '@/lib/auth';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -345,7 +345,7 @@ export async function POST(request: Request) {
     };
 
     // Hide account-level-only tools (e.g. create_drive) from a drive-scoped MCP token's tool list.
-    const scopedPageSpaceTools = filterToolsForMcpScope(pageSpaceTools, getAllowedDriveIds(auth).length > 0);
+    const scopedPageSpaceTools = filterToolsForMcpScope(pageSpaceTools, isScopedMcpAuth(auth));
 
     // Filter tools based on agent's enabled tools
     const availableTools = Array.isArray(enabledTools) && enabledTools.length > 0

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -3,7 +3,7 @@ import { convertToModelMessages, generateText, stepCountIs, hasToolCall } from '
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
-import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMcpAuth, canPrincipalViewPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMCPAuth, canPrincipalViewPage } from '@/lib/auth';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -345,7 +345,7 @@ export async function POST(request: Request) {
     };
 
     // Hide account-level-only tools (e.g. create_drive) from a drive-scoped MCP token's tool list.
-    const scopedPageSpaceTools = filterToolsForMcpScope(pageSpaceTools, isScopedMcpAuth(auth));
+    const scopedPageSpaceTools = filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(auth));
 
     // Filter tools based on agent's enabled tools
     const availableTools = Array.isArray(enabledTools) && enabledTools.length > 0

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -5,6 +5,7 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { getAppDriveMembership } from '@pagespace/lib/permissions/app-permissions';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
+import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { DEFAULT_PROVIDER, DEFAULT_MODEL, ONPREM_ALLOWED_PROVIDERS, isValidModel } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -99,9 +100,11 @@ export async function POST(request: Request) {
       }
     }
 
-    // Validate enabled tools
+    // Validate enabled tools. A drive-scoped MCP token cannot newly enable an
+    // account-level-only tool (e.g. create_drive) — mirrors the runtime
+    // chat/consult tool-list filtering.
     if (enabledTools && enabledTools.length > 0) {
-      const availableToolNames = Object.keys(pageSpaceTools);
+      const availableToolNames = Object.keys(filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(auth)));
       const invalidTools = enabledTools.filter((toolName: string) => !availableToolNames.includes(toolName));
       if (invalidTools.length > 0) {
         return NextResponse.json(

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
@@ -69,6 +69,8 @@ vi.mock('@/lib/auth', () => ({
   // The route authorizes via the principal dispatch (scoped tokens use their own
   // role); tests drive it through the same mock as the old user-level check.
   canPrincipalEditPage: (...args: unknown[]) => mockCanUserEditPage(...args),
+  isScopedMCPAuth: (auth: { tokenType?: string; allowedDriveIds?: string[] }) =>
+    auth?.tokenType === 'mcp' && (auth.allowedDriveIds?.length ?? 0) > 0,
 }));
 
 vi.mock('@/lib/ai/core/ai-tools', () => ({

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalEditPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalEditPage, isScopedMCPAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
+import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { validateAgentModelSelection } from '@/lib/ai/core/ai-providers-config';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -50,8 +51,11 @@ export async function GET(
       );
     }
 
-    // Get available tools for the UI
-    const availableTools = Object.entries(pageSpaceTools).map(([toolName, tool]) => ({
+    // Get available tools for the UI — hide account-level-only tools (e.g.
+    // create_drive) from a drive-scoped MCP token, mirroring the runtime
+    // chat/consult tool-list filtering.
+    const scopedPageSpaceTools = filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(auth));
+    const availableTools = Object.entries(scopedPageSpaceTools).map(([toolName, tool]) => ({
       name: toolName,
       description: tool.description || `${toolName} tool`,
     }));
@@ -146,9 +150,13 @@ export async function PATCH(
       );
     }
 
-    // Validate enabled tools (ensure they exist in available tools)
+    // Validate enabled tools (ensure they exist in available tools). A
+    // drive-scoped MCP token cannot newly enable an account-level-only tool
+    // (e.g. create_drive) — mirrors the runtime chat/consult tool-list
+    // filtering, so a scoped caller can't configure a tool it will never be
+    // permitted to invoke.
     if (enabledTools && Array.isArray(enabledTools)) {
-      const availableToolNames = Object.keys(pageSpaceTools);
+      const availableToolNames = Object.keys(filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(auth)));
       const invalidTools = enabledTools.filter(tool => !availableToolNames.includes(tool));
       if (invalidTools.length > 0) {
         return NextResponse.json(

--- a/apps/web/src/app/api/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/route.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn((result) => 'error' in result),
   checkMCPCreateScope: vi.fn(() => null), // Allow all creates by default
   isMCPAuthResult: vi.fn().mockReturnValue(false),
+  isScopedMCPAuth: vi.fn().mockReturnValue(false),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));
 
@@ -37,6 +38,15 @@ vi.mock('@/lib/websocket', () => ({
     type,
     ...data,
   })),
+}));
+
+// The route's own enabledTools scope-filter validation only needs tool names;
+// mock this to avoid pulling in the full real AI tool registry's heavy import graph.
+vi.mock('@/lib/ai/core/ai-tools', () => ({
+  pageSpaceTools: {
+    read_page: { description: 'Read a page' },
+    create_drive: { description: 'Create a drive' },
+  },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/app/api/pages/route.ts
+++ b/apps/web/src/app/api/pages/route.ts
@@ -6,8 +6,10 @@ import { getCreatablePageTypes } from '@pagespace/lib/content/page-types.config'
 import { PageType } from '@pagespace/lib/utils/enums'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
-import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isMCPAuthResult, canPrincipalEditPage } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isMCPAuthResult, isScopedMCPAuth, canPrincipalEditPage } from '@/lib/auth';
 import { pageService, type CreatePageParams } from '@/services/api';
+import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
+import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 const creatablePageTypes = [
@@ -59,6 +61,19 @@ export async function POST(request: Request) {
     const scopeError = checkMCPCreateScope(auth, validatedData.driveId);
     if (scopeError) {
       return scopeError;
+    }
+
+    // A drive-scoped MCP token cannot newly enable an account-level-only tool
+    // (e.g. create_drive) — mirrors the runtime chat/consult tool-list filtering.
+    if (validatedData.enabledTools && validatedData.enabledTools.length > 0) {
+      const availableToolNames = Object.keys(filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(auth)));
+      const invalidTools = validatedData.enabledTools.filter((toolName) => !availableToolNames.includes(toolName));
+      if (invalidTools.length > 0) {
+        return NextResponse.json(
+          { error: `Invalid tools: ${invalidTools.join(', ')}` },
+          { status: 400 }
+        );
+      }
     }
 
     // Track MCP source so the unread indicator (blue dot) shows for MCP-created pages.

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/mcp-scope-tool-filtering.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: unknown) => (r as { tokenType?: string })?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn((auth: { allowedDriveIds?: string[] }) => auth.allowedDriveIds ?? []),
-  isScopedMcpAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
+  isScopedMCPAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/mcp-scope-tool-filtering.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: unknown) => (r as { tokenType?: string })?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn((auth: { allowedDriveIds?: string[] }) => auth.allowedDriveIds ?? []),
+  isScopedMcpAuth: vi.fn((auth: { allowedDriveIds?: string[] }) => (auth.allowedDriveIds ?? []).length > 0),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: unknown) => (r as { tokenType?: string })?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
-  isScopedMcpAuth: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: unknown) => (r as { tokenType?: string })?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
+  isScopedMcpAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: unknown) => (r as { tokenType?: string })?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
+  isScopedMcpAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: vi.fn((r: unknown) => (r as { tokenType?: string })?.tokenType === 'mcp'),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
-  isScopedMcpAuth: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
   canPrincipalEditPage: vi.fn().mockResolvedValue(true),
 }));

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -14,7 +14,7 @@ import {
   isMCPAuthResult,
   checkMCPPageScope,
   getAllowedDriveIds,
-  isScopedMcpAuth,
+  isScopedMCPAuth,
   canPrincipalViewPage,
   canPrincipalEditPage,
 } from '@/lib/auth';
@@ -241,7 +241,7 @@ export async function POST(request: Request): Promise<Response> {
       : [stepCountIs(100)];
 
     // Hide account-level-only tools (e.g. create_drive) from a drive-scoped MCP token's tool list.
-    const isMcpScopedRequest = isScopedMcpAuth(authResult);
+    const isMcpScopedRequest = isScopedMCPAuth(authResult);
 
     if (inServerOnlyMode) {
       // server-only: existing pipeline unchanged

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -14,6 +14,7 @@ import {
   isMCPAuthResult,
   checkMCPPageScope,
   getAllowedDriveIds,
+  isScopedMcpAuth,
   canPrincipalViewPage,
   canPrincipalEditPage,
 } from '@/lib/auth';
@@ -240,7 +241,7 @@ export async function POST(request: Request): Promise<Response> {
       : [stepCountIs(100)];
 
     // Hide account-level-only tools (e.g. create_drive) from a drive-scoped MCP token's tool list.
-    const isMcpScopedRequest = getAllowedDriveIds(authResult).length > 0;
+    const isMcpScopedRequest = isScopedMcpAuth(authResult);
 
     if (inServerOnlyMode) {
       // server-only: existing pipeline unchanged

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -927,6 +927,10 @@ describe('agent-communication-tools', () => {
 
       beforeEach(() => {
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(scopedAgent);
+        // vi.clearAllMocks() (outer beforeEach) clears call history but not a
+        // mockReturnValue override, so pin this back to the module's default
+        // (unscoped) each test regardless of execution order.
+        vi.mocked(isMcpScoped).mockReturnValue(false);
       });
 
       it('excludes create_drive from the nested agent tool list when the calling context is a drive-scoped MCP token', async () => {

--- a/apps/web/src/lib/ai/tools/agent-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canActorEditPage } from './actor-permissions';
+import { canActorEditPage, isMcpScoped } from './actor-permissions';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { agentRepository } from '@pagespace/lib/repositories/agent-repository';
@@ -8,6 +8,7 @@ import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { maskIdentifier } from '@/lib/logging/mask';
 import type { ToolExecutionContext } from '../core/types';
 import { pageSpaceTools } from '../core/ai-tools';
+import { filterToolsForMcpScope } from '../core/tool-filtering';
 import { validateAgentModelSelection } from '../core/ai-providers-config';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 
@@ -53,9 +54,11 @@ export const agentTools = {
           throw new Error('Insufficient permissions to update this AI agent');
         }
 
-        // Validate enabled tools if provided
+        // Validate enabled tools if provided. A drive-scoped MCP token cannot
+        // newly enable an account-level-only tool (e.g. create_drive) —
+        // mirrors the runtime chat/consult tool-list filtering.
         if (enabledTools && enabledTools.length > 0) {
-          const availableToolNames = Object.keys(pageSpaceTools);
+          const availableToolNames = Object.keys(filterToolsForMcpScope(pageSpaceTools, isMcpScoped(context as ToolExecutionContext)));
           const invalidTools = enabledTools.filter(toolName => !availableToolNames.includes(toolName));
           if (invalidTools.length > 0) {
             throw new Error(`Invalid tools specified: ${invalidTools.join(', ')}. Available tools: ${availableToolNames.join(', ')}`);

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -447,6 +447,16 @@ export function getAllowedDriveIds(auth: AuthResult): string[] {
 }
 
 /**
+ * Whether this AuthResult carries an MCP drive-scope restriction (a non-empty
+ * allowedDriveIds). Mirrors isMcpScoped() in
+ * apps/web/src/lib/ai/tools/actor-permissions.ts, which does the same check on
+ * the AI-tool-execution ToolExecutionContext shape rather than AuthResult.
+ */
+export function isScopedMcpAuth(auth: AuthResult): boolean {
+  return getAllowedDriveIds(auth).length > 0;
+}
+
+/**
  * Check if an MCP token has access to a specific drive.
  * Returns null if access is allowed, or a 403 response if denied.
  *

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -447,16 +447,6 @@ export function getAllowedDriveIds(auth: AuthResult): string[] {
 }
 
 /**
- * Whether this AuthResult carries an MCP drive-scope restriction (a non-empty
- * allowedDriveIds). Mirrors isMcpScoped() in
- * apps/web/src/lib/ai/tools/actor-permissions.ts, which does the same check on
- * the AI-tool-execution ToolExecutionContext shape rather than AuthResult.
- */
-export function isScopedMcpAuth(auth: AuthResult): boolean {
-  return getAllowedDriveIds(auth).length > 0;
-}
-
-/**
  * Check if an MCP token has access to a specific drive.
  * Returns null if access is allowed, or a 403 response if denied.
  *


### PR DESCRIPTION
## Summary

Fast-follow to #1752 (merged), based on an 8-angle self-review of that PR's diff run while it was still open (line-by-line correctness, removed-behavior audit, cross-file tracing, reuse, simplification, efficiency, altitude, and CLAUDE.md conventions). No bugs were found in the merged code, but the review surfaced two real, actionable items:

### 1. Duplicated scope-check helper (correction)

#1752 added an inline `getAllowedDriveIds(auth).length > 0` expression, copy-pasted across 3 route files. My first fix for this added a *new* helper, `isScopedMcpAuth()` — which turned out to duplicate an **already-existing** helper, `isScopedMCPAuth()` (capital MCP) in `apps/web/src/lib/auth/principal-permissions.ts`, already re-exported from `index.ts` and already used by `apps/web/src/app/api/ai/page-agents/create/route.ts`. This PR removes my duplicate and switches `apps/web/src/app/api/ai/chat/route.ts`, `apps/web/src/app/api/v1/chat/completions/route.ts`, and `apps/web/src/app/api/ai/page-agents/consult/route.ts` to the canonical helper.

Also included: removed an eslint-disable + `any`-typed mocks in one new test file (inconsistent with its two sibling files from the same PR), and pinned a mock's return value in a `beforeEach` in `agent-communication-tools.test.ts` so two new tests don't depend on execution order.

### 2. Agent-config CRUD routes validated against the unfiltered tool registry

Two independent review agents (cross-file tracer + altitude) flagged that several agent-configuration surfaces validate/list `enabledTools` against the full `pageSpaceTools` registry instead of the new `filterToolsForMcpScope` gate from #1752 — inconsistent with the runtime chat/consult tool-list filtering. Fixed:

- `GET apps/web/src/app/api/pages/[pageId]/agent-config/route.ts` — `availableTools` (the config-UI tool picker) now hides account-level-only tools from scoped callers.
- `PATCH` on the same route, `PUT apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts`, `POST apps/web/src/app/api/ai/page-agents/create/route.ts`, the `update_agent_config` AI tool (`apps/web/src/lib/ai/tools/agent-tools.ts`), and `POST apps/web/src/app/api/pages/route.ts` now validate `enabledTools` against the scope-filtered set — a drive-scoped MCP token can no longer newly enable `create_drive` on an agent it configures.

**Why this was safe to do without a bigger design discussion:** every one of these validations only runs when the caller explicitly includes `enabledTools` (or, for `pages/route.ts`, a non-empty array) in the request body. Existing agents that already have `create_drive` enabled from before are completely untouched unless a scoped caller explicitly resubmits that field — so this closes the gap prospectively without touching existing data or requiring a reject-vs-hide product decision for already-configured agents.

## Test plan

- [x] `bun run typecheck` (apps/web) — clean (one unrelated pre-existing error on master from already-merged PR #1745, in `mcp-tokens/[tokenId]/route.ts`, confirmed present on plain `origin/master` with nothing from this branch applied)
- [x] Targeted suites green: `src/lib/ai/`, `src/app/api/ai/`, `src/app/api/v1/`, `src/app/api/pages/`, `src/services/api/`, `src/lib/auth/` — only the one pre-existing, unrelated DB-role failure in `activity-tools.test.ts` (confirmed present on master, requires DB bootstrap this sandbox doesn't have)
- [x] Updated all affected test files' `@/lib/auth` / `@/lib/ai/core/ai-tools` mocks for the new imports/exports
- [x] A broad `src/` run showed many unrelated component-test failures (`ReferenceError: React is not defined`) — this matches a known, documented dual-React resolution issue specific to `.pu` worktrees, not a regression from this change (verified via typecheck instead, per established project convention)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_014RGKNbGeXgjsQ7fHVC6JJ8