### PR TITLE
feat(oauth): implement scope grammar parse/validate/serialize (ADR 0002)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -927,6 +927,11 @@
       "import": "./dist/auth/constants.js",
       "require": "./dist/auth/constants.js"
     },
+    "./auth/oauth/scopes": {
+      "types": "./dist/auth/oauth/scopes.d.ts",
+      "import": "./dist/auth/oauth/scopes.js",
+      "require": "./dist/auth/oauth/scopes.js"
+    },
     "./auth/account-lockout": {
       "types": "./dist/auth/account-lockout.d.ts",
       "import": "./dist/auth/account-lockout.js",

--- a/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseScopeList,
+  formatScopeSet,
+  isScopeSubset,
+  scopeSetToDriveScopes,
+  checkGrantAuthority,
+  type ScopeSet,
+} from '../scopes';
+
+function drives(...entries: Array<[string, ScopeSet['drives'] extends ReadonlyMap<string, infer V> ? V : never]>): ScopeSet['drives'] {
+  return new Map(entries);
+}
+
+function emptySet(overrides: Partial<ScopeSet> = {}): ScopeSet {
+  return { account: false, offlineAccess: false, drives: new Map(), ...overrides };
+}
+
+describe('parseScopeList', () => {
+  describe('grammar productions (ADR 0002 Decision 1)', () => {
+    it('parses "account" alone', () => {
+      const result = parseScopeList('account');
+      expect(result).toEqual({ ok: true, scopes: emptySet({ account: true }) });
+    });
+
+    it('parses "offline_access" alone', () => {
+      const result = parseScopeList('offline_access');
+      expect(result).toEqual({ ok: true, scopes: emptySet({ offlineAccess: true }) });
+    });
+
+    it('parses "account offline_access" together', () => {
+      const result = parseScopeList('account offline_access');
+      expect(result).toEqual({ ok: true, scopes: emptySet({ account: true, offlineAccess: true }) });
+    });
+
+    it('parses a bare drive scope as inherit', () => {
+      const result = parseScopeList('drive:abc123');
+      expect(result).toEqual({
+        ok: true,
+        scopes: emptySet({ drives: drives(['abc123', { kind: 'drive', driveId: 'abc123', role: { kind: 'inherit' } }]) }),
+      });
+    });
+
+    it('parses drive:<id>:admin', () => {
+      const result = parseScopeList('drive:abc123:admin');
+      expect(result).toEqual({
+        ok: true,
+        scopes: emptySet({ drives: drives(['abc123', { kind: 'drive', driveId: 'abc123', role: { kind: 'admin' } }]) }),
+      });
+    });
+
+    it('parses drive:<id>:member', () => {
+      const result = parseScopeList('drive:abc123:member');
+      expect(result).toEqual({
+        ok: true,
+        scopes: emptySet({ drives: drives(['abc123', { kind: 'drive', driveId: 'abc123', role: { kind: 'member' } }]) }),
+      });
+    });
+
+    it('parses drive:<id>:role:<roleId> as a custom role', () => {
+      const result = parseScopeList('drive:abc123:role:xyz789');
+      expect(result).toEqual({
+        ok: true,
+        scopes: emptySet({
+          drives: drives(['abc123', { kind: 'drive', driveId: 'abc123', role: { kind: 'custom', customRoleId: 'xyz789' } }]),
+        }),
+      });
+    });
+
+    it('parses multiple distinct drive scopes', () => {
+      const result = parseScopeList('drive:aaa drive:bbb:admin');
+      expect(result).toEqual({
+        ok: true,
+        scopes: emptySet({
+          drives: drives(
+            ['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }],
+            ['bbb', { kind: 'drive', driveId: 'bbb', role: { kind: 'admin' } }],
+          ),
+        }),
+      });
+    });
+
+    it('parses offline_access combined with drive scopes (no account present)', () => {
+      const result = parseScopeList('offline_access drive:aaa');
+      expect(result).toEqual({
+        ok: true,
+        scopes: emptySet({
+          offlineAccess: true,
+          drives: drives(['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }]),
+        }),
+      });
+    });
+
+    it('accepts a 32-character resource id (upper bound)', () => {
+      const id = 'a'.repeat(32);
+      const result = parseScopeList(`drive:${id}`);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe('fail-closed rejections (rules 1-5, F1-F3)', () => {
+    it('rejects an empty scope string (rule 2 / F1)', () => {
+      expect(parseScopeList('')).toEqual({ ok: false, error: { code: 'empty_scope' } });
+    });
+
+    it('rejects a whitespace-only scope string (rule 2 / F1)', () => {
+      expect(parseScopeList('   ')).toEqual({ ok: false, error: { code: 'empty_scope' } });
+    });
+
+    it('rejects an unrecognized scope token (rule 1 / F1)', () => {
+      expect(parseScopeList('not_a_real_scope')).toEqual({
+        ok: false,
+        error: { code: 'unknown_scope', scope: 'not_a_real_scope' },
+      });
+    });
+
+    it('rejects the whole request when any token is unrecognized, not just that token', () => {
+      const result = parseScopeList('account bogus');
+      expect(result).toEqual({ ok: false, error: { code: 'unknown_scope', scope: 'bogus' } });
+    });
+
+    it('rejects "drive:" with a missing resource id (malformed / F1)', () => {
+      expect(parseScopeList('drive:')).toEqual({ ok: false, error: { code: 'malformed_scope', scope: 'drive:' } });
+    });
+
+    it('rejects uppercase characters in the resource id (malformed / F1)', () => {
+      expect(parseScopeList('drive:ABC123')).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: 'drive:ABC123' },
+      });
+    });
+
+    it('rejects a resource id longer than 32 characters (malformed / F1)', () => {
+      const tooLong = 'a'.repeat(33);
+      expect(parseScopeList(`drive:${tooLong}`)).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: `drive:${tooLong}` },
+      });
+    });
+
+    it('rejects "drive:<id>:owner" — OWNER is not grantable via scope (rule 5)', () => {
+      expect(parseScopeList('drive:abc:owner')).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: 'drive:abc:owner' },
+      });
+    });
+
+    it('rejects "drive:<id>:role" with a missing role id (malformed)', () => {
+      expect(parseScopeList('drive:abc:role')).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: 'drive:abc:role' },
+      });
+    });
+
+    it('rejects "drive:<id>:role:" with an empty role id (malformed)', () => {
+      expect(parseScopeList('drive:abc:role:')).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: 'drive:abc:role:' },
+      });
+    });
+
+    it('rejects a role id containing invalid characters (malformed)', () => {
+      expect(parseScopeList('drive:abc:role:BAD!')).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: 'drive:abc:role:BAD!' },
+      });
+    });
+
+    it('rejects extra trailing segments (malformed)', () => {
+      expect(parseScopeList('drive:abc:admin:extra')).toEqual({
+        ok: false,
+        error: { code: 'malformed_scope', scope: 'drive:abc:admin:extra' },
+      });
+    });
+
+    it('rejects malformed tokens produced by double spaces (no silent skipping)', () => {
+      const result = parseScopeList('account  offline_access');
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects "account" mixed with any drive:* scope (rule 3 / F2)', () => {
+      expect(parseScopeList('account drive:abc')).toEqual({
+        ok: false,
+        error: { code: 'account_drive_conflict' },
+      });
+    });
+
+    it('rejects "account" mixed with a drive:* scope regardless of order (rule 3 / F2)', () => {
+      expect(parseScopeList('drive:abc account')).toEqual({
+        ok: false,
+        error: { code: 'account_drive_conflict' },
+      });
+    });
+
+    it('rejects duplicate drive ids with identical roles (rule 4 / F3)', () => {
+      expect(parseScopeList('drive:abc drive:abc')).toEqual({
+        ok: false,
+        error: { code: 'duplicate_drive', driveId: 'abc' },
+      });
+    });
+
+    it('rejects duplicate drive ids with contradictory roles (rule 4 / F3)', () => {
+      expect(parseScopeList('drive:abc:admin drive:abc:member')).toEqual({
+        ok: false,
+        error: { code: 'duplicate_drive', driveId: 'abc' },
+      });
+    });
+  });
+
+  it('is total: never throws, even on garbage input', () => {
+    const garbageInputs = ['\n', ':::::', 'drive:::role::', '   drive:  ', 'a'.repeat(1000)];
+    for (const input of garbageInputs) {
+      expect(() => parseScopeList(input)).not.toThrow();
+    }
+  });
+});
+
+describe('formatScopeSet (canonical serialization, rule 9)', () => {
+  it('formats account alone', () => {
+    expect(formatScopeSet(emptySet({ account: true }))).toBe('account');
+  });
+
+  it('formats offline_access alone', () => {
+    expect(formatScopeSet(emptySet({ offlineAccess: true }))).toBe('offline_access');
+  });
+
+  it('orders account before offline_access regardless of construction order', () => {
+    expect(formatScopeSet(emptySet({ account: true, offlineAccess: true }))).toBe('account offline_access');
+  });
+
+  it('orders drive scopes by drive id ascending, independent of Map insertion order', () => {
+    const scopes = emptySet({
+      drives: drives(
+        ['bbb', { kind: 'drive', driveId: 'bbb', role: { kind: 'admin' } }],
+        ['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }],
+      ),
+    });
+    expect(formatScopeSet(scopes)).toBe('drive:aaa drive:bbb:admin');
+  });
+
+  it('formats each drive role kind in canonical form', () => {
+    expect(
+      formatScopeSet(emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'inherit' } }]) })),
+    ).toBe('drive:x');
+    expect(
+      formatScopeSet(emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) })),
+    ).toBe('drive:x:admin');
+    expect(
+      formatScopeSet(emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'member' } }]) })),
+    ).toBe('drive:x:member');
+    expect(
+      formatScopeSet(
+        emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]) }),
+      ),
+    ).toBe('drive:x:role:r1');
+  });
+
+  it('round-trips: parse(format(s)) deep-equals s for a representative set', () => {
+    const original = emptySet({
+      offlineAccess: true,
+      drives: drives(
+        ['bbb', { kind: 'drive', driveId: 'bbb', role: { kind: 'admin' } }],
+        ['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'custom', customRoleId: 'r9' } }],
+      ),
+    });
+    const formatted = formatScopeSet(original);
+    const reparsed = parseScopeList(formatted);
+    expect(reparsed).toEqual({ ok: true, scopes: original });
+  });
+
+  it('round-trips an account grant', () => {
+    const original = emptySet({ account: true, offlineAccess: true });
+    const reparsed = parseScopeList(formatScopeSet(original));
+    expect(reparsed).toEqual({ ok: true, scopes: original });
+  });
+
+  it('formatting is idempotent: format(parse(format(s))) === format(s)', () => {
+    const original = emptySet({
+      drives: drives(['zzz', { kind: 'drive', driveId: 'zzz', role: { kind: 'member' } }]),
+    });
+    const once = formatScopeSet(original);
+    const parsedBack = parseScopeList(once);
+    expect(parsedBack.ok).toBe(true);
+    const twice = parsedBack.ok ? formatScopeSet(parsedBack.scopes) : null;
+    expect(twice).toBe(once);
+  });
+});
+
+describe('isScopeSubset (narrowing, rule 8 / F5) — escalation must be structurally impossible', () => {
+  it('account is a subset of account', () => {
+    expect(isScopeSubset(emptySet({ account: true }), emptySet({ account: true }))).toBe(true);
+  });
+
+  it('account is never a subset of a drive-only grant (escalation attempt)', () => {
+    const requested = emptySet({ account: true });
+    const granted = emptySet({ drives: drives(['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'admin' } }]) });
+    expect(isScopeSubset(requested, granted)).toBe(false);
+  });
+
+  it('a drive scope is a subset of an account grant (account covers every drive)', () => {
+    const requested = emptySet({ drives: drives(['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'admin' } }]) });
+    const granted = emptySet({ account: true });
+    expect(isScopeSubset(requested, granted)).toBe(true);
+  });
+
+  it('drive:X:admin is NOT a subset of drive:X:member (escalation attempt, ADR example)', () => {
+    const requested = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) });
+    const granted = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'member' } }]) });
+    expect(isScopeSubset(requested, granted)).toBe(false);
+  });
+
+  it('drive:X:member is NOT a subset of drive:X:admin (no implicit privilege ordering)', () => {
+    const requested = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'member' } }]) });
+    const granted = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) });
+    expect(isScopeSubset(requested, granted)).toBe(false);
+  });
+
+  it('identical drive grants are subsets of each other', () => {
+    const set = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'inherit' } }]) });
+    expect(isScopeSubset(set, set)).toBe(true);
+  });
+
+  it('requesting a superset of granted drives is rejected (requested ⊃ granted)', () => {
+    const requested = emptySet({
+      drives: drives(
+        ['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }],
+        ['bbb', { kind: 'drive', driveId: 'bbb', role: { kind: 'inherit' } }],
+      ),
+    });
+    const granted = emptySet({ drives: drives(['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }]) });
+    expect(isScopeSubset(requested, granted)).toBe(false);
+  });
+
+  it('requesting a subset of granted drives succeeds', () => {
+    const requested = emptySet({ drives: drives(['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }]) });
+    const granted = emptySet({
+      drives: drives(
+        ['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }],
+        ['bbb', { kind: 'drive', driveId: 'bbb', role: { kind: 'inherit' } }],
+      ),
+    });
+    expect(isScopeSubset(requested, granted)).toBe(true);
+  });
+
+  it('disjoint drive sets are never subsets of one another', () => {
+    const requested = emptySet({ drives: drives(['ccc', { kind: 'drive', driveId: 'ccc', role: { kind: 'inherit' } }]) });
+    const granted = emptySet({ drives: drives(['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }]) });
+    expect(isScopeSubset(requested, granted)).toBe(false);
+  });
+
+  it('two different custom roles on the same drive are not interchangeable', () => {
+    const requested = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]),
+    });
+    const granted = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r2' } }]),
+    });
+    expect(isScopeSubset(requested, granted)).toBe(false);
+  });
+
+  it('offline_access requested but not granted is rejected', () => {
+    expect(isScopeSubset(emptySet({ offlineAccess: true }), emptySet())).toBe(false);
+  });
+
+  it('not requesting offline_access is always fine, even if granted has it', () => {
+    expect(isScopeSubset(emptySet(), emptySet({ offlineAccess: true }))).toBe(true);
+  });
+});
+
+describe('scopeSetToDriveScopes (bridge to mcp_token_drives shape, Decision 2)', () => {
+  it('produces no rows for an account-only grant', () => {
+    expect(scopeSetToDriveScopes(emptySet({ account: true }))).toEqual([]);
+  });
+
+  it('maps inherit to a null role and null customRoleId', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'inherit' } }]) });
+    expect(scopeSetToDriveScopes(scopes)).toEqual([{ driveId: 'x', role: null, customRoleId: null }]);
+  });
+
+  it('maps admin to role ADMIN', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) });
+    expect(scopeSetToDriveScopes(scopes)).toEqual([{ driveId: 'x', role: 'ADMIN', customRoleId: null }]);
+  });
+
+  it('maps member to role MEMBER', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'member' } }]) });
+    expect(scopeSetToDriveScopes(scopes)).toEqual([{ driveId: 'x', role: 'MEMBER', customRoleId: null }]);
+  });
+
+  it('maps a custom role to MEMBER + customRoleId (rule 6: custom implies MEMBER)', () => {
+    const scopes = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]),
+    });
+    expect(scopeSetToDriveScopes(scopes)).toEqual([{ driveId: 'x', role: 'MEMBER', customRoleId: 'r1' }]);
+  });
+
+  it('returns rows sorted by drive id', () => {
+    const scopes = emptySet({
+      drives: drives(
+        ['bbb', { kind: 'drive', driveId: 'bbb', role: { kind: 'admin' } }],
+        ['aaa', { kind: 'drive', driveId: 'aaa', role: { kind: 'inherit' } }],
+      ),
+    });
+    expect(scopeSetToDriveScopes(scopes)).toEqual([
+      { driveId: 'aaa', role: null, customRoleId: null },
+      { driveId: 'bbb', role: 'ADMIN', customRoleId: null },
+    ]);
+  });
+});
+
+describe('checkGrantAuthority (consent-time authority cap, Decision 2 / F4)', () => {
+  function authorityMap(
+    entries: Array<
+      [
+        string,
+        {
+          isOwner?: boolean;
+          isMember?: boolean;
+          isAdmin?: boolean;
+          ownCustomRoleId?: string | null;
+          roleBelongsToDrive?: (roleId: string) => boolean;
+        },
+      ]
+    >,
+  ) {
+    return new Map(
+      entries.map(([driveId, a]) => [
+        driveId,
+        {
+          isOwner: a.isOwner ?? false,
+          isMember: a.isMember ?? false,
+          isAdmin: a.isAdmin ?? false,
+          ownCustomRoleId: a.ownCustomRoleId ?? null,
+          roleBelongsToDrive: a.roleBelongsToDrive ?? (() => true),
+        },
+      ]),
+    );
+  }
+
+  it('allows an account-only request unconditionally (no drives to check)', () => {
+    const result = checkGrantAuthority(emptySet({ account: true }), authorityMap([]));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects with no_access when the requester has no membership row for the drive', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'inherit' } }]) });
+    const result = checkGrantAuthority(scopes, authorityMap([]));
+    expect(result).toEqual({ ok: false, reason: 'no_access', driveId: 'x' });
+  });
+
+  it('rejects with no_access when present but neither owner nor member', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'inherit' } }]) });
+    const result = checkGrantAuthority(scopes, authorityMap([['x', { isOwner: false, isMember: false }]]));
+    expect(result).toEqual({ ok: false, reason: 'no_access', driveId: 'x' });
+  });
+
+  it('rejects with admin_not_grantable when a plain member requests admin', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) });
+    const result = checkGrantAuthority(scopes, authorityMap([['x', { isMember: true, isAdmin: false }]]));
+    expect(result).toEqual({ ok: false, reason: 'admin_not_grantable', driveId: 'x' });
+  });
+
+  it('allows an admin to grant admin', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) });
+    const result = checkGrantAuthority(scopes, authorityMap([['x', { isMember: true, isAdmin: true }]]));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('allows an owner to grant admin even without an explicit isAdmin flag', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'admin' } }]) });
+    const result = checkGrantAuthority(scopes, authorityMap([['x', { isOwner: true, isAdmin: false }]]));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('allows a plain member to grant member/inherit scopes on their own drive', () => {
+    const scopes = emptySet({ drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'member' } }]) });
+    const result = checkGrantAuthority(scopes, authorityMap([['x', { isMember: true }]]));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects with custom_role_not_in_drive when the role does not belong to the drive', () => {
+    const scopes = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]),
+    });
+    const result = checkGrantAuthority(
+      scopes,
+      authorityMap([['x', { isMember: true, ownCustomRoleId: 'r1', roleBelongsToDrive: () => false }]]),
+    );
+    expect(result).toEqual({ ok: false, reason: 'custom_role_not_in_drive', driveId: 'x' });
+  });
+
+  it('rejects with foreign_custom_role when a non-admin requests a custom role that is not their own', () => {
+    const scopes = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]),
+    });
+    const result = checkGrantAuthority(
+      scopes,
+      authorityMap([['x', { isMember: true, ownCustomRoleId: 'r2', roleBelongsToDrive: () => true }]]),
+    );
+    expect(result).toEqual({ ok: false, reason: 'foreign_custom_role', driveId: 'x' });
+  });
+
+  it('allows a non-admin to grant their own assigned custom role', () => {
+    const scopes = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]),
+    });
+    const result = checkGrantAuthority(
+      scopes,
+      authorityMap([['x', { isMember: true, ownCustomRoleId: 'r1', roleBelongsToDrive: () => true }]]),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('allows an admin to grant a custom role that is not their own (admin/owner bypass foreign-role check)', () => {
+    const scopes = emptySet({
+      drives: drives(['x', { kind: 'drive', driveId: 'x', role: { kind: 'custom', customRoleId: 'r1' } }]),
+    });
+    const result = checkGrantAuthority(
+      scopes,
+      authorityMap([['x', { isMember: true, isAdmin: true, ownCustomRoleId: null, roleBelongsToDrive: () => true }]]),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('rejects the entire request at the first offending drive when multiple drives are requested', () => {
+    const scopes = emptySet({
+      drives: drives(
+        ['good', { kind: 'drive', driveId: 'good', role: { kind: 'member' } }],
+        ['bad', { kind: 'drive', driveId: 'bad', role: { kind: 'admin' } }],
+      ),
+    });
+    const result = checkGrantAuthority(
+      scopes,
+      authorityMap([
+        ['good', { isMember: true }],
+        ['bad', { isMember: true, isAdmin: false }],
+      ]),
+    );
+    expect(result).toEqual({ ok: false, reason: 'admin_not_grantable', driveId: 'bad' });
+  });
+
+  it('allows a fully authorized multi-drive request', () => {
+    const scopes = emptySet({
+      drives: drives(
+        ['a', { kind: 'drive', driveId: 'a', role: { kind: 'inherit' } }],
+        ['b', { kind: 'drive', driveId: 'b', role: { kind: 'admin' } }],
+      ),
+    });
+    const result = checkGrantAuthority(
+      scopes,
+      authorityMap([
+        ['a', { isMember: true }],
+        ['b', { isOwner: true }],
+      ]),
+    );
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/packages/lib/src/auth/oauth/scopes.ts
+++ b/packages/lib/src/auth/oauth/scopes.ts
@@ -1,0 +1,239 @@
+/**
+ * OAuth 2.1 scope grammar — parse, narrow, serialize.
+ *
+ * Implements ADR 0002 (`docs/adr/0002-oauth-scope-grammar.md`) Decisions 1-2
+ * exactly. Pure functions only: no DB, no clock, no randomness. Every branch
+ * fails closed — an unrecognized or ambiguous scope is rejected outright,
+ * never silently dropped or partially granted.
+ *
+ * @module @pagespace/lib/auth/oauth/scopes
+ */
+
+const RESOURCE_ID_RE = /^[a-z0-9]{1,32}$/;
+
+export type ParsedScope =
+  | { kind: 'account' }
+  | { kind: 'offline_access' }
+  | {
+      kind: 'drive';
+      driveId: string;
+      role: { kind: 'inherit' } | { kind: 'admin' } | { kind: 'member' } | { kind: 'custom'; customRoleId: string };
+    };
+
+export type ScopeSet = {
+  account: boolean;
+  offlineAccess: boolean;
+  drives: ReadonlyMap<string, ParsedScope & { kind: 'drive' }>;
+};
+
+export type ScopeError =
+  | { code: 'malformed_scope'; scope: string }
+  | { code: 'unknown_scope'; scope: string }
+  | { code: 'empty_scope' }
+  | { code: 'account_drive_conflict' }
+  | { code: 'duplicate_drive'; driveId: string };
+
+export type DriveScopeRow = { driveId: string; role: 'ADMIN' | 'MEMBER' | null; customRoleId: string | null };
+
+export type GrantAuthority = ReadonlyMap<
+  string,
+  {
+    isOwner: boolean;
+    isMember: boolean;
+    isAdmin: boolean;
+    ownCustomRoleId: string | null;
+    roleBelongsToDrive: (roleId: string) => boolean;
+  }
+>;
+
+export type GrantAuthorityResult =
+  | { ok: true }
+  | { ok: false; reason: 'no_access' | 'admin_not_grantable' | 'foreign_custom_role' | 'custom_role_not_in_drive'; driveId: string };
+
+function parseDriveScope(token: string): (ParsedScope & { kind: 'drive' }) | null {
+  const parts = token.split(':');
+  const driveId = parts[1];
+  if (driveId === undefined || !RESOURCE_ID_RE.test(driveId)) return null;
+
+  if (parts.length === 2) {
+    return { kind: 'drive', driveId, role: { kind: 'inherit' } };
+  }
+  if (parts.length === 3 && parts[2] === 'admin') {
+    return { kind: 'drive', driveId, role: { kind: 'admin' } };
+  }
+  if (parts.length === 3 && parts[2] === 'member') {
+    return { kind: 'drive', driveId, role: { kind: 'member' } };
+  }
+  if (parts.length === 4 && parts[2] === 'role') {
+    const customRoleId = parts[3];
+    if (!RESOURCE_ID_RE.test(customRoleId)) return null;
+    return { kind: 'drive', driveId, role: { kind: 'custom', customRoleId } };
+  }
+  return null;
+}
+
+/** Grammar (Decision 1). Total: never throws. */
+export function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { ok: false; error: ScopeError } {
+  if (raw.trim().length === 0) {
+    return { ok: false, error: { code: 'empty_scope' } };
+  }
+
+  const tokens = raw.split(' ');
+  if (tokens.some((token) => token.length === 0)) {
+    return { ok: false, error: { code: 'malformed_scope', scope: raw } };
+  }
+
+  let account = false;
+  let offlineAccess = false;
+  const drives = new Map<string, ParsedScope & { kind: 'drive' }>();
+
+  for (const token of tokens) {
+    if (token === 'account') {
+      account = true;
+      continue;
+    }
+    if (token === 'offline_access') {
+      offlineAccess = true;
+      continue;
+    }
+    if (token.startsWith('drive:')) {
+      const parsed = parseDriveScope(token);
+      if (!parsed) {
+        return { ok: false, error: { code: 'malformed_scope', scope: token } };
+      }
+      if (drives.has(parsed.driveId)) {
+        return { ok: false, error: { code: 'duplicate_drive', driveId: parsed.driveId } };
+      }
+      drives.set(parsed.driveId, parsed);
+      continue;
+    }
+    return { ok: false, error: { code: 'unknown_scope', scope: token } };
+  }
+
+  if (account && drives.size > 0) {
+    return { ok: false, error: { code: 'account_drive_conflict' } };
+  }
+
+  return { ok: true, scopes: { account, offlineAccess, drives } };
+}
+
+function formatDriveScope(scope: ParsedScope & { kind: 'drive' }): string {
+  switch (scope.role.kind) {
+    case 'inherit':
+      return `drive:${scope.driveId}`;
+    case 'admin':
+      return `drive:${scope.driveId}:admin`;
+    case 'member':
+      return `drive:${scope.driveId}:member`;
+    case 'custom':
+      return `drive:${scope.driveId}:role:${scope.role.customRoleId}`;
+  }
+}
+
+/** Canonical serialization; parse(format(s)) deep-equals s (rule 9). */
+export function formatScopeSet(scopes: ScopeSet): string {
+  const tokens: string[] = [];
+  if (scopes.account) tokens.push('account');
+  if (scopes.offlineAccess) tokens.push('offline_access');
+
+  const sortedDriveIds = [...scopes.drives.keys()].sort();
+  for (const driveId of sortedDriveIds) {
+    const scope = scopes.drives.get(driveId);
+    if (scope) tokens.push(formatDriveScope(scope));
+  }
+
+  return tokens.join(' ');
+}
+
+function roleEquals(
+  a: (ParsedScope & { kind: 'drive' })['role'],
+  b: (ParsedScope & { kind: 'drive' })['role'],
+): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'custom' && b.kind === 'custom') return a.customRoleId === b.customRoleId;
+  return true;
+}
+
+/**
+ * Narrowing (rule 8): true iff requested ⊆ granted. account ⊄ any drive
+ * set; drive:X:admin ⊄ drive:X:member; etc. Per-drive comparison is exact
+ * match only — there is no cross-role privilege ordering asserted by the
+ * grammar, so anything short of an identical role is treated as escalation
+ * and rejected (fail closed).
+ */
+export function isScopeSubset(requested: ScopeSet, granted: ScopeSet): boolean {
+  if (requested.offlineAccess && !granted.offlineAccess) return false;
+
+  if (requested.account) {
+    return granted.account;
+  }
+
+  if (granted.account) return true;
+
+  for (const [driveId, requestedScope] of requested.drives) {
+    const grantedScope = granted.drives.get(driveId);
+    if (!grantedScope) return false;
+    if (!roleEquals(requestedScope.role, grantedScope.role)) return false;
+  }
+
+  return true;
+}
+
+/** Bridge to the capability model: rows in mcp_token_drives shape (Decision 2). */
+export function scopeSetToDriveScopes(scopes: ScopeSet): DriveScopeRow[] {
+  const sortedDriveIds = [...scopes.drives.keys()].sort();
+  const rows: DriveScopeRow[] = [];
+
+  for (const driveId of sortedDriveIds) {
+    const scope = scopes.drives.get(driveId);
+    if (!scope) continue;
+
+    switch (scope.role.kind) {
+      case 'inherit':
+        rows.push({ driveId, role: null, customRoleId: null });
+        break;
+      case 'admin':
+        rows.push({ driveId, role: 'ADMIN', customRoleId: null });
+        break;
+      case 'member':
+        rows.push({ driveId, role: 'MEMBER', customRoleId: null });
+        break;
+      case 'custom':
+        // Rule 6: custom role implies MEMBER.
+        rows.push({ driveId, role: 'MEMBER', customRoleId: scope.role.customRoleId });
+        break;
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Consent-time authority check (Decision 2, mirrors mcp-tokens/route.ts:44-98).
+ * Caller fetches access facts; the decision itself is pure. Rejects the
+ * entire grant at the first offending drive (Decision 2: "any violation
+ * rejects the entire authorization request").
+ */
+export function checkGrantAuthority(scopes: ScopeSet, authority: GrantAuthority): GrantAuthorityResult {
+  for (const [driveId, scope] of scopes.drives) {
+    const auth = authority.get(driveId);
+    if (!auth || (!auth.isOwner && !auth.isMember)) {
+      return { ok: false, reason: 'no_access', driveId };
+    }
+
+    if (scope.role.kind === 'admin' && !auth.isOwner && !auth.isAdmin) {
+      return { ok: false, reason: 'admin_not_grantable', driveId };
+    }
+
+    if (scope.role.kind === 'custom') {
+      if (!auth.roleBelongsToDrive(scope.role.customRoleId)) {
+        return { ok: false, reason: 'custom_role_not_in_drive', driveId };
+      }
+      if (!auth.isOwner && !auth.isAdmin && auth.ownCustomRoleId !== scope.role.customRoleId) {
+        return { ok: false, reason: 'foreign_custom_role', driveId };
+      }
+    }
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary

Phase 1, task 3 of the SDK/CLI/OAuth-provider epic (`ea07mt5jvw0flihsbjce1iv9`): implements the OAuth scope grammar's pure functions per `docs/adr/0002-oauth-scope-grammar.md` (Decisions 1-2), exactly as specified — where the task page's naming sketch (`parseScopes`/`narrowScopes`) differed from the ADR (`parseScopeList`/`isScopeSubset`/`scopeSetToDriveScopes`/`checkGrantAuthority`), the ADR won.

- `parseScopeList(raw)` — total parser for the grammar (`account`, `offline_access`, `drive:<id>[:admin|:member|:role:<rid>]`). Fails closed: unknown/malformed tokens, empty scope, `account`+`drive:*` conflicts, and duplicate drive ids all reject the whole request (rules 1-5, F1-F3).
- `formatScopeSet(scopes)` — canonical serialization (`account`/`offline_access` first, then `drive:*` sorted by id); `parse ∘ format` is the identity on canonical sets (rule 9, round-trip tested).
- `isScopeSubset(requested, granted)` — narrowing check for refresh/re-issue (rule 8). Per-drive comparison is exact-role-match only, deliberately with no invented privilege ordering between admin/member/custom — escalation is structurally impossible by construction, not by convention.
- `scopeSetToDriveScopes(scopes)` — bridges a `ScopeSet` to the `mcp_token_drives` row shape, applying rule 6 (custom role implies `MEMBER`).
- `checkGrantAuthority(scopes, authority)` — consent-time authority cap mirroring the existing mint route (`mcp-tokens/route.ts:44-98`): drive membership required, admin not grantable by non-admins, custom roles must belong to the drive and be the caller's own unless owner/admin. Rejects the entire request at the first offending drive (Decision 2 / F4).

## Test plan
- [x] RED: `packages/lib/src/auth/oauth/__tests__/scopes.test.ts` written first, confirmed failing (module didn't exist), committed.
- [x] GREEN: `packages/lib/src/auth/oauth/scopes.ts` implemented; all 67 new tests pass.
- [x] Gate: `bun run --filter '@pagespace/lib' typecheck && bun run --filter '@pagespace/lib' test` — green (268 files, 6018 tests, no regressions).
- [x] Added `./auth/oauth/scopes` package.json exports entry per project law.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrCn7c5Zmkg2tavqqpKbfp