### PR TITLE
sdk: pages & content operations (Phase 3 task 2)

### DIFF
--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -306,13 +306,13 @@ describe('PageSpaceClient — registry-derived namespaces', () => {
     const client = makeClient({ fetch: fetchMock });
 
     expect(typeof client.drives.list).toBe('function');
-    expect(typeof client.pages.read).toBe('function');
+    expect(typeof client.pages.details).toBe('function');
 
     const drives = await client.drives.list({});
     expect(drives).toHaveLength(1);
     expect(drives[0]?.id).toBe('d1');
 
-    const page = await client.pages.read({ pageId: 'p1' });
+    const page = await client.pages.details({ pageId: 'p1' });
     expect(page.id).toBe('p1');
   });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -38,7 +38,17 @@ import {
 } from './errors.js';
 import type { AuthProvider } from './auth/provider.js';
 import { listDrives } from './operations/drives.js';
-import { readPage } from './operations/pages.js';
+import {
+  createPage,
+  getPageDetails,
+  listPages,
+  listTrash,
+  movePage,
+  renamePage,
+  restorePage,
+  trashPage,
+} from './operations/pages.js';
+import { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
 import type { Operation } from './registry/define.js';
 import { createRegistry, type OperationRegistry } from './registry/registry.js';
 import { buildRequest } from './transport/build-request.js';
@@ -50,7 +60,21 @@ import { checkServerCompatibility, MIN_SERVER_API_VERSION } from './version.js';
 
 const DEFAULT_OPERATIONS_MAP = {
   drives: { list: listDrives },
-  pages: { read: readPage },
+  pages: {
+    list: listPages,
+    listTrash: listTrash,
+    read: readDocument,
+    details: getPageDetails,
+    create: createPage,
+    rename: renamePage,
+    move: movePage,
+    trash: trashPage,
+    restore: restorePage,
+    replaceLines: replaceLines,
+    insertLines: insertLines,
+    deleteLines: deleteLines,
+    editCells: editSheetCells,
+  },
 } as const;
 
 type OperationsMap = Record<string, Record<string, Operation>>;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,7 +56,19 @@ export type { OperationRegistry } from './registry/registry.js';
 
 // Seed operations (Phase 3 grows this list).
 export { listDrives } from './operations/drives.js';
-export { readPage } from './operations/pages.js';
+
+// Pages & content operations (Phase 3 task 2) — full pagespace-mcp page.js/document.js parity.
+export {
+  createPage,
+  getPageDetails,
+  listPages,
+  listTrash,
+  movePage,
+  renamePage,
+  restorePage,
+  trashPage,
+} from './operations/pages.js';
+export { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
 
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.

--- a/packages/sdk/src/operations/__tests__/documents.test.ts
+++ b/packages/sdk/src/operations/__tests__/documents.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError, ValidationError } from '../../errors.js';
+import { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from '../documents.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+const DOCS_URL = 'https://pagespace.ai/api/mcp/documents';
+
+describe('pages.read (documents) — request shape', () => {
+  it('defaults operation to "read" and sends a bare pageId body', () => {
+    const parsed = readDocument.inputSchema.parse({ pageId: 'p1abc' });
+    const request = buildRequest(readDocument, parsed, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe(DOCS_URL);
+    expect(JSON.parse(request.body!)).toEqual({ operation: 'read', pageId: 'p1abc' });
+  });
+
+  it('serializes a startLine/endLine range', () => {
+    const parsed = readDocument.inputSchema.parse({ pageId: 'p1abc', startLine: 2, endLine: 5 });
+    const request = buildRequest(readDocument, parsed, config);
+    expect(JSON.parse(request.body!)).toEqual({ operation: 'read', pageId: 'p1abc', startLine: 2, endLine: 5 });
+  });
+
+  it('rejects endLine < startLine', () => {
+    const result = readDocument.inputSchema.safeParse({ pageId: 'p1abc', startLine: 5, endLine: 2 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a zero or negative startLine', () => {
+    const result = readDocument.inputSchema.safeParse({ pageId: 'p1abc', startLine: 0 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('pages.read (documents) — response contract: generic text page', () => {
+  const genericFixture = {
+    pageId: 'p1abc',
+    pageTitle: 'Design Doc',
+    totalLines: 3,
+    numberedLines: ['   1 | a', '   2 | b', '   3 | c'],
+    content: 'a\nb\nc',
+  };
+
+  it('parses a plain DOCUMENT/CODE page with no pageType field', () => {
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(genericFixture));
+    expect(result).toEqual(genericFixture);
+  });
+
+  it('parses a FILE page with fileMetadata attached', () => {
+    const withFile = {
+      ...genericFixture,
+      fileMetadata: { mimeType: 'application/pdf', fileSize: 1024, originalFileName: 'doc.pdf', processingStatus: 'completed' },
+    };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(withFile));
+    expect(result).toEqual(withFile);
+  });
+
+  it('parses an out-of-range read (empty content + rangeMessage)', () => {
+    const outOfRange = { ...genericFixture, numberedLines: [], content: '', rangeStart: 10, rangeEnd: 10, rangeMessage: 'beyond document length' };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(outOfRange));
+    expect(result).toEqual(outOfRange);
+  });
+});
+
+describe('pages.read (documents) — response contract: CHANNEL page', () => {
+  it('parses a channel transcript', () => {
+    const channelFixture = {
+      pageId: 'c1abc',
+      pageTitle: 'general',
+      pageType: 'CHANNEL',
+      totalLines: 2,
+      numberedLines: ['   1 | [user] Ada (2026-01-01T00:00:00.000Z): hi', '   2 | [agent] Bot (2026-01-01T00:00:01.000Z): hello'],
+      content: '[user] Ada (2026-01-01T00:00:00.000Z): hi\n[agent] Bot (2026-01-01T00:00:01.000Z): hello',
+      messageCount: 2,
+      totalMessages: 2,
+    };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(channelFixture));
+    expect(result).toEqual(channelFixture);
+  });
+
+  it('never matches the generic branch (pageType present rules it out)', () => {
+    const emptyChannel = {
+      pageId: 'c1abc',
+      pageTitle: 'general',
+      pageType: 'CHANNEL',
+      totalLines: 0,
+      numberedLines: [] as string[],
+      content: '',
+      messageCount: 0,
+      totalMessages: 0,
+    };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(emptyChannel));
+    expect(result).toEqual(emptyChannel);
+  });
+});
+
+describe('pages.read (documents) — response contract: FILE status page', () => {
+  it('parses a still-processing FILE page', () => {
+    const fixture = {
+      pageId: 'f1abc',
+      pageTitle: 'scan.pdf',
+      pageType: 'FILE',
+      status: 'processing',
+      error: 'File is still being processed',
+      suggestion: 'Please try again in a moment',
+    };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+
+  it('parses a visual FILE page (message + fileMetadata, no error)', () => {
+    const fixture = {
+      pageId: 'f2abc',
+      pageTitle: 'photo.png',
+      pageType: 'FILE',
+      status: 'visual',
+      message: 'This is a visual file (image/png). Vision-capable processing is required to interpret its content.',
+      fileMetadata: { mimeType: 'image/png', fileSize: 2048, originalFileName: 'photo.png', processingStatus: 'visual' },
+    };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+});
+
+describe('pages.read (documents) — response contract: TASK_LIST page', () => {
+  const taskListFixture = {
+    pageId: 'tl1abc',
+    pageTitle: 'Sprint Board',
+    pageType: 'TASK_LIST',
+    taskListId: 'list1abc',
+    parentTaskList: null,
+    totalLines: 1,
+    numberedLines: ['   1 | # Sprint Board'],
+    content: '# Sprint Board',
+    tasks: [
+      {
+        id: 'task1abc',
+        title: 'Ship it',
+        status: 'in_progress',
+        priority: 'high',
+        assigneeId: null,
+        assigneeAgentId: null,
+        dueDate: null,
+        position: 1,
+        completedAt: null,
+        pageId: 'task1page',
+        assignee: null,
+        assigneeAgent: null,
+        assignees: [],
+        hasContent: true,
+        subTaskCount: 2,
+        subTaskCompletedCount: 1,
+      },
+    ],
+    availableStatuses: [{ slug: 'pending', label: 'To Do', group: 'todo', position: 0 }],
+    progress: { total: 1, percentage: 0, byGroup: { todo: 0, in_progress: 1, done: 0 }, bySlug: { in_progress: 1 } },
+  };
+
+  it('parses the full TASK_LIST extras (availableStatuses, progress, tasks)', () => {
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(taskListFixture));
+    expect(result).toEqual(taskListFixture);
+  });
+
+  it('parses a nested task list with a parentTaskList reference', () => {
+    const nested = { ...taskListFixture, parentTaskList: { pageId: 'parent1', title: 'Epic', taskListId: 'listparent' } };
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(nested));
+    expect(result).toEqual(nested);
+  });
+
+  it('rejects a task missing a required field (zero-trust on the hot-path domain)', () => {
+    const malformed = { ...taskListFixture, tasks: [{ ...taskListFixture.tasks[0] }] } as { tasks: Array<Record<string, unknown>> };
+    delete malformed.tasks[0]!.subTaskCount;
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('pages.replaceLines — request shape', () => {
+  it('defaults operation to "replace"', () => {
+    const parsed = replaceLines.inputSchema.parse({ pageId: 'p1abc', startLine: 2, content: 'new line' });
+    const request = buildRequest(replaceLines, parsed, config);
+    expect(JSON.parse(request.body!)).toEqual({ operation: 'replace', pageId: 'p1abc', startLine: 2, content: 'new line' });
+  });
+
+  it('rejects endLine < startLine', () => {
+    const result = replaceLines.inputSchema.safeParse({ pageId: 'p1abc', startLine: 5, endLine: 2, content: 'x' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('pages.replaceLines — response contract', () => {
+  it('parses the replace result', () => {
+    const fixture = {
+      pageId: 'p1abc',
+      pageTitle: 'Doc',
+      totalLines: 3,
+      numberedLines: ['   1 | a', '   2 | new line', '   3 | c'],
+      operation: 'replace',
+      affectedLines: '2-2',
+    };
+    const result = parseResponse(replaceLines, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+
+  it('classifies an out-of-range 400 as ValidationError', () => {
+    const result = parseResponse(replaceLines, 400, new Headers(), JSON.stringify({ error: 'Line number out of range' }));
+    expect(result).toBeInstanceOf(ValidationError);
+  });
+
+  it('classifies a revision-conflict 409 as HttpError (not a schema mismatch)', () => {
+    const result = parseResponse(replaceLines, 409, new Headers(), JSON.stringify({ error: 'Revision mismatch', currentRevision: 4, expectedRevision: 3 }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('pages.insertLines — request/response', () => {
+  it('defaults operation to "insert" and omits endLine entirely', () => {
+    const parsed = insertLines.inputSchema.parse({ pageId: 'p1abc', startLine: 4, content: 'inserted' });
+    const request = buildRequest(insertLines, parsed, config);
+    expect(JSON.parse(request.body!)).toEqual({ operation: 'insert', pageId: 'p1abc', startLine: 4, content: 'inserted' });
+  });
+
+  it('parses the insert result', () => {
+    const fixture = {
+      pageId: 'p1abc',
+      pageTitle: 'Doc',
+      totalLines: 4,
+      numberedLines: ['   1 | a', '   2 | b', '   3 | inserted', '   4 | c'],
+      operation: 'insert',
+      insertedAt: 3,
+    };
+    const result = parseResponse(insertLines, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+});
+
+describe('pages.deleteLines — request/response', () => {
+  it('defaults operation to "delete"', () => {
+    const parsed = deleteLines.inputSchema.parse({ pageId: 'p1abc', startLine: 2, endLine: 3 });
+    const request = buildRequest(deleteLines, parsed, config);
+    expect(JSON.parse(request.body!)).toEqual({ operation: 'delete', pageId: 'p1abc', startLine: 2, endLine: 3 });
+  });
+
+  it('rejects endLine < startLine', () => {
+    const result = deleteLines.inputSchema.safeParse({ pageId: 'p1abc', startLine: 5, endLine: 1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses the delete result', () => {
+    const fixture = {
+      pageId: 'p1abc',
+      pageTitle: 'Doc',
+      totalLines: 1,
+      numberedLines: ['   1 | a'],
+      operation: 'delete',
+      deletedLines: '2-3',
+    };
+    const result = parseResponse(deleteLines, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+});
+
+describe('pages.editCells — request shape', () => {
+  it('defaults operation to "edit-cells" and sends the cells array', () => {
+    const parsed = editSheetCells.inputSchema.parse({ pageId: 's1abc', cells: [{ address: 'A1', value: '=SUM(B1:B2)' }] });
+    const request = buildRequest(editSheetCells, parsed, config);
+    expect(JSON.parse(request.body!)).toEqual({ operation: 'edit-cells', pageId: 's1abc', cells: [{ address: 'A1', value: '=SUM(B1:B2)' }] });
+  });
+
+  it('rejects an invalid A1 address client-side (fail closed)', () => {
+    const result = editSheetCells.inputSchema.safeParse({ pageId: 's1abc', cells: [{ address: 'hello', value: '1' }] });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty cells array', () => {
+    const result = editSheetCells.inputSchema.safeParse({ pageId: 's1abc', cells: [] });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('pages.editCells — response contract', () => {
+  it('parses the edit-cells result', () => {
+    const fixture = {
+      pageId: 's1abc',
+      pageTitle: 'Budget',
+      cellsUpdated: 1,
+      operation: 'edit-cells',
+      stats: { valuesSet: 0, formulasSet: 1, cellsCleared: 0, sheetDimensions: { rows: 10, columns: 5 } },
+      updatedCells: [{ address: 'A1', type: 'formula' }],
+    };
+    const result = parseResponse(editSheetCells, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+
+  it('classifies a non-sheet-page 400 as ValidationError', () => {
+    const result = parseResponse(editSheetCells, 400, new Headers(), JSON.stringify({ error: 'Page is not a sheet', pageType: 'DOCUMENT' }));
+    expect(result).toBeInstanceOf(ValidationError);
+  });
+});

--- a/packages/sdk/src/operations/__tests__/pages-details.test.ts
+++ b/packages/sdk/src/operations/__tests__/pages-details.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildRequest } from '../../transport/build-request.js';
 import { parseResponse } from '../../transport/parse-response.js';
 import { ResponseValidationError } from '../../errors.js';
-import { readPage } from '../pages.js';
+import { getPageDetails } from '../pages.js';
 
 const config = { baseUrl: 'https://pagespace.ai' };
 
@@ -38,23 +38,23 @@ const pageFixture = {
   ],
 };
 
-describe('pages.read — request shape', () => {
+describe('pages.details — request shape', () => {
   it('interpolates :pageId into the path and sends no body', () => {
-    const request = buildRequest(readPage, { pageId: 'p1abc' }, config);
+    const request = buildRequest(getPageDetails, { pageId: 'p1abc' }, config);
     expect(request.method).toBe('GET');
     expect(request.url).toBe('https://pagespace.ai/api/pages/p1abc');
     expect(request.body).toBeUndefined();
   });
 
   it('URL-encodes the pageId', () => {
-    const request = buildRequest(readPage, { pageId: 'a/b' }, config);
+    const request = buildRequest(getPageDetails, { pageId: 'a/b' }, config);
     expect(request.url).toBe('https://pagespace.ai/api/pages/a%2Fb');
   });
 });
 
-describe('pages.read — response contract', () => {
+describe('pages.details — response contract', () => {
   it('parses PageWithDetails (route truth, §2.3 get_page_details)', () => {
-    const result = parseResponse(readPage, 200, new Headers(), JSON.stringify(pageFixture));
+    const result = parseResponse(getPageDetails, 200, new Headers(), JSON.stringify(pageFixture));
     expect(result).toEqual(pageFixture);
   });
 
@@ -62,26 +62,26 @@ describe('pages.read — response contract', () => {
     const child = { ...pageFixture, id: 'c1abc' } as Record<string, unknown>;
     delete child.children;
     delete child.messages;
-    const result = parseResponse(readPage, 200, new Headers(), JSON.stringify({ ...pageFixture, children: [child] }));
+    const result = parseResponse(getPageDetails, 200, new Headers(), JSON.stringify({ ...pageFixture, children: [child] }));
     expect(result).not.toBeInstanceOf(ResponseValidationError);
   });
 
   it('rejects a response missing a required field', () => {
     const malformed = { ...pageFixture } as Record<string, unknown>;
     delete malformed.driveId;
-    const result = parseResponse(readPage, 200, new Headers(), JSON.stringify(malformed));
+    const result = parseResponse(getPageDetails, 200, new Headers(), JSON.stringify(malformed));
     expect(result).toBeInstanceOf(ResponseValidationError);
   });
 
   it('classifies a 404 as NotFoundError, never a schema mismatch', () => {
-    const result = parseResponse(readPage, 404, new Headers(), JSON.stringify({ error: 'Page not found' }));
+    const result = parseResponse(getPageDetails, 404, new Headers(), JSON.stringify({ error: 'Page not found' }));
     expect(result).not.toBeInstanceOf(ResponseValidationError);
     expect((result as { code: string }).code).toBe('NOT_FOUND');
   });
 });
 
-describe('pages.read — metadata', () => {
+describe('pages.details — metadata', () => {
   it('declares the drive-scope requirement per ADR 0002', () => {
-    expect(readPage.requiredScope).toBe('drive');
+    expect(getPageDetails.requiredScope).toBe('drive');
   });
 });

--- a/packages/sdk/src/operations/__tests__/pages-list.test.ts
+++ b/packages/sdk/src/operations/__tests__/pages-list.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { listPages, listTrash } from '../pages.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/drives/[driveId]/pages/route.ts GET (ls-mode branch, :263-272). */
+const lsFixture = {
+  mode: 'ls',
+  driveName: 'Engineering',
+  driveSlug: 'engineering',
+  location: '/engineering',
+  breadcrumb: [] as Array<{ id: string; title: string }>,
+  pages: [
+    { id: 'p1abc', title: 'Design Doc', type: 'DOCUMENT', hasChildren: false, isTaskLinked: false },
+    { id: 'p2abc', title: 'Notes', type: 'FOLDER', hasChildren: true, isTaskLinked: false },
+  ],
+  count: 2,
+  totalInDrive: 5,
+};
+
+describe('pages.list — request shape', () => {
+  it('interpolates :driveId and always sends ls=true', () => {
+    const parsed = listPages.inputSchema.parse({ driveId: 'd1abc' });
+    const request = buildRequest(listPages, parsed, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/pages?ls=true');
+  });
+
+  it('serializes parentId and recursive as query params', () => {
+    const parsed = listPages.inputSchema.parse({ driveId: 'd1abc', parentId: 'p1abc', recursive: true });
+    const request = buildRequest(listPages, parsed, config);
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/pages?ls=true&parentId=p1abc&recursive=true');
+  });
+});
+
+describe('pages.list — response contract', () => {
+  it('parses the ls-mode listing (route truth, §2.2)', () => {
+    const result = parseResponse(listPages, 200, new Headers(), JSON.stringify(lsFixture));
+    expect(result).toEqual(lsFixture);
+  });
+
+  it('rejects a page entry with an unknown type', () => {
+    const malformed = { ...lsFixture, pages: [{ ...lsFixture.pages[0], type: 'BOGUS' }] };
+    const result = parseResponse(listPages, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies an unknown parentId 404 as NotFoundError', () => {
+    const result = parseResponse(listPages, 404, new Headers(), JSON.stringify({ error: 'parentId not found or not accessible' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+});
+
+describe('pages.list — metadata', () => {
+  it('requires drive-level access', () => {
+    expect(listPages.requiredScope).toBe('drive');
+  });
+});
+
+/** Shape verified against apps/web/src/app/api/drives/[driveId]/trash/route.ts GET (buildTree over trashed pages). */
+const trashedPageFixture = {
+  id: 't1abc',
+  title: 'Old Doc',
+  type: 'DOCUMENT',
+  content: null,
+  contentMode: 'html',
+  parentId: null,
+  driveId: 'd1abc',
+  position: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+  revision: 1,
+  stateHash: null,
+  isTrashed: true,
+  trashedAt: '2026-01-03T00:00:00.000Z',
+  aiProvider: null,
+  aiModel: null,
+  systemPrompt: null,
+  enabledTools: null,
+  isPaginated: false,
+  children: [] as unknown[],
+};
+
+describe('pages.listTrash — request shape', () => {
+  it('interpolates :driveId and sends no body', () => {
+    const request = buildRequest(listTrash, { driveId: 'd1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/trash');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('pages.listTrash — response contract', () => {
+  it('parses a flat array of trashed pages with no children', () => {
+    const result = parseResponse(listTrash, 200, new Headers(), JSON.stringify([trashedPageFixture]));
+    expect(result).toEqual([trashedPageFixture]);
+  });
+
+  it('parses nested trashed pages (recursive children)', () => {
+    const nested = { ...trashedPageFixture, children: [{ ...trashedPageFixture, id: 't2abc', parentId: 't1abc' }] };
+    const result = parseResponse(listTrash, 200, new Headers(), JSON.stringify([nested]));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a non-admin 403 as PermissionDeniedError', () => {
+    const result = parseResponse(listTrash, 403, new Headers(), JSON.stringify({ error: 'Only drive owners and admins can view trash' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('pages.listTrash — metadata', () => {
+  it('requires the drive-admin floor (owner/admin-only route)', () => {
+    expect(listTrash.requiredScope).toBe('drive:admin');
+  });
+});

--- a/packages/sdk/src/operations/__tests__/pages-write.test.ts
+++ b/packages/sdk/src/operations/__tests__/pages-write.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError, ValidationError } from '../../errors.js';
+import { createPage, movePage, renamePage, restorePage, trashPage } from '../pages.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against apps/web/src/app/api/pages/route.ts POST (bare page row, :111). */
+const pageRowFixture = {
+  id: 'p1abc',
+  title: 'New Page',
+  type: 'DOCUMENT',
+  content: '',
+  contentMode: 'html',
+  parentId: null,
+  driveId: 'd1abc',
+  position: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  revision: 0,
+  stateHash: null,
+  isTrashed: false,
+  trashedAt: null,
+  aiProvider: null,
+  aiModel: null,
+  systemPrompt: null,
+  enabledTools: null,
+  isPaginated: false,
+};
+
+describe('pages.create — request shape', () => {
+  it('sends a bare POST to /api/pages with the full body', () => {
+    const request = buildRequest(createPage, { driveId: 'd1abc', title: 'New Page', type: 'DOCUMENT' }, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/pages');
+    expect(JSON.parse(request.body!)).toEqual({ driveId: 'd1abc', title: 'New Page', type: 'DOCUMENT' });
+  });
+
+  it('accepts every route-creatable type, including FILE/CODE/TERMINAL (D9)', () => {
+    for (const type of ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'FILE', 'SHEET', 'TASK_LIST', 'CODE', 'TERMINAL']) {
+      const result = createPage.inputSchema.safeParse({ driveId: 'd1abc', title: 'x', type });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown page type', () => {
+    const result = createPage.inputSchema.safeParse({ driveId: 'd1abc', title: 'x', type: 'BOGUS' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty title', () => {
+    const result = createPage.inputSchema.safeParse({ driveId: 'd1abc', title: '', type: 'DOCUMENT' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('pages.create — response contract', () => {
+  it('parses the created page row (route truth, §2.4)', () => {
+    const result = parseResponse(createPage, 201, new Headers(), JSON.stringify(pageRowFixture));
+    expect(result).toEqual(pageRowFixture);
+  });
+
+  it('classifies a 400 (e.g. missing title) as ValidationError', () => {
+    const result = parseResponse(createPage, 400, new Headers(), JSON.stringify({ error: 'Title is required' }));
+    expect(result).toBeInstanceOf(ValidationError);
+  });
+});
+
+describe('pages.rename — request shape', () => {
+  it('interpolates :pageId and sends only { title }', () => {
+    const request = buildRequest(renamePage, { pageId: 'p1abc', title: 'Renamed' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/p1abc');
+    expect(JSON.parse(request.body!)).toEqual({ title: 'Renamed' });
+  });
+});
+
+describe('pages.rename — response contract', () => {
+  it('parses the updated page row', () => {
+    const renamed = { ...pageRowFixture, title: 'Renamed' };
+    const result = parseResponse(renamePage, 200, new Headers(), JSON.stringify(renamed));
+    expect(result).toEqual(renamed);
+  });
+});
+
+describe('pages.move — request shape', () => {
+  it('builds a fixed-path PATCH with the renamed wire fields (position -> newPosition)', () => {
+    const request = buildRequest(movePage, { pageId: 'p1abc', newParentId: null, newPosition: 2 }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/reorder');
+    expect(JSON.parse(request.body!)).toEqual({ pageId: 'p1abc', newParentId: null, newPosition: 2 });
+  });
+
+  it('requires newParentId to be explicitly provided (null for root)', () => {
+    const result = movePage.inputSchema.safeParse({ pageId: 'p1abc', newPosition: 2 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('pages.move — response contract', () => {
+  it('parses the reorder success message', () => {
+    const result = parseResponse(movePage, 200, new Headers(), JSON.stringify({ message: 'Page reordered successfully' }));
+    expect(result).toEqual({ message: 'Page reordered successfully' });
+  });
+});
+
+describe('pages.move — metadata', () => {
+  it('requires the drive-admin floor (scoped tokens need OWNER/ADMIN)', () => {
+    expect(movePage.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('pages.trash — request shape', () => {
+  it('always sends trash_children explicitly (D10 fail-closed)', () => {
+    const request = buildRequest(trashPage, { pageId: 'p1abc', trash_children: false }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/p1abc');
+    expect(JSON.parse(request.body!)).toEqual({ trash_children: false });
+  });
+
+  it('rejects input missing trash_children — no implicit server-default reliance', () => {
+    const result = trashPage.inputSchema.safeParse({ pageId: 'p1abc' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('pages.trash — response contract', () => {
+  it('parses the trash success message', () => {
+    const result = parseResponse(trashPage, 200, new Headers(), JSON.stringify({ message: 'Page moved to trash successfully.' }));
+    expect(result).toEqual({ message: 'Page moved to trash successfully.' });
+  });
+
+  it('classifies a 403 as PermissionDeniedError', () => {
+    const result = parseResponse(trashPage, 403, new Headers(), JSON.stringify({ error: 'Forbidden' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('pages.restore — request shape', () => {
+  it('interpolates :pageId and sends no body', () => {
+    const request = buildRequest(restorePage, { pageId: 'p1abc' }, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/p1abc/restore');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('pages.restore — response contract', () => {
+  it('parses the restore success message', () => {
+    const result = parseResponse(restorePage, 200, new Headers(), JSON.stringify({ message: 'Page restored successfully.' }));
+    expect(result).toEqual({ message: 'Page restored successfully.' });
+  });
+
+  it('classifies a not-in-trash 400 as ValidationError', () => {
+    const result = parseResponse(restorePage, 400, new Headers(), JSON.stringify({ error: 'Page is not in trash' }));
+    expect(result).toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects a malformed success body', () => {
+    const result = parseResponse(restorePage, 200, new Headers(), JSON.stringify({ msg: 'wrong field' }));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+});

--- a/packages/sdk/src/operations/documents.ts
+++ b/packages/sdk/src/operations/documents.ts
@@ -1,0 +1,325 @@
+/**
+ * Content editing (Phase 3 task 2) — the pagespace-mcp `document.js` +
+ * `page.js` sheet-editing tools (`read_page`, `replace_lines`, `insert_lines`,
+ * `delete_lines`, `edit_sheet_cells`), all five riding one wire endpoint:
+ * POST `/api/mcp/documents` (`apps/web/src/app/api/mcp/documents/route.ts`),
+ * dispatched by an `operation` field. Each is modeled as its own `Operation`
+ * (same method/path, different input/output schema) because the response
+ * shape is entirely different per `operation` value — mirrors the old
+ * tool-per-operation split even though the wire endpoint is shared.
+ *
+ * #1760-62 fix (route-verified, `route.ts:230-232`): `read` and `replace`
+ * (and, by the same code path, `insert`/`delete`) serialize page content via
+ * `serializePageContentForAI`, not raw `page.content` — CODE pages and
+ * markdown-mode pages keep their natural line structure, HTML documents are
+ * normalized. Line numbers the SDK reports must agree with this corrected
+ * line model, which is exactly what the route itself computes.
+ *
+ * All five operations are POST — already excluded from the client's
+ * idempotent-retry path by `isIdempotentMethod` (method-based), so there is
+ * no separate "non-idempotent" flag to thread through the registry.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const DOCUMENTS_PATH = '/api/mcp/documents';
+
+const fileMetadataSchema = z.object({
+  mimeType: z.string().nullable(),
+  fileSize: z.number().nullable(),
+  originalFileName: z.string().nullable(),
+  processingStatus: z.string().nullable(),
+  extractionMethod: z.string().nullable().optional(),
+  extractionMetadata: z.unknown().nullable().optional(),
+});
+
+const taskAssigneeSchema = z.object({
+  userId: z.string().nullable(),
+  agentPageId: z.string().nullable(),
+  user: z.object({ id: z.string(), name: z.string().nullable() }).nullable(),
+  agentPage: z.object({ id: z.string(), title: z.string().nullable() }).nullable(),
+});
+
+const taskItemSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  status: z.string(),
+  priority: z.enum(['low', 'medium', 'high']),
+  assigneeId: z.string().nullable(),
+  assigneeAgentId: z.string().nullable(),
+  dueDate: z.string().nullable(),
+  position: z.number(),
+  completedAt: z.string().nullable(),
+  pageId: z.string().nullable(),
+  assignee: z.object({ id: z.string(), name: z.string().nullable(), image: z.string().nullable() }).nullable(),
+  assigneeAgent: z.object({ id: z.string(), title: z.string().nullable(), type: z.string() }).nullable(),
+  assignees: z.array(taskAssigneeSchema),
+  hasContent: z.boolean(),
+  subTaskCount: z.number(),
+  subTaskCompletedCount: z.number(),
+});
+
+/**
+ * Non-TASK_LIST, non-CHANNEL, non-in-progress-FILE pages (the generic text
+ * path, `route.ts:521-559`). `pageType` is required-absent (`z.undefined()`)
+ * so a TASK_LIST/CHANNEL/FILE-status response — which all set a literal
+ * `pageType` string — can never silently parse (and strip its extra fields)
+ * against this branch instead of its own.
+ */
+const genericReadResultSchema = z.object({
+  pageId: z.string(),
+  pageTitle: z.string().nullable(),
+  pageType: z.undefined(),
+  totalLines: z.number(),
+  numberedLines: z.array(z.string()),
+  content: z.string(),
+  fileMetadata: fileMetadataSchema.optional(),
+  rangeStart: z.number().optional(),
+  rangeEnd: z.number().optional(),
+  rangeMessage: z.string().optional(),
+});
+
+/** CHANNEL pages (`route.ts:399-474`) — transcript lines address message index, not text lines. */
+const channelReadResultSchema = z.object({
+  pageId: z.string(),
+  pageTitle: z.string().nullable(),
+  pageType: z.literal('CHANNEL'),
+  totalLines: z.number(),
+  numberedLines: z.array(z.string()),
+  content: z.string(),
+  messageCount: z.number(),
+  totalMessages: z.number(),
+  rangeStart: z.number().optional(),
+  rangeEnd: z.number().optional(),
+  rangeMessage: z.string().optional(),
+});
+
+/**
+ * FILE pages not yet in `completed` status (`route.ts:480-518`) — one shape
+ * covers all four `status` values; the fields that apply vary by status
+ * (pending/processing: `error`+`suggestion`; failed: adds `processingError`;
+ * visual: `message`+`fileMetadata` instead of `error`).
+ */
+const fileStatusReadResultSchema = z.object({
+  pageId: z.string(),
+  pageTitle: z.string().nullable(),
+  pageType: z.literal('FILE'),
+  status: z.enum(['pending', 'processing', 'failed', 'visual']),
+  error: z.string().optional(),
+  suggestion: z.string().optional(),
+  processingError: z.string().nullable().optional(),
+  message: z.string().optional(),
+  fileMetadata: z
+    .object({
+      mimeType: z.string().nullable(),
+      fileSize: z.number().nullable(),
+      originalFileName: z.string().nullable(),
+      processingStatus: z.string().nullable(),
+    })
+    .optional(),
+});
+
+/** TASK_LIST pages (`route.ts:238-383`) — the coding-harness hot path; every extra field is load-bearing. */
+const taskListReadResultSchema = z.object({
+  pageId: z.string(),
+  pageTitle: z.string().nullable(),
+  pageType: z.literal('TASK_LIST'),
+  taskListId: z.string(),
+  parentTaskList: z.object({ pageId: z.string(), title: z.string().nullable(), taskListId: z.string() }).nullable(),
+  totalLines: z.number(),
+  numberedLines: z.array(z.string()),
+  content: z.string(),
+  tasks: z.array(taskItemSchema),
+  availableStatuses: z.array(
+    z.object({
+      slug: z.string(),
+      label: z.string(),
+      group: z.string(),
+      position: z.number(),
+      color: z.string().nullable().optional(),
+    }),
+  ),
+  progress: z.object({
+    total: z.number(),
+    percentage: z.number(),
+    byGroup: z.record(z.string(), z.number()),
+    bySlug: z.record(z.string(), z.number()),
+  }),
+});
+
+const readResultSchema = z.union([
+  taskListReadResultSchema,
+  channelReadResultSchema,
+  fileStatusReadResultSchema,
+  genericReadResultSchema,
+]);
+
+/**
+ * `read_page` tool parity — POST `/api/mcp/documents` `{operation:'read', pageId, startLine?, endLine?}`
+ * (`mcp/documents/route.ts:85`, see module docs for the #1760-62 line-model fix).
+ * Output is a discriminated union on `pageType` (TASK_LIST/CHANNEL/FILE-status
+ * vs. the generic text path, which has no `pageType` at all) rather than
+ * optional-soup — per this domain's spec, a skipped variant here is a parity
+ * gap, not a schema nicety.
+ */
+export const readDocument = defineOperation({
+  name: 'pages.read',
+  method: 'POST',
+  path: DOCUMENTS_PATH,
+  inputSchema: z
+    .object({
+      operation: z.literal('read').default('read'),
+      pageId: z.string(),
+      startLine: z.number().int().min(1).optional(),
+      endLine: z.number().int().min(1).optional(),
+    })
+    .refine((v) => v.startLine === undefined || v.endLine === undefined || v.endLine >= v.startLine, {
+      message: 'endLine must be >= startLine',
+      path: ['endLine'],
+    }),
+  outputSchema: readResultSchema,
+  requiredScope: 'drive',
+  description: 'Read a page (or a line/message range of it). Response shape varies by page type.',
+});
+
+/**
+ * `replace_lines` tool parity — POST `/api/mcp/documents` `{operation:'replace', pageId, startLine, endLine?, content}`
+ * (`mcp/documents/route.ts:562-624`). 1-based, `endLine >= startLine` when
+ * both given (zod-refined, fail closed rather than trusting the route's own
+ * 400 on out-of-order ranges). Out-of-range lines → 400; revision conflict →
+ * 409/428 — both surface as typed errors via the transport's generic
+ * non-2xx classification, no special-casing needed here.
+ */
+export const replaceLines = defineOperation({
+  name: 'pages.replaceLines',
+  method: 'POST',
+  path: DOCUMENTS_PATH,
+  inputSchema: z
+    .object({
+      operation: z.literal('replace').default('replace'),
+      pageId: z.string(),
+      startLine: z.number().int().min(1),
+      endLine: z.number().int().min(1).optional(),
+      content: z.string(),
+    })
+    .refine((v) => v.endLine === undefined || v.endLine >= v.startLine, {
+      message: 'endLine must be >= startLine',
+      path: ['endLine'],
+    }),
+  outputSchema: z.object({
+    pageId: z.string(),
+    pageTitle: z.string().nullable(),
+    totalLines: z.number(),
+    numberedLines: z.array(z.string()),
+    operation: z.literal('replace'),
+    affectedLines: z.string(),
+  }),
+  requiredScope: 'drive',
+  description: 'Replace line(s) startLine..endLine with new content.',
+});
+
+/**
+ * `insert_lines` tool parity — POST `/api/mcp/documents` `{operation:'insert', pageId, startLine, content}`
+ * (`mcp/documents/route.ts:626-684`). No `endLine` — insertion is a single
+ * point, existing lines at/after `startLine` shift down.
+ */
+export const insertLines = defineOperation({
+  name: 'pages.insertLines',
+  method: 'POST',
+  path: DOCUMENTS_PATH,
+  inputSchema: z.object({
+    operation: z.literal('insert').default('insert'),
+    pageId: z.string(),
+    startLine: z.number().int().min(1),
+    content: z.string(),
+  }),
+  outputSchema: z.object({
+    pageId: z.string(),
+    pageTitle: z.string().nullable(),
+    totalLines: z.number(),
+    numberedLines: z.array(z.string()),
+    operation: z.literal('insert'),
+    insertedAt: z.number(),
+  }),
+  requiredScope: 'drive',
+  description: 'Insert content before startLine, shifting existing lines down.',
+});
+
+/**
+ * `delete_lines` tool parity — POST `/api/mcp/documents` `{operation:'delete', pageId, startLine, endLine?}`
+ * (`mcp/documents/route.ts:686-747`). Same 1-based, `endLine >= startLine` refinement as replace.
+ */
+export const deleteLines = defineOperation({
+  name: 'pages.deleteLines',
+  method: 'POST',
+  path: DOCUMENTS_PATH,
+  inputSchema: z
+    .object({
+      operation: z.literal('delete').default('delete'),
+      pageId: z.string(),
+      startLine: z.number().int().min(1),
+      endLine: z.number().int().min(1).optional(),
+    })
+    .refine((v) => v.endLine === undefined || v.endLine >= v.startLine, {
+      message: 'endLine must be >= startLine',
+      path: ['endLine'],
+    }),
+  outputSchema: z.object({
+    pageId: z.string(),
+    pageTitle: z.string().nullable(),
+    totalLines: z.number(),
+    numberedLines: z.array(z.string()),
+    operation: z.literal('delete'),
+    deletedLines: z.string(),
+  }),
+  requiredScope: 'drive',
+  description: 'Delete line(s) startLine..endLine.',
+});
+
+/** Mirrors `packages/lib/src/sheets/address.ts` `isValidCellAddress` — one or more letters, then digits, case-insensitive. */
+const cellAddressPattern = /^[A-Za-z]+[0-9]+$/;
+
+/**
+ * `edit_sheet_cells` tool parity — POST `/api/mcp/documents` `{operation:'edit-cells', pageId, cells}`
+ * (`mcp/documents/route.ts:749-840`). Cell addresses are validated client-side
+ * (fail closed, same posture as the D11 `confirmDriveName` guard) against the
+ * same A1 pattern the route enforces server-side, so malformed input never
+ * reaches the network.
+ */
+export const editSheetCells = defineOperation({
+  name: 'pages.editCells',
+  method: 'POST',
+  path: DOCUMENTS_PATH,
+  inputSchema: z.object({
+    operation: z.literal('edit-cells').default('edit-cells'),
+    pageId: z.string(),
+    cells: z
+      .array(
+        z.object({
+          address: z.string().trim().regex(cellAddressPattern, 'Invalid A1-style cell address'),
+          value: z.string(),
+        }),
+      )
+      .min(1),
+  }),
+  outputSchema: z.object({
+    pageId: z.string(),
+    pageTitle: z.string().nullable(),
+    cellsUpdated: z.number(),
+    operation: z.literal('edit-cells'),
+    stats: z.object({
+      valuesSet: z.number(),
+      formulasSet: z.number(),
+      cellsCleared: z.number(),
+      sheetDimensions: z.object({ rows: z.number(), columns: z.number() }),
+    }),
+    updatedCells: z.array(
+      z.object({
+        address: z.string(),
+        type: z.enum(['cleared', 'formula', 'value']),
+      }),
+    ),
+  }),
+  requiredScope: 'drive',
+  description: 'Edit cells in a SHEET page using A1-style addressing. Supports formulas.',
+});

--- a/packages/sdk/src/operations/pages.ts
+++ b/packages/sdk/src/operations/pages.ts
@@ -1,23 +1,28 @@
 /**
- * Seed operation: `pages.read` (Phase 2 task 5 proof-of-pattern).
+ * Pages domain (Phase 3 task 2) — full pagespace-mcp `page.js` parity plus
+ * content editing, which rides the shared `/api/mcp/documents` endpoint (see
+ * `documents.ts`). Route-verified against `apps/web/src/app/api/**` on
+ * `pu/cli-login`; the Phase 0 inventory (`docs/sdk/operations-inventory.md`
+ * §2.2-2.6) is the parity contract, D9/D10 discrepancy resolutions applied
+ * at the source (routes, not the old handler).
  *
- * Route-verified against `apps/web/src/app/api/pages/[pageId]/route.ts` GET
- * → `pageService.getPage` (docs/sdk/operations-inventory.md §2.3, parity with
- * MCP tool `get_page_details`). Response is a bare `PageWithDetails`
- * (`apps/web/src/services/api/page-service.ts:133,158`); dates serialize as
- * ISO strings over JSON. `requiredScope: 'drive'` — view access is granted
- * at the inherit/MEMBER level of the page's drive (ADR 0002 Decision 2), the
- * minimum a caller's grant must cover.
+ * Naming note: Phase 2's seed operation was named `pages.read` for
+ * GET `/api/pages/:pageId` (bare page metadata) — that is actually the old
+ * `get_page_details` tool, not `read_page`. Renamed here to `pages.details`
+ * so `pages.read` (in `documents.ts`) can mean what the tool name says:
+ * content read via `/api/mcp/documents`. Nothing downstream (Phase 4-6
+ * haven't started) depends on the old name.
  */
 import { z } from 'zod';
 import { defineOperation } from '../registry/define.js';
 
-const pageTypeSchema = z.enum([
+export const pageTypeSchema = z.enum([
   'FOLDER',
   'DOCUMENT',
   'CHANNEL',
   'AI_CHAT',
   'CANVAS',
+  'FILE',
   'SHEET',
   'TASK_LIST',
   'CODE',
@@ -65,12 +70,178 @@ const pageWithDetailsSchema = pageDataSchema.extend({
   messages: z.array(messageWithUserSchema),
 });
 
-export const readPage = defineOperation({
-  name: 'pages.read',
+/**
+ * `get_page_details` tool parity — GET `/api/pages/:pageId`
+ * (`pages/[pageId]/route.ts` GET → `pageService.getPage`, PageWithDetails).
+ * `requiredScope: 'drive'` — view access at the inherit/MEMBER level of the
+ * page's drive (ADR 0002 Decision 2), the minimum a caller's grant must cover.
+ */
+export const getPageDetails = defineOperation({
+  name: 'pages.details',
   method: 'GET',
   path: '/api/pages/:pageId',
   inputSchema: z.object({ pageId: z.string() }),
   outputSchema: pageWithDetailsSchema,
   requiredScope: 'drive',
   description: 'Get full page details (metadata, children, and chat messages) by id.',
+});
+
+/**
+ * `list_pages` tool parity — GET `/api/drives/:driveId/pages?ls=true[&parentId=][&recursive=true]`
+ * (`drives/[driveId]/pages/route.ts:91`, ls-mode branch). `ls` is always sent
+ * (defaulted, not caller-supplied) — the route's non-ls mode returns a full
+ * page tree instead and is intentionally not exposed here (inventory §2.2:
+ * "the SDK should expose both modes" is a nice-to-have, not tool parity).
+ */
+export const listPages = defineOperation({
+  name: 'pages.list',
+  method: 'GET',
+  path: '/api/drives/:driveId/pages',
+  inputSchema: z.object({
+    driveId: z.string(),
+    parentId: z.string().optional(),
+    recursive: z.boolean().optional(),
+    ls: z.literal(true).default(true),
+  }),
+  outputSchema: z.object({
+    mode: z.literal('ls'),
+    driveName: z.string(),
+    driveSlug: z.string(),
+    location: z.string(),
+    breadcrumb: z.array(z.object({ id: z.string(), title: z.string() })),
+    pages: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string().nullable(),
+        type: pageTypeSchema,
+        hasChildren: z.boolean(),
+        isTaskLinked: z.boolean(),
+      }),
+    ),
+    count: z.number(),
+    totalInDrive: z.number(),
+  }),
+  requiredScope: 'drive',
+  description: 'List pages at a location in a drive (ls-style). Defaults to direct children of the drive root.',
+});
+
+const trashedPageNodeSchema: z.ZodType<Record<string, unknown>> = pageDataSchema.extend({
+  get children() {
+    return z.array(trashedPageNodeSchema);
+  },
+});
+
+/**
+ * `list_trash` tool parity — GET `/api/drives/:driveId/trash`
+ * (`drives/[driveId]/trash/route.ts:17`). Owner/admin only — `requiredScope`
+ * is the ADMIN floor, not the plain drive-member floor `pages.list` uses.
+ * `driveSlug` is a tool-layer nicety the route never reads (inventory §2.2);
+ * omitted here.
+ */
+export const listTrash = defineOperation({
+  name: 'pages.listTrash',
+  method: 'GET',
+  path: '/api/drives/:driveId/trash',
+  inputSchema: z.object({ driveId: z.string() }),
+  outputSchema: z.array(trashedPageNodeSchema),
+  requiredScope: 'drive:admin',
+  description: 'List all trashed pages (as a tree) in a drive. Owner/admin only.',
+});
+
+/**
+ * `create_page` tool parity — POST `/api/pages` (`pages/route.ts:32`).
+ * D9 resolution: the type enum is the full creatable set (route accepts
+ * FILE, CODE, and admin-gated TERMINAL beyond the old tool's narrower list;
+ * `packages/lib/src/content/page-types.config.ts:306-308`).
+ */
+export const createPage = defineOperation({
+  name: 'pages.create',
+  method: 'POST',
+  path: '/api/pages',
+  inputSchema: z.object({
+    driveId: z.string().min(1),
+    title: z.string().min(1),
+    type: pageTypeSchema,
+    parentId: z.string().nullable().optional(),
+    content: z.string().optional(),
+    contentMode: z.enum(['html', 'markdown']).optional(),
+    systemPrompt: z.string().optional(),
+    enabledTools: z.array(z.string()).optional(),
+    aiProvider: z.string().optional(),
+    aiModel: z.string().optional(),
+  }),
+  outputSchema: pageDataSchema,
+  requiredScope: 'drive',
+  description: 'Create a new page in a drive.',
+});
+
+/**
+ * `rename_page` tool parity — PATCH `/api/pages/:pageId` (`pages/[pageId]/route.ts:62`),
+ * sending only `title`. The route accepts a broader update surface
+ * (`content`, `aiProvider`, `aiModel`, `parentId`, `isPaginated`, `isPrivate`,
+ * `expectedRevision`, `changeGroupId`) that this operation intentionally
+ * does not expose — that is a general "update page" capability the old tool
+ * set never had, out of scope for tool parity here.
+ */
+export const renamePage = defineOperation({
+  name: 'pages.rename',
+  method: 'PATCH',
+  path: '/api/pages/:pageId',
+  inputSchema: z.object({ pageId: z.string(), title: z.string() }),
+  outputSchema: pageDataSchema,
+  requiredScope: 'drive',
+  description: 'Rename an existing page.',
+});
+
+/**
+ * `move_page` tool parity — PATCH `/api/pages/reorder` (`pages/reorder/route.ts:20`).
+ * D-note: the wire body is `{pageId, newParentId, newPosition}`; the old
+ * tool's `position` field is renamed here to match the route's
+ * `reorderSchema` exactly (`newParentId` is required, pass `null` for root).
+ * Scoped tokens need OWNER/ADMIN on the drive — `requiredScope: 'drive:admin'`.
+ */
+export const movePage = defineOperation({
+  name: 'pages.move',
+  method: 'PATCH',
+  path: '/api/pages/reorder',
+  inputSchema: z.object({
+    pageId: z.string(),
+    newParentId: z.string().nullable(),
+    newPosition: z.number().finite(),
+  }),
+  outputSchema: z.object({ message: z.string() }),
+  requiredScope: 'drive:admin',
+  description: 'Move or reorder a page within its drive.',
+});
+
+/**
+ * `trash_page` tool parity — DELETE `/api/pages/:pageId` (`pages/[pageId]/route.ts:235`).
+ * D10 resolution: `trash_children` is REQUIRED (not optional) — the route's
+ * own default when the field is omitted is `true`, which silently diverges
+ * from the old tool's `withChildren=false` default. Fail closed: the SDK
+ * must always send its own explicit value, never rely on the server default.
+ */
+export const trashPage = defineOperation({
+  name: 'pages.trash',
+  method: 'DELETE',
+  path: '/api/pages/:pageId',
+  inputSchema: z.object({ pageId: z.string(), trash_children: z.boolean() }),
+  outputSchema: z.object({ message: z.string() }),
+  requiredScope: 'drive',
+  description: 'Move a page to trash (soft delete).',
+});
+
+/**
+ * `restore_page` tool parity — POST `/api/pages/:pageId/restore`
+ * (`pages/[pageId]/restore/route.ts:86`). Requires the same delete/manage
+ * permission as trashing.
+ */
+export const restorePage = defineOperation({
+  name: 'pages.restore',
+  method: 'POST',
+  path: '/api/pages/:pageId/restore',
+  inputSchema: z.object({ pageId: z.string() }),
+  outputSchema: z.object({ message: z.string() }),
+  requiredScope: 'drive',
+  description: 'Restore a trashed page back to its original location.',
 });

--- a/packages/sdk/src/transport/__tests__/build-request.test.ts
+++ b/packages/sdk/src/transport/__tests__/build-request.test.ts
@@ -110,6 +110,15 @@ describe('buildRequest — body and Content-Type', () => {
     const request = buildRequest(op({ method: 'PATCH', path: '/api/pages/:id' }), { id: 'p1', title: 'Hi' }, config);
     expect(request.url).toBe('https://pagespace.ai/api/pages/p1');
   });
+
+  it('preserves nested object fields (sorted-key ordering must not act as a stringify replacer filter)', () => {
+    const request = buildRequest(
+      op({ method: 'POST', path: '/api/pages' }),
+      { cells: [{ address: 'A1', value: '=SUM(B1:B2)' }] },
+      config,
+    );
+    expect(JSON.parse(request.body!)).toEqual({ cells: [{ address: 'A1', value: '=SUM(B1:B2)' }] });
+  });
 });
 
 describe('buildRequest — version header (ADR 0001)', () => {

--- a/packages/sdk/src/transport/build-request.ts
+++ b/packages/sdk/src/transport/build-request.ts
@@ -50,11 +50,23 @@ function serializeQuery(params: Readonly<Record<string, unknown>>): string {
   return query.length > 0 ? `?${query}` : '';
 }
 
-/** Serializes a plain object as JSON with a stable (sorted) top-level key order. */
+/**
+ * Serializes a plain object as JSON with a stable (sorted) top-level key
+ * order. Rebuilds the object with keys inserted in sorted order rather than
+ * passing the sorted-keys array as `JSON.stringify`'s replacer — a replacer
+ * array is an allow-list applied at every nesting level, so it would also
+ * silently strip properties from nested objects/array-of-object fields
+ * (e.g. `editSheetCells`'s `cells: [{address, value}]`) whose keys aren't
+ * themselves top-level field names.
+ */
 function serializeBody(fields: Readonly<Record<string, unknown>>): string | undefined {
   const keys = Object.keys(fields).sort();
   if (keys.length === 0) return undefined;
-  return JSON.stringify(fields, keys);
+  const ordered: Record<string, unknown> = {};
+  for (const key of keys) {
+    ordered[key] = fields[key];
+  }
+  return JSON.stringify(ordered);
 }
 
 /**


### PR DESCRIPTION
## Summary
Full `pagespace-mcp` `page.js`/`document.js` parity for the pages & content domain (Phase 3, SDK Resource Surface epic), following the established Phase 2 operation-registry pattern.

**Pages CRUD/lifecycle** (`pages.list`, `pages.listTrash`, `pages.create`, `pages.rename`, `pages.move`, `pages.trash`, `pages.restore`, `pages.details`):
- D9: `pages.create`'s type enum is the full route-creatable set (route truth adds `FILE`, `CODE`, `TERMINAL` beyond the old tool's narrower list); the shared `pageTypeSchema` also gains the previously-missing `FILE` variant.
- D10: `pages.trash` requires `trash_children` explicitly — never relies on the route's own default (`true` when omitted).
- `pages.move` sends the route's actual wire field names (`newParentId`/`newPosition`), not the old tool's `position`.
- Renamed the Phase 2 seed `pages.read` → `pages.details`: that operation is `GET /api/pages/:pageId`, i.e. `get_page_details` tool parity, not `read_page`. Nothing downstream (Phase 4-6 haven't started) depended on the old name.

**Content editing** (`pages.read`, `replaceLines`, `insertLines`, `deleteLines`, `editCells`) — all five ride the shared `POST /api/mcp/documents` endpoint, modeled as five distinct operations (same method/path, different input/output per `operation` value), matching the old one-tool-per-operation split:
- #1760-62: response shapes verified against the route's `serializePageContentForAI`-backed line model.
- `pages.read`'s output is a discriminated union across TASK_LIST / CHANNEL / FILE-status / generic-text (no shared discriminator field for the generic case — modeled as `pageType: z.undefined()` so a page-typed response can never silently match the wrong branch and get its extra fields stripped). Full TASK_LIST extras included (`availableStatuses`, `progress`, `tasks`, `parentTaskList`).
- `editCells`'s cell addresses are validated client-side (fail-closed) against the same A1 pattern the route enforces.

**Bug fix (shared transport layer):** `transport/build-request.ts`'s `serializeBody` passed the sorted top-level keys array as `JSON.stringify`'s replacer. A replacer array is an allow-list applied at *every* nesting level, so it silently stripped properties from any nested object/array-of-objects body field — surfaced by `editCells`'s `cells: [{address, value}]`. Fixed to rebuild the object in sorted key order instead of using it as a stringify filter; added a regression test.

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck` — green
- [x] `bun run --filter '@pagespace/sdk' test` — 268/268 green (RED commit first, GREEN second)
- [ ] Reviewer: confirm `pages.details` rename doesn't surprise any other in-flight Phase 3 branch touching `client.ts`/`index.ts`

https://claude.ai/code/session_01P1j22eWUXXqDpnKSRgC69t