### PR TITLE
sdk: scaffold @pagespace/sdk package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -514,6 +514,13 @@
         "typescript-eslint": "^8.59.0",
       },
     },
+    "packages/sdk": {
+      "name": "@pagespace/sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "^4.1.8",
+      },
+    },
   },
   "trustedDependencies": [
     "sharp",
@@ -1194,6 +1201,8 @@
     "@pagespace/lib": ["@pagespace/lib@workspace:packages/lib"],
 
     "@pagespace/processor": ["@pagespace/processor@workspace:apps/processor"],
+
+    "@pagespace/sdk": ["@pagespace/sdk@workspace:packages/sdk"],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,20 @@
+# @pagespace/sdk
+
+The one true typed client for PageSpace. SDK resource methods, `pagespace` CLI verbs, and the
+`pagespace mcp` adapter all derive from a single **operation registry** (`{ name, method, path,
+inputSchema, outputSchema }`), so tool drift across surfaces is structurally impossible.
+
+The core is **pure**: request-building and response-parsing are side-effect-free functions;
+`fetch`, the clock, and randomness are constructor-injected at the edges, never reached for
+directly, so unit tests never touch the network.
+
+**Zero trust end-to-end**: every server response is zod-validated against its output schema, and
+no code path in this package may ever log token material.
+
+`MIN_SERVER_API_VERSION` (reserved here per [ADR 0001](../../docs/adr/0001-sdk-api-versioning.md)
+D3) is a placeholder until the transport lands — the repo-level assertion
+`MIN_SERVER_API_VERSION <= API_CONTRACT_VERSION` is deferred until
+`packages/lib/src/api-contract-version.ts` exists (a later Phase 2 task).
+
+See PageSpace page `ea07mt5jvw0flihsbjce1iv9` (epic architecture + non-negotiables) and
+`docs/adr/` for the binding decisions this package follows.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@pagespace/sdk",
+  "version": "0.1.0",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "pretypecheck": "bun run build",
+    "typecheck": "tsc --noEmit",
+    "pretest": "bun run build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^4.1.8"
+  }
+}

--- a/packages/sdk/src/__tests__/scaffold.test.ts
+++ b/packages/sdk/src/__tests__/scaffold.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { MIN_SERVER_API_VERSION, SDK_VERSION } from '@pagespace/sdk';
+
+interface PackageManifest {
+  scripts?: Record<string, string>;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'),
+) as PackageManifest;
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+describe('@pagespace/sdk package scaffold', () => {
+  it('is importable by its published package name and exports a semver SDK_VERSION', () => {
+    expect(typeof SDK_VERSION).toBe('string');
+    expect(SDK_VERSION).toMatch(SEMVER);
+  });
+
+  it('reserves a semver MIN_SERVER_API_VERSION per ADR 0001 D3', () => {
+    expect(typeof MIN_SERVER_API_VERSION).toBe('string');
+    expect(MIN_SERVER_API_VERSION).toMatch(SEMVER);
+  });
+
+  it('declares build, typecheck, and test scripts for turbo/bun --filter', () => {
+    expect(packageJson.scripts).toMatchObject({
+      build: expect.any(String),
+      typecheck: expect.any(String),
+      test: expect.any(String),
+    });
+  });
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,9 @@
+/** @pagespace/sdk npm package version. */
+export const SDK_VERSION = '0.1.0';
+
+/**
+ * Reserved per ADR 0001 D3 (docs/adr/0001-sdk-api-versioning.md): the SDK's
+ * compiled-in floor for the server's API_CONTRACT_VERSION. Not yet enforced —
+ * see README for the deferred cross-check.
+ */
+export const MIN_SERVER_API_VERSION = '1.0.0';

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {}
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "paths": {}
   },
   "include": ["src"],

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx,js,jsx}'],
+  },
+});


### PR DESCRIPTION
## Summary
- Scaffolds `packages/sdk` (`@pagespace/sdk`) per Phase 2 task 1 (task page `i1nkmoax9kp7h1rwqg82eq4d`): `package.json` (`"type": "module"`, root `exports` entry, `build`/`typecheck`/`test` scripts wired for `bun run --filter`), `tsconfig.json`/`tsconfig.build.json`, `vitest.config.ts` — mirroring `packages/lib` conventions, no vitest aliases.
- `src/index.ts` exports `SDK_VERSION` and reserves `MIN_SERVER_API_VERSION` per [ADR 0001](../blob/pu/cli-login/docs/adr/0001-sdk-api-versioning.md) D3; the repo-level `MIN_SERVER_API_VERSION <= API_CONTRACT_VERSION` assertion is deferred until `packages/lib/src/api-contract-version.ts` exists (noted in the package README).
- RED test (`src/__tests__/scaffold.test.ts`) imports `@pagespace/sdk` by its published name (not a relative path) to prove real installability, and asserts the required scripts exist.
- Only runtime dependency is `zod`, per epic non-negotiable #4.

## Notes for reviewers
- The package's own `tsconfig.json` overrides `moduleResolution`/`module` to `NodeNext` and clears the inherited root `"@pagespace/*"` path-alias wildcard (`"paths": {}`). Without this, `tsc` would silently resolve the self-import via a source alias instead of genuinely validating the `exports` map — the empty override forces real `package.json`-exports resolution (matching how Vitest/Node already resolve it via Node's self-referencing-package feature).
- `pretypecheck`/`pretest` hooks run `bun run build` first, since both `tsc`'s own resolution of `@pagespace/sdk` and the entry test need `dist/` to exist.

## Test plan
- [x] `bun install && bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` green from a clean worktree (dist removed before each run)
- [x] RED test confirmed failing for the right reason before implementation existed (commit 1a7450206)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EMFSFJChydanBadPdJADvF