### PR TITLE
feat(oauth): add RFC 8414 discovery route /.well-known/oauth-authorization-server

### DIFF
--- a/apps/web/src/app/.well-known/oauth-authorization-server/__tests__/route.test.ts
+++ b/apps/web/src/app/.well-known/oauth-authorization-server/__tests__/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('GET /.well-known/oauth-authorization-server', () => {
+  beforeEach(() => {
+    process.env.WEB_APP_URL = 'https://pagespace.ai';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('returns 200 with application/json and RFC 8414 metadata derived from configured origin', async () => {
+    const { GET } = await import('../route');
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    expect(body.issuer).toBe('https://pagespace.ai');
+    expect(body.authorization_endpoint).toBe('https://pagespace.ai/api/oauth/authorize');
+    expect(body.token_endpoint).toBe('https://pagespace.ai/api/oauth/token');
+    expect(body.device_authorization_endpoint).toBe(
+      'https://pagespace.ai/api/oauth/device_authorization',
+    );
+    expect(body.revocation_endpoint).toBe('https://pagespace.ai/api/oauth/revoke');
+    expect(body.code_challenge_methods_supported).toEqual(['S256']);
+    expect(body.token_endpoint_auth_methods_supported).toEqual(['none']);
+  });
+
+  it('sets a modest public cache header — this is public metadata by spec, not a secret', async () => {
+    const { GET } = await import('../route');
+
+    const response = await GET();
+
+    const cacheControl = response.headers.get('Cache-Control') ?? '';
+    expect(cacheControl).toContain('public');
+    expect(cacheControl).toMatch(/max-age=\d+/);
+  });
+
+  it('never reflects a request Host header into the issuer — the route takes no request input', async () => {
+    const { GET } = await import('../route');
+
+    // The exported handler has no request parameter at all: there is no code
+    // path by which an attacker-controlled Host header could reach the
+    // response. Calling it with zero arguments is the proof.
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.issuer).toBe(process.env.WEB_APP_URL);
+  });
+
+  it('falls back to NEXT_PUBLIC_APP_URL when WEB_APP_URL is unset', async () => {
+    delete process.env.WEB_APP_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://fallback.example.com';
+
+    const { GET } = await import('../route');
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.issuer).toBe('https://fallback.example.com');
+  });
+});

--- a/apps/web/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/web/src/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,15 @@
+import { buildServerMetadata } from '@pagespace/lib/auth/oauth/metadata';
+
+// Metadata depends on runtime env config, not build-time state.
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  const issuer = process.env.WEB_APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? '';
+
+  return Response.json(buildServerMetadata({ issuer }), {
+    status: 200,
+    headers: {
+      'Cache-Control': 'public, max-age=300, s-maxage=300',
+    },
+  });
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -932,6 +932,11 @@
       "import": "./dist/auth/oauth/scopes.js",
       "require": "./dist/auth/oauth/scopes.js"
     },
+    "./auth/oauth/metadata": {
+      "types": "./dist/auth/oauth/metadata.d.ts",
+      "import": "./dist/auth/oauth/metadata.js",
+      "require": "./dist/auth/oauth/metadata.js"
+    },
     "./auth/account-lockout": {
       "types": "./dist/auth/account-lockout.d.ts",
       "import": "./dist/auth/account-lockout.js",
@@ -1715,6 +1720,9 @@
       ],
       "auth/oauth/pkce": [
         "./dist/auth/oauth/pkce.d.ts"
+      ],
+      "auth/oauth/metadata": [
+        "./dist/auth/oauth/metadata.d.ts"
       ],
       "auth/passkey-service": [
         "./dist/auth/passkey-service.d.ts"

--- a/packages/lib/src/auth/oauth/__tests__/metadata.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/metadata.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { buildServerMetadata } from '../metadata';
+
+describe('buildServerMetadata', () => {
+  const config = { issuer: 'https://pagespace.ai' };
+
+  it('returns exactly the RFC 8414 fields the discovery route promises', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(Object.keys(metadata).sort()).toEqual(
+      [
+        'authorization_endpoint',
+        'code_challenge_methods_supported',
+        'device_authorization_endpoint',
+        'grant_types_supported',
+        'issuer',
+        'response_types_supported',
+        'revocation_endpoint',
+        'scopes_supported',
+        'token_endpoint',
+        'token_endpoint_auth_methods_supported',
+      ].sort(),
+    );
+  });
+
+  it('derives the issuer and every endpoint from injected config, never a request Host', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(metadata.issuer).toBe('https://pagespace.ai');
+    expect(metadata.authorization_endpoint).toBe('https://pagespace.ai/api/oauth/authorize');
+    expect(metadata.token_endpoint).toBe('https://pagespace.ai/api/oauth/token');
+    expect(metadata.device_authorization_endpoint).toBe(
+      'https://pagespace.ai/api/oauth/device_authorization',
+    );
+    expect(metadata.revocation_endpoint).toBe('https://pagespace.ai/api/oauth/revoke');
+  });
+
+  it('strips a trailing slash from the configured issuer before deriving endpoints', () => {
+    const metadata = buildServerMetadata({ issuer: 'https://pagespace.ai/' });
+
+    expect(metadata.issuer).toBe('https://pagespace.ai');
+    expect(metadata.token_endpoint).toBe('https://pagespace.ai/api/oauth/token');
+  });
+
+  it('reflects a self-hosted deployment origin unchanged (no hardcoded pagespace.ai)', () => {
+    const metadata = buildServerMetadata({ issuer: 'http://onprem.internal:3000' });
+
+    expect(metadata.issuer).toBe('http://onprem.internal:3000');
+    expect(metadata.authorization_endpoint).toBe('http://onprem.internal:3000/api/oauth/authorize');
+  });
+
+  it('advertises exactly the three grant types this phase ships, in RFC 8628 form for device code', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(metadata.grant_types_supported).toEqual([
+      'authorization_code',
+      'refresh_token',
+      'urn:ietf:params:oauth:grant-type:device_code',
+    ]);
+  });
+
+  it('advertises only the code response type — no implicit/token flows', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(metadata.response_types_supported).toEqual(['code']);
+  });
+
+  it('advertises S256 only for PKCE — plain must never appear', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(metadata.code_challenge_methods_supported).toEqual(['S256']);
+    expect(metadata.code_challenge_methods_supported).not.toContain('plain');
+  });
+
+  it('advertises none for token endpoint auth — public clients only, no client secrets', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(metadata.token_endpoint_auth_methods_supported).toEqual(['none']);
+  });
+
+  it('advertises the ADR 0002 scope grammar tokens', () => {
+    const metadata = buildServerMetadata(config);
+
+    expect(metadata.scopes_supported).toContain('account');
+    expect(metadata.scopes_supported).toContain('offline_access');
+    expect(metadata.scopes_supported.some((scope) => scope.startsWith('drive:'))).toBe(true);
+  });
+
+  it('is pure: identical config in, deep-equal metadata out, no shared mutable state across calls', () => {
+    const first = buildServerMetadata(config);
+    const second = buildServerMetadata(config);
+
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+  });
+});

--- a/packages/lib/src/auth/oauth/metadata.ts
+++ b/packages/lib/src/auth/oauth/metadata.ts
@@ -1,0 +1,58 @@
+/**
+ * RFC 8414 authorization server metadata — pure construction from injected
+ * config. The issuer must come from the deployment's own base-URL config,
+ * never a request `Host` header (zero trust: `Host` is attacker-controlled).
+ * The Next.js route is a one-line shell around `buildServerMetadata`.
+ *
+ * @module @pagespace/lib/auth/oauth/metadata
+ */
+
+const GRANT_TYPES_SUPPORTED = [
+  'authorization_code',
+  'refresh_token',
+  'urn:ietf:params:oauth:grant-type:device_code',
+] as const;
+
+const RESPONSE_TYPES_SUPPORTED = ['code'] as const;
+
+const CODE_CHALLENGE_METHODS_SUPPORTED = ['S256'] as const;
+
+const TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED = ['none'] as const;
+
+/** ADR 0002 Decision 1 grammar. `drive:*` stands for the templated `drive:<driveId>[:role]` family. */
+const SCOPES_SUPPORTED = ['account', 'offline_access', 'drive:*'] as const;
+
+export interface OAuthServerConfig {
+  /** Canonical deployment origin, e.g. `https://pagespace.ai`. Trailing slash tolerated. */
+  issuer: string;
+}
+
+export interface OAuthServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  device_authorization_endpoint: string;
+  revocation_endpoint: string;
+  grant_types_supported: readonly string[];
+  response_types_supported: readonly string[];
+  code_challenge_methods_supported: readonly string[];
+  token_endpoint_auth_methods_supported: readonly string[];
+  scopes_supported: readonly string[];
+}
+
+export function buildServerMetadata(config: OAuthServerConfig): OAuthServerMetadata {
+  const issuer = config.issuer.replace(/\/+$/, '');
+
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/api/oauth/authorize`,
+    token_endpoint: `${issuer}/api/oauth/token`,
+    device_authorization_endpoint: `${issuer}/api/oauth/device_authorization`,
+    revocation_endpoint: `${issuer}/api/oauth/revoke`,
+    grant_types_supported: GRANT_TYPES_SUPPORTED,
+    response_types_supported: RESPONSE_TYPES_SUPPORTED,
+    code_challenge_methods_supported: CODE_CHALLENGE_METHODS_SUPPORTED,
+    token_endpoint_auth_methods_supported: TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED,
+    scopes_supported: SCOPES_SUPPORTED,
+  };
+}


### PR DESCRIPTION
## Summary
- Phase 1, task 5 of the PageSpace SDK/CLI/OAuth epic: RFC 8414 authorization-server metadata discovery.
- Pure `buildServerMetadata(config)` in `packages/lib/src/auth/oauth/metadata.ts` — issuer and every endpoint URL derive from injected config, never a request `Host` header (zero trust). Static, ADR-0002-grammar-derived fields: `grant_types_supported` (authorization_code, refresh_token, device_code), `response_types_supported: ["code"]`, `code_challenge_methods_supported: ["S256"]` only, `token_endpoint_auth_methods_supported: ["none"]`, `scopes_supported`.
- `GET /.well-known/oauth-authorization-server` (`apps/web/src/app/.well-known/oauth-authorization-server/route.ts`) is a one-line shell around it: reads `WEB_APP_URL`/`NEXT_PUBLIC_APP_URL`, returns JSON with `Cache-Control: public, max-age=300, s-maxage=300`, no auth required.
- New `packages/lib` subpath export `./auth/oauth/metadata` (package.json exports + typesVersions entries).

## Test plan
- [x] RED: wrote failing tests first (`metadata.test.ts`, route `route.test.ts`), confirmed both failed before implementation.
- [x] GREEN: implemented `metadata.ts` and the route; both suites pass.
- [x] `bun run --filter 'web' typecheck` — clean.
- [x] `bun run test:unit` — 4 pre-existing failures unrelated to this change (DB role `test` missing in this environment: `admin-role-version.test.ts`, `activity-tools.test.ts`; unrelated `grouping.test.ts` midnight-boundary bug; flaky `EventModal.test.tsx` timeout). Verified pre-existing by stashing this diff and re-running the same files against `pu/cli-login` tip — identical failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmZXf5W8whxg6YsZ9ov6qF