### PR TITLE
sdk: implement search operations (Phase 3 task 3)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -57,6 +57,7 @@ export type { OperationRegistry } from './registry/registry.js';
 // Seed operations (Phase 3 grows this list).
 export { listDrives } from './operations/drives.js';
 export { readPage } from './operations/pages.js';
+export { globSearch, multiDriveSearch, regexSearch } from './operations/search.js';
 
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.

--- a/packages/sdk/src/operations/__tests__/search.test.ts
+++ b/packages/sdk/src/operations/__tests__/search.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { globSearch, multiDriveSearch, regexSearch } from '../search.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+// ---------------------------------------------------------------------------
+// search.glob — /api/drives/:driveId/search/glob (route.ts, drive-search-service.ts globSearchPages)
+// ---------------------------------------------------------------------------
+
+const globFixture = {
+  success: true,
+  driveSlug: 'engineering',
+  pattern: '**/README*',
+  results: [
+    {
+      pageId: 'p1abc',
+      title: 'README',
+      type: 'DOCUMENT',
+      semanticPath: '/engineering/README',
+      matchedOn: 'title',
+    },
+  ],
+  totalResults: 1,
+  summary: 'Found 1 page matching pattern "**/README*"',
+  stats: {
+    totalPagesScanned: 42,
+    matchingPages: 1,
+    documentTypes: ['DOCUMENT'],
+    matchTypes: { path: 0, title: 1 },
+  },
+  nextSteps: [
+    'Use read_page with the pageId to examine content',
+    'Use the semantic paths to understand the structure',
+  ],
+};
+
+describe('search.glob — request shape', () => {
+  it('interpolates :driveId and sends pattern as a query param', () => {
+    const request = buildRequest(globSearch, { driveId: 'd1abc', pattern: '**/README*' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/search/glob?pattern=**%2FREADME*');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('serializes maxResults as a query param', () => {
+    const request = buildRequest(globSearch, { driveId: 'd1abc', pattern: '*.md', maxResults: 25 }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/search/glob?maxResults=25&pattern=*.md');
+  });
+
+  it('serializes includeTypes as the comma-separated string the route expects (route.ts:53-57 uses a single .get() + split(","), not repeated query keys)', () => {
+    const request = buildRequest(
+      globSearch,
+      { driveId: 'd1abc', pattern: '*', includeTypes: 'CODE,TASK_LIST' },
+      config,
+    );
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/search/glob?includeTypes=CODE%2CTASK_LIST&pattern=*');
+  });
+});
+
+describe('search.glob — input validation', () => {
+  it('rejects an empty pattern', () => {
+    const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects maxResults above the route bound of 200 (route.ts:39-43)', () => {
+    const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '*', maxResults: 201 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects maxResults below 1', () => {
+    const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '*', maxResults: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts includeTypes drawn from the route\'s current type set — FOLDER, DOCUMENT, AI_CHAT, CHANNEL, CANVAS, SHEET, CODE, TASK_LIST (route.ts:14, post #1773/74 fix)', () => {
+    const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '*', includeTypes: 'CODE,TASK_LIST' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an includeTypes entry outside the route\'s type set', () => {
+    const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '*', includeTypes: 'CODE,BOGUS' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('search.glob — response contract', () => {
+  it('parses a GlobSearchResponse (route truth, globSearchPages)', () => {
+    const result = parseResponse(globSearch, 200, new Headers(), JSON.stringify(globFixture));
+    expect(result).toEqual(globFixture);
+  });
+
+  it('parses an empty-result response', () => {
+    const empty = {
+      ...globFixture,
+      results: [],
+      totalResults: 0,
+      stats: { totalPagesScanned: 42, matchingPages: 0, documentTypes: [], matchTypes: { path: 0, title: 0 } },
+    };
+    const result = parseResponse(globSearch, 200, new Headers(), JSON.stringify(empty));
+    expect(result).toEqual(empty);
+  });
+
+  it('rejects a response that drifts from the GlobSearchResponse contract', () => {
+    const malformed = { ...globFixture, results: [{ ...globFixture.results[0], matchedOn: 'body' }] };
+    const result = parseResponse(globSearch, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 as PermissionDeniedError, never a schema mismatch', () => {
+    const result = parseResponse(globSearch, 403, new Headers(), JSON.stringify({ error: "You don't have access to this drive" }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('search.glob — metadata', () => {
+  it('declares the drive-scope requirement (driveId-bound view access, per ADR 0002)', () => {
+    expect(globSearch.requiredScope).toBe('drive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search.regex — /api/drives/:driveId/search/regex (route.ts, drive-search-service.ts regexSearchPages)
+// ---------------------------------------------------------------------------
+
+const regexFixture = {
+  success: true,
+  driveSlug: 'engineering',
+  pattern: 'TODO.*urgent',
+  searchIn: 'content',
+  results: [
+    {
+      pageId: 'p1abc',
+      title: 'Design Doc',
+      type: 'DOCUMENT',
+      semanticPath: '/engineering/Design Doc',
+      matchingLines: [{ lineNumber: 12, content: '// TODO: urgent fix needed' }],
+      totalMatches: 1,
+    },
+  ],
+  totalResults: 1,
+  summary: 'Found 1 page matching pattern "TODO.*urgent"',
+  stats: { pagesScanned: 10, pagesWithAccess: 1, documentTypes: ['DOCUMENT'] },
+  nextSteps: ['Use read_page with the pageId to examine full content'],
+};
+
+describe('search.regex — request shape', () => {
+  it('interpolates :driveId and sends pattern as a query param', () => {
+    const request = buildRequest(regexSearch, { driveId: 'd1abc', pattern: 'TODO.*urgent' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/search/regex?pattern=TODO.*urgent');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('serializes searchIn and maxResults as query params', () => {
+    const request = buildRequest(regexSearch, { driveId: 'd1abc', pattern: 'x', searchIn: 'both', maxResults: 10 }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/search/regex?maxResults=10&pattern=x&searchIn=both');
+  });
+
+  it('passes the pattern through verbatim — the server owns pattern safety, the SDK does not sanitize', () => {
+    const request = buildRequest(regexSearch, { driveId: 'd1abc', pattern: '\\d{4}-\\d{2}-\\d{2}' }, config);
+    expect(request.url).toContain(encodeURIComponent('\\d{4}-\\d{2}-\\d{2}'));
+  });
+});
+
+describe('search.regex — input validation', () => {
+  it('rejects an empty pattern', () => {
+    const result = regexSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid searchIn value (route only accepts content/title/both, route.ts:35)', () => {
+    const result = regexSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: 'x', searchIn: 'everywhere' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects maxResults above the route bound of 100 (route.ts:36-40)', () => {
+    const result = regexSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: 'x', maxResults: 101 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('search.regex — response contract', () => {
+  it('parses a RegexSearchResponse (route truth, regexSearchPages)', () => {
+    const result = parseResponse(regexSearch, 200, new Headers(), JSON.stringify(regexFixture));
+    expect(result).toEqual(regexFixture);
+  });
+
+  it('parses an empty-result response', () => {
+    const empty = { ...regexFixture, results: [], totalResults: 0, stats: { pagesScanned: 0, pagesWithAccess: 0, documentTypes: [] } };
+    const result = parseResponse(regexSearch, 200, new Headers(), JSON.stringify(empty));
+    expect(result).toEqual(empty);
+  });
+
+  it('rejects a response missing matchingLines on a result row', () => {
+    const malformed = { ...regexFixture, results: [{ ...regexFixture.results[0] }] } as Record<string, unknown>;
+    const rows = malformed.results as Array<Record<string, unknown>>;
+    delete rows[0]!.matchingLines;
+    const result = parseResponse(regexSearch, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 400 (missing pattern) as ValidationError, never a schema mismatch', () => {
+    const result = parseResponse(regexSearch, 400, new Headers(), JSON.stringify({ error: 'Pattern parameter is required' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('search.regex — metadata', () => {
+  it('declares the drive-scope requirement, matching search.glob', () => {
+    expect(regexSearch.requiredScope).toBe('drive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search.multiDrive — /api/search/multi-drive (route.ts, no driveId path param)
+// ---------------------------------------------------------------------------
+
+const multiDriveFixture = {
+  success: true,
+  searchQuery: 'quarterly report',
+  searchType: 'text',
+  results: [
+    {
+      driveId: 'd1abc',
+      driveName: 'Engineering',
+      driveSlug: 'engineering',
+      matches: [{ pageId: 'p1abc', title: 'Q3 Report', type: 'DOCUMENT', excerpt: 'quarterly report summary...' }],
+      count: 1,
+    },
+  ],
+  totalDrives: 1,
+  totalMatches: 1,
+  summary: 'Found 1 matches across 1 drive',
+  stats: { drivesSearched: 3, drivesWithResults: 1, totalMatches: 1 },
+  nextSteps: ['Use read_page with specific pageIds to examine content'],
+};
+
+describe('search.multiDrive — request shape', () => {
+  it('builds a GET to /api/search/multi-drive with no path params', () => {
+    const request = buildRequest(multiDriveSearch, { searchQuery: 'quarterly report' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/search/multi-drive?searchQuery=quarterly%20report');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('serializes searchType and maxResultsPerDrive as query params', () => {
+    const request = buildRequest(
+      multiDriveSearch,
+      { searchQuery: 'x', searchType: 'regex', maxResultsPerDrive: 5 },
+      config,
+    );
+    expect(request.url).toBe('https://pagespace.ai/api/search/multi-drive?maxResultsPerDrive=5&searchQuery=x&searchType=regex');
+  });
+});
+
+describe('search.multiDrive — input validation', () => {
+  it('rejects an empty searchQuery', () => {
+    const result = multiDriveSearch.inputSchema.safeParse({ searchQuery: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid searchType (route only accepts text/regex, route.ts:39)', () => {
+    const result = multiDriveSearch.inputSchema.safeParse({ searchQuery: 'x', searchType: 'fuzzy' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects maxResultsPerDrive above the route bound of 50 (route.ts:26-30)', () => {
+    const result = multiDriveSearch.inputSchema.safeParse({ searchQuery: 'x', maxResultsPerDrive: 51 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('search.multiDrive — response contract', () => {
+  it('parses a multi-drive response grouped per-drive (route truth, :242-264)', () => {
+    const result = parseResponse(multiDriveSearch, 200, new Headers(), JSON.stringify(multiDriveFixture));
+    expect(result).toEqual(multiDriveFixture);
+  });
+
+  it('parses the zero-accessible-drives short-circuit response (route.ts:50-68)', () => {
+    const zeroDrives = {
+      success: true,
+      searchQuery: 'x',
+      searchType: 'text',
+      results: [],
+      totalDrives: 0,
+      totalMatches: 0,
+      summary: 'Found 0 matches across 0 drives',
+      stats: { drivesSearched: 0, drivesWithResults: 0, totalMatches: 0 },
+      nextSteps: ['Try a different search query'],
+    };
+    const result = parseResponse(multiDriveSearch, 200, new Headers(), JSON.stringify(zeroDrives));
+    expect(result).toEqual(zeroDrives);
+  });
+
+  it('rejects a response with a malformed per-drive group (missing driveSlug)', () => {
+    const malformed = { ...multiDriveFixture, results: [{ ...multiDriveFixture.results[0] }] } as Record<string, unknown>;
+    const rows = malformed.results as Array<Record<string, unknown>>;
+    delete rows[0]!.driveSlug;
+    const result = parseResponse(multiDriveSearch, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 400 (missing searchQuery) as ValidationError, never a schema mismatch', () => {
+    const result = parseResponse(multiDriveSearch, 400, new Headers(), JSON.stringify({ error: 'searchQuery parameter is required' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('search.multiDrive — metadata', () => {
+  it('has no single-drive scope requirement — it enumerates the caller\'s own accessible drives (matches drives.list precedent)', () => {
+    expect(multiDriveSearch.requiredScope).toBeUndefined();
+  });
+
+  it('is named and described for MCP/CLI derivation', () => {
+    expect(multiDriveSearch.name).toBe('search.multiDrive');
+    expect(multiDriveSearch.description.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sdk/src/operations/__tests__/search.test.ts
+++ b/packages/sdk/src/operations/__tests__/search.test.ts
@@ -245,7 +245,7 @@ describe('search.multiDrive — request shape', () => {
   it('builds a GET to /api/search/multi-drive with no path params', () => {
     const request = buildRequest(multiDriveSearch, { searchQuery: 'quarterly report' }, config);
     expect(request.method).toBe('GET');
-    expect(request.url).toBe('https://pagespace.ai/api/search/multi-drive?searchQuery=quarterly%20report');
+    expect(request.url).toBe('https://pagespace.ai/api/search/multi-drive?searchQuery=quarterly+report');
     expect(request.body).toBeUndefined();
   });
 

--- a/packages/sdk/src/operations/search.ts
+++ b/packages/sdk/src/operations/search.ts
@@ -1,0 +1,190 @@
+/**
+ * Search operations (Phase 3 task 3): `search.glob`, `search.regex`,
+ * `search.multiDrive`. Old MCP tools: `glob_search`, `regex_search`,
+ * `multi_drive_search` (pagespace-mcp/src/handlers/search.js).
+ *
+ * `glob_search`/`regex_search` route-verified against
+ * `apps/web/src/app/api/drives/[driveId]/search/{glob,regex}/route.ts` GET,
+ * backed by `globSearchPages`/`regexSearchPages`
+ * (`packages/lib/src/services/drive-search-service.ts`). `multi_drive_search`
+ * route-verified against `apps/web/src/app/api/search/multi-drive/route.ts`
+ * GET (docs/sdk/operations-inventory.md §3, parity rows for all three).
+ *
+ * Patterns are passed through verbatim — the server owns pattern safety
+ * (ReDoS guards, statement timeouts); the SDK only validates request
+ * *structure* (non-empty pattern, enum/bounds matching the route's own
+ * clamps) and the server's response shape. Results are permission-filtered
+ * server-side (per-page view checks); this SDK layer does not re-filter.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+// ---------------------------------------------------------------------------
+// search.glob — GET /api/drives/:driveId/search/glob
+// ---------------------------------------------------------------------------
+
+/**
+ * The route's current type filter (`search/glob/route.ts:14`, VALID_PAGE_TYPES,
+ * post #1773/74 fix): CODE and TASK_LIST are both accepted today — the
+ * operations-inventory D8 discrepancy (TASK_LIST silently dropped) is
+ * resolved at the route, so the SDK enum matches the route enum exactly.
+ */
+const GLOB_SEARCH_PAGE_TYPES = ['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE', 'TASK_LIST'] as const;
+const globSearchPageTypeSchema = z.enum(GLOB_SEARCH_PAGE_TYPES);
+
+/**
+ * The route reads `includeTypes` with a single `searchParams.get()` call and
+ * splits on `,` (`search/glob/route.ts:38,53-57`) — a repeated query key
+ * (`includeTypes=A&includeTypes=B`) would silently lose every value but the
+ * first. This field is therefore the wire-format comma-separated string
+ * itself, not an array — `buildRequest` maps it to a single query param
+ * unchanged, matching the route exactly.
+ */
+const includeTypesSchema = z
+  .string()
+  .refine(
+    (value) => value.split(',').every((type) => globSearchPageTypeSchema.safeParse(type).success),
+    { message: `includeTypes must be a comma-separated list drawn from: ${GLOB_SEARCH_PAGE_TYPES.join(', ')}` },
+  )
+  .optional();
+
+const globSearchResultSchema = z.object({
+  pageId: z.string(),
+  title: z.string(),
+  type: z.string(),
+  semanticPath: z.string(),
+  matchedOn: z.enum(['path', 'title']),
+});
+
+const globSearchOutputSchema = z.object({
+  success: z.literal(true),
+  driveSlug: z.string().nullable(),
+  pattern: z.string(),
+  results: z.array(globSearchResultSchema),
+  totalResults: z.number(),
+  summary: z.string(),
+  stats: z.object({
+    totalPagesScanned: z.number(),
+    matchingPages: z.number(),
+    documentTypes: z.array(z.string()),
+    matchTypes: z.object({ path: z.number(), title: z.number() }),
+  }),
+  nextSteps: z.array(z.string()),
+});
+
+export const globSearch = defineOperation({
+  name: 'search.glob',
+  method: 'GET',
+  path: '/api/drives/:driveId/search/glob',
+  inputSchema: z.object({
+    driveId: z.string(),
+    pattern: z.string().min(1),
+    includeTypes: includeTypesSchema,
+    // Route clamps to 1-200, default 100 (search/glob/route.ts:39-43); the
+    // SDK rejects out-of-bounds rather than silently relying on the clamp.
+    maxResults: z.number().int().min(1).max(200).optional(),
+  }),
+  outputSchema: globSearchOutputSchema,
+  requiredScope: 'drive',
+  description:
+    'Find pages using glob-style patterns for titles and paths (e.g. "**/README*", "docs/**/*.md"). Results are permission-filtered.',
+});
+
+// ---------------------------------------------------------------------------
+// search.regex — GET /api/drives/:driveId/search/regex
+// ---------------------------------------------------------------------------
+
+const regexSearchResultSchema = z.object({
+  pageId: z.string(),
+  title: z.string(),
+  type: z.string(),
+  semanticPath: z.string(),
+  matchingLines: z.array(z.object({ lineNumber: z.number(), content: z.string() })),
+  totalMatches: z.number(),
+});
+
+const regexSearchOutputSchema = z.object({
+  success: z.literal(true),
+  driveSlug: z.string().nullable(),
+  pattern: z.string(),
+  searchIn: z.string(),
+  results: z.array(regexSearchResultSchema),
+  totalResults: z.number(),
+  summary: z.string(),
+  stats: z.object({
+    pagesScanned: z.number(),
+    pagesWithAccess: z.number(),
+    documentTypes: z.array(z.string()),
+  }),
+  nextSteps: z.array(z.string()),
+});
+
+export const regexSearch = defineOperation({
+  name: 'search.regex',
+  method: 'GET',
+  path: '/api/drives/:driveId/search/regex',
+  inputSchema: z.object({
+    driveId: z.string(),
+    pattern: z.string().min(1),
+    searchIn: z.enum(['content', 'title', 'both']).optional(),
+    // Route clamps to 1-100, default 50 (search/regex/route.ts:36-40).
+    maxResults: z.number().int().min(1).max(100).optional(),
+  }),
+  outputSchema: regexSearchOutputSchema,
+  requiredScope: 'drive',
+  description:
+    'Search page content using regular expression patterns (e.g. "TODO.*urgent", "\\\\d{4}-\\\\d{2}-\\\\d{2}"). The server owns pattern safety (ReDoS guards); results are permission-filtered.',
+});
+
+// ---------------------------------------------------------------------------
+// search.multiDrive — GET /api/search/multi-drive
+// ---------------------------------------------------------------------------
+
+const multiDriveSearchMatchSchema = z.object({
+  pageId: z.string(),
+  title: z.string(),
+  type: z.string(),
+  excerpt: z.string(),
+});
+
+const multiDriveSearchGroupSchema = z.object({
+  driveId: z.string(),
+  driveName: z.string(),
+  driveSlug: z.string(),
+  matches: z.array(multiDriveSearchMatchSchema),
+  count: z.number(),
+});
+
+const multiDriveSearchOutputSchema = z.object({
+  success: z.literal(true),
+  searchQuery: z.string(),
+  searchType: z.string(),
+  results: z.array(multiDriveSearchGroupSchema),
+  totalDrives: z.number(),
+  totalMatches: z.number(),
+  summary: z.string(),
+  stats: z.object({
+    drivesSearched: z.number(),
+    drivesWithResults: z.number(),
+    totalMatches: z.number(),
+  }),
+  nextSteps: z.array(z.string()),
+});
+
+export const multiDriveSearch = defineOperation({
+  name: 'search.multiDrive',
+  method: 'GET',
+  path: '/api/search/multi-drive',
+  inputSchema: z.object({
+    searchQuery: z.string().min(1),
+    searchType: z.enum(['text', 'regex']).optional(),
+    // Route clamps to 1-50, default 20 (search/multi-drive/route.ts:26-30).
+    maxResultsPerDrive: z.number().int().min(1).max(50).optional(),
+  }),
+  outputSchema: multiDriveSearchOutputSchema,
+  // No single driveId path param — this enumerates whatever drives the
+  // caller's own principal can already access (same rationale as
+  // `drives.list`, which also declares no requiredScope).
+  description:
+    'Search for content across all drives the caller can access. Automatically filters results based on permissions.',
+});


### PR DESCRIPTION
## Summary
- Implements `search.glob`, `search.regex`, `search.multiDrive` operations in the registry — full parity with pagespace-mcp's `glob_search`/`regex_search`/`multi_drive_search` (Phase 3 task 3, taskId `bq5jmpwi6l4usx426xh6siuf`)
- Route-verified against `apps/web/src/app/api/drives/[driveId]/search/{glob,regex}/route.ts` and `apps/web/src/app/api/search/multi-drive/route.ts`; output schemas modeled on `drive-search-service.ts`'s `GlobSearchResponse`/`RegexSearchResponse`
- `glob_search`'s `includeTypes` enum matches the route's **current** type set (`FOLDER/DOCUMENT/AI_CHAT/CHANNEL/CANVAS/SHEET/CODE/TASK_LIST`) — the operations-inventory D8 discrepancy (TASK_LIST silently dropped) is already resolved at the route source (#1773/74), so the SDK enum = route enum, no client-side narrowing needed
- `includeTypes` is modeled as a comma-separated **string**, not an array: the route reads it with a single `searchParams.get()` + `.split(',')`, so `buildRequest`'s repeated-query-key array serialization (`includeTypes=A&includeTypes=B`) would silently drop every value but the first
- `maxResults`/`maxResultsPerDrive` bounds and `searchIn`/`searchType` enums mirror each route's own clamps (glob 1-200, regex 1-100, multi-drive 1-50) — validated by zod rather than relying on the server's silent clamp
- `search.multiDrive` declares no `requiredScope`: it enumerates whatever drives the caller's own principal can already access, same rationale as `drives.list`
- Exported via explicit named re-exports in `index.ts`

## Test plan
- [x] RED: 35 contract tests written first (request shapes, zod bounds/enum rejection, fixture parsing) against nonexistent `search.ts`, confirmed failing
- [x] GREEN: implemented operations, tests pass
- [x] `bun run --filter '@pagespace/sdk' typecheck` — green
- [x] `bun run --filter '@pagespace/sdk' test` — green (242 tests, 35 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux2vy2UT7CUQDa5nUuRXFS