### PR TITLE
feat(oauth): /api/oauth/authorize endpoint + consent screen

### DIFF
--- a/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
@@ -1,0 +1,230 @@
+/**
+ * GET/POST /api/oauth/authorize (task hn80whvl8p00jdhv3gt8nlr6).
+ *
+ * Covers: open-redirect guard (unknown client / unregistered redirect_uri
+ * never redirect), error-redirect-after-validated-uri, session gate, CSRF on
+ * the consent POST, single-use code hashed at rest, state echoed verbatim.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: (result: unknown) => !!result && typeof result === 'object' && 'error' in (result as object),
+}));
+
+vi.mock('@/lib/repositories/oauth-repository', () => ({
+  ensureOAuthClientRow: vi.fn().mockResolvedValue('client-db-id-1'),
+  createAuthorizationCode: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getDriveAccess: vi.fn().mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' }),
+}));
+
+vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
+  getMemberCustomRoleId: vi.fn().mockResolvedValue(null),
+  customRoleBelongsToDrive: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+import { GET, POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { createAuthorizationCode } from '@/lib/repositories/oauth-repository';
+
+const REDIRECT_URI = 'http://127.0.0.1:51234/callback';
+const CODE_CHALLENGE = 'a'.repeat(43);
+
+function authorizeUrl(overrides: Record<string, string | undefined> = {}): string {
+  const params: Record<string, string> = {
+    client_id: 'pagespace-cli',
+    redirect_uri: REDIRECT_URI,
+    response_type: 'code',
+    code_challenge: CODE_CHALLENGE,
+    code_challenge_method: 'S256',
+    scope: 'account',
+    state: 'xyz123',
+    ...overrides,
+  };
+  const url = new URL('http://web.local/api/oauth/authorize');
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) {
+      url.searchParams.delete(key);
+    } else {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}
+
+function getRequest(overrides: Record<string, string | undefined> = {}): Request {
+  return new Request(authorizeUrl(overrides), { method: 'GET' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/oauth/authorize — open-redirect guard', () => {
+  it('renders an error page (never redirects) for an unknown client_id', async () => {
+    const res = await GET(getRequest({ client_id: 'evil-client' }) as never);
+    expect(res.status).not.toBeGreaterThanOrEqual(300);
+    expect(res.status).toBeLessThan(400);
+    expect(res.headers.get('location')).toBeNull();
+    const body = await res.text();
+    expect(body).toMatch(/error/i);
+  });
+
+  it('renders an error page (never redirects) for an unregistered redirect_uri', async () => {
+    const res = await GET(getRequest({ redirect_uri: 'http://evil.example.com/callback' }) as never);
+    expect(res.headers.get('location')).toBeNull();
+    expect(res.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('renders an error page (never redirects) for a substring/prefix-attack redirect_uri', async () => {
+    const res = await GET(getRequest({ redirect_uri: `${REDIRECT_URI}.evil.com` }) as never);
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  it('renders an error page (never redirects) for a wrong-path loopback redirect_uri', async () => {
+    const res = await GET(getRequest({ redirect_uri: 'http://127.0.0.1:51234/not-callback' }) as never);
+    expect(res.headers.get('location')).toBeNull();
+  });
+});
+
+describe('GET /api/oauth/authorize — redirect-with-error (redirect_uri already validated)', () => {
+  it('redirects to redirect_uri with error=invalid_request for plain PKCE', async () => {
+    const res = await GET(getRequest({ code_challenge_method: 'plain' }) as never);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.origin + location.pathname).toBe('http://127.0.0.1:51234/callback');
+    expect(location.searchParams.get('error')).toBe('invalid_request');
+    expect(location.searchParams.get('state')).toBe('xyz123');
+  });
+
+  it('redirects to redirect_uri with error=invalid_scope for an unknown scope', async () => {
+    const res = await GET(getRequest({ scope: 'nonsense_scope' }) as never);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.searchParams.get('error')).toBe('invalid_scope');
+  });
+
+  it('omits the state param entirely when the request had no state', async () => {
+    const res = await GET(getRequest({ scope: 'nonsense_scope', state: undefined }) as never);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.searchParams.has('state')).toBe(false);
+  });
+});
+
+describe('GET /api/oauth/authorize — session gate', () => {
+  it('redirects to signin, preserving the full authorize request, when unauthenticated', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(null, { status: 401 }),
+    } as never);
+
+    const res = await GET(getRequest() as never);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.pathname).toBe('/auth/signin');
+    const next = location.searchParams.get('next')!;
+    expect(next).toContain('/oauth/consent');
+    expect(decodeURIComponent(next)).toContain('client_id=pagespace-cli');
+    expect(decodeURIComponent(next)).toContain('state=xyz123');
+  });
+
+  it('redirects to the consent screen, preserving the full authorize request, when authenticated', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      tokenType: 'session',
+      userId: 'user-1',
+      role: 'user',
+      tokenVersion: 0,
+      adminRoleVersion: 0,
+      sessionId: 'sess-1',
+    } as never);
+
+    const res = await GET(getRequest() as never);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get('location')!);
+    expect(location.pathname).toBe('/oauth/consent');
+    expect(location.searchParams.get('client_id')).toBe('pagespace-cli');
+    expect(location.searchParams.get('state')).toBe('xyz123');
+  });
+});
+
+function postRequest(body: Record<string, unknown>): Request {
+  return new Request('http://web.local/api/oauth/authorize', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const approvalBody = {
+  clientId: 'pagespace-cli',
+  redirectUri: REDIRECT_URI,
+  responseType: 'code',
+  codeChallenge: CODE_CHALLENGE,
+  codeChallengeMethod: 'S256',
+  scope: 'account',
+  state: 'xyz123',
+  action: 'approve',
+};
+
+describe('POST /api/oauth/authorize — consent CSRF', () => {
+  it('rejects the consent decision when CSRF/session auth fails', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'CSRF validation failed' }), { status: 403 }),
+    } as never);
+
+    const res = await POST(postRequest(approvalBody) as never);
+    expect(res.status).toBe(403);
+    expect(vi.mocked(createAuthorizationCode)).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/authorize — approve', () => {
+  beforeEach(() => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      tokenType: 'session',
+      userId: 'user-1',
+      role: 'user',
+      tokenVersion: 0,
+      adminRoleVersion: 0,
+      sessionId: 'sess-1',
+    } as never);
+  });
+
+  it('issues a single-use code hashed at rest and echoes state verbatim in the redirect target', async () => {
+    const res = await POST(postRequest(approvalBody) as never);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const location = new URL(json.redirectUri);
+    expect(location.origin + location.pathname).toBe('http://127.0.0.1:51234/callback');
+    expect(location.searchParams.get('state')).toBe('xyz123');
+    const code = location.searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    expect(vi.mocked(createAuthorizationCode)).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(createAuthorizationCode).mock.calls[0][0] as { codeHash: string };
+    expect(call.codeHash).not.toBe(code);
+    expect(call.codeHash).toMatch(/^[0-9a-f]{64}$/); // SHA3-256 hex digest, never the plaintext code
+  });
+
+  it('denial redirects with error=access_denied and echoes state verbatim, without minting a code', async () => {
+    const res = await POST(postRequest({ ...approvalBody, action: 'deny' }) as never);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const location = new URL(json.redirectUri);
+    expect(location.searchParams.get('error')).toBe('access_denied');
+    expect(location.searchParams.get('state')).toBe('xyz123');
+    expect(vi.mocked(createAuthorizationCode)).not.toHaveBeenCalled();
+  });
+
+  it('never redirects for a tampered unregistered redirect_uri, even on approval', async () => {
+    const res = await POST(postRequest({ ...approvalBody, redirectUri: 'http://evil.example.com/callback' }) as never);
+    expect(res.status).toBe(400);
+    expect(vi.mocked(createAuthorizationCode)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
@@ -70,8 +70,8 @@ beforeEach(() => {
 describe('GET /api/oauth/authorize — open-redirect guard', () => {
   it('renders an error page (never redirects) for an unknown client_id', async () => {
     const res = await GET(getRequest({ client_id: 'evil-client' }) as never);
-    expect(res.status).not.toBeGreaterThanOrEqual(300);
-    expect(res.status).toBeLessThan(400);
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
     expect(res.headers.get('location')).toBeNull();
     const body = await res.text();
     expect(body).toMatch(/error/i);

--- a/apps/web/src/app/api/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/oauth/authorize/route.ts
@@ -1,0 +1,199 @@
+/**
+ * OAuth 2.1 authorization endpoint (RFC 6749 §4.1.1) + consent decision
+ * (Phase 1 task 6, epic page ea07mt5jvw0flihsbjce1iv9, ADR 0002).
+ *
+ * GET validates the request and either renders an error page (unknown
+ * client / unregistered redirect_uri — never a redirect, that's the classic
+ * open-redirect vulnerability), redirects to `redirect_uri?error=...` (every
+ * other rejection, only once redirect_uri itself is trusted), redirects to
+ * sign-in (no session), or redirects to the consent screen.
+ *
+ * POST is the consent screen's approve/deny decision: session + CSRF
+ * required, re-validates the entire request server-side (never trusts that
+ * a prior GET validated it), enforces the same grant-authority caps as
+ * mcp-tokens minting (ADR 0002 Decision 2), and returns the redirect target
+ * as JSON — the consent page's client component performs the actual
+ * top-level browser navigation, since redirect_uri is an arbitrary loopback
+ * origin `fetch()` cannot navigate to directly.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import {
+  validateAuthorizeRequest,
+  type AuthorizeRequestParams,
+} from '@pagespace/lib/auth/oauth/authorize-request';
+import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+import { checkGrantAuthority, formatScopeSet, type GrantAuthority } from '@pagespace/lib/auth/oauth/scopes';
+import { AUTHORIZATION_CODE_TTL_SECONDS } from '@pagespace/lib/auth/oauth/code-lifecycle';
+import { generateToken } from '@pagespace/lib/auth/token-utils';
+import { getDriveAccess } from '@pagespace/lib/services/drive-service';
+import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
+import { ensureOAuthClientRow, createAuthorizationCode } from '@/lib/repositories/oauth-repository';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+function extractParams(searchParams: URLSearchParams): AuthorizeRequestParams {
+  return {
+    clientId: searchParams.get('client_id') ?? undefined,
+    redirectUri: searchParams.get('redirect_uri') ?? undefined,
+    responseType: searchParams.get('response_type') ?? undefined,
+    codeChallenge: searchParams.get('code_challenge') ?? undefined,
+    codeChallengeMethod: searchParams.get('code_challenge_method') ?? undefined,
+    scope: searchParams.get('scope') ?? undefined,
+    state: searchParams.get('state') ?? undefined,
+  };
+}
+
+function renderErrorPage(message: string): NextResponse {
+  return new NextResponse(
+    `<!doctype html><html><head><title>Authorization error</title></head><body><h1>Authorization error</h1><p>${message}</p></body></html>`,
+    { status: 400, headers: { 'content-type': 'text/html; charset=utf-8' } },
+  );
+}
+
+function buildRedirectWithParams(redirectUri: string, params: Record<string, string | undefined>): string {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams, search } = new URL(req.url);
+  const params = extractParams(searchParams);
+  const client = params.clientId ? getRegisteredClient(params.clientId) : null;
+  const result = validateAuthorizeRequest(params, client);
+
+  if (!result.ok) {
+    if (result.kind === 'no_redirect') {
+      return renderErrorPage(
+        result.error === 'invalid_client' ? 'Unknown client.' : 'Invalid or unregistered redirect_uri.',
+      );
+    }
+    return NextResponse.redirect(
+      buildRedirectWithParams(result.redirectUri, { error: result.error, state: result.state }),
+      302,
+    );
+  }
+
+  const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: false });
+  const consentTarget = `/oauth/consent${search}`;
+
+  if (isAuthError(auth)) {
+    return NextResponse.redirect(
+      new URL(`/auth/signin?next=${encodeURIComponent(consentTarget)}`, req.url),
+      302,
+    );
+  }
+
+  return NextResponse.redirect(new URL(consentTarget, req.url), 302);
+}
+
+const approvalSchema = z.object({
+  clientId: z.string(),
+  redirectUri: z.string(),
+  responseType: z.string(),
+  codeChallenge: z.string(),
+  codeChallengeMethod: z.string(),
+  scope: z.string(),
+  state: z.string().optional(),
+  action: z.enum(['approve', 'deny']),
+});
+
+export async function POST(req: NextRequest) {
+  const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: true });
+  if (isAuthError(auth)) return auth.error;
+
+  let body: z.infer<typeof approvalSchema>;
+  try {
+    body = approvalSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  const params: AuthorizeRequestParams = {
+    clientId: body.clientId,
+    redirectUri: body.redirectUri,
+    responseType: body.responseType,
+    codeChallenge: body.codeChallenge,
+    codeChallengeMethod: body.codeChallengeMethod,
+    scope: body.scope,
+    state: body.state,
+  };
+  const client = getRegisteredClient(body.clientId);
+  const result = validateAuthorizeRequest(params, client);
+
+  if (!result.ok) {
+    if (result.kind === 'no_redirect') {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+    return NextResponse.json({
+      redirectUri: buildRedirectWithParams(result.redirectUri, { error: result.error, state: result.state }),
+    });
+  }
+
+  if (body.action === 'deny') {
+    auditRequest(req, {
+      eventType: 'authz.access.denied',
+      userId: auth.userId,
+      details: { clientId: result.client.clientId, oauthEvent: 'consent_denied' },
+    });
+    return NextResponse.json({
+      redirectUri: buildRedirectWithParams(result.redirectUri, { error: 'access_denied', state: result.state }),
+    });
+  }
+
+  // Consent = minting: enforce the same authority caps as mcp-tokens (ADR 0002
+  // Decision 2). Any violation rejects the entire request — no partial grant,
+  // uniform `invalid_scope` (no oracle distinguishing "no access" from "role
+  // not grantable" on an endpoint reachable pre-consent by arbitrary clients).
+  const authorityMap = new Map<string, GrantAuthority extends ReadonlyMap<string, infer V> ? V : never>();
+  for (const [driveId, scope] of result.scopes.drives) {
+    const access = await getDriveAccess(driveId, auth.userId);
+    const ownCustomRoleId = await getMemberCustomRoleId(driveId, auth.userId);
+    const customRoleOk =
+      scope.role.kind === 'custom' ? await customRoleBelongsToDrive(scope.role.customRoleId, driveId) : true;
+
+    authorityMap.set(driveId, {
+      isOwner: access.isOwner,
+      isMember: access.isMember,
+      isAdmin: access.isAdmin,
+      ownCustomRoleId,
+      roleBelongsToDrive: () => customRoleOk,
+    });
+  }
+
+  const authority = checkGrantAuthority(result.scopes, authorityMap);
+  if (!authority.ok) {
+    return NextResponse.json({
+      redirectUri: buildRedirectWithParams(result.redirectUri, { error: 'invalid_scope', state: result.state }),
+    });
+  }
+
+  const clientDbId = await ensureOAuthClientRow(result.client);
+  const { token: code, hash: codeHash, tokenPrefix: codePrefix } = generateToken('ps_ac');
+  const expiresAt = new Date(Date.now() + AUTHORIZATION_CODE_TTL_SECONDS * 1000);
+
+  await createAuthorizationCode({
+    clientDbId,
+    userId: auth.userId,
+    redirectUri: result.redirectUri,
+    codeChallenge: result.codeChallenge,
+    codeChallengeMethod: 'S256',
+    scopes: formatScopeSet(result.scopes).split(' ').filter(Boolean),
+    codeHash,
+    codePrefix,
+    expiresAt,
+  });
+
+  auditRequest(req, {
+    eventType: 'authz.access.granted',
+    userId: auth.userId,
+    details: { clientId: result.client.clientId, oauthEvent: 'consent_approved' },
+  });
+
+  return NextResponse.json({
+    redirectUri: buildRedirectWithParams(result.redirectUri, { code, state: result.state }),
+  });
+}

--- a/apps/web/src/app/oauth/consent/ConsentActions.tsx
+++ b/apps/web/src/app/oauth/consent/ConsentActions.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+import { post } from '@/lib/auth/auth-fetch';
+
+interface ConsentActionsProps {
+  clientId: string;
+  redirectUri: string;
+  responseType: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope: string;
+  state: string | undefined;
+}
+
+/**
+ * `redirect_uri` is an arbitrary loopback origin (`http://127.0.0.1:<port>`) —
+ * `fetch()` cannot navigate the top-level browsing context there, so the
+ * approve/deny decision is a CSRF-protected JSON POST (matching every other
+ * mutation in this app) and this component performs the actual navigation
+ * once the server hands back the validated target.
+ */
+export function ConsentActions(props: ConsentActionsProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function decide(action: 'approve' | 'deny') {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const { redirectUri } = await post<{ redirectUri: string }>('/api/oauth/authorize', {
+        clientId: props.clientId,
+        redirectUri: props.redirectUri,
+        responseType: props.responseType,
+        codeChallenge: props.codeChallenge,
+        codeChallengeMethod: props.codeChallengeMethod,
+        scope: props.scope,
+        state: props.state,
+        action,
+      });
+      window.location.href = redirectUri;
+    } catch {
+      setError('Something went wrong. Please try again.');
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mt-8">
+      {error && <p className="mb-3 text-sm text-destructive">{error}</p>}
+      <div className="flex gap-3">
+        <button
+          type="button"
+          disabled={isSubmitting}
+          onClick={() => decide('approve')}
+          className="flex-1 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+        >
+          Allow
+        </button>
+        <button
+          type="button"
+          disabled={isSubmitting}
+          onClick={() => decide('deny')}
+          className="flex-1 rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          Deny
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/oauth/consent/page.tsx
+++ b/apps/web/src/app/oauth/consent/page.tsx
@@ -1,0 +1,135 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { driveRoles } from '@pagespace/db/schema/members';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { validateAuthorizeRequest, type AuthorizeRequestParams } from '@pagespace/lib/auth/oauth/authorize-request';
+import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+import { describeScopeForConsent } from '@pagespace/lib/auth/oauth/consent';
+import { getSessionFromCookies } from '@/lib/auth/cookie-config';
+import { sessionRepository } from '@/lib/repositories/session-repository';
+import { ConsentActions } from './ConsentActions';
+
+interface ConsentPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function ConsentPage({ searchParams }: ConsentPageProps) {
+  const params = await searchParams;
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const v = first(value);
+    if (v !== undefined) query.set(key, v);
+  }
+
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  const sessionToken = getSessionFromCookies(cookieHeader);
+  const nextTarget = `/oauth/consent?${query.toString()}`;
+
+  if (!sessionToken) {
+    redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
+  }
+
+  const session = await sessionService.validateSession(sessionToken);
+  if (!session) {
+    redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
+  }
+
+  const authorizeParams: AuthorizeRequestParams = {
+    clientId: first(params.client_id),
+    redirectUri: first(params.redirect_uri),
+    responseType: first(params.response_type),
+    codeChallenge: first(params.code_challenge),
+    codeChallengeMethod: first(params.code_challenge_method),
+    scope: first(params.scope),
+    state: first(params.state),
+  };
+  const client = authorizeParams.clientId ? getRegisteredClient(authorizeParams.clientId) : null;
+  const result = validateAuthorizeRequest(authorizeParams, client);
+
+  if (!result.ok) {
+    if (result.kind === 'no_redirect') {
+      return (
+        <div className="mx-auto max-w-md py-16 text-center">
+          <h1 className="text-xl font-semibold">Authorization error</h1>
+          <p className="mt-2 text-muted-foreground">
+            {result.error === 'invalid_client' ? 'Unknown client.' : 'Invalid or unregistered redirect_uri.'}
+          </p>
+        </div>
+      );
+    }
+    // Defense in depth: /api/oauth/authorize should already have redirected
+    // this case before ever reaching the consent screen.
+    const url = new URL(result.redirectUri);
+    url.searchParams.set('error', result.error);
+    if (result.state) url.searchParams.set('state', result.state);
+    redirect(url.toString());
+  }
+
+  const driveIds = [...result.scopes.drives.keys()];
+  const drives = driveIds.length > 0 ? await sessionRepository.findDrivesByIds(driveIds) : [];
+  const driveNamesById = new Map(drives.map((d) => [d.id, d.name]));
+
+  const customRoleIds = [...result.scopes.drives.values()]
+    .filter((scope) => scope.role.kind === 'custom')
+    .map((scope) => (scope.role as { kind: 'custom'; customRoleId: string }).customRoleId);
+  const roleRows =
+    customRoleIds.length > 0
+      ? await Promise.all(customRoleIds.map((id) => db.query.driveRoles.findFirst({ where: eq(driveRoles.id, id) })))
+      : [];
+  const roleById = new Map(roleRows.filter((r): r is NonNullable<typeof r> => !!r).map((r) => [r.id, r]));
+
+  const scopeDescriptions: string[] = [];
+  if (result.scopes.account) {
+    scopeDescriptions.push(describeScopeForConsent({ kind: 'account' }, {}));
+  }
+  if (result.scopes.offlineAccess) {
+    scopeDescriptions.push(describeScopeForConsent({ kind: 'offline_access' }, {}));
+  }
+  for (const scope of result.scopes.drives.values()) {
+    const driveName = driveNamesById.get(scope.driveId);
+    if (scope.role.kind === 'custom') {
+      const role = roleById.get(scope.role.customRoleId);
+      scopeDescriptions.push(
+        describeScopeForConsent(scope, { driveName, roleName: role?.name, roleSummary: role?.description ?? undefined }),
+      );
+    } else {
+      scopeDescriptions.push(describeScopeForConsent(scope, { driveName }));
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md py-16">
+      <h1 className="text-xl font-semibold">
+        {result.client.name} is requesting access
+        {result.client.firstParty && (
+          <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs font-normal text-muted-foreground">
+            Built by PageSpace
+          </span>
+        )}
+      </h1>
+      <ul className="mt-6 space-y-3 text-sm">
+        {scopeDescriptions.map((text, i) => (
+          <li key={i} className="rounded border p-3">
+            {text}
+          </li>
+        ))}
+      </ul>
+      <ConsentActions
+        clientId={authorizeParams.clientId!}
+        redirectUri={result.redirectUri}
+        responseType={authorizeParams.responseType!}
+        codeChallenge={result.codeChallenge}
+        codeChallengeMethod={authorizeParams.codeChallengeMethod!}
+        scope={authorizeParams.scope!}
+        state={result.state}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth/url-utils.ts
+++ b/apps/web/src/lib/auth/url-utils.ts
@@ -45,7 +45,7 @@ export function isSafeReturnUrl(url: string | undefined): boolean {
  * here would re-introduce the URL-fragility this allowlist was designed to
  * mitigate.
  */
-export const SIGNIN_NEXT_ALLOWED_PREFIXES = ['/dashboard', '/account', '/s/'] as const;
+export const SIGNIN_NEXT_ALLOWED_PREFIXES = ['/dashboard', '/account', '/s/', '/oauth/consent'] as const;
 
 /**
  * Validates that a `next=` redirect target is both same-origin (composed via

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -1,0 +1,68 @@
+/**
+ * Repository for the OAuth 2.1 provider's persistence (Phase 1 task 6).
+ * Isolates DB access from the /api/oauth/authorize route handler.
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { oauthClients, oauthAuthorizationCodes } from '@pagespace/db/schema/oauth';
+import type { RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+
+/**
+ * First-party clients are defined in code (the static registry), not the DB —
+ * but `oauth_authorization_codes.clientId` is a foreign key into `oauth_clients`
+ * (that table's job, per ADR 0002 Decision 3, is to also accommodate future
+ * dynamically-registered clients). This ensures a matching row exists for a
+ * static registry client, keyed by the stable `clientId` string, so the FK
+ * resolves; the static registry — not this row — remains the source of truth
+ * for redirect URIs, grants, and enablement.
+ */
+export async function ensureOAuthClientRow(client: RegisteredClient): Promise<string> {
+  await db
+    .insert(oauthClients)
+    .values({
+      clientId: client.clientId,
+      name: client.name,
+      clientType: client.type,
+      redirectUris: client.redirectUris,
+      isFirstParty: client.firstParty,
+    })
+    .onConflictDoNothing({ target: oauthClients.clientId });
+
+  const row = await db.query.oauthClients.findFirst({
+    where: eq(oauthClients.clientId, client.clientId),
+    columns: { id: true },
+  });
+
+  if (!row) {
+    throw new Error(`Failed to ensure OAuth client row for ${client.clientId}`);
+  }
+
+  return row.id;
+}
+
+export interface CreateAuthorizationCodeInput {
+  clientDbId: string;
+  userId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scopes: string[];
+  codeHash: string;
+  codePrefix: string;
+  expiresAt: Date;
+}
+
+export async function createAuthorizationCode(input: CreateAuthorizationCodeInput): Promise<void> {
+  await db.insert(oauthAuthorizationCodes).values({
+    codeHash: input.codeHash,
+    codePrefix: input.codePrefix,
+    clientId: input.clientDbId,
+    userId: input.userId,
+    redirectUri: input.redirectUri,
+    codeChallenge: input.codeChallenge,
+    codeChallengeMethod: input.codeChallengeMethod,
+    scopes: input.scopes,
+    expiresAt: input.expiresAt,
+  });
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -937,6 +937,26 @@
       "import": "./dist/auth/oauth/metadata.js",
       "require": "./dist/auth/oauth/metadata.js"
     },
+    "./auth/oauth/clients": {
+      "types": "./dist/auth/oauth/clients.d.ts",
+      "import": "./dist/auth/oauth/clients.js",
+      "require": "./dist/auth/oauth/clients.js"
+    },
+    "./auth/oauth/authorize-request": {
+      "types": "./dist/auth/oauth/authorize-request.d.ts",
+      "import": "./dist/auth/oauth/authorize-request.js",
+      "require": "./dist/auth/oauth/authorize-request.js"
+    },
+    "./auth/oauth/consent": {
+      "types": "./dist/auth/oauth/consent.d.ts",
+      "import": "./dist/auth/oauth/consent.js",
+      "require": "./dist/auth/oauth/consent.js"
+    },
+    "./auth/oauth/code-lifecycle": {
+      "types": "./dist/auth/oauth/code-lifecycle.d.ts",
+      "import": "./dist/auth/oauth/code-lifecycle.js",
+      "require": "./dist/auth/oauth/code-lifecycle.js"
+    },
     "./auth/account-lockout": {
       "types": "./dist/auth/account-lockout.d.ts",
       "import": "./dist/auth/account-lockout.js",

--- a/packages/lib/src/auth/oauth/__tests__/authorize-request.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/authorize-request.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Pure validation for GET /api/oauth/authorize (ADR 0002 Decisions 1-3, task
+ * page hn80whvl8p00jdhv3gt8nlr6). Fail-closed: an unknown client or
+ * unregistered redirect_uri must NEVER produce a redirect (open-redirect
+ * guard); every other rejection redirects to the (now-validated) redirect_uri
+ * with `error=` per RFC 6749 §4.1.2.1.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateAuthorizeRequest, type AuthorizeRequestParams } from '../authorize-request';
+import { getRegisteredClient, PAGESPACE_CLI_CLIENT_ID } from '../clients';
+
+const client = getRegisteredClient(PAGESPACE_CLI_CLIENT_ID)!;
+const REDIRECT_URI = 'http://127.0.0.1:51234/callback';
+
+function baseParams(overrides: Partial<AuthorizeRequestParams> = {}): AuthorizeRequestParams {
+  return {
+    clientId: 'pagespace-cli',
+    redirectUri: REDIRECT_URI,
+    responseType: 'code',
+    codeChallenge: 'a'.repeat(43),
+    codeChallengeMethod: 'S256',
+    scope: 'account',
+    state: 'xyz123',
+    ...overrides,
+  };
+}
+
+describe('validateAuthorizeRequest', () => {
+  it('accepts a fully valid request', () => {
+    const result = validateAuthorizeRequest(baseParams(), client);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.redirectUri).toBe(REDIRECT_URI);
+      expect(result.client.clientId).toBe('pagespace-cli');
+      expect(result.codeChallenge).toBe('a'.repeat(43));
+      expect(result.state).toBe('xyz123');
+      expect(result.scopes.account).toBe(true);
+    }
+  });
+
+  it('accepts a request with no state (state is optional)', () => {
+    const result = validateAuthorizeRequest(baseParams({ state: undefined }), client);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.state).toBeUndefined();
+  });
+
+  describe('no-redirect failures (open-redirect guard)', () => {
+    it('rejects an unknown client_id without redirecting', () => {
+      const result = validateAuthorizeRequest(baseParams(), null);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('no_redirect');
+        expect(result.error).toBe('invalid_client');
+      }
+    });
+
+    it('rejects a missing redirect_uri without redirecting', () => {
+      const result = validateAuthorizeRequest(baseParams({ redirectUri: undefined }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.kind).toBe('no_redirect');
+    });
+
+    it('rejects an unregistered redirect_uri without redirecting', () => {
+      const result = validateAuthorizeRequest(baseParams({ redirectUri: 'http://evil.example.com/callback' }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('no_redirect');
+        expect(result.error).toBe('invalid_redirect_uri');
+      }
+    });
+
+    it('rejects a substring/prefix-attack redirect_uri without redirecting', () => {
+      const result = validateAuthorizeRequest(
+        baseParams({ redirectUri: 'http://127.0.0.1:51234/callback.evil.com' }),
+        client,
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.kind).toBe('no_redirect');
+    });
+
+    it('rejects a wrong-path loopback redirect_uri without redirecting', () => {
+      const result = validateAuthorizeRequest(
+        baseParams({ redirectUri: 'http://127.0.0.1:51234/other-path' }),
+        client,
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.kind).toBe('no_redirect');
+    });
+
+    it('rejects `localhost` (numeric loopback literal required, RFC 8252 §8.3)', () => {
+      const result = validateAuthorizeRequest(
+        baseParams({ redirectUri: 'http://localhost:51234/callback' }),
+        client,
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.kind).toBe('no_redirect');
+    });
+  });
+
+  describe('redirect failures (redirect_uri already validated)', () => {
+    it('rejects an unsupported response_type by redirecting with error=', () => {
+      const result = validateAuthorizeRequest(baseParams({ responseType: 'token' }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('redirect');
+        expect(result.error).toBe('unsupported_response_type');
+        expect(result.redirectUri).toBe(REDIRECT_URI);
+        expect(result.state).toBe('xyz123');
+      }
+    });
+
+    it('rejects `plain` code_challenge_method by redirecting with error=', () => {
+      const result = validateAuthorizeRequest(baseParams({ codeChallengeMethod: 'plain' }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('redirect');
+        expect(result.error).toBe('invalid_request');
+      }
+    });
+
+    it('rejects a missing code_challenge by redirecting with error=', () => {
+      const result = validateAuthorizeRequest(baseParams({ codeChallenge: undefined }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('redirect');
+        expect(result.error).toBe('invalid_request');
+      }
+    });
+
+    it('rejects a missing scope by redirecting with error=invalid_scope', () => {
+      const result = validateAuthorizeRequest(baseParams({ scope: undefined }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.kind).toBe('redirect');
+        expect(result.error).toBe('invalid_scope');
+      }
+    });
+
+    it('rejects an unknown scope token by redirecting with error=invalid_scope', () => {
+      const result = validateAuthorizeRequest(baseParams({ scope: 'account nonsense_scope' }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_scope');
+    });
+
+    it('rejects account mixed with a drive scope by redirecting with error=invalid_scope', () => {
+      const result = validateAuthorizeRequest(baseParams({ scope: 'account drive:abc123' }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_scope');
+    });
+
+    it('rejects offline_access requested alone by redirecting with error=invalid_scope', () => {
+      const result = validateAuthorizeRequest(baseParams({ scope: 'offline_access' }), client);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBe('invalid_scope');
+    });
+
+    it('echoes state verbatim on a redirect-kind failure, and omits it when absent', () => {
+      const withState = validateAuthorizeRequest(baseParams({ scope: undefined, state: 'preserve-me' }), client);
+      if (!withState.ok && withState.kind === 'redirect') expect(withState.state).toBe('preserve-me');
+
+      const withoutState = validateAuthorizeRequest(baseParams({ scope: undefined, state: undefined }), client);
+      if (!withoutState.ok && withoutState.kind === 'redirect') expect(withoutState.state).toBeUndefined();
+    });
+  });
+});

--- a/packages/lib/src/auth/oauth/__tests__/authorize-request.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/authorize-request.test.ts
@@ -101,11 +101,12 @@ describe('validateAuthorizeRequest', () => {
     it('rejects an unsupported response_type by redirecting with error=', () => {
       const result = validateAuthorizeRequest(baseParams({ responseType: 'token' }), client);
       expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.kind).toBe('redirect');
+      if (!result.ok && result.kind === 'redirect') {
         expect(result.error).toBe('unsupported_response_type');
         expect(result.redirectUri).toBe(REDIRECT_URI);
         expect(result.state).toBe('xyz123');
+      } else {
+        throw new Error('expected a redirect-kind failure');
       }
     });
 

--- a/packages/lib/src/auth/oauth/__tests__/clients.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/clients.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Static first-party OAuth client registry (ADR 0002 Decision 3) + redirect_uri
+ * validation. Registry lookup is code, not DB, for the CLI's client_id; the
+ * DB `oauth_clients` table exists only for future dynamic registration.
+ */
+import { describe, it, expect } from 'vitest';
+import { getRegisteredClient, validateRedirectUri, PAGESPACE_CLI_CLIENT_ID } from '../clients';
+
+describe('getRegisteredClient', () => {
+  it('returns the pagespace-cli client for its client_id', () => {
+    const client = getRegisteredClient(PAGESPACE_CLI_CLIENT_ID);
+    expect(client).not.toBeNull();
+    expect(client?.clientId).toBe('pagespace-cli');
+    expect(client?.type).toBe('public');
+    expect(client?.firstParty).toBe(true);
+  });
+
+  it('returns null for an unknown client_id (fail closed)', () => {
+    expect(getRegisteredClient('evil-client')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(getRegisteredClient('')).toBeNull();
+  });
+});
+
+describe('validateRedirectUri', () => {
+  const client = getRegisteredClient(PAGESPACE_CLI_CLIENT_ID)!;
+
+  it('accepts the exact registered loopback path on an arbitrary port', () => {
+    expect(validateRedirectUri(client, 'http://127.0.0.1:51234/callback')).toBe(true);
+    expect(validateRedirectUri(client, 'http://127.0.0.1:1/callback')).toBe(true);
+    expect(validateRedirectUri(client, 'http://127.0.0.1/callback')).toBe(true); // default port
+  });
+
+  it('accepts the IPv6 loopback literal on an arbitrary port', () => {
+    expect(validateRedirectUri(client, 'http://[::1]:9999/callback')).toBe(true);
+  });
+
+  it('rejects `localhost` even though it usually resolves to loopback (RFC 8252 §8.3)', () => {
+    expect(validateRedirectUri(client, 'http://localhost:51234/callback')).toBe(false);
+  });
+
+  it('rejects a mismatched path on the loopback host (substring/prefix attack)', () => {
+    expect(validateRedirectUri(client, 'http://127.0.0.1:51234/callback/evil')).toBe(false);
+    expect(validateRedirectUri(client, 'http://127.0.0.1:51234/call')).toBe(false);
+    expect(validateRedirectUri(client, 'http://127.0.0.1:51234/')).toBe(false);
+  });
+
+  it('rejects a non-loopback host entirely (open redirect attempt)', () => {
+    expect(validateRedirectUri(client, 'http://evil.example.com/callback')).toBe(false);
+    expect(validateRedirectUri(client, 'https://127.0.0.1.evil.example.com/callback')).toBe(false);
+  });
+
+  it('rejects https on the loopback pattern (scheme must match exactly)', () => {
+    expect(validateRedirectUri(client, 'https://127.0.0.1:51234/callback')).toBe(false);
+  });
+
+  it('rejects a redirect_uri carrying userinfo, query, or fragment', () => {
+    expect(validateRedirectUri(client, 'http://user@127.0.0.1:51234/callback')).toBe(false);
+    expect(validateRedirectUri(client, 'http://127.0.0.1:51234/callback?x=1')).toBe(false);
+    expect(validateRedirectUri(client, 'http://127.0.0.1:51234/callback#frag')).toBe(false);
+  });
+
+  it('rejects a malformed URI', () => {
+    expect(validateRedirectUri(client, 'not a uri')).toBe(false);
+    expect(validateRedirectUri(client, '')).toBe(false);
+  });
+
+  it('rejects everything for a client with no registered redirect URIs', () => {
+    const bareClient = { clientId: 'x', name: 'X', type: 'public' as const, redirectUris: [], allowedGrantTypes: [], firstParty: false };
+    expect(validateRedirectUri(bareClient, 'http://127.0.0.1:1/callback')).toBe(false);
+  });
+});

--- a/packages/lib/src/auth/oauth/__tests__/consent.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/consent.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Consent-screen narration (ADR 0002 Decision 5): parsed scopes + resolved
+ * names in, human-readable strings out. Pure — no DB, no fetch; the caller
+ * resolves driveName/roleName/roleSummary and passes them in.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeScopeForConsent } from '../consent';
+import type { ParsedScope } from '../scopes';
+
+describe('describeScopeForConsent', () => {
+  it('flags `account` as the maximum, full-account grant', () => {
+    const text = describeScopeForConsent({ kind: 'account' }, {});
+    expect(text).toMatch(/full access/i);
+    expect(text).toMatch(/account/i);
+  });
+
+  it('describes offline_access as a long-lived refresh credential', () => {
+    const text = describeScopeForConsent({ kind: 'offline_access' }, {});
+    expect(text).toMatch(/revoke/i);
+  });
+
+  it('describes an inherit drive scope by the resolved drive name, not the raw id', () => {
+    const scope: ParsedScope = { kind: 'drive', driveId: 'drv123', role: { kind: 'inherit' } };
+    const text = describeScopeForConsent(scope, { driveName: 'Marketing' });
+    expect(text).toMatch(/Marketing/);
+    expect(text).not.toMatch(/drv123$/); // id may appear as a suffix/tooltip, never standalone
+    expect(text).toMatch(/act as you/i);
+  });
+
+  it('describes an admin drive scope, explicitly naming private-page access', () => {
+    const scope: ParsedScope = { kind: 'drive', driveId: 'drv123', role: { kind: 'admin' } };
+    const text = describeScopeForConsent(scope, { driveName: 'Marketing' });
+    expect(text).toMatch(/admin/i);
+    expect(text).toMatch(/private/i);
+    expect(text).toMatch(/Marketing/);
+  });
+
+  it('describes a plain member drive scope as view + channel-post only', () => {
+    const scope: ParsedScope = { kind: 'drive', driveId: 'drv123', role: { kind: 'member' } };
+    const text = describeScopeForConsent(scope, { driveName: 'Marketing' });
+    expect(text).toMatch(/member/i);
+    expect(text).toMatch(/cannot edit/i);
+    expect(text).toMatch(/Marketing/);
+  });
+
+  it('describes a custom-role drive scope by resolved role name + summary', () => {
+    const scope: ParsedScope = { kind: 'drive', driveId: 'drv123', role: { kind: 'custom', customRoleId: 'role1' } };
+    const text = describeScopeForConsent(scope, {
+      driveName: 'Marketing',
+      roleName: 'Editor',
+      roleSummary: 'can edit pages, cannot delete',
+    });
+    expect(text).toMatch(/Editor/);
+    expect(text).toMatch(/Marketing/);
+    expect(text).toMatch(/can edit pages, cannot delete/);
+  });
+});

--- a/packages/lib/src/auth/oauth/authorize-request.ts
+++ b/packages/lib/src/auth/oauth/authorize-request.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure validation for `GET /api/oauth/authorize` (ADR 0002 Decisions 1-3).
+ *
+ * Fail-closed and total: never throws. The two branches carry different
+ * blast radii —
+ *  - `no_redirect`: the client or redirect_uri itself could not be trusted,
+ *    so the caller MUST render an error page and MUST NOT redirect anywhere
+ *    (redirecting to an unvalidated URI is the classic OAuth open-redirect).
+ *  - `redirect`: the redirect_uri is already validated, so the caller
+ *    redirects there with `error=` per RFC 6749 §4.1.2.1.
+ *
+ * @module @pagespace/lib/auth/oauth/authorize-request
+ */
+
+import { parseScopeList, type ScopeSet } from './scopes';
+import { validateRedirectUri, type RegisteredClient } from './clients';
+
+export interface AuthorizeRequestParams {
+  clientId: string | undefined;
+  redirectUri: string | undefined;
+  responseType: string | undefined;
+  codeChallenge: string | undefined;
+  codeChallengeMethod: string | undefined;
+  scope: string | undefined;
+  state: string | undefined;
+}
+
+export type AuthorizeNoRedirectError = 'invalid_client' | 'invalid_redirect_uri';
+export type AuthorizeRedirectError = 'unsupported_response_type' | 'invalid_request' | 'invalid_scope';
+
+export type AuthorizeValidationResult =
+  | {
+      ok: true;
+      client: RegisteredClient;
+      redirectUri: string;
+      scopes: ScopeSet;
+      codeChallenge: string;
+      state: string | undefined;
+    }
+  | { ok: false; kind: 'no_redirect'; error: AuthorizeNoRedirectError }
+  | { ok: false; kind: 'redirect'; error: AuthorizeRedirectError; redirectUri: string; state: string | undefined };
+
+/**
+ * Validate an authorize request against its (already-looked-up) client.
+ * Validation order matters: client, then redirect_uri — both no-redirect
+ * failures — before any check whose failure is reported via redirect.
+ */
+export function validateAuthorizeRequest(
+  params: AuthorizeRequestParams,
+  client: RegisteredClient | null,
+): AuthorizeValidationResult {
+  if (!client) {
+    return { ok: false, kind: 'no_redirect', error: 'invalid_client' };
+  }
+
+  if (!params.redirectUri || !validateRedirectUri(client, params.redirectUri)) {
+    return { ok: false, kind: 'no_redirect', error: 'invalid_redirect_uri' };
+  }
+
+  const redirectUri = params.redirectUri;
+  const state = params.state;
+
+  if (params.responseType !== 'code') {
+    return { ok: false, kind: 'redirect', error: 'unsupported_response_type', redirectUri, state };
+  }
+
+  if (params.codeChallengeMethod !== 'S256' || !params.codeChallenge) {
+    return { ok: false, kind: 'redirect', error: 'invalid_request', redirectUri, state };
+  }
+
+  if (!params.scope) {
+    return { ok: false, kind: 'redirect', error: 'invalid_scope', redirectUri, state };
+  }
+
+  const parsedScope = parseScopeList(params.scope);
+  if (!parsedScope.ok) {
+    return { ok: false, kind: 'redirect', error: 'invalid_scope', redirectUri, state };
+  }
+
+  return {
+    ok: true,
+    client,
+    redirectUri,
+    scopes: parsedScope.scopes,
+    codeChallenge: params.codeChallenge,
+    state,
+  };
+}

--- a/packages/lib/src/auth/oauth/clients.ts
+++ b/packages/lib/src/auth/oauth/clients.ts
@@ -1,0 +1,89 @@
+/**
+ * Static first-party OAuth client registry (ADR 0002 Decision 3).
+ *
+ * First-party clients (the CLI, `client_id: "pagespace-cli"`) are
+ * authoritatively defined here, in code — not in the `oauth_clients` DB
+ * table, which exists only to accommodate future RFC 7591 dynamic client
+ * registration (not shipped this epic). Registry lookup order: static
+ * registry first; an unknown `client_id` is rejected (`invalid_client`).
+ *
+ * @module @pagespace/lib/auth/oauth/clients
+ */
+
+export interface RegisteredClient {
+  clientId: string;
+  name: string;
+  type: 'public';
+  /** Exact-match redirect URIs; loopback entries wildcard only the port (see {@link validateRedirectUri}). */
+  redirectUris: string[];
+  allowedGrantTypes: readonly string[];
+  firstParty: boolean;
+}
+
+export const PAGESPACE_CLI_CLIENT_ID = 'pagespace-cli';
+
+const PAGESPACE_CLI_CLIENT: RegisteredClient = {
+  clientId: PAGESPACE_CLI_CLIENT_ID,
+  name: 'PageSpace CLI',
+  type: 'public',
+  redirectUris: ['http://127.0.0.1/callback', 'http://[::1]/callback'],
+  allowedGrantTypes: ['authorization_code', 'urn:ietf:params:oauth:grant-type:device_code', 'refresh_token'],
+  firstParty: true,
+};
+
+const STATIC_CLIENT_REGISTRY = new Map<string, RegisteredClient>([[PAGESPACE_CLI_CLIENT.clientId, PAGESPACE_CLI_CLIENT]]);
+
+/** Static registry lookup. Unknown `client_id` → null (caller fails closed with `invalid_client`). */
+export function getRegisteredClient(clientId: string): RegisteredClient | null {
+  if (!clientId) return null;
+  return STATIC_CLIENT_REGISTRY.get(clientId) ?? null;
+}
+
+/** The two loopback literals RFC 8252 §7.3 allows a wildcard port on. `localhost` is deliberately excluded (§8.3). */
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', '[::1]']);
+
+/**
+ * Exact-match redirect_uri validation (ADR 0002 Decision 3). The port is the
+ * only wildcard component, and only for the two loopback literals above —
+ * scheme, host, and path must match exactly. A redirect_uri carrying
+ * userinfo, a query string, or a fragment is rejected outright, matching the
+ * registration-time constraint (nothing registrable ever has one, so nothing
+ * presented at authorize time can match one either).
+ */
+export function validateRedirectUri(client: Pick<RegisteredClient, 'redirectUris'>, redirectUri: string): boolean {
+  if (typeof redirectUri !== 'string' || redirectUri.length === 0) return false;
+
+  let candidate: URL;
+  try {
+    candidate = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+
+  if (candidate.username || candidate.password || candidate.search || candidate.hash) return false;
+  if (candidate.hostname === 'localhost') return false;
+
+  for (const registered of client.redirectUris) {
+    let pattern: URL;
+    try {
+      pattern = new URL(registered);
+    } catch {
+      continue;
+    }
+
+    if (LOOPBACK_HOSTNAMES.has(pattern.hostname)) {
+      if (
+        candidate.protocol === pattern.protocol &&
+        candidate.hostname === pattern.hostname &&
+        candidate.pathname === pattern.pathname
+      ) {
+        return true;
+      }
+      continue;
+    }
+
+    if (candidate.toString() === pattern.toString()) return true;
+  }
+
+  return false;
+}

--- a/packages/lib/src/auth/oauth/consent.ts
+++ b/packages/lib/src/auth/oauth/consent.ts
@@ -1,0 +1,41 @@
+/**
+ * Consent-screen narration (ADR 0002 Decision 5). Pure — the caller resolves
+ * drive/role names and role capability summaries server-side and passes them
+ * in; this module never renders an id standalone, only alongside a name.
+ *
+ * @module @pagespace/lib/auth/oauth/consent
+ */
+
+import type { ParsedScope } from './scopes';
+
+export interface ConsentNarrationContext {
+  driveName?: string;
+  roleName?: string;
+  roleSummary?: string;
+}
+
+/** Per-scope narration text (ADR 0002 Decision 5, point 3's table). */
+export function describeScopeForConsent(scope: ParsedScope, ctx: ConsentNarrationContext): string {
+  switch (scope.kind) {
+    case 'account':
+      return 'Full access to your PageSpace account — everything you can see and do, in every drive, now and in the future.';
+    case 'offline_access':
+      return 'Stay connected until you revoke access (issues a long-lived refresh credential).';
+    case 'drive': {
+      const driveName = ctx.driveName ?? scope.driveId;
+      switch (scope.role.kind) {
+        case 'inherit':
+          return `Act as you in ${driveName} — everything you can currently do there (your access, including future changes to it). No access to any other drive.`;
+        case 'admin':
+          return `Full admin access to ${driveName} — view and edit all pages including private pages, manage sharing and deletion.`;
+        case 'member':
+          return `Member access to ${driveName} — view non-private pages and post in channels. Cannot edit other pages, share, or delete.`;
+        case 'custom': {
+          const roleName = ctx.roleName ?? scope.role.customRoleId;
+          const summary = ctx.roleSummary ? ` (${ctx.roleSummary})` : '';
+          return `Access to ${driveName} limited to the ${roleName} role${summary}.`;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 task 6 (epic page `ea07mt5jvw0flihsbjce1iv9`, phase page `qcvrenku1yqbwtmgn7pc7jbz`, task page `hn80whvl8p00jdhv3gt8nlr6`). Builds on the merged Phase 0 ADRs and Phase 1 tasks 1-4 (schema, PKCE, scopes, code lifecycle) — imports them, does not reimplement.

**Pure logic** (`packages/lib/src/auth/oauth/`):
- `clients.ts` — static first-party client registry (ADR 0002 Decision 3): `pagespace-cli` entry + `validateRedirectUri` (loopback exact-match, port wildcard only on `127.0.0.1`/`[::1]`, `localhost` rejected per RFC 8252 §8.3, no userinfo/query/fragment).
- `authorize-request.ts` — `validateAuthorizeRequest` pure function, discriminating `no_redirect` failures (unknown client, unregistered redirect_uri — open-redirect guard, never redirect) from `redirect` failures (bad response_type/PKCE/scope — redirect to the now-validated redirect_uri with `error=` per RFC 6749 §4.1.2.1).
- `consent.ts` — `describeScopeForConsent` narration per ADR 0002 Decision 5's table.

**Route** (`apps/web/src/app/api/oauth/authorize/route.ts`):
- `GET` — validates; renders an inline error page for `no_redirect` failures; redirects with `error=` for `redirect` failures; gates on session (redirects to `/auth/signin?next=...` preserving the full request, returning to consent after auth); else redirects to `/oauth/consent`.
- `POST` — session + CSRF consent decision (mirrors `mcp-tokens` route auth options). Re-validates the entire request server-side (never trusts a prior GET), enforces the same grant-authority caps as `mcp-tokens` minting via `checkGrantAuthority` (ADR 0002 Decision 2 — "consent = minting"), mints a single-use SHA3-256-hashed authorization code on approval, and returns the redirect target as JSON. `redirect_uri` is an arbitrary loopback origin `fetch()` can't navigate to, so the consent page's client component performs the actual top-level browser navigation once the server hands back the validated target.

**Repository** (`apps/web/src/lib/repositories/oauth-repository.ts`) — ensures a DB row exists for the static first-party client (the `oauth_authorization_codes.clientId` FK target; the static registry stays the source of truth for redirect URIs/grants/enablement) and inserts the authorization code row.

**UI** (`apps/web/src/app/oauth/consent/`) — server-component consent screen (session gate, defense-in-depth re-validation, drive/role name resolution for scope narration, "Built by PageSpace" badge) + a client component for the approve/deny decision. Added `/oauth/consent` to `SIGNIN_NEXT_ALLOWED_PREFIXES` so the existing signin redirect-then-return flow covers it.

Also added `package.json` exports entries for the three new subpath modules plus `code-lifecycle` (missing from Phase 1 task 4's PR #1777 — needed here for `AUTHORIZATION_CODE_TTL_SECONDS`).

## Test plan
- [x] RED: 4 failing test suites committed first (`98a0705ad`) — pure-logic modules + route, all failing to resolve (not yet implemented)
- [x] GREEN: implementation (`d675af906`) — 34 pure-logic tests + 13 route tests, all passing
- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bun run test:unit` — 10520/10537 passing; 17 pre-existing failures (DB role `"test"` missing in this sandbox, one flaky midnight-boundary test) confirmed identical via `git stash` against the base branch
- [x] `bun run test:security` — 36/43 suites green; the 7 failing suites are the same pre-existing DB-environment gap, confirmed identical via `git stash`
- [ ] Reviewer: token endpoint (task 7) will consume the authorization codes minted here via `decideCodeExchange` (already merged in `code-lifecycle.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pbxh5qiu1yGYZ47qn5eEnB