### PR TITLE
docs(api): clarify completedAt stamping is creation-only

### DIFF
--- a/docs/2.0-architecture/2.4-api/task-status-model.md
+++ b/docs/2.0-architecture/2.4-api/task-status-model.md
@@ -175,9 +175,11 @@ Error response example:
 
 `400 Bad Request`.
 
-Setting a status whose `group` is `'done'` (or, for a task list with no
-custom configs yet, a literal `status === 'completed'`) stamps
-`completedAt` on the task.
+Setting an initial `status` at creation time whose `group` is `'done'` (or,
+for a task list with no custom configs yet, a literal `status === 'completed'`)
+stamps `completedAt` on the new task. This route only creates tasks (`GET`
+and `POST` are the only handlers here) — it does not cover status changes on
+an existing task.
 
 ### `POST /api/mcp/documents` (`operation: 'read'`, `TASK_LIST` pages)
 


### PR DESCRIPTION
## Summary
Tiny precision follow-up to #1748 (merged). While self-reviewing that PR before it merged, I caught one more imprecise sentence that didn't make it into the merge in time: "Setting a status whose group is 'done' ... stamps completedAt on the task" reads as a general statement, but `apps/web/src/app/api/pages/[pageId]/tasks/route.ts` only has `GET` and `POST` handlers — this behavior is creation-time only, not a general status-update behavior. Clarified the wording accordingly.

## Test plan
- [x] N/A — documentation only
- [x] Verified the route file has no PATCH/PUT handler (`grep -n "^export async function" .../tasks/route.ts` → only GET, POST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1LZEPpCPPNJo1DRDBiw8U