### PR TITLE
sdk: implement export operations (Phase 3 task 10)

### DIFF
--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -287,7 +287,8 @@ export function isIncompatibleServerError(error: unknown): error is Incompatible
 
 export type HttpErrorHeaders = Headers | Record<string, string> | null | undefined;
 
-function getHeaderValue(headers: HttpErrorHeaders, name: string): string | null {
+/** Case-insensitive header lookup across both a real `Headers` and a plain record (house convention: tests use plain objects). */
+export function getHeaderValue(headers: HttpErrorHeaders, name: string): string | null {
   if (!headers) return null;
   if (typeof (headers as Headers).get === 'function') {
     try {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -101,6 +101,9 @@ export { listConversations, readConversation } from './operations/conversations.
 // Documents / content (Phase 3 task 2) — full pagespace-mcp document.js parity.
 export { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
 
+// Export (Phase 3 task 10) — page -> Markdown, sheet -> CSV text exports.
+export { exportPageMarkdown, exportSheetCsv } from './operations/export.js';
+
 // Drives (Phase 2 seed op + Phase 3 task 1 — full pagespace-mcp drive.js parity).
 export { listDrives } from './operations/drives.js';
 export {

--- a/packages/sdk/src/operations/__tests__/export.test.ts
+++ b/packages/sdk/src/operations/__tests__/export.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { buildRequest } from '../../transport/build-request.js';
+import { parseResponse } from '../../transport/parse-response.js';
+import { isNotFoundError, isPermissionDeniedError, isResponseValidationError, isValidationError } from '../../errors.js';
+import { exportPageMarkdown, exportSheetCsv } from '../export.js';
+
+const config = { baseUrl: 'https://pagespace.ai' };
+
+const markdownFixture = '# Project Notes\n\n- one\n- two\n\nSome **bold** text.\n';
+const csvFixture = 'Header A,Header B\r\n1,2\r\n3,4\r\n';
+
+describe('export.pageMarkdown — request shape', () => {
+  it('builds a GET to /api/pages/:pageId/export/markdown with no body', () => {
+    const request = buildRequest(exportPageMarkdown, { pageId: 'p1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/p1abc/export/markdown');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('rejects input missing pageId (path param required)', () => {
+    const result = exportPageMarkdown.inputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('export.pageMarkdown — response contract (textResponse passthrough)', () => {
+  it('passes the markdown body through verbatim on a 200 with a text/markdown Content-Type', () => {
+    const result = parseResponse(exportPageMarkdown, 200, new Headers({ 'Content-Type': 'text/markdown; charset=utf-8' }), markdownFixture);
+    expect(result).toBe(markdownFixture);
+  });
+
+  it('never attempts JSON.parse on the body — markdown containing `{[` characters round-trips unchanged', () => {
+    const trickyMarkdown = '# Title\n\nSee `{[not json` inline code.\n';
+    const result = parseResponse(exportPageMarkdown, 200, new Headers({ 'Content-Type': 'text/markdown' }), trickyMarkdown);
+    expect(result).toBe(trickyMarkdown);
+  });
+
+  it('returns a typed ResponseValidationError when the Content-Type is wrong (e.g. an error page served as text/html)', () => {
+    const result = parseResponse(exportPageMarkdown, 200, new Headers({ 'Content-Type': 'text/html' }), '<html>oops</html>');
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('returns a typed ResponseValidationError when the Content-Type header is missing', () => {
+    const result = parseResponse(exportPageMarkdown, 200, new Headers(), markdownFixture);
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('classifies a 400 (non-DOCUMENT page) as ValidationError, not a passthrough', () => {
+    const result = parseResponse(
+      exportPageMarkdown,
+      400,
+      new Headers({ 'Content-Type': 'application/json' }),
+      JSON.stringify({ error: 'Markdown export is only available for DOCUMENT pages' }),
+    );
+    expect(isValidationError(result)).toBe(true);
+  });
+
+  it('classifies a 403 (no view permission) as PermissionDeniedError', () => {
+    const result = parseResponse(exportPageMarkdown, 403, new Headers(), JSON.stringify({ error: 'Forbidden' }));
+    expect(isPermissionDeniedError(result)).toBe(true);
+  });
+
+  it('classifies a 404 (page not found) as NotFoundError', () => {
+    const result = parseResponse(exportPageMarkdown, 404, new Headers(), JSON.stringify({ error: 'Not Found' }));
+    expect(isNotFoundError(result)).toBe(true);
+  });
+});
+
+describe('export.pageMarkdown — metadata', () => {
+  it('is a GET, idempotent operation', () => {
+    expect(exportPageMarkdown.method).toBe('GET');
+  });
+
+  it('requires drive scope', () => {
+    expect(exportPageMarkdown.requiredScope).toBe('drive');
+  });
+
+  it('is flagged textResponse', () => {
+    expect(exportPageMarkdown.textResponse).toBe(true);
+  });
+
+  it('declares expectedContentType text/markdown', () => {
+    expect(exportPageMarkdown.expectedContentType).toBe('text/markdown');
+  });
+
+  it('declares an extended timeoutMsOverride beyond the client default (large-document conversion can run long)', () => {
+    expect(exportPageMarkdown.timeoutMsOverride).toBeGreaterThan(30_000);
+  });
+
+  it('is not flagged destructive (a read-only export)', () => {
+    expect(exportPageMarkdown.destructive).toBeUndefined();
+  });
+});
+
+describe('export.sheetCsv — request shape', () => {
+  it('builds a GET to /api/pages/:pageId/export/csv with no body', () => {
+    const request = buildRequest(exportSheetCsv, { pageId: 's1abc' }, config);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe('https://pagespace.ai/api/pages/s1abc/export/csv');
+    expect(request.body).toBeUndefined();
+  });
+
+  it('rejects input missing pageId (path param required)', () => {
+    const result = exportSheetCsv.inputSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('export.sheetCsv — response contract (textResponse passthrough)', () => {
+  it('passes the CSV body through verbatim, including embedded commas/CRLF line endings, on a 200 with text/csv', () => {
+    const result = parseResponse(exportSheetCsv, 200, new Headers({ 'Content-Type': 'text/csv; charset=utf-8' }), csvFixture);
+    expect(result).toBe(csvFixture);
+  });
+
+  it('never attempts JSON.parse on the body — a CSV cell containing `[` and `{` round-trips unchanged', () => {
+    const trickyCsv = 'Name,Note\r\n"Smith, Jane","{not json} [1,2]"\r\n';
+    const result = parseResponse(exportSheetCsv, 200, new Headers({ 'Content-Type': 'text/csv' }), trickyCsv);
+    expect(result).toBe(trickyCsv);
+  });
+
+  it('returns a typed ResponseValidationError when the Content-Type is wrong', () => {
+    const result = parseResponse(exportSheetCsv, 200, new Headers({ 'Content-Type': 'application/json' }), '{"error":"oops"}');
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('returns a typed ResponseValidationError when the Content-Type header is missing', () => {
+    const result = parseResponse(exportSheetCsv, 200, new Headers(), csvFixture);
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('classifies a 400 (non-SHEET page) as ValidationError', () => {
+    const result = parseResponse(
+      exportSheetCsv,
+      400,
+      new Headers({ 'Content-Type': 'application/json' }),
+      JSON.stringify({ error: 'CSV export is only available for SHEET pages' }),
+    );
+    expect(isValidationError(result)).toBe(true);
+  });
+
+  it('classifies a 404 (page not found) as NotFoundError', () => {
+    const result = parseResponse(exportSheetCsv, 404, new Headers(), JSON.stringify({ error: 'Not Found' }));
+    expect(isNotFoundError(result)).toBe(true);
+  });
+});
+
+describe('export.sheetCsv — metadata', () => {
+  it('is a GET, idempotent operation', () => {
+    expect(exportSheetCsv.method).toBe('GET');
+  });
+
+  it('requires drive scope', () => {
+    expect(exportSheetCsv.requiredScope).toBe('drive');
+  });
+
+  it('is flagged textResponse', () => {
+    expect(exportSheetCsv.textResponse).toBe(true);
+  });
+
+  it('declares expectedContentType text/csv', () => {
+    expect(exportSheetCsv.expectedContentType).toBe('text/csv');
+  });
+
+  it('declares an extended timeoutMsOverride beyond the client default (formula re-evaluation on large sheets can run long)', () => {
+    expect(exportSheetCsv.timeoutMsOverride).toBeGreaterThan(30_000);
+  });
+
+  it('is not flagged destructive (a read-only export)', () => {
+    expect(exportSheetCsv.destructive).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/operations/export.ts
+++ b/packages/sdk/src/operations/export.ts
@@ -1,0 +1,66 @@
+/**
+ * Export operations (Phase 3 task 10 — old handler `export.js`). The old
+ * handler only ever wrapped `get_page_details` (now `pages.details`, Phase 3
+ * task 2) — no MCP tool ever exposed `PageSpaceApi.requestText` (old repo
+ * `src/api.js:47`), leaving it dead code (Phase 0 inventory: "no export
+ * tools are registered"). These two live, previously-untooled routes are the
+ * actual text-export surface `requestText` was built for:
+ * `apps/web/src/app/api/pages/[pageId]/export/markdown/route.ts` GET and
+ * `.../export/csv/route.ts` GET. The sibling `xlsx`/`docx` routes under the
+ * same directory return binary
+ * (`application/vnd.openxmlformats-officedocument...`) bodies, not text —
+ * out of scope for this textResponse-based domain.
+ *
+ * Both routes return the exported body verbatim with no JSON envelope on
+ * success; `parseResponse`'s `textResponse` passthrough applies, gated by
+ * `expectedContentType` (Phase 2 task 3 extension, this task) so a
+ * misrouted/proxied non-text response — e.g. a JSON error page or an HTML
+ * error page served with a 2xx by a broken proxy — surfaces as a typed
+ * `ResponseValidationError` instead of being handed to the caller as if it
+ * were markdown/CSV.
+ */
+import { z } from 'zod';
+import { defineOperation } from '../registry/define.js';
+
+const exportPageInputSchema = z.object({ pageId: z.string() });
+
+// ---------------------------------------------------------------------------
+// export.pageMarkdown — GET /api/pages/:pageId/export/markdown
+// ---------------------------------------------------------------------------
+
+export const exportPageMarkdown = defineOperation({
+  name: 'export.pageMarkdown',
+  method: 'GET',
+  path: '/api/pages/:pageId/export/markdown',
+  inputSchema: exportPageInputSchema,
+  outputSchema: z.string(),
+  textResponse: true,
+  expectedContentType: 'text/markdown',
+  requiredScope: 'drive',
+  // Turndown conversion of a large HTML document can run well past the
+  // client's default 30s (route: markdown/route.ts:59-62).
+  timeoutMsOverride: 60_000,
+  description:
+    'Export a DOCUMENT page as Markdown. Route requires page.type === "DOCUMENT" (400 otherwise: "Markdown export is only available for DOCUMENT pages"); markdown-mode pages are returned as-is, HTML-mode pages are converted via Turndown. Response body is the raw Markdown text (Content-Type: text/markdown).',
+});
+
+// ---------------------------------------------------------------------------
+// export.sheetCsv — GET /api/pages/:pageId/export/csv
+// ---------------------------------------------------------------------------
+
+export const exportSheetCsv = defineOperation({
+  name: 'export.sheetCsv',
+  method: 'GET',
+  path: '/api/pages/:pageId/export/csv',
+  inputSchema: exportPageInputSchema,
+  outputSchema: z.string(),
+  textResponse: true,
+  expectedContentType: 'text/csv',
+  requiredScope: 'drive',
+  // Sheet parsing + full formula re-evaluation before serialization
+  // (route: csv/route.ts:57-64) can run well past the client's default 30s
+  // on a large sheet.
+  timeoutMsOverride: 60_000,
+  description:
+    'Export a SHEET page as CSV. Route requires page.type === "SHEET" (400 otherwise: "CSV export is only available for SHEET pages"); the sheet is parsed, formulas evaluated, and the display values serialized to CSV. Response body is the raw CSV text (Content-Type: text/csv).',
+});

--- a/packages/sdk/src/registry/__tests__/define.test.ts
+++ b/packages/sdk/src/registry/__tests__/define.test.ts
@@ -77,6 +77,30 @@ describe('defineOperation — runtime shape', () => {
     });
     expect(fast.timeoutMsOverride).toBeUndefined();
   });
+
+  it('captures an explicit expectedContentType, defaulting to undefined otherwise (Phase 3 task 10 export ops)', () => {
+    const exportOp = defineOperation({
+      name: 'test.export',
+      method: 'GET',
+      path: '/api/widgets/export',
+      inputSchema: z.object({}),
+      outputSchema: z.string(),
+      textResponse: true,
+      expectedContentType: 'text/csv',
+      description: 'A text-export op.',
+    });
+    expect(exportOp.expectedContentType).toBe('text/csv');
+
+    const jsonOp = defineOperation({
+      name: 'test.json',
+      method: 'GET',
+      path: '/api/widgets',
+      inputSchema: z.object({}),
+      outputSchema: z.object({}),
+      description: 'A regular op.',
+    });
+    expect(jsonOp.expectedContentType).toBeUndefined();
+  });
 });
 
 describe('defineOperation — static type inference', () => {

--- a/packages/sdk/src/registry/define.ts
+++ b/packages/sdk/src/registry/define.ts
@@ -44,6 +44,14 @@ export interface OperationConfig<
   /** Set for export-style operations whose 2xx body is raw text, not JSON. */
   readonly textResponse?: boolean;
   /**
+   * Required media type (no `; charset=...` suffix) a `textResponse` 2xx body
+   * must arrive with, e.g. `"text/markdown"`. Only consulted when
+   * `textResponse` is true (`transport/parse-response.ts`); a mismatch or
+   * missing header becomes a typed `ResponseValidationError` instead of the
+   * body being passed through blind.
+   */
+  readonly expectedContentType?: string;
+  /**
    * Overrides the client's default request timeout for this operation only
    * (e.g. `agents.ask`, whose consult loop can run up to 20 tool-calling
    * steps). Facade-enforced (client.ts `#invoke`); absent, the client's own
@@ -97,6 +105,7 @@ export interface Operation<
   readonly outputSchema: TOutputSchema;
   readonly requiredScope: RequiredScope | undefined;
   readonly textResponse: boolean | undefined;
+  readonly expectedContentType: string | undefined;
   readonly timeoutMsOverride: number | undefined;
   readonly destructive: boolean | undefined;
   readonly description: string;
@@ -118,6 +127,7 @@ export function defineOperation<
     outputSchema,
     requiredScope,
     textResponse,
+    expectedContentType,
     timeoutMsOverride,
     destructive,
     description,
@@ -131,6 +141,7 @@ export function defineOperation<
     outputSchema,
     requiredScope,
     textResponse,
+    expectedContentType,
     timeoutMsOverride,
     destructive,
     description,

--- a/packages/sdk/src/transport/__tests__/parse-response.test.ts
+++ b/packages/sdk/src/transport/__tests__/parse-response.test.ts
@@ -25,6 +25,15 @@ const exportOp: TransportOperation<string> = {
   textResponse: true,
 };
 
+const markdownExportOp: TransportOperation<string> = {
+  name: 'export.pageMarkdown',
+  method: 'GET',
+  path: '/api/pages/:id/export/markdown',
+  outputSchema: z.string(),
+  textResponse: true,
+  expectedContentType: 'text/markdown',
+};
+
 describe('parseResponse — success path', () => {
   it('returns the zod-validated output on a 2xx response matching the schema', () => {
     const result = parseResponse(widgetOp, 200, {}, JSON.stringify({ id: 'w1', ok: true }));
@@ -82,6 +91,41 @@ describe('parseResponse — non-2xx classification', () => {
   it('classifies non-2xx even for textResponse operations (does not pass errors through as text)', () => {
     const result = parseResponse(exportOp, 404, {}, JSON.stringify({ error: 'gone' }));
     expect(isNotFoundError(result)).toBe(true);
+  });
+});
+
+describe('parseResponse — expectedContentType (Phase 3 task 10 export ops)', () => {
+  it('passes bodyText through when the Content-Type header matches expectedContentType', () => {
+    const headers = new Headers({ 'Content-Type': 'text/markdown; charset=utf-8' });
+    const result = parseResponse(markdownExportOp, 200, headers, '# Heading\n\nBody text.');
+    expect(result).toBe('# Heading\n\nBody text.');
+  });
+
+  it('matches case-insensitively and ignores charset/params', () => {
+    const headers = new Headers({ 'Content-Type': 'Text/Markdown; charset=UTF-8' });
+    const result = parseResponse(markdownExportOp, 200, headers, 'ok');
+    expect(result).toBe('ok');
+  });
+
+  it('returns ResponseValidationError when Content-Type is a mismatched type (e.g. a JSON error page behind a 2xx proxy)', () => {
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    const result = parseResponse(markdownExportOp, 200, headers, '{"error":"oops"}');
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('returns ResponseValidationError when Content-Type is missing entirely', () => {
+    const result = parseResponse(markdownExportOp, 200, new Headers(), 'plain text with no header');
+    expect(isResponseValidationError(result)).toBe(true);
+  });
+
+  it('names the operation on the content-type ResponseValidationError', () => {
+    const result = parseResponse(markdownExportOp, 200, new Headers(), 'plain text with no header');
+    expect((result as Error & { operation?: string }).operation).toBe('export.pageMarkdown');
+  });
+
+  it('does not content-type-check a textResponse op with no expectedContentType set (existing exportOp)', () => {
+    const result = parseResponse(exportOp, 200, new Headers(), 'plain export text, not json {[');
+    expect(result).toBe('plain export text, not json {[');
   });
 });
 

--- a/packages/sdk/src/transport/parse-response.ts
+++ b/packages/sdk/src/transport/parse-response.ts
@@ -1,4 +1,11 @@
-import { classifyHttpError, type HttpErrorHeaders, type PageSpaceError, ResponseValidationError, type ValidationIssue } from '../errors.js';
+import {
+  classifyHttpError,
+  getHeaderValue,
+  type HttpErrorHeaders,
+  type PageSpaceError,
+  ResponseValidationError,
+  type ValidationIssue,
+} from '../errors.js';
 import type { TransportOperation } from './types.js';
 
 /** Parses JSON when possible; on empty/malformed input, returns a value the schema will reject rather than throwing. */
@@ -20,6 +27,13 @@ function toValidationIssues(issues: ReadonlyArray<{ path: PropertyKey[]; message
 
 export type ParsedResponse<TOutput> = TOutput | PageSpaceError;
 
+/** The media type portion of a Content-Type header, lowercased, `; charset=...` stripped. */
+function mediaTypeOf(headers: HttpErrorHeaders): string | null {
+  const raw = getHeaderValue(headers, 'Content-Type');
+  if (raw === null) return null;
+  return raw.split(';')[0]!.trim().toLowerCase();
+}
+
 /**
  * Pure: raw response parts → validated output or a classified error, as a
  * value (never thrown). Non-2xx statuses delegate to classifyHttpError
@@ -37,6 +51,15 @@ export function parseResponse<TOutput>(
   }
 
   if (op.textResponse) {
+    if (op.expectedContentType !== undefined && mediaTypeOf(headers) !== op.expectedContentType.toLowerCase()) {
+      const actual = getHeaderValue(headers, 'Content-Type');
+      return new ResponseValidationError(op.name, [
+        {
+          path: ['Content-Type'],
+          message: `Expected content-type "${op.expectedContentType}" for operation "${op.name}", received "${actual ?? '(missing)'}"`,
+        },
+      ]);
+    }
     return bodyText as TOutput;
   }
 

--- a/packages/sdk/src/transport/types.ts
+++ b/packages/sdk/src/transport/types.ts
@@ -15,6 +15,13 @@ export interface TransportOperation<TOutput = unknown> {
   readonly outputSchema: z.ZodType<TOutput>;
   /** Set for export-style operations whose 2xx body is raw text, not JSON. */
   readonly textResponse?: boolean;
+  /**
+   * Required media type (no `; charset=...` suffix) a `textResponse` 2xx body
+   * must arrive with, e.g. `"text/markdown"`. Only consulted when
+   * `textResponse` is true; a mismatch or missing header becomes a typed
+   * `ResponseValidationError` instead of the body being passed through blind.
+   */
+  readonly expectedContentType?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
Phase 3 task 10 (last domain in Phase 3) — SDK resource surface for text-returning export operations, per `docs/sdk/operations-inventory.md`'s parity contract and the `umdb209nhhyzgqsg4hb0oc8h` task spec.

- **`export.pageMarkdown`** — `GET /api/pages/:pageId/export/markdown` (DOCUMENT pages only; route 400s otherwise). Route-verified against `apps/web/src/app/api/pages/[pageId]/export/markdown/route.ts`.
- **`export.sheetCsv`** — `GET /api/pages/:pageId/export/csv` (SHEET pages only; route 400s otherwise). Route-verified against `apps/web/src/app/api/pages/[pageId]/export/csv/route.ts`.

**Ground-truth note:** the old MCP handler `export.js` never actually wrapped these routes — it only exposed `get_page_details` (JSON, already covered by Phase 3 task 2's `pages.details`). `PageSpaceApi.requestText` (`old repo src/api.js:47`) was dead code — "no export tools are registered" per the Phase 0 inventory. These two routes are genuine, previously-untooled, live text-export surface, matching the "untooled-but-live" pattern the Phase 3 intro calls out for `/api/mcp/documents`. The sibling `xlsx`/`docx` export routes return binary bodies and are out of scope for this `textResponse` domain.

**Shared transport extension (Phase 2 infra, opt-in):** the task spec requires "wrong-content-type → typed error," which didn't exist yet — `parseResponse` blindly passed `textResponse` bodies through with no header check. Added an optional `expectedContentType` field (`registry/define.ts`, `transport/types.ts`) consulted only when `textResponse` is set; a Content-Type mismatch or missing header on a 2xx body now returns a typed `ResponseValidationError` instead of passing untrusted text through. Undefined by default, so existing `textResponse` operations/tests are unaffected. Also exports the previously-private `getHeaderValue` from `errors.ts` for reuse.

## Test plan
- [x] RED: `src/operations/__tests__/export.test.ts` fails to resolve (no `operations/export.ts`) before implementation; all other suites green.
- [x] GREEN: `bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` — 702/702 tests green, 0 typecheck errors.
- [x] Fixture round-trips for markdown and CSV bodies containing `{`/`[`-like characters confirm no `JSON.parse` is attempted on text bodies.
- [x] Wrong-content-type and missing-content-type cases confirmed to produce typed `ResponseValidationError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCvVwCQhz4STG7tWjUNFcM