### PR TITLE
fix(ai): consult route history ordering, conversation persistence, step-cap parity

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// Ephemeral vs internal ask_agent for POST /api/ai/page-agents/consult (#1769)
+//
+// Today the route persists nothing and never returns/accepts a conversationId,
+// unlike the internal ask_agent tool which supports continuing a conversation.
+// Fix: the route must persist the question + answer and return a
+// conversationId; passing that conversationId back in must continue the SAME
+// conversation (scoped history), not the page-wide "recent" fallback.
+// ============================================================================
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
+  isMCPAuthResult: vi.fn(() => false),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+    ai: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })) },
+  },
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  supportsTemperature: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+const AGENT_ROW = {
+  __table: 'pages',
+  id: 'agent-1',
+  type: 'AI_CHAT',
+  title: 'Helper',
+  driveId: 'drive-1',
+  aiProvider: 'openai',
+  aiModel: 'openai/gpt-5.3-chat',
+  systemPrompt: 'You help.',
+  enabledTools: [],
+};
+const GATE_USER_ROW = { subscriptionTier: 'pro', role: 'user' };
+const DRIVE_ROW = { id: 'drive-1', name: 'Drive', slug: 'drive' };
+
+// Two distinct conversations already stored for this agent, so a page-wide
+// (unscoped) query would incorrectly blend them together.
+const CONVERSATION_A_MESSAGES = [
+  { id: 'a-1', role: 'user' as const, content: 'conv-a question 1', createdAt: new Date(2024, 0, 1), conversationId: 'conv-a', isActive: true },
+  { id: 'a-2', role: 'assistant' as const, content: 'conv-a answer 1', createdAt: new Date(2024, 0, 2), conversationId: 'conv-a', isActive: true },
+];
+const CONVERSATION_B_MESSAGES = [
+  { id: 'b-1', role: 'user' as const, content: 'conv-b question 1', createdAt: new Date(2024, 0, 3), conversationId: 'conv-b', isActive: true },
+  { id: 'b-2', role: 'assistant' as const, content: 'conv-b answer 1', createdAt: new Date(2024, 0, 4), conversationId: 'conv-b', isActive: true },
+];
+const ALL_MESSAGES = [...CONVERSATION_A_MESSAGES, ...CONVERSATION_B_MESSAGES];
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field: unknown, value: unknown) => ({ __eq: true, field, value })),
+  desc: vi.fn((field: unknown) => ({ __desc: true, field })),
+  and: vi.fn((...conds: unknown[]) => ({ __and: true, conds })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { __table: 'pages', id: 'id' },
+  drives: { __table: 'drives', id: 'id' },
+  chatMessages: {
+    __table: 'chatMessages',
+    pageId: 'pageId',
+    createdAt: 'createdAt',
+    conversationId: 'conversationId',
+    isActive: 'isActive',
+  },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { __table: 'users', id: 'id', subscriptionTier: 'subscriptionTier' },
+}));
+
+function findEqValue(conds: unknown[], fieldName: string): unknown {
+  for (const c of conds) {
+    const cond = c as { __eq?: boolean; field?: unknown; value?: unknown; __and?: boolean; conds?: unknown[] };
+    if (cond?.__eq && cond.field === fieldName) return cond.value;
+    if (cond?.__and && Array.isArray(cond.conds)) {
+      const nested = findEqValue(cond.conds, fieldName);
+      if (nested !== undefined) return nested;
+    }
+  }
+  return undefined;
+}
+
+vi.mock('@pagespace/db/db', () => {
+  function makeBuilder() {
+    let table: { __table?: string } | undefined;
+    const whereArgs: unknown[] = [];
+    const builder = {
+      from: vi.fn((t: { __table?: string }) => {
+        table = t;
+        return builder;
+      }),
+      where: vi.fn((arg: unknown) => {
+        whereArgs.push(arg);
+        return builder;
+      }),
+      orderBy: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) => {
+        try {
+          if (table?.__table === 'pages') return resolve([AGENT_ROW]);
+          if (table?.__table === 'users') return resolve([GATE_USER_ROW]);
+          if (table?.__table === 'drives') return resolve([DRIVE_ROW]);
+          if (table?.__table === 'chatMessages') {
+            const requestedConversationId = findEqValue(whereArgs, 'conversationId');
+            if (requestedConversationId !== undefined) {
+              return resolve(ALL_MESSAGES.filter(m => m.conversationId === requestedConversationId));
+            }
+            // No conversationId filter present: page-wide fallback (used when
+            // the caller doesn't pass conversationId at all).
+            return resolve(ALL_MESSAGES);
+          }
+          return resolve([]);
+        } catch (e) {
+          return reject?.(e);
+        }
+      },
+    };
+    return builder;
+  }
+  return { db: { select: vi.fn(() => makeBuilder()) } };
+});
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {}, provider: 'openai', modelName: 'openai/gpt-5.3-chat' }),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/core/ai-tools', () => ({ pageSpaceTools: {} }));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+}));
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  DEFAULT_PROVIDER: 'openai',
+  DEFAULT_MODEL: 'openai/gpt-5.3-chat',
+  ADMIN_ONLY_PROVIDERS: new Set<string>(['glm']),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
+}));
+
+vi.mock('@/lib/ai/core/tool-utils', () => ({ mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })) }));
+vi.mock('@/lib/ai/tools/finish-tool', () => ({ finishTool: {}, FINISH_TOOL_NAME: 'finish' }));
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+
+const saveMessageToDatabase = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  saveMessageToDatabase: (...args: unknown[]) => saveMessageToDatabase(...args),
+}));
+
+const convertToModelMessages = vi.fn().mockImplementation((msgs: unknown) => msgs);
+
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({
+    text: 'answer',
+    steps: [{ text: 'answer', content: [] }],
+    totalUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+  }),
+  convertToModelMessages: (...args: unknown[]) => convertToModelMessages(...args),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: 'user-1',
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request('https://example.com/api/ai/page-agents/consult', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('POST /api/ai/page-agents/consult — conversation continuity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+    convertToModelMessages.mockClear();
+    saveMessageToDatabase.mockClear();
+  });
+
+  it('returns a conversationId when none was provided, and persists both turns', async () => {
+    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'New question' }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(typeof body.conversationId).toBe('string');
+    expect(body.conversationId.length).toBeGreaterThan(0);
+
+    // Persists the user's question and the assistant's answer.
+    expect(saveMessageToDatabase).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'user', content: 'New question', conversationId: body.conversationId }),
+    );
+    expect(saveMessageToDatabase).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'assistant', content: 'answer', conversationId: body.conversationId }),
+    );
+  });
+
+  it('scopes history to the given conversationId instead of blending all page history', async () => {
+    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Follow-up', conversationId: 'conv-a' }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    // Continuing conv-a must echo the SAME conversationId back.
+    expect(body.conversationId).toBe('conv-a');
+
+    expect(convertToModelMessages).toHaveBeenCalledTimes(1);
+    const modelMessages = convertToModelMessages.mock.calls[0][0] as Array<{ content: string }>;
+    const historyContents = modelMessages.slice(0, -1).map(m => m.content);
+
+    // Only conv-a's two messages — conv-b content must NOT leak in.
+    expect(historyContents).toEqual(['conv-a question 1', 'conv-a answer 1']);
+    expect(historyContents.some(c => c.startsWith('conv-b'))).toBe(false);
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/credit-gate.test.ts
@@ -58,7 +58,8 @@ vi.mock('@pagespace/db/db', () => {
   };
   return { db: { select: vi.fn(() => builder) } };
 });
-vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), desc: vi.fn(), and: vi.fn() }));
+vi.mock('@/lib/ai/core/message-utils', () => ({ saveMessageToDatabase: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id' }, drives: { id: 'id' }, chatMessages: { pageId: 'pageId', createdAt: 'createdAt' } }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', subscriptionTier: 'subscriptionTier' } }));
 

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/mcp-scope-tool-filtering.test.ts
@@ -59,7 +59,8 @@ vi.mock('@pagespace/db/db', () => {
   };
   return { db: { select: vi.fn(() => builder) } };
 });
-vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), desc: vi.fn(), and: vi.fn() }));
+vi.mock('@/lib/ai/core/message-utils', () => ({ saveMessageToDatabase: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id' }, drives: { id: 'id' }, chatMessages: { pageId: 'pageId', createdAt: 'createdAt' } }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id', subscriptionTier: 'subscriptionTier' } }));
 

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// "Recent history" for POST /api/ai/page-agents/consult (#1769)
+//
+// The route's no-conversationId fallback loads context from the agent's most
+// recent chat_messages rows. `orderBy(chatMessages.createdAt).limit(10)` sorts
+// ASCENDING then takes the first 10 — the agent's FIRST 10 messages EVER, not
+// the most recent. Fix: order DESC + limit, then reverse back to chronological
+// order before handing the history to the model.
+// ============================================================================
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
+  isMCPAuthResult: vi.fn(() => false),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+    ai: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })) },
+  },
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  supportsTemperature: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+const AGENT_ROW = {
+  __table: 'pages',
+  id: 'agent-1',
+  type: 'AI_CHAT',
+  title: 'Helper',
+  driveId: 'drive-1',
+  aiProvider: 'openai',
+  aiModel: 'openai/gpt-5.3-chat',
+  systemPrompt: 'You help.',
+  enabledTools: [],
+};
+const GATE_USER_ROW = { subscriptionTier: 'pro', role: 'user' };
+const DRIVE_ROW = { id: 'drive-1', name: 'Drive', slug: 'drive' };
+
+// 15 messages, oldest (msg-1) to newest (msg-15).
+const ALL_MESSAGES = Array.from({ length: 15 }, (_, i) => ({
+  id: `msg-${i + 1}`,
+  role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+  content: `content-${i + 1}`,
+  createdAt: new Date(2024, 0, i + 1),
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field: unknown, value: unknown) => ({ __eq: true, field, value })),
+  desc: vi.fn((field: unknown) => ({ __desc: true, field })),
+  and: vi.fn((...conds: unknown[]) => ({ __and: true, conds })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { __table: 'pages', id: 'id' },
+  drives: { __table: 'drives', id: 'id' },
+  chatMessages: {
+    __table: 'chatMessages',
+    pageId: 'pageId',
+    createdAt: 'createdAt',
+    conversationId: 'conversationId',
+    isActive: 'isActive',
+  },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { __table: 'users', id: 'id', subscriptionTier: 'subscriptionTier' },
+}));
+
+vi.mock('@pagespace/db/db', () => {
+  function makeBuilder() {
+    let table: { __table?: string } | undefined;
+    let orderDesc = false;
+    let limitN: number | undefined;
+    const builder = {
+      from: vi.fn((t: { __table?: string }) => {
+        table = t;
+        return builder;
+      }),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn((arg: { __desc?: boolean }) => {
+        orderDesc = !!arg?.__desc;
+        return builder;
+      }),
+      limit: vi.fn((n: number) => {
+        limitN = n;
+        return builder;
+      }),
+      then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) => {
+        try {
+          if (table?.__table === 'pages') return resolve([AGENT_ROW]);
+          if (table?.__table === 'users') return resolve([GATE_USER_ROW]);
+          if (table?.__table === 'drives') return resolve([DRIVE_ROW]);
+          if (table?.__table === 'chatMessages') {
+            let rows = [...ALL_MESSAGES];
+            if (orderDesc) rows = rows.slice().reverse();
+            if (limitN !== undefined) rows = rows.slice(0, limitN);
+            return resolve(rows);
+          }
+          return resolve([]);
+        } catch (e) {
+          return reject?.(e);
+        }
+      },
+    };
+    return builder;
+  }
+  return { db: { select: vi.fn(() => makeBuilder()) } };
+});
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {}, provider: 'openai', modelName: 'openai/gpt-5.3-chat' }),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/core/ai-tools', () => ({ pageSpaceTools: {} }));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+}));
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  DEFAULT_PROVIDER: 'openai',
+  DEFAULT_MODEL: 'openai/gpt-5.3-chat',
+  ADMIN_ONLY_PROVIDERS: new Set<string>(['glm']),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
+}));
+
+vi.mock('@/lib/ai/core/tool-utils', () => ({ mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })) }));
+vi.mock('@/lib/ai/tools/finish-tool', () => ({ finishTool: {}, FINISH_TOOL_NAME: 'finish' }));
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  saveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+const convertToModelMessages = vi.fn().mockImplementation((msgs: unknown) => msgs);
+
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({
+    text: 'answer',
+    steps: [{ text: 'answer', content: [] }],
+    totalUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+  }),
+  convertToModelMessages: (...args: unknown[]) => convertToModelMessages(...args),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: 'user-1',
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const makeRequest = () =>
+  new Request('https://example.com/api/ai/page-agents/consult', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agentId: 'agent-1', question: 'What is up?' }),
+  });
+
+describe('POST /api/ai/page-agents/consult — recent history ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+    convertToModelMessages.mockClear();
+  });
+
+  it('uses the MOST RECENT 10 messages, in chronological order — not the first 10', async () => {
+    const response = await POST(makeRequest());
+    expect(response.status).toBe(200);
+
+    expect(convertToModelMessages).toHaveBeenCalledTimes(1);
+    const modelMessages = convertToModelMessages.mock.calls[0][0] as Array<{ content: string }>;
+
+    // Last entry is always the new consultation question, not history.
+    const historyContents = modelMessages.slice(0, -1).map(m => m.content);
+
+    // Most recent 10 of 15 messages (msg-6..msg-15), oldest-first within that window.
+    expect(historyContents).toEqual([
+      'content-6', 'content-7', 'content-8', 'content-9', 'content-10',
+      'content-11', 'content-12', 'content-13', 'content-14', 'content-15',
+    ]);
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// Step-cap drift for POST /api/ai/page-agents/consult (#1769)
+//
+// The consult route enables tools including ask_agent (via pageSpaceTools),
+// so a single external/MCP-triggered consult call could run up to 100 tool
+// steps. The internal ask_agent tool — the reference implementation the SDK
+// targets — caps sub-agent runs at 20 steps (agent-communication-tools.ts).
+// Fix: align the consult route's tool-enabled stopWhen budget to 20.
+// ============================================================================
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
+  isMCPAuthResult: vi.fn(() => false),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+    ai: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })) },
+  },
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  supportsTemperature: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+// enabledTools includes ask_agent so the route takes the tool-enabled
+// generateText branch (the one whose stopWhen budget is under test).
+const AGENT_ROW = {
+  __table: 'pages',
+  id: 'agent-1',
+  type: 'AI_CHAT',
+  title: 'Helper',
+  driveId: 'drive-1',
+  aiProvider: 'openai',
+  aiModel: 'openai/gpt-5.3-chat',
+  systemPrompt: 'You help.',
+  enabledTools: ['ask_agent'],
+};
+const GATE_USER_ROW = { subscriptionTier: 'pro', role: 'user' };
+const DRIVE_ROW = { id: 'drive-1', name: 'Drive', slug: 'drive' };
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field: unknown, value: unknown) => ({ __eq: true, field, value })),
+  desc: vi.fn((field: unknown) => ({ __desc: true, field })),
+  and: vi.fn((...conds: unknown[]) => ({ __and: true, conds })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { __table: 'pages', id: 'id' },
+  drives: { __table: 'drives', id: 'id' },
+  chatMessages: {
+    __table: 'chatMessages',
+    pageId: 'pageId',
+    createdAt: 'createdAt',
+    conversationId: 'conversationId',
+    isActive: 'isActive',
+  },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { __table: 'users', id: 'id', subscriptionTier: 'subscriptionTier' },
+}));
+
+vi.mock('@pagespace/db/db', () => {
+  function makeBuilder() {
+    let table: { __table?: string } | undefined;
+    const builder = {
+      from: vi.fn((t: { __table?: string }) => {
+        table = t;
+        return builder;
+      }),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      then: (resolve: (v: unknown[]) => unknown) => {
+        if (table?.__table === 'pages') return resolve([AGENT_ROW]);
+        if (table?.__table === 'users') return resolve([GATE_USER_ROW]);
+        if (table?.__table === 'drives') return resolve([DRIVE_ROW]);
+        if (table?.__table === 'chatMessages') return resolve([]);
+        return resolve([]);
+      },
+    };
+    return builder;
+  }
+  return { db: { select: vi.fn(() => makeBuilder()) } };
+});
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {}, provider: 'openai', modelName: 'openai/gpt-5.3-chat' }),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/core/ai-tools', () => ({
+  pageSpaceTools: { ask_agent: { description: 'ask_agent' } },
+}));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+}));
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  DEFAULT_PROVIDER: 'openai',
+  DEFAULT_MODEL: 'openai/gpt-5.3-chat',
+  ADMIN_ONLY_PROVIDERS: new Set<string>(['glm']),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
+}));
+
+vi.mock('@/lib/ai/core/tool-utils', () => ({ mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })) }));
+vi.mock('@/lib/ai/tools/finish-tool', () => ({ finishTool: {}, FINISH_TOOL_NAME: 'finish' }));
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  saveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+const stepCountIs = vi.fn().mockImplementation((n: number) => ({ __stepCountIs: n }));
+
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({
+    text: 'answer',
+    steps: [{ text: 'answer', content: [] }],
+    totalUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+  }),
+  convertToModelMessages: vi.fn().mockReturnValue([]),
+  stepCountIs: (...args: [number]) => stepCountIs(...args),
+  hasToolCall: vi.fn(() => () => false),
+}));
+
+import { generateText } from 'ai';
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: 'user-1',
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const makeRequest = () =>
+  new Request('https://example.com/api/ai/page-agents/consult', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ agentId: 'agent-1', question: 'What is up?' }),
+  });
+
+describe('POST /api/ai/page-agents/consult — step-cap parity with internal ask_agent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+    stepCountIs.mockClear();
+  });
+
+  it('caps the tool-enabled run at 20 steps, matching internal ask_agent — not 100', async () => {
+    const response = await POST(makeRequest());
+    expect(response.status).toBe(200);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const callArgs = vi.mocked(generateText).mock.calls[0][0] as { stopWhen: unknown[] };
+
+    const stepCap = (callArgs.stopWhen as Array<{ __stepCountIs?: number }>).find(s => s?.__stepCountIs !== undefined);
+    expect(stepCap?.__stepCountIs).toBe(20);
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -16,11 +16,13 @@ import { createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-mid
 import type { ToolExecutionContext } from '@/lib/ai/core/types';
 import { supportsTemperature } from '@/lib/ai/core/model-capabilities';
 import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
+import { eq, and, desc } from '@pagespace/db/operators'
 import { pages, drives, chatMessages } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { saveMessageToDatabase } from '@/lib/ai/core/message-utils';
+import { createId } from '@paralleldrive/cuid2';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
@@ -168,7 +170,7 @@ export async function POST(request: Request) {
     const userId = auth.userId;
 
     const body = await request.json();
-    const { agentId, question, context } = body;
+    const { agentId, question, context, conversationId } = body;
 
     if (!agentId || !question) {
       return NextResponse.json(
@@ -263,19 +265,42 @@ export async function POST(request: Request) {
     const systemPrompt = agent.systemPrompt || 'You are a helpful AI assistant.';
     const enabledTools = agent.enabledTools || [];
 
-    // Get recent conversation history for context (last 10 messages)
-    const recentMessages = await db
-      .select()
-      .from(chatMessages)
-      .where(eq(chatMessages.pageId, agentId))
-      .orderBy(chatMessages.createdAt)
-      .limit(10);
+    // Persistent conversation support (parity with the internal ask_agent tool):
+    // a supplied conversationId continues that exact conversation; otherwise a
+    // new one is minted and returned so the caller can continue it later.
+    const activeConversationId: string = conversationId || createId();
+
+    let historyMessages: Array<{ role: string; content: string | null }>;
+    if (conversationId) {
+      // Scoped to this conversation only, in chronological order.
+      historyMessages = await db
+        .select()
+        .from(chatMessages)
+        .where(and(
+          eq(chatMessages.pageId, agentId),
+          eq(chatMessages.conversationId, conversationId),
+          eq(chatMessages.isActive, true)
+        ))
+        .orderBy(chatMessages.createdAt);
+    } else {
+      // No conversationId: fall back to the agent's most recent messages across
+      // all conversations for lightweight context. Must order DESC then reverse
+      // — ordering ASCENDING with limit(10) returns the agent's FIRST 10
+      // messages ever, not the most recent.
+      const recentMessages = await db
+        .select()
+        .from(chatMessages)
+        .where(eq(chatMessages.pageId, agentId))
+        .orderBy(desc(chatMessages.createdAt))
+        .limit(10);
+      historyMessages = recentMessages.slice().reverse();
+    }
 
     // Build conversation messages (exclude system - handled separately)
     const conversationMessages = [];
 
     // Add recent conversation context if available
-    for (const msg of recentMessages) {
+    for (const msg of historyMessages) {
       if (msg.content) {
         conversationMessages.push({
           role: msg.role,
@@ -292,6 +317,17 @@ export async function POST(request: Request) {
     conversationMessages.push({
       role: 'user',
       content: consultationMessage
+    });
+
+    // Persist the question immediately so it survives even if generation fails below.
+    const userMessageId = createId();
+    await saveMessageToDatabase({
+      messageId: userMessageId,
+      pageId: agentId,
+      conversationId: activeConversationId,
+      userId,
+      role: 'user',
+      content: consultationMessage,
     });
 
     // Get configured AI model for agent
@@ -414,7 +450,11 @@ export async function POST(request: Request) {
             ...(tempSupported ? { temperature: 0.7 } : {}),
             maxRetries: 3,
             experimental_context: executionContext,
-            stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)],
+            // 20, not 100 — matches the internal ask_agent tool's sub-agent step
+            // budget (agent-communication-tools.ts) since this route enables the
+            // same ask_agent tool and must not allow a far larger budget for an
+            // externally/MCP-triggered call than an internally-triggered one.
+            stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(20)],
             onStepFinish: ({ toolCalls, toolResults, text }) => {
               loggers.api.debug('Agent tool execution step completed', {
                 agentId,
@@ -523,8 +563,9 @@ export async function POST(request: Request) {
           errors: toolErrors,
         });
       }
-      // Track AI usage. This is a tool loop (stepCountIs(100)); use totalUsage so
-      // every round-trip is billed, not just the final step.
+      // Track AI usage. This is a tool loop (stepCountIs(20) when tools are
+      // enabled); use totalUsage so every round-trip is billed, not just the
+      // final step.
       const usage = result.totalUsage;
       AIMonitoring.trackUsage({
         userId,
@@ -548,6 +589,17 @@ export async function POST(request: Request) {
         { status: 500 }
       );
     }
+
+    // Persist the answer so the conversation can be continued via conversationId.
+    const assistantMessageId = createId();
+    await saveMessageToDatabase({
+      messageId: assistantMessageId,
+      pageId: agentId,
+      conversationId: activeConversationId,
+      userId: null,
+      role: 'assistant',
+      content: responseText,
+    });
 
     loggers.api.info('Agent consultation completed', {
       agentId,
@@ -574,8 +626,9 @@ export async function POST(request: Request) {
       question,
       response: responseText,
       context: context || null,
+      conversationId: activeConversationId,
       metadata: {
-        conversationLength: recentMessages.length,
+        conversationLength: historyMessages.length,
         toolsAvailable: Array.isArray(enabledTools) ? enabledTools.length : 0,
         provider: agent.aiProvider || 'default',
         model: agent.aiModel || 'default',


### PR DESCRIPTION
## Summary
- "Recent history" was ordered `createdAt` ascending then `limit(10)` — returning the agent's **first** 10 messages ever, not the most recent. Fixed by ordering DESC + limit, then reversing back to chronological order for the model.
- The route was fully ephemeral (no persistence, no `conversationId` accepted or returned), unlike the internal `ask_agent` tool which supports continuing a conversation. It now:
  - Persists both the question and the answer via `saveMessageToDatabase`.
  - Accepts an optional `conversationId` to continue a specific conversation — history is scoped to that conversation instead of blending all of the agent's page-wide history.
  - Always returns `conversationId` in the response so callers can continue later.
- The tool-enabled generation step budget was `stepCountIs(100)` vs internal `ask_agent`'s `stepCountIs(20)`. Since this route enables the same `ask_agent` tool, an externally/MCP-triggered consult call could run 5x the steps of an internally-triggered one. Aligned to 20.

Closes #1769

## Test plan
- [x] TDD: added 3 new RED tests reproducing each bug (history ordering, conversation continuity/persistence, step-cap), confirmed each failed against the old code, then fixed the route until green.
- [x] Updated the 2 pre-existing consult-route test files (`credit-gate.test.ts`, `mcp-scope-tool-filtering.test.ts`) to mock the new `desc`/`and` operators and `saveMessageToDatabase` so persistence is a no-op in those unrelated-concern tests — all still pass.
- [x] `bun run --filter 'web' typecheck` — green.
- [x] `bun run test src/app/api/ai/page-agents/consult/__tests__/` — 5 files, 10 tests, all green.
- [x] Full `bun run test:unit` run: 18 pre-existing failures elsewhere (Postgres test-role/DB-setup errors in `admin-role-version.test.ts` and `activity-tools.test.ts`, a midnight-boundary flake in `grouping.test.ts`, and an `EventModal` timeout) — none touch the consult route or files changed in this PR, and none are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVTsFiUtvQpjek9Y2E3Lx9