### PR TITLE
oauth: refresh_token grant with rotation & reuse detection (Phase 1 task 8)

### DIFF
--- a/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
@@ -11,9 +11,11 @@ vi.mock('server-only', () => ({}));
 
 const ensureOAuthClientRow = vi.fn();
 const exchangeAuthorizationCode = vi.fn();
+const refreshTokenGrant = vi.fn();
 vi.mock('@/lib/repositories/oauth-repository', () => ({
   ensureOAuthClientRow: (...args: unknown[]) => ensureOAuthClientRow(...args),
   exchangeAuthorizationCode: (...args: unknown[]) => exchangeAuthorizationCode(...args),
+  refreshTokenGrant: (...args: unknown[]) => refreshTokenGrant(...args),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
@@ -235,5 +237,144 @@ describe('POST /api/oauth/token — public client confusion guard', () => {
     const res = await POST(tokenRequest(validFields()) as never);
 
     expect(res.status).toBe(200);
+  });
+});
+
+function refreshFields(overrides: Record<string, string | undefined> = {}) {
+  return {
+    grant_type: 'refresh_token',
+    refresh_token: 'raw-refresh-token-value',
+    client_id: CLIENT_ID,
+    ...overrides,
+  };
+}
+
+describe('POST /api/oauth/token — refresh_token grant, happy path', () => {
+  it('returns the RFC 6749 §5.1 token response shape with a rotated pair', async () => {
+    refreshTokenGrant.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: okTokens,
+    });
+
+    const res = await POST(tokenRequest(refreshFields()) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      access_token: okTokens.accessToken,
+      token_type: 'Bearer',
+      expires_in: 15 * 60,
+      refresh_token: okTokens.refreshToken,
+      scope: 'account',
+    });
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('passes the raw refresh token, resolved clientDbId, and requested scope through to the repository', async () => {
+    refreshTokenGrant.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: okTokens,
+    });
+
+    await POST(tokenRequest(refreshFields({ scope: 'account' })) as never);
+
+    expect(refreshTokenGrant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refreshToken: 'raw-refresh-token-value',
+        clientDbId: CLIENT_DB_ID,
+        requestedScope: 'account',
+      }),
+    );
+  });
+
+  it('passes requestedScope: null when no scope param is present', async () => {
+    refreshTokenGrant.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: okTokens,
+    });
+
+    await POST(tokenRequest(refreshFields()) as never);
+
+    expect(refreshTokenGrant).toHaveBeenCalledWith(expect.objectContaining({ requestedScope: null }));
+  });
+});
+
+describe('POST /api/oauth/token — refresh_token grant, constant-shape failures (no oracle)', () => {
+  const CONSTANT_BODY = { error: 'invalid_grant' };
+
+  it('unknown client_id → constant shape, never calls the repository', async () => {
+    const res = await POST(tokenRequest(refreshFields({ client_id: 'evil-client' })) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual(CONSTANT_BODY);
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('unknown/expired/revoked refresh token → constant shape, same as an unknown one', async () => {
+    refreshTokenGrant.mockResolvedValue({ outcome: 'invalid_grant' });
+
+    const res = await POST(tokenRequest(refreshFields()) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual(CONSTANT_BODY);
+  });
+
+  it('reuse of a rotated token (theft) → the SAME constant shape (no "we detected theft" leak)', async () => {
+    refreshTokenGrant.mockResolvedValue({ outcome: 'invalid_grant' });
+
+    const res = await POST(tokenRequest(refreshFields()) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual(CONSTANT_BODY);
+  });
+
+  it('missing refresh_token → invalid_request (malformed syntax, distinct from invalid_grant)', async () => {
+    const res = await POST(tokenRequest(refreshFields({ refresh_token: undefined })) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('missing client_id → invalid_request', async () => {
+    const res = await POST(tokenRequest(refreshFields({ client_id: undefined })) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('a client_secret presented for the public CLI client → invalid_request, never calls the repository', async () => {
+    const res = await POST(tokenRequest(refreshFields({ client_secret: 'anything' })) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('scope escalation attempt → invalid_scope (distinguishable — the credential itself was valid)', async () => {
+    refreshTokenGrant.mockResolvedValue({ outcome: 'invalid_scope' });
+
+    const res = await POST(tokenRequest(refreshFields({ scope: 'drive:abc123:admin' })) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_scope' });
+  });
+});
+
+describe('POST /api/oauth/token — unsupported grant_type', () => {
+  it('rejects an unrecognized grant_type', async () => {
+    const res = await POST(tokenRequest({ grant_type: 'client_credentials' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'unsupported_grant_type' });
+    expect(exchangeAuthorizationCode).not.toHaveBeenCalled();
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -1,22 +1,33 @@
 /**
  * OAuth 2.1 token endpoint — authorization_code + PKCE grant (RFC 6749
- * §3.2, §4.1.3, §5.1; task suty9f9jbha82c0831e9rjec). A thin shell: it
- * parses the form-encoded request, resolves the client, and delegates the
- * entire grant decision to `exchangeAuthorizationCode`, which in turn calls
- * `decideCodeExchange` (task 4) — no grant logic is reimplemented here.
+ * §3.2, §4.1.3, §5.1; task suty9f9jbha82c0831e9rjec) and refresh_token grant
+ * with rotation + reuse detection (RFC 6749 §6; ADR 0003 §3.3-3.4; task
+ * l8zlp3353f2cunjd33foq41l). A thin shell: it parses the form-encoded
+ * request, resolves the client, and delegates the entire grant decision to
+ * `exchangeAuthorizationCode` / `refreshTokenGrant`, which in turn call the
+ * pure decision functions (`decideCodeExchange`, `decideRefreshRotation`) —
+ * no grant logic is reimplemented here.
  *
- * Zero-trust posture: every rejection — unknown client, unknown/expired/
- * already-consumed code, redirect_uri mismatch, PKCE failure, malformed
- * client authentication — returns the SAME constant-shape body
+ * Zero-trust posture: every grant-validity rejection — unknown client,
+ * unknown/expired/already-consumed code, redirect_uri mismatch, PKCE
+ * failure, malformed client authentication, unknown/expired/revoked/reused
+ * refresh token — returns the SAME constant-shape body
  * (`{"error": "invalid_grant"}`, or `"invalid_request"` for malformed
  * syntax) with `Cache-Control: no-store`. No response ever differentiates
  * one failure reason from another; that differentiation is exactly the
- * error oracle OAuth 2.1's fail-closed posture forbids.
+ * error oracle OAuth 2.1's fail-closed posture forbids. `invalid_scope` is
+ * the one deliberate exception: it only fires once the presented refresh
+ * token has already proven valid, so naming it leaks nothing about the
+ * credential itself.
  */
 import { NextRequest, NextResponse } from 'next/server';
-import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+import { getRegisteredClient, type RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
 import { ACCESS_TOKEN_TTL_SECONDS } from '@pagespace/lib/auth/oauth/issue-tokens';
-import { ensureOAuthClientRow, exchangeAuthorizationCode } from '@/lib/repositories/oauth-repository';
+import {
+  ensureOAuthClientRow,
+  exchangeAuthorizationCode,
+  refreshTokenGrant,
+} from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
@@ -25,42 +36,48 @@ function noStoreJson(body: Record<string, unknown>, status: number): NextRespons
 
 const INVALID_REQUEST = { error: 'invalid_request' };
 const INVALID_GRANT = { error: 'invalid_grant' };
+const INVALID_SCOPE = { error: 'invalid_scope' };
 
-export async function POST(req: NextRequest) {
-  const contentType = req.headers.get('content-type') ?? '';
-  if (!contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
-    return noStoreJson(INVALID_REQUEST, 400);
-  }
+type ResolvedClient = { client: RegisteredClient; clientDbId: string };
+type ClientResolution = ResolvedClient | { rejection: NextResponse };
 
-  const form = new URLSearchParams(await req.text());
-  const grantType = form.get('grant_type');
-  if (grantType !== 'authorization_code') {
-    return noStoreJson({ error: 'unsupported_grant_type' }, 400);
-  }
-
-  const code = form.get('code');
-  const redirectUri = form.get('redirect_uri');
-  const clientId = form.get('client_id');
-  const codeVerifier = form.get('code_verifier');
-  const clientSecret = form.get('client_secret');
-
-  if (!code || !redirectUri || !clientId || !codeVerifier) {
-    return noStoreJson(INVALID_REQUEST, 400);
-  }
-
+/**
+ * Resolve and validate the requesting client — shared by both grants.
+ * Unknown client_id and a public client presenting a client_secret are the
+ * SAME two rejections (`invalid_grant` / `invalid_request`) either grant
+ * produces; one guard, not two divergent copies.
+ */
+async function resolveClient(form: URLSearchParams, clientId: string): Promise<ClientResolution> {
   const client = getRegisteredClient(clientId);
   if (!client) {
-    return noStoreJson(INVALID_GRANT, 400);
+    return { rejection: noStoreJson(INVALID_GRANT, 400) };
   }
 
   // Public-client confusion guard: the CLI is a public client (ADR 0003) —
   // it never has a secret, and a request presenting one is rejected outright
   // rather than silently ignored.
+  const clientSecret = form.get('client_secret');
   if (client.type === 'public' && clientSecret) {
-    return noStoreJson(INVALID_REQUEST, 400);
+    return { rejection: noStoreJson(INVALID_REQUEST, 400) };
   }
 
   const clientDbId = await ensureOAuthClientRow(client);
+  return { client, clientDbId };
+}
+
+async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
+  const code = form.get('code');
+  const redirectUri = form.get('redirect_uri');
+  const clientId = form.get('client_id');
+  const codeVerifier = form.get('code_verifier');
+
+  if (!code || !redirectUri || !clientId || !codeVerifier) {
+    return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  const resolved = await resolveClient(form, clientId);
+  if ('rejection' in resolved) return resolved.rejection;
+  const { client, clientDbId } = resolved;
 
   const result = await exchangeAuthorizationCode({
     code,
@@ -94,4 +111,76 @@ export async function POST(req: NextRequest) {
     },
     200,
   );
+}
+
+async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
+  const refreshToken = form.get('refresh_token');
+  const clientId = form.get('client_id');
+
+  if (!refreshToken || !clientId) {
+    return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  const resolved = await resolveClient(form, clientId);
+  if ('rejection' in resolved) return resolved.rejection;
+  const { client, clientDbId } = resolved;
+
+  const result = await refreshTokenGrant({
+    refreshToken,
+    clientDbId,
+    requestedScope: form.get('scope'),
+    now: new Date(),
+  });
+
+  if (result.outcome === 'invalid_scope') {
+    auditRequest(req, {
+      eventType: 'authz.access.denied',
+      details: { clientId: client.clientId, oauthEvent: 'refresh_scope_escalation' },
+    });
+    return noStoreJson(INVALID_SCOPE, 400);
+  }
+
+  if (result.outcome !== 'ok') {
+    auditRequest(req, {
+      eventType: 'authz.access.denied',
+      details: { clientId: client.clientId, oauthEvent: 'refresh_rejected' },
+    });
+    return noStoreJson(INVALID_GRANT, 400);
+  }
+
+  auditRequest(req, {
+    eventType: 'auth.token.created',
+    userId: result.userId,
+    details: { clientId: client.clientId, oauthEvent: 'refresh_rotated' },
+  });
+
+  return noStoreJson(
+    {
+      access_token: result.tokens.accessToken,
+      token_type: 'Bearer',
+      expires_in: ACCESS_TOKEN_TTL_SECONDS,
+      refresh_token: result.tokens.refreshToken,
+      scope: result.scopes.join(' '),
+    },
+    200,
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
+    return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  const form = new URLSearchParams(await req.text());
+  const grantType = form.get('grant_type');
+
+  if (grantType === 'authorization_code') {
+    return handleAuthorizationCodeGrant(req, form);
+  }
+  if (grantType === 'refresh_token') {
+    return handleRefreshTokenGrant(req, form);
+  }
+
+  return noStoreJson({ error: 'unsupported_grant_type' }, 400);
 }

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
@@ -360,7 +360,7 @@ describe('refreshTokenGrant — concurrent refresh yields exactly one winner', (
     const winner = first.outcome === 'ok' ? first : second;
     if (winner.outcome !== 'ok') throw new Error('unreachable');
     const winnerRow = refreshRows.find((r) => r.tokenHash === hashToken(winner.tokens.refreshToken));
-    expect(winnerRow?.revokedAt).toBeNull();
+    expect(winnerRow?.revokedAt).toBeFalsy();
 
     expect(refreshRows).toHaveLength(2);
     expect(accessRows).toHaveLength(1);

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Atomic refresh_token grant (task l8zlp3353f2cunjd33foq41l, RED sub-task
+ * qa0870vw0zz27x14n1vluv6z).
+ *
+ * The fake `db.transaction` below serializes callbacks on a shared in-memory
+ * "row" the same way `oauth-repository.exchange.test.ts` does — call B's
+ * callback does not start until call A's has fully settled, matching what a
+ * real `FOR UPDATE` lock on a single contended row guarantees. That lets the
+ * concurrent-refresh test exercise the real `refreshTokenGrant` control flow
+ * under a genuine `Promise.all` race instead of trusting a stub.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const H = vi.hoisted(() => ({
+  oauthRefreshTokens: {
+    __table: 'refresh',
+    id: 'rt.id',
+    tokenHash: 'rt.tokenHash',
+    clientId: 'rt.clientId',
+    familyId: 'rt.familyId',
+    revokedAt: 'rt.revokedAt',
+  } as Record<string, unknown>,
+  oauthAccessTokens: { __table: 'access', familyId: 'at.familyId', revokedAt: 'at.revokedAt' } as Record<
+    string,
+    unknown
+  >,
+  state: { dbTransactionImpl: null as null | ((cb: (tx: unknown) => unknown) => unknown) },
+}));
+
+const { oauthRefreshTokens, oauthAccessTokens } = H;
+
+vi.mock('@pagespace/db/schema/oauth', () => ({
+  oauthRefreshTokens: H.oauthRefreshTokens,
+  oauthAccessTokens: H.oauthAccessTokens,
+  oauthClients: {},
+  oauthAuthorizationCodes: {},
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { __table: 'users', id: 'users.id' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNull: vi.fn((a: unknown) => ({ _isNull: a })),
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => H.state.dbTransactionImpl!(cb),
+  },
+}));
+
+import { hashToken } from '@pagespace/lib/auth/token-utils';
+import { refreshTokenGrant } from '../oauth-repository';
+
+type Predicate = { _eq: [unknown, unknown] } | { _and: Predicate[] } | { _isNull: unknown };
+
+function columnKey(col: unknown): string {
+  return String(col).split('.').pop() as string;
+}
+
+function evalPredicate(pred: Predicate, row: Record<string, unknown>): boolean {
+  if ('_and' in pred) return pred._and.every((p) => evalPredicate(p, row));
+  if ('_eq' in pred) return row[columnKey(pred._eq[0])] === pred._eq[1];
+  if ('_isNull' in pred) return row[columnKey(pred._isNull)] == null;
+  return true;
+}
+
+interface RefreshRow {
+  id: string;
+  tokenHash: string;
+  tokenPrefix?: string;
+  clientId: string;
+  familyId: string;
+  userId: string;
+  scopes: string[];
+  tokenVersion: number;
+  expiresAt: Date;
+  familyExpiresAt: Date;
+  replacedByTokenId: string | null;
+  revokedAt: Date | null;
+  revokedReason: string | null;
+}
+
+interface AccessRow {
+  tokenHash: string;
+  familyId: string;
+  userId: string;
+  scopes: string[];
+  revokedAt: Date | null;
+  revokedReason: string | null;
+}
+
+let refreshRows: RefreshRow[] = [];
+let accessRows: AccessRow[] = [];
+let lockChain: Promise<unknown> = Promise.resolve();
+
+function makeTx() {
+  return {
+    select: () => ({
+      from: () => ({
+        where: (predicate: Predicate) => {
+          const matches = refreshRows.filter((r) => evalPredicate(predicate, r as unknown as Record<string, unknown>));
+          const p = Promise.resolve(matches) as Promise<RefreshRow[]> & { for: (mode: string) => Promise<RefreshRow[]> };
+          p.for = () => p;
+          return p;
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (patch: Record<string, unknown>) => ({
+        where: (predicate: Predicate) => {
+          if (table === oauthRefreshTokens) {
+            refreshRows
+              .filter((r) => evalPredicate(predicate, r as unknown as Record<string, unknown>))
+              .forEach((r) => Object.assign(r, patch));
+          } else if (table === oauthAccessTokens) {
+            accessRows
+              .filter((r) => evalPredicate(predicate, r as unknown as Record<string, unknown>))
+              .forEach((r) => Object.assign(r, patch));
+          }
+          return Promise.resolve();
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (row: Record<string, unknown>) => {
+        if (table === oauthRefreshTokens) refreshRows.push(row as unknown as RefreshRow);
+        else if (table === oauthAccessTokens) accessRows.push(row as unknown as AccessRow);
+        return Promise.resolve();
+      },
+    }),
+  };
+}
+
+H.state.dbTransactionImpl = ((cb: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => {
+  const run = lockChain.then(() => cb(makeTx()));
+  lockChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}) as (cb: (tx: unknown) => unknown) => unknown;
+
+const REFRESH_TOKEN = 'raw-refresh-token-value';
+const CLIENT_DB_ID = 'client-db-id-1';
+const USER_ID = 'user-1';
+const FAMILY_ID = 'family-1';
+const DAY = 24 * 60 * 60 * 1000;
+
+function seedRefreshRow(overrides: Partial<RefreshRow> = {}): RefreshRow {
+  const row: RefreshRow = {
+    id: 'refresh-row-1',
+    tokenHash: hashToken(REFRESH_TOKEN),
+    tokenPrefix: REFRESH_TOKEN.slice(0, 12),
+    clientId: CLIENT_DB_ID,
+    familyId: FAMILY_ID,
+    userId: USER_ID,
+    scopes: ['account'],
+    tokenVersion: 0,
+    expiresAt: new Date(Date.now() + 30 * DAY),
+    familyExpiresAt: new Date(Date.now() + 90 * DAY),
+    replacedByTokenId: null,
+    revokedAt: null,
+    revokedReason: null,
+    ...overrides,
+  };
+  refreshRows.push(row);
+  return row;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  refreshRows = [];
+  accessRows = [];
+  lockChain = Promise.resolve();
+});
+
+describe('refreshTokenGrant — happy path', () => {
+  it('rotates: revokes the presented token and issues a new hashed ps_at_*/ps_rt_* pair in the same family', async () => {
+    seedRefreshRow();
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.userId).toBe(USER_ID);
+    expect(result.tokens.accessToken).toMatch(/^ps_at_/);
+    expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
+    expect(result.tokens.familyId).toBe(FAMILY_ID);
+
+    expect(refreshRows[0].revokedAt).not.toBeNull();
+    expect(refreshRows[0].replacedByTokenId).not.toBeNull();
+    expect(refreshRows).toHaveLength(2);
+    expect(accessRows).toHaveLength(1);
+    expect(refreshRows[1].tokenHash).toBe(hashToken(result.tokens.refreshToken));
+    expect(refreshRows[1].familyId).toBe(FAMILY_ID);
+  });
+
+  it('never persists the raw refresh token anywhere', async () => {
+    seedRefreshRow();
+
+    await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    const serialized = JSON.stringify({ refreshRows, accessRows });
+    expect(serialized).not.toContain(REFRESH_TOKEN);
+  });
+});
+
+describe('refreshTokenGrant — constant-shape rejections', () => {
+  it('returns invalid_grant for an unknown refresh token', async () => {
+    const result = await refreshTokenGrant({
+      refreshToken: 'never-issued',
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_grant' });
+  });
+
+  it('returns invalid_grant when the token belongs to a different client (scoped lookup, no oracle)', async () => {
+    seedRefreshRow({ clientId: 'some-other-client-db-id' });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_grant' });
+  });
+
+  it('returns invalid_grant for an expired refresh token', async () => {
+    seedRefreshRow({ expiresAt: new Date(Date.now() - 1000) });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_grant' });
+  });
+
+  it('returns invalid_grant for a token past its family_expiresAt', async () => {
+    seedRefreshRow({ familyExpiresAt: new Date(Date.now() - 1000) });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_grant' });
+  });
+});
+
+describe('refreshTokenGrant — reuse detection: the theft scenario end-to-end', () => {
+  it('legitimate client rotates, attacker replays the stolen rotated token → entire family revoked, both locked out', async () => {
+    seedRefreshRow();
+
+    const legitimate = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+    expect(legitimate.outcome).toBe('ok');
+    if (legitimate.outcome !== 'ok') throw new Error('unreachable');
+
+    // Attacker replays the original (now rotated-away) token, well outside the 30s grace window.
+    const attackerAttempt = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(Date.now() + 60_000),
+    });
+    expect(attackerAttempt).toEqual({ outcome: 'invalid_grant' });
+
+    // The entire family is dead: the legitimate client's brand-new refresh token is also revoked.
+    const legitimateNewRow = refreshRows.find((r) => r.tokenHash === hashToken(legitimate.tokens.refreshToken));
+    expect(legitimateNewRow?.revokedAt).not.toBeNull();
+    expect(accessRows.every((r) => r.revokedAt !== null)).toBe(true);
+
+    // Locked out: the legitimate client can no longer refresh with its (now-revoked) new token either.
+    const legitimateRetry = await refreshTokenGrant({
+      refreshToken: legitimate.tokens.refreshToken,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(Date.now() + 61_000),
+    });
+    expect(legitimateRetry).toEqual({ outcome: 'invalid_grant' });
+  });
+});
+
+describe('refreshTokenGrant — scope narrowing', () => {
+  it('narrows scope on request and persists only the narrowed set on the new tokens', async () => {
+    seedRefreshRow({ scopes: ['account', 'offline_access'] });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: 'account',
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.scopes).toEqual(['account']);
+    expect(refreshRows[1].scopes).toEqual(['account']);
+    expect(accessRows[0].scopes).toEqual(['account']);
+  });
+
+  it('rejects any scope escalation attempt with invalid_scope', async () => {
+    seedRefreshRow({ scopes: ['account'] });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: 'account drive:abc123',
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_scope' });
+    // No tokens were rotated/minted for a rejected escalation attempt.
+    expect(refreshRows).toHaveLength(1);
+    expect(accessRows).toHaveLength(0);
+  });
+});
+
+describe('refreshTokenGrant — concurrent refresh yields exactly one winner', () => {
+  it('two simultaneous refreshes of the same token: exactly one ok, the other invalid_grant; only one new pair persisted', async () => {
+    seedRefreshRow();
+
+    const [first, second] = await Promise.all([
+      refreshTokenGrant({ refreshToken: REFRESH_TOKEN, clientDbId: CLIENT_DB_ID, requestedScope: null, now: new Date() }),
+      refreshTokenGrant({ refreshToken: REFRESH_TOKEN, clientDbId: CLIENT_DB_ID, requestedScope: null, now: new Date() }),
+    ]);
+
+    const outcomes = [first.outcome, second.outcome].sort();
+    expect(outcomes).toEqual(['invalid_grant', 'ok']);
+
+    // Family survives: this is a benign race, not attacker replay — the loser's
+    // rejection must not revoke the winner's brand-new pair.
+    const winner = first.outcome === 'ok' ? first : second;
+    if (winner.outcome !== 'ok') throw new Error('unreachable');
+    const winnerRow = refreshRows.find((r) => r.tokenHash === hashToken(winner.tokens.refreshToken));
+    expect(winnerRow?.revokedAt).toBeNull();
+
+    expect(refreshRows).toHaveLength(2);
+    expect(accessRows).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -4,6 +4,7 @@
  * route handlers.
  */
 
+import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { eq, and, isNull } from '@pagespace/db/operators';
 import { oauthClients, oauthAuthorizationCodes, oauthRefreshTokens, oauthAccessTokens } from '@pagespace/db/schema/oauth';
@@ -11,7 +12,9 @@ import { users } from '@pagespace/db/schema/auth';
 import type { RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
 import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { decideCodeExchange, type CodeExchangeDecision } from '@pagespace/lib/auth/oauth/code-lifecycle';
-import { issueInitialTokenPair, type IssuedTokenPair } from '@pagespace/lib/auth/oauth/issue-tokens';
+import { issueInitialTokenPair, issueRotatedTokenPair, type IssuedTokenPair } from '@pagespace/lib/auth/oauth/issue-tokens';
+import { decideRefreshRotation } from '@pagespace/lib/auth/oauth/refresh-rotation';
+import { parseScopeList, isScopeSubset, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
 
 /**
  * First-party clients are defined in code (the static registry), not the DB —
@@ -93,15 +96,16 @@ async function revokeTokenFamily(
   tx: Pick<typeof db, 'update'>,
   familyId: string,
   now: Date,
+  reason: string,
 ): Promise<void> {
   await tx
     .update(oauthRefreshTokens)
-    .set({ revokedAt: now, revokedReason: 'code_reuse' })
+    .set({ revokedAt: now, revokedReason: reason })
     .where(and(eq(oauthRefreshTokens.familyId, familyId), isNull(oauthRefreshTokens.revokedAt)));
 
   await tx
     .update(oauthAccessTokens)
-    .set({ revokedAt: now, revokedReason: 'code_reuse' })
+    .set({ revokedAt: now, revokedReason: reason })
     .where(and(eq(oauthAccessTokens.familyId, familyId), isNull(oauthAccessTokens.revokedAt)));
 }
 
@@ -158,7 +162,7 @@ export async function exchangeAuthorizationCode(
 
     if (decision.status === 'already_consumed') {
       if (row.issuedFamilyId) {
-        await revokeTokenFamily(tx, row.issuedFamilyId, input.now);
+        await revokeTokenFamily(tx, row.issuedFamilyId, input.now, 'code_reuse');
       }
       return { outcome: 'rejected', decision };
     }
@@ -201,5 +205,129 @@ export async function exchangeAuthorizationCode(
     });
 
     return { outcome: 'ok', userId: row.userId, scopes: row.scopes, tokens };
+  });
+}
+
+export interface RefreshTokenGrantInput {
+  /** Raw refresh token from the token request; hashed before any lookup. */
+  refreshToken: string;
+  /** Resolved `oauth_clients.id` for the request's client_id — the lookup
+   * below is scoped to this, so a token issued to a different client is
+   * indistinguishable from an unknown token (no oracle). */
+  clientDbId: string;
+  /** Raw `scope` form param, or null when absent (keep the granted scope). */
+  requestedScope: string | null;
+  now: Date;
+}
+
+export type RefreshTokenGrantResult =
+  | { outcome: 'invalid_grant' }
+  | { outcome: 'invalid_scope' }
+  | { outcome: 'ok'; userId: string; scopes: string[]; tokens: IssuedTokenPair };
+
+/**
+ * Atomically rotate a refresh token (task l8zlp3353f2cunjd33foq41l, ADR 0003
+ * §3.3-3.4). `FOR UPDATE` locks the token row for the transaction's
+ * duration — the model is identical to `exchangeAuthorizationCode`'s code
+ * lock: a second concurrent refresh of the same token blocks until the first
+ * commits, then observes the row already rotated. The grace-cache lookup
+ * (ADR 0003 §3.4) is deferred infra — this shell always supplies
+ * `graceCacheHit: false`, so `decideRefreshRotation` never returns
+ * `grace-replay` here; a genuine concurrent race lands on `grace_cache_miss`
+ * (family untouched, loser gets `invalid_grant`) rather than a false theft
+ * accusation.
+ */
+export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<RefreshTokenGrantResult> {
+  const tokenHash = hashToken(input.refreshToken);
+
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: oauthRefreshTokens.id,
+        userId: oauthRefreshTokens.userId,
+        scopes: oauthRefreshTokens.scopes,
+        tokenVersion: oauthRefreshTokens.tokenVersion,
+        expiresAt: oauthRefreshTokens.expiresAt,
+        familyExpiresAt: oauthRefreshTokens.familyExpiresAt,
+        familyId: oauthRefreshTokens.familyId,
+        revokedAt: oauthRefreshTokens.revokedAt,
+        replacedByTokenId: oauthRefreshTokens.replacedByTokenId,
+      })
+      .from(oauthRefreshTokens)
+      .where(and(eq(oauthRefreshTokens.tokenHash, tokenHash), eq(oauthRefreshTokens.clientId, input.clientDbId)))
+      .for('update');
+
+    const row = rows[0];
+    if (!row) {
+      return { outcome: 'invalid_grant' };
+    }
+
+    const decision = decideRefreshRotation(
+      {
+        expiresAt: row.expiresAt,
+        familyExpiresAt: row.familyExpiresAt,
+        revokedAt: row.revokedAt,
+        replacedByTokenId: row.replacedByTokenId,
+      },
+      input.now,
+      false,
+    );
+
+    if (!decision.ok) {
+      if (decision.revokeFamily) {
+        await revokeTokenFamily(tx, row.familyId, input.now, 'reuse_detected');
+      }
+      return { outcome: 'invalid_grant' };
+    }
+
+    if (decision.action === 'grace-replay') {
+      // Unreachable while graceCacheHit is hardcoded false above; see the
+      // module-level doc comment.
+      return { outcome: 'invalid_grant' };
+    }
+
+    let scopes = row.scopes;
+    if (input.requestedScope !== null) {
+      const requested = parseScopeList(input.requestedScope);
+      const granted = parseScopeList(row.scopes.join(' '));
+      if (!requested.ok || !granted.ok || !isScopeSubset(requested.scopes, granted.scopes)) {
+        return { outcome: 'invalid_scope' };
+      }
+      scopes = formatScopeSet(requested.scopes).split(' ');
+    }
+
+    const newRefreshId = createId();
+    const tokens = issueRotatedTokenPair(input.now, row.familyId, row.familyExpiresAt);
+
+    await tx
+      .update(oauthRefreshTokens)
+      .set({ revokedAt: input.now, revokedReason: 'rotated', replacedByTokenId: newRefreshId })
+      .where(eq(oauthRefreshTokens.id, row.id));
+
+    await tx.insert(oauthRefreshTokens).values({
+      id: newRefreshId,
+      tokenHash: tokens.refreshTokenHash,
+      tokenPrefix: tokens.refreshTokenPrefix,
+      familyId: tokens.familyId,
+      clientId: input.clientDbId,
+      userId: row.userId,
+      scopes,
+      tokenVersion: row.tokenVersion,
+      expiresAt: tokens.refreshExpiresAt,
+      familyExpiresAt: tokens.familyExpiresAt,
+    });
+
+    await tx.insert(oauthAccessTokens).values({
+      tokenHash: tokens.accessTokenHash,
+      tokenPrefix: tokens.accessTokenPrefix,
+      familyId: tokens.familyId,
+      clientId: input.clientDbId,
+      userId: row.userId,
+      scopes,
+      tokenVersion: row.tokenVersion,
+      expiresAt: tokens.accessExpiresAt,
+    });
+
+    return { outcome: 'ok', userId: row.userId, scopes, tokens };
   });
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -962,6 +962,11 @@
       "import": "./dist/auth/oauth/issue-tokens.js",
       "require": "./dist/auth/oauth/issue-tokens.js"
     },
+    "./auth/oauth/refresh-rotation": {
+      "types": "./dist/auth/oauth/refresh-rotation.d.ts",
+      "import": "./dist/auth/oauth/refresh-rotation.js",
+      "require": "./dist/auth/oauth/refresh-rotation.js"
+    },
     "./auth/account-lockout": {
       "types": "./dist/auth/account-lockout.d.ts",
       "import": "./dist/auth/account-lockout.js",

--- a/packages/lib/src/auth/oauth/__tests__/refresh-rotation.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/refresh-rotation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure refresh-token rotation decision (ADR 0003 §3.3-3.4, §6-§7; Phase 1
+ * task 8, RED sub-task qa0870vw0zz27x14n1vluv6z). No DB, no clock, no
+ * randomness — every case below hand-builds a `RefreshTokenRecord` and an
+ * injected `now`/`graceCacheHit` and asserts the resulting decision.
+ */
+import { describe, it, expect } from 'vitest';
+import { decideRefreshRotation, REFRESH_GRACE_WINDOW_MS, type RefreshTokenRecord } from '../refresh-rotation';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+function liveRecord(overrides: Partial<RefreshTokenRecord> = {}): RefreshTokenRecord {
+  return {
+    expiresAt: new Date(Date.now() + 30 * DAY),
+    familyExpiresAt: new Date(Date.now() + 90 * DAY),
+    revokedAt: null,
+    replacedByTokenId: null,
+    ...overrides,
+  };
+}
+
+describe('decideRefreshRotation — happy path', () => {
+  it('rotates a live, unexpired, unrevoked token', () => {
+    const now = new Date();
+    const decision = decideRefreshRotation(liveRecord(), now, false);
+    expect(decision).toEqual({ ok: true, action: 'rotate' });
+  });
+});
+
+describe('decideRefreshRotation — expiry', () => {
+  it('exactly-at per-token expiry fails closed as expired', () => {
+    const now = new Date(2026, 0, 1, 0, 0, 0);
+    const record = liveRecord({ expiresAt: now, familyExpiresAt: new Date(now.getTime() + DAY) });
+    expect(decideRefreshRotation(record, now, false)).toEqual({ ok: false, reason: 'expired', revokeFamily: false });
+  });
+
+  it('past per-token expiry is expired', () => {
+    const now = new Date();
+    const record = liveRecord({ expiresAt: new Date(now.getTime() - 1000) });
+    expect(decideRefreshRotation(record, now, false)).toEqual({ ok: false, reason: 'expired', revokeFamily: false });
+  });
+
+  it('family_expired takes precedence over the per-token TTL (absolute cap wins)', () => {
+    const now = new Date();
+    const record = liveRecord({
+      familyExpiresAt: new Date(now.getTime() - 1000),
+      expiresAt: new Date(now.getTime() + DAY), // per-token TTL not yet reached
+    });
+    expect(decideRefreshRotation(record, now, false)).toEqual({
+      ok: false,
+      reason: 'family_expired',
+      revokeFamily: false,
+    });
+  });
+
+  it('exactly-at family expiry fails closed as family_expired', () => {
+    const now = new Date(2026, 0, 1, 0, 0, 0);
+    const record = liveRecord({ familyExpiresAt: now });
+    expect(decideRefreshRotation(record, now, false)).toEqual({
+      ok: false,
+      reason: 'family_expired',
+      revokeFamily: false,
+    });
+  });
+});
+
+describe('decideRefreshRotation — reuse detection, grace window, grace-cache miss (ADR 0003 §7.3)', () => {
+  it('29s after revocation, replacedByTokenId set, graceCacheHit true → grace-replay', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 29_000);
+    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+
+    expect(decideRefreshRotation(record, now, true)).toEqual({ ok: true, action: 'grace-replay' });
+  });
+
+  it('same inputs with graceCacheHit false → grace_cache_miss (NOT theft — family untouched)', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 29_000);
+    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+
+    expect(decideRefreshRotation(record, now, false)).toEqual({
+      ok: false,
+      reason: 'grace_cache_miss',
+      revokeFamily: false,
+    });
+  });
+
+  it('31s after revocation (outside the 30s window), graceCacheHit true → reuse_detected regardless', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 31_000);
+    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+
+    expect(decideRefreshRotation(record, now, true)).toEqual({
+      ok: false,
+      reason: 'reuse_detected',
+      revokeFamily: true,
+    });
+  });
+
+  it('31s after revocation, graceCacheHit false → reuse_detected (same as true — cache state never overrides an out-of-window reuse)', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 31_000);
+    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+
+    expect(decideRefreshRotation(record, now, false)).toEqual({
+      ok: false,
+      reason: 'reuse_detected',
+      revokeFamily: true,
+    });
+  });
+
+  it('exactly at the 30s boundary is treated as OUTSIDE the window (fail closed) → reuse_detected', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + REFRESH_GRACE_WINDOW_MS);
+    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+
+    expect(decideRefreshRotation(record, now, true)).toEqual({
+      ok: false,
+      reason: 'reuse_detected',
+      revokeFamily: true,
+    });
+  });
+
+  it('revoked with no replacedByTokenId (e.g. already family-revoked) is reuse_detected even within 30s — no legitimate replacement to replay', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 1_000);
+    const record = liveRecord({ revokedAt, replacedByTokenId: null });
+
+    expect(decideRefreshRotation(record, now, true)).toEqual({
+      ok: false,
+      reason: 'reuse_detected',
+      revokeFamily: true,
+    });
+  });
+
+  it('the theft scenario end-to-end: legitimate client rotates, then an attacker replays the stolen pre-rotation token outside the grace window — reuse_detected, family dies', () => {
+    // Legitimate client's rotation revoked the old token at t0.
+    const t0 = new Date();
+    const legitimateRotation = decideRefreshRotation(liveRecord({ revokedAt: null }), t0, false);
+    expect(legitimateRotation).toEqual({ ok: true, action: 'rotate' });
+
+    // Attacker replays the now-revoked, rotated-away token well after the grace window.
+    const attackerNow = new Date(t0.getTime() + 60_000);
+    const stolenRecord = liveRecord({ revokedAt: t0, replacedByTokenId: 'legit-next-token-id' });
+    const attackerDecision = decideRefreshRotation(stolenRecord, attackerNow, false);
+
+    expect(attackerDecision).toEqual({ ok: false, reason: 'reuse_detected', revokeFamily: true });
+  });
+});

--- a/packages/lib/src/auth/oauth/issue-tokens.ts
+++ b/packages/lib/src/auth/oauth/issue-tokens.ts
@@ -81,3 +81,30 @@ export function issueInitialTokenPair(now: Date): IssuedTokenPair {
     familyExpiresAt,
   };
 }
+
+/**
+ * Mint a rotated token pair within an EXISTING refresh-token family (task 8,
+ * ADR 0003 §3.3). `familyId`/`familyExpiresAt` are carried over unchanged
+ * from the presented token's record — only the authorization_code grant
+ * starts a new family; rotation clamps its refresh TTL against the family's
+ * original absolute boundary, never resets it.
+ */
+export function issueRotatedTokenPair(now: Date, familyId: string, familyExpiresAt: Date): IssuedTokenPair {
+  const { accessExpiresAt, refreshExpiresAt } = issuedTokenLifetimes(now, familyExpiresAt);
+
+  const access = generateOpaqueToken('at');
+  const refresh = generateOpaqueToken('rt');
+
+  return {
+    accessToken: access.token,
+    accessTokenHash: access.tokenHash,
+    accessTokenPrefix: access.tokenPrefix,
+    accessExpiresAt,
+    refreshToken: refresh.token,
+    refreshTokenHash: refresh.tokenHash,
+    refreshTokenPrefix: refresh.tokenPrefix,
+    refreshExpiresAt,
+    familyId,
+    familyExpiresAt,
+  };
+}

--- a/packages/lib/src/auth/oauth/refresh-rotation.ts
+++ b/packages/lib/src/auth/oauth/refresh-rotation.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure refresh-token rotation decision for the OAuth 2.1 provider (ADR 0003
+ * §3.3-3.4, §6-§7; Phase 1 task 8). No I/O: takes the fetched refresh-token
+ * record, `now`, and the impure shell's grace-cache lookup *result* (it
+ * already did the cache GET before calling in — this function stays pure by
+ * taking the fact, not performing the I/O), and returns what to do. The
+ * repository fetches the record under `FOR UPDATE`, calls this, and persists
+ * whatever the decision implies — this module never touches the database, a
+ * cache, or the clock itself.
+ *
+ * Following the `code-lifecycle.ts` / `token-lifecycle-policy.ts` precedent:
+ * exhaustive discriminated unions, fail-closed at every boundary.
+ *
+ * @module @pagespace/lib/auth/oauth/refresh-rotation
+ */
+
+/** ADR 0003 §3.2: concurrent-refresh grace window. */
+export const REFRESH_GRACE_WINDOW_MS = 30_000;
+
+export interface RefreshTokenRecord {
+  /** Per-token TTL (30d), fixed at issuance/rotation. */
+  expiresAt: Date;
+  /** Absolute family cap (90d), fixed at first issuance, never extended. */
+  familyExpiresAt: Date;
+  /** Set the moment this token is rotated away or revoked; null while live. */
+  revokedAt: Date | null;
+  /** The token this one was rotated into, if any. */
+  replacedByTokenId: string | null;
+}
+
+export type RefreshRotationDecision =
+  | { ok: true; action: 'rotate' }
+  /** Caller fulfills from the ephemeral grace cache (§3.4) — hand back the
+   *  same replacement pair already minted for the first request. */
+  | { ok: true; action: 'grace-replay' }
+  | { ok: false; reason: 'expired' | 'family_expired'; revokeFamily: false }
+  /** In-window but the cache lost the pair — an infra gap, not theft. */
+  | { ok: false; reason: 'grace_cache_miss'; revokeFamily: false }
+  | { ok: false; reason: 'reuse_detected'; revokeFamily: true };
+
+/**
+ * Decide what a presented refresh token means right now.
+ *
+ * Precedence (each a distinct security posture, most specific first):
+ *  1. Already revoked (`revokedAt` set) is checked first — a revoked token
+ *     with a replacement wired up (`replacedByTokenId`) fired from a prior
+ *     rotation, not a manual/family revocation:
+ *       - inside the 30s grace window: a benign concurrent-refresh replay if
+ *         the cache still has the pair (`grace-replay`), or an infra gap if
+ *         it doesn't (`grace_cache_miss` — family is NOT revoked, this is
+ *         not attacker behavior).
+ *       - outside the window, or with no replacement to replay (e.g. the
+ *         token was revoked by a family-wide reuse revocation, not a
+ *         rotation): reuse — revoke the entire family.
+ *  2. family_expired — the absolute 90-day cap wins over a still-live
+ *     per-token TTL; it is fixed at first issuance and never extended.
+ *  3. expired — the per-token 30-day TTL.
+ *  4. otherwise — rotate: issue a fresh pair, revoke the presented token.
+ */
+export function decideRefreshRotation(
+  record: RefreshTokenRecord,
+  now: Date,
+  graceCacheHit: boolean,
+): RefreshRotationDecision {
+  if (record.revokedAt !== null) {
+    const elapsedSinceRevocation = now.getTime() - record.revokedAt.getTime();
+    const withinGraceWindow = elapsedSinceRevocation < REFRESH_GRACE_WINDOW_MS;
+
+    if (withinGraceWindow && record.replacedByTokenId !== null) {
+      return graceCacheHit
+        ? { ok: true, action: 'grace-replay' }
+        : { ok: false, reason: 'grace_cache_miss', revokeFamily: false };
+    }
+
+    return { ok: false, reason: 'reuse_detected', revokeFamily: true };
+  }
+
+  if (now.getTime() >= record.familyExpiresAt.getTime()) {
+    return { ok: false, reason: 'family_expired', revokeFamily: false };
+  }
+
+  if (now.getTime() >= record.expiresAt.getTime()) {
+    return { ok: false, reason: 'expired', revokeFamily: false };
+  }
+
+  return { ok: true, action: 'rotate' };
+}


### PR DESCRIPTION
## Summary
Implements task 8 (`l8zlp3353f2cunjd33foq41l`) of Phase 1 — OAuth 2.1 Authorization Server: the `grant_type=refresh_token` branch of `/api/oauth/token`, with single-use rotation and reuse-triggered family revocation, per ADR 0003 §3.3-3.4/§6-§7.

- **`decideRefreshRotation`** (`packages/lib/src/auth/oauth/refresh-rotation.ts`) — pure decision function, no I/O: `rotate` / `grace-replay` / `expired` / `family_expired` / `grace_cache_miss` / `reuse_detected`. Clock and grace-cache-hit fact are both injected.
- **`issueRotatedTokenPair`** (`issue-tokens.ts`) — mints a new `ps_at_*`/`ps_rt_*` pair inside an *existing* family (vs. `issueInitialTokenPair`'s new-family mint), clamping the per-token TTL to the family's original 90-day cap.
- **`refreshTokenGrant`** (`oauth-repository.ts`) — atomic `FOR UPDATE` rotation mirroring `exchangeAuthorizationCode`'s lock pattern. Reuse (a rotated-away token presented again outside the grace window, or any revoked token with no live replacement) revokes **every** refresh + access token in the family — the theft scenario is covered end-to-end. Scope narrowing via `isScopeSubset`; any escalation attempt → `invalid_scope`.
- **`/api/oauth/token`** — new `grant_type=refresh_token` branch, sharing the client-resolution guard with the `authorization_code` branch. Unknown/expired/revoked/reused tokens all collapse to the same constant-shape `invalid_grant` (no oracle); `invalid_scope` is the one deliberate exception, since it only fires once the presented token has already proven valid.

**Grace-cache infra is deliberately deferred**: no Redis/Postgres-backed cache exists yet in this repo for the 30s concurrent-refresh replay window described in ADR §3.4. The route always passes `graceCacheHit: false`, so a genuine concurrent-refresh race lands on `grace_cache_miss` (family untouched, the losing request gets `invalid_grant`) rather than a false theft accusation — this satisfies the task spec's "concurrent refresh → one winner, loser gets invalid_grant" while staying ADR-compliant (no wrongful family revocation for a benign race). Wiring an actual cache for true replay recovery is a follow-up, not blocking this task's scope (files: route + repository + `refresh-rotation.ts`).

New `./auth/oauth/refresh-rotation` subpath export added to `packages/lib/package.json`.

## Test plan
- [x] RED commit (`130db211d`): 3 new test files (pure-function, repository, route) all fail against the missing implementation.
- [x] GREEN commit (`e6a07f33a`): all new tests pass — rotation happy path, the theft scenario end-to-end (legitimate rotation → attacker replay → entire family dead, including the legitimate client's own new token), expired/family-expired, scope-narrowing + escalation rejection, concurrent-refresh single-winner.
- [x] `bun run --filter 'web' typecheck` — clean.
- [x] `bun run test:unit` — clean on every file this PR touches; verified via `git stash`/re-run that the small set of remaining failures (page-agents/consult mocking gaps, `admin-role-version.test.ts` needing a live Postgres connection unavailable in this sandbox) are pre-existing on `pu/cli-login`, not introduced here.
- [x] `bun run test:security` — same result: 7/43 suites fail identically with and without this diff (missing test-file globs + the same DB-dependent suite above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3FFWw5PrCfzMrgyRvB5pL