### PR TITLE
fix(search): TASK_LIST glob filter drop, excludeFromSearch leak, list_trash id

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/search/glob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/search/glob/__tests__/route.test.ts
@@ -252,6 +252,34 @@ describe('GET /api/drives/[driveId]/search/glob', () => {
       );
     });
 
+    it('should include TASK_LIST as a valid includeTypes value (#1773)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=TASK_LIST`);
+      await GET(request, createContext(mockDriveId));
+
+      expect(globSearchPages).toHaveBeenCalledWith(
+        mockDriveId,
+        mockUserId,
+        '*',
+        'test-drive',
+        { includeTypes: ['TASK_LIST'], maxResults: 100 }
+      );
+    });
+
+    it('should not silently drop the filter when TASK_LIST is the only requested type (#1773)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=TASK_LIST`);
+      await GET(request, createContext(mockDriveId));
+
+      const [, , , , options] = vi.mocked(globSearchPages).mock.calls[0];
+      // Must be a real, non-empty filter — NOT undefined (which would mean "return everything").
+      expect(options?.includeTypes).toEqual(['TASK_LIST']);
+    });
+
     it('should cap maxResults at 200', async () => {
       vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
       vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());

--- a/apps/web/src/app/api/drives/[driveId]/search/glob/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/search/glob/route.ts
@@ -11,7 +11,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 
-const VALID_PAGE_TYPES = ['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE'] as const;
+const VALID_PAGE_TYPES = ['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE', 'TASK_LIST'] as const;
 type PageType = (typeof VALID_PAGE_TYPES)[number];
 
 /**

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -672,6 +672,58 @@ describe('page-read-tools', () => {
 
   });
 
+  describe('list_trash', () => {
+    it('has correct tool definition', () => {
+      expect(pageReadTools.list_trash).toBeDefined();
+      expect(pageReadTools.list_trash.description).toContain('trash');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        pageReadTools.list_trash.execute!({ driveSlug: 'my-drive', driveId: 'drive-1' }, context)
+      ).rejects.toThrow('User authentication required');
+    });
+
+    // Regression test for #1774: list_trash's output had no page id, so an
+    // agent that just listed trash had nothing to pass to restore_page (which
+    // requires { id }) — it could see a trashed page but not restore it.
+    it('includes the page id for each trashed page, so restore_page can act on it', async () => {
+      mockGetUserDriveAccess.mockResolvedValue(true as unknown as never);
+      (mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([
+              {
+                id: 'page-trashed-1',
+                title: 'Old Notes',
+                type: 'DOCUMENT',
+                trashedAt: new Date('2026-01-01'),
+                parentId: null,
+                position: 0,
+                driveId: 'drive-1',
+              },
+            ]),
+          }),
+        }),
+      });
+
+      const result = await pageReadTools.list_trash.execute!(
+        { driveSlug: 'my-drive', driveId: 'drive-1' },
+        createAuthContext()
+      ) as Record<string, unknown>;
+
+      const trashedPages = result.trashedPages as Array<{ id: string; title: string }>;
+      assert({
+        given: 'list_trash result',
+        should: 'include the id of each trashed page',
+        actual: trashedPages[0]?.id,
+        expected: 'page-trashed-1',
+      });
+    });
+  });
+
   describe('read_page', () => {
     it('has correct tool definition', () => {
       expect(pageReadTools.read_page).toBeDefined();

--- a/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
@@ -1,16 +1,56 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { assert } from './riteway';
 
-// Mock only the boundary we actually test
-vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserDriveAccess: vi.fn(),
+const {
+  mockSelect, mockSelectWhere,
+  mockSelectDistinct, mockSelectDistinctWhere,
+  mockCanActorAccessDrive, mockGetActorAccessiblePagesInDrive,
+} = vi.hoisted(() => {
+  const mockSelectWhere = vi.fn();
+  const mockSelectFrom = vi.fn(() => ({ where: mockSelectWhere }));
+  const mockSelect = vi.fn(() => ({ from: mockSelectFrom }));
+  const mockSelectDistinctWhere = vi.fn();
+  const mockSelectDistinctFrom = vi.fn(() => ({ where: mockSelectDistinctWhere }));
+  const mockSelectDistinct = vi.fn(() => ({ from: mockSelectDistinctFrom }));
+  return {
+    mockSelect, mockSelectFrom, mockSelectWhere,
+    mockSelectDistinct, mockSelectDistinctFrom, mockSelectDistinctWhere,
+    mockCanActorAccessDrive: vi.fn(),
+    mockGetActorAccessiblePagesInDrive: vi.fn(),
+  };
+});
+
+// A chainable query-result stub: awaitable directly (drive lookups, or queries
+// with no .limit()) and also exposes .limit() (queries that chain it).
+function chainable<T>(rows: T[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const promise = Promise.resolve(rows) as Promise<T[]> & { limit: typeof limit };
+  return Object.assign(promise, { limit });
+}
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: mockSelect, selectDistinct: mockSelectDistinct },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
+  and: vi.fn((...conds) => ({ op: 'and', conds })),
+  inArray: vi.fn((field, values) => ({ op: 'inArray', field, values })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+    op: 'sql', strings: Array.from(strings), values,
+  })),
+  asc: vi.fn((field) => ({ op: 'asc', field })),
+}));
+vi.mock('../actor-permissions', () => ({
+  canActorAccessDrive: mockCanActorAccessDrive,
+  getActorAccessiblePagesInDrive: mockGetActorAccessiblePagesInDrive,
 }));
 
 import { searchTools } from '../search-tools';
-import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
 import type { ToolExecutionContext } from '../../core/types';
 
-const mockGetUserDriveAccess = vi.mocked(getUserDriveAccess);
+const mockEq = vi.mocked(eq);
 
 const createAuthContext = (userId = 'user-123') => ({
   toolCallId: '1',
@@ -43,17 +83,12 @@ describe('search-tools', () => {
     });
 
     it('throws error when drive access denied', async () => {
-      mockGetUserDriveAccess.mockResolvedValue(false);
-
-      const context = {
-        toolCallId: '1', messages: [],
-        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
-      };
+      mockCanActorAccessDrive.mockResolvedValue(false);
 
       await expect(
         searchTools.regex_search.execute!(
           { driveId: 'drive-1', pattern: 'TODO.*', searchIn: 'both', maxResults: 10, contentTypes: ['documents', 'conversations'] },
-          context
+          createAuthContext()
         )
       ).rejects.toThrow("You don't have access to this drive");
     });
@@ -77,19 +112,37 @@ describe('search-tools', () => {
     });
 
     it('throws error when drive access denied', async () => {
-      mockGetUserDriveAccess.mockResolvedValue(false);
-
-      const context = {
-        toolCallId: '1', messages: [],
-        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
-      };
+      mockCanActorAccessDrive.mockResolvedValue(false);
 
       await expect(
         searchTools.glob_search.execute!(
           { driveId: 'drive-1', pattern: '**/README*', maxResults: 10 },
-          context
+          createAuthContext()
         )
       ).rejects.toThrow("You don't have access to this drive");
+    });
+
+    // Regression test for #1773: the MCP tool schema and the web route both
+    // accept TASK_LIST as a filterable page type; the internal AI tool schema
+    // must match or agents asking for TASK_LIST get a silent zod rejection
+    // upstream (in the real tool-call pipeline, which validates against
+    // inputSchema before execute() ever runs).
+    it('accepts TASK_LIST as a valid includeTypes value in its schema', () => {
+      const schema = searchTools.glob_search.inputSchema as {
+        safeParse: (v: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({
+        driveId: 'drive-1',
+        pattern: '*',
+        includeTypes: ['TASK_LIST'],
+      });
+
+      assert({
+        given: 'glob_search includeTypes containing TASK_LIST',
+        should: 'validate successfully against the input schema',
+        actual: result.success,
+        expected: true,
+      });
     });
   });
 
@@ -135,7 +188,7 @@ describe('search-tools', () => {
     it('defaults contentTypes to documents and conversations', async () => {
       // contentTypes is intentionally omitted to verify the schema default behavior
       // When not specified, it should default to ['documents', 'conversations']
-      mockGetUserDriveAccess.mockResolvedValue(false);
+      mockCanActorAccessDrive.mockResolvedValue(false);
 
       // We can't fully test this without DB mocking, but we can validate
       // that the tool accepts the call without contentTypes and exercises defaulting
@@ -152,7 +205,7 @@ describe('search-tools', () => {
     });
 
     it('accepts contentTypes array parameter', async () => {
-      mockGetUserDriveAccess.mockResolvedValue(false);
+      mockCanActorAccessDrive.mockResolvedValue(false);
 
       // Validate that contentTypes parameter is accepted
       await expect(
@@ -168,6 +221,58 @@ describe('search-tools', () => {
         )
       ).rejects.toThrow("You don't have access to this drive");
       // If it got to the access check, the contentTypes param was accepted
+    });
+  });
+
+  // Regression tests for #1774: the REST/service search path filters out
+  // pages marked excludeFromSearch (drive-search-service.ts), but these
+  // internal AI tools built their own queries and never applied the same
+  // filter — an in-app agent could surface pages the product intentionally
+  // hides from search.
+  describe('excludeFromSearch filtering (issue #1774)', () => {
+    beforeEach(() => {
+      mockCanActorAccessDrive.mockResolvedValue(true);
+      mockGetActorAccessiblePagesInDrive.mockResolvedValue([]);
+    });
+
+    it('regex_search filters out pages marked excludeFromSearch', async () => {
+      mockSelectWhere
+        .mockReturnValueOnce(chainable([{ slug: 'test-drive', name: 'Test Drive' }]))
+        .mockReturnValueOnce(chainable([]));
+
+      await searchTools.regex_search.execute!(
+        { driveId: 'drive-1', pattern: 'TODO', searchIn: 'content', maxResults: 10, contentTypes: ['documents'] },
+        createAuthContext()
+      );
+
+      expect(mockEq).toHaveBeenCalledWith(pages.excludeFromSearch, false);
+    });
+
+    it('glob_search filters out pages marked excludeFromSearch', async () => {
+      mockSelectWhere
+        .mockReturnValueOnce(chainable([{ slug: 'test-drive', name: 'Test Drive' }]))
+        .mockReturnValueOnce(chainable([]));
+
+      await searchTools.glob_search.execute!(
+        { driveId: 'drive-1', pattern: '*', maxResults: 10 },
+        createAuthContext()
+      );
+
+      expect(mockEq).toHaveBeenCalledWith(pages.excludeFromSearch, false);
+    });
+
+    it('multi_drive_search filters out pages marked excludeFromSearch', async () => {
+      mockSelectDistinctWhere.mockReturnValueOnce(
+        chainable([{ id: 'drive-1', name: 'Drive', slug: 'drive-1' }])
+      );
+      mockSelectWhere.mockReturnValueOnce(chainable([]));
+
+      await searchTools.multi_drive_search.execute!(
+        { searchQuery: 'TODO', searchType: 'text', maxResultsPerDrive: 10 },
+        createAuthContext()
+      );
+
+      expect(mockEq).toHaveBeenCalledWith(pages.excludeFromSearch, false);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -855,6 +855,7 @@ export const pageReadTools = {
 
         // Define proper type for formatted output
         interface FormattedTrashNode {
+          id: string;
           title: string;
           type: string;
           trashedAt: Date | null;
@@ -868,9 +869,10 @@ export const pageReadTools = {
         // Type for tree nodes (pages with children)
         type TreeNode = typeof trashedPages[0] & { children: TreeNode[] };
 
-        // Helper function to format the tree for AI understanding  
+        // Helper function to format the tree for AI understanding
         const formatForAI = (nodes: TreeNode[], depth = 0): FormattedTrashNode[] => {
           return nodes.map(node => ({
+            id: node.id,
             title: node.title,
             type: node.type,
             trashedAt: node.trashedAt,

--- a/apps/web/src/lib/ai/tools/search-tools.ts
+++ b/apps/web/src/lib/ai/tools/search-tools.ts
@@ -59,18 +59,21 @@ export const searchTools = {
           whereConditions = and(
             eq(pages.driveId, driveId),
             eq(pages.isTrashed, false),
+            eq(pages.excludeFromSearch, false),
             sql`${pages.content} ~ ${pgPattern}`
           );
         } else if (searchIn === 'title') {
           whereConditions = and(
             eq(pages.driveId, driveId),
             eq(pages.isTrashed, false),
+            eq(pages.excludeFromSearch, false),
             sql`${pages.title} ~ ${pgPattern}`
           );
         } else {
           whereConditions = and(
             eq(pages.driveId, driveId),
             eq(pages.isTrashed, false),
+            eq(pages.excludeFromSearch, false),
             sql`${pages.content} ~ ${pgPattern} OR ${pages.title} ~ ${pgPattern}`
           );
         }
@@ -348,7 +351,7 @@ export const searchTools = {
     inputSchema: z.object({
       driveId: z.string().describe('The unique ID of the drive to search in'),
       pattern: z.string().describe('Glob pattern to match page titles/paths (e.g., "**/README*", "docs/**/*.md", "meeting-*")'),
-      includeTypes: z.array(z.enum(['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE'])).optional().describe('Filter by page types'),
+      includeTypes: z.array(z.enum(['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE', 'TASK_LIST'])).optional().describe('Filter by page types'),
       maxResults: z.number().optional().default(100).describe('Maximum number of results to return'),
     }),
     execute: async ({ driveId, pattern, includeTypes, maxResults = 100 }, { experimental_context: context }) => {
@@ -373,11 +376,13 @@ export const searchTools = {
           ? and(
               eq(pages.driveId, driveId),
               eq(pages.isTrashed, false),
+              eq(pages.excludeFromSearch, false),
               inArray(pages.type, includeTypes)
             )
           : and(
               eq(pages.driveId, driveId),
-              eq(pages.isTrashed, false)
+              eq(pages.isTrashed, false),
+              eq(pages.excludeFromSearch, false)
             );
 
         // Get all pages in drive
@@ -528,6 +533,7 @@ export const searchTools = {
             searchWhereConditions = and(
               eq(pages.driveId, drive.id),
               eq(pages.isTrashed, false),
+              eq(pages.excludeFromSearch, false),
               sql`${pages.content} ~ ${pgPattern} OR ${pages.title} ~ ${pgPattern}`
             );
           } else {
@@ -535,6 +541,7 @@ export const searchTools = {
             searchWhereConditions = and(
               eq(pages.driveId, drive.id),
               eq(pages.isTrashed, false),
+              eq(pages.excludeFromSearch, false),
               sql`${pages.content} ILIKE ${searchPattern} OR ${pages.title} ILIKE ${searchPattern}`
             );
           }


### PR DESCRIPTION
## Summary

Prerequisite fixes for SDK Phase 3 (route/tool parity audit, group "search"). Fixes #1773 and #1774.

- **#1773** — `/api/drives/[driveId]/search/glob` silently stripped `TASK_LIST` from `includeTypes`, and when TASK_LIST was the only requested type the filter collapsed to empty and fell back to returning **all** page types instead of none/task-lists-only. Added `TASK_LIST` to the route's `VALID_PAGE_TYPES`. Also added it to the internal `glob_search` AI tool's schema enum, which was missing it (the real tool-call pipeline validates against this schema before `execute` runs, so an agent requesting TASK_LIST would get silently rejected upstream).
- **#1774(1/2)** — the internal `regex_search`, `glob_search`, and `multi_drive_search` AI tools built their own DB queries and never applied `excludeFromSearch`, unlike the REST/service search path (`drive-search-service.ts`). An in-app agent could surface pages the product marks hidden from search. Added the filter to all three.
- **#1774 (2/2)** — `list_trash`'s formatted tree output had no page `id`, but `restore_page` requires `{ id }` — an agent could list trash but had nothing to pass to restore what it just saw. Added `id` to the formatted output.

Not in scope: the issue's "low" note about REST channel messages lacking principal-aware `aiMeta` — that's a suggestion for a different route, not a required fix for this group.

## Test plan
- [x] TDD: RED test written first for each bug, confirmed failing, then GREEN fix applied
- [x] `bunx vitest run` on all 3 touched test files — 121/121 passing
- [x] `bun run --filter web typecheck` — clean
- [x] `eslint` on touched files — clean
- [x] Full `bun run test:unit` — 17 pre-existing failures unrelated to this change (DB-role/env gap in `admin-role-version.test.ts`, a midnight-boundary edge case in `grouping.test.ts`, an unrelated timeout in `EventModal.test.tsx`); none touch search/tools/glob

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPL4QDjBXSbiKwMk3Hh3cS