### PR TITLE
sdk: implement AuthProvider abstraction + refresh state machine (Phase 2 task 4)

### DIFF
--- a/packages/sdk/src/auth/__tests__/decide.test.ts
+++ b/packages/sdk/src/auth/__tests__/decide.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AuthenticationError,
+  NetworkError,
+  NotFoundError,
+  PermissionDeniedError,
+  RateLimitError,
+  ServerError,
+  TimeoutError,
+  ValidationError,
+} from '../../errors.js';
+import { classifyRefreshFailure, decideTokenAction, type OAuthTokenState } from '../decide.js';
+
+function authenticated(accessExpiresAt: number): OAuthTokenState {
+  return { status: 'authenticated', accessExpiresAt };
+}
+
+describe('decideTokenAction', () => {
+  it('returns use-cached when well inside the skew window', () => {
+    expect(decideTokenAction(authenticated(100_000), 0, 60_000)).toBe('use-cached');
+  });
+
+  it('returns use-cached with exactly one ms of margin beyond the skew boundary', () => {
+    expect(decideTokenAction(authenticated(60_001), 0, 60_000)).toBe('use-cached');
+  });
+
+  it('returns refresh exactly at the skew boundary (now + skew === expiry)', () => {
+    expect(decideTokenAction(authenticated(60_000), 0, 60_000)).toBe('refresh');
+  });
+
+  it('returns refresh once already inside the skew window', () => {
+    expect(decideTokenAction(authenticated(59_999), 0, 60_000)).toBe('refresh');
+  });
+
+  it('returns refresh for an already-expired access token', () => {
+    expect(decideTokenAction(authenticated(-1), 0, 60_000)).toBe('refresh');
+  });
+
+  it('returns unauthenticated regardless of the recorded expiry once terminal', () => {
+    const state: OAuthTokenState = { status: 'unauthenticated', accessExpiresAt: Number.MAX_SAFE_INTEGER };
+    expect(decideTokenAction(state, 0, 60_000)).toBe('unauthenticated');
+  });
+
+  it('honors a caller-configured skew window rather than a hardcoded constant', () => {
+    expect(decideTokenAction(authenticated(5_000), 0, 1_000)).toBe('use-cached');
+    expect(decideTokenAction(authenticated(5_000), 4_000, 1_000)).toBe('refresh');
+  });
+});
+
+describe('classifyRefreshFailure', () => {
+  it('classifies a network failure as retryable', () => {
+    expect(classifyRefreshFailure(new NetworkError('offline'))).toBe('retryable');
+  });
+
+  it('classifies a timeout as retryable', () => {
+    expect(classifyRefreshFailure(new TimeoutError('slow'))).toBe('retryable');
+  });
+
+  it('classifies a 429 rate limit as retryable', () => {
+    expect(classifyRefreshFailure(new RateLimitError('slow down', 1000))).toBe('retryable');
+  });
+
+  it('classifies a 5xx server error as retryable', () => {
+    expect(classifyRefreshFailure(new ServerError('boom', 500))).toBe('retryable');
+    expect(classifyRefreshFailure(new ServerError('boom', 503))).toBe('retryable');
+  });
+
+  it('classifies a definitive invalid_grant-shaped 400 as terminal', () => {
+    expect(classifyRefreshFailure(new ValidationError('invalid_grant', []))).toBe('terminal');
+  });
+
+  it('classifies 401 invalid_client as terminal', () => {
+    expect(classifyRefreshFailure(new AuthenticationError('invalid_client'))).toBe('terminal');
+  });
+
+  it('classifies other definitive rejections as terminal', () => {
+    expect(classifyRefreshFailure(new PermissionDeniedError('forbidden'))).toBe('terminal');
+    expect(classifyRefreshFailure(new NotFoundError('gone'))).toBe('terminal');
+  });
+
+  it('fails closed (terminal) for an unrecognized error shape rather than retry-looping forever', () => {
+    expect(classifyRefreshFailure(new Error('mystery'))).toBe('terminal');
+    expect(classifyRefreshFailure('not an error')).toBe('terminal');
+    expect(classifyRefreshFailure(undefined)).toBe('terminal');
+  });
+});

--- a/packages/sdk/src/auth/__tests__/oauth.test.ts
+++ b/packages/sdk/src/auth/__tests__/oauth.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AuthenticationError, NetworkError, ValidationError } from '../../errors.js';
+import { OAuthTokenProvider, type OAuthTokens } from '../oauth.js';
+
+function makeTokens(overrides: Partial<OAuthTokens> = {}): OAuthTokens {
+  return {
+    accessToken: 'ps_at_initial',
+    accessExpiresAt: 1_000_000,
+    refreshToken: 'ps_rt_initial',
+    refreshExpiresAt: 5_000_000,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('OAuthTokenProvider', () => {
+  it('returns the cached access token when inside the skew window (no network call)', async () => {
+    const refreshAccessToken = vi.fn();
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 1_000_000 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    await expect(provider.getAccessToken()).resolves.toBe('ps_at_initial');
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('refreshes proactively at the skew boundary rather than waiting for a 401', async () => {
+    const refreshed = makeTokens({ accessToken: 'ps_at_new', accessExpiresAt: 2_000_000 });
+    const refreshAccessToken = vi.fn().mockResolvedValue(refreshed);
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 60_000, refreshToken: 'ps_rt_initial' }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    await expect(provider.getAccessToken()).resolves.toBe('ps_at_new');
+    expect(refreshAccessToken).toHaveBeenCalledWith('ps_rt_initial');
+  });
+
+  it('performs exactly one network refresh for N concurrent callers (single-flight)', async () => {
+    const { promise, resolve } = deferred<OAuthTokens>();
+    const refreshAccessToken = vi.fn().mockReturnValue(promise);
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 0 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    const calls = [provider.getAccessToken(), provider.getAccessToken(), provider.getAccessToken()];
+    resolve(makeTokens({ accessToken: 'ps_at_shared', accessExpiresAt: 2_000_000 }));
+
+    const results = await Promise.all(calls);
+    expect(results).toEqual(['ps_at_shared', 'ps_at_shared', 'ps_at_shared']);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a failed flight so the next call performs a fresh network refresh', async () => {
+    const first = deferred<OAuthTokens>();
+    const refreshAccessToken = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(makeTokens({ accessToken: 'ps_at_second_try', accessExpiresAt: 2_000_000 }));
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 0 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    const failingCall = provider.getAccessToken();
+    first.reject(new NetworkError('offline'));
+    await expect(failingCall).rejects.toBeInstanceOf(NetworkError);
+
+    await expect(provider.getAccessToken()).resolves.toBe('ps_at_second_try');
+    expect(refreshAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('invokes onTokensUpdated with the full rotated token payload on every successful refresh', async () => {
+    const refreshed = makeTokens({
+      accessToken: 'ps_at_new',
+      accessExpiresAt: 2_000_000,
+      refreshToken: 'ps_rt_new',
+      refreshExpiresAt: 6_000_000,
+    });
+    const refreshAccessToken = vi.fn().mockResolvedValue(refreshed);
+    const onTokensUpdated = vi.fn();
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 0 }),
+      refreshAccessToken,
+      onTokensUpdated,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    await provider.getAccessToken();
+    expect(onTokensUpdated).toHaveBeenCalledTimes(1);
+    expect(onTokensUpdated).toHaveBeenCalledWith(refreshed);
+  });
+
+  it('transitions to unauthenticated on a definitive invalid_grant rejection and does not retry-loop', async () => {
+    const refreshAccessToken = vi.fn().mockRejectedValue(new ValidationError('invalid_grant', []));
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 0 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    await expect(provider.getAccessToken()).rejects.toBeInstanceOf(AuthenticationError);
+    await expect(provider.getAccessToken()).rejects.toBeInstanceOf(AuthenticationError);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a transient refresh failure instead of going terminal', async () => {
+    const refreshAccessToken = vi
+      .fn()
+      .mockRejectedValueOnce(new NetworkError('offline'))
+      .mockResolvedValueOnce(makeTokens({ accessToken: 'ps_at_recovered', accessExpiresAt: 2_000_000 }));
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 0 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    await expect(provider.getAccessToken()).rejects.toBeInstanceOf(NetworkError);
+    await expect(provider.getAccessToken()).resolves.toBe('ps_at_recovered');
+  });
+
+  it('invalidate() forces the next call through refresh instead of replaying the rejected token', async () => {
+    const refreshAccessToken = vi
+      .fn()
+      .mockResolvedValue(makeTokens({ accessToken: 'ps_at_fresh', accessExpiresAt: 2_000_000 }));
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessToken: 'ps_at_stale', accessExpiresAt: 1_000_000 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    provider.invalidate();
+    await expect(provider.getAccessToken()).resolves.toBe('ps_at_fresh');
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op to invalidate() twice in a row', async () => {
+    const refreshAccessToken = vi
+      .fn()
+      .mockResolvedValue(makeTokens({ accessToken: 'ps_at_fresh', accessExpiresAt: 2_000_000 }));
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 1_000_000 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    provider.invalidate();
+    provider.invalidate();
+    await expect(provider.getAccessToken()).resolves.toBe('ps_at_fresh');
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('never includes a token value in a thrown error message or the provider\'s own serialization', async () => {
+    const secretRefreshToken = 'ps_rt_topsecret';
+    const secretAccessToken = 'ps_at_topsecret';
+    const refreshAccessToken = vi.fn().mockRejectedValue(new ValidationError('invalid_grant', []));
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({
+        accessToken: secretAccessToken,
+        accessExpiresAt: 0,
+        refreshToken: secretRefreshToken,
+      }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    let caught: unknown;
+    try {
+      await provider.getAccessToken();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AuthenticationError);
+    expect((caught as Error).message).not.toContain(secretRefreshToken);
+    expect((caught as Error).message).not.toContain(secretAccessToken);
+    expect(JSON.stringify(provider)).not.toContain(secretRefreshToken);
+    expect(JSON.stringify(provider)).not.toContain(secretAccessToken);
+  });
+
+  it('propagates the refresh HTTP call errors from the injected transport (no bespoke fetch inside the provider)', async () => {
+    const transportError = new NetworkError('DNS resolution failed');
+    const refreshAccessToken = vi.fn().mockRejectedValue(transportError);
+    const provider = new OAuthTokenProvider({
+      initialTokens: makeTokens({ accessExpiresAt: 0 }),
+      refreshAccessToken,
+      now: () => 0,
+      skewMs: 60_000,
+    });
+
+    await expect(provider.getAccessToken()).rejects.toBe(transportError);
+  });
+});

--- a/packages/sdk/src/auth/__tests__/static.test.ts
+++ b/packages/sdk/src/auth/__tests__/static.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { AuthenticationError } from '../../errors.js';
+import { StaticTokenProvider } from '../static.js';
+
+const TOKEN = 'mcp_super_secret_value_12345';
+
+describe('StaticTokenProvider', () => {
+  it('resolves the configured token', async () => {
+    const provider = new StaticTokenProvider(TOKEN);
+    await expect(provider.getAccessToken()).resolves.toBe(TOKEN);
+  });
+
+  it('resolves the same token across repeated calls (no refresh capability)', async () => {
+    const provider = new StaticTokenProvider(TOKEN);
+    await provider.getAccessToken();
+    await expect(provider.getAccessToken()).resolves.toBe(TOKEN);
+  });
+
+  it('fails closed with AuthenticationError after invalidate() — nothing to refresh into', async () => {
+    const provider = new StaticTokenProvider(TOKEN);
+    provider.invalidate();
+    await expect(provider.getAccessToken()).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('never exposes the token through default JSON serialization or string coercion', () => {
+    const provider = new StaticTokenProvider(TOKEN);
+    expect(JSON.stringify(provider)).not.toContain(TOKEN);
+    expect(String(provider)).not.toContain(TOKEN);
+  });
+});

--- a/packages/sdk/src/auth/decide.ts
+++ b/packages/sdk/src/auth/decide.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure decision core for OAuthTokenProvider (ADR 0003 §3.2, §6; Phase 2 task 4).
+ *
+ * No I/O. Clock and skew window are always passed in by the caller so every
+ * boundary is exhaustively testable with plain inputs.
+ */
+import {
+  isNetworkError,
+  isRateLimitError,
+  isServerError,
+  isTimeoutError,
+} from '../errors.js';
+
+export type TokenAction = 'use-cached' | 'refresh' | 'unauthenticated';
+
+export type OAuthTokenState =
+  | { status: 'authenticated'; accessExpiresAt: number }
+  | { status: 'unauthenticated'; accessExpiresAt: number };
+
+/**
+ * Decides what an OAuthTokenProvider should do for the next getAccessToken()
+ * call. Refreshes proactively once fewer than `skewMs` remain before expiry
+ * — never waits for the server to return a 401.
+ */
+export function decideTokenAction(
+  state: OAuthTokenState,
+  nowMs: number,
+  skewMs: number,
+): TokenAction {
+  if (state.status === 'unauthenticated') {
+    return 'unauthenticated';
+  }
+  return nowMs + skewMs < state.accessExpiresAt ? 'use-cached' : 'refresh';
+}
+
+export type RefreshFailureClassification = 'retryable' | 'terminal';
+
+/**
+ * Classifies a refresh-flight failure per ADR 0003 §6 classifyRefreshFailure:
+ * network errors, timeouts, 429, and 5xx are transient — retry per policy.
+ * Everything else (400 invalid_grant/invalid_request, 401 invalid_client,
+ * 403, or any error shape this SDK doesn't recognize) is treated as a
+ * definitive rejection: fail closed to 'terminal' rather than retry-loop on
+ * something that will never succeed.
+ */
+export function classifyRefreshFailure(error: unknown): RefreshFailureClassification {
+  if (
+    isNetworkError(error) ||
+    isTimeoutError(error) ||
+    isRateLimitError(error) ||
+    isServerError(error)
+  ) {
+    return 'retryable';
+  }
+  return 'terminal';
+}

--- a/packages/sdk/src/auth/oauth.ts
+++ b/packages/sdk/src/auth/oauth.ts
@@ -1,0 +1,120 @@
+/**
+ * OAuthTokenProvider (ADR 0003; Phase 2 task 4).
+ *
+ * Pure core (decide.ts) + I/O edges (clock, and the refresh HTTP call
+ * itself) constructor-injected — the "pure core, I/O edges" design law for
+ * this phase. `refreshAccessToken` is the injection point for task 3's
+ * transport against the token endpoint (form-encoded per Phase 1); this
+ * module deliberately contains no bespoke fetch of its own; the
+ * PageSpaceClient facade (task 6) wires the real transport in once it
+ * exists.
+ *
+ * Tokens live in a private class field only. Errors thrown by this class
+ * never embed a token value, and the class has no enumerable fields, so
+ * JSON.stringify/util.inspect on a provider instance never leaks a
+ * credential.
+ */
+import { AuthenticationError } from '../errors.js';
+import { classifyRefreshFailure, decideTokenAction, type OAuthTokenState } from './decide.js';
+import type { AuthProvider } from './provider.js';
+
+/** The opaque ps_at_* / ps_rt_* pair per ADR 0003 §3.1, plus their absolute expiries. */
+export interface OAuthTokens {
+  accessToken: string;
+  /** Epoch ms. */
+  accessExpiresAt: number;
+  refreshToken: string;
+  /** Epoch ms. */
+  refreshExpiresAt: number;
+}
+
+/**
+ * Performs the refresh-grant HTTP call and resolves the new token pair, or
+ * throws a PageSpaceError (see errors.ts) classifying the failure. This is
+ * the sole I/O edge of OAuthTokenProvider — implemented by the caller using
+ * the SDK's transport (task 3), never by this module.
+ */
+export type RefreshAccessToken = (refreshToken: string) => Promise<OAuthTokens>;
+
+export interface OAuthTokenProviderOptions {
+  initialTokens: OAuthTokens;
+  refreshAccessToken: RefreshAccessToken;
+  /** Injected clock; defaults to Date.now. */
+  now?: () => number;
+  /** Proactive-refresh skew window in ms; defaults to 60_000 per ADR 0003 §3.2. */
+  skewMs?: number;
+  /** Invoked with the full new token pair after every successful refresh, so the caller (CLI) can persist it. The SDK itself never touches disk. */
+  onTokensUpdated?: (tokens: OAuthTokens) => void;
+}
+
+const DEFAULT_SKEW_MS = 60_000;
+
+export class OAuthTokenProvider implements AuthProvider {
+  #tokens: OAuthTokens;
+  #status: 'authenticated' | 'unauthenticated' = 'authenticated';
+  readonly #now: () => number;
+  readonly #skewMs: number;
+  readonly #refreshAccessToken: RefreshAccessToken;
+  readonly #onTokensUpdated: ((tokens: OAuthTokens) => void) | undefined;
+  #inFlightRefresh: Promise<string> | null = null;
+
+  constructor(options: OAuthTokenProviderOptions) {
+    this.#tokens = options.initialTokens;
+    this.#refreshAccessToken = options.refreshAccessToken;
+    this.#now = options.now ?? Date.now;
+    this.#skewMs = options.skewMs ?? DEFAULT_SKEW_MS;
+    this.#onTokensUpdated = options.onTokensUpdated;
+  }
+
+  async getAccessToken(): Promise<string> {
+    const state: OAuthTokenState =
+      this.#status === 'unauthenticated'
+        ? { status: 'unauthenticated', accessExpiresAt: this.#tokens.accessExpiresAt }
+        : { status: 'authenticated', accessExpiresAt: this.#tokens.accessExpiresAt };
+
+    const action = decideTokenAction(state, this.#now(), this.#skewMs);
+
+    if (action === 'unauthenticated') {
+      throw new AuthenticationError('OAuth credential is unauthenticated; re-login required');
+    }
+    if (action === 'use-cached') {
+      return this.#tokens.accessToken;
+    }
+    return this.#refresh();
+  }
+
+  invalidate(): void {
+    if (this.#status === 'unauthenticated') {
+      return;
+    }
+    // Force the next getAccessToken() through the refresh path instead of
+    // replaying a token the caller just told us was rejected.
+    this.#tokens = { ...this.#tokens, accessExpiresAt: Number.NEGATIVE_INFINITY };
+  }
+
+  #refresh(): Promise<string> {
+    if (this.#inFlightRefresh) {
+      return this.#inFlightRefresh;
+    }
+    const flight = this.#performRefresh().finally(() => {
+      this.#inFlightRefresh = null;
+    });
+    this.#inFlightRefresh = flight;
+    return flight;
+  }
+
+  async #performRefresh(): Promise<string> {
+    try {
+      const tokens = await this.#refreshAccessToken(this.#tokens.refreshToken);
+      this.#tokens = tokens;
+      this.#onTokensUpdated?.(tokens);
+      return tokens.accessToken;
+    } catch (error) {
+      if (classifyRefreshFailure(error) === 'terminal') {
+        this.#status = 'unauthenticated';
+        throw new AuthenticationError('OAuth refresh rejected; re-login required');
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/sdk/src/auth/provider.ts
+++ b/packages/sdk/src/auth/provider.ts
@@ -1,0 +1,15 @@
+/**
+ * AuthProvider abstraction (ADR 0003; Phase 2 task 4).
+ *
+ * The one interface every credential source implements: static tokens
+ * (mcp_*, PAGESPACE_TOKEN — CI/agents) and OAuth-issued tokens (CLI login,
+ * ps_at_* / ps_rt_* per ADR 0003). Callers never branch on credential kind —
+ * they call getAccessToken() before every request and invalidate() when a
+ * request comes back 401.
+ */
+export interface AuthProvider {
+  /** Resolves the current access token, refreshing it first if the provider decides it needs to. */
+  getAccessToken(): Promise<string>;
+  /** Signals that the last token this provider returned was rejected; discard it. */
+  invalidate(): void;
+}

--- a/packages/sdk/src/auth/static.ts
+++ b/packages/sdk/src/auth/static.ts
@@ -1,0 +1,34 @@
+/**
+ * StaticTokenProvider (ADR 0003 §4; Phase 2 task 4).
+ *
+ * Wraps a fixed credential (mcp_* token, PAGESPACE_TOKEN) that is "used
+ * exactly as given: never refreshed, never written to the profile store"
+ * (ADR 0003 §4). There is no refresh path, so invalidate() has nothing to
+ * recover into — it fails closed on the next call rather than replaying a
+ * token the caller just told us was rejected.
+ *
+ * The token is held in a private class field, which util.inspect/JSON.stringify
+ * never surface — logging or serializing this provider cannot leak it.
+ */
+import { AuthenticationError } from '../errors.js';
+import type { AuthProvider } from './provider.js';
+
+export class StaticTokenProvider implements AuthProvider {
+  readonly #token: string;
+  #invalidated = false;
+
+  constructor(token: string) {
+    this.#token = token;
+  }
+
+  async getAccessToken(): Promise<string> {
+    if (this.#invalidated) {
+      throw new AuthenticationError('Static token was invalidated and has no refresh path; re-issue a new credential');
+    }
+    return this.#token;
+  }
+
+  invalidate(): void {
+    this.#invalidated = true;
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,3 +4,7 @@ export * from './transport/types.js';
 export * from './transport/build-request.js';
 export * from './transport/parse-response.js';
 export * from './transport/execute.js';
+export * from './auth/provider.js';
+export * from './auth/static.js';
+export * from './auth/oauth.js';
+export * from './auth/decide.js';


### PR DESCRIPTION
## Summary
- Implements `AuthProvider` interface + `StaticTokenProvider` + `OAuthTokenProvider` per ADR 0003 and PageSpace task page `v5quzjeb11mtn31vyxzo80zp` (Phase 2 task 4, epic `ea07mt5jvw0flihsbjce1iv9`).
- Pure decision core (`decideTokenAction`, `classifyRefreshFailure` in `decide.ts`) — clock and skew window injected, exhaustively boundary-tested.
- `OAuthTokenProvider`: proactive refresh inside a configurable skew window (never waits for a 401), single-flight refresh under concurrency (one network call for N concurrent `getAccessToken()` callers, failed flight clears so the next call retries), `onTokensUpdated(tokens)` rotation callback (SDK never touches disk — the CLI persists), and a terminal `unauthenticated` state on a definitive refresh rejection (no retry-loop).
- `refreshAccessToken` is constructor-injected — no bespoke fetch in this module; it's the drop-in point for task 3's transport against the token endpoint once that lands.
- Tokens live only in private class fields — no error message or `JSON.stringify`/`util.inspect` of a provider instance can leak a token.

## Test plan
- [x] RED: failing tests committed before implementation (`03c08caf9`)
- [x] GREEN: `bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` — green, 90 tests passing
- [x] No `any` types in new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2JuA6bDi2xBKF1cznRHXj