### PR TITLE
fix(roles,members,ai-tools): roles/members route & tool parity fixes

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import type { DriveAccessResult, MemberWithDetails } from '@pagespace/lib/servic
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   checkDriveAccess: vi.fn(),
   listDriveMembers: vi.fn(),
+  getDriveOwnerAsMember: vi.fn(),
 }));
 
 vi.mock('@/lib/repositories/drive-invite-repository', () => ({
@@ -42,7 +43,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { GET } from '../route';
-import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
+import { checkDriveAccess, listDriveMembers, getDriveOwnerAsMember } from '@pagespace/lib/services/drive-member-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isPrincipalDriveOwnerOrAdmin } from '@/lib/auth';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
@@ -122,6 +123,28 @@ const createMemberFixture = (overrides: {
   },
 });
 
+const createOwnerMemberFixture = (userId: string): MemberWithDetails => ({
+  id: `owner-${userId}`,
+  userId,
+  role: 'OWNER',
+  invitedBy: null,
+  invitedAt: null,
+  acceptedAt: null,
+  lastAccessedAt: null,
+  user: {
+    id: userId,
+    email: `${userId}@example.com`,
+    name: `User ${userId}`,
+  },
+  profile: {
+    username: userId,
+    displayName: `User ${userId}`,
+    avatarUrl: null,
+  },
+  customRole: null,
+  permissionCounts: { view: 0, edit: 0, share: 0 },
+});
+
 const createContext = (driveId: string) => ({
   params: Promise.resolve({ driveId }),
 });
@@ -140,6 +163,7 @@ describe('GET /api/drives/[driveId]/members', () => {
     vi.mocked(isAuthError).mockReturnValue(false);
     vi.mocked(checkMCPDriveScope).mockReturnValue(null);
     vi.mocked(driveInviteRepository.findUnconsumedInvitesByDrive).mockResolvedValue([]);
+    vi.mocked(getDriveOwnerAsMember).mockResolvedValue(null);
   });
 
   describe('authentication', () => {
@@ -333,6 +357,81 @@ describe('GET /api/drives/[driveId]/members', () => {
 
       expect(response.status).toBe(200);
       expect(body.members).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // Owner inclusion + unaccepted-invitee exclusion — regression coverage for
+  // #1771: the owner has no drive_members row, and pending invites must not
+  // be indistinguishable from accepted members.
+  // ==========================================================================
+  describe('owner inclusion and unaccepted-invitee exclusion', () => {
+    it('prepends the OWNER, who has no drive_members row, ahead of regular members', async () => {
+      const owner = createOwnerMemberFixture('owner_1');
+      const admin = createMemberFixture({ id: 'mem_1', userId: 'user_456', role: 'ADMIN' });
+
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: false,
+        isAdmin: true,
+        isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test', ownerId: 'owner_1' }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([admin]);
+      vi.mocked(getDriveOwnerAsMember).mockResolvedValue(owner);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.members).toHaveLength(2);
+      expect(body.members[0]).toMatchObject({ userId: 'owner_1', role: 'OWNER' });
+      expect(body.members[1]).toMatchObject({ userId: 'user_456', role: 'ADMIN' });
+    });
+
+    it('excludes drive_members rows without acceptedAt (pending invites are not members)', async () => {
+      const owner = createOwnerMemberFixture('owner_1');
+      const accepted = createMemberFixture({ id: 'mem_1', userId: 'user_456', role: 'MEMBER' });
+      const unaccepted = { ...createMemberFixture({ id: 'mem_2', userId: 'user_789', role: 'MEMBER' }), acceptedAt: null };
+
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test', ownerId: 'owner_1' }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([accepted, unaccepted]);
+      vi.mocked(getDriveOwnerAsMember).mockResolvedValue(owner);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      const userIds = body.members.map((m: { userId: string }) => m.userId);
+      expect(userIds).toEqual(['owner_1', 'user_456']);
+      expect(userIds).not.toContain('user_789');
+    });
+
+    it('does not double-count the owner if they also have an accepted drive_members row', async () => {
+      const owner = createOwnerMemberFixture('owner_1');
+      const ownerAsMemberRow = createMemberFixture({ id: 'mem_owner', userId: 'owner_1', role: 'OWNER' });
+      const regular = createMemberFixture({ id: 'mem_1', userId: 'user_456', role: 'MEMBER' });
+
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test', ownerId: 'owner_1' }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([ownerAsMemberRow, regular]);
+      vi.mocked(getDriveOwnerAsMember).mockResolvedValue(owner);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      const ownerEntries = body.members.filter((m: { userId: string }) => m.userId === 'owner_1');
+      expect(ownerEntries).toHaveLength(1);
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/members/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isPrincipalDriveOwnerOrAdmin } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
-import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
+import { checkDriveAccess, listDriveMembers, getDriveOwnerAsMember } from '@pagespace/lib/services/drive-member-service';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
@@ -32,8 +32,17 @@ export async function GET(
       return NextResponse.json({ error: 'You must be a drive member to view members' }, { status: 403 });
     }
 
-    // Get all members with their profiles and permission counts
-    const members = await listDriveMembers(driveId);
+    // Get all members with their profiles and permission counts. The owner
+    // is never a drive_members row (ownership lives on drives.ownerId), so
+    // prepend it explicitly; unaccepted invitees are pending, not members.
+    const [rawMembers, ownerMember] = await Promise.all([
+      listDriveMembers(driveId),
+      getDriveOwnerAsMember(driveId),
+    ]);
+    const acceptedMembers = rawMembers.filter(
+      (m) => m.acceptedAt !== null && m.userId !== ownerMember?.userId
+    );
+    const members = ownerMember ? [ownerMember, ...acceptedMembers] : acceptedMembers;
 
     // Pending invites are visible to OWNER/ADMIN only. The field is always an
     // array (never undefined) so client-side SWR cache shape stays stable as

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
@@ -14,13 +14,19 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
     audit: vi.fn(),
     auditRequest: vi.fn(),
 }));
-vi.mock('@pagespace/lib/services/drive-role-service', () => ({
-    checkDriveAccessForRoles: vi.fn(),
-    getRoleById: vi.fn(),
-    updateDriveRole: vi.fn(),
-    deleteDriveRole: vi.fn(),
-    validateRolePermissions: vi.fn(),
-}));
+vi.mock('@pagespace/lib/services/drive-role-service', async () => {
+    const actual = await vi.importActual<typeof import('@pagespace/lib/services/drive-role-service')>(
+      '@pagespace/lib/services/drive-role-service'
+    );
+    return {
+      ...actual,
+      checkDriveAccessForRoles: vi.fn(),
+      getRoleById: vi.fn(),
+      updateDriveRole: vi.fn(),
+      deleteDriveRole: vi.fn(),
+      validateRolePermissions: vi.fn(),
+    };
+});
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
@@ -444,6 +450,122 @@ describe('PATCH /api/drives/[driveId]/roles/[roleId]', () => {
         isDefault: true,
         permissions: undefined,
       });
+    });
+  });
+
+  // ==========================================================================
+  // permissionsPatch (read-merge-write) — regression coverage for #1765:
+  // a single-page PATCH must never wipe another page's per-page grant.
+  // ==========================================================================
+  describe('permissionsPatch (read-merge-write)', () => {
+    beforeEach(() => {
+      vi.mocked(checkDriveAccessForRoles).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      vi.mocked(updateDriveRole).mockResolvedValue({
+        role: createRoleFixture({ id: mockRoleId, name: 'Original', driveId: mockDriveId }),
+        wasDefault: false,
+      });
+    });
+
+    it('merges a single-page patch into the existing map instead of replacing it — page_1 survives a page_2-only PATCH', async () => {
+      vi.mocked(getRoleById).mockResolvedValue(
+        createRoleFixture({
+          id: mockRoleId,
+          name: 'Original',
+          driveId: mockDriveId,
+          permissions: {
+            page_1: { canView: true, canEdit: true, canShare: false },
+          },
+        })
+      );
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/roles/${mockRoleId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          permissionsPatch: {
+            page_2: { canView: true, canEdit: false, canShare: false },
+          },
+        }),
+      });
+      const response = await PATCH(request, createContext(mockDriveId, mockRoleId));
+
+      expect(response.status).toBe(200);
+      expect(updateDriveRole).toHaveBeenCalledWith(mockDriveId, mockRoleId, expect.objectContaining({
+        permissions: {
+          page_1: { canView: true, canEdit: true, canShare: false },
+          page_2: { canView: true, canEdit: false, canShare: false },
+        },
+      }));
+    });
+
+    it('a null patch entry prunes the page key (falls back to drive-wide) instead of writing an all-false entry', async () => {
+      vi.mocked(getRoleById).mockResolvedValue(
+        createRoleFixture({
+          id: mockRoleId,
+          name: 'Original',
+          driveId: mockDriveId,
+          permissions: {
+            page_1: { canView: true, canEdit: true, canShare: false },
+            page_2: { canView: true, canEdit: false, canShare: false },
+          },
+        })
+      );
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/roles/${mockRoleId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          permissionsPatch: { page_1: null },
+        }),
+      });
+      const response = await PATCH(request, createContext(mockDriveId, mockRoleId));
+
+      expect(response.status).toBe(200);
+      expect(updateDriveRole).toHaveBeenCalledWith(mockDriveId, mockRoleId, expect.objectContaining({
+        permissions: {
+          page_2: { canView: true, canEdit: false, canShare: false },
+        },
+      }));
+    });
+
+    it('rejects a request specifying both permissions and permissionsPatch', async () => {
+      vi.mocked(getRoleById).mockResolvedValue(
+        createRoleFixture({ id: mockRoleId, name: 'Original', driveId: mockDriveId })
+      );
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/roles/${mockRoleId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          permissions: { page_1: { canView: true, canEdit: false, canShare: false } },
+          permissionsPatch: { page_2: { canView: true, canEdit: false, canShare: false } },
+        }),
+      });
+      const response = await PATCH(request, createContext(mockDriveId, mockRoleId));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Cannot specify both permissions and permissionsPatch');
+      expect(updateDriveRole).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid permissionsPatch structure', async () => {
+      vi.mocked(getRoleById).mockResolvedValue(
+        createRoleFixture({ id: mockRoleId, name: 'Original', driveId: mockDriveId })
+      );
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/roles/${mockRoleId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          permissionsPatch: { page_1: { canView: 'yes' } },
+        }),
+      });
+      const response = await PATCH(request, createContext(mockDriveId, mockRoleId));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid permissionsPatch structure');
+      expect(updateDriveRole).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateDriveWidePermissions } from '@pagespace/lib/services/drive-role-service';
+import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch, mergeRolePermissionsPatch, validateDriveWidePermissions } from '@pagespace/lib/services/drive-role-service';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
@@ -98,7 +98,7 @@ export async function PATCH(
     }
 
     const body = await request.json();
-    const { name, description, color, isDefault, permissions, driveWidePermissions } = body;
+    const { name, description, color, isDefault, permissions, permissionsPatch, driveWidePermissions } = body;
 
     // Validate name length if provided
     if (name !== undefined) {
@@ -108,21 +108,33 @@ export async function PATCH(
       }
     }
 
+    if (permissions !== undefined && permissionsPatch !== undefined) {
+      return NextResponse.json({ error: 'Cannot specify both permissions and permissionsPatch' }, { status: 400 });
+    }
+
     // Validate permissions structure if provided
     if (permissions !== undefined && !validateRolePermissions(permissions)) {
       return NextResponse.json({ error: 'Invalid permissions structure' }, { status: 400 });
     }
 
-    if (driveWidePermissions !== undefined && !validateDriveWidePermissions(driveWidePermissions)) {
-      return NextResponse.json({ error: 'Invalid driveWidePermissions structure' }, { status: 400 });
+    // permissionsPatch is a read-merge-write per-page patch: unlike `permissions`
+    // (a full-map replace), pages not named in the patch are left untouched — a
+    // single-page PATCH can never wipe another page's grant. `null` prunes a
+    // page's override rather than persisting an explicit all-false entry.
+    if (permissionsPatch !== undefined && !validateRolePermissionsPatch(permissionsPatch)) {
+      return NextResponse.json({ error: 'Invalid permissionsPatch structure' }, { status: 400 });
     }
+
+    const resolvedPermissions = permissionsPatch !== undefined
+      ? mergeRolePermissionsPatch(existingRole.permissions, permissionsPatch)
+      : permissions;
 
     const { role: updatedRole } = await updateDriveRole(driveId, roleId, {
       name,
       description,
       color,
       isDefault,
-      permissions,
+      permissions: resolvedPermissions,
       ...(driveWidePermissions !== undefined && { driveWidePermissions }),
     });
 
@@ -140,7 +152,7 @@ export async function PATCH(
       roleId,
       roleName: updatedRole.name,
       driveId,
-      permissions: permissions ? summarizePermissions(permissions) : undefined,
+      permissions: resolvedPermissions ? summarizePermissions(resolvedPermissions) : undefined,
       previousPermissions: summarizePermissions(existingRole.permissions),
       driveWidePermissions: driveWidePermissions !== undefined ? (driveWidePermissions ?? null) : undefined,
       previousDriveWidePermissions: existingRole.driveWidePermissions ?? null,

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -104,16 +104,21 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 vi.mock('@/lib/logging/mask', () => ({
   maskIdentifier: vi.fn((id) => `***${id?.slice(-4) || ''}`),
 }));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  checkDriveAccess: vi.fn(),
+}));
 
 import { pageReadTools } from '../page-read-tools';
 import { db } from '@pagespace/db/db';
 import { getUserAccessLevel, getUserAccessiblePagesInDriveWithDetails, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockDb = vi.mocked(db);
 const mockGetUserAccessLevel = vi.mocked(getUserAccessLevel);
 const mockGetUserAccessiblePagesInDrive = vi.mocked(getUserAccessiblePagesInDriveWithDetails);
 const mockGetUserDriveAccess = vi.mocked(getUserDriveAccess);
+const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
 
 const createMockPage = (content: string, type = 'DOCUMENT') => ({
   id: 'page-1',
@@ -690,7 +695,7 @@ describe('page-read-tools', () => {
     // agent that just listed trash had nothing to pass to restore_page (which
     // requires { id }) — it could see a trashed page but not restore it.
     it('includes the page id for each trashed page, so restore_page can act on it', async () => {
-      mockGetUserDriveAccess.mockResolvedValue(true as unknown as never);
+      mockCheckDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, drive: null });
       (mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -721,6 +726,50 @@ describe('page-read-tools', () => {
         actual: trashedPages[0]?.id,
         expected: 'page-trashed-1',
       });
+    });
+
+    // ========================================================================
+    // Regression coverage for #1772: list_trash only required drive
+    // membership, unlike GET /api/drives/[driveId]/trash which requires
+    // owner/admin. The bars must agree.
+    // ========================================================================
+    it('denies a plain drive member (not owner or admin) from listing trash', async () => {
+      mockCheckDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false, isMember: true, drive: null });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'member-user' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageReadTools.list_trash.execute!(
+          { driveSlug: 'my-drive', driveId: 'drive-1' },
+          context
+        )
+      ).rejects.toThrow('Only drive owners and admins');
+    });
+
+    it('allows the drive owner to list trash', async () => {
+      mockCheckDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, drive: null });
+      (mockDb.select as ReturnType<typeof vi.fn>).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'owner-user' } as ToolExecutionContext,
+      };
+
+      const result = await pageReadTools.list_trash.execute!(
+        { driveSlug: 'my-drive', driveId: 'drive-1' },
+        context
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
     });
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -118,6 +118,7 @@ vi.mock('@/lib/logging/mask', () => ({
 
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   getDriveRecipientUserIds: vi.fn().mockResolvedValue([]),
+  checkDriveAccess: vi.fn(),
 }));
 
 vi.mock('@/services/api/task-sync-service', () => ({
@@ -131,6 +132,7 @@ import { getAgentAccessLevel } from '@pagespace/lib/permissions/agent-permission
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
@@ -140,6 +142,11 @@ const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
 const mockEnsureTaskListForPage = vi.mocked(ensureTaskListForPage);
+const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
+
+const ownerAccess = { isOwner: true, isAdmin: true, isMember: true, drive: null };
+const adminAccess = { isOwner: false, isAdmin: true, isMember: true, drive: null };
+const deniedAccess = { isOwner: false, isAdmin: false, isMember: true, drive: null };
 
 describe('page-write-tools', () => {
   beforeEach(() => {
@@ -824,7 +831,8 @@ describe('page-write-tools', () => {
 
     it('trashes a drive when confirmDriveName matches', async () => {
       // Arrange
-      mockDriveRepo.findByIdAndOwner.mockResolvedValue({
+      mockCheckDriveAccess.mockResolvedValue(ownerAccess);
+      mockDriveRepo.findById.mockResolvedValue({
         id: 'drive-1',
         name: 'My Drive',
         slug: 'my-drive',
@@ -854,7 +862,8 @@ describe('page-write-tools', () => {
     });
 
     it('rejects when confirmDriveName does not match the drive name', async () => {
-      mockDriveRepo.findByIdAndOwner.mockResolvedValue({
+      mockCheckDriveAccess.mockResolvedValue(ownerAccess);
+      mockDriveRepo.findById.mockResolvedValue({
         id: 'drive-1',
         name: 'My Drive',
         slug: 'my-drive',
@@ -902,6 +911,52 @@ describe('page-write-tools', () => {
       const ok = schema.safeParse({ id: 'drive-1', confirmDriveName: '  My Drive  ' });
       expect(ok.success).toBe(true);
       expect(ok.data?.confirmDriveName).toBe('My Drive');
+    });
+
+    // Regression coverage for #1772: trash_drive was owner-only, unlike
+    // DELETE /api/drives/[driveId] which allows owner OR admin.
+    it('allows a drive admin (not just the owner) to trash the drive — matches DELETE /api/drives/[driveId]', async () => {
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+      mockDriveRepo.findById.mockResolvedValue({
+        id: 'drive-1',
+        name: 'My Drive',
+        slug: 'my-drive',
+        ownerId: 'owner-999',
+        kind: 'STANDARD' as const,
+        isTrashed: false,
+        trashedAt: null,
+      });
+      mockDriveRepo.trash.mockResolvedValue(undefined);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'admin-user' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.trash_drive.execute!(
+        { id: 'drive-1', confirmDriveName: 'My Drive' },
+        context
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockDriveRepo.trash).toHaveBeenCalledWith('drive-1');
+    });
+
+    it('denies a plain member (not owner or admin) from trashing the drive', async () => {
+      mockCheckDriveAccess.mockResolvedValue(deniedAccess);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'member-user' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.trash_drive.execute!(
+          { id: 'drive-1', confirmDriveName: 'My Drive' },
+          context
+        )
+      ).rejects.toThrow('do not have permission');
+      expect(mockDriveRepo.trash).not.toHaveBeenCalled();
     });
   });
 
@@ -1065,6 +1120,60 @@ describe('page-write-tools', () => {
           context
         )
       ).rejects.toThrow('User authentication required');
+    });
+
+    // Regression coverage for #1772: move_page only required per-page edit
+    // permission, unlike /api/pages/reorder which requires drive owner/admin
+    // for the same move+position operation. The bars must agree.
+    it('denies a member with page-edit access but no drive owner/admin role', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Test Page', type: 'DOCUMENT',
+        content: '', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      // Edit permission is granted, but the actor is a plain member — under
+      // the aligned bar this must NOT be enough to move the page.
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockCheckDriveAccess.mockResolvedValue(deniedAccess);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'member-user' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.move_page.execute!(
+          { title: 'Test Page', pageId: 'page-1', position: 1 },
+          context
+        )
+      ).rejects.toThrow('Only drive owners and admins can move pages');
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('allows a drive admin to move a page, matching /api/pages/reorder', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1', title: 'Test Page', type: 'DOCUMENT',
+        content: '', contentMode: 'html' as const,
+        driveId: 'drive-1', parentId: null, position: 1,
+        isTrashed: false, trashedAt: null, revision: 1, stateHash: null,
+      });
+      mockCheckDriveAccess.mockResolvedValue(adminAccess);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'admin-user' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.move_page.execute!(
+        { title: 'Test Page', pageId: 'page-1', position: 2 },
+        context
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({ pageId: 'page-1', operation: 'move' })
+      );
     });
   });
 
@@ -1254,7 +1363,8 @@ describe('trash_drive — Home drive guard', () => {
   });
 
   it('throws when trying to trash a Home drive', async () => {
-    mockDriveRepo.findByIdAndOwner.mockResolvedValue({
+    mockCheckDriveAccess.mockResolvedValue(ownerAccess);
+    mockDriveRepo.findById.mockResolvedValue({
       id: 'home-drive',
       name: 'Home',
       slug: 'home',
@@ -1272,11 +1382,12 @@ describe('trash_drive — Home drive guard', () => {
     ).rejects.toThrow();
   });
 
-  it('driveRepository.findByIdAndOwner selects kind column', async () => {
+  it('driveRepository.findById selects kind column', async () => {
     // This test verifies kind is included in the drive record returned by
-    // findByIdAndOwner so guards can fire. If kind is missing, Home drives
-    // would be silently treated as STANDARD.
-    mockDriveRepo.findByIdAndOwner.mockResolvedValue({
+    // findById so guards can fire. If kind is missing, Home drives would be
+    // silently treated as STANDARD.
+    mockCheckDriveAccess.mockResolvedValue(ownerAccess);
+    mockDriveRepo.findById.mockResolvedValue({
       id: 'home-drive',
       name: 'Home',
       slug: 'home',
@@ -1295,8 +1406,8 @@ describe('trash_drive — Home drive guard', () => {
       // Expected to throw
     }
 
-    // The key assertion: findByIdAndOwner was called (proving kind flows through)
-    expect(mockDriveRepo.findByIdAndOwner).toHaveBeenCalledWith('home-drive', 'user-123');
+    // The key assertion: findById was called (proving kind flows through)
+    expect(mockDriveRepo.findById).toHaveBeenCalledWith('home-drive');
   });
 });
 

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -6,7 +6,7 @@ import { pages, chatMessages } from '@pagespace/db/schema/core'
 import { taskItems, taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
 import { channelMessages } from '@pagespace/db/schema/chat';
 import { buildTree } from '@pagespace/lib/content/tree-utils';
-import { getActorAccessiblePagesInDrive, canActorViewPage, canActorAccessDrive } from './actor-permissions';
+import { getActorAccessiblePagesInDrive, canActorViewPage, canActorAccessDrive, canActorManageDrive } from './actor-permissions';
 import { getPageTypeEmoji, isFolderPage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import type { ToolExecutionContext } from '../core/types';
@@ -836,8 +836,10 @@ export const pageReadTools = {
       }
 
       try {
-        if (!await canActorAccessDrive(context as ToolExecutionContext, driveId)) {
-          throw new Error(`You don't have access to the "${driveSlug}" workspace`);
+        // Trash listing requires drive owner/admin — mirrors GET
+        // /api/drives/[driveId]/trash, which gates on the same bar.
+        if (!await canActorManageDrive(context as ToolExecutionContext, driveId)) {
+          throw new Error(`Only drive owners and admins can view the "${driveSlug}" workspace's trash`);
         }
 
         // Get all trashed pages in the drive (flat list)

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canActorEditPage, canActorDeletePage, driveDeniedByAppToken } from './actor-permissions';
+import { canActorEditPage, canActorDeletePage, canActorManageDrive, driveDeniedByAppToken } from './actor-permissions';
 import { isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
@@ -285,12 +285,17 @@ async function trashPage(
 
 // Helper: Trash a drive
 async function trashDrive(
-  userId: string,
+  context: ToolExecutionContext,
   driveId: string,
   confirmDriveName: string
 ): Promise<{ id: string; name: string; slug: string }> {
-  // Use repository seam for drive lookup
-  const drive = await driveRepository.findByIdAndOwner(driveId, userId);
+  // Owner or admin — mirrors DELETE /api/drives/[driveId], which allows both,
+  // not just the owner (canActorManageDrive handles MCP scope/app-token ceilings).
+  if (!(await canActorManageDrive(context, driveId))) {
+    throw new Error('Drive not found or you do not have permission to delete it');
+  }
+
+  const drive = await driveRepository.findById(driveId);
 
   if (!drive) {
     throw new Error('Drive not found or you do not have permission to delete it');
@@ -863,7 +868,7 @@ export const pageWriteTools = {
         if (!confirmDriveName) {
           throw new Error('Drive name confirmation is required for trashing drives (confirmDriveName parameter)');
         }
-        const drive = await trashDrive(userId, id, confirmDriveName);
+        const drive = await trashDrive(context as ToolExecutionContext, id, confirmDriveName);
 
         // Log activity for AI-generated drive trash (fire-and-forget)
         logDriveActivityAsync(userId, 'trash', {
@@ -1002,10 +1007,11 @@ export const pageWriteTools = {
           throw new Error(`Page with ID "${pageId}" not found`);
         }
 
-        // Check permissions on the source page
-        const canEdit = await canActorEditPage(context as ToolExecutionContext,page.id);
-        if (!canEdit) {
-          throw new Error('Insufficient permissions to move this page');
+        // Moving/reordering a page requires drive owner or admin — mirrors the
+        // /api/pages/reorder REST route's authorization bar for the same operation.
+        const canManage = await canActorManageDrive(context as ToolExecutionContext, page.driveId);
+        if (!canManage) {
+          throw new Error('Only drive owners and admins can move pages');
         }
 
         // If newParentId is provided, verify it exists and is in the same drive
@@ -1013,14 +1019,6 @@ export const pageWriteTools = {
           const parentExists = await pageRepository.existsInDrive(newParentId, page.driveId);
           if (!parentExists) {
             throw new Error(`Parent page with ID "${newParentId}" not found in this drive`);
-          }
-        }
-
-        // Check permissions on the destination if moving to a folder
-        if (newParentId) {
-          const canEditDest = await canActorEditPage(context as ToolExecutionContext,newParentId);
-          if (!canEditDest) {
-            throw new Error('Insufficient permissions to move page to this destination');
           }
         }
 

--- a/packages/lib/src/services/drive-member-service.ts
+++ b/packages/lib/src/services/drive-member-service.ts
@@ -272,6 +272,46 @@ export async function listDriveMembers(driveId: string): Promise<MemberWithDetai
 }
 
 /**
+ * Build a MemberWithDetails-shaped entry for the drive owner. The owner is
+ * never a row in drive_members (ownership lives on drives.ownerId), so
+ * listDriveMembers alone omits them — callers that need a complete roster
+ * (e.g. the members list API) must prepend this. Returns null only if the
+ * drive itself doesn't exist.
+ */
+export async function getDriveOwnerAsMember(driveId: string): Promise<MemberWithDetails | null> {
+  const [row] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      username: userProfiles.username,
+      displayName: userProfiles.displayName,
+      avatarUrl: userProfiles.avatarUrl,
+    })
+    .from(drives)
+    .innerJoin(users, eq(drives.ownerId, users.id))
+    .leftJoin(userProfiles, eq(userProfiles.userId, users.id))
+    .where(eq(drives.id, driveId))
+    .limit(1);
+
+  if (!row) return null;
+
+  return {
+    id: `owner-${row.id}`,
+    userId: row.id,
+    role: 'OWNER',
+    invitedBy: null,
+    invitedAt: null,
+    acceptedAt: null,
+    lastAccessedAt: null,
+    user: { id: row.id, email: row.email, name: row.name },
+    profile: { username: row.username, displayName: row.displayName, avatarUrl: row.avatarUrl },
+    customRole: null,
+    permissionCounts: { view: 0, edit: 0, share: 0 },
+  };
+}
+
+/**
  * Check if a user is already a member of a drive
  */
 export async function isMemberOfDrive(driveId: string, userId: string): Promise<boolean> {

--- a/packages/lib/src/services/drive-role-service.ts
+++ b/packages/lib/src/services/drive-role-service.ts
@@ -34,6 +34,10 @@ export interface DriveRole {
 
 export type RolePermissions = Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }>;
 
+// Per-page permission patch: a value merges/overwrites that page's entry, `null` prunes it
+// (falls back to driveWidePermissions) rather than writing an explicit all-false entry.
+export type RolePermissionsPatch = Record<string, { canView: boolean; canEdit: boolean; canShare: boolean } | null>;
+
 export interface CreateRoleInput {
   name: string;
   description?: string | null;
@@ -357,4 +361,46 @@ export function validateRolePermissions(permissions: unknown): permissions is Ro
   }
 
   return true;
+}
+
+/**
+ * Validate a per-page permissions patch structure (same as RolePermissions,
+ * except each entry may also be `null` to signal "prune this page's override").
+ */
+export function validateRolePermissionsPatch(patch: unknown): patch is RolePermissionsPatch {
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) return false;
+
+  for (const [pageId, perms] of Object.entries(patch)) {
+    if (typeof pageId !== 'string') return false;
+    if (perms === null) continue;
+    if (!perms || typeof perms !== 'object') return false;
+    const p = perms as Record<string, unknown>;
+    if (typeof p.canView !== 'boolean' ||
+        typeof p.canEdit !== 'boolean' ||
+        typeof p.canShare !== 'boolean') return false;
+  }
+
+  return true;
+}
+
+/**
+ * Merge a per-page permissions patch into an existing permissions map.
+ * Read-merge-write: pages not named in the patch are left untouched (unlike a
+ * full `permissions` replace, which wipes everything not in the payload).
+ * A `null` entry prunes the key so resolution falls back to
+ * driveWidePermissions, rather than persisting an explicit all-false entry.
+ */
+export function mergeRolePermissionsPatch(
+  existing: RolePermissions,
+  patch: RolePermissionsPatch,
+): RolePermissions {
+  const merged = { ...existing };
+  for (const [pageId, perms] of Object.entries(patch)) {
+    if (perms === null) {
+      delete merged[pageId];
+    } else {
+      merged[pageId] = perms;
+    }
+  }
+  return merged;
 }


### PR DESCRIPTION
## Summary

Route & Tool Parity workstream — **roles & members** group. Fixes three bugs surfaced by the MCP↔internal-AI-SDK parity audit (2026-07-03): a data-destroying role-permissions PATCH, a members API that omits the drive owner, and a permission-bar mismatch between three internal AI tools and their REST equivalents.

Closes #1765
Closes #1771
Closes #1772

### #1765 — `updateDriveRole` wholesale-replace (data-destroying)

`PATCH /api/drives/[driveId]/roles/[roleId]` passed `permissions` straight through to `updateDriveRole`, which **replaces** the entire per-page permissions map. A single-page update from a caller that doesn't hold the full map (e.g. the MCP server) silently wiped every other page's grant.

- Added `permissionsPatch`: a per-page patch merged **server-side** against the role's existing permissions (read-merge-write). `null` prunes a page's override (falls back to `driveWidePermissions`) instead of persisting an explicit all-false entry, which would otherwise win in resolution over drive-wide permissions.
- `permissions` still full-replaces, preserved for `RoleEditor.tsx` (the one caller that legitimately has the complete map loaded and needs full-replace semantics).
- Test proves a second page's grants **survive** a first-page-only `permissionsPatch` PATCH, and that pruning removes the key rather than writing falses.

### #1771 — members API omits OWNER, returns unaccepted invitees as members

`GET /api/drives/[driveId]/members` returned raw `drive_members` rows only — the owner is never a row in that table (ownership lives on `drives.ownerId`), so the owner never appeared. No `acceptedAt` filter meant invited-but-unaccepted users were indistinguishable from real members.

- Added `getDriveOwnerAsMember` to synthesize an `OWNER`-shaped entry from `drives.ownerId`.
- Route now prepends the owner and filters `drive_members` rows to `acceptedAt !== null`, deduping in case the owner also holds an accepted membership row.

### #1772 — permission-bar drift: list_trash, move_page/reorder, trash_drive

Three internal AI tools authorized the same operations as their REST counterparts, but at a different bar:

| Operation | REST bar | Tool bar (before) |
|---|---|---|
| Trash listing | owner/admin | any drive member |
| Page move (`/api/pages/reorder`) | owner/admin | per-page edit permission |
| Trash a drive | owner OR admin | owner only |

Aligned all three to `canActorManageDrive` (MCP-scope and app-token-ceiling aware) — tightening `list_trash` and `move_page` to match REST, and loosening `trash_drive` to admit admins like `DELETE /api/drives/[driveId]` already does.

## Non-negotiables checklist

- [x] TDD: RED test written and confirmed failing before each fix, GREEN after
- [x] Zero trust: fail closed; no data-destroying write shipped (proved by test); no permission leaks (bars tightened where the tool was looser than REST)
- [x] Pure decision logic where feasible (`mergeRolePermissionsPatch`, `validateRolePermissionsPatch`)
- [x] bun only, no `any`, Next 15 `await params` preserved
- [x] Permissions via centralized helpers (`canActorManageDrive`, `isDriveOwnerOrAdmin`)
- [x] Rebased on latest `origin/master` — resolved the flagged `list_trash` overlap with the search group's PR #1791 (page-id addition); source merged cleanly, test file conflict resolved to keep both regression tests

## Test plan

- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bun run --filter '@pagespace/lib' typecheck` — clean
- [x] Touched suites green: roles route (35 tests), members route (20 tests), page-read-tools (62 tests), page-write-tools (61 tests) — 178 total
- [x] `bun run test:security` — 7 pre-existing failures confirmed unrelated (missing local Postgres `test` role for DB-integration auth/session tests; one `no test files found` config issue) via stash-and-rerun against clean baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5cKsKp7sPZgrEjHRhueHE