### PR TITLE
sdk: implement roles & permissions operations (Phase 3 task 7)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -520,6 +520,9 @@
       "dependencies": {
         "zod": "^4.1.8",
       },
+      "devDependencies": {
+        "@pagespace/lib": "workspace:*",
+      },
     },
   },
   "trustedDependencies": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,5 +23,8 @@
   },
   "dependencies": {
     "zod": "^4.1.8"
+  },
+  "devDependencies": {
+    "@pagespace/lib": "workspace:*"
   }
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -52,6 +52,16 @@ import {
 } from './operations/pages.js';
 import { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
 import {
+  createDriveRole,
+  deleteDriveRole,
+  getDriveRole,
+  listDriveRoles,
+  removeRolePagePermissions,
+  setRoleDriveWidePermissions,
+  setRolePagePermissions,
+  updateDriveRole,
+} from './operations/roles.js';
+import {
   createTask,
   createTaskStatus,
   deleteTask,
@@ -86,6 +96,16 @@ const DEFAULT_OPERATIONS_MAP = {
     insertLines: insertLines,
     deleteLines: deleteLines,
     editCells: editSheetCells,
+  },
+  roles: {
+    list: listDriveRoles,
+    get: getDriveRole,
+    create: createDriveRole,
+    update: updateDriveRole,
+    delete: deleteDriveRole,
+    setPagePermissions: setRolePagePermissions,
+    setDriveWidePermissions: setRoleDriveWidePermissions,
+    removePagePermissions: removeRolePagePermissions,
   },
   tasks: {
     create: createTask,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -54,53 +54,9 @@ export type { Operation, OperationConfig, PathParamNames, RequiredScope, ValidOp
 export { createRegistry, getOperation, hasOperation, listOperations } from './registry/registry.js';
 export type { OperationRegistry } from './registry/registry.js';
 
-// Seed operations (Phase 3 grows this list).
-export { listDrives } from './operations/drives.js';
+// Domain operations (Phase 3), alphabetical by domain.
 
-// Pages & content operations (Phase 3 task 2) — full pagespace-mcp page.js/document.js parity.
-export {
-  createPage,
-  getPageDetails,
-  listPages,
-  listTrash,
-  movePage,
-  renamePage,
-  restorePage,
-  trashPage,
-} from './operations/pages.js';
-export { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
-
-// Search operations (Phase 3 task 3).
-export { globSearch, multiDriveSearch, regexSearch } from './operations/search.js';
-
-// Drives & members operations (Phase 3 task 1).
-export {
-  assertDriveNameConfirmed,
-  createDrive,
-  renameDrive,
-  restoreDrive,
-  trashDrive,
-  updateDriveContext,
-} from './operations/drives.js';
-export type { ConfirmMismatch, Result } from './operations/drives.js';
-export { listDriveMembers } from './operations/members.js';
-export { listCollaborators } from './operations/collaborators.js';
-
-// Tasks & statuses operations (Phase 3 task 4).
-export {
-  classifyTaskCompletionGate,
-  createTask,
-  createTaskStatus,
-  deleteTask,
-  deleteTaskTrigger,
-  getAssignedTasks,
-  reorderTask,
-  setTaskTrigger,
-  updateTask,
-} from './operations/tasks.js';
-export type { TaskCompletionGatedError } from './operations/tasks.js';
-
-// Agents & conversations operations (Phase 3 task 5).
+// Agents (Phase 3 task 5).
 export {
   askAgent,
   filterModelCatalog,
@@ -110,9 +66,8 @@ export {
   updateAgentConfig,
 } from './operations/agents.js';
 export type { CatalogModel, CatalogProvider, ModelCatalogFilter } from './operations/agents.js';
-export { listConversations, readConversation } from './operations/conversations.js';
 
-// Calendar operations (Phase 3 task 6).
+// Calendar (Phase 3 task 6).
 export {
   computeFreeSlots,
   createCalendarEvent,
@@ -127,6 +82,79 @@ export {
   updateCalendarEvent,
 } from './operations/calendar.js';
 export type { FreeSlot } from './operations/calendar.js';
+
+// Collaborators (Phase 3 task 1).
+export { listCollaborators } from './operations/collaborators.js';
+
+// Conversations (Phase 3 task 5).
+export { listConversations, readConversation } from './operations/conversations.js';
+
+// Documents / content (Phase 3 task 2) — full pagespace-mcp document.js parity.
+export { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
+
+// Drives (Phase 2 seed op + Phase 3 task 1 — full pagespace-mcp drive.js parity).
+export { listDrives } from './operations/drives.js';
+export {
+  assertDriveNameConfirmed,
+  createDrive,
+  renameDrive,
+  restoreDrive,
+  trashDrive,
+  updateDriveContext,
+} from './operations/drives.js';
+export type { ConfirmMismatch, Result } from './operations/drives.js';
+
+// Members (Phase 3 task 1).
+export { listDriveMembers } from './operations/members.js';
+
+// Pages (Phase 3 task 2) — full pagespace-mcp page.js parity.
+export {
+  createPage,
+  getPageDetails,
+  listPages,
+  listTrash,
+  movePage,
+  renamePage,
+  restorePage,
+  trashPage,
+} from './operations/pages.js';
+
+// Roles & permissions (Phase 3 task 7).
+export {
+  buildRemoveRolePagePermissionsInput,
+  buildSetRoleDriveWidePermissionsInput,
+  buildSetRolePagePermissionsInput,
+  createDriveRole,
+  deleteDriveRole,
+  getDriveRole,
+  listDriveRoles,
+  removeRolePagePermissions,
+  setRoleDriveWidePermissions,
+  setRolePagePermissions,
+  updateDriveRole,
+} from './operations/roles.js';
+export type {
+  RemoveRolePagePermissionsArgs,
+  SetRoleDriveWidePermissionsArgs,
+  SetRolePagePermissionsArgs,
+} from './operations/roles.js';
+
+// Search (Phase 3 task 3).
+export { globSearch, multiDriveSearch, regexSearch } from './operations/search.js';
+
+// Tasks & statuses (Phase 3 task 4).
+export {
+  classifyTaskCompletionGate,
+  createTask,
+  createTaskStatus,
+  deleteTask,
+  deleteTaskTrigger,
+  getAssignedTasks,
+  reorderTask,
+  setTaskTrigger,
+  updateTask,
+} from './operations/tasks.js';
+export type { TaskCompletionGatedError } from './operations/tasks.js';
 
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.

--- a/packages/sdk/src/operations/__tests__/roles.test.ts
+++ b/packages/sdk/src/operations/__tests__/roles.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import {
+  buildRemoveRolePagePermissionsInput,
+  buildSetRoleDriveWidePermissionsInput,
+  buildSetRolePagePermissionsInput,
+  createDriveRole,
+  deleteDriveRole,
+  getDriveRole,
+  listDriveRoles,
+  removeRolePagePermissions,
+  setRoleDriveWidePermissions,
+  setRolePagePermissions,
+  updateDriveRole,
+} from '../roles.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Shape verified against packages/lib/src/services/drive-role-service.ts DriveRole (route-serialized: Date -> ISO string). */
+const roleFixture = {
+  id: 'r1abc',
+  driveId: 'd1abc',
+  name: 'Editor',
+  description: 'Can edit but not share',
+  color: '#6366f1',
+  isDefault: false,
+  permissions: {
+    p1abc: { canView: true, canEdit: true, canShare: false },
+  },
+  driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+  position: 1,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+};
+
+describe('roles.list — request shape', () => {
+  it('builds a GET to /api/drives/:driveId/roles', () => {
+    const request = buildRequest(listDriveRoles, { driveId: 'd1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/roles');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('rejects input missing driveId before any network call', () => {
+    const result = listDriveRoles.inputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('roles.list — response contract', () => {
+  it('parses { roles } (route truth: drives/[driveId]/roles/route.ts GET)', () => {
+    const result = parseResponse(listDriveRoles, 200, new Headers(), JSON.stringify({ roles: [roleFixture] }));
+    expect(result).toEqual({ roles: [roleFixture] });
+  });
+
+  it('parses an empty roles list', () => {
+    const result = parseResponse(listDriveRoles, 200, new Headers(), JSON.stringify({ roles: [] }));
+    expect(result).toEqual({ roles: [] });
+  });
+
+  it('rejects a response that drifts from the DriveRole contract', () => {
+    const malformed = { roles: [{ ...roleFixture, permissions: 'not-a-record' }] };
+    const result = parseResponse(listDriveRoles, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (not a member) as PermissionDeniedError', () => {
+    const result = parseResponse(listDriveRoles, 403, new Headers(), JSON.stringify({ error: 'Not a member of this drive' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('roles.list — metadata', () => {
+  it('requires only drive-member scope (read op)', () => {
+    expect(listDriveRoles.requiredScope).toBe('drive');
+  });
+});
+
+describe('roles.get — request shape', () => {
+  it('interpolates driveId and roleId with no body', () => {
+    const request = buildRequest(getDriveRole, { driveId: 'd1abc', roleId: 'r1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/roles/r1abc');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('roles.get — response contract', () => {
+  it('parses { role } (route truth: drives/[driveId]/roles/[roleId]/route.ts GET)', () => {
+    const result = parseResponse(getDriveRole, 200, new Headers(), JSON.stringify({ role: roleFixture }));
+    expect(result).toEqual({ role: roleFixture });
+  });
+
+  it('classifies a 404 (role not found) as NotFoundError', () => {
+    const result = parseResponse(getDriveRole, 404, new Headers(), JSON.stringify({ error: 'Role not found' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+});
+
+describe('roles.get — metadata', () => {
+  it('requires only drive-member scope', () => {
+    expect(getDriveRole.requiredScope).toBe('drive');
+  });
+});
+
+describe('roles.create — request shape', () => {
+  it('builds a POST with name + permissions in the body (route requires both)', () => {
+    const request = buildRequest(
+      createDriveRole,
+      { driveId: 'd1abc', name: 'Editor', permissions: { p1abc: { canView: true, canEdit: true, canShare: false } } },
+      config,
+    );
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/roles');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      name: 'Editor',
+      permissions: { p1abc: { canView: true, canEdit: true, canShare: false } },
+    });
+  });
+
+  it('rejects an empty name (route: 1-50 chars)', () => {
+    const result = createDriveRole.inputSchema.safeParse({ driveId: 'd1abc', name: '', permissions: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a name over 50 chars', () => {
+    const result = createDriveRole.inputSchema.safeParse({ driveId: 'd1abc', name: 'x'.repeat(51), permissions: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a permissions entry missing a required flag (no partial triples)', () => {
+    const result = createDriveRole.inputSchema.safeParse({
+      driveId: 'd1abc',
+      name: 'Editor',
+      permissions: { p1abc: { canView: true, canEdit: true } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an empty permissions map (route requires the key present, not non-empty)', () => {
+    const result = createDriveRole.inputSchema.safeParse({ driveId: 'd1abc', name: 'Editor', permissions: {} });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('roles.create — response contract', () => {
+  it('parses a 201 { role }', () => {
+    const result = parseResponse(createDriveRole, 201, new Headers(), JSON.stringify({ role: roleFixture }));
+    expect(result).toEqual({ role: roleFixture });
+  });
+
+  it('classifies a 409 (duplicate name) as a typed error', () => {
+    const result = parseResponse(createDriveRole, 409, new Headers(), JSON.stringify({ error: 'A role with this name already exists' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('roles.create — metadata', () => {
+  it('requires drive:admin scope (owner/admin-gated route)', () => {
+    expect(createDriveRole.requiredScope).toBe('drive:admin');
+  });
+
+  it('states the required authority in its description', () => {
+    expect(createDriveRole.description.toLowerCase()).toMatch(/owner|admin/);
+  });
+});
+
+describe('roles.update — request shape', () => {
+  it('sends only the provided fields, never a wholesale permissions map', () => {
+    const request = buildRequest(updateDriveRole, { driveId: 'd1abc', roleId: 'r1abc', name: 'Renamed' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/roles/r1abc');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ name: 'Renamed' });
+  });
+
+  it('can replace driveWidePermissions wholesale (single object, not a per-page map)', () => {
+    const request = buildRequest(
+      updateDriveRole,
+      { driveId: 'd1abc', roleId: 'r1abc', driveWidePermissions: { canView: true, canEdit: false, canShare: false } },
+      config,
+    );
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+    });
+  });
+
+  it('can clear driveWidePermissions with an explicit null', () => {
+    const request = buildRequest(updateDriveRole, { driveId: 'd1abc', roleId: 'r1abc', driveWidePermissions: null }, config);
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ driveWidePermissions: null });
+  });
+
+  it('does not accept a wholesale permissions field at all (must use setRolePagePermissions instead)', () => {
+    const result = updateDriveRole.inputSchema.safeParse({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      permissions: { p1abc: { canView: true, canEdit: true, canShare: true } },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('roles.update — response contract', () => {
+  it('parses { role }', () => {
+    const result = parseResponse(updateDriveRole, 200, new Headers(), JSON.stringify({ role: roleFixture }));
+    expect(result).toEqual({ role: roleFixture });
+  });
+
+  it('classifies a 403 (not owner/admin) as PermissionDeniedError', () => {
+    const result = parseResponse(updateDriveRole, 403, new Headers(), JSON.stringify({ error: 'Only owners and admins can update roles' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('roles.update — metadata', () => {
+  it('requires drive:admin scope', () => {
+    expect(updateDriveRole.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('roles.delete — request shape', () => {
+  it('builds a DELETE to /api/drives/:driveId/roles/:roleId', () => {
+    const request = buildRequest(deleteDriveRole, { driveId: 'd1abc', roleId: 'r1abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/roles/r1abc');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('roles.delete — response contract', () => {
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteDriveRole, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('roles.delete — metadata (high-privilege, destructive, non-idempotent)', () => {
+  it('requires drive:admin scope', () => {
+    expect(deleteDriveRole.requiredScope).toBe('drive:admin');
+  });
+
+  it('is flagged destructive so the CLI requires --yes', () => {
+    expect(deleteDriveRole.destructive).toBe(true);
+  });
+
+  it('uses DELETE, which isIdempotentMethod classifies as non-idempotent (no auto-retry)', () => {
+    expect(deleteDriveRole.method).toBe('DELETE');
+  });
+});
+
+describe('roles.setPagePermissions — request shape', () => {
+  it('sends a permissionsPatch keyed by pageId, never a wholesale permissions replace', () => {
+    const request = buildRequest(
+      setRolePagePermissions,
+      { driveId: 'd1abc', roleId: 'r1abc', permissionsPatch: { p1abc: { canView: true, canEdit: true, canShare: false } } },
+      config,
+    );
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/drives/d1abc/roles/r1abc');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      permissionsPatch: { p1abc: { canView: true, canEdit: true, canShare: false } },
+    });
+  });
+
+  it('rejects a null entry (this op only sets — removal is a distinct operation)', () => {
+    const result = setRolePagePermissions.inputSchema.safeParse({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      permissionsPatch: { p1abc: null },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a partial permission triple (an omitted flag is not treated as false)', () => {
+    const result = setRolePagePermissions.inputSchema.safeParse({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      permissionsPatch: { p1abc: { canView: true, canEdit: true } },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('roles.setPagePermissions — response contract', () => {
+  it('parses { role }', () => {
+    const result = parseResponse(setRolePagePermissions, 200, new Headers(), JSON.stringify({ role: roleFixture }));
+    expect(result).toEqual({ role: roleFixture });
+  });
+});
+
+describe('roles.setPagePermissions — metadata', () => {
+  it('requires drive:admin scope', () => {
+    expect(setRolePagePermissions.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('buildSetRolePagePermissionsInput — ergonomic single-page builder (pure)', () => {
+  it('nests the flat pageId + flags into a single-entry permissionsPatch', () => {
+    const input = buildSetRolePagePermissionsInput({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      pageId: 'p1abc',
+      canView: true,
+      canEdit: true,
+      canShare: false,
+    });
+    expect(input).toEqual({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      permissionsPatch: { p1abc: { canView: true, canEdit: true, canShare: false } },
+    });
+  });
+
+  it('is total and pure — identical input always yields a deep-equal (new) object', () => {
+    const args = { driveId: 'd1', roleId: 'r1', pageId: 'p1', canView: false, canEdit: false, canShare: false };
+    const a = buildSetRolePagePermissionsInput(args);
+    const b = buildSetRolePagePermissionsInput(args);
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('roles.setDriveWidePermissions — request shape', () => {
+  it('nests canView/canEdit/canShare under driveWidePermissions (single object, no merge needed)', () => {
+    const request = buildRequest(
+      setRoleDriveWidePermissions,
+      { driveId: 'd1abc', roleId: 'r1abc', driveWidePermissions: { canView: true, canEdit: false, canShare: false } },
+      config,
+    );
+    expect(request.method).toBe('PATCH');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+    });
+  });
+
+  it('rejects a partial permission triple', () => {
+    const result = setRoleDriveWidePermissions.inputSchema.safeParse({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      driveWidePermissions: { canView: true },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('roles.setDriveWidePermissions — response contract', () => {
+  it('parses { role }', () => {
+    const result = parseResponse(setRoleDriveWidePermissions, 200, new Headers(), JSON.stringify({ role: roleFixture }));
+    expect(result).toEqual({ role: roleFixture });
+  });
+});
+
+describe('roles.setDriveWidePermissions — metadata', () => {
+  it('requires drive:admin scope', () => {
+    expect(setRoleDriveWidePermissions.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('buildSetRoleDriveWidePermissionsInput — ergonomic builder (pure)', () => {
+  it('nests the flat flags under driveWidePermissions', () => {
+    const input = buildSetRoleDriveWidePermissionsInput({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      canView: true,
+      canEdit: false,
+      canShare: false,
+    });
+    expect(input).toEqual({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      driveWidePermissions: { canView: true, canEdit: false, canShare: false },
+    });
+  });
+});
+
+describe('roles.removePagePermissions — request shape', () => {
+  it('sends a permissionsPatch with a null entry (prune, not an explicit all-false grant)', () => {
+    const request = buildRequest(
+      removeRolePagePermissions,
+      { driveId: 'd1abc', roleId: 'r1abc', permissionsPatch: { p1abc: null } },
+      config,
+    );
+    expect(request.method).toBe('PATCH');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ permissionsPatch: { p1abc: null } });
+  });
+
+  it('rejects a non-null entry (this op only prunes — setting is a distinct operation)', () => {
+    const result = removeRolePagePermissions.inputSchema.safeParse({
+      driveId: 'd1abc',
+      roleId: 'r1abc',
+      permissionsPatch: { p1abc: { canView: true, canEdit: false, canShare: false } },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('roles.removePagePermissions — response contract', () => {
+  it('parses { role }', () => {
+    const result = parseResponse(removeRolePagePermissions, 200, new Headers(), JSON.stringify({ role: roleFixture }));
+    expect(result).toEqual({ role: roleFixture });
+  });
+});
+
+describe('roles.removePagePermissions — metadata (destructive: prunes a grant)', () => {
+  it('requires drive:admin scope', () => {
+    expect(removeRolePagePermissions.requiredScope).toBe('drive:admin');
+  });
+
+  it('is flagged destructive so the CLI requires --yes, even though the server-side effect is idempotent', () => {
+    expect(removeRolePagePermissions.destructive).toBe(true);
+  });
+});
+
+describe('buildRemoveRolePagePermissionsInput — ergonomic single-page builder (pure)', () => {
+  it('nests the flat pageId into a single-entry null permissionsPatch', () => {
+    const input = buildRemoveRolePagePermissionsInput({ driveId: 'd1abc', roleId: 'r1abc', pageId: 'p1abc' });
+    expect(input).toEqual({ driveId: 'd1abc', roleId: 'r1abc', permissionsPatch: { p1abc: null } });
+  });
+});

--- a/packages/sdk/src/operations/roles.ts
+++ b/packages/sdk/src/operations/roles.ts
@@ -1,0 +1,243 @@
+/**
+ * Roles & permissions operations (Phase 3 task 7).
+ *
+ * Route-verified against `apps/web/src/app/api/drives/[driveId]/roles/route.ts`
+ * (GET/POST) and `.../roles/[roleId]/route.ts` (GET/PATCH/DELETE)
+ * (docs/sdk/operations-inventory.md §2.12, parity with MCP tools
+ * `list_drive_roles`, `get_drive_role`, `create_drive_role`,
+ * `update_drive_role`, `delete_drive_role`, `set_role_page_permissions`,
+ * `set_role_drive_wide_permissions`, `remove_role_page_permissions`).
+ *
+ * IMPORTANT — the inventory's §2.12 rows (D-register era) describe the PATCH
+ * route's page-permission field as a wholesale `permissions` map replace.
+ * That is stale: fix #1765 added `permissionsPatch`, a read-merge-write
+ * per-page patch — pages not named in the patch are untouched, and a `null`
+ * entry prunes that page's override (falls back to driveWidePermissions)
+ * instead of persisting an explicit all-false deny. The CURRENT route
+ * (`roles/[roleId]/route.ts` PATCH, read above) accepts EITHER `permissions`
+ * (wholesale replace) OR `permissionsPatch` (merge), rejecting both being
+ * sent together. This SDK deliberately narrows to `permissionsPatch` for
+ * every per-page mutation (`roles.setPagePermissions`, `roles.removePagePermissions`)
+ * and never exposes the wholesale `permissions` field at all — a single-page
+ * SDK call must never be able to wipe another page's grant. `roles.update`
+ * only ever replaces `driveWidePermissions` (a single object, not a map, so
+ * a wholesale replace there is safe).
+ *
+ * Transport note: `buildRequest` (Phase 2 task 3) serializes an operation's
+ * non-path-param input fields as the JSON body verbatim — it has no
+ * per-operation transform step. Since the wire body for page-permission ops
+ * nests the target pageId as a *dynamic object key* inside `permissionsPatch`
+ * (`{ permissionsPatch: { [pageId]: {...} } }`), the registry operations
+ * below take `permissionsPatch`/`driveWidePermissions` as already-shaped
+ * input fields. `buildSetRolePagePermissionsInput`, `buildRemoveRolePagePermissionsInput`,
+ * and `buildSetRoleDriveWidePermissionsInput` are the pure ergonomic builders
+ * (this phase's "resource module methods") that bridge the old MCP tools'
+ * flat single-page arguments (`driveId, roleId, pageId, canView, canEdit,
+ * canShare`) into that shape — CLI/MCP call sites use the builder, never
+ * hand-construct the patch object.
+ */
+import { z } from 'zod';
+import type { PagePerm } from '@pagespace/lib/permissions/membership-queries';
+import { defineOperation } from '../registry/define.js';
+
+/**
+ * Structurally checked against the canonical `PagePerm` lattice
+ * (`packages/lib/src/permissions/membership-queries.ts`) via `satisfies` —
+ * the SDK must not restate the view/edit/share triple by hand and drift.
+ * All three flags are always required (never optional): the route treats an
+ * omitted flag on write as an explicit `false`, so a partial triple would
+ * silently grant less than the caller intended — fail closed instead.
+ */
+const pagePermSchema = z.object({
+  canView: z.boolean(),
+  canEdit: z.boolean(),
+  canShare: z.boolean(),
+}) satisfies z.ZodType<PagePerm>;
+
+/** `DriveRole` (`packages/lib/src/services/drive-role-service.ts`), Date fields ISO-serialized over JSON. */
+const driveRoleSchema = z.object({
+  id: z.string(),
+  driveId: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  color: z.string().nullable(),
+  isDefault: z.boolean(),
+  permissions: z.record(z.string(), pagePermSchema),
+  driveWidePermissions: pagePermSchema.nullable(),
+  position: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+const roleEnvelopeSchema = z.object({ role: driveRoleSchema });
+
+export const listDriveRoles = defineOperation({
+  name: 'roles.list',
+  method: 'GET',
+  path: '/api/drives/:driveId/roles',
+  inputSchema: z.object({ driveId: z.string() }),
+  outputSchema: z.object({ roles: z.array(driveRoleSchema) }),
+  requiredScope: 'drive',
+  description: 'List all custom roles defined in a drive. Requires drive membership (owner or member).',
+});
+
+export const getDriveRole = defineOperation({
+  name: 'roles.get',
+  method: 'GET',
+  path: '/api/drives/:driveId/roles/:roleId',
+  inputSchema: z.object({ driveId: z.string(), roleId: z.string() }),
+  outputSchema: roleEnvelopeSchema,
+  requiredScope: 'drive',
+  description: 'Get a single drive role with its full permission configuration. Requires drive membership.',
+});
+
+export const createDriveRole = defineOperation({
+  name: 'roles.create',
+  method: 'POST',
+  path: '/api/drives/:driveId/roles',
+  inputSchema: z.object({
+    driveId: z.string(),
+    name: z.string().min(1).max(50),
+    description: z.string().nullable().optional(),
+    color: z.string().nullable().optional(),
+    isDefault: z.boolean().optional(),
+    permissions: z.record(z.string(), pagePermSchema),
+    driveWidePermissions: pagePermSchema.nullable().optional(),
+  }),
+  outputSchema: roleEnvelopeSchema,
+  requiredScope: 'drive:admin',
+  description:
+    'Create a new custom role in a drive. Requires owner or admin authority. The route requires `permissions` to be present (an empty map is valid) even though this operation only manages drive-wide/whole-map creation — use roles.setPagePermissions afterward for read-merge-write per-page grants.',
+});
+
+export const updateDriveRole = defineOperation({
+  name: 'roles.update',
+  method: 'PATCH',
+  path: '/api/drives/:driveId/roles/:roleId',
+  inputSchema: z
+    .object({
+      driveId: z.string(),
+      roleId: z.string(),
+      name: z.string().min(1).max(50).optional(),
+      description: z.string().nullable().optional(),
+      color: z.string().nullable().optional(),
+      isDefault: z.boolean().optional(),
+      driveWidePermissions: pagePermSchema.nullable().optional(),
+    })
+    .strict(), // wholesale `permissions` deliberately excluded — see module doc; use roles.setPagePermissions/roles.removePagePermissions
+  outputSchema: roleEnvelopeSchema,
+  requiredScope: 'drive:admin',
+  description:
+    "Update a role's name, description, color, default flag, or drive-wide baseline permissions. Requires owner or admin authority. Per-page permissions are never touched here — use roles.setPagePermissions or roles.removePagePermissions, which patch a single page without disturbing others.",
+});
+
+export const deleteDriveRole = defineOperation({
+  name: 'roles.delete',
+  method: 'DELETE',
+  path: '/api/drives/:driveId/roles/:roleId',
+  inputSchema: z.object({ driveId: z.string(), roleId: z.string() }),
+  outputSchema: z.object({ success: z.literal(true) }),
+  requiredScope: 'drive:admin',
+  destructive: true,
+  description:
+    'Delete a custom role from a drive, permanently discarding its permission grants. Requires owner or admin authority. Irreversible — the CLI requires --yes.',
+});
+
+export const setRolePagePermissions = defineOperation({
+  name: 'roles.setPagePermissions',
+  method: 'PATCH',
+  path: '/api/drives/:driveId/roles/:roleId',
+  inputSchema: z.object({
+    driveId: z.string(),
+    roleId: z.string(),
+    /** Read-merge-write: pages not named here are untouched. Every entry must be a full triple — this op only sets, never prunes (see roles.removePagePermissions). */
+    permissionsPatch: z.record(z.string(), pagePermSchema),
+  }),
+  outputSchema: roleEnvelopeSchema,
+  requiredScope: 'drive:admin',
+  description:
+    "Grant or update a role's permissions on one or more specific pages via a server-side read-merge-write patch — other pages' grants are untouched. Requires owner or admin authority.",
+});
+
+export const setRoleDriveWidePermissions = defineOperation({
+  name: 'roles.setDriveWidePermissions',
+  method: 'PATCH',
+  path: '/api/drives/:driveId/roles/:roleId',
+  inputSchema: z.object({
+    driveId: z.string(),
+    roleId: z.string(),
+    driveWidePermissions: pagePermSchema,
+  }),
+  outputSchema: roleEnvelopeSchema,
+  requiredScope: 'drive:admin',
+  description:
+    "Set the drive-wide baseline permissions for a role (applies to all pages unless overridden per-page). Single-object replace — no merge needed. Requires owner or admin authority.",
+});
+
+export const removeRolePagePermissions = defineOperation({
+  name: 'roles.removePagePermissions',
+  method: 'PATCH',
+  path: '/api/drives/:driveId/roles/:roleId',
+  inputSchema: z.object({
+    driveId: z.string(),
+    roleId: z.string(),
+    /** Every entry must be `null` (prune) — this op only removes, never sets (see roles.setPagePermissions). */
+    permissionsPatch: z.record(z.string(), z.null()),
+  }),
+  outputSchema: roleEnvelopeSchema,
+  requiredScope: 'drive:admin',
+  destructive: true,
+  description:
+    "Remove a role's per-page permission entry for one or more specific pages via a server-side patch, so the role falls back to its drive-wide permissions there. Other pages' grants are preserved. Server-side effect is idempotent, but the CLI still requires --yes since a grant is discarded. Requires owner or admin authority.",
+});
+
+// ---------------------------------------------------------------------------
+// Ergonomic single-page builders (pure) — bridge the old MCP tools' flat
+// `{driveId, roleId, pageId, canView, canEdit, canShare}` argument shape into
+// the `permissionsPatch` input the registry operations above require. See
+// module doc for why buildRequest cannot do this transform generically.
+// ---------------------------------------------------------------------------
+
+export interface SetRolePagePermissionsArgs {
+  readonly driveId: string;
+  readonly roleId: string;
+  readonly pageId: string;
+  readonly canView: boolean;
+  readonly canEdit: boolean;
+  readonly canShare: boolean;
+}
+
+export function buildSetRolePagePermissionsInput(
+  args: SetRolePagePermissionsArgs,
+): { driveId: string; roleId: string; permissionsPatch: Record<string, PagePerm> } {
+  const { driveId, roleId, pageId, canView, canEdit, canShare } = args;
+  return { driveId, roleId, permissionsPatch: { [pageId]: { canView, canEdit, canShare } } };
+}
+
+export interface RemoveRolePagePermissionsArgs {
+  readonly driveId: string;
+  readonly roleId: string;
+  readonly pageId: string;
+}
+
+export function buildRemoveRolePagePermissionsInput(
+  args: RemoveRolePagePermissionsArgs,
+): { driveId: string; roleId: string; permissionsPatch: Record<string, null> } {
+  const { driveId, roleId, pageId } = args;
+  return { driveId, roleId, permissionsPatch: { [pageId]: null } };
+}
+
+export interface SetRoleDriveWidePermissionsArgs {
+  readonly driveId: string;
+  readonly roleId: string;
+  readonly canView: boolean;
+  readonly canEdit: boolean;
+  readonly canShare: boolean;
+}
+
+export function buildSetRoleDriveWidePermissionsInput(
+  args: SetRoleDriveWidePermissionsArgs,
+): { driveId: string; roleId: string; driveWidePermissions: PagePerm } {
+  const { driveId, roleId, canView, canEdit, canShare } = args;
+  return { driveId, roleId, driveWidePermissions: { canView, canEdit, canShare } };
+}

--- a/packages/sdk/src/registry/define.ts
+++ b/packages/sdk/src/registry/define.ts
@@ -50,6 +50,14 @@ export interface OperationConfig<
    * `timeoutMs` applies.
    */
   readonly timeoutMsOverride?: number;
+  /**
+   * Marks a non-idempotent operation whose effect is destructive/irreversible
+   * (deletes a resource, prunes a grant). The CLI layer (Phase 5) requires
+   * `--yes` before invoking any operation with this flag set; `isIdempotentMethod`
+   * (retry.ts) already blocks auto-retry for these methods, so this is purely a
+   * confirmation-gate signal, not a retry-safety one.
+   */
+  readonly destructive?: boolean;
   /** Mandatory: becomes the MCP tool description in Phase 6. */
   readonly description: string;
 }
@@ -90,6 +98,7 @@ export interface Operation<
   readonly requiredScope: RequiredScope | undefined;
   readonly textResponse: boolean | undefined;
   readonly timeoutMsOverride: number | undefined;
+  readonly destructive: boolean | undefined;
   readonly description: string;
 }
 
@@ -101,8 +110,18 @@ export function defineOperation<
 >(
   config: ValidOperationConfig<TPath, TInputSchema, TOutputSchema>,
 ): Operation<TPath, TInputSchema, TOutputSchema> {
-  const { name, method, path, inputSchema, outputSchema, requiredScope, textResponse, timeoutMsOverride, description } =
-    config as OperationConfig<TPath, TInputSchema, TOutputSchema>;
+  const {
+    name,
+    method,
+    path,
+    inputSchema,
+    outputSchema,
+    requiredScope,
+    textResponse,
+    timeoutMsOverride,
+    destructive,
+    description,
+  } = config as OperationConfig<TPath, TInputSchema, TOutputSchema>;
 
   return Object.freeze({
     name,
@@ -113,6 +132,7 @@ export function defineOperation<
     requiredScope,
     textResponse,
     timeoutMsOverride,
+    destructive,
     description,
   });
 }


### PR DESCRIPTION
## Summary
- Implements the 8-op `roles` domain in `@pagespace/sdk` (Phase 3 task 7, epic `ea07mt5jvw0flihsbjce1iv9`): `roles.list`, `roles.get`, `roles.create`, `roles.update`, `roles.delete`, `roles.setPagePermissions`, `roles.setDriveWidePermissions`, `roles.removePagePermissions` — full parity with the old MCP tool surface (`list_drive_roles`, `get_drive_role`, `create_drive_role`, `update_drive_role`, `delete_drive_role`, `set_role_page_permissions`, `set_role_drive_wide_permissions`, `remove_role_page_permissions`).
- Route-verified against the **current** `apps/web/src/app/api/drives/[driveId]/roles/**` source, not the stale `operations-inventory.md` §2.12 rows — those predate fix #1765, which replaced the wholesale-`permissions`-replace page-permission write with `permissionsPatch` (read-merge-write, `null` prunes). `roles.update` deliberately excludes the wholesale `permissions` field entirely (`.strict()`) so no SDK call can wipe another page's grant; only `roles.setPagePermissions`/`roles.removePagePermissions` (via `permissionsPatch`) touch per-page grants.
- Adds `destructive?: boolean` to `Operation`/`OperationConfig` (`registry/define.ts`) — additive, optional, doesn't affect existing operations. Flags `roles.delete` and `roles.removePagePermissions` so Phase 5's CLI can gate them behind `--yes`.
- Adds three pure ergonomic builders (`buildSetRolePagePermissionsInput`, `buildRemoveRolePagePermissionsInput`, `buildSetRoleDriveWidePermissionsInput`) that bridge the old tools' flat `{driveId, roleId, pageId, canView, canEdit, canShare}` arguments into the nested `permissionsPatch`/`driveWidePermissions` shape the wire body needs — `buildRequest` has no per-operation transform, so a dynamic `pageId` object key can only reach the body if the operation's own input field is already shaped that way.
- Permission-flag zod schema is checked against the canonical `PagePerm` type (`@pagespace/lib/permissions/membership-queries`) via `satisfies`, so the SDK can't silently restate/drift from the permission lattice. Adds `@pagespace/lib` as a `devDependency` of `@pagespace/sdk` for this type-only import (erased at build; no runtime dependency added to the published package).
- Wired into `client.ts`'s `DEFAULT_OPERATIONS_MAP` (`client.roles.*`) and `index.ts`'s explicit named barrel exports (no `export *`), alphabetized by domain.

**Rebased twice onto `pu/cli-login`** as sibling Phase 3 PRs landed:
1. After pages & content (#1806) — union-resolved `client.ts`'s `DEFAULT_OPERATIONS_MAP` (pages block + roles block).
2. After agents & conversations (#1810) and calendar (#1811) — union-resolved `registry/define.ts` (agents' PR added `timeoutMsOverride` to the same `Operation`/`OperationConfig` type this PR adds `destructive` to; both fields now coexist). `client.ts`/`index.ts` auto-merged cleanly this round; re-alphabetized the full barrel (agents, calendar, collaborators, conversations, documents, drives, members, pages, roles, search, tasks) for consistency. Note: `calendar`/`search`/`members`/`collaborators`/full document-write ops are exported but not wired into `DEFAULT_OPERATIONS_MAP` upstream either — that's a pre-existing inconsistency in already-merged PRs, not introduced here.

## Test plan
- [x] RED commit: 50 contract tests added, fail because `operations/roles.ts` doesn't exist.
- [x] GREEN commit: implementation lands, same 50 tests pass.
- [x] `bun run --filter '@pagespace/sdk' typecheck` — clean.
- [x] `bun run --filter '@pagespace/sdk' test` — 565/565 passing after second rebase (full suite, no regressions; 50 in the roles suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqzE1qnjqhkSjRghHc4Az4