### PR TITLE
sdk: implement operation registry + seed operations (Phase 2 task 5)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,3 +8,7 @@ export * from './auth/provider.js';
 export * from './auth/static.js';
 export * from './auth/oauth.js';
 export * from './auth/decide.js';
+export * from './registry/define.js';
+export * from './registry/registry.js';
+export * from './operations/drives.js';
+export * from './operations/pages.js';

--- a/packages/sdk/src/operations/__tests__/drives.test.ts
+++ b/packages/sdk/src/operations/__tests__/drives.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { listDrives } from '../drives.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/drives/route.ts GET (drive-service.ts DriveWithAccess). */
+const driveFixture = {
+  id: 'd1abc',
+  name: 'Engineering',
+  slug: 'engineering',
+  ownerId: 'u1abc',
+  kind: 'STANDARD',
+  isTrashed: false,
+  trashedAt: null,
+  drivePrompt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+  isOwned: true,
+  role: 'OWNER',
+  lastAccessedAt: null,
+  homePageId: null,
+};
+
+describe('drives.list — request shape', () => {
+  it('builds a bare GET to /api/drives with no path params', () => {
+    const request = buildRequest(listDrives, {}, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('serializes includeTrash/tokenScopable as query params', () => {
+    const request = buildRequest(listDrives, { includeTrash: true, tokenScopable: false }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives?includeTrash=true&tokenScopable=false');
+  });
+});
+
+describe('drives.list — response contract', () => {
+  it('parses a bare array of DriveWithAccess rows (route truth, §2.1)', () => {
+    const result = parseResponse(listDrives, 200, new Headers(), JSON.stringify([driveFixture]));
+    expect(result).toEqual([driveFixture]);
+  });
+
+  it('parses an empty drive list', () => {
+    const result = parseResponse(listDrives, 200, new Headers(), JSON.stringify([]));
+    expect(result).toEqual([]);
+  });
+
+  it('rejects a response that drifts from the DriveWithAccess contract', () => {
+    const malformed = [{ ...driveFixture, role: 'SUPERADMIN' }];
+    const result = parseResponse(listDrives, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a non-2xx response as a typed error, never a schema mismatch', () => {
+    const result = parseResponse(listDrives, 403, new Headers(), JSON.stringify({ error: 'This token does not have access to this drive' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('drives.list — metadata', () => {
+  it('is named and described for MCP/CLI derivation', () => {
+    expect(listDrives.name).toBe('drives.list');
+    expect(listDrives.description.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sdk/src/operations/__tests__/pages.test.ts
+++ b/packages/sdk/src/operations/__tests__/pages.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { readPage } from '../pages.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/pages/[pageId]/route.ts GET → pageService.getPage (PageWithDetails). */
+const pageFixture = {
+  id: 'p1abc',
+  title: 'Design Doc',
+  type: 'DOCUMENT',
+  content: '<p>Hello</p>',
+  contentMode: 'html',
+  parentId: null,
+  driveId: 'd1abc',
+  position: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+  revision: 3,
+  stateHash: 'abc123',
+  isTrashed: false,
+  trashedAt: null,
+  aiProvider: null,
+  aiModel: null,
+  systemPrompt: null,
+  enabledTools: null,
+  isPaginated: false,
+  children: [],
+  messages: [
+    {
+      id: 'm1abc',
+      content: 'Looks good',
+      createdAt: '2026-01-02T00:00:00.000Z',
+      user: { id: 'u1abc', name: 'Ada', email: 'ada@example.com', image: null },
+    },
+  ],
+};
+
+describe('pages.read — request shape', () => {
+  it('interpolates :pageId into the path and sends no body', () => {
+    const request = buildRequest(readPage, { pageId: 'p1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/p1abc');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('URL-encodes the pageId', () => {
+    const request = buildRequest(readPage, { pageId: 'a/b' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/pages/a%2Fb');
+  });
+});
+
+describe('pages.read — response contract', () => {
+  it('parses PageWithDetails (route truth, §2.3 get_page_details)', () => {
+    const result = parseResponse(readPage, 200, new Headers(), JSON.stringify(pageFixture));
+    expect(result).toEqual(pageFixture);
+  });
+
+  it('parses a page with children (PageData rows, no nested children/messages)', () => {
+    const child = { ...pageFixture, id: 'c1abc' } as Record<string, unknown>;
+    delete child.children;
+    delete child.messages;
+    const result = parseResponse(readPage, 200, new Headers(), JSON.stringify({ ...pageFixture, children: [child] }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('rejects a response missing a required field', () => {
+    const malformed = { ...pageFixture } as Record<string, unknown>;
+    delete malformed.driveId;
+    const result = parseResponse(readPage, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 404 as NotFoundError, never a schema mismatch', () => {
+    const result = parseResponse(readPage, 404, new Headers(), JSON.stringify({ error: 'Page not found' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+});
+
+describe('pages.read — metadata', () => {
+  it('declares the drive-scope requirement per ADR 0002', () => {
+    expect(readPage.requiredScope).toBe('drive');
+  });
+});

--- a/packages/sdk/src/operations/drives.ts
+++ b/packages/sdk/src/operations/drives.ts
@@ -1,0 +1,40 @@
+/**
+ * Seed operation: `drives.list` (Phase 2 task 5 proof-of-pattern).
+ *
+ * Route-verified against `apps/web/src/app/api/drives/route.ts` GET
+ * (docs/sdk/operations-inventory.md §2.1, parity with MCP tool `list_drives`).
+ * Response is a bare array of `DriveWithAccess`
+ * (`packages/lib/src/services/drive-service.ts:20`); dates serialize as ISO
+ * strings over JSON.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const driveSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  ownerId: z.string(),
+  kind: z.enum(['STANDARD', 'HOME']),
+  isTrashed: z.boolean(),
+  trashedAt: z.string().nullable(),
+  drivePrompt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  isOwned: z.boolean(),
+  role: z.enum(['OWNER', 'ADMIN', 'MEMBER']),
+  lastAccessedAt: z.string().nullable(),
+  homePageId: z.string().nullable(),
+});
+
+export const listDrives = defineOperation({
+  name: 'drives.list',
+  method: 'GET',
+  path: '/api/drives',
+  inputSchema: z.object({
+    includeTrash: z.boolean().optional(),
+    tokenScopable: z.boolean().optional(),
+  }),
+  outputSchema: z.array(driveSchema),
+  description: 'List drives the caller can access.',
+});

--- a/packages/sdk/src/operations/pages.ts
+++ b/packages/sdk/src/operations/pages.ts
@@ -1,0 +1,76 @@
+/**
+ * Seed operation: `pages.read` (Phase 2 task 5 proof-of-pattern).
+ *
+ * Route-verified against `apps/web/src/app/api/pages/[pageId]/route.ts` GET
+ * → `pageService.getPage` (docs/sdk/operations-inventory.md §2.3, parity with
+ * MCP tool `get_page_details`). Response is a bare `PageWithDetails`
+ * (`apps/web/src/services/api/page-service.ts:133,158`); dates serialize as
+ * ISO strings over JSON. `requiredScope: 'drive'` — view access is granted
+ * at the inherit/MEMBER level of the page's drive (ADR 0002 Decision 2), the
+ * minimum a caller's grant must cover.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const pageTypeSchema = z.enum([
+  'FOLDER',
+  'DOCUMENT',
+  'CHANNEL',
+  'AI_CHAT',
+  'CANVAS',
+  'SHEET',
+  'TASK_LIST',
+  'CODE',
+  'TERMINAL',
+]);
+
+const pageDataSchema = z.object({
+  id: z.string(),
+  title: z.string().nullable(),
+  type: pageTypeSchema,
+  content: z.string().nullable(),
+  contentMode: z.enum(['html', 'markdown']),
+  parentId: z.string().nullable(),
+  driveId: z.string(),
+  position: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  revision: z.number(),
+  stateHash: z.string().nullable(),
+  isTrashed: z.boolean(),
+  trashedAt: z.string().nullable(),
+  aiProvider: z.string().nullable(),
+  aiModel: z.string().nullable(),
+  systemPrompt: z.string().nullable(),
+  enabledTools: z.array(z.string()).nullable(),
+  isPaginated: z.boolean().nullable(),
+});
+
+const messageWithUserSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  createdAt: z.string(),
+  user: z
+    .object({
+      id: z.string(),
+      name: z.string().nullable(),
+      email: z.string(),
+      image: z.string().nullable(),
+    })
+    .nullable(),
+});
+
+const pageWithDetailsSchema = pageDataSchema.extend({
+  children: z.array(pageDataSchema),
+  messages: z.array(messageWithUserSchema),
+});
+
+export const readPage = defineOperation({
+  name: 'pages.read',
+  method: 'GET',
+  path: '/api/pages/:pageId',
+  inputSchema: z.object({ pageId: z.string() }),
+  outputSchema: pageWithDetailsSchema,
+  requiredScope: 'drive',
+  description: 'Get full page details (metadata, children, and chat messages) by id.',
+});

--- a/packages/sdk/src/registry/__tests__/define.test.ts
+++ b/packages/sdk/src/registry/__tests__/define.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { z } from 'zod';
+import { defineOperation } from '../define.js';
+import type { Operation, PathParamNames, RequiredScope } from '../define.js';
+
+describe('PathParamNames — type-level path param extraction', () => {
+  it('extracts a single param', () => {
+    expectTypeOf<PathParamNames<'/api/drives/:driveId'>>().toEqualTypeOf<'driveId'>();
+  });
+
+  it('extracts multiple params', () => {
+    expectTypeOf<PathParamNames<'/api/drives/:driveId/pages/:pageId'>>().toEqualTypeOf<'driveId' | 'pageId'>();
+  });
+
+  it('is never for a path with no params', () => {
+    expectTypeOf<PathParamNames<'/api/drives'>>().toEqualTypeOf<never>();
+  });
+});
+
+describe('defineOperation — runtime shape', () => {
+  it('captures every field verbatim', () => {
+    const inputSchema = z.object({ driveId: z.string() });
+    const outputSchema = z.object({ ok: z.boolean() });
+    const op = defineOperation({
+      name: 'test.op',
+      method: 'GET',
+      path: '/api/drives/:driveId',
+      inputSchema,
+      outputSchema,
+      requiredScope: 'drive',
+      description: 'A test operation.',
+    });
+
+    expect(op.name).toBe('test.op');
+    expect(op.method).toBe('GET');
+    expect(op.path).toBe('/api/drives/:driveId');
+    expect(op.inputSchema).toBe(inputSchema);
+    expect(op.outputSchema).toBe(outputSchema);
+    expect(op.requiredScope).toBe('drive');
+    expect(op.description).toBe('A test operation.');
+    expect(op.textResponse).toBeUndefined();
+  });
+
+  it('requiredScope and textResponse are optional', () => {
+    const op = defineOperation({
+      name: 'test.noscope',
+      method: 'GET',
+      path: '/api/widgets',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      description: 'No scope needed.',
+    });
+
+    expect(op.requiredScope).toBeUndefined();
+    expect(op.textResponse).toBeUndefined();
+  });
+});
+
+describe('defineOperation — static type inference', () => {
+  it('preserves the path as a literal type', () => {
+    const op = defineOperation({
+      name: 'test.op',
+      method: 'GET',
+      path: '/api/drives/:driveId',
+      inputSchema: z.object({ driveId: z.string() }),
+      outputSchema: z.object({ ok: z.boolean() }),
+      description: 'A test operation.',
+    });
+
+    expectTypeOf(op.path).toEqualTypeOf<'/api/drives/:driveId'>();
+  });
+
+  it('infers input/output types from the zod schemas', () => {
+    const op = defineOperation({
+      name: 'test.op',
+      method: 'POST',
+      path: '/api/widgets',
+      inputSchema: z.object({ title: z.string() }),
+      outputSchema: z.object({ id: z.string(), title: z.string() }),
+      description: 'A test operation.',
+    });
+
+    type Input = z.infer<typeof op.inputSchema>;
+    type Output = z.infer<typeof op.outputSchema>;
+    expectTypeOf<Input>().toEqualTypeOf<{ title: string }>();
+    expectTypeOf<Output>().toEqualTypeOf<{ id: string; title: string }>();
+  });
+
+  it('narrows requiredScope to the ADR 0002 grammar union, not a free string', () => {
+    expectTypeOf<RequiredScope>().toEqualTypeOf<'account' | 'drive' | 'drive:admin' | 'drive:member'>();
+  });
+
+  it('rejects an inputSchema missing a path param at compile time', () => {
+    // @ts-expect-error inputSchema has no `driveId` field to satisfy the `:driveId` path param.
+    defineOperation({
+      name: 'test.missing-param',
+      method: 'GET',
+      path: '/api/drives/:driveId',
+      inputSchema: z.object({ unrelated: z.string() }),
+      outputSchema: z.object({}),
+      description: 'Should not compile.',
+    });
+  });
+
+  it('accepts an inputSchema covering all path params plus extra fields', () => {
+    const op = defineOperation({
+      name: 'test.covers-params',
+      method: 'GET',
+      path: '/api/drives/:driveId/pages/:pageId',
+      inputSchema: z.object({ driveId: z.string(), pageId: z.string(), recursive: z.boolean().optional() }),
+      outputSchema: z.object({}),
+      description: 'Covers both params plus an extra query field.',
+    });
+
+    expectTypeOf(op).toMatchTypeOf<Operation>();
+  });
+});

--- a/packages/sdk/src/registry/__tests__/registry.test.ts
+++ b/packages/sdk/src/registry/__tests__/registry.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { defineOperation } from '../define.js';
+import { createRegistry, getOperation, hasOperation, listOperations } from '../registry.js';
+
+function op(name: string) {
+  return defineOperation({
+    name,
+    method: 'GET' as const,
+    path: '/api/widgets',
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+    description: `Operation ${name}.`,
+  });
+}
+
+describe('createRegistry — duplicate rejection', () => {
+  it('throws at construction when two operations share a name', () => {
+    expect(() => createRegistry([op('drives.list'), op('drives.list')])).toThrow(/drives\.list/);
+  });
+
+  it('does not throw for distinct names', () => {
+    expect(() => createRegistry([op('drives.list'), op('pages.read')])).not.toThrow();
+  });
+
+  it('constructs an empty registry without throwing', () => {
+    expect(() => createRegistry([])).not.toThrow();
+  });
+});
+
+describe('createRegistry — lookup', () => {
+  it('getOperation finds a registered operation by name', () => {
+    const registry = createRegistry([op('drives.list'), op('pages.read')]);
+    expect(getOperation(registry, 'pages.read')?.name).toBe('pages.read');
+  });
+
+  it('getOperation returns undefined for an unregistered name', () => {
+    const registry = createRegistry([op('drives.list')]);
+    expect(getOperation(registry, 'nope')).toBeUndefined();
+  });
+
+  it('hasOperation reflects registered names', () => {
+    const registry = createRegistry([op('drives.list')]);
+    expect(hasOperation(registry, 'drives.list')).toBe(true);
+    expect(hasOperation(registry, 'pages.read')).toBe(false);
+  });
+});
+
+describe('createRegistry — iteration', () => {
+  it('listOperations exposes every registered operation', () => {
+    const registry = createRegistry([op('drives.list'), op('pages.read')]);
+    const names = listOperations(registry)
+      .map((o) => o.name)
+      .sort();
+    expect(names).toEqual(['drives.list', 'pages.read']);
+  });
+
+  it('listOperations reflects registration order', () => {
+    const registry = createRegistry([op('b'), op('a'), op('c')]);
+    expect(listOperations(registry).map((o) => o.name)).toEqual(['b', 'a', 'c']);
+  });
+});
+
+describe('createRegistry — immutability', () => {
+  it('mutating the returned operations list does not affect subsequent lookups', () => {
+    const registry = createRegistry([op('drives.list')]);
+    const ops = listOperations(registry);
+    expect(() => {
+      (ops as unknown as unknown[]).push(op('pages.read'));
+    }).toThrow();
+  });
+});

--- a/packages/sdk/src/registry/define.ts
+++ b/packages/sdk/src/registry/define.ts
@@ -1,0 +1,109 @@
+/**
+ * Operation registry — the load-bearing abstraction (Phase 2 task 5).
+ *
+ * `defineOperation` is the single place an operation's method, path, and
+ * zod schemas are declared; SDK resource methods (Phase 3), CLI verbs
+ * (Phase 5), and MCP tool definitions (Phase 6) are all derived from the
+ * `Operation` values it produces. Path interpolation reuses task 3's pure
+ * `buildRequest`/`parseResponse` core (`Operation` extends `TransportOperation`
+ * unchanged) — this module never reimplements it.
+ */
+import type { z } from 'zod';
+import type { HttpMethod } from '../transport/types.js';
+
+/**
+ * Scope required to invoke this operation, per ADR 0002's grammar
+ * (docs/adr/0002-oauth-scope-grammar.md Decision 1). Excludes the specific
+ * driveId (bound per-call from the operation's own path params, not the
+ * definition) and the custom-role variant (a role id is a per-grant value,
+ * not a per-operation constant) — this is the minimum drive relationship
+ * the CLI/MCP layers need to pre-flight a permission error before the
+ * network layer, not a full scope grant.
+ */
+export type RequiredScope = 'account' | 'drive' | 'drive:admin' | 'drive:member';
+
+/** Names of the `:param` segments in a path template, as a type-level union. */
+export type PathParamNames<TPath extends string> = TPath extends `${string}:${infer Param}/${infer Rest}`
+  ? Param | PathParamNames<Rest>
+  : TPath extends `${string}:${infer Param}`
+    ? Param
+    : never;
+
+export interface OperationConfig<
+  TPath extends string,
+  TInputSchema extends z.ZodType,
+  TOutputSchema extends z.ZodType,
+> {
+  readonly name: string;
+  readonly method: HttpMethod;
+  /** Template path with `:paramName` segments, e.g. `/api/drives/:driveId/pages`. */
+  readonly path: TPath;
+  readonly inputSchema: TInputSchema;
+  readonly outputSchema: TOutputSchema;
+  readonly requiredScope?: RequiredScope;
+  /** Set for export-style operations whose 2xx body is raw text, not JSON. */
+  readonly textResponse?: boolean;
+  /** Mandatory: becomes the MCP tool description in Phase 6. */
+  readonly description: string;
+}
+
+/**
+ * Compile-time check that every `:param` in `path` has a matching field in
+ * `inputSchema`'s inferred type. On failure, adds a `__missingPathParams`
+ * property naming the offenders so the error surfaces at the call site.
+ */
+export type ValidOperationConfig<
+  TPath extends string,
+  TInputSchema extends z.ZodType,
+  TOutputSchema extends z.ZodType,
+> = [PathParamNames<TPath>] extends [keyof z.infer<TInputSchema>]
+  ? OperationConfig<TPath, TInputSchema, TOutputSchema>
+  : OperationConfig<TPath, TInputSchema, TOutputSchema> & {
+      readonly __missingPathParams: Exclude<PathParamNames<TPath>, keyof z.infer<TInputSchema>>;
+    };
+
+/**
+ * Structurally compatible with `TransportOperation<z.infer<TOutputSchema>>`
+ * (task 3) by field shape, not a formal `extends` — a generic `extends`
+ * across zod's invariant `ZodType<Output, Input>` params does not typecheck
+ * for an abstract `TOutputSchema`, only for the concrete schema each real
+ * operation supplies. `buildRequest`/`parseResponse` accept any `Operation`
+ * unchanged.
+ */
+export interface Operation<
+  TPath extends string = string,
+  TInputSchema extends z.ZodType = z.ZodType,
+  TOutputSchema extends z.ZodType = z.ZodType,
+> {
+  readonly name: string;
+  readonly method: HttpMethod;
+  readonly path: TPath;
+  readonly inputSchema: TInputSchema;
+  readonly outputSchema: TOutputSchema;
+  readonly requiredScope: RequiredScope | undefined;
+  readonly textResponse: boolean | undefined;
+  readonly description: string;
+}
+
+/** Pure: an operation config in, an immutable `Operation` value out. Never throws. */
+export function defineOperation<
+  TPath extends string,
+  TInputSchema extends z.ZodType,
+  TOutputSchema extends z.ZodType,
+>(
+  config: ValidOperationConfig<TPath, TInputSchema, TOutputSchema>,
+): Operation<TPath, TInputSchema, TOutputSchema> {
+  const { name, method, path, inputSchema, outputSchema, requiredScope, textResponse, description } =
+    config as OperationConfig<TPath, TInputSchema, TOutputSchema>;
+
+  return Object.freeze({
+    name,
+    method,
+    path,
+    inputSchema,
+    outputSchema,
+    requiredScope,
+    textResponse,
+    description,
+  });
+}

--- a/packages/sdk/src/registry/registry.ts
+++ b/packages/sdk/src/registry/registry.ts
@@ -1,0 +1,37 @@
+/**
+ * Registry container (Phase 2 task 5). Immutable data + pure lookups —
+ * `createRegistry` is the only place that can throw (duplicate names at
+ * construction); `getOperation`/`hasOperation`/`listOperations` are total,
+ * side-effect-free reads over the frozen result.
+ */
+import type { Operation } from './define.js';
+
+export interface OperationRegistry {
+  readonly byName: ReadonlyMap<string, Operation>;
+  readonly all: readonly Operation[];
+}
+
+/** Rejects duplicate operation names at construction; never mutated afterward. */
+export function createRegistry(ops: readonly Operation[]): OperationRegistry {
+  const byName = new Map<string, Operation>();
+  for (const op of ops) {
+    if (byName.has(op.name)) {
+      throw new Error(`Duplicate operation name in registry: "${op.name}"`);
+    }
+    byName.set(op.name, op);
+  }
+  return Object.freeze({ byName, all: Object.freeze([...ops]) });
+}
+
+export function getOperation(registry: OperationRegistry, name: string): Operation | undefined {
+  return registry.byName.get(name);
+}
+
+export function hasOperation(registry: OperationRegistry, name: string): boolean {
+  return registry.byName.has(name);
+}
+
+/** Phase 6 walks this to emit MCP tool definitions. */
+export function listOperations(registry: OperationRegistry): readonly Operation[] {
+  return registry.all;
+}


### PR DESCRIPTION
## Summary
- Implements `defineOperation` and `createRegistry` — the load-bearing abstraction of the SDK/CLI/OAuth epic (Phase 2 task 5).
- `defineOperation({name, method, path, inputSchema, outputSchema, requiredScope?, textResponse?, description})` captures full static types: the path template's `:param` segments are extracted at the type level (`PathParamNames<TPath>`) and checked against `inputSchema`'s inferred keys at compile time.
- `createRegistry(ops)` rejects duplicate operation names at construction; the result is immutable data with pure `getOperation`/`hasOperation`/`listOperations` reads.
- `requiredScope` is a type-level union derived from ADR 0002's scope grammar (`'account' | 'drive' | 'drive:admin' | 'drive:member'`), not a free string.
- Path interpolation is not duplicated — `Operation` is structurally compatible with task 3's `TransportOperation`, so `buildRequest`/`parseResponse` work on registry operations unchanged.
- Defines the first two real operations end-to-end as executable proof of the pattern Phase 3 will replicate ~80x:
  - `drives.list` — GET `/api/drives`, route-verified against `apps/web/src/app/api/drives/route.ts`.
  - `pages.read` — GET `/api/pages/:pageId`, route-verified against `apps/web/src/app/api/pages/[pageId]/route.ts` + `page-service.ts`.

## Test plan
- [x] RED: 4 failing test suites committed first (type inference via `expectTypeOf`, duplicate rejection, iteration/lookup, seed-op request shapes + fixture parsing) — separate commit.
- [x] GREEN: `bun run --filter '@pagespace/sdk' typecheck` passes.
- [x] GREEN: `bun run --filter '@pagespace/sdk' test` — 157/157 passing (up from 124 baseline).
- [x] No `any` types; registry data is immutable (frozen); zero-trust — every response validated against the operation's zod output schema, no `z.any()` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgzAXV8B8DVVt3fsC1KJ1v