### PR TITLE
fix(drives): remove unused validateDriveWidePermissions import

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch, mergeRolePermissionsPatch, validateDriveWidePermissions } from '@pagespace/lib/services/drive-role-service';
+import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch, mergeRolePermissionsPatch } from '@pagespace/lib/services/drive-role-service';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';


### PR DESCRIPTION
## Summary
- `validateDriveWidePermissions` is imported in `apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts` (added in #1794) but never called there.
- It's not a missing validation call: `updateDriveRole()` in `packages/lib/src/services/drive-role-service.ts` already validates `driveWidePermissions` internally and throws on invalid input before persisting anything, so the route-level import was genuinely dead code.
- This currently fails `bun run lint` (`@typescript-eslint/no-unused-vars`) on `master`, which blocks the required `ci / Lint & TypeScript Check` check for every PR rebased on top of it (surfaced this while converging an unrelated PR).

## Test plan
- [x] `bun run lint` (full monorepo, matching CI) — passes, `web:lint` clean
- [x] `bun run typecheck` — unaffected (unused-var is lint-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eeG2Ut4VspnwZwsEiLLGf