### PR TITLE
fix(ai): mock isScopedMCPAuth in consult route tests

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({


### PR DESCRIPTION
## Summary
- `apps/web/src/app/api/ai/page-agents/consult/route.ts:384` calls `isScopedMCPAuth(auth)` for MCP tool-scope filtering — this predates #1786, it's not new.
- The three test files added in #1786 (`conversation-continuity.test.ts`, `recent-history-ordering.test.ts`, `step-cap-parity.test.ts`) mock `@/lib/auth` but omit `isScopedMCPAuth`. Vitest's strict auto-mock throws `No "isScopedMCPAuth" export is defined on the "@/lib/auth" mock` the instant the route calls it, which the route's outer `catch` turns into a 500 — failing all three tests' `expect(response.status).toBe(200)` assertion.
- Fix mirrors the sibling `credit-gate.test.ts` / `mcp-scope-tool-filtering.test.ts` in the same directory, which already mock `isScopedMCPAuth: vi.fn(() => false)` correctly.
- This currently fails `ci / Unit Tests` on `master` (confirmed via `gh run list --branch master`, 3 consecutive failing Test Suite runs since #1786 merged), blocking the required check for every PR rebased on top of it — surfaced while converging an unrelated PR.

## Test plan
- [x] `bun run test -- <the 5 consult-route test files>` — 10/10 passing (was 4 failing)
- [x] `bunx eslint` on the 3 changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eeG2Ut4VspnwZwsEiLLGf