### PR TITLE
fix(oauth): reject refresh-only (offline_access-alone) scope grants — Codex #1754

### DIFF
--- a/docs/adr/0002-oauth-scope-grammar.md
+++ b/docs/adr/0002-oauth-scope-grammar.md
@@ -73,7 +73,7 @@ Scope tokens and their meaning:
 | `drive:<driveId>:admin` | Explicit ADMIN in this drive. | Drive row `role = 'ADMIN'`. |
 | `drive:<driveId>:member` | Explicit plain MEMBER in this drive. | Drive row `role = 'MEMBER'`, `customRoleId = NULL`. |
 | `drive:<driveId>:role:<roleId>` | Custom drive role. | Drive row `role = 'MEMBER'`, `customRoleId = <roleId>`. |
-| `offline_access` | Request a refresh token (OAuth 2.1 convention). | Grant flag; orthogonal to access scopes. |
+| `offline_access` | Request a refresh token (OAuth 2.1 convention). Must accompany `account` or ≥1 `drive:*` scope — see rule 10. | Grant flag; orthogonal to access scopes. |
 
 Grammar rules (each is a testable assertion; all fail closed):
 
@@ -108,6 +108,12 @@ Grammar rules (each is a testable assertion; all fail closed):
 9. **Canonical serialization:** scopes are emitted sorted (`account`/`offline_access` first,
    then `drive:*` by drive id), lowercase, single-space separated. `parse ∘ format` is the
    identity on canonical sets (round-trip law for tests).
+10. **`offline_access` alone → reject.** Decision 2 defines a principal shape for `account` and
+    for any `drive:*` set, but none for a grant with neither. A refresh token issued for such a
+    grant could only ever mint access tokens with no access scope — meaningless, and a
+    zero-trust liability (a token that exists but authorizes nothing invites callers to assume
+    it authorizes something). `offline_access` MUST be combined with `account` or at least one
+    `drive:*` scope in the same request. (Found by independent review, Codex P2 on PR #1754.)
 
 ### Considered and rejected: resource-family scopes (`pages:read`, `tasks:write`, …)
 
@@ -263,7 +269,8 @@ type ScopeError =
   | { code: 'unknown_scope'; scope: string }
   | { code: 'empty_scope' }
   | { code: 'account_drive_conflict' }
-  | { code: 'duplicate_drive'; driveId: string };
+  | { code: 'duplicate_drive'; driveId: string }
+  | { code: 'offline_access_alone' };
 
 // Grammar (Decision 1). Total: never throws.
 function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { ok: false; error: ScopeError };
@@ -314,6 +321,7 @@ function describeScopeForConsent(
 | F10 | PKCE verifier missing/unstorable/mismatched on provider side | Flow fails; no PKCE-less fallback |
 | F11 | Unresolvable custom role at consent render | Already rejected pre-render (F4); screen never shows placeholders |
 | F12 | Scope needed but DB unreachable at any decision point | Deny (no cached/assumed authority) |
+| F13 | `offline_access` requested alone (no `account`, no `drive:*`) | Reject, `invalid_scope` (rule 10) |
 
 ## Consequences
 

--- a/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
@@ -23,11 +23,6 @@ describe('parseScopeList', () => {
       expect(result).toEqual({ ok: true, scopes: emptySet({ account: true }) });
     });
 
-    it('parses "offline_access" alone', () => {
-      const result = parseScopeList('offline_access');
-      expect(result).toEqual({ ok: true, scopes: emptySet({ offlineAccess: true }) });
-    });
-
     it('parses "account offline_access" together', () => {
       const result = parseScopeList('account offline_access');
       expect(result).toEqual({ ok: true, scopes: emptySet({ account: true, offlineAccess: true }) });
@@ -203,6 +198,13 @@ describe('parseScopeList', () => {
       expect(parseScopeList('drive:abc:admin drive:abc:member')).toEqual({
         ok: false,
         error: { code: 'duplicate_drive', driveId: 'abc' },
+      });
+    });
+
+    it('rejects "offline_access" alone — no account/drive:* means no access scope to refresh into (rule 10 / F13, Codex #1754)', () => {
+      expect(parseScopeList('offline_access')).toEqual({
+        ok: false,
+        error: { code: 'offline_access_alone' },
       });
     });
   });

--- a/packages/lib/src/auth/oauth/scopes.ts
+++ b/packages/lib/src/auth/oauth/scopes.ts
@@ -31,7 +31,8 @@ export type ScopeError =
   | { code: 'unknown_scope'; scope: string }
   | { code: 'empty_scope' }
   | { code: 'account_drive_conflict' }
-  | { code: 'duplicate_drive'; driveId: string };
+  | { code: 'duplicate_drive'; driveId: string }
+  | { code: 'offline_access_alone' };
 
 export type DriveScopeRow = { driveId: string; role: 'ADMIN' | 'MEMBER' | null; customRoleId: string | null };
 
@@ -112,6 +113,14 @@ export function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { 
 
   if (account && drives.size > 0) {
     return { ok: false, error: { code: 'account_drive_conflict' } };
+  }
+
+  // Rule 10: offline_access alone has no principal shape (Decision 2) — a
+  // refresh token minted for it could only ever mint access tokens with no
+  // access scope. Reject rather than grant a token that is structurally
+  // useless (fail closed, Codex #1754).
+  if (offlineAccess && !account && drives.size === 0) {
+    return { ok: false, error: { code: 'offline_access_alone' } };
   }
 
   return { ok: true, scopes: { account, offlineAccess, drives } };


### PR DESCRIPTION
## Summary

Fixes an independent-reviewer finding (Codex, P2) on merged PR #1754, `docs/adr/0002-oauth-scope-grammar.md:76` — "Reject refresh-only scope requests":

> `scope=offline_access` alone currently parses as VALID, but Decision 2 has no principal shape for a grant with neither `account` nor any `drive:*` scope. A refresh token issued for such a grant could mint access tokens with no access scope — meaningless. It must be rejected with `invalid_scope`.

The finding propagated into the merged implementation: `packages/lib/src/auth/oauth/scopes.ts` returned `ok: true` for `offline_access`-only requests, and the test suite asserted that as correct behavior.

## Changes

- **`docs/adr/0002-oauth-scope-grammar.md`**: adds grammar rule 10 — `offline_access` must accompany `account` or ≥1 `drive:*` scope in the same request, alone it is rejected. Adds `F13` to the fail-closed posture table and updates the `offline_access` row in Decision 1's scope table and the `ScopeError` union in the pure-function-signatures section.
- **`packages/lib/src/auth/oauth/scopes.ts`**: `parseScopeList` now rejects `offline_access`-alone requests with a new `offline_access_alone` `ScopeError` code, fail-closed alongside the existing `account_drive_conflict` / `duplicate_drive` checks.
- **`packages/lib/src/auth/oauth/__tests__/scopes.test.ts`**: RED-before-GREEN — replaced the stale `parses "offline_access" alone` (`ok: true`) assertion with a rejection test asserting `{ ok: false, error: { code: 'offline_access_alone' } }`.

## Test plan

- [x] New test written RED first (confirmed failing against pre-fix `scopes.ts`), then GREEN after the fix
- [x] `bun test packages/lib/src/auth/oauth/__tests__/scopes.test.ts` — 67/67 pass
- [x] Confirmed `bun run typecheck` has no new errors introduced by this change (pre-existing unrelated failures in the worktree, verified identical before/after via `git stash`)
- [x] Pure function, no I/O; zero-trust fail-closed behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu152kWKKqCNwXLjdie184