### PR TITLE
sdk: implement drives & members operations (Phase 3 task 1)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -58,6 +58,19 @@ export type { OperationRegistry } from './registry/registry.js';
 export { listDrives } from './operations/drives.js';
 export { readPage } from './operations/pages.js';
 
+// Drives & members operations (Phase 3 task 1).
+export {
+  assertDriveNameConfirmed,
+  createDrive,
+  renameDrive,
+  restoreDrive,
+  trashDrive,
+  updateDriveContext,
+} from './operations/drives.js';
+export type { ConfirmMismatch, Result } from './operations/drives.js';
+export { listDriveMembers } from './operations/members.js';
+export { listCollaborators } from './operations/collaborators.js';
+
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.
 export type { HttpMethod } from './transport/types.js';

--- a/packages/sdk/src/operations/__tests__/collaborators.test.ts
+++ b/packages/sdk/src/operations/__tests__/collaborators.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { listCollaborators } from '../collaborators.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/connections/route.ts GET ({connections: validConnections}). */
+const connectionFixture = {
+  id: 'c1abc',
+  status: 'ACCEPTED',
+  requestedAt: '2026-01-01T00:00:00.000Z',
+  acceptedAt: '2026-01-02T00:00:00.000Z',
+  requestMessage: null,
+  user1Id: 'u1abc',
+  user2Id: 'u2abc',
+  requestedBy: 'u1abc',
+  user: {
+    id: 'u2abc',
+    name: 'Grace',
+    email: 'grace@example.com',
+    image: null,
+    username: 'grace',
+    displayName: 'Grace Hopper',
+    bio: null,
+    avatarUrl: null,
+  },
+  isRequester: true,
+};
+
+describe('collaborators.list — request shape', () => {
+  it('builds a bare GET to /api/connections with no status filter', () => {
+    const request = buildRequest(listCollaborators, {}, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/connections');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('serializes status as a query param', () => {
+    const request = buildRequest(listCollaborators, { status: 'PENDING' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/connections?status=PENDING');
+  });
+
+  it('rejects a status outside the enum before any network call', () => {
+    const result = listCollaborators.inputSchema.safeParse({ status: 'FRIENDS' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('collaborators.list — response contract', () => {
+  it('parses {connections} (route truth §2.15 list_collaborators)', () => {
+    const result = parseResponse(listCollaborators, 200, new Headers(), JSON.stringify({ connections: [connectionFixture] }));
+    expect(result).toEqual({ connections: [connectionFixture] });
+  });
+
+  it('parses an empty connections array', () => {
+    const result = parseResponse(listCollaborators, 200, new Headers(), JSON.stringify({ connections: [] }));
+    expect(result).toEqual({ connections: [] });
+  });
+
+  it('rejects a response drifting to a bare array (the old handler assumption)', () => {
+    const result = parseResponse(listCollaborators, 200, new Headers(), JSON.stringify([connectionFixture]));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('collaborators.list — metadata', () => {
+  it('is named and described for MCP/CLI derivation', () => {
+    expect(listCollaborators.name).toBe('collaborators.list');
+    expect(listCollaborators.description.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/sdk/src/operations/__tests__/drives.test.ts
+++ b/packages/sdk/src/operations/__tests__/drives.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { buildRequest } from '../../transport/build-request.js';
 import { parseResponse } from '../../transport/parse-response.js';
 import { ResponseValidationError } from '../../errors.js';
-import { listDrives } from '../drives.js';
+import {
+  assertDriveNameConfirmed,
+  createDrive,
+  listDrives,
+  renameDrive,
+  restoreDrive,
+  trashDrive,
+  updateDriveContext,
+} from '../drives.js';
 
 const config = { baseUrl: 'https://pagespace.ai' };
 
@@ -66,5 +74,176 @@ describe('drives.list — metadata', () => {
   it('is named and described for MCP/CLI derivation', () => {
     expect(listDrives.name).toBe('drives.list');
     expect(listDrives.description.length).toBeGreaterThan(0);
+  });
+});
+
+/** Shape verified against apps/web/src/app/api/drives/[driveId]/route.ts PATCH → drives.$inferSelect (raw row, not DriveWithAccess). */
+const driveRowFixture = {
+  id: 'd1abc',
+  name: 'Engineering',
+  slug: 'engineering',
+  ownerId: 'u1abc',
+  kind: 'STANDARD',
+  isTrashed: false,
+  trashedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+  drivePrompt: null,
+  publishSubdomain: null,
+  homePageId: null,
+  publishDefaultOgImageUrl: null,
+};
+
+describe('drives.create — request shape', () => {
+  it('builds a POST to /api/drives with name in the body', () => {
+    const request = buildRequest(createDrive, { name: 'New Drive' }, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/drives');
+    expect(request.body).toBe(JSON.stringify({ name: 'New Drive' }));
+  });
+
+  it('rejects an empty name before any network call', () => {
+    const result = createDrive.inputSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('drives.create — response contract', () => {
+  it('parses a 201 DriveWithAccess row (route truth, §2.1 create_drive)', () => {
+    const result = parseResponse(createDrive, 201, new Headers(), JSON.stringify(driveFixture));
+    expect(result).toEqual(driveFixture);
+  });
+
+  it('classifies a 400 (reserved name) as a typed ValidationError', () => {
+    const result = parseResponse(createDrive, 400, new Headers(), JSON.stringify({ error: 'Cannot create a drive with that name.' }));
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('drives.rename — request shape', () => {
+  it('interpolates :driveId and sends only name in the body', () => {
+    const request = buildRequest(renameDrive, { driveId: 'd1abc', name: 'Renamed' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc');
+    expect(request.body).toBe(JSON.stringify({ name: 'Renamed' }));
+  });
+});
+
+describe('drives.rename — response contract', () => {
+  it('parses the raw updated drive row (route truth — not DriveWithAccess)', () => {
+    const result = parseResponse(renameDrive, 200, new Headers(), JSON.stringify(driveRowFixture));
+    expect(result).toEqual(driveRowFixture);
+  });
+
+  it('rejects a response drifting back to the DriveWithAccess shape', () => {
+    const result = parseResponse(renameDrive, 200, new Headers(), JSON.stringify(driveFixture));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (home drive / not owner-admin) as PermissionDeniedError', () => {
+    const result = parseResponse(renameDrive, 403, new Headers(), JSON.stringify({ error: 'Only drive owners and admins can update drive settings' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('drives.rename — metadata', () => {
+  it('declares drive:admin as the minimum required scope', () => {
+    expect(renameDrive.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('drives.updateContext — request shape', () => {
+  it('interpolates :driveId and sends only drivePrompt in the body', () => {
+    const request = buildRequest(updateDriveContext, { driveId: 'd1abc', drivePrompt: 'Be concise.' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc');
+    expect(request.body).toBe(JSON.stringify({ drivePrompt: 'Be concise.' }));
+  });
+
+  it('rejects a drivePrompt over 10000 chars (route limit)', () => {
+    const result = updateDriveContext.inputSchema.safeParse({ driveId: 'd1abc', drivePrompt: 'x'.repeat(10001) });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('drives.updateContext — response contract', () => {
+  it('parses the raw updated drive row', () => {
+    const result = parseResponse(updateDriveContext, 200, new Headers(), JSON.stringify({ ...driveRowFixture, drivePrompt: 'Be concise.' }));
+    expect(result).toEqual({ ...driveRowFixture, drivePrompt: 'Be concise.' });
+  });
+});
+
+describe('drives.updateContext — metadata', () => {
+  it('documents the token-cost caveat in its description', () => {
+    expect(updateDriveContext.description.toLowerCase()).toContain('token');
+  });
+});
+
+describe('drives.trash — request shape', () => {
+  it('builds a DELETE to /api/drives/:driveId', () => {
+    const request = buildRequest(trashDrive, { driveId: 'd1abc', confirmDriveName: 'Engineering' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc');
+  });
+});
+
+describe('drives.trash — response contract', () => {
+  it('parses {success:true}', () => {
+    const result = parseResponse(trashDrive, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+
+  it('classifies a 403 (home drive) as PermissionDeniedError', () => {
+    const result = parseResponse(trashDrive, 403, new Headers(), JSON.stringify({ error: 'Home drives cannot be trashed' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('drives.trash — metadata (non-idempotent, no auto-retry)', () => {
+  it('uses DELETE, which isIdempotentMethod classifies as non-idempotent', () => {
+    expect(trashDrive.method).toBe('DELETE');
+  });
+});
+
+describe('assertDriveNameConfirmed — D11 client-side guardrail', () => {
+  it('succeeds when the confirmation matches the actual drive name', () => {
+    const result = assertDriveNameConfirmed('Engineering', 'Engineering');
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails closed when the confirmation does not match', () => {
+    const result = assertDriveNameConfirmed('Engineering', 'engineering');
+    expect(result).toEqual({ ok: false, error: { actualName: 'Engineering', confirmName: 'engineering' } });
+  });
+
+  it('is case-sensitive and whitespace-sensitive (no fuzzy matching)', () => {
+    const result = assertDriveNameConfirmed('Engineering', 'Engineering ');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('drives.restore — request shape', () => {
+  it('builds a POST to /api/drives/:driveId/restore with no body', () => {
+    const request = buildRequest(restoreDrive, { driveId: 'd1abc' }, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/restore');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('drives.restore — response contract', () => {
+  it('parses {success:true}', () => {
+    const result = parseResponse(restoreDrive, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+
+  it('classifies a 400 (not in trash) as a typed ValidationError', () => {
+    const result = parseResponse(restoreDrive, 400, new Headers(), JSON.stringify({ error: 'Drive is not in trash' }));
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('classifies a 404 (not found / not owner) as NotFoundError', () => {
+    const result = parseResponse(restoreDrive, 404, new Headers(), JSON.stringify({ error: 'Drive not found or access denied' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
   });
 });

--- a/packages/sdk/src/operations/__tests__/members.test.ts
+++ b/packages/sdk/src/operations/__tests__/members.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { listDriveMembers } from '../members.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/drives/[driveId]/members/route.ts GET (MemberWithDetails[] + pendingInvites + currentUserRole). */
+const memberFixture = {
+  id: 'm1abc',
+  userId: 'u1abc',
+  role: 'MEMBER',
+  invitedBy: 'u0owner',
+  invitedAt: '2026-01-01T00:00:00.000Z',
+  acceptedAt: '2026-01-02T00:00:00.000Z',
+  lastAccessedAt: '2026-01-03T00:00:00.000Z',
+  user: { id: 'u1abc', email: 'ada@example.com', name: 'Ada' },
+  profile: { username: 'ada', displayName: 'Ada Lovelace', avatarUrl: null },
+  customRole: null,
+  permissionCounts: { view: 3, edit: 1, share: 0 },
+};
+
+const ownerFixture = {
+  id: 'owner-u0owner',
+  userId: 'u0owner',
+  role: 'OWNER',
+  invitedBy: null,
+  invitedAt: null,
+  acceptedAt: null,
+  lastAccessedAt: null,
+  user: { id: 'u0owner', email: 'owner@example.com', name: 'Owner' },
+  profile: { username: null, displayName: null, avatarUrl: null },
+  customRole: null,
+  permissionCounts: { view: 0, edit: 0, share: 0 },
+};
+
+const pendingInviteFixture = {
+  id: 'inv1abc',
+  email: 'pending@example.com',
+  role: 'MEMBER',
+  customRoleId: null,
+  customRoleName: null,
+  customRoleColor: null,
+  driveId: 'd1abc',
+  invitedByName: 'Owner',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  expiresAt: '2026-02-01T00:00:00.000Z',
+};
+
+describe('members.list — request shape', () => {
+  it('interpolates :driveId into the path and sends no body', () => {
+    const request = buildRequest(listDriveMembers, { driveId: 'd1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/members');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('members.list — response contract', () => {
+  it('parses {members, pendingInvites, currentUserRole} (route truth §2.15)', () => {
+    const body = { members: [ownerFixture, memberFixture], pendingInvites: [pendingInviteFixture], currentUserRole: 'OWNER' };
+    const result = parseResponse(listDriveMembers, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('parses an empty pendingInvites array for a plain MEMBER caller (route always returns an array)', () => {
+    const body = { members: [ownerFixture, memberFixture], pendingInvites: [], currentUserRole: 'MEMBER' };
+    const result = parseResponse(listDriveMembers, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('rejects a response missing currentUserRole', () => {
+    const malformed = { members: [], pendingInvites: [] };
+    const result = parseResponse(listDriveMembers, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (not a drive member) as PermissionDeniedError', () => {
+    const result = parseResponse(listDriveMembers, 403, new Headers(), JSON.stringify({ error: 'You must be a drive member to view members' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+
+  it('classifies a 404 (drive not found) as NotFoundError', () => {
+    const result = parseResponse(listDriveMembers, 404, new Headers(), JSON.stringify({ error: 'Drive not found' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+});
+
+describe('members.list — metadata', () => {
+  it('declares drive as the minimum required scope (member-gated view)', () => {
+    expect(listDriveMembers.requiredScope).toBe('drive');
+  });
+});

--- a/packages/sdk/src/operations/collaborators.ts
+++ b/packages/sdk/src/operations/collaborators.ts
@@ -1,0 +1,49 @@
+/**
+ * Collaborators operation: `collaborators.list` (Phase 3 task 1, drives &
+ * members domain).
+ *
+ * Route-verified against `apps/web/src/app/api/connections/route.ts` GET,
+ * parity with MCP tool `list_collaborators`
+ * (docs/sdk/operations-inventory.md §2.15). Response is `{connections}`, not
+ * a bare array — the old handler's `Array.isArray(response) ? response : []`
+ * fallback masked this; the SDK fails closed on the bare-array shape instead
+ * of silently accepting it. `status` defaults server-side to `ACCEPTED` when
+ * omitted (`connections/route.ts:26`).
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const connectionStatusSchema = z.enum(['PENDING', 'ACCEPTED', 'BLOCKED']);
+
+const connectionUserSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  email: z.string(),
+  image: z.string().nullable(),
+  username: z.string().nullable(),
+  displayName: z.string().nullable(),
+  bio: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+});
+
+const connectionSchema = z.object({
+  id: z.string(),
+  status: connectionStatusSchema,
+  requestedAt: z.string(),
+  acceptedAt: z.string().nullable(),
+  requestMessage: z.string().nullable(),
+  user1Id: z.string(),
+  user2Id: z.string(),
+  requestedBy: z.string(),
+  user: connectionUserSchema,
+  isRequester: z.boolean(),
+});
+
+export const listCollaborators = defineOperation({
+  name: 'collaborators.list',
+  method: 'GET',
+  path: '/api/connections',
+  inputSchema: z.object({ status: connectionStatusSchema.optional() }),
+  outputSchema: z.object({ connections: z.array(connectionSchema) }),
+  description: "List the caller's connections (collaborators). Defaults to ACCEPTED status server-side when omitted.",
+});

--- a/packages/sdk/src/operations/drives.ts
+++ b/packages/sdk/src/operations/drives.ts
@@ -38,3 +38,101 @@ export const listDrives = defineOperation({
   outputSchema: z.array(driveSchema),
   description: 'List drives the caller can access.',
 });
+
+export const createDrive = defineOperation({
+  name: 'drives.create',
+  method: 'POST',
+  path: '/api/drives',
+  inputSchema: z.object({ name: z.string().min(1, 'Missing name') }),
+  outputSchema: driveSchema,
+  requiredScope: 'account',
+  description:
+    'Create a new drive (workspace). Scoped MCP tokens cannot create drives (route-enforced 403) — this always requires an account-level grant.',
+});
+
+/**
+ * Raw `drives` table row (`packages/db/src/schema/core.ts`), route-verified
+ * against `apps/web/src/app/api/drives/[driveId]/route.ts` PATCH →
+ * `updateDrive` (`drives.$inferSelect`). Deliberately distinct from
+ * `driveSchema`: this endpoint never synthesizes `isOwned`/`role`/
+ * `lastAccessedAt` the way list/create do.
+ */
+const driveRowSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  ownerId: z.string(),
+  kind: z.enum(['STANDARD', 'HOME']),
+  isTrashed: z.boolean(),
+  trashedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  drivePrompt: z.string().nullable(),
+  publishSubdomain: z.string().nullable(),
+  homePageId: z.string().nullable(),
+  publishDefaultOgImageUrl: z.string().nullable(),
+});
+
+export const renameDrive = defineOperation({
+  name: 'drives.rename',
+  method: 'PATCH',
+  path: '/api/drives/:driveId',
+  inputSchema: z.object({ driveId: z.string(), name: z.string() }),
+  outputSchema: driveRowSchema,
+  requiredScope: 'drive:admin',
+  description: "Rename a drive. Requires owner/admin authority; a drive's Home drive cannot be renamed.",
+});
+
+export const updateDriveContext = defineOperation({
+  name: 'drives.updateContext',
+  method: 'PATCH',
+  path: '/api/drives/:driveId',
+  inputSchema: z.object({ driveId: z.string(), drivePrompt: z.string().max(10000) }),
+  outputSchema: driveRowSchema,
+  requiredScope: 'drive:admin',
+  description:
+    "Update a drive's AI context prompt. This prompt is loaded into every AI call within the drive, so it directly inflates the token cost of every request there — keep it concise. Requires owner/admin authority.",
+});
+
+export const trashDrive = defineOperation({
+  name: 'drives.trash',
+  method: 'DELETE',
+  path: '/api/drives/:driveId',
+  inputSchema: z.object({ driveId: z.string(), confirmDriveName: z.string() }),
+  outputSchema: z.object({ success: z.literal(true) }),
+  requiredScope: 'drive:admin',
+  description:
+    'Move a drive and all its pages to trash. DELETE is never auto-retried (non-idempotent, per isIdempotentMethod). `confirmDriveName` is a client-side-only guardrail (inventory D11) — the route has no such field and will trash on a bare DELETE — so callers MUST call `assertDriveNameConfirmed(drive.name, confirmDriveName)` before invoking this operation. Requires owner/admin authority; Home drives cannot be trashed.',
+});
+
+export const restoreDrive = defineOperation({
+  name: 'drives.restore',
+  method: 'POST',
+  path: '/api/drives/:driveId/restore',
+  inputSchema: z.object({ driveId: z.string() }),
+  outputSchema: z.object({ success: z.literal(true) }),
+  requiredScope: 'drive',
+  description:
+    'Restore a trashed drive and its pages back to active. OWNER only — an explicit ADMIN-scoped grant is insufficient; only an inherit-scoped principal (acting with its owner\'s authority) can succeed here, so the minimum pre-flightable scope is plain drive access.',
+});
+
+export interface ConfirmMismatch {
+  readonly actualName: string;
+  readonly confirmName: string;
+}
+
+export type Result<TValue, TError> = { readonly ok: true; readonly value: TValue } | { readonly ok: false; readonly error: TError };
+
+/**
+ * D11: `trash_drive`'s `confirmDriveName` guardrail is client-side only —
+ * the route (`apps/web/src/app/api/drives/[driveId]/route.ts` DELETE) has no
+ * such field and trashes unconditionally. Every caller of `trashDrive`
+ * (CLI, MCP adapter) MUST run this first and fail closed on a mismatch.
+ * Pure, total, case- and whitespace-sensitive (no fuzzy matching).
+ */
+export function assertDriveNameConfirmed(actualName: string, confirmName: string): Result<void, ConfirmMismatch> {
+  if (actualName === confirmName) {
+    return { ok: true, value: undefined };
+  }
+  return { ok: false, error: { actualName, confirmName } };
+}

--- a/packages/sdk/src/operations/members.ts
+++ b/packages/sdk/src/operations/members.ts
@@ -1,0 +1,81 @@
+/**
+ * Members operation: `members.list` (Phase 3 task 1, drives & members domain).
+ *
+ * Route-verified against `apps/web/src/app/api/drives/[driveId]/members/route.ts`
+ * GET → `listDriveMembers` + `getDriveOwnerAsMember`
+ * (`packages/lib/src/services/drive-member-service.ts`), parity with MCP tool
+ * `list_drive_members` (docs/sdk/operations-inventory.md §2.15). The owner is
+ * never a `drive_members` row, so the route prepends a synthesized owner entry;
+ * `pendingInvites` is always an array (empty for non-owner/admin callers, never
+ * omitted) to keep the response shape stable across viewer roles.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const memberRoleSchema = z.enum(['OWNER', 'ADMIN', 'MEMBER']);
+
+const driveMemberSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  role: memberRoleSchema,
+  invitedBy: z.string().nullable(),
+  invitedAt: z.string().nullable(),
+  acceptedAt: z.string().nullable(),
+  lastAccessedAt: z.string().nullable(),
+  user: z
+    .object({
+      id: z.string(),
+      email: z.string(),
+      name: z.string().nullable(),
+    })
+    .nullable(),
+  profile: z
+    .object({
+      username: z.string().nullable(),
+      displayName: z.string().nullable(),
+      avatarUrl: z.string().nullable(),
+    })
+    .nullable(),
+  customRole: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+      color: z.string().nullable(),
+    })
+    .nullable(),
+  permissionCounts: z
+    .object({
+      view: z.number(),
+      edit: z.number(),
+      share: z.number(),
+    })
+    .optional(),
+});
+
+const pendingInviteSchema = z.object({
+  id: z.string(),
+  email: z.string(),
+  role: memberRoleSchema,
+  customRoleId: z.string().nullable(),
+  customRoleName: z.string().nullable(),
+  customRoleColor: z.string().nullable(),
+  driveId: z.string(),
+  invitedByName: z.string(),
+  createdAt: z.string(),
+  expiresAt: z.string().nullable(),
+});
+
+export const listDriveMembers = defineOperation({
+  name: 'members.list',
+  method: 'GET',
+  path: '/api/drives/:driveId/members',
+  inputSchema: z.object({ driveId: z.string() }),
+  outputSchema: z.object({
+    members: z.array(driveMemberSchema),
+    pendingInvites: z.array(pendingInviteSchema),
+    currentUserRole: memberRoleSchema,
+  }),
+  requiredScope: 'drive',
+  description:
+    'List all members of a drive (including the owner) with roles and permission counts. Pending invites are visible to OWNER/ADMIN callers only, but the field is always an array.',
+});


### PR DESCRIPTION
## Summary
Phase 3 task 1 of the SDK/CLI/OAuth epic — drives & members operations for `@pagespace/sdk`, TDD (RED commit then GREEN commit).

- `drives.create`, `drives.rename`, `drives.updateContext`, `drives.trash`, `drives.restore` — registry operations added to `packages/sdk/src/operations/drives.ts` alongside the existing `drives.list` seed op.
- `drives.rename`/`drives.updateContext` output the **raw `drives.$inferSelect` row** (route truth per `apps/web/src/app/api/drives/[driveId]/route.ts` PATCH), which is a different shape from the `DriveWithAccess` row `drives.list`/`drives.create` return — verified against source, not assumed.
- `assertDriveNameConfirmed` — pure D11 guardrail: `confirmDriveName` on `trash_drive` is client-side only (the DELETE route enforces no such field), so CLI/MCP callers must call this before invoking `drives.trash`.
- `members.list` (new `packages/sdk/src/operations/members.ts`) — `{members, pendingInvites, currentUserRole}`; the owner is synthesized and prepended since it's never a `drive_members` row.
- `collaborators.list` (new `packages/sdk/src/operations/collaborators.ts`) — `{connections}`, not the bare array the old MCP handler assumed.
- All new operations exported via explicit named re-exports in `packages/sdk/src/index.ts` (no `export *`).

Every output schema is route-verified against current `apps/web/src/app/api/**` source (not the old `pagespace-mcp` handlers) per the Phase 3 non-negotiable — routes are truth, handlers are parity intent.

## Test plan
- [x] RED commit: 24 failing contract tests (registry entries, `buildRequest` shapes, zod rejection, fixture parsing, typed error surfacing) — mocked fetch only.
- [x] GREEN commit: `bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` — 245/245 passing.
- [x] No `any` types, no `z.any()` escapes.
- [x] `requiredScope` annotated per ADR 0002 grammar on every scope-restricted operation.

https://claude.ai/code/session_016tu6AtjZaHAzNBAHXdCdev