### PR TITLE
sdk: implement workflows & commands operations (Phase 3 task 8)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -86,6 +86,9 @@ export type { FreeSlot } from './operations/calendar.js';
 // Collaborators (Phase 3 task 1).
 export { listCollaborators } from './operations/collaborators.js';
 
+// Commands (Phase 3 task 8).
+export { createCommand, deleteCommand, listCommands, updateCommand } from './operations/commands.js';
+
 // Conversations (Phase 3 task 5).
 export { listConversations, readConversation } from './operations/conversations.js';
 
@@ -155,6 +158,9 @@ export {
   updateTask,
 } from './operations/tasks.js';
 export type { TaskCompletionGatedError } from './operations/tasks.js';
+
+// Workflows (Phase 3 task 8).
+export { createWorkflow, deleteWorkflow, listWorkflows, updateWorkflow } from './operations/workflows.js';
 
 // Transport primitive types needed to declare custom operations. buildRequest/
 // parseResponse/executeRequest stay internal — the facade is the only caller.

--- a/packages/sdk/src/operations/__tests__/commands.test.ts
+++ b/packages/sdk/src/operations/__tests__/commands.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { createCommand, deleteCommand, listCommands, updateCommand } from '../commands.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** `CommandResponse` (`commands/command-route-helpers.ts`), Date fields ISO-serialized over JSON. */
+const commandFixture = {
+  id: 'c1abc',
+  scope: 'drive' as const,
+  driveId: 'd1abc',
+  trigger: 'summarize-thread',
+  description: 'Summarize the current channel thread.',
+  entryPageId: 'p1abc',
+  type: 'document' as const,
+  enabled: true,
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+describe('commands.list — request shape', () => {
+  it('builds a GET to /api/commands with no query params (route reads none — driveId filtering is gone)', () => {
+    const request = buildRequest(listCommands, {}, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/commands');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('takes no input fields at all', () => {
+    const result = listCommands.inputSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('commands.list — response contract', () => {
+  it('parses { commands } enriched with entryPageTitle/entryPageDriveId/entryPageAvailable/authorName (route truth: commands/route.ts GET)', () => {
+    const listItem = {
+      ...commandFixture,
+      entryPageTitle: 'Summarize Thread',
+      entryPageDriveId: 'd1abc',
+      entryPageAvailable: true,
+      authorName: 'Ada',
+    };
+    const result = parseResponse(listCommands, 200, new Headers(), JSON.stringify({ commands: [listItem] }));
+    expect(result).toEqual({ commands: [listItem] });
+  });
+
+  it('parses an unavailable/suppressed entry page as nulled metadata', () => {
+    const listItem = {
+      ...commandFixture,
+      entryPageTitle: null,
+      entryPageDriveId: null,
+      entryPageAvailable: false,
+      authorName: null,
+    };
+    const result = parseResponse(listCommands, 200, new Headers(), JSON.stringify({ commands: [listItem] }));
+    expect(result).toEqual({ commands: [listItem] });
+  });
+
+  it('parses an empty list', () => {
+    const result = parseResponse(listCommands, 200, new Headers(), JSON.stringify({ commands: [] }));
+    expect(result).toEqual({ commands: [] });
+  });
+
+  it('rejects a response that drifts from the contract', () => {
+    const malformed = { commands: [{ ...commandFixture, enabled: 'yes' }] };
+    const result = parseResponse(listCommands, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('commands.list — metadata', () => {
+  it('requires only account scope (no drive-scoping input at all)', () => {
+    expect(listCommands.requiredScope).toBe('account');
+  });
+});
+
+describe('commands.create — request shape', () => {
+  it('builds a POST with trigger/description/entryPageId in the body', () => {
+    const request = buildRequest(
+      createCommand,
+      { trigger: 'summarize-thread', description: 'Summarize the current channel thread.', entryPageId: 'p1abc' },
+      config,
+    );
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/commands');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      trigger: 'summarize-thread',
+      description: 'Summarize the current channel thread.',
+      entryPageId: 'p1abc',
+    });
+  });
+
+  it('accepts an optional driveId for a drive-scoped command', () => {
+    const request = buildRequest(
+      createCommand,
+      { trigger: 'summarize-thread', description: 'Summarize.', entryPageId: 'p1abc', driveId: 'd1abc' },
+      config,
+    );
+    expect(JSON.parse(request.body ?? '{}')).toMatchObject({ driveId: 'd1abc' });
+  });
+
+  it('rejects a trigger with uppercase or underscores (Agent Skills name rules: lowercase alphanumeric + single hyphens)', () => {
+    const result = createCommand.inputSchema.safeParse({
+      trigger: 'Summarize_Thread',
+      description: 'Summarize.',
+      entryPageId: 'p1abc',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a trigger with consecutive or leading hyphens', () => {
+    const result = createCommand.inputSchema.safeParse({
+      trigger: '-summarize--thread',
+      description: 'Summarize.',
+      entryPageId: 'p1abc',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a trigger over 64 chars', () => {
+    const result = createCommand.inputSchema.safeParse({
+      trigger: 'a'.repeat(65),
+      description: 'Summarize.',
+      entryPageId: 'p1abc',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty description', () => {
+    const result = createCommand.inputSchema.safeParse({ trigger: 'summarize-thread', description: '', entryPageId: 'p1abc' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a description over 1024 chars', () => {
+    const result = createCommand.inputSchema.safeParse({
+      trigger: 'summarize-thread',
+      description: 'x'.repeat(1025),
+      entryPageId: 'p1abc',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unrecognized field (userId/scope must never be settable from create input)', () => {
+    const result = createCommand.inputSchema.safeParse({
+      trigger: 'summarize-thread',
+      description: 'Summarize.',
+      entryPageId: 'p1abc',
+      userId: 'sneaky',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('commands.create — response contract', () => {
+  it('parses a 201 { command }', () => {
+    const result = parseResponse(createCommand, 201, new Headers(), JSON.stringify({ command: commandFixture }));
+    expect(result).toEqual({ command: commandFixture });
+  });
+
+  it('classifies a 409 (duplicate trigger in scope) as a typed error, not a schema drift', () => {
+    const result = parseResponse(createCommand, 409, new Headers(), JSON.stringify({ error: "A command with trigger 'summarize-thread' already exists in this scope" }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (non-owner/admin creating a drive command) as PermissionDeniedError', () => {
+    const result = parseResponse(createCommand, 403, new Headers(), JSON.stringify({ error: 'Only the drive owner or admins can manage drive commands' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('commands.create — metadata', () => {
+  it('requires only account scope (drive-admin authority is enforced server-side only when driveId is supplied)', () => {
+    expect(createCommand.requiredScope).toBe('account');
+  });
+});
+
+describe('commands.update — request shape', () => {
+  it('interpolates :commandId and sends only the provided fields', () => {
+    const request = buildRequest(updateCommand, { commandId: 'c1abc', enabled: false }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/commands/c1abc');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ enabled: false });
+  });
+
+  it('rejects driveId (the route 400s: command scope cannot be changed)', () => {
+    const result = updateCommand.inputSchema.safeParse({ commandId: 'c1abc', driveId: 'd2abc' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an invalid trigger on update the same way create does', () => {
+    const result = updateCommand.inputSchema.safeParse({ commandId: 'c1abc', trigger: 'Not Valid' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('commands.update — response contract', () => {
+  it('parses { command }', () => {
+    const result = parseResponse(updateCommand, 200, new Headers(), JSON.stringify({ command: commandFixture }));
+    expect(result).toEqual({ command: commandFixture });
+  });
+
+  it('classifies a 404 (command not found / not owned) as NotFoundError', () => {
+    const result = parseResponse(updateCommand, 404, new Headers(), JSON.stringify({ error: 'Command not found' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+});
+
+describe('commands.update — metadata', () => {
+  it('requires only account scope', () => {
+    expect(updateCommand.requiredScope).toBe('account');
+  });
+});
+
+describe('commands.delete — request shape', () => {
+  it('builds a DELETE to /api/commands/:commandId', () => {
+    const request = buildRequest(deleteCommand, { commandId: 'c1abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/commands/c1abc');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('commands.delete — response contract', () => {
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteCommand, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('commands.delete — metadata (destructive, non-idempotent)', () => {
+  it('requires only account scope', () => {
+    expect(deleteCommand.requiredScope).toBe('account');
+  });
+
+  it('is flagged destructive so the CLI requires --yes', () => {
+    expect(deleteCommand.destructive).toBe(true);
+  });
+
+  it('uses DELETE, which isIdempotentMethod classifies as non-idempotent (no auto-retry)', () => {
+    expect(deleteCommand.method).toBe('DELETE');
+  });
+});

--- a/packages/sdk/src/operations/__tests__/workflows.test.ts
+++ b/packages/sdk/src/operations/__tests__/workflows.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { createWorkflow, deleteWorkflow, listWorkflows, updateWorkflow } from '../workflows.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Bare `workflows` row (`packages/db/src/schema/workflows.ts`), route-serialized (Date -> ISO string). */
+const workflowFixture = {
+  id: 'w1abc',
+  driveId: 'd1abc',
+  createdBy: 'u1abc',
+  name: 'Daily standup summary',
+  agentPageId: 'ag1abc',
+  prompt: 'Summarize yesterday\'s activity.',
+  contextPageIds: ['p1abc'],
+  cronExpression: '0 9 * * *',
+  timezone: 'UTC',
+  triggerType: 'cron',
+  eventTriggers: null,
+  watchedFolderIds: null,
+  eventDebounceSecs: 30,
+  instructionPageId: null,
+  isEnabled: true,
+  nextRunAt: '2026-07-04T09:00:00.000Z',
+  createdAt: '2026-07-01T00:00:00.000Z',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+};
+
+describe('workflows.list — request shape', () => {
+  it('builds a GET to /api/workflows?driveId=... (driveId is a query param, not a path segment)', () => {
+    const request = buildRequest(listWorkflows, { driveId: 'd1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/workflows?driveId=d1abc');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('rejects input missing driveId before any network call (route: 400 without it)', () => {
+    const result = listWorkflows.inputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('workflows.list — response contract', () => {
+  it('parses a bare array of workflow rows with a lastRun summary (route truth: workflows/route.ts GET)', () => {
+    const withRun = {
+      ...workflowFixture,
+      lastRun: { status: 'success', startedAt: '2026-07-03T09:00:00.000Z', endedAt: '2026-07-03T09:00:05.000Z', error: null, durationMs: 5000 },
+    };
+    const result = parseResponse(listWorkflows, 200, new Headers(), JSON.stringify([withRun]));
+    expect(result).toEqual([withRun]);
+  });
+
+  it('parses a workflow with no runs yet as lastRun: null', () => {
+    const noRun = { ...workflowFixture, lastRun: null };
+    const result = parseResponse(listWorkflows, 200, new Headers(), JSON.stringify([noRun]));
+    expect(result).toEqual([noRun]);
+  });
+
+  it('parses an empty list', () => {
+    const result = parseResponse(listWorkflows, 200, new Headers(), JSON.stringify([]));
+    expect(result).toEqual([]);
+  });
+
+  it('rejects a response that drifts from the workflow row contract', () => {
+    const malformed = [{ ...workflowFixture, lastRun: null, contextPageIds: 'not-an-array' }];
+    const result = parseResponse(listWorkflows, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (not owner/admin) as PermissionDeniedError', () => {
+    const result = parseResponse(listWorkflows, 403, new Headers(), JSON.stringify({ error: 'Only drive owners and admins can manage workflows' }));
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('workflows.list — metadata', () => {
+  it('requires drive:admin scope — the route gates list/GET on owner-or-admin, not plain membership', () => {
+    expect(listWorkflows.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('workflows.create — request shape', () => {
+  it('sends driveId/name/agentPageId/cronExpression + prompt in the body (route truth: instructionPageId IS accepted post-#1768)', () => {
+    const request = buildRequest(
+      createWorkflow,
+      { driveId: 'd1abc', name: 'Daily standup summary', agentPageId: 'ag1abc', prompt: 'Summarize.', cronExpression: '0 9 * * *' },
+      config,
+    );
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/workflows');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      driveId: 'd1abc',
+      name: 'Daily standup summary',
+      agentPageId: 'ag1abc',
+      prompt: 'Summarize.',
+      cronExpression: '0 9 * * *',
+    });
+  });
+
+  it('accepts instructionPageId instead of prompt (route: createWorkflowSchema now allows it, #1768 fix)', () => {
+    const result = createWorkflow.inputSchema.safeParse({
+      driveId: 'd1abc',
+      name: 'Daily standup summary',
+      agentPageId: 'ag1abc',
+      instructionPageId: 'ins1abc',
+      cronExpression: '0 9 * * *',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when neither prompt nor instructionPageId is present (route .refine())', () => {
+    const result = createWorkflow.inputSchema.safeParse({
+      driveId: 'd1abc',
+      name: 'Daily standup summary',
+      agentPageId: 'ag1abc',
+      cronExpression: '0 9 * * *',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unrecognized field (route schema is .strict())', () => {
+    const result = createWorkflow.inputSchema.safeParse({
+      driveId: 'd1abc',
+      name: 'x',
+      agentPageId: 'ag1abc',
+      prompt: 'go',
+      cronExpression: '0 9 * * *',
+      bogusField: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a name over 200 chars (route: max(200))', () => {
+    const result = createWorkflow.inputSchema.safeParse({
+      driveId: 'd1abc',
+      name: 'x'.repeat(201),
+      agentPageId: 'ag1abc',
+      prompt: 'go',
+      cronExpression: '0 9 * * *',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('workflows.create — response contract', () => {
+  it('parses a 201 bare workflow row (no envelope, no lastRun on a freshly created workflow)', () => {
+    const result = parseResponse(createWorkflow, 201, new Headers(), JSON.stringify(workflowFixture));
+    expect(result).toEqual(workflowFixture);
+  });
+
+  it('classifies a 400 (invalid agent page) as a typed error, not a schema drift', () => {
+    const result = parseResponse(createWorkflow, 400, new Headers(), JSON.stringify({ error: 'Agent page not found in this drive' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+});
+
+describe('workflows.create — metadata', () => {
+  it('requires drive:admin scope', () => {
+    expect(createWorkflow.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('workflows.update — request shape', () => {
+  it('interpolates :workflowId and sends only the provided fields', () => {
+    const request = buildRequest(updateWorkflow, { workflowId: 'w1abc', name: 'Renamed' }, config);
+    expect(request.method).toBe('PATCH');
+    expect(request.url).toBe('https://pagespace.ai/api/workflows/w1abc');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ name: 'Renamed' });
+  });
+
+  it('accepts instructionPageId on update too', () => {
+    const result = updateWorkflow.inputSchema.safeParse({ workflowId: 'w1abc', instructionPageId: 'ins1abc' });
+    expect(result.success).toBe(true);
+  });
+
+  it('can clear cronExpression with an explicit null (route: nullable().optional())', () => {
+    const request = buildRequest(updateWorkflow, { workflowId: 'w1abc', cronExpression: null }, config);
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ cronExpression: null });
+  });
+
+  it('rejects an unrecognized field (route schema is .strict())', () => {
+    const result = updateWorkflow.inputSchema.safeParse({ workflowId: 'w1abc', bogusField: true });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty update with no fields at all beyond workflowId (nothing to send)', () => {
+    const result = updateWorkflow.inputSchema.safeParse({ workflowId: 'w1abc' });
+    expect(result.success).toBe(true); // schema-valid; route itself has no "must provide one field" guard for PATCH
+  });
+});
+
+describe('workflows.update — response contract', () => {
+  it('parses a bare updated workflow row', () => {
+    const result = parseResponse(updateWorkflow, 200, new Headers(), JSON.stringify(workflowFixture));
+    expect(result).toEqual(workflowFixture);
+  });
+
+  it('classifies a 404 (workflow not found, or a backing non-cron workflow) as NotFoundError', () => {
+    const result = parseResponse(updateWorkflow, 404, new Headers(), JSON.stringify({ error: 'Workflow not found' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+});
+
+describe('workflows.update — metadata', () => {
+  it('requires drive:admin scope', () => {
+    expect(updateWorkflow.requiredScope).toBe('drive:admin');
+  });
+});
+
+describe('workflows.delete — request shape', () => {
+  it('builds a DELETE to /api/workflows/:workflowId', () => {
+    const request = buildRequest(deleteWorkflow, { workflowId: 'w1abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/workflows/w1abc');
+    expect(request.body).toBeUndefined();
+  });
+});
+
+describe('workflows.delete — response contract', () => {
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteWorkflow, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('workflows.delete — metadata (destructive, non-idempotent)', () => {
+  it('requires drive:admin scope', () => {
+    expect(deleteWorkflow.requiredScope).toBe('drive:admin');
+  });
+
+  it('is flagged destructive so the CLI requires --yes', () => {
+    expect(deleteWorkflow.destructive).toBe(true);
+  });
+
+  it('uses DELETE, which isIdempotentMethod classifies as non-idempotent (no auto-retry)', () => {
+    expect(deleteWorkflow.method).toBe('DELETE');
+  });
+});

--- a/packages/sdk/src/operations/commands.ts
+++ b/packages/sdk/src/operations/commands.ts
@@ -1,0 +1,132 @@
+/**
+ * Slash command operations (Phase 3 task 8).
+ *
+ * Route-verified against `apps/web/src/app/api/commands/route.ts` (GET/POST)
+ * and `apps/web/src/app/api/commands/[commandId]/route.ts` (PATCH/DELETE)
+ * (docs/sdk/operations-inventory.md §2.11, parity with MCP tools
+ * `list_commands`, `create_command`, `update_command`, `delete_command`).
+ *
+ * Commands are slash commands scoped to EITHER a user (personal) OR a drive
+ * (shared with every drive member), never both (`commands_scope_chk`,
+ * `packages/db/src/schema/commands.ts`) — the Universal Commands epic's
+ * Agent Skills surface: a command's entry page is the skill body, its direct
+ * children are discoverable resources. Trigger/description validation
+ * (`triggerSchema`/`descriptionSchema` below) is imported straight from
+ * `@pagespace/lib/commands/command-core` rather than restated, so the SDK
+ * cannot drift from the route's own validators.
+ *
+ * DISCREPANCY vs the old MCP tool (`list_commands`, tools.js:1032): the tool
+ * accepted an optional `driveId` filter, but the CURRENT GET route
+ * (`commands/route.ts`) reads no query parameters at all — it always
+ * returns every command visible to the caller (personal + every drive they
+ * belong to, MCP-scope-filtered server-side). `commands.list` below takes no
+ * input, matching route truth; filter the returned array client-side for a
+ * single drive.
+ *
+ * `requiredScope: 'account'` on every write op here is the safe common
+ * floor: an unscoped (account-level) principal can always create/update/
+ * delete a PERSONAL command, and a personal command is what happens when
+ * `driveId` is omitted. Supplying `driveId` additionally requires drive
+ * owner/admin authority server-side — a per-call condition this static
+ * registry field cannot express (same limitation the ADR 0002 scope grammar
+ * accepts for every operation whose authority depends on its own input).
+ */
+import { z } from 'zod';
+import {
+  COMMAND_DESCRIPTION_MAX_LENGTH,
+  COMMAND_TRIGGER_MAX_LENGTH,
+  COMMAND_TRIGGER_PATTERN,
+} from '@pagespace/lib/commands/command-core';
+import { defineOperation } from '../registry/define.js';
+
+const commandScopeEnum = z.enum(['user', 'drive']);
+const commandTypeEnum = z.enum(['document', 'prompt_template', 'builtin']);
+
+/** Agent Skills 'name' rules (`packages/lib/src/commands/command-core.ts`), mirrored so an invalid trigger is rejected before the network call. */
+const triggerSchema = z.string().min(1).max(COMMAND_TRIGGER_MAX_LENGTH).regex(COMMAND_TRIGGER_PATTERN);
+const descriptionSchema = z.string().min(1).max(COMMAND_DESCRIPTION_MAX_LENGTH);
+
+/** `CommandResponse` (`commands/command-route-helpers.ts`), Date fields ISO-serialized over JSON. */
+const commandResponseSchema = z.object({
+  id: z.string(),
+  scope: commandScopeEnum,
+  driveId: z.string().nullable(),
+  trigger: z.string(),
+  description: z.string(),
+  entryPageId: z.string(),
+  type: commandTypeEnum,
+  enabled: z.boolean(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** `CommandListItem` — what GET /api/commands adds for the settings lists. */
+const commandListItemSchema = commandResponseSchema.extend({
+  entryPageTitle: z.string().nullable(),
+  entryPageDriveId: z.string().nullable(),
+  entryPageAvailable: z.boolean(),
+  authorName: z.string().nullable(),
+});
+
+const commandEnvelopeSchema = z.object({ command: commandResponseSchema });
+
+export const listCommands = defineOperation({
+  name: 'commands.list',
+  method: 'GET',
+  path: '/api/commands',
+  inputSchema: z.object({}),
+  outputSchema: z.object({ commands: z.array(commandListItemSchema) }),
+  requiredScope: 'account',
+  description:
+    "List every command visible to the caller: their personal commands plus every command from a drive they belong to. Takes no filter — the route ignores driveId entirely.",
+});
+
+export const createCommand = defineOperation({
+  name: 'commands.create',
+  method: 'POST',
+  path: '/api/commands',
+  inputSchema: z
+    .object({
+      trigger: triggerSchema,
+      description: descriptionSchema,
+      entryPageId: z.string().min(1),
+      driveId: z.string().min(1).optional(),
+      enabled: z.boolean().optional(),
+    })
+    .strict(),
+  outputSchema: commandEnvelopeSchema,
+  requiredScope: 'account',
+  description:
+    'Create a slash command. Omit driveId for a personal command visible only to you; provide driveId for a drive command shared with every member (requires owner/admin authority on that drive). The entry page must exist, not be trashed, be viewable by you, and — for drive commands — live in the same drive.',
+});
+
+export const updateCommand = defineOperation({
+  name: 'commands.update',
+  method: 'PATCH',
+  path: '/api/commands/:commandId',
+  inputSchema: z
+    .object({
+      commandId: z.string(),
+      trigger: triggerSchema.optional(),
+      description: descriptionSchema.optional(),
+      entryPageId: z.string().min(1).optional(),
+      enabled: z.boolean().optional(),
+    })
+    .strict(),
+  outputSchema: commandEnvelopeSchema,
+  requiredScope: 'account',
+  description:
+    "Update a command's trigger, description, entry page, or enabled state. A command's scope (personal vs. drive) can never be changed once created. Personal commands require ownership; drive commands require owner/admin authority on that drive.",
+});
+
+export const deleteCommand = defineOperation({
+  name: 'commands.delete',
+  method: 'DELETE',
+  path: '/api/commands/:commandId',
+  inputSchema: z.object({ commandId: z.string() }),
+  outputSchema: z.object({ success: z.literal(true) }),
+  requiredScope: 'account',
+  destructive: true,
+  description:
+    'Delete a command, permanently discarding its trigger. Personal commands require ownership; drive commands require owner/admin authority on that drive. Irreversible — the CLI requires --yes.',
+});

--- a/packages/sdk/src/operations/workflows.ts
+++ b/packages/sdk/src/operations/workflows.ts
@@ -1,0 +1,143 @@
+/**
+ * Scheduled workflow operations (Phase 3 task 8).
+ *
+ * Route-verified against `apps/web/src/app/api/workflows/route.ts` (GET/POST)
+ * and `apps/web/src/app/api/workflows/[workflowId]/route.ts` (GET/PATCH/DELETE)
+ * (docs/sdk/operations-inventory.md §2.14, parity with MCP tools
+ * `list_workflows`, `create_workflow`, `update_workflow`, `delete_workflow`).
+ * The route also exposes a single-workflow GET, which was never a registered
+ * MCP tool (inventory: "unexposed") — out of scope here, matching the old
+ * tool surface exactly.
+ *
+ * DISCREPANCY vs the Phase 0 inventory's D7 row: D7 recorded the create/
+ * update route schemas as `.strict()` with `prompt` required and no
+ * `instructionPageId`. Re-reading the CURRENT route source shows fix #1768
+ * landed since: both schemas now accept `instructionPageId` (nullable,
+ * optional) alongside `prompt`, with a `.refine()` requiring at least one.
+ * These operations mirror that current, fixed contract — not the stale D7
+ * resolution.
+ *
+ * Every operation here (including `list`/GET) is gated on
+ * `isPrincipalDriveOwnerOrAdmin` — unlike most list/read operations
+ * elsewhere in this SDK, plain drive membership is not enough to even list
+ * a drive's workflows. All four therefore declare `requiredScope: 'drive:admin'`.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+/** `EventTrigger` (`packages/db/src/schema/workflows.ts`) — only populated on event-triggered backing workflows, never on the cron rows this surface manages, but the column is part of the row shape either way. */
+const eventTriggerSchema = z.object({
+  operation: z.string(),
+  resourceType: z.string(),
+});
+
+/**
+ * Bare `workflows` table row (`packages/db/src/schema/workflows.ts`),
+ * route-serialized (Date fields -> ISO string over JSON). Shared by
+ * create/update (returned as-is) and list (extended below with `lastRun`).
+ */
+const workflowRowSchema = z.object({
+  id: z.string(),
+  driveId: z.string(),
+  createdBy: z.string(),
+  name: z.string(),
+  agentPageId: z.string(),
+  prompt: z.string(),
+  contextPageIds: z.array(z.string()).nullable(),
+  cronExpression: z.string().nullable(),
+  timezone: z.string(),
+  triggerType: z.enum(['cron', 'event']),
+  eventTriggers: z.array(eventTriggerSchema).nullable(),
+  watchedFolderIds: z.array(z.string()).nullable(),
+  eventDebounceSecs: z.number().nullable(),
+  instructionPageId: z.string().nullable(),
+  isEnabled: z.boolean(),
+  nextRunAt: z.string().nullable(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+/** Single-row LATERAL projection from `workflow_runs` (`workflows/route.ts` GET), null when the workflow has never fired. */
+const workflowRunSummarySchema = z.object({
+  status: z.enum(['running', 'success', 'error', 'cancelled']),
+  startedAt: z.string().nullable(),
+  endedAt: z.string().nullable(),
+  error: z.string().nullable(),
+  durationMs: z.number().nullable(),
+});
+
+const workflowListItemSchema = workflowRowSchema.extend({
+  lastRun: workflowRunSummarySchema.nullable(),
+});
+
+export const listWorkflows = defineOperation({
+  name: 'workflows.list',
+  method: 'GET',
+  path: '/api/workflows',
+  inputSchema: z.object({ driveId: z.string().min(1) }),
+  outputSchema: z.array(workflowListItemSchema),
+  requiredScope: 'drive:admin',
+  description:
+    "List a drive's cron-scheduled workflows, each with a summary of its most recent run. Requires drive owner or admin authority — plain membership is not enough.",
+});
+
+export const createWorkflow = defineOperation({
+  name: 'workflows.create',
+  method: 'POST',
+  path: '/api/workflows',
+  inputSchema: z
+    .object({
+      driveId: z.string().min(1),
+      name: z.string().min(1).max(200),
+      agentPageId: z.string().min(1),
+      prompt: z.string().min(1).optional(),
+      instructionPageId: z.string().nullable().optional(),
+      contextPageIds: z.array(z.string()).default([]),
+      cronExpression: z.string().min(1),
+      timezone: z.string().default('UTC'),
+      isEnabled: z.boolean().default(true),
+    })
+    .strict()
+    .refine((data) => Boolean(data.prompt?.trim()) || Boolean(data.instructionPageId), {
+      message: 'Either prompt or instructionPageId is required',
+    }),
+  outputSchema: workflowRowSchema,
+  requiredScope: 'drive:admin',
+  description:
+    'Create a cron-scheduled workflow that runs an AI agent on a schedule. The agent page must be an AI_CHAT page in the same drive; provide a prompt, an instructionPageId, or both. Requires drive owner or admin authority.',
+});
+
+export const updateWorkflow = defineOperation({
+  name: 'workflows.update',
+  method: 'PATCH',
+  path: '/api/workflows/:workflowId',
+  inputSchema: z
+    .object({
+      workflowId: z.string(),
+      name: z.string().min(1).max(200).optional(),
+      agentPageId: z.string().min(1).optional(),
+      prompt: z.string().min(1).optional(),
+      instructionPageId: z.string().nullable().optional(),
+      contextPageIds: z.array(z.string()).optional(),
+      cronExpression: z.string().min(1).nullable().optional(),
+      timezone: z.string().optional(),
+      isEnabled: z.boolean().optional(),
+    })
+    .strict(),
+  outputSchema: workflowRowSchema,
+  requiredScope: 'drive:admin',
+  description:
+    'Update a cron-scheduled workflow. Only cron-triggered, owner/admin-manageable workflows are editable here — a backing workflow owned by a task or calendar trigger 404s. Requires drive owner or admin authority.',
+});
+
+export const deleteWorkflow = defineOperation({
+  name: 'workflows.delete',
+  method: 'DELETE',
+  path: '/api/workflows/:workflowId',
+  inputSchema: z.object({ workflowId: z.string() }),
+  outputSchema: z.object({ success: z.literal(true) }),
+  requiredScope: 'drive:admin',
+  destructive: true,
+  description:
+    'Delete a cron-scheduled workflow, permanently discarding its schedule and run history reference. Requires drive owner or admin authority. Irreversible — the CLI requires --yes.',
+});


### PR DESCRIPTION
## Summary
- Full SDK registry parity for scheduled workflows (`workflows.list/create/update/delete`) and slash commands (`commands.list/create/update/delete`) — Phase 3 task 8 of the SDK/CLI/OAuth epic.
- Route-verified against the CURRENT `apps/web/src/app/api/workflows/**` and `apps/web/src/app/api/commands/**` sources (not the old MCP handlers, not the stale Phase 0 inventory D7 row — fix #1768 already landed instructionPageId support on the workflow routes).
- `commands.list` takes no input at all: the current GET route ignores `driveId` entirely, a discrepancy vs. the old MCP tool's optional filter param — noted in the module doc.
- Trigger/description validation for commands imported directly from `@pagespace/lib/commands/command-core` so the SDK cannot drift from the route's own validators.
- `workflows.delete` / `commands.delete` flagged `destructive: true` (CLI `--yes` gate downstream).

## Test plan
- [x] RED: contract tests committed failing (missing module) — `82b538d88`
- [x] GREEN: registry entries + resource methods — `e32570ae9`
- [x] `bun run --filter '@pagespace/sdk' typecheck` — clean
- [x] `bun run --filter '@pagespace/sdk' test` — 624/624 passing (59 new: 29 workflows + 30 commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E99zZug8iQyr9Mx4258YsL