### PR TITLE
sdk: implement tasks & statuses operations (Phase 3 task 4)

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -39,6 +39,16 @@ import {
 import type { AuthProvider } from './auth/provider.js';
 import { listDrives } from './operations/drives.js';
 import { readPage } from './operations/pages.js';
+import {
+  createTask,
+  createTaskStatus,
+  deleteTask,
+  deleteTaskTrigger,
+  getAssignedTasks,
+  reorderTask,
+  setTaskTrigger,
+  updateTask,
+} from './operations/tasks.js';
 import type { Operation } from './registry/define.js';
 import { createRegistry, type OperationRegistry } from './registry/registry.js';
 import { buildRequest } from './transport/build-request.js';
@@ -51,6 +61,16 @@ import { checkServerCompatibility, MIN_SERVER_API_VERSION } from './version.js';
 const DEFAULT_OPERATIONS_MAP = {
   drives: { list: listDrives },
   pages: { read: readPage },
+  tasks: {
+    create: createTask,
+    update: updateTask,
+    delete: deleteTask,
+    reorder: reorderTask,
+    createStatus: createTaskStatus,
+    setTrigger: setTaskTrigger,
+    deleteTrigger: deleteTaskTrigger,
+    getAssigned: getAssignedTasks,
+  },
 } as const;
 
 type OperationsMap = Record<string, Record<string, Operation>>;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -72,6 +72,20 @@ export type { ConfirmMismatch, Result } from './operations/drives.js';
 export { listDriveMembers } from './operations/members.js';
 export { listCollaborators } from './operations/collaborators.js';
 
+// Tasks & statuses operations (Phase 3 task 4).
+export {
+  classifyTaskCompletionGate,
+  createTask,
+  createTaskStatus,
+  deleteTask,
+  deleteTaskTrigger,
+  getAssignedTasks,
+  reorderTask,
+  setTaskTrigger,
+  updateTask,
+} from './operations/tasks.js';
+export type { TaskCompletionGatedError } from './operations/tasks.js';
+
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.
 export type { HttpMethod } from './transport/types.js';

--- a/packages/sdk/src/operations/__tests__/tasks.test.ts
+++ b/packages/sdk/src/operations/__tests__/tasks.test.ts
@@ -1,0 +1,460 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { HttpError, ResponseValidationError } from '../../errors.js';
+import {
+  classifyTaskCompletionGate,
+  createTask,
+  createTaskStatus,
+  deleteTask,
+  deleteTaskTrigger,
+  getAssignedTasks,
+  reorderTask,
+  setTaskTrigger,
+  updateTask,
+} from '../tasks.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/pages/[pageId]/tasks/route.ts POST (§2.7 create_task). */
+const taskFixture = {
+  id: 't1abc',
+  userId: 'u1abc',
+  assigneeId: null,
+  assigneeAgentId: null,
+  pageId: 'p1task',
+  status: 'pending',
+  priority: 'medium',
+  position: 1,
+  dueDate: null,
+  metadata: { createdAt: '2026-01-01T00:00:00.000Z', note: null },
+  completedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  assignee: null,
+  assigneeAgent: null,
+  user: { id: 'u1abc', name: 'Ada', image: null },
+  page: { id: 'p1task', title: 'Write the spec' },
+  assignees: [],
+  title: 'Write the spec',
+};
+
+describe('tasks.create — request shape', () => {
+  it('interpolates :pageId and sends the rest as a JSON body', () => {
+    const request = buildRequest(createTask, { pageId: 'pg1', title: 'Write the spec' }, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/pg1/tasks');
+    expect(request.body).toBe(JSON.stringify({ title: 'Write the spec' }));
+  });
+
+  it('serializes a nested agentTrigger object without dropping its fields', () => {
+    const request = buildRequest(
+      createTask,
+      {
+        pageId: 'pg1',
+        title: 'Ship it',
+        dueDate: '2026-02-01T00:00:00.000Z',
+        agentTrigger: { agentPageId: 'ag1', prompt: 'Ship it' },
+      },
+      config,
+    );
+    const body = JSON.parse(request.body!);
+    expect(body.agentTrigger).toEqual({ agentPageId: 'ag1', prompt: 'Ship it' });
+  });
+});
+
+describe('tasks.create — input refinements', () => {
+  it('accepts a minimal valid task', () => {
+    expect(createTask.inputSchema.safeParse({ pageId: 'pg1', title: 'Write the spec' }).success).toBe(true);
+  });
+
+  it('rejects a missing title', () => {
+    expect(createTask.inputSchema.safeParse({ pageId: 'pg1' }).success).toBe(false);
+  });
+
+  it('rejects an agentTrigger with neither prompt nor instructionPageId', () => {
+    const result = createTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      title: 'Ship it',
+      dueDate: '2026-02-01T00:00:00.000Z',
+      agentTrigger: { agentPageId: 'ag1' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an agentTrigger with only instructionPageId', () => {
+    const result = createTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      title: 'Ship it',
+      dueDate: '2026-02-01T00:00:00.000Z',
+      agentTrigger: { agentPageId: 'ag1', instructionPageId: 'instr1' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a due_date agentTrigger (the default triggerType) with no dueDate on the task', () => {
+    const result = createTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      title: 'Ship it',
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Ship it' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a completion agentTrigger with no dueDate', () => {
+    const result = createTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      title: 'Ship it',
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Ship it', triggerType: 'completion' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects contextPageIds beyond the 10-item cap', () => {
+    const result = createTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      title: 'Ship it',
+      dueDate: '2026-02-01T00:00:00.000Z',
+      agentTrigger: {
+        agentPageId: 'ag1',
+        prompt: 'Ship it',
+        contextPageIds: Array.from({ length: 11 }, (_, i) => `p${i}`),
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('tasks.create — response contract', () => {
+  it('parses the created task (route truth, §2.7 create_task)', () => {
+    const result = parseResponse(createTask, 200, new Headers(), JSON.stringify(taskFixture));
+    expect(result).toEqual(taskFixture);
+  });
+
+  it('parses a task with multiple assignees', () => {
+    const withAssignees = {
+      ...taskFixture,
+      assignees: [
+        {
+          id: 'ta1',
+          taskId: 't1abc',
+          userId: 'u2abc',
+          agentPageId: null,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          user: { id: 'u2abc', name: 'Bo', image: null },
+          agentPage: null,
+        },
+      ],
+    };
+    const result = parseResponse(createTask, 200, new Headers(), JSON.stringify(withAssignees));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('rejects a response missing a required field', () => {
+    const malformed = { ...taskFixture } as Record<string, unknown>;
+    delete malformed.pageId;
+    const result = parseResponse(createTask, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies an invalid-status 400 as ValidationError, not a schema mismatch', () => {
+    const result = parseResponse(createTask, 400, new Headers(), JSON.stringify({ error: 'Invalid status "bogus". Valid statuses: pending, completed' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('tasks.update — request shape', () => {
+  it('interpolates :pageId and :taskId and omits position from its input', () => {
+    const request = buildRequest(updateTask, { pageId: 'pg1', taskId: 't1', title: 'New title' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/pg1/tasks/t1');
+    expect(request.body).toBe(JSON.stringify({ title: 'New title' }));
+  });
+
+  it('rejects a position field (reorder_task owns position, not update_task)', () => {
+    const result = updateTask.inputSchema.safeParse({ pageId: 'pg1', taskId: 't1', position: 2 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('tasks.update — input refinements', () => {
+  it('rejects an explicit-null dueDate paired with a due_date agentTrigger in the same call', () => {
+    const result = updateTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      taskId: 't1',
+      dueDate: null,
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Ship it' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a due_date agentTrigger when dueDate is omitted (server falls back to the existing task due date)', () => {
+    const result = updateTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      taskId: 't1',
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Ship it' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a due_date agentTrigger when dueDate is set in this same call', () => {
+    const result = updateTask.inputSchema.safeParse({
+      pageId: 'pg1',
+      taskId: 't1',
+      dueDate: '2026-02-01T00:00:00.000Z',
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Ship it' },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('tasks.update — response contract', () => {
+  it('parses the updated task', () => {
+    const result = parseResponse(updateTask, 200, new Headers(), JSON.stringify(taskFixture));
+    expect(result).toEqual(taskFixture);
+  });
+
+  it('classifies the 422 sub-tasks-incomplete gate as an HttpError carrying status 422', () => {
+    const result = parseResponse(
+      updateTask,
+      422,
+      new Headers(),
+      JSON.stringify({ code: 'SUBTASKS_INCOMPLETE', error: 'Complete all sub-tasks first (2 of 5 remaining)', pending: 2, total: 5 }),
+    );
+    expect(result).toBeInstanceOf(HttpError);
+    expect((result as HttpError).status).toBe(422);
+  });
+});
+
+describe('tasks.reorder — request shape', () => {
+  it('PATCHes the same task route with only { position }', () => {
+    const request = buildRequest(reorderTask, { pageId: 'pg1', taskId: 't1', position: 3 }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/pg1/tasks/t1');
+    expect(request.body).toBe(JSON.stringify({ position: 3 }));
+  });
+});
+
+describe('tasks.reorder — response contract', () => {
+  it('parses the updated task row', () => {
+    const result = parseResponse(reorderTask, 200, new Headers(), JSON.stringify(taskFixture));
+    expect(result).toEqual(taskFixture);
+  });
+});
+
+describe('tasks.delete — request shape and response', () => {
+  it('DELETEs the task route with no body', () => {
+    const request = buildRequest(deleteTask, { pageId: 'pg1', taskId: 't1' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/pg1/tasks/t1');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteTask, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('tasks.createStatus — request shape, refinements, response', () => {
+  it('interpolates :pageId and sends name/color/group/position as body', () => {
+    const request = buildRequest(
+      createTaskStatus,
+      { pageId: 'pg1', name: 'Review', color: 'bg-blue-100', group: 'in_progress' },
+      config,
+    );
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/pg1/tasks/statuses');
+    expect(request.body).toBe(JSON.stringify({ color: 'bg-blue-100', group: 'in_progress', name: 'Review' }));
+  });
+
+  it('rejects a group outside todo/in_progress/done', () => {
+    const result = createTaskStatus.inputSchema.safeParse({
+      pageId: 'pg1',
+      name: 'Review',
+      color: 'bg-blue-100',
+      group: 'archived',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses the created status config row (route truth, §2.7 create_task_status)', () => {
+    const statusFixture = {
+      id: 's1abc',
+      taskListId: 'tl1abc',
+      name: 'Review',
+      slug: 'review',
+      color: 'bg-blue-100',
+      group: 'in_progress',
+      position: 4,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const result = parseResponse(createTaskStatus, 201, new Headers(), JSON.stringify(statusFixture));
+    expect(result).toEqual(statusFixture);
+  });
+
+  it('classifies a slug-collision 409 as an HttpError, never a schema mismatch', () => {
+    const result = parseResponse(createTaskStatus, 409, new Headers(), JSON.stringify({ error: 'A status with slug "review" already exists' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('HTTP_ERROR');
+  });
+});
+
+describe('tasks.setTrigger — request shape, refinements, response', () => {
+  it('interpolates :taskId and sends the trigger fields as body', () => {
+    const request = buildRequest(
+      setTaskTrigger,
+      { taskId: 't1', triggerType: 'due_date', agentPageId: 'ag1', prompt: 'Nudge me' },
+      config,
+    );
+    expect(request.method).toBe('PUT');
+    expect(request.url).toBe('https://pagespace.ai/api/tasks/t1/triggers');
+    expect(request.body).toBe(JSON.stringify({ agentPageId: 'ag1', prompt: 'Nudge me', triggerType: 'due_date' }));
+  });
+
+  it('rejects a trigger with neither prompt nor instructionPageId (route .strict().refine())', () => {
+    const result = setTaskTrigger.inputSchema.safeParse({ taskId: 't1', triggerType: 'due_date', agentPageId: 'ag1' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a trigger with only instructionPageId', () => {
+    const result = setTaskTrigger.inputSchema.safeParse({
+      taskId: 't1',
+      triggerType: 'completion',
+      agentPageId: 'ag1',
+      instructionPageId: 'instr1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('parses { trigger } including the linked workflow fields', () => {
+    const triggerFixture = {
+      trigger: {
+        id: 'tr1abc',
+        taskItemId: 't1',
+        triggerType: 'due_date',
+        nextRunAt: '2026-02-01T00:00:00.000Z',
+        lastFiredAt: null,
+        lastFireError: null,
+        isEnabled: true,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        workflowId: 'wf1abc',
+        agentPageId: 'ag1',
+        prompt: 'Nudge me',
+        instructionPageId: null,
+        contextPageIds: [],
+      },
+    };
+    const result = parseResponse(setTaskTrigger, 200, new Headers(), JSON.stringify(triggerFixture));
+    expect(result).toEqual(triggerFixture);
+  });
+});
+
+describe('tasks.deleteTrigger — request shape, response, and MCP-auth parity fix', () => {
+  it('interpolates both :taskId and :triggerType', () => {
+    const request = buildRequest(deleteTaskTrigger, { taskId: 't1', triggerType: 'completion' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/tasks/t1/triggers/completion');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteTaskTrigger, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+
+  it('declares drive scope, not sessionOnly — route now allows mcp tokens (#1764/66/67/70 fix, was D2)', () => {
+    expect(deleteTaskTrigger.requiredScope).toBe('drive');
+  });
+});
+
+describe('tasks.getAssigned — request shape, refinements, response', () => {
+  it('sends filters as query params with no path params', () => {
+    const request = buildRequest(getAssignedTasks, { context: 'drive', driveId: 'd1', limit: 10 }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/tasks?context=drive&driveId=d1&limit=10');
+  });
+
+  it('serializes boolean filters as literal "true"/"false" query strings', () => {
+    const request = buildRequest(getAssignedTasks, { showAllAssignees: true }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/tasks?showAllAssignees=true');
+  });
+
+  it('rejects context "drive" with no driveId (route 400: "driveId is required for drive context")', () => {
+    const result = getAssignedTasks.inputSchema.safeParse({ context: 'drive' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts context "user" with no driveId', () => {
+    const result = getAssignedTasks.inputSchema.safeParse({ context: 'user' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a limit above the route cap of 100', () => {
+    const result = getAssignedTasks.inputSchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses { tasks, statusConfigsByTaskList, pagination } (route truth, §2.7 get_assigned_tasks)', () => {
+    const responseFixture = {
+      tasks: [
+        {
+          ...taskFixture,
+          page: { id: 'p1task', title: 'Write the spec', isTrashed: false, parentId: 'pglist1' },
+          driveId: 'd1abc',
+          taskListPageId: 'pglist1',
+          taskListPageTitle: 'Sprint Board',
+          statusGroup: 'todo',
+          statusLabel: 'To Do',
+          statusColor: 'bg-slate-100 text-slate-700',
+        },
+      ],
+      statusConfigsByTaskList: {
+        pglist1: [{ id: 's1', taskListId: 'tl1', name: 'To Do', slug: 'pending', color: 'bg-slate-100', group: 'todo', position: 0 }],
+      },
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    };
+    const result = parseResponse(getAssignedTasks, 200, new Headers(), JSON.stringify(responseFixture));
+    expect(result).toEqual(responseFixture);
+  });
+
+  it('parses an empty result set', () => {
+    const empty = { tasks: [], statusConfigsByTaskList: {}, pagination: { total: 0, limit: 50, offset: 0, hasMore: false } };
+    const result = parseResponse(getAssignedTasks, 200, new Headers(), JSON.stringify(empty));
+    expect(result).toEqual(empty);
+  });
+});
+
+describe('classifyTaskCompletionGate — pure gating-error classifier', () => {
+  it('recovers pending/total from a 422 HttpError raised by tasks.update', () => {
+    const error = new HttpError('Complete all sub-tasks first (2 of 5 remaining)', 422, 'tasks.update');
+    expect(classifyTaskCompletionGate(error)).toEqual({ pending: 2, total: 5 });
+  });
+
+  it('returns null for a non-422 HttpError', () => {
+    const error = new HttpError('Something else', 409, 'tasks.update');
+    expect(classifyTaskCompletionGate(error)).toBeNull();
+  });
+
+  it('returns null for a 422 error whose message does not match the gating shape', () => {
+    const error = new HttpError('HTTP 422', 422, 'tasks.update');
+    expect(classifyTaskCompletionGate(error)).toBeNull();
+  });
+
+  it('returns null for a non-error value', () => {
+    expect(classifyTaskCompletionGate({ status: 422, message: '(2 of 5 remaining)' })).toBeNull();
+  });
+});
+
+describe('tasks operations — metadata', () => {
+  it('every operation is named, described, and scoped for MCP/CLI derivation', () => {
+    const ops = [createTask, updateTask, deleteTask, reorderTask, createTaskStatus, setTaskTrigger, deleteTaskTrigger, getAssignedTasks];
+    for (const op of ops) {
+      expect(op.name.startsWith('tasks.')).toBe(true);
+      expect(op.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/sdk/src/operations/tasks.ts
+++ b/packages/sdk/src/operations/tasks.ts
@@ -1,0 +1,358 @@
+/**
+ * Tasks & statuses operations (Phase 3 task 4).
+ *
+ * Route-verified against `apps/web/src/app/api/pages/[pageId]/tasks/route.ts`,
+ * `.../tasks/[taskId]/route.ts`, `.../tasks/statuses/route.ts`,
+ * `apps/web/src/app/api/tasks/route.ts`, `apps/web/src/app/api/tasks/[taskId]/triggers/route.ts`
+ * and `.../triggers/[triggerType]/route.ts` (docs/sdk/operations-inventory.md
+ * §2.7 + §2.13, parity with MCP tools `create_task`, `update_task`,
+ * `delete_task`, `reorder_task`, `create_task_status`, `set_task_trigger`,
+ * `delete_task_trigger`, `get_assigned_tasks`). `reorder_task` targets the
+ * same PATCH route as `update_task` with a position-only body — the MCP
+ * layer deliberately splits them, so the registry does too (`tasks.update`
+ * rejects `position`; only `tasks.reorder` accepts it).
+ *
+ * D2 fix: `delete_task_trigger`'s route was session-only prior to
+ * #1764/66/67/70; it now accepts `['session','mcp']`, so this op declares
+ * `requiredScope: 'drive'` like every other op here, not `sessionOnly`.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+import { HttpError, isHttpError } from '../errors.js';
+
+const priorityEnum = z.enum(['low', 'medium', 'high']);
+const statusGroupEnum = z.enum(['todo', 'in_progress', 'done']);
+const triggerTypeEnum = z.enum(['due_date', 'completion']);
+
+const userRefSchema = z
+  .object({ id: z.string(), name: z.string().nullable(), image: z.string().nullable() })
+  .nullable();
+
+const agentRefSchema = z
+  .object({ id: z.string(), title: z.string().nullable(), type: z.string() })
+  .nullable();
+
+const assigneeEntrySchema = z.object({
+  id: z.string(),
+  taskId: z.string(),
+  userId: z.string().nullable(),
+  agentPageId: z.string().nullable(),
+  createdAt: z.string(),
+  user: userRefSchema,
+  agentPage: agentRefSchema,
+});
+
+/** `taskItems` row shape shared by create/update/reorder/get_assigned responses. */
+const taskItemBaseSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  assigneeId: z.string().nullable(),
+  assigneeAgentId: z.string().nullable(),
+  pageId: z.string(),
+  status: z.string().describe('A status slug from the task list. Valid slugs come from read_page on the TASK_LIST page (availableStatuses), or tasks.createStatus output.'),
+  priority: priorityEnum,
+  position: z.number(),
+  dueDate: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  completedAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** `{ ...taskWithRelations, title }` shape returned by create_task/update_task/reorder_task. */
+const taskWithRelationsSchema = taskItemBaseSchema.extend({
+  assignee: userRefSchema,
+  assigneeAgent: agentRefSchema,
+  user: userRefSchema,
+  page: z.object({ id: z.string(), title: z.string().nullable() }).nullable(),
+  assignees: z.array(assigneeEntrySchema),
+  title: z.string(),
+});
+
+const assigneeEntryInputSchema = z.object({ type: z.enum(['user', 'agent']), id: z.string() });
+
+/**
+ * `agentTrigger` on create_task/update_task. Route truth (`tasks/route.ts:389`,
+ * `tasks/[taskId]/route.ts:208`) requires prompt OR instructionPageId — not a
+ * strict XOR; the route never rejects both being present together.
+ */
+const agentTriggerInputSchema = z
+  .object({
+    agentPageId: z.string().min(1),
+    triggerType: triggerTypeEnum.optional().describe('Defaults to "due_date" server-side when omitted.'),
+    prompt: z.string().max(10000).optional(),
+    instructionPageId: z.string().optional(),
+    contextPageIds: z.array(z.string()).max(10).optional(),
+  })
+  .refine((v) => Boolean(v.prompt) || Boolean(v.instructionPageId), {
+    message: 'agentTrigger needs either a prompt or an instructionPageId',
+    path: ['prompt'],
+  });
+
+export const createTask = defineOperation({
+  name: 'tasks.create',
+  method: 'POST',
+  path: '/api/pages/:pageId/tasks',
+  inputSchema: z
+    .object({
+      pageId: z.string(),
+      title: z.string().min(1),
+      status: z.string().optional().describe('Status slug. Valid slugs come from read_page on the TASK_LIST page (availableStatuses).'),
+      priority: priorityEnum.optional(),
+      assigneeId: z.string().optional(),
+      assigneeAgentId: z.string().optional(),
+      assigneeIds: z.array(assigneeEntryInputSchema).optional(),
+      dueDate: z.string().optional(),
+      note: z.string().optional(),
+      position: z.number().optional(),
+      timezone: z.string().optional(),
+      agentTrigger: agentTriggerInputSchema.optional(),
+    })
+    .refine(
+      (v) => {
+        if (!v.agentTrigger) return true;
+        const triggerType = v.agentTrigger.triggerType ?? 'due_date';
+        return triggerType !== 'due_date' || Boolean(v.dueDate);
+      },
+      { message: 'A due_date agentTrigger requires dueDate to be set on the task', path: ['dueDate'] },
+    ),
+  outputSchema: taskWithRelationsSchema,
+  requiredScope: 'drive',
+  description: 'Create a task on a TASK_LIST page. Status slugs come from that list\'s availableStatuses (see read_page).',
+});
+
+export const updateTask = defineOperation({
+  name: 'tasks.update',
+  method: 'PATCH',
+  path: '/api/pages/:pageId/tasks/:taskId',
+  inputSchema: z
+    .object({
+      pageId: z.string(),
+      taskId: z.string(),
+      title: z.string().min(1).optional(),
+      status: z.string().optional().describe('Status slug. Valid slugs come from read_page on the TASK_LIST page (availableStatuses).'),
+      priority: priorityEnum.optional(),
+      assigneeId: z.string().optional(),
+      assigneeAgentId: z.string().optional(),
+      assigneeIds: z.array(assigneeEntryInputSchema).optional(),
+      dueDate: z.string().nullable().optional(),
+      note: z.string().optional(),
+      timezone: z.string().optional(),
+      agentTrigger: agentTriggerInputSchema.optional(),
+    })
+    .strict() // position belongs to tasks.reorder, not tasks.update
+    .refine(
+      (v) => {
+        if (!v.agentTrigger) return true;
+        const triggerType = v.agentTrigger.triggerType ?? 'due_date';
+        if (triggerType !== 'due_date') return true;
+        // Only refine when dueDate is explicit and falsy in THIS call — when
+        // omitted, the server falls back to the task's existing dueDate,
+        // which the client cannot see; failing closed there would reject
+        // valid updates.
+        if (v.dueDate === undefined) return true;
+        return Boolean(v.dueDate);
+      },
+      {
+        message: 'A due_date agentTrigger requires dueDate — either set in this update or already present on the task',
+        path: ['dueDate'],
+      },
+    ),
+  outputSchema: taskWithRelationsSchema,
+  requiredScope: 'drive',
+  description:
+    'Update a task\'s fields. Position is owned by tasks.reorder, not this operation. On a 422 response, use classifyTaskCompletionGate to detect the "sub-tasks incomplete" gate.',
+});
+
+export const reorderTask = defineOperation({
+  name: 'tasks.reorder',
+  method: 'PATCH',
+  path: '/api/pages/:pageId/tasks/:taskId',
+  inputSchema: z.object({
+    pageId: z.string(),
+    taskId: z.string(),
+    position: z.number(),
+  }),
+  outputSchema: taskWithRelationsSchema,
+  requiredScope: 'drive',
+  description: 'Move a task to a new position within its task list (same route as tasks.update, position-only body).',
+});
+
+export const deleteTask = defineOperation({
+  name: 'tasks.delete',
+  method: 'DELETE',
+  path: '/api/pages/:pageId/tasks/:taskId',
+  inputSchema: z.object({ pageId: z.string(), taskId: z.string() }),
+  outputSchema: z.object({ success: z.boolean() }),
+  requiredScope: 'drive',
+  description: 'Delete a task by trashing its linked TASK_LIST child page.',
+});
+
+const taskStatusConfigSchema = z.object({
+  id: z.string(),
+  taskListId: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  color: z.string(),
+  group: statusGroupEnum,
+  position: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const createTaskStatus = defineOperation({
+  name: 'tasks.createStatus',
+  method: 'POST',
+  path: '/api/pages/:pageId/tasks/statuses',
+  inputSchema: z.object({
+    pageId: z.string(),
+    name: z.string().min(1),
+    color: z.string().min(1),
+    group: statusGroupEnum,
+    position: z.number().optional(),
+  }),
+  outputSchema: taskStatusConfigSchema,
+  requiredScope: 'drive',
+  description: 'Create a custom status on a task list. The returned slug becomes a valid value for tasks.create/tasks.update\'s status field.',
+});
+
+const taskTriggerSchema = z.object({
+  id: z.string(),
+  taskItemId: z.string(),
+  triggerType: triggerTypeEnum,
+  nextRunAt: z.string().nullable(),
+  lastFiredAt: z.string().nullable(),
+  lastFireError: z.string().nullable(),
+  isEnabled: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  workflowId: z.string(),
+  agentPageId: z.string(),
+  prompt: z.string(),
+  instructionPageId: z.string().nullable(),
+  contextPageIds: z.array(z.string()).nullable(),
+});
+
+export const setTaskTrigger = defineOperation({
+  name: 'tasks.setTrigger',
+  method: 'PUT',
+  path: '/api/tasks/:taskId/triggers',
+  inputSchema: z
+    .object({
+      taskId: z.string(),
+      triggerType: triggerTypeEnum,
+      agentPageId: z.string().min(1),
+      prompt: z.string().max(10000).optional(),
+      instructionPageId: z.string().nullable().optional(),
+      contextPageIds: z.array(z.string()).max(10).optional(),
+      timezone: z.string().optional(),
+    })
+    .refine((v) => Boolean(v.prompt?.trim()) || Boolean(v.instructionPageId), {
+      message: 'Either prompt or instructionPageId is required',
+      path: ['prompt'],
+    }),
+  outputSchema: z.object({ trigger: taskTriggerSchema }),
+  requiredScope: 'drive',
+  description: 'Set (upsert) an agent trigger for a task — fires on the due date or on completion.',
+});
+
+export const deleteTaskTrigger = defineOperation({
+  name: 'tasks.deleteTrigger',
+  method: 'DELETE',
+  path: '/api/tasks/:taskId/triggers/:triggerType',
+  inputSchema: z.object({ taskId: z.string(), triggerType: triggerTypeEnum }),
+  outputSchema: z.object({ success: z.boolean() }),
+  requiredScope: 'drive',
+  description: 'Remove one trigger (due_date or completion) from a task.',
+});
+
+const assignedTaskSchema = taskItemBaseSchema.extend({
+  assignee: userRefSchema,
+  assigneeAgent: agentRefSchema,
+  assignees: z.array(assigneeEntrySchema),
+  user: userRefSchema,
+  page: z.object({ id: z.string(), title: z.string().nullable(), isTrashed: z.boolean(), parentId: z.string().nullable() }).nullable(),
+  title: z.string(),
+  driveId: z.string(),
+  taskListPageId: z.string(),
+  taskListPageTitle: z.string().nullable(),
+  statusGroup: statusGroupEnum,
+  statusLabel: z.string(),
+  statusColor: z.string(),
+});
+
+export const getAssignedTasks = defineOperation({
+  name: 'tasks.getAssigned',
+  method: 'GET',
+  path: '/api/tasks',
+  inputSchema: z
+    .object({
+      context: z.enum(['user', 'drive']).optional(),
+      driveId: z.string().optional(),
+      status: z.string().optional(),
+      priority: priorityEnum.optional(),
+      startDate: z.string().optional(),
+      endDate: z.string().optional(),
+      search: z.string().optional(),
+      assigneeId: z.string().optional(),
+      assigneeAgentId: z.string().optional(),
+      showAllAssignees: z.boolean().optional(),
+      includeCompleted: z.boolean().optional(),
+      dueDateFilter: z.enum(['overdue', 'today', 'this_week', 'upcoming']).optional(),
+      statusGroup: z.enum(['all', 'active', 'completed']).optional(),
+      limit: z.number().int().min(1).max(100).optional(),
+      offset: z.number().int().min(0).optional(),
+    })
+    .refine((v) => v.context !== 'drive' || Boolean(v.driveId), {
+      message: 'driveId is required for drive context',
+      path: ['driveId'],
+    }),
+  outputSchema: z.object({
+    tasks: z.array(assignedTaskSchema),
+    statusConfigsByTaskList: z.record(
+      z.string(),
+      z.array(
+        z.object({
+          id: z.string(),
+          taskListId: z.string(),
+          name: z.string(),
+          slug: z.string(),
+          color: z.string(),
+          group: statusGroupEnum,
+          position: z.number(),
+        }),
+      ),
+    ),
+    pagination: z.object({
+      total: z.number(),
+      limit: z.number(),
+      offset: z.number(),
+      hasMore: z.boolean(),
+    }),
+  }),
+  description: 'List tasks assigned to the caller (or filtered) across one drive or every accessible drive.',
+});
+
+export interface TaskCompletionGatedError {
+  readonly pending: number;
+  readonly total: number;
+}
+
+const SUBTASKS_INCOMPLETE_PATTERN = /\((\d+) of (\d+) remaining\)/;
+
+/**
+ * Detects the tasks.update "complete sub-tasks first" gate (422,
+ * `SUBTASKS_INCOMPLETE` — `packages/lib` completion-guard.ts) on an
+ * already-classified error, recovering the pending/total counts embedded
+ * in its message. Message-based, not body-based: `classifyHttpError`
+ * (Phase 2) never retains the raw response body on `HttpError` (zero
+ * trust — no oracle for server-echoed fields), so the counts baked into
+ * the human-readable message are the only surviving structured data.
+ */
+export function classifyTaskCompletionGate(error: unknown): TaskCompletionGatedError | null {
+  if (!isHttpError(error)) return null;
+  if ((error as HttpError).status !== 422) return null;
+  const match = SUBTASKS_INCOMPLETE_PATTERN.exec(error.message);
+  if (!match) return null;
+  return { pending: Number(match[1]), total: Number(match[2]) };
+}

--- a/packages/sdk/src/transport/__tests__/build-request.test.ts
+++ b/packages/sdk/src/transport/__tests__/build-request.test.ts
@@ -110,6 +110,27 @@ describe('buildRequest — body and Content-Type', () => {
     const request = buildRequest(op({ method: 'PATCH', path: '/api/pages/:id' }), { id: 'p1', title: 'Hi' }, config);
     expect(request.url).toBe('https://pagespace.ai/api/pages/p1');
   });
+
+  it('preserves nested object fields whose keys do not appear at the top level', () => {
+    // Regression: a plain `JSON.stringify(fields, sortedTopLevelKeys)` replacer-array
+    // call filters property names at every nesting level, not just the top, so a
+    // nested field like `agentTrigger: { agentPageId, prompt }` would serialize as `{}`.
+    const request = buildRequest(
+      op({ method: 'POST', path: '/api/pages/:pageId/tasks' }),
+      { pageId: 'pg1', title: 'Hi', agentTrigger: { agentPageId: 'ag1', prompt: 'Do it' } },
+      config,
+    );
+    expect(request.body).toBe(JSON.stringify({ agentTrigger: { agentPageId: 'ag1', prompt: 'Do it' }, title: 'Hi' }));
+  });
+
+  it('preserves fields inside an array of nested objects', () => {
+    const request = buildRequest(
+      op({ method: 'POST', path: '/api/pages/:pageId/tasks' }),
+      { pageId: 'pg1', assigneeIds: [{ type: 'user', id: 'u1' }] },
+      config,
+    );
+    expect(request.body).toBe(JSON.stringify({ assigneeIds: [{ id: 'u1', type: 'user' }] }));
+  });
 });
 
 describe('buildRequest — version header (ADR 0001)', () => {

--- a/packages/sdk/src/transport/build-request.ts
+++ b/packages/sdk/src/transport/build-request.ts
@@ -50,11 +50,30 @@ function serializeQuery(params: Readonly<Record<string, unknown>>): string {
   return query.length > 0 ? `?${query}` : '';
 }
 
-/** Serializes a plain object as JSON with a stable (sorted) top-level key order. */
+/**
+ * Recursively rebuilds an object/array with object keys in sorted order, so
+ * `JSON.stringify` (no replacer) produces a deterministic body. A replacer
+ * *array* would look like the obvious way to get sorted keys, but per spec
+ * it filters property names at every nesting level, not just the top —
+ * `JSON.stringify({a:{b:1}}, ['a'])` silently drops `b`. Any nested object
+ * field (e.g. an operation's `agentTrigger`) would come out empty.
+ */
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      sorted[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/** Serializes a plain object as JSON with a stable (sorted) key order at every nesting level. */
 function serializeBody(fields: Readonly<Record<string, unknown>>): string | undefined {
-  const keys = Object.keys(fields).sort();
-  if (keys.length === 0) return undefined;
-  return JSON.stringify(fields, keys);
+  if (Object.keys(fields).length === 0) return undefined;
+  return JSON.stringify(sortKeysDeep(fields));
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 3 task 4 of the SDK/CLI/OAuth epic — full parity for the tasks & statuses domain (route-verified against `docs/sdk/operations-inventory.md` §2.7/§2.13 and the current routes under `apps/web/src/app/api/pages/[pageId]/tasks/**`, `apps/web/src/app/api/tasks/**`).

- 8 operations: `tasks.create`, `tasks.update`, `tasks.delete`, `tasks.reorder`, `tasks.createStatus`, `tasks.setTrigger`, `tasks.deleteTrigger`, `tasks.getAssigned`.
- `reorder_task`/`update_task` share a route; `tasks.update`'s input schema is `.strict()` and rejects `position` so it stays owned by `tasks.reorder`, mirroring the MCP tool split.
- `agentTrigger` refinements encode route truth: prompt **or** instructionPageId (the route only requires OR, not a strict XOR), and a `due_date` trigger requires `dueDate`. `tasks.update`'s due-date refinement only fires when `dueDate` is explicit and falsy in the *same* call — an omitted `dueDate` falls back server-side to the task's existing value, which the client can't see, so refining on that path would reject valid updates.
- `tasks.deleteTrigger` declares `requiredScope: 'drive'`, not `sessionOnly` — `#1764/66/67/70` added `mcp` to that route's allow-list, resolving inventory discrepancy D2.
- `tasks.getAssigned` refines `driveId` required for `context: 'drive'` and caps `limit` at the route's 1–100.
- `classifyTaskCompletionGate`: a pure classifier that recovers `pending`/`total` from the 422 `SUBTASKS_INCOMPLETE` gate's message. `classifyHttpError` never retains the raw response body on `HttpError` by design (zero trust — no server-echo oracle), so the counts baked into the human-readable message are the only surviving structured data once the error reaches a caller.
- Wired into `client.tasks.*` (`DEFAULT_OPERATIONS_MAP`) and the package barrel via explicit named exports (no `export *`).

**Bug fix (found while writing contract tests):** `buildRequest`'s `serializeBody` used `JSON.stringify`'s array-replacer for "sorted key order," but a replacer array filters property names at *every* nesting level, not just the top — `JSON.stringify({a:{b:1}}, ['a'])` silently drops `b`. Any operation with a nested object body (this domain's `agentTrigger`, `assigneeIds`) would have serialized nested fields as `{}`. Fixed with a deep key-sort pass instead of a replacer array; regression tests added to `build-request.test.ts`.

## Test plan
- [x] RED commit: contract tests fail (module doesn't exist)
- [x] GREEN commit: `bun run --filter '@pagespace/sdk' typecheck` passes
- [x] GREEN commit: `bun run --filter '@pagespace/sdk' test` passes (329/329 after rebase onto latest `pu/cli-login`)
- [x] Rebased onto `pu/cli-login` (picked up Phase 3 tasks 1 & 3, drives/members + search)