### PR TITLE
sdk: implement SDK error taxonomy (Phase 2 task 2)

### DIFF
--- a/packages/sdk/src/__tests__/errors.test.ts
+++ b/packages/sdk/src/__tests__/errors.test.ts
@@ -1,0 +1,395 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AuthenticationError,
+  classifyHttpError,
+  HttpError,
+  IncompatibleServerError,
+  isAuthenticationError,
+  isHttpError,
+  isIncompatibleServerError,
+  isNetworkError,
+  isNotFoundError,
+  isPageSpaceError,
+  isPermissionDeniedError,
+  isRateLimitError,
+  isResponseValidationError,
+  isServerError,
+  isTimeoutError,
+  isValidationError,
+  NetworkError,
+  NotFoundError,
+  PageSpaceError,
+  PermissionDeniedError,
+  RateLimitError,
+  ResponseValidationError,
+  ServerError,
+  TimeoutError,
+  ValidationError,
+} from '../errors.js';
+
+const SECRET_TOKEN = 'ps_sess_SUPERSECRETTOKEN123';
+const SECRET_PASSWORD = 'hunter2correcthorse';
+
+describe('classifyHttpError — classification matrix', () => {
+  it.each([
+    [401, AuthenticationError, 'AUTHENTICATION_ERROR'],
+    [403, PermissionDeniedError, 'PERMISSION_DENIED'],
+    [404, NotFoundError, 'NOT_FOUND'],
+    [400, ValidationError, 'VALIDATION_ERROR'],
+    [429, RateLimitError, 'RATE_LIMITED'],
+    [500, ServerError, 'SERVER_ERROR'],
+    [502, ServerError, 'SERVER_ERROR'],
+    [503, ServerError, 'SERVER_ERROR'],
+    [599, ServerError, 'SERVER_ERROR'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ] as Array<[number, new (...args: any[]) => PageSpaceError, string]>)(
+    'maps HTTP %i to %s (code %s)',
+    (status, ctor, code) => {
+      const err = classifyHttpError(status, {}, { error: 'boom' });
+      expect(err).toBeInstanceOf(PageSpaceError);
+      expect(err).toBeInstanceOf(ctor);
+      expect(err.code).toBe(code);
+    },
+  );
+
+  it('falls back to a generic HttpError for unmapped statuses (never throws, never misclassifies)', () => {
+    for (const status of [402, 409, 418, 301, 200, 0, -1]) {
+      const err = classifyHttpError(status, {}, null);
+      expect(err).toBeInstanceOf(PageSpaceError);
+      expect(err).toBeInstanceOf(HttpError);
+      expect(err.code).toBe('HTTP_ERROR');
+      expect(isHttpError(err)).toBe(true);
+    }
+  });
+
+  it('records the HTTP status on status-carrying errors', () => {
+    expect((classifyHttpError(404, {}, null) as NotFoundError).status).toBe(404);
+    expect((classifyHttpError(503, {}, null) as ServerError).status).toBe(503);
+    expect((classifyHttpError(409, {}, null) as HttpError).status).toBe(409);
+  });
+
+  it('attaches the operation name when provided', () => {
+    const err = classifyHttpError(404, {}, null, 'pages.get');
+    expect(err.operation).toBe('pages.get');
+  });
+
+  it('leaves operation undefined when not provided', () => {
+    const err = classifyHttpError(404, {}, null);
+    expect(err.operation).toBeUndefined();
+  });
+});
+
+describe('classifyHttpError — ValidationError issues', () => {
+  it('extracts a string body.error as the message with no issues', () => {
+    const err = classifyHttpError(400, {}, { error: 'name is required' }) as ValidationError;
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.message).toBe('name is required');
+    expect(err.issues).toEqual([]);
+  });
+
+  it('extracts an array body.error as structured issues (zod-issue-shaped)', () => {
+    const err = classifyHttpError(400, {}, {
+      error: [
+        { path: ['name'], message: 'Required' },
+        { path: ['age', 0], message: 'Expected number' },
+      ],
+    }) as ValidationError;
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.issues).toEqual([
+      { path: ['name'], message: 'Required' },
+      { path: ['age', 0], message: 'Expected number' },
+    ]);
+  });
+
+  it('ignores malformed issue entries instead of throwing', () => {
+    const err = classifyHttpError(400, {}, {
+      error: [null, 42, { path: ['ok'], message: 'fine' }, { message: 'no path' }, {}],
+    }) as ValidationError;
+    expect(err).toBeInstanceOf(ValidationError);
+    expect(err.issues).toEqual([{ path: ['ok'], message: 'fine' }]);
+  });
+});
+
+describe('classifyHttpError — retryAfterMs parsing', () => {
+  it('parses a numeric Retry-After header (seconds) into ms', () => {
+    const err = classifyHttpError(429, { 'Retry-After': '30' }, null) as RateLimitError;
+    expect(err.retryAfterMs).toBe(30_000);
+  });
+
+  it('is case-insensitive for plain header records', () => {
+    const err = classifyHttpError(429, { 'retry-after': '5' }, null) as RateLimitError;
+    expect(err.retryAfterMs).toBe(5_000);
+  });
+
+  it('reads from a Headers instance', () => {
+    const headers = new Headers({ 'Retry-After': '12' });
+    const err = classifyHttpError(429, headers, null) as RateLimitError;
+    expect(err.retryAfterMs).toBe(12_000);
+  });
+
+  it('is null when the header is missing', () => {
+    const err = classifyHttpError(429, {}, null) as RateLimitError;
+    expect(err.retryAfterMs).toBeNull();
+  });
+
+  it('is null (not NaN, not throwing) when the header is not numeric', () => {
+    const err = classifyHttpError(429, { 'Retry-After': 'never' }, null) as RateLimitError;
+    expect(err.retryAfterMs).toBeNull();
+  });
+
+  it('is null for a negative Retry-After value', () => {
+    const err = classifyHttpError(429, { 'Retry-After': '-5' }, null) as RateLimitError;
+    expect(err.retryAfterMs).toBeNull();
+  });
+});
+
+describe('classifyHttpError — junk body resilience', () => {
+  const junkBodies: unknown[] = [
+    null,
+    undefined,
+    '',
+    '<html><body>502 Bad Gateway</body></html>',
+    '   ',
+    42,
+    true,
+    [],
+    [1, 2, 3],
+    {},
+    { error: 123 },
+    { error: null },
+    { error: { nested: 'object' } },
+    { error: undefined },
+  ];
+
+  it.each(junkBodies.map((b) => [b] as const))('never throws for junk body %j', (body) => {
+    expect(() => classifyHttpError(401, {}, body)).not.toThrow();
+    expect(() => classifyHttpError(400, {}, body)).not.toThrow();
+    expect(() => classifyHttpError(429, {}, body)).not.toThrow();
+    expect(() => classifyHttpError(500, {}, body)).not.toThrow();
+    expect(() => classifyHttpError(418, {}, body)).not.toThrow();
+  });
+
+  it('never throws for junk headers', () => {
+    const junkHeaders: unknown[] = [null, undefined, '', 42, [], { '': '' }];
+    for (const headers of junkHeaders) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(() => classifyHttpError(429, headers as any, null)).not.toThrow();
+    }
+  });
+
+  it('produces a non-empty message even for empty/garbage responses', () => {
+    for (const body of [null, undefined, '', {}, []]) {
+      const err = classifyHttpError(500, {}, body);
+      expect(typeof err.message).toBe('string');
+      expect(err.message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('zero trust — no secret leakage', () => {
+  it('does not embed extraneous body fields (e.g. echoed tokens/passwords) in the error', () => {
+    const err = classifyHttpError(401, {}, {
+      error: 'Unauthorized',
+      requestHeaders: { Authorization: `Bearer ${SECRET_TOKEN}` },
+      requestBody: { password: SECRET_PASSWORD },
+    });
+    const serialized = JSON.stringify(err) + err.message + String(err.stack);
+    expect(serialized).not.toContain(SECRET_TOKEN);
+    expect(serialized).not.toContain(SECRET_PASSWORD);
+  });
+
+  it('does not embed secret-bearing response headers beyond the parsed Retry-After value', () => {
+    const err = classifyHttpError(429, {
+      'Retry-After': '10',
+      'X-Secret-Session': SECRET_TOKEN,
+    }, null);
+    const serialized = JSON.stringify(err) + err.message + String(err.stack);
+    expect(serialized).not.toContain(SECRET_TOKEN);
+  });
+
+  it('does not embed a token passed as a NetworkError cause message beyond what the caller supplies safely', () => {
+    const err = new NetworkError('fetch failed', { operation: 'pages.get' });
+    const serialized = JSON.stringify(err) + err.message + String(err.stack);
+    expect(serialized).not.toContain(SECRET_TOKEN);
+  });
+
+  it('ValidationError issues never carry a raw request body, only path/message pairs', () => {
+    const err = classifyHttpError(400, {}, {
+      error: [{ path: ['token'], message: 'Invalid', receivedValue: SECRET_TOKEN }],
+    }) as ValidationError;
+    const serialized = JSON.stringify(err.issues);
+    expect(serialized).not.toContain(SECRET_TOKEN);
+    expect(err.issues).toEqual([{ path: ['token'], message: 'Invalid' }]);
+  });
+});
+
+describe('instanceof AND .code discrimination', () => {
+  it('every classified error is discriminable both ways', () => {
+    const cases: Array<[number, string]> = [
+      [401, 'AUTHENTICATION_ERROR'],
+      [403, 'PERMISSION_DENIED'],
+      [404, 'NOT_FOUND'],
+      [400, 'VALIDATION_ERROR'],
+      [429, 'RATE_LIMITED'],
+      [500, 'SERVER_ERROR'],
+      [409, 'HTTP_ERROR'],
+    ];
+    for (const [status, code] of cases) {
+      const err = classifyHttpError(status, {}, null);
+      expect(err instanceof PageSpaceError).toBe(true);
+      switch (err.code) {
+        case 'AUTHENTICATION_ERROR':
+          expect(err instanceof AuthenticationError).toBe(true);
+          break;
+        case 'PERMISSION_DENIED':
+          expect(err instanceof PermissionDeniedError).toBe(true);
+          break;
+        case 'NOT_FOUND':
+          expect(err instanceof NotFoundError).toBe(true);
+          break;
+        case 'VALIDATION_ERROR':
+          expect(err instanceof ValidationError).toBe(true);
+          break;
+        case 'RATE_LIMITED':
+          expect(err instanceof RateLimitError).toBe(true);
+          break;
+        case 'SERVER_ERROR':
+          expect(err instanceof ServerError).toBe(true);
+          break;
+        case 'HTTP_ERROR':
+          expect(err instanceof HttpError).toBe(true);
+          break;
+        default:
+          throw new Error(`unexpected code ${err.code}`);
+      }
+      expect(err.code).toBe(code);
+    }
+  });
+
+  it('realm-independent type guards agree with instanceof for every class', () => {
+    expect(isAuthenticationError(classifyHttpError(401, {}, null))).toBe(true);
+    expect(isPermissionDeniedError(classifyHttpError(403, {}, null))).toBe(true);
+    expect(isNotFoundError(classifyHttpError(404, {}, null))).toBe(true);
+    expect(isValidationError(classifyHttpError(400, {}, null))).toBe(true);
+    expect(isRateLimitError(classifyHttpError(429, {}, null))).toBe(true);
+    expect(isServerError(classifyHttpError(500, {}, null))).toBe(true);
+    expect(isHttpError(classifyHttpError(409, {}, null))).toBe(true);
+    expect(isNetworkError(new NetworkError('offline'))).toBe(true);
+    expect(isTimeoutError(new TimeoutError('timed out'))).toBe(true);
+    expect(isResponseValidationError(new ResponseValidationError('pages.get', []))).toBe(true);
+    expect(isIncompatibleServerError(
+      new IncompatibleServerError({ ok: false, reason: 'server-too-old', serverVersion: '1.0.0', sdkMinVersion: '1.1.0' }),
+    )).toBe(true);
+  });
+
+  it('guards reject errors of other codes and non-error values', () => {
+    expect(isAuthenticationError(classifyHttpError(403, {}, null))).toBe(false);
+    expect(isAuthenticationError(new Error('plain'))).toBe(false);
+    expect(isAuthenticationError(null)).toBe(false);
+    expect(isAuthenticationError(undefined)).toBe(false);
+    expect(isAuthenticationError('AUTHENTICATION_ERROR')).toBe(false);
+    expect(isPageSpaceError(new Error('plain'))).toBe(false);
+    expect(isPageSpaceError(classifyHttpError(401, {}, null))).toBe(true);
+  });
+});
+
+describe('NetworkError / TimeoutError', () => {
+  it('NetworkError carries code, operation, and an optional cause without throwing', () => {
+    const cause = new TypeError('fetch failed');
+    const err = new NetworkError('network request failed', { operation: 'drives.list', cause });
+    expect(err).toBeInstanceOf(PageSpaceError);
+    expect(err.code).toBe('NETWORK_ERROR');
+    expect(err.operation).toBe('drives.list');
+    expect(err.cause).toBe(cause);
+  });
+
+  it('TimeoutError carries code and optional timeoutMs', () => {
+    const err = new TimeoutError('request timed out', { operation: 'pages.get', timeoutMs: 30_000 });
+    expect(err).toBeInstanceOf(PageSpaceError);
+    expect(err.code).toBe('TIMEOUT_ERROR');
+    expect(err.timeoutMs).toBe(30_000);
+  });
+});
+
+describe('ResponseValidationError — server-drift signal', () => {
+  it('carries the operation name and zod-issue-shaped issues', () => {
+    const err = new ResponseValidationError('pages.get', [
+      { path: ['title'], message: 'Expected string, received number' },
+    ]);
+    expect(err).toBeInstanceOf(PageSpaceError);
+    expect(err.code).toBe('RESPONSE_VALIDATION_ERROR');
+    expect(err.operation).toBe('pages.get');
+    expect(err.issues).toEqual([{ path: ['title'], message: 'Expected string, received number' }]);
+  });
+});
+
+describe('IncompatibleServerError — ADR 0001 D6', () => {
+  it('constructs from a failed CompatibilityResult and names both versions in the message', () => {
+    const err = new IncompatibleServerError({
+      ok: false,
+      reason: 'major-mismatch',
+      serverVersion: '2.0.0',
+      sdkMinVersion: '1.3.0',
+    });
+    expect(err).toBeInstanceOf(PageSpaceError);
+    expect(err.code).toBe('INCOMPATIBLE_SERVER');
+    expect(err.reason).toBe('major-mismatch');
+    expect(err.serverVersion).toBe('2.0.0');
+    expect(err.sdkMinVersion).toBe('1.3.0');
+    expect(err.message).toContain('2.0.0');
+    expect(err.message).toContain('1.3.0');
+  });
+
+  it('supports a null serverVersion (missing-header reason)', () => {
+    const err = new IncompatibleServerError({
+      ok: false,
+      reason: 'missing-header',
+      serverVersion: null,
+      sdkMinVersion: '1.0.0',
+    });
+    expect(err.serverVersion).toBeNull();
+    expect(err.reason).toBe('missing-header');
+  });
+
+  it.each(['missing-header', 'malformed-version', 'major-mismatch', 'server-too-old'] as const)(
+    'accepts reason %s',
+    (reason) => {
+      const err = new IncompatibleServerError({
+        ok: false,
+        reason,
+        serverVersion: 'x',
+        sdkMinVersion: '1.0.0',
+      });
+      expect(err.reason).toBe(reason);
+    },
+  );
+});
+
+describe('PageSpaceError base class', () => {
+  it('cannot be discriminated from a plain Error via instanceof alone at the base without a code', () => {
+    // Every concrete instance still reports its class name distinctly.
+    const err = classifyHttpError(404, {}, null);
+    expect(err.name).toBe('NotFoundError');
+  });
+
+  it('every constructed error has a stable string .code and a message', () => {
+    const errors: PageSpaceError[] = [
+      classifyHttpError(401, {}, null),
+      classifyHttpError(403, {}, null),
+      classifyHttpError(404, {}, null),
+      classifyHttpError(400, {}, null),
+      classifyHttpError(429, {}, null),
+      classifyHttpError(500, {}, null),
+      classifyHttpError(409, {}, null),
+      new NetworkError('offline'),
+      new TimeoutError('timed out'),
+      new ResponseValidationError('op', []),
+      new IncompatibleServerError({ ok: false, reason: 'missing-header', serverVersion: null, sdkMinVersion: '1.0.0' }),
+    ];
+    for (const err of errors) {
+      expect(typeof err.code).toBe('string');
+      expect(err.code.length).toBeGreaterThan(0);
+      expect(typeof err.message).toBe('string');
+    }
+  });
+});

--- a/packages/sdk/src/__tests__/errors.test.ts
+++ b/packages/sdk/src/__tests__/errors.test.ts
@@ -3,6 +3,7 @@ import {
   AuthenticationError,
   classifyHttpError,
   HttpError,
+  type HttpErrorHeaders,
   IncompatibleServerError,
   isAuthenticationError,
   isHttpError,
@@ -32,25 +33,32 @@ const SECRET_PASSWORD = 'hunter2correcthorse';
 
 describe('classifyHttpError — classification matrix', () => {
   it.each([
-    [401, AuthenticationError, 'AUTHENTICATION_ERROR'],
-    [403, PermissionDeniedError, 'PERMISSION_DENIED'],
-    [404, NotFoundError, 'NOT_FOUND'],
-    [400, ValidationError, 'VALIDATION_ERROR'],
-    [429, RateLimitError, 'RATE_LIMITED'],
-    [500, ServerError, 'SERVER_ERROR'],
-    [502, ServerError, 'SERVER_ERROR'],
-    [503, ServerError, 'SERVER_ERROR'],
-    [599, ServerError, 'SERVER_ERROR'],
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ] as Array<[number, new (...args: any[]) => PageSpaceError, string]>)(
-    'maps HTTP %i to %s (code %s)',
-    (status, ctor, code) => {
-      const err = classifyHttpError(status, {}, { error: 'boom' });
-      expect(err).toBeInstanceOf(PageSpaceError);
-      expect(err).toBeInstanceOf(ctor);
-      expect(err.code).toBe(code);
-    },
-  );
+    [401, 'AUTHENTICATION_ERROR'],
+    [403, 'PERMISSION_DENIED'],
+    [404, 'NOT_FOUND'],
+    [400, 'VALIDATION_ERROR'],
+    [429, 'RATE_LIMITED'],
+    [500, 'SERVER_ERROR'],
+    [502, 'SERVER_ERROR'],
+    [503, 'SERVER_ERROR'],
+    [599, 'SERVER_ERROR'],
+  ] as Array<[number, string]>)('maps HTTP %i to code %s', (status, code) => {
+    const err = classifyHttpError(status, {}, { error: 'boom' });
+    expect(err).toBeInstanceOf(PageSpaceError);
+    expect(err.code).toBe(code);
+  });
+
+  it('maps each status to its distinct concrete class', () => {
+    expect(classifyHttpError(401, {}, null)).toBeInstanceOf(AuthenticationError);
+    expect(classifyHttpError(403, {}, null)).toBeInstanceOf(PermissionDeniedError);
+    expect(classifyHttpError(404, {}, null)).toBeInstanceOf(NotFoundError);
+    expect(classifyHttpError(400, {}, null)).toBeInstanceOf(ValidationError);
+    expect(classifyHttpError(429, {}, null)).toBeInstanceOf(RateLimitError);
+    expect(classifyHttpError(500, {}, null)).toBeInstanceOf(ServerError);
+    expect(classifyHttpError(502, {}, null)).toBeInstanceOf(ServerError);
+    expect(classifyHttpError(503, {}, null)).toBeInstanceOf(ServerError);
+    expect(classifyHttpError(599, {}, null)).toBeInstanceOf(ServerError);
+  });
 
   it('falls back to a generic HttpError for unmapped statuses (never throws, never misclassifies)', () => {
     for (const status of [402, 409, 418, 301, 200, 0, -1]) {
@@ -172,8 +180,7 @@ describe('classifyHttpError — junk body resilience', () => {
   it('never throws for junk headers', () => {
     const junkHeaders: unknown[] = [null, undefined, '', 42, [], { '': '' }];
     for (const headers of junkHeaders) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect(() => classifyHttpError(429, headers as any, null)).not.toThrow();
+      expect(() => classifyHttpError(429, headers as HttpErrorHeaders, null)).not.toThrow();
     }
   });
 

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,0 +1,379 @@
+/**
+ * SDK error taxonomy (ADR 0001 D6; Phase 2 task 2).
+ *
+ * House convention (cf. packages/lib/src/services/validated-service-token.ts,
+ * packages/lib/src/utils/fetch-with-timeout.ts): every error is a named
+ * `class X extends Error` with a `readonly code` literal and a
+ * realm-independent `isX` type guard — `instanceof` still works within a
+ * realm (and is asserted in tests), but the guard is what cross-package/
+ * cross-realm consumers (CLI, MCP adapter) should rely on.
+ *
+ * classifyHttpError is the pure, total classification core: status/headers/
+ * body in, typed error out. It never throws — real servers return junk
+ * bodies, HTML error pages, and empty responses, and classification must
+ * survive all of them. It never copies unknown body/header fields into the
+ * resulting error (zero trust: no oracle for tokens or secrets that a
+ * misbehaving or compromised server echoes back).
+ */
+
+export type PageSpaceErrorCode =
+  | 'AUTHENTICATION_ERROR'
+  | 'PERMISSION_DENIED'
+  | 'NOT_FOUND'
+  | 'VALIDATION_ERROR'
+  | 'RATE_LIMITED'
+  | 'SERVER_ERROR'
+  | 'HTTP_ERROR'
+  | 'NETWORK_ERROR'
+  | 'TIMEOUT_ERROR'
+  | 'RESPONSE_VALIDATION_ERROR'
+  | 'INCOMPATIBLE_SERVER';
+
+export interface ValidationIssue {
+  path: Array<string | number>;
+  message: string;
+}
+
+export type IncompatibilityReason =
+  | 'missing-header'
+  | 'malformed-version'
+  | 'major-mismatch'
+  | 'server-too-old';
+
+export type CompatibilityResult =
+  | { ok: true; serverVersion: string }
+  | {
+      ok: false;
+      reason: IncompatibilityReason;
+      serverVersion: string | null;
+      sdkMinVersion: string;
+    };
+
+/** Base class for every error the SDK throws. Catch this to catch them all. */
+export abstract class PageSpaceError extends Error {
+  abstract readonly code: PageSpaceErrorCode;
+  readonly operation: string | undefined;
+
+  protected constructor(message: string, operation?: string) {
+    super(message);
+    this.name = new.target.name;
+    this.operation = operation;
+  }
+}
+
+export class AuthenticationError extends PageSpaceError {
+  readonly code = 'AUTHENTICATION_ERROR' as const;
+  readonly status = 401 as const;
+
+  constructor(message: string, operation?: string) {
+    super(message, operation);
+  }
+}
+
+export class PermissionDeniedError extends PageSpaceError {
+  readonly code = 'PERMISSION_DENIED' as const;
+  readonly status = 403 as const;
+
+  constructor(message: string, operation?: string) {
+    super(message, operation);
+  }
+}
+
+export class NotFoundError extends PageSpaceError {
+  readonly code = 'NOT_FOUND' as const;
+  readonly status = 404 as const;
+
+  constructor(message: string, operation?: string) {
+    super(message, operation);
+  }
+}
+
+export class ValidationError extends PageSpaceError {
+  readonly code = 'VALIDATION_ERROR' as const;
+  readonly status = 400 as const;
+  readonly issues: ValidationIssue[];
+
+  constructor(message: string, issues: ValidationIssue[], operation?: string) {
+    super(message, operation);
+    this.issues = issues;
+  }
+}
+
+export class RateLimitError extends PageSpaceError {
+  readonly code = 'RATE_LIMITED' as const;
+  readonly status = 429 as const;
+  readonly retryAfterMs: number | null;
+
+  constructor(message: string, retryAfterMs: number | null, operation?: string) {
+    super(message, operation);
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export class ServerError extends PageSpaceError {
+  readonly code = 'SERVER_ERROR' as const;
+  readonly status: number;
+
+  constructor(message: string, status: number, operation?: string) {
+    super(message, operation);
+    this.status = status;
+  }
+}
+
+/** Fallback for any HTTP status not otherwise classified (e.g. 402, 409, unexpected 3xx). */
+export class HttpError extends PageSpaceError {
+  readonly code = 'HTTP_ERROR' as const;
+  readonly status: number;
+
+  constructor(message: string, status: number, operation?: string) {
+    super(message, operation);
+    this.status = status;
+  }
+}
+
+export interface NetworkErrorOptions {
+  operation?: string;
+  cause?: unknown;
+}
+
+/** The request never produced an HTTP response (offline, DNS, connection reset, ...). */
+export class NetworkError extends PageSpaceError {
+  readonly code = 'NETWORK_ERROR' as const;
+  readonly cause: unknown;
+
+  constructor(message: string, options: NetworkErrorOptions = {}) {
+    super(message, options.operation);
+    this.cause = options.cause;
+  }
+}
+
+export interface TimeoutErrorOptions {
+  operation?: string;
+  timeoutMs?: number;
+}
+
+/** The request was aborted because it exceeded its deadline. */
+export class TimeoutError extends PageSpaceError {
+  readonly code = 'TIMEOUT_ERROR' as const;
+  readonly timeoutMs: number | undefined;
+
+  constructor(message: string, options: TimeoutErrorOptions = {}) {
+    super(message, options.operation);
+    this.timeoutMs = options.timeoutMs;
+  }
+}
+
+/**
+ * The server-drift signal: a 2xx response whose body failed the operation's
+ * zod output schema. Distinct from ValidationError (which classifies a 400
+ * the server itself returned for a bad *request*).
+ */
+export class ResponseValidationError extends PageSpaceError {
+  readonly code = 'RESPONSE_VALIDATION_ERROR' as const;
+  readonly issues: ValidationIssue[];
+
+  constructor(operation: string, issues: ValidationIssue[]) {
+    super(`Response for operation "${operation}" did not match its output schema`, operation);
+    this.issues = issues;
+  }
+}
+
+/** Thrown per ADR 0001 D4/D6 when the server fails the compatibility check. */
+export class IncompatibleServerError extends PageSpaceError {
+  readonly code = 'INCOMPATIBLE_SERVER' as const;
+  readonly reason: IncompatibilityReason;
+  readonly serverVersion: string | null;
+  readonly sdkMinVersion: string;
+
+  constructor(result: Extract<CompatibilityResult, { ok: false }>) {
+    super(
+      `Incompatible server (${result.reason}): server reports "${result.serverVersion ?? 'none'}", ` +
+        `SDK requires >= "${result.sdkMinVersion}"`,
+    );
+    this.reason = result.reason;
+    this.serverVersion = result.serverVersion;
+    this.sdkMinVersion = result.sdkMinVersion;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Realm-independent type guards (house convention: code + message shape,
+// not instanceof — safe across bundled copies of this package).
+// ---------------------------------------------------------------------------
+
+function hasErrorCode(error: unknown, code: PageSpaceErrorCode): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === code &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  );
+}
+
+const PAGESPACE_ERROR_CODES: ReadonlySet<PageSpaceErrorCode> = new Set([
+  'AUTHENTICATION_ERROR',
+  'PERMISSION_DENIED',
+  'NOT_FOUND',
+  'VALIDATION_ERROR',
+  'RATE_LIMITED',
+  'SERVER_ERROR',
+  'HTTP_ERROR',
+  'NETWORK_ERROR',
+  'TIMEOUT_ERROR',
+  'RESPONSE_VALIDATION_ERROR',
+  'INCOMPATIBLE_SERVER',
+] satisfies PageSpaceErrorCode[]);
+
+export function isPageSpaceError(error: unknown): error is PageSpaceError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    PAGESPACE_ERROR_CODES.has((error as { code: PageSpaceErrorCode }).code) &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  );
+}
+
+export function isAuthenticationError(error: unknown): error is AuthenticationError {
+  return hasErrorCode(error, 'AUTHENTICATION_ERROR');
+}
+
+export function isPermissionDeniedError(error: unknown): error is PermissionDeniedError {
+  return hasErrorCode(error, 'PERMISSION_DENIED');
+}
+
+export function isNotFoundError(error: unknown): error is NotFoundError {
+  return hasErrorCode(error, 'NOT_FOUND');
+}
+
+export function isValidationError(error: unknown): error is ValidationError {
+  return hasErrorCode(error, 'VALIDATION_ERROR');
+}
+
+export function isRateLimitError(error: unknown): error is RateLimitError {
+  return hasErrorCode(error, 'RATE_LIMITED');
+}
+
+export function isServerError(error: unknown): error is ServerError {
+  return hasErrorCode(error, 'SERVER_ERROR');
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+  return hasErrorCode(error, 'HTTP_ERROR');
+}
+
+export function isNetworkError(error: unknown): error is NetworkError {
+  return hasErrorCode(error, 'NETWORK_ERROR');
+}
+
+export function isTimeoutError(error: unknown): error is TimeoutError {
+  return hasErrorCode(error, 'TIMEOUT_ERROR');
+}
+
+export function isResponseValidationError(error: unknown): error is ResponseValidationError {
+  return hasErrorCode(error, 'RESPONSE_VALIDATION_ERROR');
+}
+
+export function isIncompatibleServerError(error: unknown): error is IncompatibleServerError {
+  return hasErrorCode(error, 'INCOMPATIBLE_SERVER');
+}
+
+// ---------------------------------------------------------------------------
+// classifyHttpError — the pure classification core
+// ---------------------------------------------------------------------------
+
+export type HttpErrorHeaders = Headers | Record<string, string> | null | undefined;
+
+function getHeaderValue(headers: HttpErrorHeaders, name: string): string | null {
+  if (!headers) return null;
+  if (typeof (headers as Headers).get === 'function') {
+    try {
+      return (headers as Headers).get(name);
+    } catch {
+      return null;
+    }
+  }
+  const record = headers as Record<string, string>;
+  const lowerName = name.toLowerCase();
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() === lowerName) {
+      const value = record[key];
+      return typeof value === 'string' ? value : null;
+    }
+  }
+  return null;
+}
+
+/** Parses a Retry-After header (seconds, per house convention) into ms, or null if absent/invalid. */
+function parseRetryAfterMs(headers: HttpErrorHeaders): number | null {
+  const raw = getHeaderValue(headers, 'Retry-After');
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const seconds = Number(trimmed);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+  return seconds * 1000;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Extracts a safe string message from a response body, defaulting per status. */
+function extractMessage(status: number, body: unknown): string {
+  if (isPlainObject(body) && typeof body.error === 'string' && body.error.length > 0) {
+    return body.error;
+  }
+  return `HTTP ${status}`;
+}
+
+function isValidationIssue(value: unknown): value is ValidationIssue {
+  return (
+    isPlainObject(value) &&
+    Array.isArray(value.path) &&
+    value.path.every((segment) => typeof segment === 'string' || typeof segment === 'number') &&
+    typeof value.message === 'string'
+  );
+}
+
+/** Extracts zod-issue-shaped entries from body.error, dropping anything malformed. */
+function extractValidationIssues(body: unknown): ValidationIssue[] {
+  if (!isPlainObject(body) || !Array.isArray(body.error)) return [];
+  return body.error
+    .filter(isValidationIssue)
+    .map((issue) => ({ path: [...issue.path], message: issue.message }));
+}
+
+/**
+ * Pure, total classification: HTTP status + response headers + response body
+ * → a typed PageSpaceError. Never throws.
+ */
+export function classifyHttpError(
+  status: number,
+  headers: HttpErrorHeaders,
+  body: unknown,
+  operation?: string,
+): PageSpaceError {
+  const message = extractMessage(status, body);
+
+  switch (status) {
+    case 401:
+      return new AuthenticationError(message, operation);
+    case 403:
+      return new PermissionDeniedError(message, operation);
+    case 404:
+      return new NotFoundError(message, operation);
+    case 400:
+      return new ValidationError(message, extractValidationIssues(body), operation);
+    case 429:
+      return new RateLimitError(message, parseRetryAfterMs(headers), operation);
+    default:
+      if (status >= 500 && status <= 599) {
+        return new ServerError(message, status, operation);
+      }
+      return new HttpError(message, status, operation);
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,5 @@
+export * from './errors.js';
+
 /** @pagespace/sdk npm package version. */
 export const SDK_VERSION = '0.1.0';
 


### PR DESCRIPTION
## Summary
- Implements `packages/sdk/src/errors.ts`: `PageSpaceError` base class + typed subclasses (`AuthenticationError` 401, `PermissionDeniedError` 403, `NotFoundError` 404, `ValidationError` 400 + issues, `RateLimitError` 429 + `retryAfterMs`, `ServerError` 5xx, `HttpError` fallback, `NetworkError`, `TimeoutError`, `ResponseValidationError`, `IncompatibleServerError` per ADR 0001 D6).
- `classifyHttpError(status, headers, body, operation?)`: pure, total classifier — never throws, tested against junk bodies/HTML error pages/empty responses/malformed issue arrays.
- Realm-independent `isXError` type guards alongside `instanceof`, per the house convention (`validated-service-token.ts`, `fetch-with-timeout.ts`).
- Zero trust: classification only ever lifts the known-safe `error` string/issue-array field out of a response body — never the full body/headers — so a misbehaving server echoing tokens/secrets elsewhere in the response can't leak into a constructed error. Asserted directly in tests.
- Re-exported from `packages/sdk/src/index.ts`.

Strict TDD: RED commit (54f7495a4, failing tests) → GREEN commit (651908f10, implementation). PageSpace task board (epic `ea07mt5jvw0flihsbjce1iv9`, task `ske8t5t63fzi0shqeu56v350`) updated to completed.

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck` — green
- [x] `bun run --filter '@pagespace/sdk' test` — 60/60 passing
- [x] No `any` types
- [x] Rebased onto `origin/pu/cli-login` (picks up merged SDK scaffold, ADRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVXP6Y14Ciy8cafEsRS1uo