### PR TITLE
feat(oauth): authorization & device code lifecycle pure functions

### DIFF
--- a/packages/lib/src/auth/oauth/__tests__/code-lifecycle.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/code-lifecycle.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import {
+  decideCodeExchange,
+  decideDevicePoll,
+  decideDeviceApproval,
+  type AuthorizationCodeRecord,
+  type DeviceCodeRecord,
+} from '../code-lifecycle';
+
+function s256(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+const NOW = new Date('2026-07-03T12:00:00.000Z');
+const VERIFIER = 'a-valid-code-verifier-value-1234567890';
+const CHALLENGE = s256(VERIFIER);
+
+function authCode(overrides: Partial<AuthorizationCodeRecord> = {}): AuthorizationCodeRecord {
+  return {
+    clientId: 'pagespace-cli',
+    userId: 'user-1',
+    scopes: ['drive:read'],
+    redirectUri: 'http://127.0.0.1:51000/callback',
+    codeChallenge: CHALLENGE,
+    expiresAt: new Date(NOW.getTime() + 60_000),
+    consumedAt: null,
+    ...overrides,
+  };
+}
+
+describe('decideCodeExchange', () => {
+  it('returns ok(grant) for a valid, unconsumed, unexpired code with matching redirect + PKCE', () => {
+    const record = authCode();
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision).toEqual({
+      status: 'ok',
+      grant: { clientId: 'pagespace-cli', userId: 'user-1', scopes: ['drive:read'] },
+    });
+  });
+
+  it('fails closed exactly at the expiry boundary', () => {
+    const record = authCode({ expiresAt: NOW });
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'expired' });
+  });
+
+  it('fails when now is after expiresAt', () => {
+    const record = authCode({ expiresAt: new Date(NOW.getTime() - 1) });
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'expired' });
+  });
+
+  it('succeeds one tick before expiry', () => {
+    const record = authCode({ expiresAt: new Date(NOW.getTime() + 1) });
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision.status).toBe('ok');
+  });
+
+  it('returns already_consumed with a revoke signal for a double-consume attempt', () => {
+    const record = authCode({ consumedAt: new Date(NOW.getTime() - 1000) });
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'already_consumed', revokeIssuedTokens: true });
+  });
+
+  it('treats already_consumed as the highest-priority failure (wins over expired)', () => {
+    const record = authCode({
+      consumedAt: new Date(NOW.getTime() - 1000),
+      expiresAt: new Date(NOW.getTime() - 500),
+    });
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: 'http://wrong', codeVerifier: 'wrong-verifier' },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'already_consumed', revokeIssuedTokens: true });
+  });
+
+  it('rejects an exact-match-required redirect_uri mismatch', () => {
+    const record = authCode();
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: 'http://127.0.0.1:51000/callback/', codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'redirect_mismatch' });
+  });
+
+  it('checks redirect_uri before PKCE (redirect_mismatch wins over pkce_failed)', () => {
+    const record = authCode();
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: 'http://attacker.example/callback', codeVerifier: 'totally-wrong' },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'redirect_mismatch' });
+  });
+
+  it('checks expiry before redirect_uri (expired wins over redirect_mismatch)', () => {
+    const record = authCode({ expiresAt: new Date(NOW.getTime() - 1) });
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: 'http://attacker.example/callback', codeVerifier: VERIFIER },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'expired' });
+  });
+
+  it('rejects a PKCE verifier that does not hash to the stored challenge', () => {
+    const record = authCode();
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: 'not-the-right-verifier' },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'pkce_failed' });
+  });
+
+  it('rejects an empty PKCE verifier', () => {
+    const record = authCode();
+    const decision = decideCodeExchange(
+      record,
+      { redirectUri: record.redirectUri, codeVerifier: '' },
+      NOW,
+    );
+    expect(decision).toEqual({ status: 'pkce_failed' });
+  });
+});
+
+function deviceCode(
+  status: 'pending' | 'approved' | 'denied',
+  overrides: Record<string, unknown> = {},
+): DeviceCodeRecord {
+  const base = {
+    clientId: 'pagespace-cli',
+    scopes: ['drive:read'],
+    expiresAt: new Date(NOW.getTime() + 1_800_000),
+    lastPolledAt: null,
+    pollIntervalSeconds: 5,
+    ...overrides,
+  };
+  if (status === 'approved') {
+    return { status: 'approved', approvedUserId: 'user-1', ...base } as DeviceCodeRecord;
+  }
+  return { status, ...base } as DeviceCodeRecord;
+}
+
+describe('decideDevicePoll', () => {
+  it('returns authorization_pending for a fresh pending code with no prior poll', () => {
+    const record = deviceCode('pending');
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'authorization_pending' });
+  });
+
+  it('returns slow_down when polling faster than the interval', () => {
+    const record = deviceCode('pending', { lastPolledAt: new Date(NOW.getTime() - 4000) });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'slow_down' });
+  });
+
+  it('does not slow_down exactly at the poll interval boundary', () => {
+    const record = deviceCode('pending', { lastPolledAt: new Date(NOW.getTime() - 5000) });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'authorization_pending' });
+  });
+
+  it('allows polling once more than the interval has elapsed', () => {
+    const record = deviceCode('pending', { lastPolledAt: new Date(NOW.getTime() - 6000) });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'authorization_pending' });
+  });
+
+  it('fails closed exactly at the expiry boundary regardless of status', () => {
+    const record = deviceCode('pending', { expiresAt: NOW });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'expired_token' });
+  });
+
+  it('fails when now is after expiresAt', () => {
+    const record = deviceCode('pending', { expiresAt: new Date(NOW.getTime() - 1) });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'expired_token' });
+  });
+
+  it('returns expired_token even for an approved-but-expired code', () => {
+    const record = deviceCode('approved', { expiresAt: NOW });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'expired_token' });
+  });
+
+  it('returns access_denied for a denied code', () => {
+    const record = deviceCode('denied');
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'access_denied' });
+  });
+
+  it('returns ok(grant) for an approved code', () => {
+    const record = deviceCode('approved');
+    expect(decideDevicePoll(record, NOW)).toEqual({
+      status: 'ok',
+      grant: { clientId: 'pagespace-cli', userId: 'user-1', scopes: ['drive:read'] },
+    });
+  });
+
+  it('delivers an approved grant immediately even if polled faster than the interval', () => {
+    const record = deviceCode('approved', { lastPolledAt: new Date(NOW.getTime() - 1) });
+    expect(decideDevicePoll(record, NOW)).toEqual({
+      status: 'ok',
+      grant: { clientId: 'pagespace-cli', userId: 'user-1', scopes: ['drive:read'] },
+    });
+  });
+
+  it('delivers access_denied immediately even if polled faster than the interval', () => {
+    const record = deviceCode('denied', { lastPolledAt: new Date(NOW.getTime() - 1) });
+    expect(decideDevicePoll(record, NOW)).toEqual({ status: 'access_denied' });
+  });
+});
+
+describe('decideDeviceApproval', () => {
+  it('transitions pending -> approved and returns the grant', () => {
+    const record = deviceCode('pending');
+    const decision = decideDeviceApproval(record, 'approve', 'user-1', NOW);
+    expect(decision).toEqual({
+      status: 'approved',
+      grant: { clientId: 'pagespace-cli', userId: 'user-1', scopes: ['drive:read'] },
+    });
+  });
+
+  it('transitions pending -> denied', () => {
+    const record = deviceCode('pending');
+    const decision = decideDeviceApproval(record, 'deny', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'denied' });
+  });
+
+  it('rejects a repeat approve on an already-approved record', () => {
+    const record = deviceCode('approved');
+    const decision = decideDeviceApproval(record, 'approve', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'already_settled', existingStatus: 'approved' });
+  });
+
+  it('rejects approve-after-deny (settled record wins regardless of the new action)', () => {
+    const record = deviceCode('denied');
+    const decision = decideDeviceApproval(record, 'approve', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'already_settled', existingStatus: 'denied' });
+  });
+
+  it('rejects a repeat deny on an already-denied record', () => {
+    const record = deviceCode('denied');
+    const decision = decideDeviceApproval(record, 'deny', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'already_settled', existingStatus: 'denied' });
+  });
+
+  it('rejects deny-after-approve', () => {
+    const record = deviceCode('approved');
+    const decision = decideDeviceApproval(record, 'deny', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'already_settled', existingStatus: 'approved' });
+  });
+
+  it('fails closed exactly at the expiry boundary for a still-pending record', () => {
+    const record = deviceCode('pending', { expiresAt: NOW });
+    const decision = decideDeviceApproval(record, 'approve', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'expired' });
+  });
+
+  it('fails when now is after expiresAt for a still-pending record', () => {
+    const record = deviceCode('pending', { expiresAt: new Date(NOW.getTime() - 1) });
+    const decision = decideDeviceApproval(record, 'approve', 'user-1', NOW);
+    expect(decision).toEqual({ status: 'expired' });
+  });
+
+  it('succeeds one tick before expiry', () => {
+    const record = deviceCode('pending', { expiresAt: new Date(NOW.getTime() + 1) });
+    const decision = decideDeviceApproval(record, 'approve', 'user-1', NOW);
+    expect(decision.status).toBe('approved');
+  });
+});

--- a/packages/lib/src/auth/oauth/__tests__/code-lifecycle.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/code-lifecycle.test.ts
@@ -13,7 +13,7 @@ function s256(verifier: string): string {
 }
 
 const NOW = new Date('2026-07-03T12:00:00.000Z');
-const VERIFIER = 'a-valid-code-verifier-value-1234567890';
+const VERIFIER = 'a-valid-code-verifier-value-1234567890-abcdef';
 const CHALLENGE = s256(VERIFIER);
 
 function authCode(overrides: Partial<AuthorizationCodeRecord> = {}): AuthorizationCodeRecord {

--- a/packages/lib/src/auth/oauth/code-lifecycle.ts
+++ b/packages/lib/src/auth/oauth/code-lifecycle.ts
@@ -1,0 +1,221 @@
+/**
+ * Pure authorization-code and device-code lifecycle decisions for the OAuth 2.1
+ * provider (Phase 1).
+ *
+ * No I/O: every function takes the fetched record, the request facts, and an
+ * injected `now`, and returns a decision. The endpoint route (Phase 1 tasks
+ * 7/9) fetches the record, calls these, and persists whatever the decision
+ * implies (revoke, mark consumed, transition status) — this module never
+ * reaches into the database or the clock itself.
+ *
+ * Following the `token-lifecycle-policy.ts` precedent: exhaustive discriminated
+ * unions instead of booleans-with-meanings, fail-closed at every boundary.
+ */
+
+import { createHash } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Policy constants — named, not buried as literals in the branches below.
+// Downstream creation sites (the /authorize, /token, and device-authorization
+// routes) use these when minting new code records; the decide functions here
+// only ever compare against Dates/numbers already stored on the record.
+// ---------------------------------------------------------------------------
+
+/** OAuth 2.1 requires authorization codes to be short-lived. */
+export const AUTHORIZATION_CODE_TTL_SECONDS = 60;
+
+/** RFC 8628 §3.2 example default device-code lifetime. */
+export const DEVICE_CODE_TTL_SECONDS = 1800;
+
+/** RFC 8628 §3.2 default minimum poll interval. */
+export const DEVICE_CODE_POLL_INTERVAL_SECONDS = 5;
+
+// ---------------------------------------------------------------------------
+// Authorization-code exchange (decideCodeExchange)
+// ---------------------------------------------------------------------------
+
+export interface AuthorizationCodeRecord {
+  clientId: string;
+  userId: string;
+  scopes: string[];
+  redirectUri: string;
+  /** S256 PKCE challenge captured at /authorize time. */
+  codeChallenge: string;
+  expiresAt: Date;
+  /** Set once the code has been exchanged; null while still live. */
+  consumedAt: Date | null;
+}
+
+export interface CodeExchangeInput {
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+export interface CodeExchangeGrant {
+  clientId: string;
+  userId: string;
+  scopes: string[];
+}
+
+export type CodeExchangeDecision =
+  | { status: 'ok'; grant: CodeExchangeGrant }
+  | { status: 'expired' }
+  | { status: 'already_consumed'; revokeIssuedTokens: true }
+  | { status: 'redirect_mismatch' }
+  | { status: 'pkce_failed' };
+
+function verifyPkceS256(codeVerifier: string, codeChallenge: string): boolean {
+  if (!codeVerifier) return false;
+  const computed = createHash('sha256').update(codeVerifier).digest('base64url');
+  return computed === codeChallenge;
+}
+
+/**
+ * Decide the outcome of exchanging an authorization code.
+ *
+ * Precedence (each a distinct security posture, most severe first):
+ *  1. already_consumed — a replay of a used code is OAuth 2.1's theft signal;
+ *     it wins over every other check, including a since-expired window.
+ *  2. expired — an absolute time boundary; exactly-at-expiry fails closed.
+ *  3. redirect_mismatch — exact-match only (no substring/prefix matching).
+ *  4. pkce_failed — the last defense once the client is otherwise legitimate.
+ */
+export function decideCodeExchange(
+  record: AuthorizationCodeRecord,
+  input: CodeExchangeInput,
+  now: Date,
+): CodeExchangeDecision {
+  if (record.consumedAt !== null) {
+    return { status: 'already_consumed', revokeIssuedTokens: true };
+  }
+
+  if (now.getTime() >= record.expiresAt.getTime()) {
+    return { status: 'expired' };
+  }
+
+  if (input.redirectUri !== record.redirectUri) {
+    return { status: 'redirect_mismatch' };
+  }
+
+  if (!verifyPkceS256(input.codeVerifier, record.codeChallenge)) {
+    return { status: 'pkce_failed' };
+  }
+
+  return {
+    status: 'ok',
+    grant: { clientId: record.clientId, userId: record.userId, scopes: record.scopes },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Device-authorization grant (RFC 8628 §3.5): poll + approval state machines
+// ---------------------------------------------------------------------------
+
+interface DeviceCodeCommon {
+  clientId: string;
+  scopes: string[];
+  expiresAt: Date;
+  /** Null on the very first poll — no throttle to apply yet. */
+  lastPolledAt: Date | null;
+  pollIntervalSeconds: number;
+}
+
+export type DeviceCodeRecord =
+  | ({ status: 'pending' } & DeviceCodeCommon)
+  | ({ status: 'approved'; approvedUserId: string } & DeviceCodeCommon)
+  | ({ status: 'denied' } & DeviceCodeCommon);
+
+export interface DeviceGrant {
+  clientId: string;
+  userId: string;
+  scopes: string[];
+}
+
+export type DevicePollDecision =
+  | { status: 'authorization_pending' }
+  | { status: 'slow_down' }
+  | { status: 'expired_token' }
+  | { status: 'access_denied' }
+  | { status: 'ok'; grant: DeviceGrant };
+
+/**
+ * Decide the response to a device-code poll (RFC 8628 §3.5).
+ *
+ * Precedence:
+ *  1. expired_token — absolute boundary, checked before anything else,
+ *     including an already-approved-but-unexchanged code.
+ *  2. A settled record (approved/denied) reports its outcome immediately —
+ *     the poll-interval throttle only governs *continued waiting*, not
+ *     delivery of an already-decided result.
+ *  3. pending — throttle repeated polling faster than pollIntervalSeconds;
+ *     exactly-at-interval is allowed (only strictly-less-than throttles).
+ */
+export function decideDevicePoll(record: DeviceCodeRecord, now: Date): DevicePollDecision {
+  if (now.getTime() >= record.expiresAt.getTime()) {
+    return { status: 'expired_token' };
+  }
+
+  if (record.status === 'denied') {
+    return { status: 'access_denied' };
+  }
+
+  if (record.status === 'approved') {
+    return {
+      status: 'ok',
+      grant: {
+        clientId: record.clientId,
+        userId: record.approvedUserId,
+        scopes: record.scopes,
+      },
+    };
+  }
+
+  if (
+    record.lastPolledAt !== null &&
+    now.getTime() - record.lastPolledAt.getTime() < record.pollIntervalSeconds * 1000
+  ) {
+    return { status: 'slow_down' };
+  }
+
+  return { status: 'authorization_pending' };
+}
+
+export type DeviceApprovalAction = 'approve' | 'deny';
+
+export type DeviceApprovalDecision =
+  | { status: 'approved'; grant: DeviceGrant }
+  | { status: 'denied' }
+  | { status: 'already_settled'; existingStatus: 'approved' | 'denied' }
+  | { status: 'expired' };
+
+/**
+ * Decide the outcome of a user's approve/deny action at the /activate screen.
+ *
+ * A settled record (already approved or denied) always rejects further
+ * decisions — that check runs before expiry, since a terminal outcome stays
+ * terminal regardless of whether the code has since expired. A still-pending
+ * record fails closed exactly at (and after) its expiry boundary.
+ */
+export function decideDeviceApproval(
+  record: DeviceCodeRecord,
+  action: DeviceApprovalAction,
+  userId: string,
+  now: Date,
+): DeviceApprovalDecision {
+  if (record.status !== 'pending') {
+    return { status: 'already_settled', existingStatus: record.status };
+  }
+
+  if (now.getTime() >= record.expiresAt.getTime()) {
+    return { status: 'expired' };
+  }
+
+  if (action === 'deny') {
+    return { status: 'denied' };
+  }
+
+  return {
+    status: 'approved',
+    grant: { clientId: record.clientId, userId, scopes: record.scopes },
+  };
+}

--- a/packages/lib/src/auth/oauth/code-lifecycle.ts
+++ b/packages/lib/src/auth/oauth/code-lifecycle.ts
@@ -12,7 +12,7 @@
  * unions instead of booleans-with-meanings, fail-closed at every boundary.
  */
 
-import { createHash } from 'crypto';
+import { verifyPkceChallenge } from './pkce';
 
 // ---------------------------------------------------------------------------
 // Policy constants — named, not buried as literals in the branches below.
@@ -64,12 +64,6 @@ export type CodeExchangeDecision =
   | { status: 'redirect_mismatch' }
   | { status: 'pkce_failed' };
 
-function verifyPkceS256(codeVerifier: string, codeChallenge: string): boolean {
-  if (!codeVerifier) return false;
-  const computed = createHash('sha256').update(codeVerifier).digest('base64url');
-  return computed === codeChallenge;
-}
-
 /**
  * Decide the outcome of exchanging an authorization code.
  *
@@ -97,7 +91,7 @@ export function decideCodeExchange(
     return { status: 'redirect_mismatch' };
   }
 
-  if (!verifyPkceS256(input.codeVerifier, record.codeChallenge)) {
+  if (!verifyPkceChallenge(input.codeVerifier, record.codeChallenge, 'S256')) {
     return { status: 'pkce_failed' };
   }
 


### PR DESCRIPTION
## Summary
- Implements Phase 1 task 4: `decideCodeExchange`, `decideDevicePoll`, `decideDeviceApproval` in `packages/lib/src/auth/oauth/code-lifecycle.ts`.
- Pure, no-I/O state machines with injected clock, per ADR 0003 / epic non-negotiables. Follows the `token-lifecycle-policy.ts` precedent (exhaustive discriminated unions, no booleans-with-meanings).
- `decideCodeExchange`: `ok(grant) | expired | already_consumed | redirect_mismatch | pkce_failed`. `already_consumed` carries `revokeIssuedTokens: true` (OAuth 2.1 single-use + theft response). Precedence: already_consumed > expired > redirect_mismatch > pkce_failed.
- `decideDevicePoll` (RFC 8628 §3.5): `authorization_pending | slow_down | expired_token | access_denied | ok(grant)`. Expiry checked first regardless of status; a settled outcome (approved/denied) delivers immediately without being blocked by the poll-interval throttle, which only governs continued `pending` waits.
- `decideDeviceApproval`: pending → approved|denied exactly once; a settled record rejects further decisions (`already_settled`) before the expiry check even applies.
- Lifetimes are named exported constants (`AUTHORIZATION_CODE_TTL_SECONDS`, `DEVICE_CODE_TTL_SECONDS`, `DEVICE_CODE_POLL_INTERVAL_SECONDS`) for downstream creation-side tasks (7/9) to consume — never literals inside the decision branches. `decideRefresh` (Phase 1 task 8) is explicitly out of scope here.

## Test plan
- [x] RED commit (`a03ab0d3e`): 31 tests written first, confirmed failing because the module didn't exist.
- [x] GREEN commit (`dd3cc3871`): implementation, all 31 tests pass.
- [x] Gate: `bun run --filter '@pagespace/lib' typecheck` — clean.
- [x] Gate: `bun run --filter '@pagespace/lib' test` — 268 files / 5982 tests passed, no regressions.
- [x] Boundary coverage: exactly-at-expiry (both state machines), exactly-at-poll-interval, double-consume, poll-too-fast, approve-after-deny/deny-after-approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmqxQuk1dv4r69mYo57vxh