### PR TITLE
oauth: device authorization grant + /activate page (Phase 1 task 9)

### DIFF
--- a/apps/web/src/app/activate/ActivateFlow.tsx
+++ b/apps/web/src/app/activate/ActivateFlow.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import { post } from '@/lib/auth/auth-fetch';
+
+interface VerifyResponse {
+  userCode: string;
+  clientName: string;
+  firstParty: boolean;
+  scopeDescriptions: string[];
+}
+
+type Step =
+  | { name: 'entry' }
+  | { name: 'consent'; data: VerifyResponse }
+  | { name: 'done'; action: 'approve' | 'deny' };
+
+interface ActivateFlowProps {
+  initialUserCode: string;
+}
+
+/**
+ * Drives the device-flow verification screen end to end: enter code → verify
+ * (rate-limited, session-gated) → render the SAME consent narration task 6's
+ * /oauth/consent uses → approve/deny (CSRF-protected) → confirmation. Every
+ * step re-hits the server; nothing here is trusted client-side state.
+ */
+export function ActivateFlow({ initialUserCode }: ActivateFlowProps) {
+  const [userCode, setUserCode] = useState(initialUserCode);
+  const [step, setStep] = useState<Step>({ name: 'entry' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function verify() {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const data = await post<VerifyResponse>('/api/oauth/device_authorization/verify', { userCode });
+      setStep({ name: 'consent', data });
+    } catch {
+      setError('That code is invalid or has expired.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function decide(action: 'approve' | 'deny', verifiedUserCode: string) {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await post('/api/oauth/device_authorization/decision', { userCode: verifiedUserCode, action });
+      setStep({ name: 'done', action });
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (step.name === 'done') {
+    return (
+      <div className="mt-8">
+        <p className="text-sm">
+          {step.action === 'approve'
+            ? 'Device connected. You may return to your terminal.'
+            : 'Access denied. You may close this window.'}
+        </p>
+      </div>
+    );
+  }
+
+  if (step.name === 'consent') {
+    const { data } = step;
+    return (
+      <div className="mt-8">
+        <h2 className="text-lg font-medium">
+          {data.clientName} is requesting access
+          {data.firstParty && (
+            <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs font-normal text-muted-foreground">
+              Built by PageSpace
+            </span>
+          )}
+        </h2>
+        <ul className="mt-4 space-y-3 text-sm">
+          {data.scopeDescriptions.map((text, i) => (
+            <li key={i} className="rounded border p-3">
+              {text}
+            </li>
+          ))}
+        </ul>
+        {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+        <div className="mt-6 flex gap-3">
+          <button
+            type="button"
+            disabled={isSubmitting}
+            onClick={() => decide('approve', data.userCode)}
+            className="flex-1 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            Allow
+          </button>
+          <button
+            type="button"
+            disabled={isSubmitting}
+            onClick={() => decide('deny', data.userCode)}
+            className="flex-1 rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
+          >
+            Deny
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-8">
+      <label htmlFor="user-code" className="block text-sm font-medium">
+        Device code
+      </label>
+      <input
+        id="user-code"
+        type="text"
+        autoCapitalize="characters"
+        autoComplete="off"
+        value={userCode}
+        onChange={(e) => setUserCode(e.target.value)}
+        placeholder="XXXX-XXXX"
+        className="mt-2 w-full rounded border px-3 py-2 text-sm"
+      />
+      {error && <p className="mt-3 text-sm text-destructive">{error}</p>}
+      <button
+        type="button"
+        disabled={isSubmitting || userCode.trim().length === 0}
+        onClick={verify}
+        className="mt-4 w-full rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+      >
+        Continue
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/activate/page.tsx
+++ b/apps/web/src/app/activate/page.tsx
@@ -1,0 +1,49 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { getSessionFromCookies } from '@/lib/auth/cookie-config';
+import { ActivateFlow } from './ActivateFlow';
+
+interface ActivatePageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * RFC 8628 device-flow verification page (task mwexjazwha2uhw5bmvc9a7kw):
+ * "CLI shows a short code, human enters it here on any signed-in device."
+ * Session-gated only — the user code itself is verified + rate-limited
+ * server-side by `ActivateFlow`'s calls to the /verify and /decision API
+ * routes, never trusted from this page's own render.
+ */
+export default async function ActivatePage({ searchParams }: ActivatePageProps) {
+  const params = await searchParams;
+  const userCode = first(params.user_code) ?? '';
+  const nextTarget = userCode ? `/activate?user_code=${encodeURIComponent(userCode)}` : '/activate';
+
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  const sessionToken = getSessionFromCookies(cookieHeader);
+
+  if (!sessionToken) {
+    redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
+  }
+
+  const session = await sessionService.validateSession(sessionToken);
+  if (!session) {
+    redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
+  }
+
+  return (
+    <div className="mx-auto max-w-md py-16">
+      <h1 className="text-xl font-semibold">Activate a device</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Enter the code shown on your device to connect it to your PageSpace account.
+      </p>
+      <ActivateFlow initialUserCode={userCode} />
+    </div>
+  );
+}

--- a/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
@@ -14,6 +14,8 @@ vi.mock('@/lib/repositories/oauth-repository', () => ({
   createDeviceAuthorization: (...args: unknown[]) => createDeviceAuthorization(...args),
 }));
 
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
 import { POST } from '../route';
 
 const CLIENT_ID = 'pagespace-cli';

--- a/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/**
+ * POST /api/oauth/device_authorization (task mwexjazwha2uhw5bmvc9a7kw).
+ * RFC 8628 §3.1-3.2: form-encoding enforcement, unknown client rejection,
+ * scope grammar validation, the response shape, and hashed storage.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const ensureOAuthClientRow = vi.fn();
+const createDeviceAuthorization = vi.fn();
+vi.mock('@/lib/repositories/oauth-repository', () => ({
+  ensureOAuthClientRow: (...args: unknown[]) => ensureOAuthClientRow(...args),
+  createDeviceAuthorization: (...args: unknown[]) => createDeviceAuthorization(...args),
+}));
+
+import { POST } from '../route';
+
+const CLIENT_ID = 'pagespace-cli';
+const CLIENT_DB_ID = 'client-db-id-1';
+
+function deviceAuthRequest(fields: Record<string, string | undefined>, contentType = 'application/x-www-form-urlencoded'): Request {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) body.set(key, value);
+  }
+  return new Request('http://web.local/api/oauth/device_authorization', {
+    method: 'POST',
+    headers: { 'content-type': contentType },
+    body: body.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureOAuthClientRow.mockResolvedValue(CLIENT_DB_ID);
+  createDeviceAuthorization.mockResolvedValue(undefined);
+});
+
+describe('POST /api/oauth/device_authorization — form-encoding enforcement', () => {
+  it('rejects a JSON content-type with invalid_request', async () => {
+    const req = new Request('http://web.local/api/oauth/device_authorization', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ client_id: CLIENT_ID }),
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(createDeviceAuthorization).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/device_authorization — client validation', () => {
+  it('missing client_id → invalid_request', async () => {
+    const res = await POST(deviceAuthRequest({}) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(createDeviceAuthorization).not.toHaveBeenCalled();
+  });
+
+  it('unknown client_id → invalid_client', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: 'evil-client' }) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_client' });
+    expect(createDeviceAuthorization).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/device_authorization — scope validation', () => {
+  it('malformed scope → invalid_scope, never persists', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID, scope: 'not a real scope!' }) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_scope' });
+    expect(createDeviceAuthorization).not.toHaveBeenCalled();
+  });
+
+  it('accepts a well-formed scope and forwards the parsed set to the repository', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID, scope: 'account offline_access' }) as never);
+    expect(res.status).toBe(200);
+    expect(createDeviceAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: ['account', 'offline_access'] }),
+    );
+  });
+});
+
+describe('POST /api/oauth/device_authorization — happy path', () => {
+  it('returns the RFC 8628 §3.2 response shape', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      device_code: expect.any(String),
+      user_code: expect.stringMatching(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/),
+      verification_uri: expect.stringContaining('/activate'),
+      verification_uri_complete: expect.stringContaining('/activate?user_code='),
+      expires_in: expect.any(Number),
+      interval: expect.any(Number),
+    });
+  });
+
+  it('sets Cache-Control: no-store (the response carries secrets)', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('persists only hashed device_code and user_code — never the raw values', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+    const body = await res.json();
+
+    expect(createDeviceAuthorization).toHaveBeenCalledTimes(1);
+    const call = createDeviceAuthorization.mock.calls[0][0];
+    expect(call.deviceCodeHash).not.toBe(body.device_code);
+    expect(call.userCodeHash).not.toBe(body.user_code);
+    expect(call.clientDbId).toBe(CLIENT_DB_ID);
+  });
+
+  it('resolves the client DB row before minting codes', async () => {
+    await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+    expect(ensureOAuthClientRow).toHaveBeenCalledWith(expect.objectContaining({ clientId: CLIENT_ID }));
+  });
+});

--- a/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+/**
+ * POST /api/oauth/device_authorization/decision (task
+ * mwexjazwha2uhw5bmvc9a7kw). CSRF-protected approve/deny for the /activate
+ * screen: session + CSRF gate, per-session/IP rate limiting, code
+ * normalization, and single-settlement passthrough from
+ * `decideDeviceApproval` (task 4).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: (result: unknown) => !!result && typeof result === 'object' && 'error' in (result as object),
+  getClientIP: vi.fn().mockReturnValue('203.0.113.7'),
+}));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: { OAUTH_VERIFY: { maxAttempts: 10, windowMs: 300_000, progressiveDelay: false } },
+}));
+
+const recordDeviceApproval = vi.fn();
+vi.mock('@/lib/repositories/oauth-repository', () => ({
+  recordDeviceApproval: (...args: unknown[]) => recordDeviceApproval(...args),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const AUTHENTICATED = {
+  tokenType: 'session',
+  userId: 'user-1',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  sessionId: 'sess-1',
+};
+
+function decisionRequest(body: unknown): Request {
+  return new Request('http://web.local/api/oauth/device_authorization/decision', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const ALLOWED = { allowed: true, attemptsRemaining: 9 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(AUTHENTICATED as never);
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('POST /api/oauth/device_authorization/decision — CSRF/session gate', () => {
+  it('rejects when CSRF/session auth fails, never records a decision', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'CSRF validation failed' }), { status: 403 }),
+    } as never);
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(403);
+    expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+
+  it('requires requireCSRF: true on the authentication call', async () => {
+    await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requireCSRF: true }),
+    );
+  });
+});
+
+describe('POST /api/oauth/device_authorization/decision — brute-force rate limiting', () => {
+  it('blocks when the per-IP limit is exceeded, never recording a decision', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-device-decide:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(429);
+    expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+
+  it('blocks when the per-session limit is exceeded, never recording a decision', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-device-decide:session:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(429);
+    expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/device_authorization/decision — code normalization', () => {
+  it('normalizes case and hyphens before recording the decision', async () => {
+    recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
+    await POST(decisionRequest({ userCode: 'abcd-efgh', action: 'approve' }) as never);
+
+    expect(recordDeviceApproval).toHaveBeenCalledWith(expect.objectContaining({ userCode: 'ABCDEFGH' }));
+  });
+});
+
+describe('POST /api/oauth/device_authorization/decision — outcomes', () => {
+  it('approve → { ok: true, action: "approved" }', async () => {
+    recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, action: 'approved' });
+  });
+
+  it('deny → { ok: true, action: "denied" } (a legitimate outcome, not an error)', async () => {
+    recordDeviceApproval.mockResolvedValue({ outcome: 'denied' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'deny' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, action: 'denied' });
+  });
+
+  it('unknown code → invalid_code', async () => {
+    recordDeviceApproval.mockResolvedValue({ outcome: 'not_found' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_code' });
+  });
+
+  it('already-settled code (single-settlement) → invalid_code', async () => {
+    recordDeviceApproval.mockResolvedValue({
+      outcome: 'invalid',
+      decision: { status: 'already_settled', existingStatus: 'approved' },
+    });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_code' });
+  });
+
+  it('expired code → invalid_code', async () => {
+    recordDeviceApproval.mockResolvedValue({ outcome: 'invalid', decision: { status: 'expired' } });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_code' });
+  });
+
+  it('invalid action value → invalid_request', async () => {
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'destroy' }) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
@@ -69,6 +69,8 @@ describe('POST /api/oauth/device_authorization/decision — CSRF/session gate', 
   });
 
   it('requires requireCSRF: true on the authentication call', async () => {
+    recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
     await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
     expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
@@ -1,0 +1,72 @@
+/**
+ * CSRF-protected approve/deny decision for the /activate screen (task
+ * mwexjazwha2uhw5bmvc9a7kw). Re-normalizes, re-rate-limits, and re-validates
+ * the user code from scratch — never trusts an earlier /verify call — then
+ * records the decision via `decideDeviceApproval` (task 4, not
+ * reimplemented).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
+import { normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
+import { recordDeviceApproval } from '@/lib/repositories/oauth-repository';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const bodySchema = z.object({
+  userCode: z.string().min(1).max(32),
+  action: z.enum(['approve', 'deny']),
+});
+
+export async function POST(req: NextRequest) {
+  const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: true });
+  if (isAuthError(auth)) return auth.error;
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  const ip = getClientIP(req);
+  const [ipLimit, sessionLimit] = await Promise.all([
+    checkDistributedRateLimit(`oauth-device-decide:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_VERIFY),
+    checkDistributedRateLimit(`oauth-device-decide:session:${auth.userId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_VERIFY),
+  ]);
+
+  if (!ipLimit.allowed || !sessionLimit.allowed) {
+    auditRequest(req, {
+      eventType: 'security.rate.limited',
+      userId: auth.userId,
+      details: { oauthEvent: 'device_decision_rate_limited' },
+    });
+    const retryAfter = Math.max(ipLimit.retryAfter ?? 0, sessionLimit.retryAfter ?? 0);
+    return NextResponse.json({ error: 'rate_limited', retryAfter }, { status: 429 });
+  }
+
+  const normalized = normalizeUserCode(body.userCode);
+  const result = await recordDeviceApproval({
+    userCode: normalized,
+    action: body.action,
+    userId: auth.userId,
+    now: new Date(),
+  });
+
+  if (result.outcome === 'not_found' || result.outcome === 'invalid') {
+    auditRequest(req, {
+      eventType: 'authz.access.denied',
+      userId: auth.userId,
+      details: { oauthEvent: 'device_decision_rejected' },
+    });
+    return NextResponse.json({ error: 'invalid_code' }, { status: 400 });
+  }
+
+  auditRequest(req, {
+    eventType: result.outcome === 'approved' ? 'authz.access.granted' : 'authz.access.denied',
+    userId: auth.userId,
+    details: { oauthEvent: result.outcome === 'approved' ? 'device_approved' : 'device_denied' },
+  });
+
+  return NextResponse.json({ ok: true, action: result.outcome });
+}

--- a/apps/web/src/app/api/oauth/device_authorization/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/route.ts
@@ -1,0 +1,88 @@
+/**
+ * RFC 8628 §3.1-3.2 device authorization endpoint (Phase 1 task 9,
+ * mwexjazwha2uhw5bmvc9a7kw). Public, unauthenticated — the whole point of the
+ * device grant is that the CLI has no session yet. Form-encoded POST with
+ * `client_id` (+ optional `scope`) mints a `device_code` (opaque, high
+ * entropy) and a `user_code` (short, unambiguous-alphabet, human-typed at
+ * `/activate`) — both hashed at rest, only ever returned to the caller once.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { randomBytes } from 'crypto';
+import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+import { parseScopeList, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
+import { generateUserCode, normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
+import { generateToken, hashToken } from '@pagespace/lib/auth/token-utils';
+import { DEVICE_CODE_TTL_SECONDS, DEVICE_CODE_POLL_INTERVAL_SECONDS } from '@pagespace/lib/auth/oauth/code-lifecycle';
+import { ensureOAuthClientRow, createDeviceAuthorization } from '@/lib/repositories/oauth-repository';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
+  return NextResponse.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+export async function POST(req: NextRequest) {
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
+    return noStoreJson({ error: 'invalid_request' }, 400);
+  }
+
+  const form = new URLSearchParams(await req.text());
+  const clientId = form.get('client_id');
+  if (!clientId) {
+    return noStoreJson({ error: 'invalid_request' }, 400);
+  }
+
+  const client = getRegisteredClient(clientId);
+  if (!client) {
+    return noStoreJson({ error: 'invalid_client' }, 400);
+  }
+
+  const rawScope = form.get('scope');
+  let scopes: string[] = [];
+  if (rawScope) {
+    const parsed = parseScopeList(rawScope);
+    if (!parsed.ok) {
+      return noStoreJson({ error: 'invalid_scope' }, 400);
+    }
+    scopes = formatScopeSet(parsed.scopes).split(' ').filter(Boolean);
+  }
+
+  const clientDbId = await ensureOAuthClientRow(client);
+
+  const { token: deviceCode, hash: deviceCodeHash, tokenPrefix: deviceCodePrefix } = generateToken('ps_dc');
+  const userCode = generateUserCode(randomBytes);
+  const userCodeHash = hashToken(normalizeUserCode(userCode));
+  const userCodePrefix = userCode.substring(0, 4);
+  const expiresAt = new Date(Date.now() + DEVICE_CODE_TTL_SECONDS * 1000);
+
+  await createDeviceAuthorization({
+    clientDbId,
+    scopes,
+    deviceCodeHash,
+    deviceCodePrefix,
+    userCodeHash,
+    userCodePrefix,
+    expiresAt,
+    pollIntervalSeconds: DEVICE_CODE_POLL_INTERVAL_SECONDS,
+  });
+
+  const issuer = (process.env.WEB_APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? '').replace(/\/+$/, '');
+  const verificationUri = `${issuer}/activate`;
+
+  auditRequest(req, {
+    eventType: 'auth.device.registered',
+    details: { clientId: client.clientId, oauthEvent: 'device_authorization_requested' },
+  });
+
+  return noStoreJson(
+    {
+      device_code: deviceCode,
+      user_code: userCode,
+      verification_uri: verificationUri,
+      verification_uri_complete: `${verificationUri}?user_code=${encodeURIComponent(userCode)}`,
+      expires_in: DEVICE_CODE_TTL_SECONDS,
+      interval: DEVICE_CODE_POLL_INTERVAL_SECONDS,
+    },
+    200,
+  );
+}

--- a/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
@@ -103,6 +103,8 @@ describe('POST /api/oauth/device_authorization/verify — brute-force rate limit
   });
 
   it('checks both the IP and the session identity as distinct rate-limit keys', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'not_found' });
+
     await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
 
     const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);

--- a/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * POST /api/oauth/device_authorization/verify (task mwexjazwha2uhw5bmvc9a7kw).
+ * Session-gated user-code lookup for the /activate screen: rate limiting
+ * (per session AND per IP), code normalization, and the constant "invalid
+ * or expired" collapse for anything that isn't currently pending+unexpired.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: (result: unknown) => !!result && typeof result === 'object' && 'error' in (result as object),
+  getClientIP: vi.fn().mockReturnValue('203.0.113.7'),
+}));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: { OAUTH_VERIFY: { maxAttempts: 10, windowMs: 300_000, progressiveDelay: false } },
+}));
+
+const verifyDeviceUserCode = vi.fn();
+vi.mock('@/lib/repositories/oauth-repository', () => ({
+  verifyDeviceUserCode: (...args: unknown[]) => verifyDeviceUserCode(...args),
+}));
+
+vi.mock('@/lib/repositories/session-repository', () => ({
+  sessionRepository: { findDrivesByIds: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { query: { driveRoles: { findFirst: vi.fn().mockResolvedValue(undefined) } } },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/schema/members', () => ({ driveRoles: {} }));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const AUTHENTICATED = {
+  tokenType: 'session',
+  userId: 'user-1',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  sessionId: 'sess-1',
+};
+
+function verifyRequest(body: unknown): Request {
+  return new Request('http://web.local/api/oauth/device_authorization/verify', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const ALLOWED = { allowed: true, attemptsRemaining: 9 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(AUTHENTICATED as never);
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('POST /api/oauth/device_authorization/verify — session gate', () => {
+  it('rejects when unauthenticated, never checks rate limits or the repository', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 }),
+    } as never);
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    expect(res.status).toBe(401);
+    expect(checkDistributedRateLimit).not.toHaveBeenCalled();
+    expect(verifyDeviceUserCode).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/device_authorization/verify — brute-force rate limiting', () => {
+  it('blocks when the per-IP limit is exceeded, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-device-verify:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    expect(res.status).toBe(429);
+    expect(verifyDeviceUserCode).not.toHaveBeenCalled();
+  });
+
+  it('blocks when the per-session limit is exceeded, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-device-verify:session:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    expect(res.status).toBe(429);
+    expect(verifyDeviceUserCode).not.toHaveBeenCalled();
+  });
+
+  it('checks both the IP and the session identity as distinct rate-limit keys', async () => {
+    await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('ip:203.0.113.7'))).toBe(true);
+    expect(keys.some((k) => k.includes('session:user-1'))).toBe(true);
+  });
+});
+
+describe('POST /api/oauth/device_authorization/verify — code normalization', () => {
+  it('normalizes case and hyphens before looking up the code', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['account'] });
+
+    await POST(verifyRequest({ userCode: 'abcd-efgh' }) as never);
+
+    expect(verifyDeviceUserCode).toHaveBeenCalledWith(expect.objectContaining({ userCode: 'ABCDEFGH' }));
+  });
+});
+
+describe('POST /api/oauth/device_authorization/verify — outcomes', () => {
+  it('returns invalid_code for an unknown/expired/already-settled code', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'not_found' });
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_code' });
+  });
+
+  it('returns the client name, first-party flag, and scope narration for a pending code', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['account'] });
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.clientName).toBe('PageSpace CLI');
+    expect(body.firstParty).toBe(true);
+    expect(body.userCode).toBe('ABCDEFGH');
+    expect(body.scopeDescriptions.length).toBeGreaterThan(0);
+  });
+
+  it('missing userCode → invalid_request', async () => {
+    const res = await POST(verifyRequest({}) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+  });
+});

--- a/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
@@ -1,0 +1,109 @@
+/**
+ * Session-gated user-code verification for the /activate screen (task
+ * mwexjazwha2uhw5bmvc9a7kw). Read-only: normalizes the submitted code,
+ * rate-limits aggressively per session AND per IP (short human-typed codes
+ * are brute-forceable — this is the attack surface of the whole device
+ * flow), and returns the requesting client's identity + the SAME scope
+ * narration task 6's consent screen uses — never the device/user code
+ * record itself.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
+import { normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
+import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+import { parseScopeList } from '@pagespace/lib/auth/oauth/scopes';
+import { describeScopeForConsent } from '@pagespace/lib/auth/oauth/consent';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { driveRoles } from '@pagespace/db/schema/members';
+import { verifyDeviceUserCode } from '@/lib/repositories/oauth-repository';
+import { sessionRepository } from '@/lib/repositories/session-repository';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const bodySchema = z.object({ userCode: z.string().min(1).max(32) });
+
+export async function POST(req: NextRequest) {
+  const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: false });
+  if (isAuthError(auth)) return auth.error;
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  const ip = getClientIP(req);
+  const [ipLimit, sessionLimit] = await Promise.all([
+    checkDistributedRateLimit(`oauth-device-verify:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_VERIFY),
+    checkDistributedRateLimit(`oauth-device-verify:session:${auth.userId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_VERIFY),
+  ]);
+
+  if (!ipLimit.allowed || !sessionLimit.allowed) {
+    auditRequest(req, {
+      eventType: 'security.rate.limited',
+      userId: auth.userId,
+      details: { oauthEvent: 'device_verify_rate_limited' },
+    });
+    const retryAfter = Math.max(ipLimit.retryAfter ?? 0, sessionLimit.retryAfter ?? 0);
+    return NextResponse.json({ error: 'rate_limited', retryAfter }, { status: 429 });
+  }
+
+  const normalized = normalizeUserCode(body.userCode);
+  const result = await verifyDeviceUserCode({ userCode: normalized, now: new Date() });
+
+  if (result.outcome !== 'ok') {
+    return NextResponse.json({ error: 'invalid_code' }, { status: 400 });
+  }
+
+  const client = getRegisteredClient(result.clientId);
+  if (!client) {
+    return NextResponse.json({ error: 'invalid_code' }, { status: 400 });
+  }
+
+  const scopeDescriptions: string[] = [];
+  const parsed = result.scopes.length > 0 ? parseScopeList(result.scopes.join(' ')) : null;
+
+  if (parsed?.ok) {
+    if (parsed.scopes.account) {
+      scopeDescriptions.push(describeScopeForConsent({ kind: 'account' }, {}));
+    }
+    if (parsed.scopes.offlineAccess) {
+      scopeDescriptions.push(describeScopeForConsent({ kind: 'offline_access' }, {}));
+    }
+
+    const driveIds = [...parsed.scopes.drives.keys()];
+    const drives = driveIds.length > 0 ? await sessionRepository.findDrivesByIds(driveIds) : [];
+    const driveNamesById = new Map(drives.map((d) => [d.id, d.name]));
+
+    const customRoleIds = [...parsed.scopes.drives.values()]
+      .filter((scope) => scope.role.kind === 'custom')
+      .map((scope) => (scope.role as { kind: 'custom'; customRoleId: string }).customRoleId);
+    const roleRows =
+      customRoleIds.length > 0
+        ? await Promise.all(customRoleIds.map((id) => db.query.driveRoles.findFirst({ where: eq(driveRoles.id, id) })))
+        : [];
+    const roleById = new Map(roleRows.filter((r): r is NonNullable<typeof r> => !!r).map((r) => [r.id, r]));
+
+    for (const scope of parsed.scopes.drives.values()) {
+      const driveName = driveNamesById.get(scope.driveId);
+      if (scope.role.kind === 'custom') {
+        const role = roleById.get(scope.role.customRoleId);
+        scopeDescriptions.push(
+          describeScopeForConsent(scope, { driveName, roleName: role?.name, roleSummary: role?.description ?? undefined }),
+        );
+      } else {
+        scopeDescriptions.push(describeScopeForConsent(scope, { driveName }));
+      }
+    }
+  }
+
+  return NextResponse.json({
+    userCode: normalized,
+    clientName: client.name,
+    firstParty: client.firstParty,
+    scopeDescriptions,
+  });
+}

--- a/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
@@ -12,10 +12,12 @@ vi.mock('server-only', () => ({}));
 const ensureOAuthClientRow = vi.fn();
 const exchangeAuthorizationCode = vi.fn();
 const refreshTokenGrant = vi.fn();
+const pollDeviceToken = vi.fn();
 vi.mock('@/lib/repositories/oauth-repository', () => ({
   ensureOAuthClientRow: (...args: unknown[]) => ensureOAuthClientRow(...args),
   exchangeAuthorizationCode: (...args: unknown[]) => exchangeAuthorizationCode(...args),
   refreshTokenGrant: (...args: unknown[]) => refreshTokenGrant(...args),
+  pollDeviceToken: (...args: unknown[]) => pollDeviceToken(...args),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
@@ -376,5 +378,109 @@ describe('POST /api/oauth/token — unsupported grant_type', () => {
     expect(await res.json()).toEqual({ error: 'unsupported_grant_type' });
     expect(exchangeAuthorizationCode).not.toHaveBeenCalled();
     expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+});
+
+const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+function deviceFields(overrides: Record<string, string | undefined> = {}) {
+  return {
+    grant_type: DEVICE_GRANT_TYPE,
+    device_code: 'raw-device-code-value',
+    client_id: CLIENT_ID,
+    ...overrides,
+  };
+}
+
+describe('POST /api/oauth/token — device_code grant, happy path', () => {
+  it('returns the RFC 6749 §5.1 token response shape on approval', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'ok', userId: 'user-1', scopes: ['account'], tokens: okTokens });
+
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      access_token: okTokens.accessToken,
+      token_type: 'Bearer',
+      expires_in: 15 * 60,
+      refresh_token: okTokens.refreshToken,
+      scope: 'account',
+    });
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('passes the raw device_code and resolved clientDbId through to the repository', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'ok', userId: 'user-1', scopes: ['account'], tokens: okTokens });
+
+    await POST(tokenRequest(deviceFields()) as never);
+
+    expect(pollDeviceToken).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceCode: 'raw-device-code-value', clientDbId: CLIENT_DB_ID }),
+    );
+  });
+});
+
+describe('POST /api/oauth/token — device_code grant, RFC 8628 §3.5 poll outcomes', () => {
+  it('authorization_pending → distinct error (the CLI must keep polling)', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'authorization_pending' });
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'authorization_pending' });
+  });
+
+  it('slow_down → distinct error (the CLI must back off its poll interval)', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'slow_down' });
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'slow_down' });
+  });
+
+  it('expired_token → distinct error (the CLI must restart the flow)', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'expired_token' });
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'expired_token' });
+  });
+
+  it('access_denied → distinct error (the user said no)', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'access_denied' });
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'access_denied' });
+  });
+
+  it('unknown device_code (not_found) → invalid_grant, same as an unknown auth code', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'not_found' });
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_grant' });
+  });
+
+  it('sets Cache-Control: no-store on every poll outcome', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'authorization_pending' });
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('unknown client_id → invalid_grant, never calls the repository', async () => {
+    const res = await POST(tokenRequest(deviceFields({ client_id: 'evil-client' })) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_grant' });
+    expect(pollDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('missing device_code → invalid_request', async () => {
+    const res = await POST(tokenRequest(deviceFields({ device_code: undefined })) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(pollDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('a client_secret presented for the public CLI client → invalid_request, never calls the repository', async () => {
+    const res = await POST(tokenRequest(deviceFields({ client_secret: 'anything' })) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(pollDeviceToken).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -1,24 +1,31 @@
 /**
  * OAuth 2.1 token endpoint — authorization_code + PKCE grant (RFC 6749
- * §3.2, §4.1.3, §5.1; task suty9f9jbha82c0831e9rjec) and refresh_token grant
+ * §3.2, §4.1.3, §5.1; task suty9f9jbha82c0831e9rjec), refresh_token grant
  * with rotation + reuse detection (RFC 6749 §6; ADR 0003 §3.3-3.4; task
- * l8zlp3353f2cunjd33foq41l). A thin shell: it parses the form-encoded
+ * l8zlp3353f2cunjd33foq41l), and device_code grant polling (RFC 8628 §3.4-3.5;
+ * task mwexjazwha2uhw5bmvc9a7kw). A thin shell: it parses the form-encoded
  * request, resolves the client, and delegates the entire grant decision to
- * `exchangeAuthorizationCode` / `refreshTokenGrant`, which in turn call the
- * pure decision functions (`decideCodeExchange`, `decideRefreshRotation`) —
- * no grant logic is reimplemented here.
+ * `exchangeAuthorizationCode` / `refreshTokenGrant` / `pollDeviceToken`, which
+ * in turn call the pure decision functions (`decideCodeExchange`,
+ * `decideRefreshRotation`, `decideDevicePoll`) — no grant logic is
+ * reimplemented here.
  *
- * Zero-trust posture: every grant-validity rejection — unknown client,
- * unknown/expired/already-consumed code, redirect_uri mismatch, PKCE
- * failure, malformed client authentication, unknown/expired/revoked/reused
- * refresh token — returns the SAME constant-shape body
- * (`{"error": "invalid_grant"}`, or `"invalid_request"` for malformed
- * syntax) with `Cache-Control: no-store`. No response ever differentiates
- * one failure reason from another; that differentiation is exactly the
- * error oracle OAuth 2.1's fail-closed posture forbids. `invalid_scope` is
- * the one deliberate exception: it only fires once the presented refresh
- * token has already proven valid, so naming it leaks nothing about the
- * credential itself.
+ * Zero-trust posture: every grant-validity rejection on the code/refresh
+ * grants — unknown client, unknown/expired/already-consumed code,
+ * redirect_uri mismatch, PKCE failure, malformed client authentication,
+ * unknown/expired/revoked/reused refresh token — returns the SAME
+ * constant-shape body (`{"error": "invalid_grant"}`, or `"invalid_request"`
+ * for malformed syntax) with `Cache-Control: no-store`. No response ever
+ * differentiates one failure reason from another; that differentiation is
+ * exactly the error oracle OAuth 2.1's fail-closed posture forbids.
+ * `invalid_scope` is one deliberate exception on the refresh grant: it only
+ * fires once the presented refresh token has already proven valid, so naming
+ * it leaks nothing about the credential itself. The device_code grant is the
+ * OTHER deliberate exception, by protocol design rather than by leak: RFC
+ * 8628 §3.5 requires the polling CLI to distinguish authorization_pending /
+ * slow_down / expired_token / access_denied so it knows whether to keep
+ * polling, back off, or tell the user to restart — only an unrecognized
+ * device_code falls back to the shared invalid_grant.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { getRegisteredClient, type RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
@@ -27,6 +34,7 @@ import {
   ensureOAuthClientRow,
   exchangeAuthorizationCode,
   refreshTokenGrant,
+  pollDeviceToken,
 } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
@@ -166,6 +174,62 @@ async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams):
   );
 }
 
+/**
+ * RFC 8628 §3.5 device-code poll outcomes each get their OWN error string —
+ * unlike the other two grants, this is not an oracle leak. The polling CLI
+ * genuinely needs to distinguish "keep waiting" from "user said no" from
+ * "restart the flow", and the RFC names these outcomes explicitly. Only an
+ * unrecognized device_code (never issued) falls back to invalid_grant, same
+ * treatment as an unknown authorization code or refresh token.
+ */
+const DEVICE_POLL_ERROR_BODY: Record<Exclude<Awaited<ReturnType<typeof pollDeviceToken>>['outcome'], 'ok'>, Record<string, unknown>> = {
+  not_found: INVALID_GRANT,
+  authorization_pending: { error: 'authorization_pending' },
+  slow_down: { error: 'slow_down' },
+  expired_token: { error: 'expired_token' },
+  access_denied: { error: 'access_denied' },
+};
+
+async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
+  const deviceCode = form.get('device_code');
+  const clientId = form.get('client_id');
+
+  if (!deviceCode || !clientId) {
+    return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  const resolved = await resolveClient(form, clientId);
+  if ('rejection' in resolved) return resolved.rejection;
+  const { client, clientDbId } = resolved;
+
+  const result = await pollDeviceToken({ deviceCode, clientDbId, now: new Date() });
+
+  if (result.outcome !== 'ok') {
+    auditRequest(req, {
+      eventType: 'authz.access.denied',
+      details: { clientId: client.clientId, oauthEvent: 'device_poll_rejected', outcome: result.outcome },
+    });
+    return noStoreJson(DEVICE_POLL_ERROR_BODY[result.outcome], 400);
+  }
+
+  auditRequest(req, {
+    eventType: 'auth.token.created',
+    userId: result.userId,
+    details: { clientId: client.clientId, oauthEvent: 'device_poll_granted' },
+  });
+
+  return noStoreJson(
+    {
+      access_token: result.tokens.accessToken,
+      token_type: 'Bearer',
+      expires_in: ACCESS_TOKEN_TTL_SECONDS,
+      refresh_token: result.tokens.refreshToken,
+      scope: result.scopes.join(' '),
+    },
+    200,
+  );
+}
+
 export async function POST(req: NextRequest) {
   const contentType = req.headers.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
@@ -180,6 +244,9 @@ export async function POST(req: NextRequest) {
   }
   if (grantType === 'refresh_token') {
     return handleRefreshTokenGrant(req, form);
+  }
+  if (grantType === 'urn:ietf:params:oauth:grant-type:device_code') {
+    return handleDeviceCodeGrant(req, form);
   }
 
   return noStoreJson({ error: 'unsupported_grant_type' }, 400);

--- a/apps/web/src/lib/auth/url-utils.ts
+++ b/apps/web/src/lib/auth/url-utils.ts
@@ -45,7 +45,7 @@ export function isSafeReturnUrl(url: string | undefined): boolean {
  * here would re-introduce the URL-fragility this allowlist was designed to
  * mitigate.
  */
-export const SIGNIN_NEXT_ALLOWED_PREFIXES = ['/dashboard', '/account', '/s/', '/oauth/consent'] as const;
+export const SIGNIN_NEXT_ALLOWED_PREFIXES = ['/dashboard', '/account', '/s/', '/oauth/consent', '/activate'] as const;
 
 /**
  * Validates that a `next=` redirect target is both same-origin (composed via

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Device authorization grant persistence (task mwexjazwha2uhw5bmvc9a7kw):
+ * `createDeviceAuthorization`, `pollDeviceToken`, `verifyDeviceUserCode`,
+ * `recordDeviceApproval`. Mirrors the fake-transaction harness in
+ * `oauth-repository.exchange.test.ts` — `eq`/`and` are mocked to structured
+ * markers and `evalPredicate` re-interprets them against an in-memory row, so
+ * client-scoped lookups genuinely exercise the WHERE intent instead of
+ * trusting an unconditional stub.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const H = vi.hoisted(() => ({
+  oauthDeviceCodes: {
+    __table: 'device_codes',
+    id: 'device_codes.id',
+    deviceCodeHash: 'device_codes.deviceCodeHash',
+    userCodeHash: 'device_codes.userCodeHash',
+    clientId: 'device_codes.clientId',
+    userId: 'device_codes.userId',
+    scopes: 'device_codes.scopes',
+    expiresAt: 'device_codes.expiresAt',
+    approvedAt: 'device_codes.approvedAt',
+    deniedAt: 'device_codes.deniedAt',
+    lastPolledAt: 'device_codes.lastPolledAt',
+    pollIntervalSeconds: 'device_codes.pollIntervalSeconds',
+  } as Record<string, unknown>,
+  oauthClients: {
+    __table: 'clients',
+    id: 'clients.id',
+    clientId: 'clients.clientId',
+  } as Record<string, unknown>,
+  oauthRefreshTokens: { __table: 'refresh', familyId: 'rt.familyId' } as Record<string, unknown>,
+  oauthAccessTokens: { __table: 'access', familyId: 'at.familyId' } as Record<string, unknown>,
+  usersTable: { __table: 'users', id: 'users.id' } as Record<string, unknown>,
+  state: { dbTransactionImpl: null as null | ((cb: (tx: unknown) => unknown) => unknown) },
+}));
+
+const { oauthDeviceCodes, oauthClients, usersTable } = H;
+
+vi.mock('@pagespace/db/schema/oauth', () => ({
+  oauthDeviceCodes: H.oauthDeviceCodes,
+  oauthClients: H.oauthClients,
+  oauthRefreshTokens: H.oauthRefreshTokens,
+  oauthAccessTokens: H.oauthAccessTokens,
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: H.usersTable,
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNull: vi.fn((a: unknown) => ({ _isNull: a })),
+}));
+
+type Predicate = { _eq: [unknown, unknown] } | { _and: Predicate[] } | { _isNull: unknown };
+
+function columnKey(col: unknown): string {
+  return String(col).split('.').pop() as string;
+}
+
+function evalPredicate(pred: Predicate, row: Record<string, unknown>): boolean {
+  if ('_and' in pred) return pred._and.every((p) => evalPredicate(p, row));
+  if ('_eq' in pred) return row[columnKey(pred._eq[0])] === pred._eq[1];
+  if ('_isNull' in pred) return row[columnKey(pred._isNull)] == null;
+  return true;
+}
+
+interface DeviceRow {
+  id: string;
+  deviceCodeHash: string;
+  userCodeHash: string;
+  clientId: string;
+  userId: string | null;
+  scopes: string[];
+  expiresAt: Date;
+  approvedAt: Date | null;
+  deniedAt: Date | null;
+  lastPolledAt: Date | null;
+  pollIntervalSeconds: number;
+}
+
+interface TokenRow {
+  tokenHash: string;
+  tokenPrefix: string;
+  familyId: string;
+  clientId: string;
+  userId: string;
+  scopes: string[];
+  tokenVersion: number;
+  expiresAt: Date;
+  familyExpiresAt?: Date;
+}
+
+let deviceRow: DeviceRow | null = null;
+let insertedDeviceRows: Record<string, unknown>[] = [];
+let refreshRows: TokenRow[] = [];
+let accessRows: TokenRow[] = [];
+let userTokenVersion = 0;
+let lockChain: Promise<unknown> = Promise.resolve();
+
+function makeTx() {
+  return {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: (predicate: Predicate) => {
+          if (table === usersTable) {
+            return Promise.resolve([{ tokenVersion: userTokenVersion }]);
+          }
+          const matches = deviceRow && evalPredicate(predicate, deviceRow as unknown as Record<string, unknown>);
+          const rows = matches ? [{ ...deviceRow }] : [];
+          const p = Promise.resolve(rows) as Promise<DeviceRow[]> & { for: (mode: string) => Promise<DeviceRow[]> };
+          p.for = () => p;
+          return p;
+        },
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (patch: Record<string, unknown>) => ({
+        where: () => {
+          if (table === oauthDeviceCodes && deviceRow) {
+            Object.assign(deviceRow, patch);
+          }
+          return Promise.resolve();
+        },
+      }),
+    }),
+    insert: (table: unknown) => ({
+      values: (row: TokenRow) => {
+        if (table === H.oauthRefreshTokens) refreshRows.push({ ...row });
+        else if (table === H.oauthAccessTokens) accessRows.push({ ...row });
+        return Promise.resolve();
+      },
+    }),
+  };
+}
+
+H.state.dbTransactionImpl = ((cb: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) => {
+  const run = lockChain.then(() => cb(makeTx()));
+  lockChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}) as (cb: (tx: unknown) => unknown) => unknown;
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => H.state.dbTransactionImpl!(cb),
+    insert: (table: unknown) => ({
+      values: (row: Record<string, unknown>) => {
+        if (table === oauthDeviceCodes) insertedDeviceRows.push({ ...row });
+        return Promise.resolve();
+      },
+    }),
+    select: () => ({
+      from: (table: unknown) => ({
+        innerJoin: (_joinTable: unknown, _on: unknown) => ({
+          where: (predicate: Predicate) => {
+            if (table !== oauthDeviceCodes) return Promise.resolve([]);
+            const matches = deviceRow && evalPredicate(predicate, deviceRow as unknown as Record<string, unknown>);
+            if (!matches || !deviceRow) return Promise.resolve([]);
+            return Promise.resolve([
+              {
+                scopes: deviceRow.scopes,
+                expiresAt: deviceRow.expiresAt,
+                approvedAt: deviceRow.approvedAt,
+                deniedAt: deviceRow.deniedAt,
+                clientStringId: 'pagespace-cli',
+              },
+            ]);
+          },
+        }),
+      }),
+    }),
+  },
+}));
+
+import { hashToken } from '@pagespace/lib/auth/token-utils';
+import {
+  createDeviceAuthorization,
+  pollDeviceToken,
+  verifyDeviceUserCode,
+  recordDeviceApproval,
+} from '../oauth-repository';
+
+const DEVICE_CODE = 'raw-device-code-value';
+const USER_CODE = 'ABCDEFGH';
+const CLIENT_DB_ID = 'client-db-id-1';
+const USER_ID = 'user-1';
+
+function seedDeviceRow(overrides: Partial<DeviceRow> = {}): void {
+  deviceRow = {
+    id: 'device-row-1',
+    deviceCodeHash: hashToken(DEVICE_CODE),
+    userCodeHash: hashToken(USER_CODE),
+    clientId: CLIENT_DB_ID,
+    userId: null,
+    scopes: ['account'],
+    expiresAt: new Date(Date.now() + 1800_000),
+    approvedAt: null,
+    deniedAt: null,
+    lastPolledAt: null,
+    pollIntervalSeconds: 5,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  deviceRow = null;
+  insertedDeviceRows = [];
+  refreshRows = [];
+  accessRows = [];
+  userTokenVersion = 0;
+  lockChain = Promise.resolve();
+});
+
+describe('createDeviceAuthorization', () => {
+  it('persists only the hashed device_code and user_code, never raw values', async () => {
+    await createDeviceAuthorization({
+      clientDbId: CLIENT_DB_ID,
+      scopes: ['account'],
+      deviceCodeHash: hashToken(DEVICE_CODE),
+      deviceCodePrefix: 'ps_dc_abcd',
+      userCodeHash: hashToken(USER_CODE),
+      userCodePrefix: 'ABCD',
+      expiresAt: new Date(Date.now() + 1800_000),
+      pollIntervalSeconds: 5,
+    });
+
+    expect(insertedDeviceRows).toHaveLength(1);
+    const row = insertedDeviceRows[0];
+    expect(row.deviceCodeHash).toBe(hashToken(DEVICE_CODE));
+    expect(row.userCodeHash).toBe(hashToken(USER_CODE));
+    expect(JSON.stringify(row)).not.toContain(DEVICE_CODE);
+    expect(JSON.stringify(row)).not.toContain(USER_CODE);
+  });
+});
+
+describe('pollDeviceToken', () => {
+  it('returns not_found for an unknown device_code', async () => {
+    deviceRow = null;
+    const result = await pollDeviceToken({ deviceCode: 'never-issued', clientDbId: CLIENT_DB_ID, now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+
+  it('returns not_found when the device_code belongs to a different client (scoped lookup, no oracle)', async () => {
+    seedDeviceRow({ clientId: 'some-other-client-db-id' });
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+
+  it('returns authorization_pending on the first poll and persists lastPolledAt', async () => {
+    seedDeviceRow();
+    const now = new Date();
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now });
+
+    expect(result).toEqual({ outcome: 'authorization_pending' });
+    expect(deviceRow?.lastPolledAt).toEqual(now);
+  });
+
+  it('returns slow_down when polling faster than the interval, and updates lastPolledAt regardless', async () => {
+    const first = new Date();
+    seedDeviceRow({ lastPolledAt: first, pollIntervalSeconds: 5 });
+
+    const tooSoon = new Date(first.getTime() + 2000);
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: tooSoon });
+
+    expect(result).toEqual({ outcome: 'slow_down' });
+    expect(deviceRow?.lastPolledAt).toEqual(tooSoon);
+  });
+
+  it('enforces the throttle across separate polls via the persisted lastPolledAt', async () => {
+    seedDeviceRow({ pollIntervalSeconds: 5 });
+    const t0 = new Date();
+
+    const poll1 = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: t0 });
+    expect(poll1).toEqual({ outcome: 'authorization_pending' });
+
+    const poll2 = await pollDeviceToken({
+      deviceCode: DEVICE_CODE,
+      clientDbId: CLIENT_DB_ID,
+      now: new Date(t0.getTime() + 2000),
+    });
+    expect(poll2).toEqual({ outcome: 'slow_down' });
+
+    const poll3 = await pollDeviceToken({
+      deviceCode: DEVICE_CODE,
+      clientDbId: CLIENT_DB_ID,
+      now: new Date(t0.getTime() + 5000),
+    });
+    expect(poll3).toEqual({ outcome: 'authorization_pending' });
+  });
+
+  it('returns expired_token once past expiry, regardless of status', async () => {
+    seedDeviceRow({ expiresAt: new Date(Date.now() - 1000) });
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+    expect(result).toEqual({ outcome: 'expired_token' });
+  });
+
+  it('returns access_denied for a denied device code', async () => {
+    seedDeviceRow({ deniedAt: new Date() });
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+    expect(result).toEqual({ outcome: 'access_denied' });
+  });
+
+  it('mints a hashed ps_at_*/ps_rt_* token pair for an approved device code', async () => {
+    seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['account', 'offline_access'] });
+
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.userId).toBe(USER_ID);
+    expect(result.scopes).toEqual(['account', 'offline_access']);
+    expect(result.tokens.accessToken).toMatch(/^ps_at_/);
+    expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
+    expect(refreshRows).toHaveLength(1);
+    expect(accessRows).toHaveLength(1);
+    expect(refreshRows[0].tokenHash).toBe(hashToken(result.tokens.refreshToken));
+  });
+
+  it('does not persist lastPolledAt for an already-settled (approved) record', async () => {
+    seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, lastPolledAt: null });
+    await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+    expect(deviceRow?.lastPolledAt).toBeNull();
+  });
+});
+
+describe('verifyDeviceUserCode', () => {
+  it('returns not_found for an unknown user code', async () => {
+    deviceRow = null;
+    const result = await verifyDeviceUserCode({ userCode: 'NEVERISSU', now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+
+  it('returns ok with the resolved client_id and scopes for a pending, unexpired code', async () => {
+    seedDeviceRow({ scopes: ['account'] });
+    const result = await verifyDeviceUserCode({ userCode: USER_CODE, now: new Date() });
+    expect(result).toEqual({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['account'] });
+  });
+
+  it('returns not_found for an expired code (fail closed, no oracle)', async () => {
+    seedDeviceRow({ expiresAt: new Date(Date.now() - 1000) });
+    const result = await verifyDeviceUserCode({ userCode: USER_CODE, now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+
+  it('returns not_found for an already-approved code (settled, cannot re-verify)', async () => {
+    seedDeviceRow({ approvedAt: new Date(), userId: USER_ID });
+    const result = await verifyDeviceUserCode({ userCode: USER_CODE, now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+
+  it('returns not_found for an already-denied code (settled, cannot re-verify)', async () => {
+    seedDeviceRow({ deniedAt: new Date() });
+    const result = await verifyDeviceUserCode({ userCode: USER_CODE, now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+});
+
+describe('recordDeviceApproval', () => {
+  it('returns not_found for an unknown user code', async () => {
+    deviceRow = null;
+    const result = await recordDeviceApproval({ userCode: 'NEVERISSU', action: 'approve', userId: USER_ID, now: new Date() });
+    expect(result).toEqual({ outcome: 'not_found' });
+  });
+
+  it('approves a pending code exactly once, persisting approvedAt + userId', async () => {
+    seedDeviceRow();
+    const now = new Date();
+
+    const result = await recordDeviceApproval({ userCode: USER_CODE, action: 'approve', userId: USER_ID, now });
+
+    expect(result).toEqual({ outcome: 'approved' });
+    expect(deviceRow?.approvedAt).toEqual(now);
+    expect(deviceRow?.userId).toBe(USER_ID);
+  });
+
+  it('denies a pending code, persisting deniedAt', async () => {
+    seedDeviceRow();
+    const now = new Date();
+
+    const result = await recordDeviceApproval({ userCode: USER_CODE, action: 'deny', userId: USER_ID, now });
+
+    expect(result).toEqual({ outcome: 'denied' });
+    expect(deviceRow?.deniedAt).toEqual(now);
+  });
+
+  it('rejects a repeat decision on an already-approved code (single-settlement)', async () => {
+    seedDeviceRow({ approvedAt: new Date(), userId: USER_ID });
+
+    const result = await recordDeviceApproval({ userCode: USER_CODE, action: 'deny', userId: USER_ID, now: new Date() });
+
+    expect(result).toEqual({ outcome: 'invalid', decision: { status: 'already_settled', existingStatus: 'approved' } });
+  });
+
+  it('rejects a repeat decision on an already-denied code (single-settlement)', async () => {
+    seedDeviceRow({ deniedAt: new Date() });
+
+    const result = await recordDeviceApproval({ userCode: USER_CODE, action: 'approve', userId: USER_ID, now: new Date() });
+
+    expect(result).toEqual({ outcome: 'invalid', decision: { status: 'already_settled', existingStatus: 'denied' } });
+  });
+
+  it('rejects approval of an expired-but-still-pending code', async () => {
+    seedDeviceRow({ expiresAt: new Date(Date.now() - 1000) });
+
+    const result = await recordDeviceApproval({ userCode: USER_CODE, action: 'approve', userId: USER_ID, now: new Date() });
+
+    expect(result).toEqual({ outcome: 'invalid', decision: { status: 'expired' } });
+  });
+});

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
@@ -37,7 +37,7 @@ const H = vi.hoisted(() => ({
   state: { dbTransactionImpl: null as null | ((cb: (tx: unknown) => unknown) => unknown) },
 }));
 
-const { oauthDeviceCodes, oauthClients, usersTable } = H;
+const { oauthDeviceCodes, usersTable } = H;
 
 vi.mock('@pagespace/db/schema/oauth', () => ({
   oauthDeviceCodes: H.oauthDeviceCodes,
@@ -261,7 +261,7 @@ describe('pollDeviceToken', () => {
     expect(deviceRow?.lastPolledAt).toEqual(now);
   });
 
-  it('returns slow_down when polling faster than the interval, and updates lastPolledAt regardless', async () => {
+  it('returns slow_down when polling faster than the interval, and does NOT reset the anchor', async () => {
     const first = new Date();
     seedDeviceRow({ lastPolledAt: first, pollIntervalSeconds: 5 });
 
@@ -269,7 +269,9 @@ describe('pollDeviceToken', () => {
     const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: tooSoon });
 
     expect(result).toEqual({ outcome: 'slow_down' });
-    expect(deviceRow?.lastPolledAt).toEqual(tooSoon);
+    // The anchor stays at `first` — a throttled poll must not buy the client
+    // a fresh countdown, or tight retries could push it forward forever.
+    expect(deviceRow?.lastPolledAt).toEqual(first);
   });
 
   it('enforces the throttle across separate polls via the persisted lastPolledAt', async () => {

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -7,11 +7,18 @@
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { eq, and, isNull } from '@pagespace/db/operators';
-import { oauthClients, oauthAuthorizationCodes, oauthRefreshTokens, oauthAccessTokens } from '@pagespace/db/schema/oauth';
+import { oauthClients, oauthAuthorizationCodes, oauthRefreshTokens, oauthAccessTokens, oauthDeviceCodes } from '@pagespace/db/schema/oauth';
 import { users } from '@pagespace/db/schema/auth';
 import type { RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
 import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { decideCodeExchange, type CodeExchangeDecision } from '@pagespace/lib/auth/oauth/code-lifecycle';
+import {
+  decideDevicePoll,
+  decideDeviceApproval,
+  type DeviceCodeRecord,
+  type DeviceApprovalAction,
+  type DeviceApprovalDecision,
+} from '@pagespace/lib/auth/oauth/code-lifecycle';
 import { issueInitialTokenPair, issueRotatedTokenPair, type IssuedTokenPair } from '@pagespace/lib/auth/oauth/issue-tokens';
 import { decideRefreshRotation } from '@pagespace/lib/auth/oauth/refresh-rotation';
 import { parseScopeList, isScopeSubset, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
@@ -329,5 +336,281 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
     });
 
     return { outcome: 'ok', userId: row.userId, scopes, tokens };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Device authorization grant (RFC 8628; task mwexjazwha2uhw5bmvc9a7kw).
+// ---------------------------------------------------------------------------
+
+interface DeviceCodeRow {
+  id: string;
+  clientId: string;
+  userId: string | null;
+  scopes: string[];
+  expiresAt: Date;
+  approvedAt: Date | null;
+  deniedAt: Date | null;
+  lastPolledAt: Date | null;
+  pollIntervalSeconds: number;
+}
+
+/** Map a DB row onto task 4's `DeviceCodeRecord` discriminated union. */
+function toDeviceCodeRecord(row: DeviceCodeRow): DeviceCodeRecord {
+  const common = {
+    clientId: row.clientId,
+    scopes: row.scopes,
+    expiresAt: row.expiresAt,
+    lastPolledAt: row.lastPolledAt,
+    pollIntervalSeconds: row.pollIntervalSeconds,
+  };
+
+  if (row.deniedAt !== null) {
+    return { status: 'denied', ...common };
+  }
+  if (row.approvedAt !== null && row.userId !== null) {
+    return { status: 'approved', approvedUserId: row.userId, ...common };
+  }
+  return { status: 'pending', ...common };
+}
+
+export interface CreateDeviceAuthorizationInput {
+  clientDbId: string;
+  scopes: string[];
+  deviceCodeHash: string;
+  deviceCodePrefix: string;
+  userCodeHash: string;
+  userCodePrefix: string;
+  expiresAt: Date;
+  pollIntervalSeconds: number;
+}
+
+export async function createDeviceAuthorization(input: CreateDeviceAuthorizationInput): Promise<void> {
+  await db.insert(oauthDeviceCodes).values({
+    deviceCodeHash: input.deviceCodeHash,
+    deviceCodePrefix: input.deviceCodePrefix,
+    userCodeHash: input.userCodeHash,
+    userCodePrefix: input.userCodePrefix,
+    clientId: input.clientDbId,
+    scopes: input.scopes,
+    expiresAt: input.expiresAt,
+    pollIntervalSeconds: input.pollIntervalSeconds,
+  });
+}
+
+export interface PollDeviceTokenInput {
+  /** Raw device_code from the token request; hashed before any lookup. */
+  deviceCode: string;
+  /** Resolved `oauth_clients.id` — scopes the lookup so a device_code minted
+   * for a different client is indistinguishable from an unknown one. */
+  clientDbId: string;
+  now: Date;
+}
+
+export type PollDeviceTokenResult =
+  | { outcome: 'not_found' }
+  | { outcome: 'authorization_pending' }
+  | { outcome: 'slow_down' }
+  | { outcome: 'expired_token' }
+  | { outcome: 'access_denied' }
+  | { outcome: 'ok'; userId: string; scopes: string[]; tokens: IssuedTokenPair };
+
+/**
+ * Atomically poll a device code (RFC 8628 §3.4-3.5). `FOR UPDATE` locks the
+ * row for the transaction's duration, mirroring `exchangeAuthorizationCode`'s
+ * lock model. `decideDevicePoll` (task 4, not reimplemented) makes the
+ * decision; this function's only added responsibility is persisting
+ * `lastPolledAt` — real persistence is what makes the `slow_down` throttle
+ * enforceable across separate HTTP requests rather than just describable in
+ * memory — and, on `ok`, minting the initial token pair via the exact same
+ * path task 7 uses.
+ *
+ * The anchor only advances on an *allowed* poll (`authorization_pending`),
+ * never on a throttled one: a client hammering the endpoint faster than
+ * `pollIntervalSeconds` must wait out the interval from its last ALLOWED
+ * poll, not get a fresh countdown on every rejected attempt — otherwise
+ * tight retries could push the anchor forward indefinitely and the interval
+ * would never actually elapse from the client's point of view.
+ */
+export async function pollDeviceToken(input: PollDeviceTokenInput): Promise<PollDeviceTokenResult> {
+  const deviceCodeHash = hashToken(input.deviceCode);
+
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: oauthDeviceCodes.id,
+        clientId: oauthDeviceCodes.clientId,
+        userId: oauthDeviceCodes.userId,
+        scopes: oauthDeviceCodes.scopes,
+        expiresAt: oauthDeviceCodes.expiresAt,
+        approvedAt: oauthDeviceCodes.approvedAt,
+        deniedAt: oauthDeviceCodes.deniedAt,
+        lastPolledAt: oauthDeviceCodes.lastPolledAt,
+        pollIntervalSeconds: oauthDeviceCodes.pollIntervalSeconds,
+      })
+      .from(oauthDeviceCodes)
+      .where(and(eq(oauthDeviceCodes.deviceCodeHash, deviceCodeHash), eq(oauthDeviceCodes.clientId, input.clientDbId)))
+      .for('update');
+
+    const row = rows[0];
+    if (!row) {
+      return { outcome: 'not_found' };
+    }
+
+    const record = toDeviceCodeRecord(row);
+    const decision = decideDevicePoll(record, input.now);
+
+    if (decision.status === 'authorization_pending') {
+      await tx.update(oauthDeviceCodes).set({ lastPolledAt: input.now }).where(eq(oauthDeviceCodes.id, row.id));
+    }
+
+    if (decision.status !== 'ok') {
+      return { outcome: decision.status };
+    }
+
+    const userRows = await tx
+      .select({ tokenVersion: users.tokenVersion })
+      .from(users)
+      .where(eq(users.id, decision.grant.userId));
+    const tokenVersion = userRows[0]?.tokenVersion ?? 0;
+
+    const tokens = issueInitialTokenPair(input.now);
+
+    await tx.insert(oauthRefreshTokens).values({
+      tokenHash: tokens.refreshTokenHash,
+      tokenPrefix: tokens.refreshTokenPrefix,
+      familyId: tokens.familyId,
+      clientId: input.clientDbId,
+      userId: decision.grant.userId,
+      scopes: decision.grant.scopes,
+      tokenVersion,
+      expiresAt: tokens.refreshExpiresAt,
+      familyExpiresAt: tokens.familyExpiresAt,
+    });
+
+    await tx.insert(oauthAccessTokens).values({
+      tokenHash: tokens.accessTokenHash,
+      tokenPrefix: tokens.accessTokenPrefix,
+      familyId: tokens.familyId,
+      clientId: input.clientDbId,
+      userId: decision.grant.userId,
+      scopes: decision.grant.scopes,
+      tokenVersion,
+      expiresAt: tokens.accessExpiresAt,
+    });
+
+    return { outcome: 'ok', userId: decision.grant.userId, scopes: decision.grant.scopes, tokens };
+  });
+}
+
+export interface VerifyDeviceUserCodeInput {
+  /** Already-normalized user code (uppercased, hyphen-free); hashed here. */
+  userCode: string;
+  now: Date;
+}
+
+export type VerifyDeviceUserCodeResult =
+  | { outcome: 'not_found' }
+  | { outcome: 'ok'; clientId: string; scopes: string[] };
+
+/**
+ * Read-only lookup for the /activate screen: is this user code currently
+ * pending and unexpired? Unknown, expired, and already-settled (approved or
+ * denied) codes all collapse to the same `not_found` outcome — a code that
+ * can no longer be acted on is not this endpoint's business to explain.
+ * Joins to `oauth_clients` to recover the static registry's string
+ * `client_id` (the device-code row only carries the DB id).
+ */
+export async function verifyDeviceUserCode(input: VerifyDeviceUserCodeInput): Promise<VerifyDeviceUserCodeResult> {
+  const userCodeHash = hashToken(input.userCode);
+
+  const rows = await db
+    .select({
+      scopes: oauthDeviceCodes.scopes,
+      expiresAt: oauthDeviceCodes.expiresAt,
+      approvedAt: oauthDeviceCodes.approvedAt,
+      deniedAt: oauthDeviceCodes.deniedAt,
+      clientStringId: oauthClients.clientId,
+    })
+    .from(oauthDeviceCodes)
+    .innerJoin(oauthClients, eq(oauthDeviceCodes.clientId, oauthClients.id))
+    .where(eq(oauthDeviceCodes.userCodeHash, userCodeHash));
+
+  const row = rows[0];
+  if (!row) {
+    return { outcome: 'not_found' };
+  }
+
+  const isSettled = row.approvedAt !== null || row.deniedAt !== null;
+  const isExpired = input.now.getTime() >= row.expiresAt.getTime();
+  if (isSettled || isExpired) {
+    return { outcome: 'not_found' };
+  }
+
+  return { outcome: 'ok', clientId: row.clientStringId, scopes: row.scopes };
+}
+
+export interface RecordDeviceApprovalInput {
+  /** Already-normalized user code; hashed here. */
+  userCode: string;
+  action: DeviceApprovalAction;
+  userId: string;
+  now: Date;
+}
+
+export type RecordDeviceApprovalResult =
+  | { outcome: 'not_found' }
+  | { outcome: 'invalid'; decision: Extract<DeviceApprovalDecision, { status: 'already_settled' } | { status: 'expired' }> }
+  | { outcome: 'approved' }
+  | { outcome: 'denied' };
+
+/**
+ * Atomically record the user's approve/deny decision at /activate.
+ * `decideDeviceApproval` (task 4, not reimplemented) makes the decision under
+ * a `FOR UPDATE` lock, so a double-submit of the same code (double-click,
+ * replayed request) settles exactly once.
+ */
+export async function recordDeviceApproval(input: RecordDeviceApprovalInput): Promise<RecordDeviceApprovalResult> {
+  const userCodeHash = hashToken(input.userCode);
+
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select({
+        id: oauthDeviceCodes.id,
+        clientId: oauthDeviceCodes.clientId,
+        userId: oauthDeviceCodes.userId,
+        scopes: oauthDeviceCodes.scopes,
+        expiresAt: oauthDeviceCodes.expiresAt,
+        approvedAt: oauthDeviceCodes.approvedAt,
+        deniedAt: oauthDeviceCodes.deniedAt,
+        lastPolledAt: oauthDeviceCodes.lastPolledAt,
+        pollIntervalSeconds: oauthDeviceCodes.pollIntervalSeconds,
+      })
+      .from(oauthDeviceCodes)
+      .where(eq(oauthDeviceCodes.userCodeHash, userCodeHash))
+      .for('update');
+
+    const row = rows[0];
+    if (!row) {
+      return { outcome: 'not_found' };
+    }
+
+    const record = toDeviceCodeRecord(row);
+    const decision = decideDeviceApproval(record, input.action, input.userId, input.now);
+
+    if (decision.status === 'approved') {
+      await tx
+        .update(oauthDeviceCodes)
+        .set({ approvedAt: input.now, userId: input.userId })
+        .where(eq(oauthDeviceCodes.id, row.id));
+      return { outcome: 'approved' };
+    }
+
+    if (decision.status === 'denied') {
+      await tx.update(oauthDeviceCodes).set({ deniedAt: input.now }).where(eq(oauthDeviceCodes.id, row.id));
+      return { outcome: 'denied' };
+    }
+
+    return { outcome: 'invalid', decision };
   });
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -967,6 +967,11 @@
       "import": "./dist/auth/oauth/refresh-rotation.js",
       "require": "./dist/auth/oauth/refresh-rotation.js"
     },
+    "./auth/oauth/user-code": {
+      "types": "./dist/auth/oauth/user-code.d.ts",
+      "import": "./dist/auth/oauth/user-code.js",
+      "require": "./dist/auth/oauth/user-code.js"
+    },
     "./auth/account-lockout": {
       "types": "./dist/auth/account-lockout.d.ts",
       "import": "./dist/auth/account-lockout.js",

--- a/packages/lib/src/auth/oauth/__tests__/user-code.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/user-code.test.ts
@@ -1,0 +1,103 @@
+/**
+ * User-code generation + normalization (task mwexjazwha2uhw5bmvc9a7kw).
+ * Pure functions: randomness injected, no clock, no I/O.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateUserCode, normalizeUserCode, USER_CODE_ALPHABET } from '../user-code';
+
+function fixedBytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+describe('USER_CODE_ALPHABET', () => {
+  it('is exactly 32 characters (unbiased byte % 32 mapping)', () => {
+    expect(USER_CODE_ALPHABET.length).toBe(32);
+  });
+
+  it('excludes the ambiguous characters 0, O, 1, I', () => {
+    for (const ambiguous of ['0', 'O', '1', 'I']) {
+      expect(USER_CODE_ALPHABET).not.toContain(ambiguous);
+    }
+  });
+
+  it('has no duplicate characters', () => {
+    expect(new Set(USER_CODE_ALPHABET).size).toBe(USER_CODE_ALPHABET.length);
+  });
+});
+
+describe('generateUserCode', () => {
+  it('requests exactly 8 bytes of randomness', () => {
+    let requestedSize: number | undefined;
+    generateUserCode((size) => {
+      requestedSize = size;
+      return fixedBytes(0, 0, 0, 0, 0, 0, 0, 0);
+    });
+
+    expect(requestedSize).toBe(8);
+  });
+
+  it('formats as XXXX-XXXX using only alphabet characters', () => {
+    const code = generateUserCode(() => fixedBytes(1, 2, 3, 4, 5, 6, 7, 8));
+
+    expect(code).toMatch(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    const stripped = code.replace('-', '');
+    for (const ch of stripped) {
+      expect(USER_CODE_ALPHABET).toContain(ch);
+    }
+  });
+
+  it('is deterministic for a given random byte sequence', () => {
+    const bytes = fixedBytes(0, 1, 2, 3, 4, 5, 6, 7);
+    const expected = Array.from(bytes, (b) => USER_CODE_ALPHABET[b % 32]);
+    const code = generateUserCode(() => bytes);
+
+    expect(code).toBe(`${expected.slice(0, 4).join('')}-${expected.slice(4).join('')}`);
+  });
+
+  it('maps a full byte range (0-255) without bias via modulo 32', () => {
+    // 256 is evenly divisible by 32 — byte 224 (7*32) and byte 0 both map to
+    // alphabet index 0; this asserts the wraparound is exact, not off-by-one.
+    const code = generateUserCode(() => fixedBytes(224, 0, 31, 32, 255, 0, 0, 0));
+    const expectedChars = [224, 0, 31, 32, 255, 0, 0, 0].map((b) => USER_CODE_ALPHABET[b % 32]);
+    expect(code).toBe(`${expectedChars.slice(0, 4).join('')}-${expectedChars.slice(4).join('')}`);
+  });
+
+  it('never contains ambiguous characters across many random seeds', () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const bytes = fixedBytes(seed, seed + 1, seed + 2, seed + 3, seed + 4, seed + 5, seed + 6, seed + 7);
+      const code = generateUserCode(() => bytes);
+      for (const ambiguous of ['0', 'O', '1', 'I']) {
+        expect(code).not.toContain(ambiguous);
+      }
+    }
+  });
+});
+
+describe('normalizeUserCode', () => {
+  it('uppercases lowercase input', () => {
+    expect(normalizeUserCode('abcd-efgh')).toBe('ABCDEFGH');
+  });
+
+  it('strips hyphens', () => {
+    expect(normalizeUserCode('ABCD-EFGH')).toBe('ABCDEFGH');
+  });
+
+  it('strips surrounding and internal whitespace', () => {
+    expect(normalizeUserCode('  ABCD EFGH  ')).toBe('ABCDEFGH');
+  });
+
+  it('strips hyphens, case, and whitespace together', () => {
+    expect(normalizeUserCode(' abcd - efgh ')).toBe('ABCDEFGH');
+  });
+
+  it('round-trips a generated code to its hyphen-free canonical form', () => {
+    const code = generateUserCode(() => fixedBytes(2, 4, 6, 8, 10, 12, 14, 16));
+    expect(normalizeUserCode(code)).toBe(code.replace('-', ''));
+  });
+
+  it('is idempotent on an already-normalized code', () => {
+    const code = generateUserCode(() => fixedBytes(3, 5, 7, 9, 11, 13, 15, 17));
+    const normalized = normalizeUserCode(code);
+    expect(normalizeUserCode(normalized)).toBe(normalized);
+  });
+});

--- a/packages/lib/src/auth/oauth/user-code.ts
+++ b/packages/lib/src/auth/oauth/user-code.ts
@@ -1,0 +1,45 @@
+/**
+ * RFC 8628 §6.1 user-code generation + normalization for the device
+ * authorization grant (Phase 1 task 9, mwexjazwha2uhw5bmvc9a7kw). Pure:
+ * randomness is injected via `randomBytesFn`, no I/O, no clock — the
+ * `/api/oauth/device_authorization` route is the impure edge that supplies
+ * Node's `crypto.randomBytes`.
+ *
+ * @module @pagespace/lib/auth/oauth/user-code
+ */
+
+/**
+ * Unambiguous 32-character alphabet: excludes 0/O and 1/I (RFC 8628 §6.1
+ * recommends avoiding characters a human can misread over the phone or a
+ * blurry terminal). 32 = 2^5, so one byte's low 5 bits (`byte % 32`) map to a
+ * character with zero modulo bias — 256 is evenly divisible by 32.
+ */
+export const USER_CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+/** Characters before the canonical `XXXX-XXXX` hyphen is inserted. */
+const USER_CODE_LENGTH = 8;
+
+export type RandomBytesFn = (size: number) => Uint8Array;
+
+/**
+ * Generate an `XXXX-XXXX` user code from injected randomness. One byte per
+ * character, drawn from `USER_CODE_ALPHABET` via `byte % 32`.
+ */
+export function generateUserCode(randomBytesFn: RandomBytesFn): string {
+  const bytes = randomBytesFn(USER_CODE_LENGTH);
+  const chars: string[] = [];
+  for (let i = 0; i < USER_CODE_LENGTH; i++) {
+    chars.push(USER_CODE_ALPHABET[bytes[i] % USER_CODE_ALPHABET.length]);
+  }
+  return `${chars.slice(0, 4).join('')}-${chars.slice(4).join('')}`;
+}
+
+/**
+ * Normalize user input before hashing/lookup: uppercase, strip hyphens and
+ * whitespace. Generation-time storage and verification-time lookup both run
+ * input through this exact function, so the two hashes only ever match when
+ * the underlying 8 characters do.
+ */
+export function normalizeUserCode(raw: string): string {
+  return raw.toUpperCase().replace(/[^A-Z0-9]/g, '');
+}


### PR DESCRIPTION
## Summary
RFC 8628 device authorization grant — `pagespace login --device` for SSH boxes and headless machines: CLI gets a short user code, human enters it at `/activate` on any signed-in device.

- **`packages/lib/src/auth/oauth/user-code.ts`** — pure `generateUserCode`/`normalizeUserCode`. 32-char unambiguous alphabet (no `0`/`O`/`1`/`I`), injected randomness, unbiased `byte % 32` mapping (256 divides evenly by 32).
- **`oauth-repository.ts`** — `createDeviceAuthorization`, `pollDeviceToken`, `verifyDeviceUserCode`, `recordDeviceApproval`: thin persistence shells over task 4's `decideDevicePoll`/`decideDeviceApproval` (reused, not reimplemented). The poll throttle anchors `lastPolledAt` only on an *allowed* poll, never a throttled one — otherwise tight retries could push the interval forward indefinitely.
- **`POST /api/oauth/device_authorization`** — mints `device_code` + `user_code` (both SHA3-256 hashed at rest), returns the RFC 8628 §3.2 response shape.
- **`POST /api/oauth/device_authorization/verify`** — session-gated, rate-limited (per session AND per IP via `DISTRIBUTED_RATE_LIMITS.OAUTH_VERIFY`) user-code lookup for `/activate`; reuses task 6's `describeScopeForConsent` narration.
- **`POST /api/oauth/device_authorization/decision`** — CSRF-protected approve/deny, same dual rate limiting, records via `decideDeviceApproval`.
- **`/api/oauth/token`** — new `device_code` grant branch. RFC 8628 §3.5 poll outcomes (`authorization_pending`/`slow_down`/`expired_token`/`access_denied`) each get their own distinct error string — a deliberate protocol requirement, not an oracle leak like the other two grants; only an unknown `device_code` falls back to the shared `invalid_grant`.
- **`apps/web/src/app/activate/`** — session-gated page + `ActivateFlow` client component driving enter-code → verify → consent → approve/deny → done.
- `url-utils.ts`: `/activate` added to `SIGNIN_NEXT_ALLOWED_PREFIXES`.
- `packages/lib/package.json`: new `./auth/oauth/user-code` exports entry.

Scope note: `device_code` is not marked single-use after a successful token exchange (unlike `authorization_code`'s `issuedFamilyId`/`consumedAt`). RFC 8628 doesn't require it and the task's test list doesn't call for it; a compliant CLI stops polling once it has tokens. Flagging as a candidate follow-up, same spirit as task 8's grace-cache scope note.

## Test plan
- [x] RED commit (`2f5cc159d`): 5 new/extended test files, 31 failing / 26 pre-existing passing — confirmed failing before implementation (module resolution errors / `unsupported_grant_type`).
- [x] GREEN commit (`9a710b94b`): all new tests pass.
- [x] `bun run --filter 'web' typecheck` — clean.
- [x] `bun run --filter 'web' lint` — clean (0 new warnings, pre-existing warnings untouched).
- [x] `bun run --filter '@pagespace/lib' typecheck && lint` — clean.
- [x] `bun run test:unit` — 16 failures / 3 files, confirmed identical via `git stash` (live-Postgres-only tests + one pre-existing midnight-boundary flake, unrelated to this change).
- [x] `bun run test:security` — 7/43 suites fail, confirmed identical via `git stash` (same DB-environment gap as tasks 6-8's documented baseline). `security-audit-coverage` passes — device_authorization POST now audits via `auth.device.registered` (previously-unused enum value, no schema change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pRss6aSpdhgY85mxcXNGt