### PR TITLE
fix(mcp): line-number parity, write guardrails & read parity for documents API

### DIFF
--- a/apps/web/src/app/api/mcp/documents/__tests__/route.line-numbering.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.line-numbering.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * #1760 — MCP documents API line numbers must be computed from the same
+ * serialized content the internal read_page/replace_lines tools use
+ * (serializePageContentForAI), not raw stored TipTap HTML (which has no
+ * newlines and collapses a whole document to one "line").
+ */
+
+const mockFindFirstPage = vi.fn();
+const mockApplyPageMutation = vi.fn();
+const mockGetActorInfo = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  authenticateMCPRequest: vi.fn().mockResolvedValue({
+    userId: 'user_123',
+    tokenType: 'mcp',
+    tokenId: 'token_123',
+    role: 'user',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    allowedDriveIds: [],
+  }),
+  isAuthError: (result: unknown) => 'error' in (result as object),
+  isMCPAuthResult: () => true,
+  getPrincipalAccessLevel: vi.fn().mockResolvedValue({
+    canView: true,
+    canEdit: true,
+    canShare: false,
+    canDelete: false,
+  }),
+}));
+
+vi.mock('@pagespace/lib/sheets/sheet', () => ({
+  isSheetType: vi.fn(() => false),
+  parseSheetContent: vi.fn(),
+  serializeSheetContent: vi.fn(),
+  updateSheetCells: vi.fn(),
+  isValidCellAddress: vi.fn(() => true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return {
+    loggers: {
+      api: childLogger,
+      security: { warn: vi.fn() },
+      ai: { ...childLogger, child: vi.fn(() => childLogger) },
+    },
+    logger: { child: vi.fn(() => childLogger) },
+  };
+});
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: (...args: unknown[]) => mockGetActorInfo(...args),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(),
+}));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: (...args: unknown[]) => mockApplyPageMutation(...args),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@/services/api/task-sync-service', () => ({
+  backfillMissingTaskItems: vi.fn(),
+  ensureTaskListForPage: vi.fn(),
+  seedDefaultTaskStatusConfigs: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/tools/task-helpers', () => ({
+  fetchEnrichedTasks: vi.fn().mockResolvedValue([]),
+  serializeTaskItem: vi.fn((t: unknown) => t),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: (...args: unknown[]) => mockFindFirstPage(...args) },
+      taskLists: { findFirst: vi.fn() },
+      taskStatusConfigs: { findMany: vi.fn().mockResolvedValue([]) },
+      channelMessages: { findMany: vi.fn() },
+    },
+    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  asc: vi.fn(),
+  and: vi.fn(),
+  count: vi.fn(),
+  isNotNull: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed' },
+}));
+
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { pageId: 'taskItems.pageId', completedAt: 'taskItems.completedAt' },
+  taskLists: { pageId: 'taskLists.pageId' },
+  taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
+  DEFAULT_TASK_STATUSES: [],
+}));
+
+vi.mock('@pagespace/db/schema/chat', () => ({
+  channelMessages: { pageId: 'channelMessages.pageId', isActive: 'channelMessages.isActive', createdAt: 'channelMessages.createdAt' },
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/mcp/documents', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE_PAGE = {
+  id: 'page_123',
+  title: 'Test Page',
+  revision: 1,
+  parentId: null,
+  driveId: 'drive_123',
+  contentMode: 'html',
+};
+
+describe('MCP Documents API — line numbering parity (#1760)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActorInfo.mockResolvedValue({ actorEmail: 'a@b.com', actorDisplayName: 'A' });
+    mockApplyPageMutation.mockResolvedValue(undefined);
+  });
+
+  it('numbers an HTML document by its AI-serialized (line-broken) form, not raw stored HTML', async () => {
+    mockFindFirstPage.mockResolvedValue({
+      ...BASE_PAGE,
+      type: 'DOCUMENT',
+      content: '<p>First</p><p>Second</p>',
+    });
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+    const data = await response.json();
+
+    // Raw stored content has zero newlines and would collapse to 1 line —
+    // the fix must expand it via the same addLineBreaksForAI normalization
+    // the internal read_page/replace_lines tools use.
+    expect(data.totalLines).toBeGreaterThan(1);
+    expect(data.numberedLines.length).toBe(data.totalLines);
+    expect(data.content).not.toBe('<p>First</p><p>Second</p>');
+  });
+
+  it('leaves CODE page content raw (unbroken) — matches internal isRawText handling', async () => {
+    const codeContent = '<Foo>\n<Bar/>\n</Foo>';
+    mockFindFirstPage.mockResolvedValue({
+      ...BASE_PAGE,
+      type: 'CODE',
+      contentMode: 'html',
+      content: codeContent,
+    });
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+    const data = await response.json();
+
+    // CODE pages must never be run through addLineBreaksForAI (it would mangle
+    // raw markup) — line count must match the raw newline-delimited source.
+    expect(data.totalLines).toBe(3);
+    expect(data.content).toBe(codeContent);
+  });
+
+  it('leaves markdown contentMode content raw', async () => {
+    const mdContent = '# Heading\n\nSome *text*';
+    mockFindFirstPage.mockResolvedValue({
+      ...BASE_PAGE,
+      type: 'DOCUMENT',
+      contentMode: 'markdown',
+      content: mdContent,
+    });
+
+    const { POST } = await import('../route');
+    const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+    const data = await response.json();
+
+    expect(data.content).toBe(mdContent);
+    expect(data.totalLines).toBe(3);
+  });
+
+  it('replace targets the line numbers from the serialized form, agreeing with what read returned', async () => {
+    mockFindFirstPage.mockResolvedValue({
+      ...BASE_PAGE,
+      type: 'DOCUMENT',
+      content: '<p>First</p><p>Second</p>',
+    });
+
+    const { POST } = await import('../route');
+
+    // First, read to discover line numbers the way an MCP agent would.
+    const readResponse = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+    const readData = await readResponse.json();
+    expect(readData.totalLines).toBe(6); // <p> \n First \n </p> \n <p> \n Second \n </p>
+
+    // Replacing line 2 ("First") must succeed against that same numbering —
+    // before the fix, raw content was 1 line and this would 400 as out-of-range.
+    const replaceResponse = await POST(makeRequest({
+      operation: 'replace',
+      pageId: 'page_123',
+      startLine: 2,
+      content: 'Replaced',
+    }));
+
+    expect(replaceResponse.status).toBe(200);
+    expect(mockApplyPageMutation).toHaveBeenCalledTimes(1);
+    const mutationCall = mockApplyPageMutation.mock.calls[0][0];
+    expect(mutationCall.updates.content).toContain('Replaced');
+    expect(mutationCall.updates.content).not.toContain('First');
+  });
+});

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.read-parity.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.read-parity.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * #1762 — Read-path gaps in /api/mcp/documents vs internal read_page:
+ * 1. startLine/endLine ignored on read.
+ * 2. No CHANNEL branch (returns empty raw content).
+ * 3. No FILE processing-status handling / fileMetadata.
+ * 4. TASK_LIST reads omit parentTaskList and per-task subtask counts.
+ */
+
+const mockFindFirstPage = vi.fn();
+const mockFindFirstTaskList = vi.fn();
+const mockFindManyStatusConfigs = vi.fn();
+const mockFindManyChannelMessages = vi.fn();
+const mockFetchEnrichedTasks = vi.fn();
+const mockSerializeTaskItem = vi.fn();
+const mockSelectFrom = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  authenticateMCPRequest: vi.fn().mockResolvedValue({
+    userId: 'user_123',
+    tokenType: 'mcp',
+    tokenId: 'token_123',
+    role: 'user',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    allowedDriveIds: [],
+  }),
+  isAuthError: (result: unknown) => 'error' in (result as object),
+  isMCPAuthResult: () => true,
+  getPrincipalAccessLevel: vi.fn().mockResolvedValue({
+    canView: true,
+    canEdit: true,
+    canShare: false,
+    canDelete: false,
+  }),
+}));
+
+vi.mock('@pagespace/lib/sheets/sheet', () => ({
+  isSheetType: vi.fn(() => false),
+  parseSheetContent: vi.fn(),
+  serializeSheetContent: vi.fn(),
+  updateSheetCells: vi.fn(),
+  isValidCellAddress: vi.fn(() => true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return {
+    loggers: {
+      api: childLogger,
+      security: { warn: vi.fn() },
+      ai: { ...childLogger, child: vi.fn(() => childLogger) },
+    },
+    logger: { child: vi.fn(() => childLogger) },
+  };
+});
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'a@b.com', actorDisplayName: 'A' }),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(),
+}));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn(),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@/services/api/task-sync-service', () => ({
+  backfillMissingTaskItems: vi.fn().mockResolvedValue(undefined),
+  ensureTaskListForPage: vi.fn(async (_db: unknown, params: { pageId: string }) => {
+    const existing = await mockFindFirstTaskList();
+    if (existing) return existing;
+    return { id: 'tl_new', pageId: params.pageId };
+  }),
+  seedDefaultTaskStatusConfigs: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/ai/tools/task-helpers', () => ({
+  fetchEnrichedTasks: (...args: unknown[]) => mockFetchEnrichedTasks(...args),
+  serializeTaskItem: (...args: unknown[]) => mockSerializeTaskItem(...args),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: (...args: unknown[]) => mockFindFirstPage(...args) },
+      taskLists: { findFirst: (...args: unknown[]) => mockFindFirstTaskList(...args) },
+      taskStatusConfigs: { findMany: (...args: unknown[]) => mockFindManyStatusConfigs(...args) },
+      channelMessages: { findMany: (...args: unknown[]) => mockFindManyChannelMessages(...args) },
+    },
+    select: (...args: unknown[]) => mockSelectFrom(...args),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  asc: vi.fn(),
+  and: vi.fn(),
+  count: vi.fn(() => 'count()'),
+  isNotNull: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed' },
+}));
+
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { pageId: 'taskItems.pageId', completedAt: 'taskItems.completedAt' },
+  taskLists: { pageId: 'taskLists.pageId' },
+  taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
+  DEFAULT_TASK_STATUSES: [
+    { slug: 'pending', name: 'To Do', group: 'todo', position: 0, color: '#gray' },
+    { slug: 'in_progress', name: 'In Progress', group: 'in_progress', position: 1, color: '#amber' },
+    { slug: 'blocked', name: 'Blocked', group: 'in_progress', position: 2, color: '#red' },
+    { slug: 'completed', name: 'Done', group: 'done', position: 3, color: '#green' },
+  ],
+}));
+
+vi.mock('@pagespace/db/schema/chat', () => ({
+  channelMessages: { pageId: 'channelMessages.pageId', isActive: 'channelMessages.isActive', createdAt: 'channelMessages.createdAt' },
+}));
+
+// db.select(...).from(...) is used two shapes in the route:
+// - .select({id}).from(pages).where(...) — awaited directly (child-page backfill check)
+// - .select({...}).from(taskItems).innerJoin(pages, ...).where(...).groupBy(...) — sub-task counts
+// Make the mock support both chains off a single .from() call.
+function makeChainableSelectResult(baseRows: unknown[], groupedRows: unknown[]) {
+  return {
+    groupBy: () => Promise.resolve(groupedRows),
+    then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(baseRows).then(resolve, reject),
+  };
+}
+
+function makeFromResult(baseRows: unknown[] = [], groupedRows: unknown[] = []) {
+  return {
+    where: () => makeChainableSelectResult(baseRows, groupedRows),
+    innerJoin: () => ({
+      where: () => makeChainableSelectResult(baseRows, groupedRows),
+    }),
+  };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/mcp/documents', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE_PAGE = {
+  id: 'page_123',
+  title: 'Test Page',
+  revision: 1,
+  parentId: null,
+  driveId: 'drive_123',
+  contentMode: 'html',
+};
+
+describe('MCP Documents API — read parity (#1762)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirstTaskList.mockResolvedValue(null);
+    mockFindManyStatusConfigs.mockResolvedValue([]);
+    mockFetchEnrichedTasks.mockResolvedValue([]);
+    mockSerializeTaskItem.mockImplementation((t: unknown) => t);
+    mockSelectFrom.mockReturnValue({
+      from: () => makeFromResult(),
+    });
+  });
+
+  describe('1. ranged reads', () => {
+    it('honors startLine/endLine on a document read', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'DOCUMENT',
+        content: 'line one\nline two\nline three\nline four',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123', startLine: 2, endLine: 3 }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.rangeStart).toBe(2);
+      expect(data.rangeEnd).toBe(3);
+      expect(data.numberedLines.length).toBe(2);
+      expect(data.content).toBe('line two\nline three');
+      expect(data.content).not.toContain('line one');
+      expect(data.content).not.toContain('line four');
+    });
+
+    it('reports out-of-range starts without erroring', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, type: 'DOCUMENT', content: 'only line' });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123', startLine: 50 }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.numberedLines).toEqual([]);
+      expect(data.rangeMessage).toBeDefined();
+    });
+  });
+
+  describe('2. CHANNEL pages', () => {
+    it('returns a message transcript instead of empty raw content', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, type: 'CHANNEL', content: '' });
+      mockFindManyChannelMessages.mockResolvedValue([
+        {
+          id: 'm1',
+          content: JSON.stringify({ originalContent: 'hello there' }),
+          userId: 'user_123',
+          aiMeta: null,
+          user: { id: 'user_123', name: 'Alice' },
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        {
+          id: 'm2',
+          content: JSON.stringify({ originalContent: 'general kenobi' }),
+          userId: null,
+          aiMeta: { senderType: 'agent', senderName: 'Bot' },
+          user: null,
+          createdAt: new Date('2026-01-01T00:01:00.000Z'),
+        },
+      ]);
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.totalMessages).toBe(2);
+      expect(data.content).toContain('hello there');
+      expect(data.content).toContain('general kenobi');
+      expect(data.numberedLines.length).toBe(2);
+    });
+
+    it('returns an empty transcript summary for a channel with no messages', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, type: 'CHANNEL', content: '' });
+      mockFindManyChannelMessages.mockResolvedValue([]);
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.totalMessages).toBe(0);
+      expect(data.content).toBe('');
+    });
+  });
+
+  describe('3. FILE pages', () => {
+    it('reports pending processing status instead of returning empty content', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'FILE',
+        content: '',
+        processingStatus: 'pending',
+        mimeType: 'application/pdf',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe('pending');
+      expect(data.error).toMatch(/processed/i);
+    });
+
+    it('reports failed processing with the processingError', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'FILE',
+        content: '',
+        processingStatus: 'failed',
+        processingError: 'OCR timed out',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+      const data = await response.json();
+
+      expect(data.status).toBe('failed');
+      expect(data.processingError).toBe('OCR timed out');
+    });
+
+    it('includes fileMetadata for a completed file read', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'FILE',
+        content: 'extracted text',
+        processingStatus: 'completed',
+        mimeType: 'text/plain',
+        fileSize: 123,
+        originalFileName: 'notes.txt',
+        extractionMethod: 'text',
+        extractionMetadata: null,
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_123' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.fileMetadata).toBeDefined();
+      expect(data.fileMetadata.mimeType).toBe('text/plain');
+      expect(data.fileMetadata.originalFileName).toBe('notes.txt');
+      expect(data.content).toContain('extracted text');
+    });
+  });
+
+  describe('4. TASK_LIST sub-task counts and parent list', () => {
+    it('includes subTaskCount/subTaskCompletedCount per task', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, id: 'page_tl', type: 'TASK_LIST', content: '' });
+      mockFindFirstTaskList.mockResolvedValue({ id: 'tl_1', pageId: 'page_tl' });
+      mockFetchEnrichedTasks.mockResolvedValue([
+        { id: 't1', status: 'pending', completedAt: null, pageId: 'task_page_1' },
+      ]);
+      mockSerializeTaskItem.mockImplementation((t: { id: string; pageId: string }) => ({ id: t.id, pageId: t.pageId }));
+      mockSelectFrom.mockReturnValue({
+        from: () => makeFromResult([], [{ parentId: 'task_page_1', total: 3 }]),
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.tasks[0].subTaskCount).toBe(3);
+      expect(data.tasks[0]).toHaveProperty('subTaskCompletedCount');
+    });
+
+    it('includes parentTaskList when nested under another TASK_LIST page', async () => {
+      mockFindFirstPage.mockImplementation(async () => {
+        // First call resolves the requested page; second call (inside the route)
+        // resolves the parent page lookup.
+        const call = mockFindFirstPage.mock.calls.length;
+        if (call === 1) {
+          return { ...BASE_PAGE, id: 'page_child_tl', type: 'TASK_LIST', content: '', parentId: 'page_parent_tl' };
+        }
+        return { id: 'page_parent_tl', title: 'Parent List', type: 'TASK_LIST' };
+      });
+      mockFindFirstTaskList.mockImplementation(async () => {
+        const call = mockFindFirstTaskList.mock.calls.length;
+        if (call === 1) return { id: 'tl_child', pageId: 'page_child_tl' };
+        return { id: 'tl_parent', pageId: 'page_parent_tl' };
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_child_tl' }));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.parentTaskList).toBeDefined();
+      expect(data.parentTaskList.pageId).toBe('page_parent_tl');
+      expect(data.parentTaskList.taskListId).toBe('tl_parent');
+    });
+
+    it('parentTaskList is null for a top-level task list', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, id: 'page_tl', type: 'TASK_LIST', content: '', parentId: null });
+      mockFindFirstTaskList.mockResolvedValue({ id: 'tl_1', pageId: 'page_tl' });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
+      const data = await response.json();
+
+      expect(data.parentTaskList).toBeNull();
+    });
+  });
+});

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.task-list.test.ts
@@ -428,7 +428,7 @@ describe('MCP Documents API — TASK_LIST read', () => {
     expect(mockSerializeTaskItem).toHaveBeenCalledWith(raw[0]);
     // Only a boolean flag is exposed — never the child page body, which belongs
     // to a page this principal may not be authorized to read.
-    expect(data.tasks[0]).toEqual({ ...serialized, hasContent: true });
+    expect(data.tasks[0]).toEqual({ ...serialized, hasContent: true, subTaskCount: 0, subTaskCompletedCount: 0 });
   });
 
   it('reports hasContent false when the linked task page has no description', async () => {
@@ -441,7 +441,7 @@ describe('MCP Documents API — TASK_LIST read', () => {
     const response = await POST(makeRequest({ operation: 'read', pageId: 'page_tl' }));
 
     const data = await response.json();
-    expect(data.tasks[0]).toEqual({ ...serialized, hasContent: false });
+    expect(data.tasks[0]).toEqual({ ...serialized, hasContent: false, subTaskCount: 0, subTaskCompletedCount: 0 });
   });
 
   it('never returns child task page bodies (no inheritance: parent grant must not leak child content)', async () => {

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.write-guardrails.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.write-guardrails.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+/**
+ * #1761 — Three write-path hazards in /api/mcp/documents:
+ * 1. Unconditional addLineBreaksForAI corrupts CODE/markdown content on write.
+ * 2. No FILE/SHEET guardrails — MCP splices lines into any page type.
+ * 3. Silent current-page fallback when pageId is omitted.
+ */
+
+const mockFindFirstPage = vi.fn();
+const mockApplyPageMutation = vi.fn();
+const mockGetActorInfo = vi.fn();
+const mockIsSheetType = vi.fn((..._args: unknown[]) => false);
+
+vi.mock('@/lib/auth', () => ({
+  authenticateMCPRequest: vi.fn().mockResolvedValue({
+    userId: 'user_123',
+    tokenType: 'mcp',
+    tokenId: 'token_123',
+    role: 'user',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    allowedDriveIds: [],
+  }),
+  isAuthError: (result: unknown) => 'error' in (result as object),
+  isMCPAuthResult: () => true,
+  getPrincipalAccessLevel: vi.fn().mockResolvedValue({
+    canView: true,
+    canEdit: true,
+    canShare: false,
+    canDelete: false,
+  }),
+}));
+
+vi.mock('@pagespace/lib/sheets/sheet', () => ({
+  isSheetType: (...args: unknown[]) => mockIsSheetType(...args),
+  parseSheetContent: vi.fn(),
+  serializeSheetContent: vi.fn(),
+  updateSheetCells: vi.fn(),
+  isValidCellAddress: vi.fn(() => true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return {
+    loggers: {
+      api: childLogger,
+      security: { warn: vi.fn() },
+      ai: { ...childLogger, child: vi.fn(() => childLogger) },
+    },
+    logger: { child: vi.fn(() => childLogger) },
+  };
+});
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: (...args: unknown[]) => mockGetActorInfo(...args),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(),
+}));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: (...args: unknown[]) => mockApplyPageMutation(...args),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@/services/api/task-sync-service', () => ({
+  backfillMissingTaskItems: vi.fn(),
+  ensureTaskListForPage: vi.fn(),
+  seedDefaultTaskStatusConfigs: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/tools/task-helpers', () => ({
+  fetchEnrichedTasks: vi.fn().mockResolvedValue([]),
+  serializeTaskItem: vi.fn((t: unknown) => t),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: (...args: unknown[]) => mockFindFirstPage(...args) },
+      taskLists: { findFirst: vi.fn() },
+      taskStatusConfigs: { findMany: vi.fn().mockResolvedValue([]) },
+      channelMessages: { findMany: vi.fn() },
+    },
+    select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  asc: vi.fn(),
+  and: vi.fn(),
+  count: vi.fn(),
+  isNotNull: vi.fn(),
+  inArray: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed' },
+}));
+
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { pageId: 'taskItems.pageId', completedAt: 'taskItems.completedAt' },
+  taskLists: { pageId: 'taskLists.pageId' },
+  taskStatusConfigs: { taskListId: 'taskStatusConfigs.taskListId', position: 'taskStatusConfigs.position' },
+  DEFAULT_TASK_STATUSES: [],
+}));
+
+vi.mock('@pagespace/db/schema/chat', () => ({
+  channelMessages: { pageId: 'channelMessages.pageId', isActive: 'channelMessages.isActive', createdAt: 'channelMessages.createdAt' },
+}));
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/mcp/documents', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE_PAGE = {
+  id: 'page_123',
+  title: 'Test Page',
+  revision: 1,
+  parentId: null,
+  driveId: 'drive_123',
+};
+
+describe('MCP Documents API — write guardrails (#1761)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSheetType.mockReturnValue(false);
+    mockGetActorInfo.mockResolvedValue({ actorEmail: 'a@b.com', actorDisplayName: 'A' });
+    mockApplyPageMutation.mockResolvedValue(undefined);
+  });
+
+  describe('1. normalization must not corrupt CODE/markdown content', () => {
+    it('does not run addLineBreaksForAI on a CODE page replace', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'CODE',
+        contentMode: 'html',
+        content: '<Foo>\n<Bar/>\n</Foo>',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({
+        operation: 'replace',
+        pageId: 'page_123',
+        startLine: 2,
+        content: '<Baz/>',
+      }));
+
+      expect(response.status).toBe(200);
+      const mutationCall = mockApplyPageMutation.mock.calls[0][0];
+      // addLineBreaksForAI would inject newlines around block-like tags —
+      // raw code content must pass through untouched apart from the edited line.
+      expect(mutationCall.updates.content).toBe('<Foo>\n<Baz/>\n</Foo>');
+    });
+
+    it('does not run addLineBreaksForAI on a markdown-mode insert', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'DOCUMENT',
+        contentMode: 'markdown',
+        content: '# Title\n\nBody',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({
+        operation: 'insert',
+        pageId: 'page_123',
+        startLine: 1,
+        content: '<div>raw html the user typed</div>',
+      }));
+
+      expect(response.status).toBe(200);
+      const mutationCall = mockApplyPageMutation.mock.calls[0][0];
+      expect(mutationCall.updates.content).toBe('<div>raw html the user typed</div>\n# Title\n\nBody');
+    });
+
+    it('still normalizes HTML document writes (unchanged behavior for DOCUMENT/html)', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'DOCUMENT',
+        contentMode: 'html',
+        content: '<p>Hello</p>',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({
+        operation: 'delete',
+        pageId: 'page_123',
+        startLine: 1,
+        endLine: 1,
+      }));
+
+      expect(response.status).toBe(200);
+      expect(mockApplyPageMutation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('2. FILE/SHEET guardrails', () => {
+    it('rejects replace on a FILE page', async () => {
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'FILE',
+        content: 'extracted text',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({
+        operation: 'replace',
+        pageId: 'page_123',
+        startLine: 1,
+        content: 'malicious overwrite',
+      }));
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toMatch(/FILE/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('rejects insert on a FILE page', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, type: 'FILE', content: 'x' });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'insert', pageId: 'page_123', startLine: 1, content: 'y' }));
+
+      expect(response.status).toBe(400);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('rejects delete on a FILE page', async () => {
+      mockFindFirstPage.mockResolvedValue({ ...BASE_PAGE, type: 'FILE', content: 'x\ny' });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'delete', pageId: 'page_123', startLine: 1 }));
+
+      expect(response.status).toBe(400);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('rejects line-replace on a SHEET page and redirects to edit-cells', async () => {
+      mockIsSheetType.mockReturnValue(true);
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'SHEET',
+        content: '[cells]\nA1 = "1"',
+      });
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({
+        operation: 'replace',
+        pageId: 'page_123',
+        startLine: 1,
+        content: 'garbage',
+      }));
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error).toMatch(/sheet/i);
+      expect(data.message ?? data.suggestion).toMatch(/edit-cells/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('still allows edit-cells on a SHEET page (guardrail only blocks line ops)', async () => {
+      mockIsSheetType.mockReturnValue(true);
+      mockFindFirstPage.mockResolvedValue({
+        ...BASE_PAGE,
+        type: 'SHEET',
+        content: '[cells]\nA1 = "1"',
+      });
+
+      const sheetModule = await import('@pagespace/lib/sheets/sheet');
+      (sheetModule.parseSheetContent as ReturnType<typeof vi.fn>).mockReturnValue({ cells: {}, rowCount: 1, columnCount: 1 });
+      (sheetModule.updateSheetCells as ReturnType<typeof vi.fn>).mockReturnValue({ cells: {}, rowCount: 1, columnCount: 1 });
+      (sheetModule.serializeSheetContent as ReturnType<typeof vi.fn>).mockReturnValue('[cells]\nA1 = "2"');
+
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({
+        operation: 'edit-cells',
+        pageId: 'page_123',
+        cells: [{ address: 'A1', value: '2' }],
+      }));
+
+      expect(response.status).toBe(200);
+      expect(mockApplyPageMutation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('3. pageId is required — no silent current-page fallback', () => {
+    it('returns a 400 validation error when pageId is omitted on read', async () => {
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'read' }));
+
+      expect(response.status).toBe(400);
+      expect(mockFindFirstPage).not.toHaveBeenCalled();
+    });
+
+    it('returns a 400 validation error when pageId is omitted on replace', async () => {
+      const { POST } = await import('../route');
+      const response = await POST(makeRequest({ operation: 'replace', startLine: 1, content: 'x' }));
+
+      expect(response.status).toBe(400);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -1,46 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, asc, and } from '@pagespace/db/operators'
+import { eq, asc, and, count, isNotNull, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
-import { taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
+import { taskItems, taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
+import { channelMessages } from '@pagespace/db/schema/chat';
 import { fetchEnrichedTasks, serializeTaskItem } from '@/lib/ai/tools/task-helpers';
 import { backfillMissingTaskItems, ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { computeHasContent } from '@/app/api/pages/[pageId]/tasks/task-utils';
 import { PageType } from '@pagespace/lib/utils/enums';
+import { isCodePage } from '@pagespace/lib/content/page-types.config';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets/sheet';
 import { z } from 'zod/v4';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
+import { serializePageContentForAI } from '@/lib/ai/core/page-serializer';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult, getPrincipalAccessLevel } from '@/lib/auth';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
-
-// Get the current page ID for the user
-async function getCurrentPageId(userId: string): Promise<string | null> {
-  try {
-    // For now, we'll get the user's most recently modified page
-    // In a future iteration, we might track the "active" page differently
-    const userPage = await db.query.pages.findFirst({
-      where: (pages, { isNull }) => isNull(pages.isTrashed),
-      with: {
-        drive: true,
-      },
-      orderBy: (pages, { desc }) => [desc(pages.updatedAt)],
-    });
-    
-    // Filter for pages owned by the user
-    if (userPage && userPage.drive.ownerId === userId) {
-      return userPage.id;
-    }
-    
-    return null;
-  } catch (error) {
-    loggers.api.error('Error getting current page:', error as Error);
-    return null;
-  }
-}
 
 // Get drive slug from page for socket broadcasting
 async function getDriveIdFromPage(pageId: string): Promise<string | null> {
@@ -51,7 +29,7 @@ async function getDriveIdFromPage(pageId: string): Promise<string | null> {
         drive: true,
       },
     });
-    
+
     return page?.drive?.id || null;
   } catch (error) {
     loggers.api.error('Error getting drive id:', error as Error);
@@ -66,20 +44,74 @@ function getNumberedLines(content: string): string[] {
   return lines.map((line, index) => `${(index + 1).toString().padStart(4, ' ')} | ${line}`);
 }
 
+// Extract display text from a channel message's JSON content, mirroring the
+// internal read_page CHANNEL handling so MCP transcripts match exactly.
+function extractChannelMessageText(content: string): string {
+  try {
+    const parsed = JSON.parse(content) as {
+      originalContent?: unknown;
+      parts?: Array<{ type?: string; text?: string }>;
+      textParts?: string[];
+    };
+
+    if (typeof parsed.originalContent === 'string') {
+      return parsed.originalContent;
+    }
+
+    if (Array.isArray(parsed.parts)) {
+      const textParts = parsed.parts
+        .filter(part => part?.type === 'text' && typeof part.text === 'string')
+        .map(part => part.text as string);
+      if (textParts.length > 0) {
+        return textParts.join('\n');
+      }
+    }
+
+    if (Array.isArray(parsed.textParts)) {
+      return parsed.textParts.join('\n');
+    }
+  } catch {
+    // Fall through and return raw content
+  }
+
+  return content;
+}
+
+interface ChannelMessageForSender {
+  userId: string | null;
+  user?: { id: string; name: string | null } | null;
+  aiMeta?: { senderType?: string; senderName?: string } | null;
+}
+
+function getChannelSenderInfo(message: ChannelMessageForSender) {
+  const senderName = message.aiMeta?.senderName || message.user?.name || 'Unknown';
+
+  if (message.aiMeta?.senderType === 'agent') {
+    return { senderType: 'agent' as const, senderName, prefix: '[agent]' };
+  }
+
+  if (message.aiMeta?.senderType === 'global_assistant') {
+    return { senderType: 'global_assistant' as const, senderName, prefix: '[assistant]' };
+  }
+
+  return { senderType: 'user' as const, senderName, prefix: '[user]' };
+}
+
 // Schema for cell updates
 const cellUpdateSchema = z.object({
   address: z.string(),
   value: z.string(),
 });
 
-// Schema for line/cell operations
+// Schema for line/cell operations. pageId is required — MCP tools must always
+// name their target page explicitly (no silent "current page" fallback).
 const lineOperationSchema = z.object({
   operation: z.enum(['read', 'replace', 'insert', 'delete', 'edit-cells']),
-  pageId: z.string().optional(), // Optional page ID, will use current page if not provided
+  pageId: z.string(),
   startLine: z.number().min(1).optional(),
   endLine: z.number().min(1).optional(),
   content: z.string().optional(),
-  cells: z.array(cellUpdateSchema).optional(), // For edit-cells operation
+  cells: z.array(cellUpdateSchema).optional(),
 });
 
 export async function POST(req: NextRequest) {
@@ -97,14 +129,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { operation, pageId: providedPageId, startLine, endLine, content, cells } = lineOperationSchema.parse(body);
-
-    // Get the page ID (use provided or get current)
-    const pageId = providedPageId || await getCurrentPageId(userId);
-
-    if (!pageId) {
-      return NextResponse.json({ error: 'No active document found' }, { status: 404 });
-    }
+    const { operation, pageId, startLine, endLine, content, cells } = lineOperationSchema.parse(body);
 
     // Check drive scope restrictions before permission check
     if (allowedDriveIds.length > 0) {
@@ -167,14 +192,45 @@ export async function POST(req: NextRequest) {
     const page = await db.query.pages.findFirst({
       where: eq(pages.id, pageId),
     });
-    
+
     if (!page) {
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
-    
-    const currentContent = page.content || '';
-    const lines = currentContent.split('\n');
-    
+
+    // Guardrails for line-based write operations, mirroring the internal
+    // replace_lines tool exactly: FILE pages are read-only (system-managed
+    // extraction), and SHEET pages use structured cell data, not lines.
+    if (operation === 'replace' || operation === 'insert' || operation === 'delete') {
+      if (page.type === PageType.FILE) {
+        return NextResponse.json({
+          error: 'Cannot edit FILE pages',
+          message: 'This is an uploaded file. File content is read-only and managed by the system.',
+          suggestion: 'To modify content, create a new document page instead of editing the uploaded file.',
+          pageInfo: { pageId: page.id, title: page.title, type: page.type, mimeType: page.mimeType },
+        }, { status: 400 });
+      }
+
+      if (isSheetType(page.type as PageType)) {
+        return NextResponse.json({
+          error: 'Cannot use line editing on sheets',
+          message: 'Sheet pages use structured cell data. Use the edit-cells operation instead for cell-level edits.',
+          suggestion: 'Use operation: "edit-cells" with cell addresses (A1, B2, etc.) to modify sheet content.',
+          pageInfo: { pageId: page.id, title: page.title, type: page.type },
+        }, { status: 400 });
+      }
+    }
+
+    const rawContent = page.content || '';
+
+    // CODE and markdown pages have natural line structure (and CODE may
+    // contain raw HTML/XML that addLineBreaksForAI would mangle); HTML
+    // documents are normalized. Shared with the internal read_page/
+    // replace_lines tools via serializePageContentForAI so both surfaces
+    // agree on line numbers.
+    const isRawText = page.contentMode === 'markdown' || isCodePage(page.type as PageType);
+    const serializedContent = serializePageContentForAI(page);
+    const lines = serializedContent.split('\n');
+
     switch (operation) {
       case 'read': {
         auditRequest(req, { eventType: 'data.read', userId, resourceType: 'page', resourceId: pageId, details: { source: 'mcp', operation: 'read' } });
@@ -244,11 +300,57 @@ export async function POST(req: NextRequest) {
           const completedCount = byGroup.done || 0;
           const progressPercentage = totalTasks > 0 ? Math.round((completedCount / totalTasks) * 100) : 0;
 
+          // Resolve parent task list (if this list is nested under another task).
+          let parentTaskList: { pageId: string; title: string; taskListId: string } | null = null;
+          if (page.parentId) {
+            const parentPage = await db.query.pages.findFirst({
+              where: and(eq(pages.id, page.parentId), eq(pages.isTrashed, false)),
+              columns: { id: true, title: true, type: true },
+            });
+            if (parentPage?.type === PageType.TASK_LIST) {
+              const parentList = await db.query.taskLists.findFirst({
+                where: eq(taskLists.pageId, parentPage.id),
+                columns: { id: true },
+              });
+              if (parentList) {
+                parentTaskList = { pageId: parentPage.id, title: parentPage.title, taskListId: parentList.id };
+              }
+            }
+          }
+
+          // Batch sub-task counts (total + completed) per task page.
+          const taskPageIds = tasks.map(t => t.pageId).filter((id): id is string => !!id);
+          const subTaskCountMap = new Map<string, number>();
+          const subTaskCompletedMap = new Map<string, number>();
+          if (taskPageIds.length > 0) {
+            const baseWhere = and(inArray(pages.parentId, taskPageIds), eq(pages.isTrashed, false));
+            const [subTaskRows, completedRows] = await Promise.all([
+              db
+                .select({ parentId: pages.parentId, total: count() })
+                .from(taskItems)
+                .innerJoin(pages, eq(pages.id, taskItems.pageId))
+                .where(baseWhere)
+                .groupBy(pages.parentId),
+              db
+                .select({ parentId: pages.parentId, total: count() })
+                .from(taskItems)
+                .innerJoin(pages, eq(pages.id, taskItems.pageId))
+                .where(and(baseWhere, isNotNull(taskItems.completedAt)))
+                .groupBy(pages.parentId),
+            ]);
+            for (const row of subTaskRows) {
+              if (row.parentId) subTaskCountMap.set(row.parentId, Number(row.total));
+            }
+            for (const row of completedRows) {
+              if (row.parentId) subTaskCompletedMap.set(row.parentId, Number(row.total));
+            }
+          }
+
           // A TASK_LIST page also has its own content body (e.g. an
           // individual task page whose body holds the description / sub-tasks).
           // This body belongs to `pageId` itself — already authorized above —
           // so it is safe to return. Render both the body and the task view.
-          const numberedLines = getNumberedLines(currentContent);
+          const numberedLines = getNumberedLines(serializedContent);
 
           // Each task is a child TASK_LIST page. Page permissions do NOT inherit
           // to children, and this route only authorizes `pageId`, so we must NOT
@@ -260,10 +362,16 @@ export async function POST(req: NextRequest) {
             pageTitle: page.title,
             pageType: 'TASK_LIST',
             taskListId: taskList.id,
+            parentTaskList,
             totalLines: lines.length,
             numberedLines,
-            content: currentContent,
-            tasks: tasks.map(t => ({ ...serializeTaskItem(t), hasContent: computeHasContent(t.page?.content) })),
+            content: serializedContent,
+            tasks: tasks.map(t => ({
+              ...serializeTaskItem(t),
+              hasContent: computeHasContent(t.page?.content),
+              subTaskCount: subTaskCountMap.get(t.pageId ?? '') ?? 0,
+              subTaskCompletedCount: subTaskCompletedMap.get(t.pageId ?? '') ?? 0,
+            })),
             availableStatuses,
             progress: {
               total: totalTasks,
@@ -274,36 +382,204 @@ export async function POST(req: NextRequest) {
           });
         }
 
-        const numberedLines = getNumberedLines(currentContent);
+        // Validate line range parameters (shared by CHANNEL and the generic
+        // text path below).
+        if (startLine !== undefined && startLine < 1) {
+          return NextResponse.json({ error: 'Invalid line range: line numbers must be positive integers' }, { status: 400 });
+        }
+        if (endLine !== undefined && endLine < 1) {
+          return NextResponse.json({ error: 'Invalid line range: line numbers must be positive integers' }, { status: 400 });
+        }
+        if (startLine !== undefined && endLine !== undefined && startLine > endLine) {
+          return NextResponse.json({ error: `Invalid line range: startLine (${startLine}) cannot be greater than endLine (${endLine})` }, { status: 400 });
+        }
+
+        const isRangeRequest = startLine !== undefined || endLine !== undefined;
+
+        if (page.type === PageType.CHANNEL) {
+          const messages = await db.query.channelMessages.findMany({
+            where: and(
+              eq(channelMessages.pageId, page.id),
+              eq(channelMessages.isActive, true)
+            ),
+            with: {
+              user: {
+                columns: { id: true, name: true },
+              },
+            },
+            orderBy: [asc(channelMessages.createdAt)],
+          });
+
+          const totalMessages = messages.length;
+
+          if (totalMessages === 0) {
+            return NextResponse.json({
+              pageId,
+              pageTitle: page.title,
+              pageType: 'CHANNEL',
+              totalLines: 0,
+              numberedLines: [],
+              content: '',
+              messageCount: 0,
+              totalMessages: 0,
+            });
+          }
+
+          const effectiveStart = startLine ?? 1;
+          const effectiveEnd = endLine !== undefined ? Math.min(endLine, totalMessages) : totalMessages;
+
+          if (effectiveStart > totalMessages) {
+            return NextResponse.json({
+              pageId,
+              pageTitle: page.title,
+              pageType: 'CHANNEL',
+              totalLines: totalMessages,
+              numberedLines: [],
+              content: '',
+              messageCount: 0,
+              totalMessages,
+              rangeStart: effectiveStart,
+              rangeEnd: effectiveEnd,
+              rangeMessage: `Requested range (${effectiveStart}-${endLine ?? totalMessages}) is beyond channel length (${totalMessages} messages)`,
+            });
+          }
+
+          const selectedMessages = messages.slice(effectiveStart - 1, effectiveEnd);
+
+          const numberedLines = selectedMessages.map((message, index) => {
+            const lineNumber = effectiveStart + index;
+            const sender = getChannelSenderInfo(message);
+            const timestamp = message.createdAt.toISOString();
+            const text = extractChannelMessageText(message.content);
+            return `${lineNumber.toString().padStart(4, ' ')} | ${sender.prefix} ${sender.senderName} (${timestamp}): ${text}`;
+          });
+
+          const channelContent = selectedMessages.map(message => {
+            const sender = getChannelSenderInfo(message);
+            const timestamp = message.createdAt.toISOString();
+            const text = extractChannelMessageText(message.content);
+            return `${sender.prefix} ${sender.senderName} (${timestamp}): ${text}`;
+          }).join('\n');
+
+          return NextResponse.json({
+            pageId,
+            pageTitle: page.title,
+            pageType: 'CHANNEL',
+            totalLines: totalMessages,
+            numberedLines,
+            content: channelContent,
+            messageCount: selectedMessages.length,
+            totalMessages,
+            ...(isRangeRequest && { rangeStart: effectiveStart, rangeEnd: effectiveEnd }),
+          });
+        }
+
+        // FILE pages: surface processing status instead of falling through to
+        // (empty/partial) raw content. 'completed' falls through to the
+        // generic text path below, with fileMetadata attached.
+        if (page.type === PageType.FILE) {
+          if (page.processingStatus === 'pending' || page.processingStatus === 'processing') {
+            return NextResponse.json({
+              pageId,
+              pageTitle: page.title,
+              pageType: 'FILE',
+              status: page.processingStatus,
+              error: 'File is still being processed',
+              suggestion: 'Please try again in a moment',
+            });
+          }
+
+          if (page.processingStatus === 'failed') {
+            return NextResponse.json({
+              pageId,
+              pageTitle: page.title,
+              pageType: 'FILE',
+              status: page.processingStatus,
+              error: 'Failed to extract content from this file',
+              processingError: page.processingError,
+              suggestion: 'Try reprocessing the file or contact support',
+            });
+          }
+
+          if (page.processingStatus === 'visual') {
+            return NextResponse.json({
+              pageId,
+              pageTitle: page.title,
+              pageType: 'FILE',
+              status: page.processingStatus,
+              message: `This is a visual file (${page.mimeType || 'image'}). Vision-capable processing is required to interpret its content.`,
+              fileMetadata: {
+                mimeType: page.mimeType,
+                fileSize: page.fileSize,
+                originalFileName: page.originalFileName,
+                processingStatus: page.processingStatus,
+              },
+            });
+          }
+        }
+
+        const fileMetadata = page.type === PageType.FILE ? {
+          mimeType: page.mimeType,
+          fileSize: page.fileSize,
+          originalFileName: page.originalFileName,
+          processingStatus: page.processingStatus,
+          extractionMethod: page.extractionMethod,
+          extractionMetadata: page.extractionMetadata,
+        } : undefined;
+
+        const totalLines = lines.length;
+        const effectiveStart = startLine ?? 1;
+        const effectiveEnd = endLine !== undefined ? Math.min(endLine, totalLines) : totalLines;
+
+        if (effectiveStart > totalLines) {
+          return NextResponse.json({
+            pageId,
+            pageTitle: page.title,
+            totalLines,
+            numberedLines: [],
+            content: '',
+            rangeStart: effectiveStart,
+            rangeEnd: effectiveEnd,
+            rangeMessage: `Requested range (${effectiveStart}-${endLine ?? totalLines}) is beyond document length (${totalLines} lines)`,
+          });
+        }
+
+        const selectedLines = lines.slice(effectiveStart - 1, effectiveEnd);
+        const numberedLines = selectedLines.map((line, index) => `${(effectiveStart + index).toString().padStart(4, ' ')} | ${line}`);
+        const rangeContent = selectedLines.join('\n');
+
         return NextResponse.json({
           pageId,
           pageTitle: page.title,
-          totalLines: lines.length,
+          totalLines,
           numberedLines,
-          content: currentContent,
+          content: rangeContent,
+          ...(fileMetadata && { fileMetadata }),
+          ...(isRangeRequest && { rangeStart: effectiveStart, rangeEnd: effectiveEnd }),
         });
       }
-      
+
       case 'replace': {
         if (!startLine || !content) {
           return NextResponse.json({ error: 'startLine and content are required for replace' }, { status: 400 });
         }
-        
+
         const actualEndLine = endLine || startLine;
-        
+
         if (startLine > lines.length || actualEndLine > lines.length) {
           return NextResponse.json({ error: 'Line number out of range' }, { status: 400 });
         }
-        
+
         // Replace lines (convert to 0-based index)
         const newLines = [
           ...lines.slice(0, startLine - 1),
           ...content.split('\n'),
           ...lines.slice(actualEndLine),
         ];
-        
-        const newContent = addLineBreaksForAI(newLines.join('\n'));
-        
+
+        const joined = newLines.join('\n');
+        const newContent = isRawText ? joined : addLineBreaksForAI(joined);
+
         const actorInfo = await getActorInfo(userId);
         await applyPageMutation({
           pageId,
@@ -322,7 +598,7 @@ export async function POST(req: NextRequest) {
             },
           },
         });
-        
+
         // Broadcast content update event
         const driveId = await getDriveIdFromPage(pageId);
         if (driveId) {
@@ -346,7 +622,7 @@ export async function POST(req: NextRequest) {
           affectedLines: `${startLine}-${actualEndLine}`,
         });
       }
-      
+
       case 'insert': {
         if (!startLine || !content) {
           return NextResponse.json({ error: 'startLine and content are required for insert' }, { status: 400 });
@@ -360,7 +636,8 @@ export async function POST(req: NextRequest) {
           ...lines.slice(insertIndex),
         ];
 
-        const newContent = addLineBreaksForAI(newLines.join('\n'));
+        const joined = newLines.join('\n');
+        const newContent = isRawText ? joined : addLineBreaksForAI(joined);
 
         const actorInfo = await getActorInfo(userId);
         await applyPageMutation({
@@ -405,7 +682,7 @@ export async function POST(req: NextRequest) {
           insertedAt: startLine,
         });
       }
-      
+
       case 'delete': {
         if (!startLine) {
           return NextResponse.json({ error: 'startLine is required for delete' }, { status: 400 });
@@ -423,7 +700,8 @@ export async function POST(req: NextRequest) {
           ...lines.slice(actualEndLine),
         ];
 
-        const newContent = addLineBreaksForAI(newLines.join('\n'));
+        const joined = newLines.join('\n');
+        const newContent = isRawText ? joined : addLineBreaksForAI(joined);
 
         const actorInfo = await getActorInfo(userId);
         await applyPageMutation({
@@ -492,7 +770,7 @@ export async function POST(req: NextRequest) {
         }
 
         // Parse existing sheet content
-        const sheetData = parseSheetContent(currentContent);
+        const sheetData = parseSheetContent(rawContent);
 
         // Apply cell updates
         const updatedSheet = updateSheetCells(sheetData, cells);

--- a/docs/2.0-architecture/2.4-api/mcp-documents-api.md
+++ b/docs/2.0-architecture/2.4-api/mcp-documents-api.md
@@ -62,34 +62,29 @@ const cellUpdateSchema = z.object({
 
 {
   operation: 'read' | 'replace' | 'insert' | 'delete' | 'edit-cells',
-  pageId?: string,       // optional — see fallback caveat below if omitted
-  startLine?: number,    // replace / insert / delete
-  endLine?: number,      // replace / delete (defaults to startLine)
-  content?: string,      // replace / insert
+  pageId: string,         // required — no "current page" fallback
+  startLine?: number,     // read (ranged) / replace / insert / delete
+  endLine?: number,       // read (ranged) / replace / delete (defaults to startLine)
+  content?: string,       // replace / insert
   cells?: { address: string; value: string }[],  // edit-cells
 }
 ```
 
-**`pageId` omitted:** the route calls `getCurrentPageId(userId)`
-(`route.ts` ~line 21), which is **not** a user-scoped "your most recent
-page" lookup, and as currently written **never resolves to a page at all**.
-Its query filters with `isNull(pages.isTrashed)` — but `pages.isTrashed` is
-`boolean(...).default(false).notNull()` (`packages/db/src/schema/core.ts`),
-so it is never actually `NULL`; that predicate matches zero rows for every
-normal page, on any instance, for any user. The intent was almost certainly
-`eq(pages.isTrashed, false)` ("not trashed"). Until that's fixed,
-`getCurrentPageId` always returns `null` and omitting `pageId` always 404s
-with `{ "error": "No active document found" }`. **Treat `pageId` as
-required** — there is currently no working fallback.
+**`pageId` is required.** There used to be a fallback to
+`getCurrentPageId(userId)` when it was omitted — a broken, unpredictable
+"most recently updated page" lookup with no relation to the calling agent's
+actual target. It has been removed. Omitting `pageId` now fails Zod
+validation and returns `400` with the schema issues, before any page is
+touched.
 
 ## Operations
 
 | Operation | Purpose | Requires |
 |---|---|---|
-| `read` | Return page content with numbered lines. For `TASK_LIST` pages, also returns tasks, `availableStatuses`, and progress rollups. | view |
-| `replace` | Replace lines `startLine`–`endLine` with `content`. | edit |
-| `insert` | Insert `content` before `startLine`. | edit |
-| `delete` | Delete lines `startLine`–`endLine`. | edit |
+| `read` | Return page content with numbered lines. Supports `startLine`/`endLine` for a ranged read (1-indexed, inclusive). `TASK_LIST` pages return tasks, `availableStatuses`, progress rollups, `parentTaskList`, and per-task `subTaskCount`/`subTaskCompletedCount` instead of line content. `CHANNEL` pages return a numbered message transcript (`startLine`/`endLine` address message index, not line number). `FILE` pages surface `processingStatus` (`pending`/`processing`/`failed`/`visual` short-circuit with a status body; `completed` returns content plus `fileMetadata`). | view |
+| `replace` | Replace lines `startLine`–`endLine` with `content`. Rejected on `FILE`/`SHEET` pages (400 — see guardrails below). | edit |
+| `insert` | Insert `content` before `startLine`. Rejected on `FILE`/`SHEET` pages. | edit |
+| `delete` | Delete lines `startLine`–`endLine`. Rejected on `FILE`/`SHEET` pages. | edit |
 | `edit-cells` | Set/clear cells on a `SHEET` page. See below. | edit |
 
 `replace`/`insert`/`delete` all persist through `applyPageMutation` with the
@@ -99,21 +94,53 @@ broadcast a `content-updated` websocket event, and write a
 `data.write`/`data.delete` audit log entry. `read` writes a `data.read` audit
 log entry and does not mutate anything.
 
+### Line numbering
+
+`read` and the line-based write operations number lines from the page's
+content serialized through `serializePageContentForAI`
+(`apps/web/src/lib/ai/core/page-serializer.ts`) — the same normalization the
+in-process `read_page`/`replace_lines` AI tools use. CODE pages and
+`contentMode: 'markdown'` documents pass through raw (their content already
+has natural line structure, and normalizing raw code/markdown would mangle
+it). Everything else (plain HTML documents) is expanded via
+`addLineBreaksForAI` so line numbers correspond to block-level elements
+instead of collapsing the whole stored document into one line. A line number
+seen from a `read` always addresses the same content on a subsequent
+`replace`/`insert`/`delete` against the same page.
+
+Writes mirror that same `isRawText` check: CODE/markdown content is written
+back exactly as spliced, with no re-normalization; HTML documents are
+re-normalized with `addLineBreaksForAI` after the splice.
+
 ## `edit-cells` — sheet editing
 
 This is the intended, cell-aware way to edit `SHEET` page content over the
 MCP HTTP API. There is no separate `/api/mcp/sheets` or similar route —
 sheet edits go through `/api/mcp/documents` with `operation: 'edit-cells'`.
 
-**Caveat:** the `replace`/`insert`/`delete` branches do **not** check
-`isSheetType` before applying their line-based edit to `page.content` — only
-`edit-cells` does. Nothing currently stops an external client from calling
-`replace`/`insert`/`delete` against a `SHEET` page; doing so would apply a
-raw line splice directly to the sheet's serialized text representation
-rather than going through `parseSheetContent`/`updateSheetCells`, which is
-unsafe and unsupported (it can desync rows/columns or produce invalid
-serialized content) even though the API won't reject it. Always use
-`edit-cells` for `SHEET` pages.
+The `replace`/`insert`/`delete` branches check `isSheetType(page.type)` before
+touching content and reject with `400` on a `SHEET` page:
+```json
+{
+  "error": "Cannot use line editing on sheets",
+  "message": "Sheet pages use structured cell data. Use the edit-cells operation instead for cell-level edits.",
+  "suggestion": "Use operation: \"edit-cells\" with cell addresses (A1, B2, etc.) to modify sheet content."
+}
+```
+A raw line splice against a sheet's serialized TOML representation (bypassing
+`parseSheetContent`/`updateSheetCells`) can desync rows/columns or produce
+invalid content — this guardrail mirrors the equivalent check in the
+in-process `replace_lines` AI tool. Always use `edit-cells` for `SHEET` pages.
+
+`FILE` pages are rejected the same way (`400`) from all three line-editing
+operations — uploaded file content is read-only and system-managed:
+```json
+{
+  "error": "Cannot edit FILE pages",
+  "message": "This is an uploaded file. File content is read-only and managed by the system.",
+  "suggestion": "To modify content, create a new document page instead of editing the uploaded file."
+}
+```
 
 ### Validation, in order
 
@@ -232,14 +259,17 @@ Content-Type: application/json
 | Condition | Status | Body |
 |---|---|---|
 | No Bearer token / invalid `mcp_...` token | 401 | auth-error shaped by `authenticateMCPRequest` |
+| `pageId` omitted or any other schema violation | 400 | `{ "error": [...] }` (Zod issues array) — fails before any page lookup |
 | Page's drive not in token's `allowedDriveIds` | 403 | `{ "error": "This token does not have access to this drive" }` |
 | No view access to `pageId` | 403 | `"Forbidden"` (plain text) |
 | Mutating op without edit access | 403 | `{ "error": "Write permission required", "details": "..." }` |
-| Page not found | 404 | `{ "error": "Page not found" }` (or `{ "error": "No active document found" }` — currently **always** returned when `pageId` is omitted, see caveat above) |
+| Page not found | 404 | `{ "error": "Page not found" }` |
+| `replace`/`insert`/`delete` on a `FILE` page | 400 | `{ "error": "Cannot edit FILE pages", "message": "...", "suggestion": "...", "pageInfo": {...} }` |
+| `replace`/`insert`/`delete` on a `SHEET` page | 400 | `{ "error": "Cannot use line editing on sheets", "message": "...", "suggestion": "...", "pageInfo": {...} }` |
 | `edit-cells` on a non-sheet page | 400 | `{ "error": "Page is not a sheet", "message": "...", "pageType": "..." }` |
 | `edit-cells` with empty/missing `cells` | 400 | `{ "error": "cells array is required for edit-cells operation" }` |
 | `edit-cells` with malformed cell address | 400 | `{ "error": "Invalid cell addresses: ..." }` |
-| Zod schema validation failure | 400 | `{ "error": [...] }` (Zod issues array) |
+| Invalid line range on `read`/`replace`/`delete` | 400 | `{ "error": "Invalid line range: ..." }` or `{ "error": "Line number out of range" }` |
 | Revision conflict (rare — only a same-request race; see `edit-cells` above) | 409 | `{ "error": "...", "currentRevision": n, "expectedRevision": n }` |
 | Unrecognized `operation` | 400 | `{ "error": "Invalid operation" }` |
 | Unhandled exception | 500 | `{ "error": "Failed to perform document operation" }` |


### PR DESCRIPTION
## Summary

Fixes three parity bugs surfaced by the MCP ↔ internal AI SDK audit in `/api/mcp/documents`, part of the Route & Tool Parity workstream (prerequisite for SDK Phase 3 — "routes are truth", so the route itself needed fixing first).

- **#1760** — Line numbers were computed from raw stored TipTap HTML (no newlines), so numbering never agreed with the internal `read_page`/`replace_lines` tools. Read and write now number lines via `serializePageContentForAI` (the same normalization the internal tools use): `addLineBreaksForAI` for HTML, raw passthrough for CODE/markdown.
- **#1761** — Three write-path hazards:
  - `addLineBreaksForAI` ran unconditionally on every write, corrupting CODE/markdown content — now skipped for `isRawText` pages, matching `replace_lines`.
  - No FILE/SHEET guardrails — `replace`/`insert`/`delete` now reject with `400` on FILE (read-only) and SHEET (use `edit-cells`) pages.
  - `pageId` had a silent "current page" fallback (a broken query that always returned `null` in practice) — `pageId` is now a required schema field, no fallback.
- **#1762** — Read-path gaps vs internal `read_page`:
  - `startLine`/`endLine` are now honored on read (1-indexed inclusive range).
  - `CHANNEL` pages return a numbered message transcript instead of empty raw content.
  - `FILE` pages surface `processingStatus` (pending/processing/failed/visual short-circuit; completed includes `fileMetadata`).
  - `TASK_LIST` reads include `parentTaskList` and per-task `subTaskCount`/`subTaskCompletedCount`.

Also updates `docs/2.0-architecture/2.4-api/mcp-documents-api.md`, which documented these bugs as known caveats.

## Test plan
- [x] TDD: RED tests written first for all three issues, confirmed failing against unfixed route, then made GREEN.
- [x] `bunx vitest run src/app/api/mcp/documents/__tests__/` — 55/55 passing (3 new test files + 2 pre-existing, one updated for the new TASK_LIST response fields).
- [x] `bun run --filter 'web' typecheck` — clean.
- [x] `bunx eslint` on changed files — clean.
- [x] Broader regression sweep (`src/lib/ai/core`, `src/lib/ai/tools`, `src/lib/editor` test suites) — 1399/1400 passing; the 1 failure (`activity-tools.test.ts`) is a pre-existing DB-connection issue unrelated to this change (requires a real Postgres role not present in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zduyaatsUxTZZrKJiCtjH