### PR TITLE
sdk: implement channels & activity operations (Phase 3 task 9)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -56,6 +56,9 @@ export type { OperationRegistry } from './registry/registry.js';
 
 // Domain operations (Phase 3), alphabetical by domain.
 
+// Activity (Phase 3 task 9).
+export { getActivity } from './operations/activity.js';
+
 // Agents (Phase 3 task 5).
 export {
   askAgent,
@@ -82,6 +85,9 @@ export {
   updateCalendarEvent,
 } from './operations/calendar.js';
 export type { FreeSlot } from './operations/calendar.js';
+
+// Channels (Phase 3 task 9).
+export { deleteChannelMessage, sendChannelMessage } from './operations/channels.js';
 
 // Collaborators (Phase 3 task 1).
 export { listCollaborators } from './operations/collaborators.js';

--- a/packages/sdk/src/operations/__tests__/activity.test.ts
+++ b/packages/sdk/src/operations/__tests__/activity.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { getActivity } from '../activity.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** Bare `activity_logs` row (`packages/db/src/schema/monitoring.ts`) + `user` relation, route-serialized. */
+const activityLogFixture = {
+  id: 'a1abc',
+  timestamp: '2026-07-03T12:00:00.000Z',
+  userId: 'u1abc',
+  actorEmail: 'ada@example.com',
+  actorDisplayName: 'Ada Lovelace',
+  isAiGenerated: false,
+  aiProvider: null,
+  aiModel: null,
+  aiConversationId: null,
+  operation: 'update',
+  resourceType: 'page',
+  resourceId: 'p1abc',
+  resourceTitle: 'Q3 Plan',
+  driveId: 'd1abc',
+  pageId: 'p1abc',
+  contentSnapshot: null,
+  contentFormat: null,
+  contentRef: null,
+  contentSize: null,
+  rollbackFromActivityId: null,
+  rollbackSourceOperation: null,
+  rollbackSourceTimestamp: null,
+  rollbackSourceTitle: null,
+  updatedFields: ['title'],
+  previousValues: { title: 'Q2 Plan' },
+  newValues: { title: 'Q3 Plan' },
+  metadata: null,
+  streamId: null,
+  streamSeq: null,
+  changeGroupId: null,
+  changeGroupType: null,
+  stateHashBefore: null,
+  stateHashAfter: null,
+  dataCategory: 'content',
+  legalBasis: 'contract',
+  retentionPolicy: 'account_lifetime',
+  recipients: null,
+  isArchived: false,
+  chainSeq: 42,
+  previousLogHash: 'hash0',
+  logHash: 'hash1',
+  chainSeed: null,
+  user: { id: 'u1abc', name: 'Ada Lovelace', email: 'ada@example.com', image: null },
+};
+
+describe('activity.get — request shape (D1: GET, not the old tool\'s POST)', () => {
+  it('builds a GET to /api/activities with no params (context defaults server-side)', () => {
+    const request = buildRequest(getActivity, {}, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/activities');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('sends context/driveId/pageId/operation/resourceType/limit/offset as query params', () => {
+    const request = buildRequest(
+      getActivity,
+      { context: 'drive', driveId: 'd1abc', operation: 'update', resourceType: 'page', limit: 25, offset: 10 },
+      config,
+    );
+    expect(request.method).toBe('GET');
+    const url = new URL(request.url);
+    expect(url.pathname).toBe('/api/activities');
+    expect(url.searchParams.get('context')).toBe('drive');
+    expect(url.searchParams.get('driveId')).toBe('d1abc');
+    expect(url.searchParams.get('operation')).toBe('update');
+    expect(url.searchParams.get('resourceType')).toBe('page');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('offset')).toBe('10');
+  });
+
+  it('sends startDate/endDate as ISO strings, not Date objects (query params are strings)', () => {
+    const request = buildRequest(
+      getActivity,
+      { startDate: '2026-07-01T00:00:00.000Z', endDate: '2026-07-03T00:00:00.000Z' },
+      config,
+    );
+    const url = new URL(request.url);
+    expect(url.searchParams.get('startDate')).toBe('2026-07-01T00:00:00.000Z');
+    expect(url.searchParams.get('endDate')).toBe('2026-07-03T00:00:00.000Z');
+  });
+
+  it('rejects an invalid context (route enum: user | drive | page)', () => {
+    const result = getActivity.inputSchema.safeParse({ context: 'bogus' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a malformed startDate', () => {
+    const result = getActivity.inputSchema.safeParse({ startDate: 'not-a-date' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects limit above the route clamp of 100', () => {
+    const result = getActivity.inputSchema.safeParse({ limit: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a negative offset', () => {
+    const result = getActivity.inputSchema.safeParse({ offset: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('has no `types` filter (D1: dropped — operation/resourceType are the route\'s real equivalents)', () => {
+    const shape = getActivity.inputSchema as unknown as { shape?: Record<string, unknown> };
+    expect(shape.shape).not.toHaveProperty('types');
+  });
+});
+
+describe('activity.get — response contract', () => {
+  it('parses {activities, pagination} (route truth: activities/route.ts GET, not a bare array)', () => {
+    const body = {
+      activities: [activityLogFixture],
+      pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+    };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('parses an empty activity feed', () => {
+    const body = { activities: [], pagination: { total: 0, limit: 50, offset: 0, hasMore: false } };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('parses an AI-generated activity entry', () => {
+    const aiEntry = {
+      ...activityLogFixture,
+      isAiGenerated: true,
+      aiProvider: 'anthropic',
+      aiModel: 'claude-sonnet-5',
+      aiConversationId: 'c1abc',
+    };
+    const body = { activities: [aiEntry], pagination: { total: 1, limit: 50, offset: 0, hasMore: false } };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('parses a null user (userId set-null on account deletion, audit trail preserved)', () => {
+    const orphaned = { ...activityLogFixture, userId: null, user: null };
+    const body = { activities: [orphaned], pagination: { total: 1, limit: 50, offset: 0, hasMore: false } };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('parses hasMore: true with a partial page', () => {
+    const body = { activities: [activityLogFixture], pagination: { total: 5, limit: 1, offset: 0, hasMore: true } };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(body));
+    expect(result).toEqual(body);
+  });
+
+  it('rejects a response that drifts from the activity row contract', () => {
+    const malformed = { activities: [{ ...activityLogFixture, isArchived: 'nope' }], pagination: { total: 1, limit: 50, offset: 0, hasMore: false } };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('rejects an unrecognized resourceType (route enum drift)', () => {
+    const malformed = { activities: [{ ...activityLogFixture, resourceType: 'bogus' }], pagination: { total: 1, limit: 50, offset: 0, hasMore: false } };
+    const result = parseResponse(getActivity, 200, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 400 (missing driveId for drive context) as a typed error, not schema drift', () => {
+    const result = parseResponse(getActivity, 400, new Headers(), JSON.stringify({ error: 'driveId is required for drive context' }));
+    expect(result).not.toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (no access to the requested drive) as PermissionDeniedError', () => {
+    const result = parseResponse(
+      getActivity,
+      403,
+      new Headers(),
+      JSON.stringify({ error: 'Unauthorized - you do not have access to this drive' }),
+    );
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('activity.get — metadata', () => {
+  it('does not declare a fixed requiredScope (context is caller-selected: user/drive/page, no single driveId path param)', () => {
+    expect(getActivity.requiredScope).toBeUndefined();
+  });
+
+  it('uses GET, which isIdempotentMethod allows the transport to auto-retry safely', () => {
+    expect(getActivity.method).toBe('GET');
+  });
+});

--- a/packages/sdk/src/operations/__tests__/channels.test.ts
+++ b/packages/sdk/src/operations/__tests__/channels.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { ResponseValidationError } from '../../errors.js';
+import { deleteChannelMessage, sendChannelMessage } from '../channels.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+/** `loadChannelMessageWithRelations` row shape (`channel-message-repository.ts`), route-serialized. */
+const channelMessageFixture = {
+  id: 'm1abc',
+  content: 'hello channel',
+  createdAt: '2026-07-03T12:00:00.000Z',
+  pageId: 'p1abc',
+  userId: 'u1abc',
+  fileId: null,
+  attachmentMeta: null,
+  isActive: true,
+  editedAt: null,
+  aiMeta: null,
+  parentId: null,
+  replyCount: 0,
+  lastReplyAt: null,
+  mirroredFromId: null,
+  quotedMessageId: null,
+  user: { id: 'u1abc', name: 'Ada Lovelace', image: null },
+  file: null,
+  reactions: [],
+  mirroredFrom: null,
+  quotedMessage: null,
+};
+
+describe('channels.sendMessage — request shape', () => {
+  it('builds a POST to /api/channels/:pageId/messages with content in the body', () => {
+    const request = buildRequest(sendChannelMessage, { pageId: 'p1abc', content: 'hello channel' }, config);
+    expect(request.method).toBe('POST');
+    expect(request.url).toBe('https://pagespace.ai/api/channels/p1abc/messages');
+    expect(JSON.parse(request.body ?? '{}')).toEqual({ content: 'hello channel' });
+  });
+
+  it('sends fileId/attachmentMeta/parentId/alsoSendToParent/quotedMessageId when present', () => {
+    const request = buildRequest(
+      sendChannelMessage,
+      {
+        pageId: 'p1abc',
+        content: 'reply',
+        parentId: 'root1',
+        alsoSendToParent: true,
+      },
+      config,
+    );
+    expect(JSON.parse(request.body ?? '{}')).toEqual({
+      content: 'reply',
+      parentId: 'root1',
+      alsoSendToParent: true,
+    });
+  });
+
+  it('rejects input missing pageId (path param required)', () => {
+    const result = sendChannelMessage.inputSchema.safeParse({ content: 'hi' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects input missing content', () => {
+    const result = sendChannelMessage.inputSchema.safeParse({ pageId: 'p1abc' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an empty content string (route: attachment-only messages are valid, no min-length guard)', () => {
+    const result = sendChannelMessage.inputSchema.safeParse({ pageId: 'p1abc', content: '', fileId: 'f1abc' });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('channels.sendMessage — response contract', () => {
+  it('parses a 201 top-level message with quotedMessage: null', () => {
+    const result = parseResponse(sendChannelMessage, 201, new Headers(), JSON.stringify(channelMessageFixture));
+    expect(result).toEqual(channelMessageFixture);
+  });
+
+  it('parses a 201 top-level message with a quotedMessage snapshot', () => {
+    const withQuote = {
+      ...channelMessageFixture,
+      quotedMessageId: 'q1abc',
+      quotedMessage: {
+        id: 'q1abc',
+        authorId: 'u2abc',
+        authorName: 'Grace Hopper',
+        authorImage: null,
+        contentSnippet: 'original message',
+        createdAt: '2026-07-03T11:00:00.000Z',
+        isActive: true,
+      },
+    };
+    const result = parseResponse(sendChannelMessage, 201, new Headers(), JSON.stringify(withQuote));
+    expect(result).toEqual(withQuote);
+  });
+
+  it('parses a thread-reply response that omits the quotedMessage key entirely (route: thread branch never calls attachQuotedMessages)', () => {
+    const threadReply: Record<string, unknown> = { ...channelMessageFixture, parentId: 'root1' };
+    delete threadReply.quotedMessage;
+    const result = parseResponse(sendChannelMessage, 201, new Headers(), JSON.stringify(threadReply));
+    expect(result).toEqual(threadReply);
+  });
+
+  it('parses a message carrying a file attachment and reactions', () => {
+    const withFileAndReaction = {
+      ...channelMessageFixture,
+      fileId: 'f1abc',
+      attachmentMeta: { originalName: 'report.pdf', size: 1024, mimeType: 'application/pdf', contentHash: 'abc123' },
+      file: { id: 'f1abc', mimeType: 'application/pdf', sizeBytes: 1024 },
+      reactions: [
+        { id: 'r1abc', messageId: 'm1abc', userId: 'u2abc', emoji: '👍', createdAt: '2026-07-03T12:01:00.000Z', user: { id: 'u2abc', name: 'Grace Hopper' } },
+      ],
+    };
+    const result = parseResponse(sendChannelMessage, 201, new Headers(), JSON.stringify(withFileAndReaction));
+    expect(result).toEqual(withFileAndReaction);
+  });
+
+  it('parses an AI-authored message (aiMeta set)', () => {
+    const aiMessage = {
+      ...channelMessageFixture,
+      userId: 'agent1',
+      user: { id: 'agent1', name: 'Support Agent', image: null },
+      aiMeta: { senderType: 'agent', senderName: 'Support Agent', agentPageId: 'ag1abc' },
+    };
+    const result = parseResponse(sendChannelMessage, 201, new Headers(), JSON.stringify(aiMessage));
+    expect(result).toEqual(aiMessage);
+  });
+
+  it('rejects a response that drifts from the message row contract', () => {
+    const malformed = { ...channelMessageFixture, replyCount: 'not-a-number' };
+    const result = parseResponse(sendChannelMessage, 201, new Headers(), JSON.stringify(malformed));
+    expect(result).toBeInstanceOf(ResponseValidationError);
+  });
+
+  it('classifies a 403 (no edit permission) as PermissionDeniedError', () => {
+    const result = parseResponse(
+      sendChannelMessage,
+      403,
+      new Headers(),
+      JSON.stringify({ error: 'You need edit permission to send messages in this channel' }),
+    );
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('channels.sendMessage — metadata (non-idempotent)', () => {
+  it('requires drive scope', () => {
+    expect(sendChannelMessage.requiredScope).toBe('drive');
+  });
+
+  it('uses POST, which isIdempotentMethod classifies as non-idempotent (no auto-retry — a retried send double-posts)', () => {
+    expect(sendChannelMessage.method).toBe('POST');
+  });
+
+  it('is not flagged destructive (sending a message is additive, not irreversible data loss)', () => {
+    expect(sendChannelMessage.destructive).toBeUndefined();
+  });
+});
+
+describe('channels.deleteMessage — request shape', () => {
+  it('builds a DELETE to /api/channels/:pageId/messages/:messageId with no body', () => {
+    const request = buildRequest(deleteChannelMessage, { pageId: 'p1abc', messageId: 'm1abc' }, config);
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe('https://pagespace.ai/api/channels/p1abc/messages/m1abc');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('rejects input missing messageId', () => {
+    const result = deleteChannelMessage.inputSchema.safeParse({ pageId: 'p1abc' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('channels.deleteMessage — response contract', () => {
+  it('parses { success: true }', () => {
+    const result = parseResponse(deleteChannelMessage, 200, new Headers(), JSON.stringify({ success: true }));
+    expect(result).toEqual({ success: true });
+  });
+
+  it('classifies a 404 (message not found, or already deleted) as NotFoundError — a concurrent delete is not re-broadcast', () => {
+    const result = parseResponse(deleteChannelMessage, 404, new Headers(), JSON.stringify({ error: 'Message not found' }));
+    expect((result as { code: string }).code).toBe('NOT_FOUND');
+  });
+
+  it('classifies a 403 (not the message author) as PermissionDeniedError', () => {
+    const result = parseResponse(
+      deleteChannelMessage,
+      403,
+      new Headers(),
+      JSON.stringify({ error: 'You can only delete your own messages' }),
+    );
+    expect((result as { code: string }).code).toBe('PERMISSION_DENIED');
+  });
+});
+
+describe('channels.deleteMessage — metadata (destructive, non-idempotent)', () => {
+  it('requires drive scope', () => {
+    expect(deleteChannelMessage.requiredScope).toBe('drive');
+  });
+
+  it('is flagged destructive so the CLI requires --yes', () => {
+    expect(deleteChannelMessage.destructive).toBe(true);
+  });
+
+  it('uses DELETE, which isIdempotentMethod classifies as non-idempotent (no auto-retry)', () => {
+    expect(deleteChannelMessage.method).toBe('DELETE');
+  });
+});

--- a/packages/sdk/src/operations/activity.ts
+++ b/packages/sdk/src/operations/activity.ts
@@ -1,0 +1,146 @@
+/**
+ * Activity feed operations (Phase 3 task 9, part 2/2 — old handler's
+ * activity feed, actually served by `apps/web/src/app/api/activities/route.ts`,
+ * not `conversation.js`). Old MCP tool: `get_activity`. Channel-messaging
+ * operations from the same old handler file belong to `channels.ts`.
+ *
+ * DISCREPANCY (Phase 0 inventory D1, binding — routes are the contract, never
+ * a handler-side workaround): `tools.js` describes `get_activity` as POSTing
+ * a JSON body with a `types[]` filter to `/api/activities`; the route exports
+ * **GET only** and has no `types` param (`activities/route.ts:39,14-26`) — the
+ * old tool 405s on every call. This operation implements the route's real
+ * contract: GET with query params `context` ('user' default, no driveId
+ * required)/`driveId`/`pageId`/`startDate`/`endDate`/`actorId`/`operation`/
+ * `resourceType`/`limit` (1-100, default 50)/`offset` (>=0, default 0).
+ * `operation` + `resourceType` are the route's real nearest equivalents to
+ * the dropped `types` filter.
+ *
+ * Output is the bare `activity_logs` row (`packages/db/src/schema/monitoring.ts`)
+ * plus a denormalized `user` relation, route-serialized as-is (Date -> ISO
+ * string) — including internal hash-chain and GDPR Art 30 processing fields
+ * the route does not strip. No `z.any()`: `previousValues`/`newValues`/
+ * `metadata` are `z.record(z.string(), z.unknown())` — genuinely arbitrary
+ * per-operation payloads, same idiom as `tasks.ts`'s task `metadata` field.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+/** Same strict ISO 8601 pattern as `calendar.ts`'s `isoDatetimeSchema` — the route's `z.coerce.date()` accepts it verbatim. */
+const ISO_8601_PATTERN = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+const isoDatetimeSchema = z.string().refine(
+  (value) => ISO_8601_PATTERN.test(value) && !Number.isNaN(new Date(value).getTime()),
+  {
+    message:
+      'Must be a strict ISO 8601 date or datetime string (e.g. "2026-02-19", "2026-02-19T19:00:00", or "2026-02-19T19:00:00Z")',
+  },
+);
+
+/** `activityResourceEnum` (`packages/db/src/schema/monitoring.ts`). */
+const activityResourceTypeSchema = z.enum([
+  'page',
+  'drive',
+  'permission',
+  'agent',
+  'user',
+  'member',
+  'role',
+  'file',
+  'token',
+  'device',
+  'message',
+  'conversation',
+]);
+
+const activityActorSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+  image: z.string().nullable(),
+});
+
+/** Bare `activity_logs` row (route: `db.query.activityLogs.findMany` with no `columns` restriction — every column crosses the wire). */
+const activityLogEntrySchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  userId: z.string().nullable(),
+  actorEmail: z.string(),
+  actorDisplayName: z.string().nullable(),
+  isAiGenerated: z.boolean(),
+  aiProvider: z.string().nullable(),
+  aiModel: z.string().nullable(),
+  aiConversationId: z.string().nullable(),
+  operation: z.string(),
+  resourceType: activityResourceTypeSchema,
+  resourceId: z.string(),
+  resourceTitle: z.string().nullable(),
+  driveId: z.string().nullable(),
+  pageId: z.string().nullable(),
+  contentSnapshot: z.string().nullable(),
+  contentFormat: z.enum(['text', 'html', 'json', 'tiptap']).nullable(),
+  contentRef: z.string().nullable(),
+  contentSize: z.number().nullable(),
+  rollbackFromActivityId: z.string().nullable(),
+  rollbackSourceOperation: z.string().nullable(),
+  rollbackSourceTimestamp: z.string().nullable(),
+  rollbackSourceTitle: z.string().nullable(),
+  updatedFields: z.array(z.string()).nullable(),
+  previousValues: z.record(z.string(), z.unknown()).nullable(),
+  newValues: z.record(z.string(), z.unknown()).nullable(),
+  metadata: z.record(z.string(), z.unknown()).nullable(),
+  streamId: z.string().nullable(),
+  streamSeq: z.number().nullable(),
+  changeGroupId: z.string().nullable(),
+  changeGroupType: z.enum(['user', 'ai', 'automation', 'system']).nullable(),
+  stateHashBefore: z.string().nullable(),
+  stateHashAfter: z.string().nullable(),
+  dataCategory: z.string().nullable(),
+  legalBasis: z.string().nullable(),
+  retentionPolicy: z.string().nullable(),
+  recipients: z.array(z.string()).nullable(),
+  isArchived: z.boolean(),
+  chainSeq: z.number(),
+  previousLogHash: z.string().nullable(),
+  logHash: z.string().nullable(),
+  chainSeed: z.string().nullable(),
+  // Nullable: `userId` is `onDelete: 'set null'` — a deleted actor's rows survive for audit-trail preservation.
+  user: activityActorSchema.nullable(),
+});
+
+const getActivityOutputSchema = z.object({
+  activities: z.array(activityLogEntrySchema),
+  pagination: z.object({
+    total: z.number(),
+    limit: z.number(),
+    offset: z.number(),
+    hasMore: z.boolean(),
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// activity.get — GET /api/activities (D1)
+// ---------------------------------------------------------------------------
+
+export const getActivity = defineOperation({
+  name: 'activity.get',
+  method: 'GET',
+  path: '/api/activities',
+  inputSchema: z.object({
+    context: z.enum(['user', 'drive', 'page']).optional(),
+    driveId: z.string().optional(),
+    pageId: z.string().optional(),
+    startDate: isoDatetimeSchema.optional(),
+    endDate: isoDatetimeSchema.optional(),
+    // actorId is ignored by the route in 'user' context (already scoped to the caller).
+    actorId: z.string().optional(),
+    operation: z.string().optional(),
+    resourceType: z.string().optional(),
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+  }),
+  outputSchema: getActivityOutputSchema,
+  // No fixed driveId path param — `context: 'user'` (the default) scopes to
+  // whatever drives the caller's own principal/token can already reach, same
+  // rationale as `search.multiDrive` and `agents.listMultiDrive`.
+  description:
+    "Fetch the activity feed (D1: GET, not the old tool's POST — that 405s on every call). `context` selects scope: \"user\" (default, the caller's own activity, optionally driveId-filtered), \"drive\" (requires driveId), or \"page\" (requires pageId). `operation`/`resourceType` are the route's real filters — there is no `types[]` filter.",
+});

--- a/packages/sdk/src/operations/channels.ts
+++ b/packages/sdk/src/operations/channels.ts
@@ -1,0 +1,152 @@
+/**
+ * Channel messaging operations (Phase 3 task 9, part 1/2 — old handler
+ * `conversation.js` channel ops): `channels.sendMessage`, `channels.deleteMessage`.
+ * Old MCP tools: `send_channel_message`, `delete_channel_message`. The
+ * activity-feed operation from the same old handler file belongs to
+ * `activity.ts` (Phase 3 task 9, part 2/2).
+ *
+ * Route-verified against `apps/web/src/app/api/channels/[pageId]/messages/route.ts`
+ * POST and `apps/web/src/app/api/channels/[pageId]/messages/[messageId]/route.ts`
+ * DELETE (docs/sdk/operations-inventory.md D12: the old tool's "session-only,
+ * may 401" warning is stale — the route accepts mcp tokens too).
+ *
+ * Channel messages are NOT AI SDK `UIMessage`s: `channel_messages.content`
+ * (`packages/db/src/schema/chat.ts`) is a flat text column, not a `parts`
+ * array, unlike `conversations.ts`'s AI-agent messages. `packages/lib/src/types.ts`'s
+ * canonical `parts` structure genuinely does not apply to this route's
+ * response — using it here would be a locally-invented shape masquerading as
+ * project law. The output schema below is the wire-format mirror of
+ * `loadChannelMessageWithRelations` (`channel-message-repository.ts`) plus
+ * `attachQuotedMessages` (`quote-enrichment.ts`) — the actual DB row and its
+ * `user`/`file`/`reactions`/`mirroredFrom`/`quotedMessage` relations.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const attachmentMetaSchema = z.object({
+  originalName: z.string(),
+  size: z.number(),
+  mimeType: z.string(),
+  contentHash: z.string(),
+});
+
+const channelCommandExecutionSchema = z.object({
+  label: z.string(),
+  status: z.enum(['used', 'skipped']),
+  reason: z.enum(['page_trashed', 'no_access', 'not_found', 'disabled']).optional(),
+  entryPageTitle: z.string().optional(),
+});
+
+/** Set when a channel message was posted by an AI tool (`channel-message-repository.ts` `ChannelMessageAiMeta`). */
+const channelMessageAiMetaSchema = z.object({
+  senderType: z.enum(['global_assistant', 'agent']),
+  senderName: z.string(),
+  agentPageId: z.string().optional(),
+  commandExecution: channelCommandExecutionSchema.optional(),
+});
+
+const channelMessageUserSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable(),
+  image: z.string().nullable(),
+});
+
+const channelMessageFileSchema = z.object({
+  id: z.string(),
+  mimeType: z.string().nullable(),
+  sizeBytes: z.number(),
+});
+
+const channelMessageReactionSchema = z.object({
+  id: z.string(),
+  messageId: z.string(),
+  userId: z.string(),
+  emoji: z.string(),
+  createdAt: z.string(),
+  user: z.object({ id: z.string(), name: z.string().nullable() }),
+});
+
+const mirroredFromSchema = z.object({
+  parentId: z.string().nullable(),
+});
+
+/** Denormalized quote snapshot (`quote-enrichment.ts` `QuotedMessageSnapshot`). */
+const quotedMessageSnapshotSchema = z.object({
+  id: z.string(),
+  authorId: z.string().nullable(),
+  authorName: z.string().nullable(),
+  authorImage: z.string().nullable(),
+  contentSnippet: z.string(),
+  createdAt: z.string(),
+  isActive: z.boolean(),
+});
+
+/**
+ * `loadChannelMessageWithRelations` row shape. `quotedMessage` is declared
+ * `.optional()` (not just `.nullable()`) because only the top-level POST
+ * branch runs `attachQuotedMessages` (`messages/route.ts`); the thread-reply
+ * branch returns `replyWithRelations` as-is and never adds the key.
+ */
+const channelMessageSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  createdAt: z.string(),
+  pageId: z.string(),
+  userId: z.string(),
+  fileId: z.string().nullable(),
+  attachmentMeta: attachmentMetaSchema.nullable(),
+  isActive: z.boolean(),
+  editedAt: z.string().nullable(),
+  aiMeta: channelMessageAiMetaSchema.nullable(),
+  parentId: z.string().nullable(),
+  replyCount: z.number(),
+  lastReplyAt: z.string().nullable(),
+  mirroredFromId: z.string().nullable(),
+  quotedMessageId: z.string().nullable(),
+  user: channelMessageUserSchema,
+  file: channelMessageFileSchema.nullable(),
+  reactions: z.array(channelMessageReactionSchema),
+  mirroredFrom: mirroredFromSchema.nullable(),
+  quotedMessage: quotedMessageSnapshotSchema.nullable().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// channels.sendMessage — POST /api/channels/:pageId/messages
+// ---------------------------------------------------------------------------
+
+export const sendChannelMessage = defineOperation({
+  name: 'channels.sendMessage',
+  method: 'POST',
+  path: '/api/channels/:pageId/messages',
+  inputSchema: z.object({
+    pageId: z.string(),
+    // Route coerces a non-string body to '' (`typeof content === 'string' ? content : ''`)
+    // and never enforces a minimum length — attachment-only messages send an empty string.
+    content: z.string(),
+    fileId: z.string().optional(),
+    attachmentMeta: attachmentMetaSchema.optional(),
+    parentId: z.string().optional(),
+    alsoSendToParent: z.boolean().optional(),
+    quotedMessageId: z.string().optional(),
+  }),
+  outputSchema: channelMessageSchema,
+  requiredScope: 'drive',
+  description:
+    'Send a message to a CHANNEL page, or reply in a thread when `parentId` is set (`alsoSendToParent` mirrors the reply to the top level too). `quotedMessageId` inline-quotes a top-level message and cannot be combined with `parentId` (route: 400 if both are set). Non-idempotent: POST is never auto-retried by the facade (isIdempotentMethod only retries GET) — a retried send double-posts.',
+});
+
+// ---------------------------------------------------------------------------
+// channels.deleteMessage — DELETE /api/channels/:pageId/messages/:messageId
+// ---------------------------------------------------------------------------
+
+export const deleteChannelMessage = defineOperation({
+  name: 'channels.deleteMessage',
+  method: 'DELETE',
+  path: '/api/channels/:pageId/messages/:messageId',
+  inputSchema: z.object({ pageId: z.string(), messageId: z.string() }),
+  outputSchema: z.object({ success: z.literal(true) }),
+  requiredScope: 'drive',
+  destructive: true,
+  description:
+    'Soft-delete a channel message. Only the message author may delete their own message (route: 403 otherwise); softDeleteChannelMessage is gated on isActive=true, so a concurrent or repeated delete of an already-deleted message 404s rather than re-succeeding. Irreversible from the caller\'s perspective — the CLI requires --yes.',
+});


### PR DESCRIPTION
## Summary
- Phase 3 task 9 of the PageSpace SDK/CLI/OAuth epic: `channels.sendMessage`, `channels.deleteMessage`, `activity.get` as typed registry operations + barrel exports.
- `channels.sendMessage` / `channels.deleteMessage` — route-verified against `channels/[pageId]/messages/route.ts` (POST) and `.../[messageId]/route.ts` (DELETE). D12: the old tool's "session-only, may 401" warning is stale (route accepts mcp tokens). Channel messages are flat-content rows, not AI SDK `UIMessage` parts — the output schema mirrors `loadChannelMessageWithRelations` + `attachQuotedMessages` faithfully, including that `quotedMessage` is absent (not just null) on thread-reply responses. `sendMessage` is non-idempotent (no auto-retry); `deleteMessage` is `destructive: true`.
- `activity.get` — implements D1: the route is GET-only with a real query schema (`context`/`driveId`/`pageId`/dates/`actorId`/`operation`/`resourceType`/`limit`/`offset`), not the old tool's POST + `types[]` (which 405s on every call). Output schema is the bare `activity_logs` row + `user` relation, faithful to the route's un-columned select (includes hash-chain/GDPR Art 30 fields the route doesn't strip). No fixed `requiredScope` — `context: 'user'` (default) has no driveId path param, same rationale as `search.multiDrive`.
- TDD: RED commit (contract tests, 42 tests, module-not-found failure) → GREEN commit (registry ops + resource exports).

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck` — green
- [x] `bun run --filter '@pagespace/sdk' test` — 666/666 passing (42 new: 23 channels + 19 activity)
- [x] Rebased onto latest `origin/pu/cli-login` (352ac6aa1) before starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CS4rpQoXTc79jgPwe447Kw