### PR TITLE
feat(auth): provider-side PKCE S256 verification pure functions

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -992,6 +992,11 @@
       "import": "./dist/auth/pkce.js",
       "require": "./dist/auth/pkce.js"
     },
+    "./auth/oauth/pkce": {
+      "types": "./dist/auth/oauth/pkce.d.ts",
+      "import": "./dist/auth/oauth/pkce.js",
+      "require": "./dist/auth/oauth/pkce.js"
+    },
     "./auth/passkey-service": {
       "types": "./dist/auth/passkey-service.d.ts",
       "import": "./dist/auth/passkey-service.js",
@@ -1702,6 +1707,9 @@
       ],
       "auth/pkce": [
         "./dist/auth/pkce.d.ts"
+      ],
+      "auth/oauth/pkce": [
+        "./dist/auth/oauth/pkce.d.ts"
       ],
       "auth/passkey-service": [
         "./dist/auth/passkey-service.d.ts"

--- a/packages/lib/src/auth/oauth/__tests__/pkce.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/pkce.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Provider-side PKCE S256 verification (OAuth 2.1 authorization server).
+ *
+ * Divergence from `packages/lib/src/auth/pkce.ts` (deliberate, per ADR 0003 §1.7
+ * / ADR 0002 Decision 3): that module is PageSpace acting as an OAuth *client*
+ * to Google/Apple and is fail-open by design (DB down → flow proceeds without
+ * PKCE, see its own docstring). It stores verifiers in Postgres and has no
+ * `verifyPkceChallenge`-shaped export at all — there is nothing inert to
+ * extract; it is a full generate/store/consume flow, not a pure comparator.
+ * This module is the new fail-closed, zero-I/O provider-side counterpart.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  verifyPkceChallenge,
+  generateCodeVerifier,
+  deriveCodeChallenge,
+  isValidCodeVerifier,
+} from '../pkce';
+
+// RFC 7636 Appendix B — the spec's own worked example, verbatim.
+const RFC_7636_APPENDIX_B_VERIFIER = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+const RFC_7636_APPENDIX_B_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+describe('verifyPkceChallenge', () => {
+  it('given the RFC 7636 Appendix B vector with method S256, returns true', () => {
+    expect(
+      verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, RFC_7636_APPENDIX_B_CHALLENGE, 'S256'),
+    ).toBe(true);
+  });
+
+  it('given method "plain", returns false even when verifier equals challenge', () => {
+    const verifier = 'a'.repeat(43);
+    expect(verifyPkceChallenge(verifier, verifier, 'plain')).toBe(false);
+  });
+
+  it('given an unknown method string, returns false', () => {
+    expect(
+      verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, RFC_7636_APPENDIX_B_CHALLENGE, 'sha256'),
+    ).toBe(false);
+  });
+
+  it('given method "S256" with wrong case, returns false (no case-insensitive fallback)', () => {
+    expect(
+      verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, RFC_7636_APPENDIX_B_CHALLENGE, 's256'),
+    ).toBe(false);
+  });
+
+  it('given an absent/undefined method, returns false', () => {
+    expect(
+      verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, RFC_7636_APPENDIX_B_CHALLENGE, undefined),
+    ).toBe(false);
+  });
+
+  it('given a null method, returns false', () => {
+    expect(
+      verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, RFC_7636_APPENDIX_B_CHALLENGE, null),
+    ).toBe(false);
+  });
+
+  it('given a verifier one char under the RFC 7636 §4.1 minimum length (42), rejects before hashing', () => {
+    const shortVerifier = 'a'.repeat(42);
+    // Challenge deliberately matches nothing real — a false result here proves
+    // shape validation runs, not that the hash happened not to collide.
+    expect(verifyPkceChallenge(shortVerifier, deriveCodeChallenge(shortVerifier + 'a'), 'S256')).toBe(
+      false,
+    );
+  });
+
+  it('given a verifier one char over the RFC 7636 §4.1 maximum length (129), rejects before hashing', () => {
+    const longVerifier = 'a'.repeat(129);
+    expect(verifyPkceChallenge(longVerifier, deriveCodeChallenge(longVerifier), 'S256')).toBe(false);
+  });
+
+  it('given a verifier with an out-of-charset character (+ is base64 std, not base64url), rejects', () => {
+    const badVerifier = '+'.repeat(43);
+    expect(verifyPkceChallenge(badVerifier, deriveCodeChallenge(badVerifier), 'S256')).toBe(false);
+  });
+
+  it('given a verifier with base64 padding (=), rejects', () => {
+    const badVerifier = 'a'.repeat(42) + '=';
+    expect(verifyPkceChallenge(badVerifier, deriveCodeChallenge(badVerifier), 'S256')).toBe(false);
+  });
+
+  it('given a verifier containing a space, rejects', () => {
+    const badVerifier = 'a'.repeat(21) + ' ' + 'a'.repeat(21);
+    expect(verifyPkceChallenge(badVerifier, deriveCodeChallenge(badVerifier), 'S256')).toBe(false);
+  });
+
+  it('given a valid verifier at the exact minimum length (43), accepts a correctly derived challenge', () => {
+    const verifier = 'a'.repeat(43);
+    expect(verifyPkceChallenge(verifier, deriveCodeChallenge(verifier), 'S256')).toBe(true);
+  });
+
+  it('given a valid verifier at the exact maximum length (128), accepts a correctly derived challenge', () => {
+    const verifier = 'a'.repeat(128);
+    expect(verifyPkceChallenge(verifier, deriveCodeChallenge(verifier), 'S256')).toBe(true);
+  });
+
+  it('given a tampered challenge (one char flipped), returns false', () => {
+    const tampered =
+      RFC_7636_APPENDIX_B_CHALLENGE.slice(0, -1) +
+      (RFC_7636_APPENDIX_B_CHALLENGE.at(-1) === 'M' ? 'N' : 'M');
+    expect(verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, tampered, 'S256')).toBe(false);
+  });
+
+  it('given a non-string verifier, returns false without throwing', () => {
+    expect(verifyPkceChallenge(12345 as unknown as string, RFC_7636_APPENDIX_B_CHALLENGE, 'S256')).toBe(
+      false,
+    );
+  });
+
+  it('given a non-string challenge, returns false without throwing', () => {
+    expect(
+      verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, null as unknown as string, 'S256'),
+    ).toBe(false);
+  });
+
+  it('given an empty challenge, returns false', () => {
+    expect(verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, '', 'S256')).toBe(false);
+  });
+});
+
+describe('isValidCodeVerifier', () => {
+  it('accepts the RFC 7636 Appendix B verifier', () => {
+    expect(isValidCodeVerifier(RFC_7636_APPENDIX_B_VERIFIER)).toBe(true);
+  });
+
+  it('rejects a verifier below 43 chars', () => {
+    expect(isValidCodeVerifier('a'.repeat(42))).toBe(false);
+  });
+
+  it('rejects a verifier above 128 chars', () => {
+    expect(isValidCodeVerifier('a'.repeat(129))).toBe(false);
+  });
+
+  it('accepts the full RFC 7636 §4.1 unreserved charset boundary characters', () => {
+    // charset is [A-Za-z0-9-._~]; pad to a valid length with 'a'.
+    const verifier = ('-._~' + 'a'.repeat(39)).slice(0, 43);
+    expect(isValidCodeVerifier(verifier)).toBe(true);
+  });
+});
+
+describe('generateCodeVerifier', () => {
+  it('is deterministic given the same injected random bytes', () => {
+    const fixedBytes = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+    const first = generateCodeVerifier(fixedBytes);
+    const second = generateCodeVerifier(fixedBytes);
+    expect(first).toBe(second);
+  });
+
+  it('matches base64url(bytes) for the injected randomness (no hidden extra entropy source)', () => {
+    const fixedBytes = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+    expect(generateCodeVerifier(fixedBytes)).toBe(fixedBytes.toString('base64url'));
+  });
+
+  it('produces output that is itself a valid RFC 7636 §4.1 code verifier', () => {
+    const fixedBytes = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+    expect(isValidCodeVerifier(generateCodeVerifier(fixedBytes))).toBe(true);
+  });
+
+  it('produces different output for different injected bytes', () => {
+    const bytesA = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+    const bytesB = Buffer.from(Array.from({ length: 32 }, (_, i) => i + 1));
+    expect(generateCodeVerifier(bytesA)).not.toBe(generateCodeVerifier(bytesB));
+  });
+});
+
+describe('deriveCodeChallenge', () => {
+  it('derives the RFC 7636 Appendix B challenge from its verifier', () => {
+    expect(deriveCodeChallenge(RFC_7636_APPENDIX_B_VERIFIER)).toBe(RFC_7636_APPENDIX_B_CHALLENGE);
+  });
+
+  it('is deterministic (pure — same input, same output)', () => {
+    expect(deriveCodeChallenge(RFC_7636_APPENDIX_B_VERIFIER)).toBe(
+      deriveCodeChallenge(RFC_7636_APPENDIX_B_VERIFIER),
+    );
+  });
+});
+
+describe('full round trip (generation -> derivation -> verification)', () => {
+  it('a freshly generated verifier and its derived challenge verify successfully under S256', () => {
+    const fixedBytes = Buffer.from(Array.from({ length: 32 }, (_, i) => 31 - i));
+    const verifier = generateCodeVerifier(fixedBytes);
+    const challenge = deriveCodeChallenge(verifier);
+    expect(verifyPkceChallenge(verifier, challenge, 'S256')).toBe(true);
+  });
+});

--- a/packages/lib/src/auth/oauth/__tests__/pkce.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/pkce.test.ts
@@ -98,9 +98,9 @@ describe('verifyPkceChallenge', () => {
   });
 
   it('given a tampered challenge (one char flipped), returns false', () => {
+    const lastChar = RFC_7636_APPENDIX_B_CHALLENGE[RFC_7636_APPENDIX_B_CHALLENGE.length - 1];
     const tampered =
-      RFC_7636_APPENDIX_B_CHALLENGE.slice(0, -1) +
-      (RFC_7636_APPENDIX_B_CHALLENGE.at(-1) === 'M' ? 'N' : 'M');
+      RFC_7636_APPENDIX_B_CHALLENGE.slice(0, -1) + (lastChar === 'M' ? 'N' : 'M');
     expect(verifyPkceChallenge(RFC_7636_APPENDIX_B_VERIFIER, tampered, 'S256')).toBe(false);
   });
 

--- a/packages/lib/src/auth/oauth/pkce.ts
+++ b/packages/lib/src/auth/oauth/pkce.ts
@@ -1,0 +1,86 @@
+/**
+ * Provider-side PKCE (RFC 7636) for the OAuth 2.1 authorization server.
+ *
+ * Pure and fail-closed by construction: no I/O, no clock, no ambient
+ * randomness — every decision is a function of its arguments only.
+ *
+ * Deliberately NOT an extension of `../pkce.ts`: that module is PageSpace
+ * acting as an OAuth *client* to Google/Apple and is fail-open by design (DB
+ * down → flow proceeds without PKCE — acceptable there, per ADR 0003 §1.7).
+ * The provider side must never degrade: a missing/invalid/mismatched
+ * verifier always refuses the grant, never falls back to "no PKCE".
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7636
+ * @module @pagespace/lib/auth/oauth/pkce
+ */
+
+import { createHash } from 'crypto';
+import { secureCompare } from '../secure-compare';
+
+/** RFC 7636 §4.1: code_verifier = 43*128unreserved; unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~" */
+const CODE_VERIFIER_PATTERN = /^[A-Za-z0-9\-._~]{43,128}$/;
+
+/** OAuth 2.1 forbids `plain`; this is the only method ever accepted. */
+const SUPPORTED_METHOD = 'S256';
+
+/**
+ * Validate a code_verifier's shape per RFC 7636 §4.1: length 43-128,
+ * unreserved charset only. Does not perform any hashing.
+ */
+export function isValidCodeVerifier(verifier: string): boolean {
+  return typeof verifier === 'string' && CODE_VERIFIER_PATTERN.test(verifier);
+}
+
+/**
+ * Derive the S256 code_challenge for a code_verifier:
+ * BASE64URL(SHA256(ASCII(verifier))).
+ *
+ * Pure hash derivation only — callers that accept untrusted verifiers must
+ * validate shape first (see {@link verifyPkceChallenge}, which does).
+ */
+export function deriveCodeChallenge(verifier: string): string {
+  return createHash('sha256').update(verifier, 'ascii').digest('base64url');
+}
+
+/**
+ * Verify a code_verifier against a stored code_challenge for the given
+ * code_challenge_method. Total function — never throws, always returns a
+ * boolean, fails closed on any malformed or unexpected input.
+ *
+ * - `method` must be exactly `"S256"`; `"plain"`, any other string, or an
+ *   absent/non-string method all return false (OAuth 2.1 forbids `plain`;
+ *   there is no fallback method).
+ * - `verifier` is shape-validated against RFC 7636 §4.1 before any hashing
+ *   occurs, so a malformed verifier is rejected without a hash comparison.
+ * - The derived challenge and the stored challenge are compared via
+ *   {@link secureCompare} (SHA3-256 both sides, then `timingSafeEqual`) per
+ *   project convention for secret-derived string comparisons — never `===`.
+ */
+export function verifyPkceChallenge(verifier: unknown, challenge: unknown, method: unknown): boolean {
+  if (method !== SUPPORTED_METHOD) {
+    return false;
+  }
+  if (typeof verifier !== 'string' || !isValidCodeVerifier(verifier)) {
+    return false;
+  }
+  if (typeof challenge !== 'string' || challenge.length === 0) {
+    return false;
+  }
+
+  const derivedChallenge = deriveCodeChallenge(verifier);
+  return secureCompare(derivedChallenge, challenge);
+}
+
+/**
+ * Derive a code_verifier from injected randomness (RFC 7636 §4.1 recommends
+ * ≥32 octets). Randomness is injected so callers stay pure and testable —
+ * this function performs no I/O and reads no ambient CSPRNG state itself.
+ *
+ * Base64url has no padding and its alphabet (`A-Za-z0-9-_`) is a strict
+ * subset of the RFC 7636 unreserved charset, so any output is automatically
+ * a valid code_verifier as long as the byte count keeps the encoded length
+ * within 43-128 (32 octets encodes to exactly 43 chars).
+ */
+export function generateCodeVerifier(randomBytes: Uint8Array): string {
+  return Buffer.from(randomBytes).toString('base64url');
+}


### PR DESCRIPTION
## Summary
- Phase 1 task 2 (epic: PageSpace SDK, CLI & OAuth Provider, task `j1kgh0p8t2eb9ja9t7jtgwjr`) — implements the fail-closed provider-side PKCE S256 verification pure functions per ADR 0003 §1.7 / ADR 0002 Decision 3.
- New module `packages/lib/src/auth/oauth/pkce.ts`, deliberately independent of the existing `packages/lib/src/auth/pkce.ts` (that module is PageSpace acting as an OAuth *client* to Google/Apple and is fail-open by design — DB down → flow proceeds without PKCE. The provider side must never degrade, so it is new code, not an extension).
- `verifyPkceChallenge(verifier, challenge, method)`: total, zero-I/O function. Rejects `plain`/unknown/absent methods, rejects a verifier outside RFC 7636 §4.1 shape (length 43-128, unreserved charset) before any hashing, and compares the derived challenge to the stored one via `secureCompare` (SHA3-256 both sides + `timingSafeEqual`) per project convention — never `===` on secret-derived strings.
- `generateCodeVerifier(randomBytes)` / `deriveCodeChallenge(verifier)`: pure helpers with injected randomness, reused by the CLI side later in the epic.
- Adds the `./auth/oauth/pkce` subpath to `packages/lib/package.json` (`exports` + `typesVersions`).

## Test plan
- [x] RED: `packages/lib/src/auth/oauth/__tests__/pkce.test.ts` committed first, failed on module resolution.
- [x] GREEN: 28/28 tests pass — RFC 7636 Appendix B vector, plain/unknown/case-mismatched/absent method rejection, charset/length boundary rejections (42/43/128/129 chars, `+`, `=`, space), tampered-challenge rejection, non-string input handling, deterministic generation under injected bytes, full generate→derive→verify round trip.
- [x] `bun run --filter '@pagespace/lib' typecheck` — green.
- [x] `bun run --filter '@pagespace/lib' test` — 268 files / 5979 tests green (includes the 28 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPZ9fFS55zMc7QQHsAiLJj