### PR TITLE
sdk: implement calendar operations (Phase 3 task 6)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -112,6 +112,22 @@ export {
 export type { CatalogModel, CatalogProvider, ModelCatalogFilter } from './operations/agents.js';
 export { listConversations, readConversation } from './operations/conversations.js';
 
+// Calendar operations (Phase 3 task 6).
+export {
+  computeFreeSlots,
+  createCalendarEvent,
+  deleteCalendarEvent,
+  deleteCalendarTrigger,
+  getCalendarEvent,
+  inviteCalendarAttendees,
+  listCalendarEvents,
+  removeCalendarAttendee,
+  rsvpCalendarEvent,
+  setCalendarTrigger,
+  updateCalendarEvent,
+} from './operations/calendar.js';
+export type { FreeSlot } from './operations/calendar.js';
+
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.
 export type { HttpMethod } from './transport/types.js';

--- a/packages/sdk/src/operations/__tests__/calendar.test.ts
+++ b/packages/sdk/src/operations/__tests__/calendar.test.ts
@@ -1,0 +1,687 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { HttpError, ResponseValidationError } from '../../errors.js';
+import {
+  computeFreeSlots,
+  createCalendarEvent,
+  deleteCalendarEvent,
+  deleteCalendarTrigger,
+  getCalendarEvent,
+  inviteCalendarAttendees,
+  listCalendarEvents,
+  removeCalendarAttendee,
+  rsvpCalendarEvent,
+  setCalendarTrigger,
+  updateCalendarEvent,
+} from '../calendar.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Nested-user shape (id/name/image, no email) used inside event.attendees (route: `attendees.with.user.columns`). */
+const nestedUser = { id: 'u1abc', name: 'Ada', image: null };
+
+/** Shape verified against apps/web/src/app/api/calendar/events/[eventId]/route.ts GET (§2.10 get_calendar_event). */
+const eventFixture = {
+  id: 'ev1abc',
+  driveId: 'd1abc',
+  createdById: 'u1abc',
+  pageId: null,
+  title: 'Standup',
+  description: null,
+  location: null,
+  startAt: '2026-02-19T19:00:00.000Z',
+  endAt: '2026-02-19T19:30:00.000Z',
+  allDay: false,
+  timezone: 'America/Chicago',
+  recurrenceRule: null,
+  recurrenceExceptions: [],
+  recurringEventId: null,
+  originalStartAt: null,
+  visibility: 'DRIVE',
+  color: 'default',
+  metadata: null,
+  isTrashed: false,
+  trashedAt: null,
+  googleEventId: null,
+  googleCalendarId: null,
+  syncedFromGoogle: false,
+  googleSyncReadOnly: null,
+  lastGoogleSync: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  createdBy: nestedUser,
+  attendees: [
+    {
+      id: 'att1',
+      eventId: 'ev1abc',
+      userId: 'u1abc',
+      status: 'ACCEPTED',
+      responseNote: null,
+      isOrganizer: true,
+      isOptional: false,
+      invitedAt: '2026-01-01T00:00:00.000Z',
+      respondedAt: '2026-01-01T00:00:00.000Z',
+      user: nestedUser,
+    },
+  ],
+  page: null,
+  drive: { id: 'd1abc', name: 'Engineering', slug: 'engineering' },
+};
+
+describe('calendar.list — request shape', () => {
+  it('sends startDate/endDate as query params with no path params', () => {
+    const request = buildRequest(
+      listCalendarEvents,
+      { startDate: '2026-02-01T00:00:00Z', endDate: '2026-02-28T00:00:00Z' },
+      config,
+    );
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe(
+      'https://pagespace.ai/api/calendar/events?endDate=2026-02-28T00%3A00%3A00Z&startDate=2026-02-01T00%3A00%3A00Z',
+    );
+  });
+
+  it('sends context/driveId/includePersonal as additional query params', () => {
+    const request = buildRequest(
+      listCalendarEvents,
+      {
+        startDate: '2026-02-01',
+        endDate: '2026-02-28',
+        context: 'drive',
+        driveId: 'd1abc',
+        includePersonal: false,
+      },
+      config,
+    );
+    expect(request.url).toBe(
+      'https://pagespace.ai/api/calendar/events?context=drive&driveId=d1abc&endDate=2026-02-28&includePersonal=false&startDate=2026-02-01',
+    );
+  });
+});
+
+describe('calendar.list — input refinements', () => {
+  it('accepts date-only ISO strings', () => {
+    expect(listCalendarEvents.inputSchema.safeParse({ startDate: '2026-02-01', endDate: '2026-02-28' }).success).toBe(true);
+  });
+
+  it('accepts naive (no timezone indicator) ISO datetimes', () => {
+    const result = listCalendarEvents.inputSchema.safeParse({
+      startDate: '2026-02-01T09:00:00',
+      endDate: '2026-02-01T17:00:00',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a bare garbage startDate', () => {
+    const result = listCalendarEvents.inputSchema.safeParse({ startDate: 'not-a-date', endDate: '2026-02-28' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a calendrically invalid date (month 13)', () => {
+    const result = listCalendarEvents.inputSchema.safeParse({ startDate: '2026-13-01', endDate: '2026-02-28' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects natural-language input ("tomorrow")', () => {
+    const result = listCalendarEvents.inputSchema.safeParse({ startDate: 'tomorrow', endDate: '2026-02-28' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects context "drive" with no driveId (route 400: "driveId is required for drive context")', () => {
+    const result = listCalendarEvents.inputSchema.safeParse({
+      startDate: '2026-02-01',
+      endDate: '2026-02-28',
+      context: 'drive',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts context "user" with no driveId', () => {
+    const result = listCalendarEvents.inputSchema.safeParse({
+      startDate: '2026-02-01',
+      endDate: '2026-02-28',
+      context: 'user',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('calendar.list — response contract', () => {
+  it('parses { events, workflowEvents } (route truth, §2.10/D4 — never a bare array)', () => {
+    const fixture = {
+      events: [{ ...eventFixture, hasAgentTrigger: true }],
+      workflowEvents: [
+        {
+          id: 'workflow-run-r1',
+          title: 'Workflow: Nightly digest',
+          startAt: '2026-02-19T06:00:00.000Z',
+          endAt: '2026-02-19T06:05:00.000Z',
+          allDay: false,
+          source: 'workflow',
+          workflowId: 'wf1abc',
+          driveId: 'd1abc',
+          color: 'amber',
+          triggerType: 'cron',
+        },
+      ],
+    };
+    const result = parseResponse(listCalendarEvents, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+
+  it('parses an empty result set', () => {
+    const empty = { events: [], workflowEvents: [] };
+    const result = parseResponse(listCalendarEvents, 200, new Headers(), JSON.stringify(empty));
+    expect(result).toEqual(empty);
+  });
+
+  it('parses a recurring-event occurrence carrying recurringBaseStartAt/EndAt', () => {
+    const withRecurrence = {
+      events: [
+        {
+          ...eventFixture,
+          hasAgentTrigger: false,
+          recurrenceRule: { frequency: 'WEEKLY', interval: 1, byDay: ['MO', 'WE'] },
+          recurringBaseStartAt: '2026-01-05T19:00:00.000Z',
+          recurringBaseEndAt: '2026-01-05T19:30:00.000Z',
+        },
+      ],
+      workflowEvents: [],
+    };
+    const result = parseResponse(listCalendarEvents, 200, new Headers(), JSON.stringify(withRecurrence));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('rejects a bare array response (the D4 bug the old handler relied on)', () => {
+    const result = parseResponse(listCalendarEvents, 200, new Headers(), JSON.stringify([eventFixture]));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('parses an event missing the drive relation (drive-context list omits it)', () => {
+    const { drive: _drive, ...withoutDrive } = eventFixture;
+    const fixture = { events: [{ ...withoutDrive, hasAgentTrigger: false }], workflowEvents: [] };
+    const result = parseResponse(listCalendarEvents, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('calendar.get — request shape and response', () => {
+  it('interpolates :eventId with no query/body', () => {
+    const request = buildRequest(getCalendarEvent, { eventId: 'ev1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('parses the bare event object (route truth, §2.10 get_calendar_event)', () => {
+    const result = parseResponse(getCalendarEvent, 200, new Headers(), JSON.stringify(eventFixture));
+    expect(result).toEqual(eventFixture);
+  });
+
+  it('classifies a 404 as NotFoundError, not a schema mismatch', () => {
+    const result = parseResponse(getCalendarEvent, 404, new Headers(), JSON.stringify({ error: 'Event not found' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+
+  it('classifies a 403 as PermissionDeniedError (canAccessEvent fail-closed)', () => {
+    const result = parseResponse(getCalendarEvent, 403, new Headers(), JSON.stringify({ error: 'Access denied' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('calendar.create — request shape', () => {
+  it('sends the full field set as a JSON body with no path params', () => {
+    const request = buildRequest(
+      createCalendarEvent,
+      { title: 'Standup', startAt: '2026-02-19T19:00:00Z', endAt: '2026-02-19T19:30:00Z', driveId: 'd1abc' },
+      config,
+    );
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events');
+    const body = JSON.parse(request.body!);
+    expect(body).toEqual({
+      driveId: 'd1abc',
+      endAt: '2026-02-19T19:30:00Z',
+      startAt: '2026-02-19T19:00:00Z',
+      title: 'Standup',
+    });
+  });
+
+  it('uses attendeeIds, not userIds (D5 fix — the old handler field silently dropped invitees)', () => {
+    const request = buildRequest(
+      createCalendarEvent,
+      {
+        title: 'Standup',
+        startAt: '2026-02-19T19:00:00Z',
+        endAt: '2026-02-19T19:30:00Z',
+        attendeeIds: ['u2abc', 'u3abc'],
+      },
+      config,
+    );
+    const body = JSON.parse(request.body!);
+    expect(body.attendeeIds).toEqual(['u2abc', 'u3abc']);
+    expect(body.userIds).toBeUndefined();
+  });
+
+  it('serializes a nested recurrenceRule without dropping fields', () => {
+    const request = buildRequest(
+      createCalendarEvent,
+      {
+        title: 'Sprint planning',
+        startAt: '2026-02-19T19:00:00Z',
+        endAt: '2026-02-19T19:30:00Z',
+        recurrenceRule: { frequency: 'WEEKLY', interval: 2, byDay: ['MO'] },
+      },
+      config,
+    );
+    const body = JSON.parse(request.body!);
+    expect(body.recurrenceRule).toEqual({ frequency: 'WEEKLY', interval: 2, byDay: ['MO'] });
+  });
+});
+
+describe('calendar.create — input refinements', () => {
+  it('accepts a minimal valid event', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing title', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a bare-garbage startAt', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: 'whenever',
+      endAt: '2026-02-19T19:30:00Z',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an agentTrigger with no driveId (route 400: "Agent triggers require a drive event")', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Summarize' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an agentTrigger paired with a driveId', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+      driveId: 'd1abc',
+      agentTrigger: { agentPageId: 'ag1', prompt: 'Summarize' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an agentTrigger with neither prompt nor instructionPageId', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+      driveId: 'd1abc',
+      agentTrigger: { agentPageId: 'ag1' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects recurrenceRule.byMonthDay values outside 1-31', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+      recurrenceRule: { frequency: 'MONTHLY', interval: 1, byMonthDay: [32] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown visibility value', () => {
+    const result = createCalendarEvent.inputSchema.safeParse({
+      title: 'Standup',
+      startAt: '2026-02-19T19:00:00Z',
+      endAt: '2026-02-19T19:30:00Z',
+      visibility: 'PUBLIC',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('calendar.create — response contract', () => {
+  it('parses the created event (201, route truth §2.10 create_calendar_event)', () => {
+    const result = parseResponse(createCalendarEvent, 201, new Headers(), JSON.stringify(eventFixture));
+    expect(result).toEqual(eventFixture);
+  });
+
+  it('classifies a 400 (end before start) as ValidationError', () => {
+    const result = parseResponse(createCalendarEvent, 400, new Headers(), JSON.stringify({ error: 'End date must be after start date' }));
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('calendar.update — request shape', () => {
+  it('interpolates :eventId and sends only the changed fields', () => {
+    const request = buildRequest(updateCalendarEvent, { eventId: 'ev1abc', title: 'Renamed standup' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc');
+    expect(request.body).toBe(JSON.stringify({ title: 'Renamed standup' }));
+  });
+
+  it('forwards an explicit-null agentTrigger to clear it (3-state field, not a default)', () => {
+    const request = buildRequest(updateCalendarEvent, { eventId: 'ev1abc', agentTrigger: null }, config);
+    const body = JSON.parse(request.body!);
+    expect(body).toEqual({ agentTrigger: null });
+  });
+});
+
+describe('calendar.update — input refinements', () => {
+  it('accepts a partial update with no required fields beyond eventId', () => {
+    expect(updateCalendarEvent.inputSchema.safeParse({ eventId: 'ev1abc' }).success).toBe(true);
+  });
+
+  it('rejects a bare-garbage endAt', () => {
+    const result = updateCalendarEvent.inputSchema.safeParse({ eventId: 'ev1abc', endAt: 'soon' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a null agentTrigger (clears the trigger)', () => {
+    const result = updateCalendarEvent.inputSchema.safeParse({ eventId: 'ev1abc', agentTrigger: null });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an agentTrigger object with neither prompt nor instructionPageId', () => {
+    const result = updateCalendarEvent.inputSchema.safeParse({
+      eventId: 'ev1abc',
+      agentTrigger: { agentPageId: 'ag1' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('calendar.update — response contract', () => {
+  it('parses the updated event', () => {
+    const result = parseResponse(updateCalendarEvent, 200, new Headers(), JSON.stringify(eventFixture));
+    expect(result).toEqual(eventFixture);
+  });
+
+  it('classifies a 403 (not creator/admin) as PermissionDeniedError', () => {
+    const result = parseResponse(updateCalendarEvent, 403, new Headers(), JSON.stringify({ error: 'You do not have permission to edit this event' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('calendar.delete — request shape and response', () => {
+  it('DELETEs the event route with no body', () => {
+    const request = buildRequest(deleteCalendarEvent, { eventId: 'ev1abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteCalendarEvent, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('calendar.rsvp — request shape, refinements, response', () => {
+  it('interpolates :eventId and sends status as body', () => {
+    const request = buildRequest(rsvpCalendarEvent, { eventId: 'ev1abc', status: 'ACCEPTED' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc/attendees');
+    expect(request.body).toBe(JSON.stringify({ status: 'ACCEPTED' }));
+  });
+
+  it('accepts the full route enum including PENDING (old tool only exposed ACCEPTED/DECLINED/TENTATIVE)', () => {
+    const result = rsvpCalendarEvent.inputSchema.safeParse({ eventId: 'ev1abc', status: 'PENDING' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an unknown status', () => {
+    const result = rsvpCalendarEvent.inputSchema.safeParse({ eventId: 'ev1abc', status: 'MAYBE' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a responseNote over 500 chars', () => {
+    const result = rsvpCalendarEvent.inputSchema.safeParse({
+      eventId: 'ev1abc',
+      status: 'ACCEPTED',
+      responseNote: 'x'.repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses the bare updated attendee row (no nested user — route .returning())', () => {
+    const attendeeRow = {
+      id: 'att1',
+      eventId: 'ev1abc',
+      userId: 'u1abc',
+      status: 'ACCEPTED',
+      responseNote: null,
+      isOrganizer: false,
+      isOptional: false,
+      invitedAt: '2026-01-01T00:00:00.000Z',
+      respondedAt: '2026-01-02T00:00:00.000Z',
+    };
+    const result = parseResponse(rsvpCalendarEvent, 200, new Headers(), JSON.stringify(attendeeRow));
+    expect(result).toEqual(attendeeRow);
+  });
+});
+
+describe('calendar.inviteAttendees — request shape, refinements, response', () => {
+  it('interpolates :eventId and sends userIds/isOptional as body', () => {
+    const request = buildRequest(
+      inviteCalendarAttendees,
+      { eventId: 'ev1abc', userIds: ['u2abc', 'u3abc'], isOptional: true },
+      config,
+    );
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc/attendees');
+    expect(JSON.parse(request.body!)).toEqual({ isOptional: true, userIds: ['u2abc', 'u3abc'] });
+  });
+
+  it('rejects an empty userIds array', () => {
+    const result = inviteCalendarAttendees.inputSchema.safeParse({ eventId: 'ev1abc', userIds: [] });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses { attendees } with the email-bearing user shape (route truth, attendees endpoint)', () => {
+    const fixture = {
+      attendees: [
+        {
+          id: 'att2',
+          eventId: 'ev1abc',
+          userId: 'u2abc',
+          status: 'PENDING',
+          responseNote: null,
+          isOrganizer: false,
+          isOptional: true,
+          invitedAt: '2026-01-01T00:00:00.000Z',
+          respondedAt: null,
+          user: { id: 'u2abc', name: 'Bo', email: 'bo@example.com', image: null },
+        },
+      ],
+    };
+    const result = parseResponse(inviteCalendarAttendees, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+
+  it('parses the "all users already attendees" short-circuit shape ({ message })', () => {
+    const fixture = { message: 'All users are already attendees' };
+    const result = parseResponse(inviteCalendarAttendees, 200, new Headers(), JSON.stringify(fixture));
+    expect(result).toEqual(fixture);
+  });
+});
+
+describe('calendar.removeAttendee — request shape (D6 fix) and response', () => {
+  it('sends userId as a query param on DELETE, never a JSON body', () => {
+    const request = buildRequest(removeCalendarAttendee, { eventId: 'ev1abc', userId: 'u2abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc/attendees?userId=u2abc');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('URL-encodes a userId containing reserved characters', () => {
+    const request = buildRequest(removeCalendarAttendee, { eventId: 'ev1abc', userId: 'u2/abc' }, config);
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc/attendees?userId=u2%2Fabc');
+  });
+
+  it('parses { success: true }', () => {
+    const result = parseResponse(removeCalendarAttendee, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+
+  it('classifies a 400 (organizer removal blocked) as ValidationError', () => {
+    const result = parseResponse(removeCalendarAttendee, 400, new Headers(), JSON.stringify({ error: 'Cannot remove the event organizer' }));
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('calendar.setTrigger — request shape, refinements, response', () => {
+  it('interpolates :eventId and sends trigger fields as body', () => {
+    const request = buildRequest(
+      setCalendarTrigger,
+      { eventId: 'ev1abc', agentPageId: 'ag1', prompt: 'Summarize the meeting' },
+      config,
+    );
+    expect(request.method).toBe('PUT');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc/triggers');
+    expect(JSON.parse(request.body!)).toEqual({ agentPageId: 'ag1', prompt: 'Summarize the meeting' });
+  });
+
+  it('rejects a trigger with neither prompt nor instructionPageId (route .strict().refine())', () => {
+    const result = setCalendarTrigger.inputSchema.safeParse({ eventId: 'ev1abc', agentPageId: 'ag1' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a trigger with only instructionPageId', () => {
+    const result = setCalendarTrigger.inputSchema.safeParse({
+      eventId: 'ev1abc',
+      agentPageId: 'ag1',
+      instructionPageId: 'instr1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects contextPageIds beyond the 10-item cap', () => {
+    const result = setCalendarTrigger.inputSchema.safeParse({
+      eventId: 'ev1abc',
+      agentPageId: 'ag1',
+      prompt: 'Summarize',
+      contextPageIds: Array.from({ length: 11 }, (_, i) => `p${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('parses { success: true }', () => {
+    const result = parseResponse(setCalendarTrigger, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+
+  it('classifies a 400 (personal event, "Agent triggers require a drive event") as ValidationError', () => {
+    const result = parseResponse(setCalendarTrigger, 400, new Headers(), JSON.stringify({ error: 'Agent triggers require a drive event' }));
+    expect((result as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('calendar.deleteTrigger — request shape and response', () => {
+  it('interpolates :eventId with no body', () => {
+    const request = buildRequest(deleteCalendarTrigger, { eventId: 'ev1abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/calendar/events/ev1abc/triggers');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('parses { success: true } (idempotent — succeeds even with no existing trigger)', () => {
+    const result = parseResponse(deleteCalendarTrigger, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('computeFreeSlots — pure availability computation (check_calendar_availability, D4 resolution)', () => {
+  it('returns the whole range as free when there are no events', () => {
+    const slots = computeFreeSlots([], { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T10:00:00.000Z' });
+    expect(slots).toEqual([{ startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T10:00:00.000Z' }]);
+  });
+
+  it('computes the gap before, between, and after two events', () => {
+    const slots = computeFreeSlots(
+      [
+        { startAt: '2026-02-01T02:00:00.000Z', endAt: '2026-02-01T03:00:00.000Z' },
+        { startAt: '2026-02-01T05:00:00.000Z', endAt: '2026-02-01T06:00:00.000Z' },
+      ],
+      { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T10:00:00.000Z' },
+    );
+    expect(slots).toEqual([
+      { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T02:00:00.000Z' },
+      { startAt: '2026-02-01T03:00:00.000Z', endAt: '2026-02-01T05:00:00.000Z' },
+      { startAt: '2026-02-01T06:00:00.000Z', endAt: '2026-02-01T10:00:00.000Z' },
+    ]);
+  });
+
+  it('returns no slots when a single event spans the entire range', () => {
+    const slots = computeFreeSlots(
+      [{ startAt: '2026-01-31T00:00:00.000Z', endAt: '2026-02-02T00:00:00.000Z' }],
+      { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T10:00:00.000Z' },
+    );
+    expect(slots).toEqual([]);
+  });
+
+  it('merges overlapping events into a single busy block (mirrors the old handler\'s running-current-pointer algorithm)', () => {
+    const slots = computeFreeSlots(
+      [
+        { startAt: '2026-02-01T01:00:00.000Z', endAt: '2026-02-01T04:00:00.000Z' },
+        { startAt: '2026-02-01T02:00:00.000Z', endAt: '2026-02-01T03:00:00.000Z' },
+      ],
+      { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T05:00:00.000Z' },
+    );
+    expect(slots).toEqual([
+      { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T01:00:00.000Z' },
+      { startAt: '2026-02-01T04:00:00.000Z', endAt: '2026-02-01T05:00:00.000Z' },
+    ]);
+  });
+
+  it('is order-independent — unsorted input events produce the same result as sorted input', () => {
+    const events = [
+      { startAt: '2026-02-01T05:00:00.000Z', endAt: '2026-02-01T06:00:00.000Z' },
+      { startAt: '2026-02-01T02:00:00.000Z', endAt: '2026-02-01T03:00:00.000Z' },
+    ];
+    const range = { startAt: '2026-02-01T00:00:00.000Z', endAt: '2026-02-01T10:00:00.000Z' };
+    expect(computeFreeSlots(events, range)).toEqual(computeFreeSlots([...events].reverse(), range));
+  });
+});
+
+describe('calendar operations — metadata', () => {
+  it('every operation is named, described, and MCP/CLI derivable', () => {
+    const ops = [
+      listCalendarEvents,
+      getCalendarEvent,
+      createCalendarEvent,
+      updateCalendarEvent,
+      deleteCalendarEvent,
+      rsvpCalendarEvent,
+      inviteCalendarAttendees,
+      removeCalendarAttendee,
+      setCalendarTrigger,
+      deleteCalendarTrigger,
+    ];
+    for (const op of ops) {
+      expect(op.name.startsWith('calendar.')).toBe(true);
+      expect(op.description.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/sdk/src/operations/calendar.ts
+++ b/packages/sdk/src/operations/calendar.ts
@@ -1,0 +1,509 @@
+/**
+ * Calendar operations (Phase 3 task 6): 11 old MCP tools — `list_calendar_events`,
+ * `get_calendar_event`, `create_calendar_event`, `update_calendar_event`,
+ * `delete_calendar_event`, `check_calendar_availability`, `rsvp_calendar_event`,
+ * `invite_calendar_attendees`, `remove_calendar_attendee`, `set_calendar_trigger`,
+ * `delete_calendar_trigger` (old handler `calendar.js` + `trigger.js`).
+ *
+ * Route-verified against `apps/web/src/app/api/calendar/events/route.ts`,
+ * `.../events/[eventId]/route.ts`, `.../events/[eventId]/attendees/route.ts`,
+ * `.../events/[eventId]/triggers/route.ts` (docs/sdk/operations-inventory.md
+ * §2.10, D4/D5/D6).
+ *
+ * `requiredScope` is intentionally omitted on every operation here. Unlike
+ * tasks/pages (always attached to a page, always in a drive), a calendar
+ * event may be personal (`driveId: null`) or drive-scoped, and which one
+ * applies is runtime data the caller doesn't know until the event is
+ * fetched — there is no static drive relationship to pre-flight (ADR 0002's
+ * `RequiredScope` models a per-operation constant, not a per-call value).
+ * A scoped MCP/OAuth token still can't touch a personal event: `canAccessEvent`/
+ * `canEditEvent`/`canManageEventTrigger` (route source) all fail closed via
+ * `isScopedMCPAuth` when `event.driveId` is null — that check just can't be
+ * expressed as a static registry tag.
+ *
+ * D4: `list_calendar_events` / `check_calendar_availability` both hit
+ * GET /api/calendar/events, which returns `{events, workflowEvents}` — the
+ * old handler iterated the response as a bare array and threw on every
+ * non-empty result. Resolution here: `listCalendarEvents`'s output schema is
+ * `{events, workflowEvents}`, and `check_calendar_availability` is not a
+ * registry operation at all — it's the pure `computeFreeSlots(events, range)`
+ * below, run over `listCalendarEvents`'s output (testable with plain inputs,
+ * no network mock needed).
+ *
+ * D5: `create_calendar_event`'s input field is `attendeeIds` (route truth),
+ * not the old handler's `userIds` — a `userIds` field would be silently
+ * stripped by the route's zod schema and invitees would never be added.
+ *
+ * D6: `remove_calendar_attendee`'s DELETE route reads the target user
+ * exclusively from the `?userId=` query string and ignores the JSON body,
+ * defaulting to the *caller* when the param is absent — the old handler sent
+ * a JSON body and so silently removed the caller instead of the target. This
+ * operation's `path` template embeds `:userId` after a literal `?userId=`
+ * so `buildRequest`'s generic `:param` interpolation (which matches `:name`
+ * tokens anywhere in the path string, not just before `/`) puts it on the
+ * URL for a DELETE request — `buildRequest` only ever query-serializes GET
+ * input, so this is the one way to land a field in the query string of a
+ * non-GET operation without changing the shared transport code.
+ *
+ * Timezone contract (documented, not assumed — read `apps/web/src/lib/ai/core/
+ * timestamp-utils.ts`): `startAt`/`startDate`/`endAt`/`endDate` accept a
+ * strict ISO 8601 date or datetime string. A *naive* datetime (no `Z`/offset,
+ * e.g. `"2026-02-19T19:00:00"`) is interpreted server-side in the request's
+ * own `timezone` field (`isNaiveISODatetime` + `parseNaiveDatetimeInTimezone`)
+ * — NOT UTC. A datetime carrying `Z` or an explicit offset is an absolute
+ * instant and `timezone` has no effect on it. `startDate`/`endDate` on
+ * `calendar.list` go through plain `z.coerce.date()` server-side (no naive
+ * reinterpretation) since listing has no single owning timezone.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+// ---------------------------------------------------------------------------
+// Shared primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * Strict ISO 8601 date/datetime refinement. Accepts date-only
+ * (`"2026-02-19"`), naive datetime (`"2026-02-19T19:00:00"`, `"...T19:00"`,
+ * `"...T19:00:00.123"`), and datetime with `Z` or a numeric offset
+ * (`"2026-02-19T19:00:00Z"`, `"...+05:00"`). Rejects natural language,
+ * slash-delimited dates, and any string `Date` cannot parse (e.g. month 13)
+ * — client-side fail-fast for garbage the route's `z.coerce.date()` would
+ * also reject, never narrower than what the server actually accepts.
+ */
+const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
+const isoDatetimeSchema = z.string().refine(
+  (value) => ISO_8601_PATTERN.test(value) && !Number.isNaN(new Date(value).getTime()),
+  {
+    message:
+      'Must be a strict ISO 8601 date or datetime string (e.g. "2026-02-19", "2026-02-19T19:00:00", or "2026-02-19T19:00:00Z")',
+  },
+);
+
+const eventVisibilityEnum = z.enum(['DRIVE', 'ATTENDEES_ONLY', 'PRIVATE']);
+const attendeeStatusEnum = z.enum(['PENDING', 'ACCEPTED', 'DECLINED', 'TENTATIVE']);
+const recurrenceFrequencyEnum = z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY']);
+const weekdayEnum = z.enum(['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']);
+
+/** Input shape for create/update, bounds matched to the route's own clamps. */
+const recurrenceRuleInputSchema = z.object({
+  frequency: recurrenceFrequencyEnum,
+  interval: z.number().int().min(1).optional(),
+  byDay: z.array(weekdayEnum).optional(),
+  byMonthDay: z.array(z.number().int().min(1).max(31)).optional(),
+  byMonth: z.array(z.number().int().min(1).max(12)).optional(),
+  count: z.number().int().min(1).optional(),
+  until: z.string().optional(),
+});
+
+/** Output shape — faithful to stored data, no re-imposed input bounds. */
+const recurrenceRuleOutputSchema = z.object({
+  frequency: recurrenceFrequencyEnum,
+  interval: z.number(),
+  byDay: z.array(weekdayEnum).optional(),
+  byMonthDay: z.array(z.number()).optional(),
+  byMonth: z.array(z.number()).optional(),
+  count: z.number().optional(),
+  until: z.string().optional(),
+});
+
+/** `{id,name,image}` — createdBy on events, and the nested user on event.attendees. */
+const userRefSchema = z.object({ id: z.string(), name: z.string().nullable(), image: z.string().nullable() }).nullable();
+
+/** `{id,name,email,image}` — the nested user shape returned only by the attendees endpoints. */
+const userWithEmailRefSchema = z
+  .object({ id: z.string(), name: z.string().nullable(), email: z.string().nullable(), image: z.string().nullable() })
+  .nullable();
+
+const pageRefSchema = z.object({ id: z.string(), title: z.string().nullable(), type: z.string() }).nullable();
+const driveRefSchema = z.object({ id: z.string(), name: z.string(), slug: z.string() }).nullable();
+
+/** Raw `eventAttendees` row (`packages/db/src/schema/calendar.ts`). */
+const attendeeBaseSchema = z.object({
+  id: z.string(),
+  eventId: z.string(),
+  userId: z.string(),
+  status: attendeeStatusEnum,
+  responseNote: z.string().nullable(),
+  isOrganizer: z.boolean(),
+  isOptional: z.boolean(),
+  invitedAt: z.string(),
+  respondedAt: z.string().nullable(),
+});
+
+/** Attendee as nested under `event.attendees` (no email — `attendees.with.user.columns`). */
+const eventNestedAttendeeSchema = attendeeBaseSchema.extend({ user: userRefSchema });
+
+/** Attendee as returned bare by the attendees endpoints (`GET`/`POST .../attendees`, includes email). */
+const attendeeWithEmailSchema = attendeeBaseSchema.extend({ user: userWithEmailRefSchema });
+
+/**
+ * Full `calendarEvents` row + relations, matching the shape returned by
+ * GET single event / create / update. `drive` is present only on GET single
+ * event and `calendar.list`'s user-context branch (absent on create/update/
+ * drive-context list) — modeled as optional so both cases parse.
+ */
+const calendarEventSchema = z.object({
+  id: z.string(),
+  driveId: z.string().nullable(),
+  createdById: z.string(),
+  pageId: z.string().nullable(),
+  title: z.string(),
+  description: z.string().nullable(),
+  location: z.string().nullable(),
+  startAt: z.string(),
+  endAt: z.string(),
+  allDay: z.boolean(),
+  timezone: z.string(),
+  recurrenceRule: recurrenceRuleOutputSchema.nullable(),
+  recurrenceExceptions: z.array(z.string()).nullable(),
+  recurringEventId: z.string().nullable(),
+  originalStartAt: z.string().nullable(),
+  visibility: eventVisibilityEnum,
+  color: z.string().nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  isTrashed: z.boolean(),
+  trashedAt: z.string().nullable(),
+  googleEventId: z.string().nullable(),
+  googleCalendarId: z.string().nullable(),
+  syncedFromGoogle: z.boolean(),
+  googleSyncReadOnly: z.boolean().nullable(),
+  lastGoogleSync: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  createdBy: userRefSchema,
+  attendees: z.array(eventNestedAttendeeSchema),
+  page: pageRefSchema,
+  drive: driveRefSchema.optional(),
+});
+
+/**
+ * List-only event shape: `hasAgentTrigger` is annotated by the route for
+ * every event; `recurringBaseStartAt`/`recurringBaseEndAt` are added only to
+ * expanded recurrence occurrences (`expandRecurringEvents`,
+ * `apps/web/src/lib/workflows/recurrence-utils.ts`), absent on non-recurring
+ * events and on `calendar.get`/create/update responses.
+ */
+const calendarListEventSchema = calendarEventSchema.extend({
+  hasAgentTrigger: z.boolean(),
+  recurringBaseStartAt: z.string().optional(),
+  recurringBaseEndAt: z.string().optional(),
+});
+
+/** Virtual (non-persisted) workflow-schedule entries appended to the list response. */
+const workflowEventSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  startAt: z.string(),
+  endAt: z.string(),
+  allDay: z.boolean(),
+  source: z.literal('workflow'),
+  workflowId: z.string(),
+  driveId: z.string(),
+  color: z.string(),
+  triggerType: z.string().optional(),
+});
+
+/** `agentTrigger` shared shape (create/setTrigger): requires prompt or instructionPageId. */
+const agentTriggerInputSchema = z
+  .object({
+    agentPageId: z.string().min(1),
+    prompt: z.string().trim().max(10000).optional(),
+    instructionPageId: z.string().nullable().optional(),
+    contextPageIds: z.array(z.string()).max(10).optional(),
+  })
+  .refine((v) => Boolean(v.prompt) || Boolean(v.instructionPageId), {
+    message: 'agentTrigger needs either a prompt or an instructionPageId',
+    path: ['prompt'],
+  });
+
+const successSchema = z.object({ success: z.literal(true) });
+
+// ---------------------------------------------------------------------------
+// calendar.list — GET /api/calendar/events (list_calendar_events)
+// ---------------------------------------------------------------------------
+
+export const listCalendarEvents = defineOperation({
+  name: 'calendar.list',
+  method: 'GET',
+  path: '/api/calendar/events',
+  inputSchema: z
+    .object({
+      context: z.enum(['user', 'drive']).optional(),
+      driveId: z.string().optional(),
+      startDate: isoDatetimeSchema,
+      endDate: isoDatetimeSchema,
+      /**
+       * Route truth (`calendar/events/route.ts:30`): coerced server-side via
+       * `z.coerce.boolean()`, which is `Boolean(str)` — ANY non-empty string,
+       * including the literal `"false"`, coerces to `true`. There is
+       * currently no way to exclude personal events from a `context: 'user'`
+       * list through this endpoint; passing `includePersonal: false` has no
+       * effect server-side. Kept faithful to the route's declared input
+       * rather than silently dropped, but documented so callers aren't
+       * surprised.
+       */
+      includePersonal: z.boolean().optional(),
+    })
+    .refine((v) => v.context !== 'drive' || Boolean(v.driveId), {
+      message: 'driveId is required for drive context',
+      path: ['driveId'],
+    }),
+  outputSchema: z.object({
+    events: z.array(calendarListEventSchema),
+    workflowEvents: z.array(workflowEventSchema),
+  }),
+  description:
+    'List calendar events in a date range. Returns {events, workflowEvents} — never a bare array. Use context "drive" with driveId to scope to one drive, or "user" (default) to aggregate personal + attending + accessible-drive events.',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.get — GET /api/calendar/events/:eventId (get_calendar_event)
+// ---------------------------------------------------------------------------
+
+export const getCalendarEvent = defineOperation({
+  name: 'calendar.get',
+  method: 'GET',
+  path: '/api/calendar/events/:eventId',
+  inputSchema: z.object({ eventId: z.string() }),
+  outputSchema: calendarEventSchema,
+  description: 'Get a single calendar event by id. Fails closed with 404/403 per canAccessEvent visibility rules.',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.create — POST /api/calendar/events (create_calendar_event)
+// ---------------------------------------------------------------------------
+
+export const createCalendarEvent = defineOperation({
+  name: 'calendar.create',
+  method: 'POST',
+  path: '/api/calendar/events',
+  inputSchema: z
+    .object({
+      driveId: z.string().nullable().optional(),
+      pageId: z.string().nullable().optional(),
+      title: z.string().min(1).max(500),
+      description: z.string().max(10000).nullable().optional(),
+      location: z.string().max(1000).nullable().optional(),
+      startAt: isoDatetimeSchema,
+      endAt: isoDatetimeSchema,
+      allDay: z.boolean().optional(),
+      timezone: z.string().optional(),
+      recurrenceRule: recurrenceRuleInputSchema.nullable().optional(),
+      visibility: eventVisibilityEnum.optional(),
+      color: z.string().optional(),
+      /** D5: the route field is `attendeeIds`, not the old handler's `userIds`. */
+      attendeeIds: z.array(z.string()).optional(),
+      agentTrigger: agentTriggerInputSchema.optional(),
+    })
+    .refine((v) => !v.agentTrigger || Boolean(v.driveId), {
+      message: 'Agent triggers require a drive event',
+      path: ['agentTrigger'],
+    }),
+  outputSchema: calendarEventSchema,
+  description:
+    'Create a calendar event. Pass driveId for a drive event or omit it for a personal event (agentTrigger requires a driveId). attendeeIds invites drive members; the creator is always added as organizer.',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.update — PATCH /api/calendar/events/:eventId (update_calendar_event)
+// ---------------------------------------------------------------------------
+
+export const updateCalendarEvent = defineOperation({
+  name: 'calendar.update',
+  method: 'PATCH',
+  path: '/api/calendar/events/:eventId',
+  inputSchema: z.object({
+    eventId: z.string(),
+    title: z.string().min(1).max(500).optional(),
+    description: z.string().max(10000).nullable().optional(),
+    location: z.string().max(1000).nullable().optional(),
+    startAt: isoDatetimeSchema.optional(),
+    endAt: isoDatetimeSchema.optional(),
+    allDay: z.boolean().optional(),
+    timezone: z.string().optional(),
+    recurrenceRule: recurrenceRuleInputSchema.nullable().optional(),
+    visibility: eventVisibilityEnum.optional(),
+    color: z.string().optional(),
+    pageId: z.string().nullable().optional(),
+    /**
+     * Three-state field, not a default: `undefined` leaves any existing
+     * trigger alone, `null` removes it, an object upserts it. The route
+     * requires the event to already have a driveId for the object case, but
+     * that isn't visible from this input alone (unlike create), so it's not
+     * refined client-side — mirrors `tasks.update`'s precedent of not
+     * failing closed on server-only state.
+     */
+    agentTrigger: agentTriggerInputSchema.nullable().optional(),
+  }),
+  outputSchema: calendarEventSchema,
+  description:
+    'Update a calendar event\'s fields. agentTrigger is three-state: omit to leave it alone, null to remove it, or an object to upsert it (requires the event already have a drive).',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.delete — DELETE /api/calendar/events/:eventId (delete_calendar_event)
+// ---------------------------------------------------------------------------
+
+export const deleteCalendarEvent = defineOperation({
+  name: 'calendar.delete',
+  method: 'DELETE',
+  path: '/api/calendar/events/:eventId',
+  inputSchema: z.object({ eventId: z.string() }),
+  outputSchema: z.object({ success: z.boolean() }),
+  description: 'Soft-delete (trash) a calendar event. Only the creator or a drive owner/admin may delete it.',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.rsvp — PATCH /api/calendar/events/:eventId/attendees (rsvp_calendar_event)
+// ---------------------------------------------------------------------------
+
+export const rsvpCalendarEvent = defineOperation({
+  name: 'calendar.rsvp',
+  method: 'PATCH',
+  path: '/api/calendar/events/:eventId/attendees',
+  inputSchema: z.object({
+    eventId: z.string(),
+    /** Full route enum (the old tool only exposed ACCEPTED/DECLINED/TENTATIVE) — PENDING is a legal RSVP too. */
+    status: attendeeStatusEnum,
+    responseNote: z.string().max(500).nullable().optional(),
+  }),
+  outputSchema: attendeeBaseSchema,
+  description:
+    "Update the caller's own RSVP status for an event. Returns the bare updated attendee row (no nested user). The caller must already be an attendee.",
+});
+
+// ---------------------------------------------------------------------------
+// calendar.inviteAttendees — POST /api/calendar/events/:eventId/attendees (invite_calendar_attendees)
+// ---------------------------------------------------------------------------
+
+export const inviteCalendarAttendees = defineOperation({
+  name: 'calendar.inviteAttendees',
+  method: 'POST',
+  path: '/api/calendar/events/:eventId/attendees',
+  inputSchema: z.object({
+    eventId: z.string(),
+    userIds: z.array(z.string()).min(1),
+    isOptional: z.boolean().optional(),
+  }),
+  /**
+   * The route has two 200 shapes: `{attendees}` normally, or `{message}`
+   * when every requested user is already an attendee (route source:
+   * `attendees/route.ts:244-249`). Modeled as a union so both parse.
+   */
+  outputSchema: z.union([z.object({ attendees: z.array(attendeeWithEmailSchema) }), z.object({ message: z.string() })]),
+  description:
+    'Invite users to a drive event (only the creator may add attendees; all invitees must already be drive members). Personal (driveless) and PRIVATE events reject additional attendees.',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.removeAttendee — DELETE /api/calendar/events/:eventId/attendees?userId= (remove_calendar_attendee)
+// ---------------------------------------------------------------------------
+
+export const removeCalendarAttendee = defineOperation({
+  name: 'calendar.removeAttendee',
+  method: 'DELETE',
+  /**
+   * D6: the route reads the target exclusively from the `?userId=` query
+   * param (defaulting to the *caller* when absent) and ignores any JSON
+   * body. Embedding `:userId` in the path template after a literal
+   * `?userId=` makes `buildRequest`'s path interpolation put it on the URL
+   * for this DELETE request — the only way to land a field in the query
+   * string of a non-GET operation without touching the shared transport.
+   */
+  path: '/api/calendar/events/:eventId/attendees?userId=:userId',
+  inputSchema: z.object({ eventId: z.string(), userId: z.string() }),
+  outputSchema: successSchema,
+  description:
+    "Remove an attendee from an event. The event creator can remove anyone; any attendee can remove themselves. Cannot remove the organizer. userId travels as a query param, never a body field (D6 fix — the route ignores the body).",
+});
+
+// ---------------------------------------------------------------------------
+// calendar.setTrigger — PUT /api/calendar/events/:eventId/triggers (set_calendar_trigger)
+// ---------------------------------------------------------------------------
+
+export const setCalendarTrigger = defineOperation({
+  name: 'calendar.setTrigger',
+  method: 'PUT',
+  path: '/api/calendar/events/:eventId/triggers',
+  inputSchema: z
+    .object({
+      eventId: z.string(),
+      agentPageId: z.string().min(1),
+      prompt: z.string().trim().max(10000).optional(),
+      instructionPageId: z.string().nullable().optional(),
+      contextPageIds: z.array(z.string()).max(10).optional(),
+    })
+    .strict()
+    .refine((v) => Boolean(v.prompt) || Boolean(v.instructionPageId), {
+      message: 'Either prompt or instructionPageId is required',
+      path: ['prompt'],
+    }),
+  outputSchema: successSchema,
+  description:
+    'Set (upsert) the single agent trigger for a calendar event — fires at the event start time. Requires a drive event (personal events reject with 400); only the creator or a drive owner/admin may set it.',
+});
+
+// ---------------------------------------------------------------------------
+// calendar.deleteTrigger — DELETE /api/calendar/events/:eventId/triggers (delete_calendar_trigger)
+// ---------------------------------------------------------------------------
+
+export const deleteCalendarTrigger = defineOperation({
+  name: 'calendar.deleteTrigger',
+  method: 'DELETE',
+  path: '/api/calendar/events/:eventId/triggers',
+  inputSchema: z.object({ eventId: z.string() }),
+  outputSchema: successSchema,
+  description: "Remove the agent trigger from a calendar event. Idempotent — succeeds even if no trigger exists.",
+});
+
+// ---------------------------------------------------------------------------
+// computeFreeSlots — pure availability computation (check_calendar_availability, D4)
+// ---------------------------------------------------------------------------
+
+export interface FreeSlot {
+  readonly startAt: string;
+  readonly endAt: string;
+}
+
+interface TimedEvent {
+  readonly startAt: string;
+  readonly endAt: string;
+}
+
+/**
+ * `check_calendar_availability` hits the same route as `calendar.list` and
+ * computed free/busy gaps client-side (old handler `calendar.js:118-139`).
+ * Rather than a second network operation, this models that computation as a
+ * pure function over `listCalendarEvents`'s `events` array: sort by start,
+ * walk a running "busy until" pointer, and record the gaps before, between,
+ * and after events within `range`. Overlapping/adjacent events merge into
+ * one busy block. No working-hours windowing, no recurrence expansion beyond
+ * what `calendar.list` already returned (matches the old handler's
+ * documented limitations).
+ */
+export function computeFreeSlots(events: readonly TimedEvent[], range: { startAt: string; endAt: string }): FreeSlot[] {
+  const rangeStart = new Date(range.startAt);
+  const rangeEnd = new Date(range.endAt);
+
+  const sorted = [...events].sort((a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime());
+
+  const freeSlots: FreeSlot[] = [];
+  let current = rangeStart;
+
+  for (const event of sorted) {
+    const eventStart = new Date(event.startAt);
+    if (eventStart > current) {
+      freeSlots.push({ startAt: current.toISOString(), endAt: eventStart.toISOString() });
+    }
+    const eventEnd = new Date(event.endAt);
+    if (eventEnd > current) current = eventEnd;
+  }
+
+  if (current < rangeEnd) {
+    freeSlots.push({ startAt: current.toISOString(), endAt: rangeEnd.toISOString() });
+  }
+
+  return freeSlots;
+}


### PR DESCRIPTION
## Summary

Phase 3 task 6 of the [PageSpace SDK, CLI & OAuth Provider epic](https://app.pagespace.ai) — implements all 11 calendar tools as typed SDK operations, route-verified against `apps/web/src/app/api/calendar/events/**` (`docs/sdk/operations-inventory.md` §2.10).

- **CRUD**: `calendar.list`, `calendar.get`, `calendar.create`, `calendar.update`, `calendar.delete`
- **Attendees**: `calendar.rsvp`, `calendar.inviteAttendees`, `calendar.removeAttendee`
- **Triggers**: `calendar.setTrigger`, `calendar.deleteTrigger` (mirrors the task-trigger pattern from Phase 3 task 4)
- **Availability**: `computeFreeSlots` — a pure function over `calendar.list`'s output, not a separate registry op (D4 resolution)

### Discrepancy-register fixes applied (route is truth, not the old handler)

- **D4** — `GET /api/calendar/events` returns `{events, workflowEvents}`, not a bare array. `calendar.list`'s output schema enforces this; a bare-array response is now rejected as a `ResponseValidationError`. `check_calendar_availability` is modeled as `computeFreeSlots(events, range)`, a pure function testable with plain inputs.
- **D5** — `calendar.create`'s input field is `attendeeIds` (route truth), not the old handler's `userIds`, which the route's zod schema silently stripped.
- **D6** — `calendar.removeAttendee` sends `userId` as a `?userId=` query param on the DELETE request, never a JSON body. The route ignores the body and defaults to the *caller* when the query param is absent — the old handler's JSON-body approach removed the wrong person. Implemented by embedding `:userId` in the operation's `path` template after a literal `?userId=`, so `buildRequest`'s existing `:param` interpolation (which matches tokens anywhere in the path string) lands it on the URL — no changes to shared transport code.

### Other notes

- All date/time inputs (`startAt`, `endAt`, `startDate`, `endDate`) go through a strict ISO 8601 zod refinement, documented against the naive-datetime timezone contract in `apps/web/src/lib/ai/core/timestamp-utils.ts` (a datetime with no `Z`/offset is interpreted server-side in the request's own `timezone` field, not UTC).
- `requiredScope` is intentionally omitted across the whole domain — calendar events may be personal or drive-scoped, a distinction only known once the event is fetched, so there's no static drive relationship to pre-flight the way `tasks.*`/`pages.*` have. Documented in the file header.
- `includePersonal`'s server-side `z.coerce.boolean()` footgun (any non-empty string, including `"false"`, coerces to `true`) is documented on the field rather than silently worked around.

## Test plan

- [x] `bun run --filter '@pagespace/sdk' typecheck` — clean
- [x] `bun run --filter '@pagespace/sdk' test` — 397/397 passing (68 new calendar contract tests, no regressions)
- [x] RED commit (contract tests, calendar.ts absent) → GREEN commit (implementation), per TDD non-negotiable