### PR TITLE
fix(tasks): parity fixes for triggers & task REST routes (#1764, #1766, #1767, #1770)

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -37,6 +37,15 @@ vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
   cancelTaskDueDateTrigger: vi.fn().mockResolvedValue(undefined),
   fireCompletionTrigger: vi.fn().mockResolvedValue(undefined),
   disableTaskTriggers: vi.fn().mockResolvedValue(undefined),
+  createTaskTriggerWorkflow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/ai/tools/task-helpers', () => ({
+  reorderTaskPeers: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@pagespace/lib/utils/enums', () => ({
@@ -160,6 +169,9 @@ import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import { createTaskAssignedNotification, createMentionNotification } from '@pagespace/lib/notifications/notifications';
 import { checkSubTasksComplete } from '@/lib/tasks/completion-guard';
+import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
+import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 
 // ---------- Helpers ----------
 
@@ -1124,6 +1136,100 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     expect(createMentionNotification).not.toHaveBeenCalled();
   });
 
+  it('stores note (and status change) in task metadata lastUpdate', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    vi.mocked(db.query.taskItems.findFirst)
+      .mockResolvedValueOnce({ ...baseTask, status: 'pending', metadata: { existing: true } } as never) // existingTask lookup
+      .mockResolvedValueOnce({ ...baseTask, status: 'completed', assignee: null, assigneeAgent: null, user: null, assignees: [] } as never); // relations lookup
+    vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+
+    let capturedUpdateArgs: Record<string, unknown> | null = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (vi.mocked(db.transaction) as any).mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+      const txUpdateReturning = vi.fn().mockResolvedValue([{ ...baseTask, status: 'completed' }]);
+      const txUpdateWhere = vi.fn(() => ({ returning: txUpdateReturning }));
+      const txUpdateSet = vi.fn((vals: Record<string, unknown>) => {
+        capturedUpdateArgs = vals;
+        return { where: txUpdateWhere };
+      });
+      const tx = {
+        update: vi.fn(() => ({ set: txUpdateSet })),
+        delete: vi.fn(() => ({ where: vi.fn() })),
+        insert: vi.fn(() => ({ values: vi.fn(() => ({ returning: vi.fn() })) })),
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([]) })) })),
+        })),
+      };
+      return callback(tx);
+    });
+
+    const response = await PATCH(createPatchRequest({ status: 'completed', note: 'done early' }), context);
+    expect(response.status).toBe(200);
+    expect(capturedUpdateArgs).toMatchObject({
+      metadata: {
+        existing: true,
+        lastUpdate: expect.objectContaining({
+          note: 'done early',
+          statusChange: { from: 'pending', to: 'completed' },
+        }),
+      },
+    });
+  });
+
+  it('delegates position updates to reorderTaskPeers for clamping and re-densification', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup();
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    setupTransaction(baseTask);
+    setupRelationsLookup({ ...baseTask, position: 2, assignee: null, assigneeAgent: null, user: null, assignees: [] });
+    vi.mocked(reorderTaskPeers).mockResolvedValue(2);
+
+    const response = await PATCH(createPatchRequest({ position: 99 }), context);
+    expect(response.status).toBe(200);
+    expect(reorderTaskPeers).toHaveBeenCalledWith(mockPageId, mockTaskId, 99);
+  });
+
+  it('creates an agent trigger workflow when agentTrigger is provided', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, dueDate: new Date('2025-06-01') });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    setupTransaction({ ...baseTask, dueDate: new Date('2025-06-01') });
+    setupRelationsLookup({ ...baseTask, dueDate: new Date('2025-06-01'), assignee: null, assigneeAgent: null, user: null, assignees: [] });
+    vi.mocked(getUserTimezone).mockResolvedValue('America/New_York');
+
+    const response = await PATCH(createPatchRequest({
+      agentTrigger: { agentPageId: 'agent-1', prompt: 'go', triggerType: 'due_date' },
+    }), context);
+
+    expect(response.status).toBe(200);
+    expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+      driveId: 'drive-1',
+      taskId: mockTaskId,
+      agentTrigger: expect.objectContaining({ agentPageId: 'agent-1', triggerType: 'due_date' }),
+      timezone: 'America/New_York',
+    }));
+  });
+
+  it('returns 400 for a due_date agentTrigger when the task has no due date', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, dueDate: null });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+
+    const response = await PATCH(createPatchRequest({
+      agentTrigger: { agentPageId: 'agent-1', prompt: 'go', triggerType: 'due_date' },
+    }), context);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/due date/i);
+    expect(createTaskTriggerWorkflow).not.toHaveBeenCalled();
+  });
+
   it('returns 200 even when createMentionNotification throws during task update', async () => {
     setupAuth();
     setupCanEdit(true);
@@ -1321,6 +1427,61 @@ describe('DELETE /api/pages/[pageId]/tasks/[taskId]', () => {
     expect(response.status).toBe(200);
     expect(applyPageMutation).not.toHaveBeenCalled();
     expect(broadcastPageEvent).not.toHaveBeenCalled();
+  });
+
+  it('hard-deletes the taskItems row after trashing the linked page (no resurrection on restore)', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
+      ...baseTask, pageId: 'linked-page-1',
+    } as never);
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([{ revision: 3 }]),
+        })),
+      })),
+    } as never);
+    vi.mocked(applyPageMutation).mockResolvedValue({ deferredTrigger: undefined } as never);
+
+    let deleteWhereArg: unknown = null;
+    vi.mocked(db.delete).mockReturnValue({
+      where: vi.fn((cond: unknown) => {
+        deleteWhereArg = cond;
+        return Promise.resolve(undefined);
+      }),
+    } as never);
+
+    const response = await DELETE(createDeleteRequest(), context);
+    expect(response.status).toBe(200);
+    expect(db.delete).toHaveBeenCalledTimes(1);
+    expect(deleteWhereArg).toBeTruthy();
+  });
+
+  it('does not hard-delete the taskItems row when trashing hits a revision conflict', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
+      ...baseTask, pageId: 'linked-page-1',
+    } as never);
+
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([{ revision: 3 }]),
+        })),
+      })),
+    } as never);
+
+    const { PageRevisionMismatchError: PRME } = await import('@/services/api/page-mutation-service');
+    vi.mocked(applyPageMutation).mockRejectedValueOnce(new PRME('Conflict', 5, 3));
+
+    const response = await DELETE(createDeleteRequest(), context);
+    expect(response.status).toBe(409);
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   it('skips page broadcast when taskListPage is null but linkedPage exists', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -12,8 +12,10 @@ import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/pag
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
 
-import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers } from '@/lib/workflows/task-trigger-helpers';
+import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers, createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { checkSubTasksComplete, SUBTASKS_INCOMPLETE_STATUS } from '@/lib/tasks/completion-guard';
+import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
+import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -61,7 +63,7 @@ export async function PATCH(
   }
 
   const body = await req.json();
-  const { title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, position } = body;
+  const { title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, position, note, timezone, agentTrigger } = body;
 
   // Build update object
   const updates: Partial<typeof taskItems.$inferInsert> = {};
@@ -112,6 +114,18 @@ export async function PATCH(
         updates.completedAt = null;
       }
     }
+  }
+
+  // Add note to metadata (mirrors the internal update_task tool)
+  if (note || status !== undefined) {
+    updates.metadata = {
+      ...(existingTask.metadata as Record<string, unknown> || {}),
+      lastUpdate: {
+        at: new Date().toISOString(),
+        note,
+        ...(status !== undefined ? { statusChange: { from: existingTask.status, to: status } } : {}),
+      },
+    };
   }
 
   if (priority !== undefined) {
@@ -182,8 +196,33 @@ export async function PATCH(
     updates.dueDate = dueDate ? new Date(dueDate) : null;
   }
 
-  if (position !== undefined) {
-    updates.position = position;
+  // Validate agentTrigger shape up front (before any writes), mirroring the POST route.
+  let normalizedAgentTrigger: typeof agentTrigger | undefined;
+  if (agentTrigger) {
+    if (!taskListPage?.driveId) {
+      return NextResponse.json({ error: 'Agent triggers require a drive-based task list' }, { status: 400 });
+    }
+    if (!agentTrigger.agentPageId || typeof agentTrigger.agentPageId !== 'string') {
+      return NextResponse.json({ error: 'agentTrigger.agentPageId is required' }, { status: 400 });
+    }
+    if (!agentTrigger.prompt && !agentTrigger.instructionPageId) {
+      return NextResponse.json({ error: 'Agent trigger needs either a prompt or instructionPageId' }, { status: 400 });
+    }
+    if (agentTrigger.prompt && (typeof agentTrigger.prompt !== 'string' || agentTrigger.prompt.length > 10000)) {
+      return NextResponse.json({ error: 'agentTrigger.prompt must be a string of at most 10000 characters' }, { status: 400 });
+    }
+    const triggerType = agentTrigger.triggerType || 'due_date';
+    if (triggerType !== 'due_date' && triggerType !== 'completion') {
+      return NextResponse.json({ error: 'agentTrigger.triggerType must be "due_date" or "completion"' }, { status: 400 });
+    }
+    const effectiveDueDate = dueDate !== undefined ? (dueDate ? new Date(dueDate) : null) : existingTask.dueDate;
+    if (triggerType === 'due_date' && !effectiveDueDate) {
+      return NextResponse.json({ error: 'Due date is required for due_date triggers' }, { status: 400 });
+    }
+    if (agentTrigger.contextPageIds && (!Array.isArray(agentTrigger.contextPageIds) || agentTrigger.contextPageIds.length > 10)) {
+      return NextResponse.json({ error: 'contextPageIds must be an array of at most 10 page IDs' }, { status: 400 });
+    }
+    normalizedAgentTrigger = { ...agentTrigger, triggerType };
   }
 
   // Completion guard: cannot mark a task done while it has incomplete sub-tasks
@@ -312,6 +351,29 @@ export async function PATCH(
       );
     }
     throw error;
+  }
+
+  // Clamp + re-densify positions (0..n-1), matching the reorder_task tool — replaces
+  // the previous raw, unclamped position write that could leave duplicate/gapped positions.
+  if (position !== undefined) {
+    await reorderTaskPeers(pageId, taskId, position);
+  }
+
+  // Create the agent trigger workflow after the transaction commits, mirroring update_task.
+  if (normalizedAgentTrigger && taskListPage?.driveId) {
+    const resolvedTimezone = typeof timezone === 'string' && timezone.trim()
+      ? timezone.trim()
+      : (await getUserTimezone(userId)) || 'UTC';
+    await createTaskTriggerWorkflow({
+      database: db,
+      driveId: taskListPage.driveId,
+      userId,
+      taskId,
+      taskMetadata: updatedTask.metadata as Record<string, unknown> | null,
+      agentTrigger: normalizedAgentTrigger,
+      dueDate: updatedTask.dueDate,
+      timezone: resolvedTimezone,
+    });
   }
 
   // Task trigger cascades (after transaction commits)
@@ -512,8 +574,14 @@ export async function DELETE(
     }
   }
 
-  // Disable triggers only after successful page trash
-  void disableTaskTriggers(taskId, 'Task deleted');
+  // Disable triggers before hard-deleting the task row: task_triggers cascades on
+  // taskItemId, so deleting first would wipe the rows this helper needs to read.
+  await disableTaskTriggers(taskId, 'Task deleted');
+
+  // Hard-delete the task row (REST parity with the internal delete_task tool) —
+  // trashing the linked page alone left a resurrectable "deleted" task: restoring
+  // the trashed page brought the task back since the taskItems row still existed.
+  await db.delete(taskItems).where(eq(taskItems.id, taskId));
 
   // Broadcast events
   const broadcasts: Promise<void>[] = [

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -164,9 +164,19 @@ vi.mock('@pagespace/lib/notifications/notifications', () => ({
   createMentionNotification: (...args: unknown[]) => mockCreateMentionNotification(...args),
 }));
 
+vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
+  createTaskTriggerWorkflow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 import { db } from '@pagespace/db/db';
 import { broadcastTaskEvent } from '@/lib/websocket';
 
@@ -858,6 +868,154 @@ describe('Task API Routes', () => {
       );
 
       expect(response.status).toBe(201);
+    });
+
+    it('stores note in task metadata on create', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      let capturedTaskInsert: Record<string, unknown> | null = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (vi.mocked(db.transaction) as any).mockImplementationOnce(async (callback: (tx: unknown) => Promise<unknown>) => {
+        let insertCallCount = 0;
+        const tx = {
+          insert: vi.fn(() => ({
+            values: vi.fn((vals: Record<string, unknown>) => {
+              insertCallCount++;
+              if (insertCallCount === 2) capturedTaskInsert = vals;
+              return {
+                returning: vi.fn().mockResolvedValue(insertCallCount === 1 ? transactionPageResult : transactionTaskResult),
+              };
+            }),
+          })),
+        };
+        return callback(tx);
+      });
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never) // taskListPage
+        .mockResolvedValueOnce(null as never); // lastChildPage
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(createRequest({ title: 'Task', note: 'remember this' }), { params: mockParams });
+
+      expect(response.status).toBe(201);
+      expect(capturedTaskInsert).toMatchObject({ metadata: { note: 'remember this' } });
+    });
+
+    it('uses the explicit position for the new task when provided', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 7 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      let capturedTaskInsert: Record<string, unknown> | null = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (vi.mocked(db.transaction) as any).mockImplementationOnce(async (callback: (tx: unknown) => Promise<unknown>) => {
+        let insertCallCount = 0;
+        const tx = {
+          insert: vi.fn(() => ({
+            values: vi.fn((vals: Record<string, unknown>) => {
+              insertCallCount++;
+              if (insertCallCount === 2) capturedTaskInsert = vals;
+              return {
+                returning: vi.fn().mockResolvedValue(insertCallCount === 1 ? transactionPageResult : transactionTaskResult),
+              };
+            }),
+          })),
+        };
+        return callback(tx);
+      });
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never) // taskListPage
+        .mockResolvedValueOnce(null as never); // lastChildPage
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(createRequest({ title: 'Task', position: 7 }), { params: mockParams });
+
+      expect(response.status).toBe(201);
+      expect(capturedTaskInsert).toMatchObject({ position: 7 });
+    });
+
+    it('uses the request body timezone for the agent trigger workflow', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never) // taskListPage
+        .mockResolvedValueOnce(null as never); // lastChildPage
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(createRequest({
+        title: 'Task',
+        dueDate: '2025-12-31',
+        timezone: 'America/Chicago',
+        agentTrigger: { agentPageId: 'agent-1', prompt: 'go' },
+      }), { params: mockParams });
+
+      expect(response.status).toBe(201);
+      expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'America/Chicago' }));
+      expect(getUserTimezone).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the user profile timezone for the agent trigger workflow when body omits it', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(getUserTimezone).mockResolvedValue('Europe/Berlin');
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never) // taskListPage
+        .mockResolvedValueOnce(null as never); // lastChildPage
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(createRequest({
+        title: 'Task',
+        dueDate: '2025-12-31',
+        agentTrigger: { agentPageId: 'agent-1', prompt: 'go' },
+      }), { params: mockParams });
+
+      expect(response.status).toBe(201);
+      expect(getUserTimezone).toHaveBeenCalledWith(mockUserId);
+      expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'Europe/Berlin' }));
     });
 
     it('creates task page as TASK_LIST type with empty content', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -14,6 +14,7 @@ import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activit
 import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
 import { computeHasContent } from './task-utils';
 import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
+import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -337,6 +338,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     assigneeAgentId,
     assigneeIds,
     dueDate,
+    note,
+    position,
+    timezone,
     agentTrigger,
   } = body;
 
@@ -429,10 +433,17 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   });
 
   const nextPosition = (lastChildPage?.position ?? 0) + 1;
+  const taskPosition = typeof position === 'number' ? position : nextPosition;
 
   // Determine primary assignee for backward compat fields (derive from assigneeIds if present)
   const primaryAssigneeId = assigneeId || assigneeIds?.find((a: { type: string }) => a.type === 'user')?.id || null;
   const primaryAgentId = assigneeAgentId || assigneeIds?.find((a: { type: string }) => a.type === 'agent')?.id || null;
+
+  // Resolve the trigger timezone once, up front: explicit body value wins, else
+  // the caller's profile timezone, else UTC — matching the internal create_task tool.
+  const resolvedTimezone = agentTrigger
+    ? (typeof timezone === 'string' && timezone.trim() ? timezone.trim() : (await getUserTimezone(userId)) || 'UTC')
+    : 'UTC';
 
   // Create task and its document page in a transaction
   const result = await db.transaction(async (tx) => {
@@ -456,8 +467,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       assigneeId: primaryAssigneeId,
       assigneeAgentId: primaryAgentId,
       dueDate: dueDate ? new Date(dueDate) : null,
-      position: nextPosition,
+      position: taskPosition,
       completedAt: initialCompletedAt,
+      metadata: {
+        createdAt: new Date().toISOString(),
+        note,
+      },
     }).returning();
 
     // Create assignees in junction table
@@ -496,7 +511,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         taskMetadata: newTask.metadata as Record<string, unknown> | null,
         agentTrigger,
         dueDate: dueDate ? new Date(dueDate) : null,
-        timezone: 'UTC',
+        timezone: resolvedTimezone,
       });
     }
 

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, canPrincipalEditPage } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
@@ -11,7 +10,7 @@ import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { recomputeTaskTriggerMetadata } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastTaskEvent } from '@/lib/websocket';
 
-const SESSION_WRITE = { allow: ['session'] as const, requireCSRF: true };
+const SESSION_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
 const triggerTypeParam = z.enum(['due_date', 'completion']);
 
@@ -55,7 +54,7 @@ export async function DELETE(
     return NextResponse.json({ error: 'Task list page not found' }, { status: 404 });
   }
 
-  const canEdit = await canUserEditPage(userId, taskListPageId);
+  const canEdit = await canPrincipalEditPage(auth, taskListPageId);
   if (!canEdit) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -7,10 +7,6 @@ vi.mock('@/lib/auth', () => ({
   canPrincipalEditPage: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/permissions/permissions', () => ({
-  canUserEditPage: vi.fn(),
-}));
-
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
@@ -24,6 +20,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
   createTaskTriggerWorkflow: vi.fn().mockResolvedValue(undefined),
   recomputeTaskTriggerMetadata: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/websocket', () => ({
@@ -63,9 +63,9 @@ vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id', agentP
 vi.mock('@pagespace/db/schema/task-triggers', () => ({ taskTriggers: { id: 'id', taskItemId: 'taskItemId', triggerType: 'triggerType', workflowId: 'workflowId', isEnabled: 'isEnabled', nextRunAt: 'nextRunAt', lastFiredAt: 'lastFiredAt', lastFireError: 'lastFireError', createdAt: 'createdAt', updatedAt: 'updatedAt' } }));
 
 import { authenticateRequestWithOptions, isAuthError, canPrincipalEditPage } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { createTaskTriggerWorkflow, recomputeTaskTriggerMetadata } from '@/lib/workflows/task-trigger-helpers';
+import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 import { GET, PUT } from '../route';
 import { DELETE } from '../[triggerType]/route';
 
@@ -212,6 +212,76 @@ describe('Task triggers API', () => {
       expect(createTaskTriggerWorkflow).toHaveBeenCalledOnce();
     });
 
+    it('uses the request body timezone for the trigger workflow', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, page: { parentId: pageId }, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canPrincipalEditPage).mockResolvedValue(true);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue([{ id: 'trg-3', triggerType: 'completion', workflowId: 'wf-3' }]),
+          })),
+        })),
+      } as never);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'completion', agentPageId, prompt: 'go', timezone: 'America/Chicago' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(200);
+      expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'America/Chicago' }));
+      expect(getUserTimezone).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the user profile timezone when the body omits it', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, page: { parentId: pageId }, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canPrincipalEditPage).mockResolvedValue(true);
+      vi.mocked(getUserTimezone).mockResolvedValue('Asia/Tokyo');
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue([{ id: 'trg-4', triggerType: 'completion', workflowId: 'wf-4' }]),
+          })),
+        })),
+      } as never);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'completion', agentPageId, prompt: 'go' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(200);
+      expect(getUserTimezone).toHaveBeenCalledWith(userId);
+      expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'Asia/Tokyo' }));
+    });
+
+    it('falls back to UTC when neither the body nor the user profile provide a timezone', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, page: { parentId: pageId }, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canPrincipalEditPage).mockResolvedValue(true);
+      vi.mocked(getUserTimezone).mockResolvedValue(undefined);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue([{ id: 'trg-5', triggerType: 'completion', workflowId: 'wf-5' }]),
+          })),
+        })),
+      } as never);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'completion', agentPageId, prompt: 'go' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(200);
+      expect(createTaskTriggerWorkflow).toHaveBeenCalledWith(expect.objectContaining({ timezone: 'UTC' }));
+    });
+
     it('returns 500 if the trigger row is missing after upsert', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
       vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, page: { parentId: pageId }, dueDate: null, metadata: null } as never);
@@ -254,7 +324,7 @@ describe('Task triggers API', () => {
       } as never);
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId } as never);
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
-      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(canPrincipalEditPage).mockResolvedValue(true);
 
       const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
       expect(res.status).toBe(200);
@@ -263,6 +333,41 @@ describe('Task triggers API', () => {
       expect(db.update).toHaveBeenCalledTimes(1);
       // Metadata recompute is delegated to the shared helper (DB-truth source)
       expect(recomputeTaskTriggerMetadata).toHaveBeenCalledWith(db, taskId, taskMetadata);
+    });
+
+    it('returns 403 when principal lacks edit permission (mcp-aware check)', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
+        id: taskId,
+        page: { parentId: pageId },
+        metadata: null,
+      } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
+      vi.mocked(canPrincipalEditPage).mockResolvedValue(false);
+
+      const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
+      expect(res.status).toBe(403);
+    });
+
+    it('requests mcp-compatible auth options, matching the sibling PUT/GET route', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
+        id: taskId,
+        page: { parentId: pageId },
+        metadata: null,
+      } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
+      vi.mocked(canPrincipalEditPage).mockResolvedValue(true);
+
+      const request = mkRequest('DELETE');
+      await DELETE(request, { params: mkDeleteParams('completion') });
+
+      expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+        request,
+        { allow: ['session', 'mcp'], requireCSRF: true },
+      );
     });
   });
 });

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
@@ -11,6 +11,7 @@ import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 
 const logger = loggers.api.child({ module: 'task-triggers-api' });
 
@@ -23,6 +24,7 @@ const upsertTriggerSchema = z.object({
   prompt: z.string().max(10000).optional(),
   instructionPageId: z.string().nullable().optional(),
   contextPageIds: z.array(z.string()).max(10).optional(),
+  timezone: z.string().optional(),
 }).strict().refine(
   (data) => Boolean(data.prompt?.trim()) || Boolean(data.instructionPageId),
   { message: 'Either prompt or instructionPageId is required' }
@@ -33,7 +35,6 @@ type ResolvedTaskContext = {
   taskListPageId: string;
   taskListId: string | undefined;
   driveId: string;
-  timezone: string;
 };
 
 async function resolveTaskContext(taskId: string): Promise<ResolvedTaskContext | null> {
@@ -61,7 +62,6 @@ async function resolveTaskContext(taskId: string): Promise<ResolvedTaskContext |
     taskListPageId,
     taskListId: taskList?.id,
     driveId: page.driveId,
-    timezone: 'UTC',
   };
 }
 
@@ -157,6 +157,10 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
     );
   }
 
+  // Explicit body value wins, else the caller's profile timezone, else UTC —
+  // matching the internal update_task/create_task tools.
+  const timezone = parsed.data.timezone?.trim() || (await getUserTimezone(userId)) || 'UTC';
+
   try {
     await createTaskTriggerWorkflow({
       database: db,
@@ -172,7 +176,7 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
         triggerType: parsed.data.triggerType,
       },
       dueDate: ctx.task.dueDate,
-      timezone: ctx.timezone,
+      timezone,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to save trigger';

--- a/apps/web/src/app/api/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/__tests__/route.test.ts
@@ -45,7 +45,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', driveId: 'driveId', type: 'type', isTrashed: 'isTrashed', title: 'title', parentId: 'parentId' },
 }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
-  taskItems: { assigneeId: 'assigneeId', pageId: 'pageId', status: 'status', priority: 'priority', createdAt: 'createdAt', updatedAt: 'updatedAt', description: 'description' },
+  taskItems: { assigneeId: 'assigneeId', pageId: 'pageId', status: 'status', priority: 'priority', createdAt: 'createdAt', updatedAt: 'updatedAt', description: 'description', completedAt: 'completedAt' },
   taskLists: { id: 'id', pageId: 'pageId' },
   taskStatusConfigs: { taskListId: 'taskListId' },
 }));
@@ -103,6 +103,8 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isNull } from '@pagespace/db/operators';
+import { taskItems } from '@pagespace/db/schema/tasks';
 
 // ============================================================================
 // Test Helpers
@@ -430,6 +432,55 @@ describe('GET /api/tasks', () => {
       const body = await response.json();
 
       expect(body.pagination.hasMore).toBe(true);
+    });
+  });
+
+  describe('completion default (parity with internal get_assigned_tasks)', () => {
+    beforeEach(() => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        createPageFixture({ id: 'page_tasklist', driveId: 'drive_1', title: 'Tasks' }),
+      ]);
+      vi.mocked(db.query.taskLists.findMany).mockResolvedValue([
+        createTaskListFixture({ id: 'tasklist_1', pageId: 'page_tasklist' }),
+      ]);
+    });
+
+    it('excludes completed tasks by default when no status/statusGroup filter is given', async () => {
+      const request = new Request('https://example.com/api/tasks?context=user');
+      await GET(request);
+
+      expect(isNull).toHaveBeenCalledWith(taskItems.completedAt);
+    });
+
+    it('does not exclude completed tasks when includeCompleted=true', async () => {
+      const request = new Request('https://example.com/api/tasks?context=user&includeCompleted=true');
+      await GET(request);
+
+      const completedAtCalls = vi.mocked(isNull).mock.calls.filter(([col]) => col === taskItems.completedAt);
+      expect(completedAtCalls).toHaveLength(0);
+    });
+
+    it('does not add the completedAt exclusion when an explicit status filter is given', async () => {
+      const request = new Request('https://example.com/api/tasks?context=user&status=completed');
+      await GET(request);
+
+      const completedAtCalls = vi.mocked(isNull).mock.calls.filter(([col]) => col === taskItems.completedAt);
+      expect(completedAtCalls).toHaveLength(0);
+    });
+
+    it('does not add the completedAt exclusion when statusGroup is explicitly provided', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        createPageFixture({ id: 'page_tasklist', driveId: 'drive_1', title: 'Tasks' }),
+      ]);
+      vi.mocked(db.query.taskLists.findMany).mockResolvedValue([
+        createTaskListFixture({ id: 'tasklist_1', pageId: 'page_tasklist' }),
+      ]);
+
+      const request = new Request('https://example.com/api/tasks?context=user&statusGroup=completed');
+      await GET(request);
+
+      const completedAtCalls = vi.mocked(isNull).mock.calls.filter(([col]) => col === taskItems.completedAt);
+      expect(completedAtCalls).toHaveLength(0);
     });
   });
 

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -33,6 +33,7 @@ const querySchema = z.object({
   assigneeId: z.string().optional(),
   assigneeAgentId: z.string().optional(),
   showAllAssignees: z.enum(['true', 'false']).transform(v => v === 'true').optional(),
+  includeCompleted: z.enum(['true', 'false']).transform(v => v === 'true').optional(),
   dueDateFilter: z.enum(['overdue', 'today', 'this_week', 'upcoming']).optional(),
   // Group-level status filter: 'active' = todo + in_progress, 'completed' = done.
   // Custom per-task-list status configs are honoured; fall back to DEFAULT_STATUS_CONFIG
@@ -83,6 +84,7 @@ export async function GET(request: Request) {
       assigneeId: searchParams.get('assigneeId') ?? undefined,
       assigneeAgentId: searchParams.get('assigneeAgentId') ?? undefined,
       showAllAssignees: searchParams.get('showAllAssignees') ?? undefined,
+      includeCompleted: searchParams.get('includeCompleted') ?? undefined,
       dueDateFilter: searchParams.get('dueDateFilter') ?? undefined,
       statusGroup: searchParams.get('statusGroup') ?? undefined,
       limit: searchParams.get('limit') ?? undefined,
@@ -250,6 +252,11 @@ export async function GET(request: Request) {
 
     if (params.status) {
       filterConditions.push(eq(taskItems.status, params.status));
+    } else if (!params.includeCompleted && !params.statusGroup) {
+      // Exclude completed tasks by default, matching the internal get_assigned_tasks
+      // tool. Skipped when the caller already scopes completion via statusGroup
+      // (which may itself request 'completed') or explicitly opts in.
+      filterConditions.push(isNull(taskItems.completedAt));
     }
     if (params.priority) {
       filterConditions.push(eq(taskItems.priority, params.priority));


### PR DESCRIPTION
## Summary

Fixes four route/tool parity bugs from the MCP↔internal-AI-SDK parity audit, in the tasks-and-triggers group of the [Route & Tool Parity workstream](../../issues?q=1760..1775). These are prerequisites for SDK Phase 3 (the SDK's client wraps these routes — "routes are truth" — so the routes must be correct first).

- **#1764** — `DELETE /api/tasks/[taskId]/triggers/[triggerType]` declared `allow: ['session']` and used `canUserEditPage`, unlike its sibling PUT/GET routes (`allow: ['session', 'mcp']` + `canPrincipalEditPage`). Every `delete_task_trigger` call from the MCP server failed auth. Fixed to match its siblings.
- **#1766** — Task REST endpoints lagged the internal AI tools:
  - `PATCH /api/pages/[pageId]/tasks/[taskId]` ignored `note` and `agentTrigger` (both supported by internal `update_task`).
  - `POST /api/pages/[pageId]/tasks` ignored `note` and `position` (both supported by internal `create_task`).
  - `DELETE /api/pages/[pageId]/tasks/[taskId]` trashed the linked page and disabled triggers but never hard-deleted the `taskItems` row — restoring the trashed page resurrected a REST-"deleted" task. Now hard-deletes the row (disabling triggers first, since `task_triggers` cascades on `taskItemId`), matching internal `deleteTask`.
  - PATCH's raw `position` write had no clamping or peer re-densification (duplicate/gapped positions possible). Now delegates to `reorderTaskPeers`, the same logic backing the `reorder_task` tool.
- **#1767** — `POST /api/pages/[pageId]/tasks` and `PUT /api/tasks/[taskId]/triggers` hardcoded `timezone: 'UTC'` for the due-date trigger workflow. Agent triggers created via REST/MCP fired at the wrong local time for non-UTC users. Both routes now accept an optional `timezone` in the request body, falling back to the caller's profile timezone (`getUserTimezone`), falling back to UTC.
- **#1770** — `GET /api/tasks` included completed tasks by default (only excluded via an explicit `status` filter), unlike internal `get_assigned_tasks` which excludes completed unless `includeCompleted: true`. Added an `includeCompleted` query param and applied the same `isNull(completedAt)` default exclusion, skipped when a `status` filter or `statusGroup` scope is already given.

Every fix follows TDD: a RED test reproducing the bug against the corrected-behavior assertion, then the route/tool fix to green.

## Test plan
- [x] `bun run --filter 'web' typecheck` — green
- [x] `bun run --filter 'web' lint` — no new errors (pre-existing warnings in unrelated files untouched)
- [x] Touched suites green (220 tests): `pages/[pageId]/tasks`, `pages/[pageId]/tasks/[taskId]`, `pages/[pageId]/tasks/reorder`, `pages/[pageId]/tasks/statuses`, `tasks`, `tasks/[taskId]/triggers`
- [x] `bun run test:security` — 36/43 suites pass; the 7 failing suites (Session Service, Device Auth, Permissions, Login/Signup/Mobile Login, Admin Role Versioning) fail identically on `master` with no changes applied (`role "test" does not exist` — missing local Postgres test-DB role), confirmed unrelated to this diff

Closes #1764
Closes #1766
Closes #1767
Closes #1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JXWpCXq5qN7FgzcP3LkYA2