### PR TITLE
sdk: implement pure request/response core (Phase 2 task 3)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,11 +1,6 @@
 export * from './errors.js';
-
-/** @pagespace/sdk npm package version. */
-export const SDK_VERSION = '0.1.0';
-
-/**
- * Reserved per ADR 0001 D3 (docs/adr/0001-sdk-api-versioning.md): the SDK's
- * compiled-in floor for the server's API_CONTRACT_VERSION. Not yet enforced —
- * see README for the deferred cross-check.
- */
-export const MIN_SERVER_API_VERSION = '1.0.0';
+export * from './version.js';
+export * from './transport/types.js';
+export * from './transport/build-request.js';
+export * from './transport/parse-response.js';
+export * from './transport/execute.js';

--- a/packages/sdk/src/transport/__tests__/build-request.test.ts
+++ b/packages/sdk/src/transport/__tests__/build-request.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { buildRequest } from '../build-request.js';
+import type { ClientConfig, TransportOperation } from '../types.js';
+
+const config: ClientConfig = { baseUrl: 'https://pagespace.ai' };
+
+function op(overrides: Partial<TransportOperation> = {}): TransportOperation {
+  return {
+    name: 'test.op',
+    method: 'GET',
+    path: '/api/widgets',
+    outputSchema: z.object({ ok: z.boolean() }),
+    ...overrides,
+  };
+}
+
+describe('buildRequest — path interpolation', () => {
+  it('interpolates a single path param', () => {
+    const request = buildRequest(op({ path: '/api/drives/:driveId' }), { driveId: 'abc123' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives/abc123');
+  });
+
+  it('interpolates multiple path params', () => {
+    const request = buildRequest(
+      op({ path: '/api/drives/:driveId/pages/:pageId' }),
+      { driveId: 'd1', pageId: 'p1' },
+      config,
+    );
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1/pages/p1');
+  });
+
+  it('URL-encodes a path param containing a literal slash', () => {
+    const request = buildRequest(op({ path: '/api/drives/:driveId' }), { driveId: 'a/b' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives/a%2Fb');
+  });
+
+  it('URL-encodes unicode in a path param', () => {
+    const request = buildRequest(op({ path: '/api/drives/:driveId' }), { driveId: '日本語' }, config);
+    expect(request.url).toBe(`https://pagespace.ai/api/drives/${encodeURIComponent('日本語')}`);
+  });
+
+  it('interpolates an empty-string path param without throwing', () => {
+    const request = buildRequest(op({ path: '/api/drives/:driveId' }), { driveId: '' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives/');
+  });
+
+  it('throws when a required path param is missing from input', () => {
+    expect(() => buildRequest(op({ path: '/api/drives/:driveId' }), {}, config)).toThrow();
+  });
+});
+
+describe('buildRequest — query serialization', () => {
+  it('serializes remaining GET input fields as a query string in deterministic (sorted) key order', () => {
+    const request = buildRequest(op({ path: '/api/pages' }), { zeta: '1', alpha: '2', mid: '3' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/pages?alpha=2&mid=3&zeta=1');
+  });
+
+  it('produces the same query string regardless of input key insertion order', () => {
+    const a = buildRequest(op({ path: '/api/pages' }), { b: '2', a: '1' }, config);
+    const b = buildRequest(op({ path: '/api/pages' }), { a: '1', b: '2' }, config);
+    expect(a.url).toBe(b.url);
+  });
+
+  it('omits path params from the query string', () => {
+    const request = buildRequest(
+      op({ path: '/api/drives/:driveId/pages' }),
+      { driveId: 'd1', recursive: true },
+      config,
+    );
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1/pages?recursive=true');
+  });
+
+  it('drops undefined/null query fields', () => {
+    const request = buildRequest(
+      op({ path: '/api/pages' }),
+      { parentId: undefined, recursive: null, ls: true },
+      config,
+    );
+    expect(request.url).toBe('https://pagespace.ai/api/pages?ls=true');
+  });
+
+  it('repeats a query key for array values', () => {
+    const request = buildRequest(op({ path: '/api/pages' }), { tag: ['a', 'b'] }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/pages?tag=a&tag=b');
+  });
+
+  it('produces no trailing "?" when there are no remaining fields', () => {
+    const request = buildRequest(op({ path: '/api/pages' }), {}, config);
+    expect(request.url).toBe('https://pagespace.ai/api/pages');
+  });
+});
+
+describe('buildRequest — body and Content-Type', () => {
+  it('sends remaining fields as a JSON body for non-GET methods', () => {
+    const request = buildRequest(op({ method: 'POST', path: '/api/pages' }), { title: 'Hi', driveId: 'd1' }, config);
+    expect(request.body).toBe(JSON.stringify({ driveId: 'd1', title: 'Hi' }));
+  });
+
+  it('sets Content-Type only when a body is present', () => {
+    const withBody = buildRequest(op({ method: 'POST', path: '/api/pages' }), { title: 'Hi' }, config);
+    expect(withBody.headers['Content-Type']).toBe('application/json');
+
+    const withoutBody = buildRequest(op({ method: 'DELETE', path: '/api/pages/:id' }), { id: 'p1' }, config);
+    expect(withoutBody.headers['Content-Type']).toBeUndefined();
+    expect(withoutBody.body).toBeUndefined();
+  });
+
+  it('never puts remaining fields into the query string for non-GET methods', () => {
+    const request = buildRequest(op({ method: 'PATCH', path: '/api/pages/:id' }), { id: 'p1', title: 'Hi' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/pages/p1');
+  });
+});
+
+describe('buildRequest — version header (ADR 0001)', () => {
+  it('attaches X-PageSpace-API-Version defaulting to MIN_SERVER_API_VERSION', () => {
+    const request = buildRequest(op(), {}, config);
+    expect(request.headers['X-PageSpace-API-Version']).toBe('1.0.0');
+  });
+
+  it('honors an explicit config.apiVersion override', () => {
+    const request = buildRequest(op(), {}, { baseUrl: 'https://pagespace.ai', apiVersion: '1.4.2' });
+    expect(request.headers['X-PageSpace-API-Version']).toBe('1.4.2');
+  });
+});
+
+describe('buildRequest — no token in ClientConfig', () => {
+  it('ClientConfig has no token field; Authorization is attached by the facade (task 6), never here', () => {
+    // @ts-expect-error ClientConfig must never accept a token/credential field.
+    const withToken: ClientConfig = { baseUrl: 'https://pagespace.ai', token: 'ps_sess_x' };
+    expect(withToken).toBeDefined();
+  });
+
+  it('never emits an Authorization header itself', () => {
+    const request = buildRequest(op(), {}, config);
+    expect(Object.keys(request.headers)).not.toContain('Authorization');
+  });
+});

--- a/packages/sdk/src/transport/__tests__/execute.test.ts
+++ b/packages/sdk/src/transport/__tests__/execute.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NetworkError, TimeoutError } from '../../errors.js';
+import { executeRequest } from '../execute.js';
+import type { RequestDescriptor } from '../types.js';
+
+const descriptor: RequestDescriptor = {
+  method: 'GET',
+  url: 'https://pagespace.ai/api/widgets/w1',
+  headers: { 'X-PageSpace-API-Version': '1.0.0' },
+  body: undefined,
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('executeRequest — success', () => {
+  it('resolves with status, headers, and bodyText from the injected fetch', async () => {
+    const response = new Response('{"ok":true}', { status: 200, headers: { 'X-Test': '1' } });
+    const fetchMock = vi.fn(async () => response);
+
+    const result = await executeRequest(descriptor, {
+      fetch: fetchMock as unknown as typeof fetch,
+      timeoutMs: 1000,
+      abortFactory: () => new AbortController(),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get('X-Test')).toBe('1');
+    expect(result.bodyText).toBe('{"ok":true}');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      descriptor.url,
+      expect.objectContaining({ method: 'GET', headers: descriptor.headers }),
+    );
+  });
+});
+
+describe('executeRequest — timeout', () => {
+  it('maps an abort triggered by the timeout to TimeoutError, using a fake abort factory', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchMock = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          controller.signal.addEventListener('abort', () => {
+            const abortError = new Error('The operation was aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          });
+        }),
+    );
+
+    const promise = executeRequest(descriptor, {
+      fetch: fetchMock as unknown as typeof fetch,
+      timeoutMs: 30,
+      abortFactory: () => controller,
+    });
+    const assertion = expect(promise).rejects.toBeInstanceOf(TimeoutError);
+
+    await vi.advanceTimersByTimeAsync(30);
+    await assertion;
+  });
+
+  it('sets timeoutMs on the thrown TimeoutError', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const fetchMock = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          controller.signal.addEventListener('abort', () => {
+            const abortError = new Error('aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          });
+        }),
+    );
+
+    const promise = executeRequest(descriptor, {
+      fetch: fetchMock as unknown as typeof fetch,
+      timeoutMs: 30,
+      abortFactory: () => controller,
+    });
+    const assertion = promise.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(30);
+    const error = (await assertion) as TimeoutError;
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect(error.timeoutMs).toBe(30);
+  });
+});
+
+describe('executeRequest — network failure', () => {
+  it('maps a non-abort fetch rejection to NetworkError, preserving the cause', async () => {
+    const original = new Error('getaddrinfo ENOTFOUND pagespace.ai');
+    const fetchMock = vi.fn(async () => {
+      throw original;
+    });
+
+    const promise = executeRequest(descriptor, {
+      fetch: fetchMock as unknown as typeof fetch,
+      timeoutMs: 1000,
+      abortFactory: () => new AbortController(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(NetworkError);
+    const error = (await promise.catch((e: unknown) => e)) as NetworkError;
+    expect(error.cause).toBe(original);
+  });
+});

--- a/packages/sdk/src/transport/__tests__/parse-response.test.ts
+++ b/packages/sdk/src/transport/__tests__/parse-response.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  isAuthenticationError,
+  isNotFoundError,
+  isResponseValidationError,
+  isServerError,
+  PageSpaceError,
+} from '../../errors.js';
+import { parseResponse } from '../parse-response.js';
+import type { TransportOperation } from '../types.js';
+
+const widgetOp: TransportOperation<{ id: string; ok: boolean }> = {
+  name: 'widgets.get',
+  method: 'GET',
+  path: '/api/widgets/:id',
+  outputSchema: z.object({ id: z.string(), ok: z.boolean() }),
+};
+
+const exportOp: TransportOperation<string> = {
+  name: 'pages.export',
+  method: 'GET',
+  path: '/api/pages/:id/export',
+  outputSchema: z.string(),
+  textResponse: true,
+};
+
+describe('parseResponse — success path', () => {
+  it('returns the zod-validated output on a 2xx response matching the schema', () => {
+    const result = parseResponse(widgetOp, 200, {}, JSON.stringify({ id: 'w1', ok: true }));
+    expect(result).toEqual({ id: 'w1', ok: true });
+  });
+
+  it('passes 2xx bodyText through unparsed for textResponse operations', () => {
+    const result = parseResponse(exportOp, 200, {}, 'plain export text, not json {[');
+    expect(result).toBe('plain export text, not json {[');
+  });
+});
+
+describe('parseResponse — response drift', () => {
+  it('returns ResponseValidationError when the 2xx body does not match the output schema', () => {
+    const result = parseResponse(widgetOp, 200, {}, JSON.stringify({ id: 'w1', ok: 'not-a-boolean' }));
+    expect(result).toBeInstanceOf(PageSpaceError);
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('never throws on malformed JSON in a 2xx body — returns ResponseValidationError instead', () => {
+    expect(() => parseResponse(widgetOp, 200, {}, '{not valid json')).not.toThrow();
+    const result = parseResponse(widgetOp, 200, {}, '{not valid json');
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('never throws on an empty 2xx body when the schema requires content', () => {
+    expect(() => parseResponse(widgetOp, 200, {}, '')).not.toThrow();
+    const result = parseResponse(widgetOp, 200, {}, '');
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('names the operation on the ResponseValidationError', () => {
+    const result = parseResponse(widgetOp, 200, {}, JSON.stringify({ id: 'w1' }));
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error & { operation?: string }).operation).toBe('widgets.get');
+  });
+});
+
+describe('parseResponse — non-2xx classification', () => {
+  it('classifies a 404 via task 2 classifyHttpError', () => {
+    const result = parseResponse(widgetOp, 404, {}, JSON.stringify({ error: 'not found' }));
+    expect(isNotFoundError(result)).toBe(true);
+  });
+
+  it('classifies a 401 via task 2 classifyHttpError', () => {
+    const result = parseResponse(widgetOp, 401, {}, JSON.stringify({ error: 'nope' }));
+    expect(isAuthenticationError(result)).toBe(true);
+  });
+
+  it('classifies a 500 via task 2 classifyHttpError, even with an unparseable body', () => {
+    const result = parseResponse(widgetOp, 500, {}, '<html>Internal Server Error</html>');
+    expect(isServerError(result)).toBe(true);
+  });
+
+  it('classifies non-2xx even for textResponse operations (does not pass errors through as text)', () => {
+    const result = parseResponse(exportOp, 404, {}, JSON.stringify({ error: 'gone' }));
+    expect(isNotFoundError(result)).toBe(true);
+  });
+});
+
+describe('parseResponse — never throws on junk', () => {
+  it('handles arbitrary garbage bodies across statuses without throwing', () => {
+    const garbageBodies = ['', 'null', 'undefined', '<xml/>', '{"a":', '[1,2,3', String.fromCharCode(0)];
+    const statuses = [200, 201, 400, 404, 500];
+    for (const status of statuses) {
+      for (const body of garbageBodies) {
+        expect(() => parseResponse(widgetOp, status, {}, body)).not.toThrow();
+      }
+    }
+  });
+});

--- a/packages/sdk/src/transport/build-request.ts
+++ b/packages/sdk/src/transport/build-request.ts
@@ -1,0 +1,99 @@
+import { MIN_SERVER_API_VERSION } from '../version.js';
+import type { ClientConfig, RequestDescriptor, TransportOperation } from './types.js';
+
+const PATH_PARAM_PATTERN = /:([A-Za-z0-9_]+)/g;
+
+/** Names of the `:param` segments in an operation path template, in order. */
+export function extractPathParamNames(path: string): string[] {
+  return [...path.matchAll(PATH_PARAM_PATTERN)].map((match) => match[1]!);
+}
+
+/**
+ * Interpolates `:param` segments from `input`, URL-encoding each value so a
+ * literal `/` or unicode in a param can never smuggle in an extra path
+ * segment. Returns the resolved path plus the set of input keys it consumed,
+ * so the caller can serialize the remainder as query/body.
+ */
+export function interpolatePath(
+  path: string,
+  input: Readonly<Record<string, unknown>>,
+  operation: string,
+): { path: string; consumed: ReadonlySet<string> } {
+  const consumed = new Set<string>();
+  const resolved = path.replace(PATH_PARAM_PATTERN, (_match, name: string) => {
+    const value = input[name];
+    if (value === undefined || value === null) {
+      throw new TypeError(`Operation "${operation}" is missing path parameter "${name}"`);
+    }
+    consumed.add(name);
+    return encodeURIComponent(String(value));
+  });
+  return { path: resolved, consumed };
+}
+
+/** Serializes a plain object as a query string with a stable (sorted) key order. */
+function serializeQuery(params: Readonly<Record<string, unknown>>): string {
+  const search = new URLSearchParams();
+  for (const key of Object.keys(params).sort()) {
+    const value = params[key];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item === undefined || item === null) continue;
+        search.append(key, String(item));
+      }
+      continue;
+    }
+    search.append(key, String(value));
+  }
+  const query = search.toString();
+  return query.length > 0 ? `?${query}` : '';
+}
+
+/** Serializes a plain object as JSON with a stable (sorted) top-level key order. */
+function serializeBody(fields: Readonly<Record<string, unknown>>): string | undefined {
+  const keys = Object.keys(fields).sort();
+  if (keys.length === 0) return undefined;
+  return JSON.stringify(fields, keys);
+}
+
+/**
+ * Pure: operation descriptor + validated input + client config → request
+ * descriptor. No fetch, no clock, no randomness. Input's path-param fields
+ * are interpolated into the URL; everything else becomes query params (GET)
+ * or a JSON body (all other methods). Never sees or emits a token/Authorization
+ * header — that is the facade's job (task 6), attached from the AuthProvider.
+ */
+export function buildRequest<TOutput>(
+  op: TransportOperation<TOutput>,
+  input: Readonly<Record<string, unknown>>,
+  config: ClientConfig,
+): RequestDescriptor {
+  const { path, consumed } = interpolatePath(op.path, input, op.name);
+
+  const remaining: Record<string, unknown> = {};
+  for (const key of Object.keys(input)) {
+    if (!consumed.has(key)) remaining[key] = input[key];
+  }
+
+  const isGet = op.method === 'GET';
+  const query = isGet ? serializeQuery(remaining) : '';
+  const body = isGet ? undefined : serializeBody(remaining);
+
+  const headers: Record<string, string> = {
+    // Declares the contract floor this SDK build requires (ADR 0001 D3);
+    // the server's compatibility response header is a separate concern
+    // verified by the facade, not built here.
+    'X-PageSpace-API-Version': config.apiVersion ?? MIN_SERVER_API_VERSION,
+  };
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  return {
+    method: op.method,
+    url: `${config.baseUrl}${path}${query}`,
+    headers,
+    body,
+  };
+}

--- a/packages/sdk/src/transport/execute.ts
+++ b/packages/sdk/src/transport/execute.ts
@@ -1,0 +1,50 @@
+import { NetworkError, TimeoutError } from '../errors.js';
+import type { RequestDescriptor } from './types.js';
+
+export interface RawResponse {
+  readonly status: number;
+  readonly headers: Headers;
+  readonly bodyText: string;
+}
+
+export interface ExecuteRequestOptions {
+  readonly fetch: typeof fetch;
+  readonly timeoutMs: number;
+  /** Injected so tests can control abort deterministically without touching real timers/network. */
+  readonly abortFactory: () => AbortController;
+}
+
+/**
+ * The fetch shell: enforces a timeout via an injected AbortController and
+ * maps failures to typed errors. No retry, no logging — that's the facade's
+ * job (task 6).
+ */
+export async function executeRequest(
+  descriptor: RequestDescriptor,
+  options: ExecuteRequestOptions,
+): Promise<RawResponse> {
+  const controller = options.abortFactory();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, options.timeoutMs);
+
+  try {
+    const response = await options.fetch(descriptor.url, {
+      method: descriptor.method,
+      headers: descriptor.headers,
+      body: descriptor.body,
+      signal: controller.signal,
+    });
+    const bodyText = await response.text();
+    return { status: response.status, headers: response.headers, bodyText };
+  } catch (error) {
+    if (timedOut) {
+      throw new TimeoutError(`Request timed out after ${options.timeoutMs}ms`, { timeoutMs: options.timeoutMs });
+    }
+    throw new NetworkError('Network request failed', { cause: error });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/sdk/src/transport/parse-response.ts
+++ b/packages/sdk/src/transport/parse-response.ts
@@ -1,0 +1,48 @@
+import { classifyHttpError, type HttpErrorHeaders, type PageSpaceError, ResponseValidationError, type ValidationIssue } from '../errors.js';
+import type { TransportOperation } from './types.js';
+
+/** Parses JSON when possible; on empty/malformed input, returns a value the schema will reject rather than throwing. */
+function tryParseJson(text: string): unknown {
+  if (text.length === 0) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function toValidationIssues(issues: ReadonlyArray<{ path: PropertyKey[]; message: string }>): ValidationIssue[] {
+  return issues.map((issue) => ({
+    path: issue.path.filter((segment): segment is string | number => typeof segment === 'string' || typeof segment === 'number'),
+    message: issue.message,
+  }));
+}
+
+export type ParsedResponse<TOutput> = TOutput | PageSpaceError;
+
+/**
+ * Pure: raw response parts → validated output or a classified error, as a
+ * value (never thrown). Non-2xx statuses delegate to classifyHttpError
+ * (task 2) before any schema is consulted — a proxy error page with no
+ * recognizable body must still surface as a server/transport error.
+ */
+export function parseResponse<TOutput>(
+  op: TransportOperation<TOutput>,
+  status: number,
+  headers: HttpErrorHeaders,
+  bodyText: string,
+): ParsedResponse<TOutput> {
+  if (status < 200 || status > 299) {
+    return classifyHttpError(status, headers, tryParseJson(bodyText), op.name);
+  }
+
+  if (op.textResponse) {
+    return bodyText as TOutput;
+  }
+
+  const result = op.outputSchema.safeParse(tryParseJson(bodyText));
+  if (result.success) {
+    return result.data;
+  }
+  return new ResponseValidationError(op.name, toValidationIssues(result.error.issues));
+}

--- a/packages/sdk/src/transport/types.ts
+++ b/packages/sdk/src/transport/types.ts
@@ -1,0 +1,36 @@
+import type { z } from 'zod';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+/**
+ * The subset of an operation descriptor (full shape lands in task 5's
+ * `defineOperation`) that buildRequest/parseResponse need: enough to
+ * interpolate the path, serialize the rest, and validate the response.
+ */
+export interface TransportOperation<TOutput = unknown> {
+  readonly name: string;
+  readonly method: HttpMethod;
+  /** Template path with `:paramName` segments, e.g. `/api/drives/:driveId/pages`. */
+  readonly path: string;
+  readonly outputSchema: z.ZodType<TOutput>;
+  /** Set for export-style operations whose 2xx body is raw text, not JSON. */
+  readonly textResponse?: boolean;
+}
+
+/**
+ * Client-wide config threaded into buildRequest. Deliberately has no token/
+ * credential field — the facade (task 6) attaches Authorization from the
+ * AuthProvider; buildRequest must never see one.
+ */
+export interface ClientConfig {
+  readonly baseUrl: string;
+  /** Overrides the request's X-PageSpace-API-Version header; defaults to MIN_SERVER_API_VERSION. */
+  readonly apiVersion?: string;
+}
+
+export interface RequestDescriptor {
+  readonly method: HttpMethod;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string | undefined;
+}

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,0 +1,9 @@
+/** @pagespace/sdk npm package version. */
+export const SDK_VERSION = '0.1.0';
+
+/**
+ * Reserved per ADR 0001 D3 (docs/adr/0001-sdk-api-versioning.md): the SDK's
+ * compiled-in floor for the server's API_CONTRACT_VERSION. Not yet enforced —
+ * see README for the deferred cross-check.
+ */
+export const MIN_SERVER_API_VERSION = '1.0.0';


### PR DESCRIPTION
## Summary

Implements Phase 2 task 3 of the SDK/CLI/OAuth epic (PageSpace page `ea07mt5jvw0flihsbjce1iv9`, phase `o7wnjxgbim03kl5ol5lg5p5q`, task `q9k4r88zpat9h278oi5j65y1`): the pure request/response core for `@pagespace/sdk`.

- **`packages/sdk/src/transport/build-request.ts`** — `buildRequest(op, input, config)`, pure. Interpolates `:param` path segments (URL-encoded — a literal `/` or unicode value can't smuggle in an extra path segment), routes remaining input to a deterministically sorted-key query string (GET) or JSON body (all other methods), sets `Content-Type` only when a body exists, and stamps `X-PageSpace-API-Version` from `config.apiVersion` (default `MIN_SERVER_API_VERSION`) per ADR 0001. `ClientConfig` has no token field, enforced with a `@ts-expect-error` test — Authorization is attached by the facade (task 6), never here.
- **`packages/sdk/src/transport/parse-response.ts`** — `parseResponse(op, status, headers, bodyText)`, pure, total, never throws. Non-2xx delegates to task 2's `classifyHttpError` before any schema runs (so a proxy error page with no recognizable body still surfaces as a server/transport error, not a false schema-drift signal). 2xx zod-validates against `op.outputSchema`, returning `ResponseValidationError` on drift or malformed/empty JSON. `textResponse` operations pass `bodyText` through unparsed.
- **`packages/sdk/src/transport/execute.ts`** — `executeRequest(descriptor, { fetch, timeoutMs, abortFactory })`, the only I/O in this task. Enforces the timeout via an injected `AbortController`, maps a timeout-triggered abort to `TimeoutError` and any other fetch rejection to `NetworkError` (cause preserved). No retry, no logging.
- Extracted `SDK_VERSION`/`MIN_SERVER_API_VERSION` out of `index.ts` into `version.ts` so `build-request.ts` can import the constant without a cycle; re-exported unchanged from `index.ts`.

**Design note for reviewers:** ADR 0001 only specifies `X-PageSpace-API-Version` as a *server response* header (D2/D3). The task spec asked `buildRequest` to attach a "version header per ADR 0001" on the *request*, which the ADR doesn't literally define. I interpreted this as the SDK declaring its compiled-in `MIN_SERVER_API_VERSION` floor on every outbound request (reusing the same header name), giving the server visibility into the oldest contract the caller expects. Flagging in case the intended semantics differ — this is the one judgment call in an otherwise ADR-literal implementation.

Depends on tasks 1–2 (scaffold + error taxonomy), already merged into `pu/cli-login`. Sets up task 5 (operation registry), which is instructed to reuse `buildRequest`'s path-interpolation helpers (`interpolatePath`/`extractPathParamNames`, both exported) rather than reimplementing them.

## Test plan

- [x] RED: failing tests committed before any transport module existed (fails at TS2307 module resolution)
- [x] GREEN: `bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` — green, 94/94 tests (33 new: 19 build-request, 11 parse-response, 4 execute — wait, that's 34; see commits for exact breakdown)
- [x] No other package in the monorepo yet imports `@pagespace/sdk` — confirmed no downstream breakage
- [ ] Reviewer: confirm the request-side version-header interpretation above

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NcN7yN2AkdgeWJkQ5monLm