### PR TITLE
oauth: /api/oauth/revoke + authenticateRequest integration (Phase 1 task 10)

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/__tests__/oauth-integration.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/__tests__/oauth-integration.test.ts
@@ -1,0 +1,181 @@
+/**
+ * OAuth access-token integration test (task qyqgrjbvntpsdh578k0yiwgr) —
+ * proves the FULL authenticateRequest chain end to end against a real
+ * protected route: `@/lib/auth` is NOT mocked here (unlike
+ * `route.test.ts`'s contract tests), only its DB/session edges are, so this
+ * exercises the real hash lookup, expiry/revocation/suspension checks, and
+ * `checkMCPDriveScope` drive-scope gating for an OAuth access token exactly
+ * as production would.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: { validateSession: vi.fn().mockResolvedValue(null) },
+}));
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+  EnforcedAuthContext: class EnforcedAuthContext {
+    static fromSession(sessionClaims: unknown): unknown {
+      return sessionClaims;
+    }
+  },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+const mcpTokensFindFirst = vi.fn();
+const oauthAccessTokensFindFirst = vi.fn();
+const dbUpdateSet = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      mcpTokens: { findFirst: (...args: unknown[]) => mcpTokensFindFirst(...args) },
+    },
+    update: vi.fn().mockReturnValue({
+      set: (...args: unknown[]) => {
+        dbUpdateSet(...args);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      },
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ field, value })),
+  and: vi.fn((...conditions) => conditions),
+  isNull: vi.fn((field) => ({ field, isNull: true })),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({ mcpTokens: {} }));
+vi.mock('@pagespace/db/schema/oauth', () => ({ oauthAccessTokens: {} }));
+vi.mock('@pagespace/lib/auth/token-lookup', () => ({
+  findOAuthAccessTokenByValue: (...args: unknown[]) => oauthAccessTokensFindFirst(...args),
+}));
+
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getDriveById: vi.fn(),
+  getDriveWithAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+vi.mock('@/lib/websocket', () => ({
+  broadcastDriveEvent: vi.fn().mockResolvedValue(undefined),
+  createDriveEventPayload: vi.fn(),
+}));
+vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
+  getAppDriveMembership: vi.fn(),
+  getAppDriveAccessLevel: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({}),
+  logDriveActivity: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: vi.fn().mockResolvedValue([]),
+}));
+
+import { GET } from '../route';
+import { getDriveById, getDriveWithAccess } from '@pagespace/lib/services/drive-service';
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
+
+const USER_ID = 'test-user-id';
+const IN_SCOPE_DRIVE = 'driveinscope1';
+const OUT_OF_SCOPE_DRIVE = 'driveoutofscope1';
+
+function oauthRequest(driveId: string, token: string): { request: Request; context: { params: Promise<{ driveId: string }> } } {
+  return {
+    request: new Request(`http://localhost/api/drives/${driveId}`, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    context: { params: Promise.resolve({ driveId }) },
+  };
+}
+
+function baseOAuthTokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'oauth-token-1',
+    userId: USER_ID,
+    scopes: [`drive:${IN_SCOPE_DRIVE}`],
+    tokenVersion: 0,
+    expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+    revokedAt: null,
+    user: { id: USER_ID, role: 'user', tokenVersion: 0, adminRoleVersion: 0, suspendedAt: null },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mcpTokensFindFirst.mockResolvedValue(null);
+  vi.mocked(getDriveById).mockResolvedValue({ id: IN_SCOPE_DRIVE } as never);
+  vi.mocked(getDriveWithAccess).mockResolvedValue({ id: IN_SCOPE_DRIVE, name: 'Drive' } as never);
+});
+
+describe('GET /api/drives/[driveId] — OAuth access-token integration', () => {
+  it('accepts a valid OAuth access token scoped to this drive (in-scope → 200)', async () => {
+    oauthAccessTokensFindFirst.mockResolvedValue(baseOAuthTokenRow());
+
+    const { request, context } = oauthRequest(IN_SCOPE_DRIVE, 'ps_at_' + 'a'.repeat(43));
+    const res = await GET(request, context);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects the same token for an out-of-scope drive — scope narrowing bites (403)', async () => {
+    oauthAccessTokensFindFirst.mockResolvedValue(baseOAuthTokenRow());
+
+    const { request, context } = oauthRequest(OUT_OF_SCOPE_DRIVE, 'ps_at_' + 'a'.repeat(43));
+    const res = await GET(request, context);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('accepts an account-scoped OAuth token for ANY drive (full-user credential parity)', async () => {
+    oauthAccessTokensFindFirst.mockResolvedValue(baseOAuthTokenRow({ scopes: ['account'] }));
+
+    const { request, context } = oauthRequest(OUT_OF_SCOPE_DRIVE, 'ps_at_' + 'b'.repeat(43));
+    const res = await GET(request, context);
+
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects an expired OAuth access token (401)', async () => {
+    oauthAccessTokensFindFirst.mockResolvedValue(
+      baseOAuthTokenRow({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+
+    const { request, context } = oauthRequest(IN_SCOPE_DRIVE, 'ps_at_' + 'c'.repeat(43));
+    const res = await GET(request, context);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a revoked/unknown OAuth access token — indistinguishable from expired (401)', async () => {
+    oauthAccessTokensFindFirst.mockResolvedValue(null);
+
+    const { request, context } = oauthRequest(IN_SCOPE_DRIVE, 'ps_at_' + 'd'.repeat(43));
+    const res = await GET(request, context);
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an OAuth access token belonging to a suspended user, and revokes it on sight (401)', async () => {
+    oauthAccessTokensFindFirst.mockResolvedValue(
+      baseOAuthTokenRow({ user: { id: USER_ID, role: 'user', tokenVersion: 0, adminRoleVersion: 0, suspendedAt: new Date() } }),
+    );
+
+    const { request, context } = oauthRequest(IN_SCOPE_DRIVE, 'ps_at_' + 'e'.repeat(43));
+    const res = await GET(request, context);
+
+    expect(res.status).toBe(401);
+    expect(dbUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ revokedAt: expect.any(Date) }));
+    expect(logSecurityEvent).toHaveBeenCalledWith(
+      'unauthorized',
+      expect.objectContaining({ reason: 'oauth_token_user_suspended' }),
+    );
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
@@ -183,7 +183,7 @@ describe('GET /api/drives/[driveId]', () => {
 
       expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
         request,
-        { allow: ['session', 'mcp'], requireCSRF: false }
+        { allow: ['session', 'mcp', 'oauth'], requireCSRF: false }
       );
     });
   });

--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -12,7 +12,7 @@ import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activi
 import { trackDriveOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { syncPublishedHomeRoot } from '@/lib/canvas/publish-page';
 
-const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_READ = { allow: ['session', 'mcp', 'oauth'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
 const patchSchema = z.object({

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/lib/auth', () => ({
   authenticateMCPRequest: (...args: unknown[]) => mockAuthenticateMCPRequest(...args),
   isAuthError: (result: unknown) => 'error' in (result as object),
   isMCPAuthResult: (result: unknown) => !('error' in (result as object)) && (result as { tokenType?: string }).tokenType === 'mcp',
+  isOAuthAuthResult: (result: unknown) => !('error' in (result as object)) && (result as { tokenType?: string }).tokenType === 'oauth',
   // Delegate to the REAL principal dispatch (unit-tested in
   // src/lib/auth/__tests__/principal-permissions.test.ts) so the security
   // assertions below still verify that scoped tokens resolve app-level

--- a/apps/web/src/app/api/oauth/revoke/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/revoke/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+/**
+ * POST /api/oauth/revoke — RFC 7009 token revocation (task
+ * qyqgrjbvntpsdh578k0yiwgr). Zero-trust posture: an unknown, foreign, or
+ * already-revoked token is INDISTINGUISHABLE from a successful revocation —
+ * revocation endpoints never confirm token existence (no oracle), while
+ * form-level malformed requests (missing token/client_id) still get a
+ * distinct invalid_request, matching the token endpoint's precedent for
+ * malformed-syntax vs credential-shaped rejections.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const ensureOAuthClientRow = vi.fn();
+const revokeOAuthToken = vi.fn();
+vi.mock('@/lib/repositories/oauth-repository', () => ({
+  ensureOAuthClientRow: (...args: unknown[]) => ensureOAuthClientRow(...args),
+  revokeOAuthToken: (...args: unknown[]) => revokeOAuthToken(...args),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const CLIENT_ID = 'pagespace-cli';
+const CLIENT_DB_ID = 'client-db-id-1';
+
+function revokeRequest(fields: Record<string, string | undefined>, contentType = 'application/x-www-form-urlencoded'): Request {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) body.set(key, value);
+  }
+  return new Request('http://web.local/api/oauth/revoke', {
+    method: 'POST',
+    headers: { 'content-type': contentType },
+    body: body.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureOAuthClientRow.mockResolvedValue(CLIENT_DB_ID);
+  revokeOAuthToken.mockResolvedValue(undefined);
+});
+
+describe('POST /api/oauth/revoke — form-encoding enforcement', () => {
+  it('rejects a JSON content-type with invalid_request', async () => {
+    const req = new Request('http://web.local/api/oauth/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: 'ps_at_x', client_id: CLIENT_ID }),
+    });
+
+    const res = await POST(req as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(revokeOAuthToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/revoke — happy path', () => {
+  it('revokes a refresh token and returns 200 with an empty body', async () => {
+    const res = await POST(
+      revokeRequest({ token: 'ps_rt_' + 'a'.repeat(43), client_id: CLIENT_ID }) as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
+    expect(revokeOAuthToken).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'ps_rt_' + 'a'.repeat(43), clientDbId: CLIENT_DB_ID }),
+    );
+  });
+
+  it('revokes an access token and returns 200 with an empty body', async () => {
+    const res = await POST(
+      revokeRequest({ token: 'ps_at_' + 'b'.repeat(43), client_id: CLIENT_ID }) as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
+    expect(revokeOAuthToken).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'ps_at_' + 'b'.repeat(43), clientDbId: CLIENT_DB_ID }),
+    );
+  });
+
+  it('sets Cache-Control: no-store', async () => {
+    const res = await POST(revokeRequest({ token: 'ps_at_' + 'c'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('honors token_type_hint when present without changing the outcome', async () => {
+    const res = await POST(
+      revokeRequest({ token: 'ps_at_' + 'd'.repeat(43), client_id: CLIENT_ID, token_type_hint: 'access_token' }) as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(revokeOAuthToken).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/revoke — no oracle (unknown/foreign/already-revoked → 200)', () => {
+  it('an unknown token still returns 200, empty body', async () => {
+    const res = await POST(revokeRequest({ token: 'ps_at_' + 'e'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
+  });
+
+  it('a garbage/malformed token value (not ps_at_/ps_rt_ shaped) still returns 200', async () => {
+    const res = await POST(revokeRequest({ token: 'totally-not-a-token', client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
+    expect(revokeOAuthToken).toHaveBeenCalledWith(
+      expect.objectContaining({ token: 'totally-not-a-token' }),
+    );
+  });
+
+  it('an unknown client_id still returns 200, empty body — same as an unknown token', async () => {
+    const res = await POST(revokeRequest({ token: 'ps_at_' + 'f'.repeat(43), client_id: 'evil-client' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
+    expect(revokeOAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('a repository no-op (already revoked / foreign to this client) still returns 200', async () => {
+    revokeOAuthToken.mockResolvedValue(undefined);
+
+    const res = await POST(revokeRequest({ token: 'ps_rt_' + 'g'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('');
+  });
+});
+
+describe('POST /api/oauth/revoke — malformed request (invalid_request, distinguishable from a credential rejection)', () => {
+  it('missing token → invalid_request, never calls the repository', async () => {
+    const res = await POST(revokeRequest({ client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(revokeOAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('missing client_id → invalid_request, never calls the repository', async () => {
+    const res = await POST(revokeRequest({ token: 'ps_at_' + 'h'.repeat(43) }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(revokeOAuthToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/revoke — audit logging', () => {
+  it('audits a successful revocation', async () => {
+    await POST(revokeRequest({ token: 'ps_at_' + 'i'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'auth.token.revoked' }),
+    );
+  });
+});

--- a/apps/web/src/app/api/oauth/revoke/route.ts
+++ b/apps/web/src/app/api/oauth/revoke/route.ts
@@ -1,0 +1,61 @@
+/**
+ * OAuth 2.1 token revocation endpoint (RFC 7009; Phase 1 task
+ * qyqgrjbvntpsdh578k0yiwgr). A thin shell: parses the form-encoded request,
+ * resolves the client, and delegates the actual revocation to
+ * `revokeOAuthToken`, which decides refresh-vs-access-token semantics.
+ *
+ * Zero-trust posture: an unknown token, a token belonging to a different
+ * client, an already-revoked token, or an unknown client_id ALL produce the
+ * SAME 200 response with an empty body — revocation endpoints never confirm
+ * token existence (RFC 7009 §2.2: "the authorization server responds with
+ * HTTP status code 200 if the token has been revoked successfully or if the
+ * client submitted an invalid token"). Only malformed requests (missing
+ * `token` or `client_id`) get a distinct `invalid_request`, matching the
+ * token endpoint's precedent for malformed syntax vs credential-shaped
+ * rejections.
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
+import { ensureOAuthClientRow, revokeOAuthToken } from '@/lib/repositories/oauth-repository';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
+  return NextResponse.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+function noStoreEmpty(): NextResponse {
+  return new NextResponse(null, { status: 200, headers: { 'Cache-Control': 'no-store' } });
+}
+
+const INVALID_REQUEST = { error: 'invalid_request' };
+
+export async function POST(req: NextRequest) {
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
+    return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  const form = new URLSearchParams(await req.text());
+  const token = form.get('token');
+  const clientId = form.get('client_id');
+
+  if (!token || !clientId) {
+    return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  const client = getRegisteredClient(clientId);
+  if (!client) {
+    // No oracle: an unknown client_id is indistinguishable from an unknown token.
+    return noStoreEmpty();
+  }
+
+  const clientDbId = await ensureOAuthClientRow(client);
+  await revokeOAuthToken({ token, clientDbId, now: new Date() });
+
+  auditRequest(req, {
+    eventType: 'auth.token.revoked',
+    details: { clientId: client.clientId, oauthEvent: 'revoke' },
+  });
+
+  return noStoreEmpty();
+}

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -5,10 +5,12 @@ import {
   authenticateHybridRequest,
   authenticateRequestWithOptions,
   validateMCPToken,
+  validateOAuthAccessToken,
   validateSessionToken,
   isAuthError,
   isMCPAuthResult,
   isSessionAuthResult,
+  isOAuthAuthResult,
 } from '../index';
 
 // Mock dependencies
@@ -19,6 +21,9 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   sessionService: {
     validateSession: vi.fn(),
   },
+}));
+vi.mock('@pagespace/lib/auth/token-lookup', () => ({
+  findOAuthAccessTokenByValue: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
@@ -38,6 +43,9 @@ vi.mock('@pagespace/db/db', () => ({
       mcpTokens: {
         findFirst: vi.fn(),
       },
+      oauthAccessTokens: {
+        findFirst: vi.fn(),
+      },
     },
     update: vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -54,6 +62,9 @@ vi.mock('@pagespace/db/operators', () => ({
 vi.mock('@pagespace/db/schema/auth', () => ({
   mcpTokens: {},
 }));
+vi.mock('@pagespace/db/schema/oauth', () => ({
+  oauthAccessTokens: {},
+}));
 
 vi.mock('../csrf-validation', () => ({
   validateCSRF: vi.fn().mockResolvedValue(null),
@@ -68,6 +79,7 @@ vi.mock('../cookie-config', () => ({
 }));
 
 import { sessionService } from '@pagespace/lib/auth/session-service';
+import { findOAuthAccessTokenByValue } from '@pagespace/lib/auth/token-lookup';
 import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { db } from '@pagespace/db/db';
 import { validateCSRF } from '../csrf-validation';
@@ -90,6 +102,7 @@ describe('Auth Middleware', () => {
     vi.clearAllMocks();
     vi.mocked(sessionService.validateSession).mockResolvedValue(null);
     vi.mocked(db.query.mcpTokens.findFirst).mockResolvedValue(null as never);
+    vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(null);
     vi.mocked(validateCSRF).mockResolvedValue(null);
     vi.mocked(validateOrigin).mockReturnValue(null);
     vi.mocked(getSessionFromCookies).mockReturnValue(null);
@@ -271,6 +284,130 @@ describe('Auth Middleware', () => {
           userId: 'test-user-id',
           tokenId: 'token-id',
           authType: 'mcp',
+          action: 'revoke_and_deny',
+        })
+      );
+    });
+  });
+
+  describe('validateOAuthAccessToken', () => {
+    const baseUser = {
+      id: 'test-user-id',
+      role: 'user' as const,
+      tokenVersion: 0,
+      adminRoleVersion: 0,
+      suspendedAt: null as Date | null,
+    };
+
+    function mockOAuthToken(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'oauth-token-id',
+        userId: 'test-user-id',
+        scopes: ['account'],
+        tokenVersion: 0,
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+        revokedAt: null,
+        user: { ...baseUser },
+        ...overrides,
+      };
+    }
+
+    it('returns null for token without ps_at_ prefix', async () => {
+      const result = await validateOAuthAccessToken('mcp_some-token');
+      expect(result).toBeNull();
+      expect(findOAuthAccessTokenByValue).not.toHaveBeenCalled();
+    });
+
+    it('returns null for empty token', async () => {
+      const result = await validateOAuthAccessToken('');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when token not found in database', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(null as never);
+
+      const result = await validateOAuthAccessToken('ps_at_valid-token');
+      expect(result).toBeNull();
+    });
+
+    it('returns auth details for a valid account-scoped OAuth token (full access, like an unscoped MCP token)', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(mockOAuthToken() as never);
+
+      const result = await validateOAuthAccessToken('ps_at_valid-token');
+      expect(result).toEqual({
+        userId: 'test-user-id',
+        role: 'user',
+        tokenVersion: 0,
+        adminRoleVersion: 0,
+        tokenId: 'oauth-token-id',
+        scopes: { account: true, offlineAccess: false, drives: new Map() },
+        driveScopes: [],
+        allowedDriveIds: [],
+      });
+    });
+
+    it('returns auth details for a drive-scoped OAuth token, resolving allowedDriveIds from the scope', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(
+        mockOAuthToken({ scopes: ['drive:abc123def456:admin'] }) as never
+      );
+
+      const result = await validateOAuthAccessToken('ps_at_valid-token');
+      expect(result?.allowedDriveIds).toEqual(['abc123def456']);
+      expect(result?.driveScopes).toEqual([{ driveId: 'abc123def456', role: 'ADMIN', customRoleId: null }]);
+    });
+
+    it('returns null for an expired token', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(
+        mockOAuthToken({ expiresAt: new Date(Date.now() - 1000) }) as never
+      );
+
+      const result = await validateOAuthAccessToken('ps_at_expired-token');
+      expect(result).toBeNull();
+    });
+
+    it('returns null and fails closed on corrupt/unparseable stored scopes', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(
+        mockOAuthToken({ scopes: ['not a valid scope grammar!!'] }) as never
+      );
+
+      const result = await validateOAuthAccessToken('ps_at_valid-token');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when tokenVersion is stale (global logout/password change invalidates it)', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(
+        mockOAuthToken({ tokenVersion: 0, user: { ...baseUser, tokenVersion: 1 } }) as never
+      );
+
+      const result = await validateOAuthAccessToken('ps_at_valid-token');
+      expect(result).toBeNull();
+    });
+
+    it('denies and revokes an OAuth access token for a suspended user, mirroring mcp_token_user_suspended', async () => {
+      vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(
+        mockOAuthToken({ user: { ...baseUser, suspendedAt: new Date('2026-01-01T00:00:00.000Z') } }) as never
+      );
+
+      let capturedSetValues: Record<string, unknown> | undefined;
+      const mockSet = vi.fn().mockImplementation((values: Record<string, unknown>) => {
+        capturedSetValues = values;
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      });
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
+
+      const result = await validateOAuthAccessToken('ps_at_suspended-user-token');
+
+      expect(result).toBeNull();
+      expect(db.update).toHaveBeenCalled();
+      expect(mockSet).toHaveBeenCalled();
+      expect(capturedSetValues!.revokedAt).toBeInstanceOf(Date);
+      expect(logSecurityEvent).toHaveBeenCalledWith(
+        'unauthorized',
+        expect.objectContaining({
+          reason: 'oauth_token_user_suspended',
+          userId: 'test-user-id',
+          tokenId: 'oauth-token-id',
+          authType: 'oauth',
           action: 'revoke_and_deny',
         })
       );
@@ -566,6 +703,60 @@ describe('Auth Middleware', () => {
         // Assert
         expect(isAuthError(result)).toBe(false);
         expect(isMCPAuthResult(result)).toBe(true);
+      });
+
+      it('rejects an OAuth access token when oauth type is not allowed', async () => {
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer ps_at_some-token' },
+        });
+
+        const result = await authenticateRequestWithOptions(request, { allow: ['session', 'mcp'] });
+
+        expect(isAuthError(result)).toBe(true);
+        if (isAuthError(result)) {
+          const body = await result.error.json();
+          expect(body.error).toContain('not permitted');
+        }
+      });
+
+      it('allows an OAuth access token when oauth type is allowed', async () => {
+        const mockOAuthToken = {
+          id: 'oauth-token-id',
+          userId: 'test-user-id',
+          scopes: ['account'],
+          tokenVersion: 0,
+          expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+          revokedAt: null,
+          user: { id: 'test-user-id', role: 'user', tokenVersion: 0, adminRoleVersion: 0, suspendedAt: null },
+        };
+        vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(mockOAuthToken as never);
+
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer ps_at_valid-token' },
+        });
+
+        const result = await authenticateRequestWithOptions(request, { allow: ['oauth'] });
+
+        expect(isAuthError(result)).toBe(false);
+        expect(isOAuthAuthResult(result)).toBe(true);
+        if (!isAuthError(result)) {
+          expect(result.userId).toBe('test-user-id');
+        }
+      });
+
+      it('rejects an invalid/expired/revoked OAuth access token the same way as unknown (no oracle)', async () => {
+        vi.mocked(findOAuthAccessTokenByValue).mockResolvedValue(null as never);
+
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer ps_at_revoked-token' },
+        });
+
+        const result = await authenticateRequestWithOptions(request, { allow: ['oauth'] });
+
+        expect(isAuthError(result)).toBe(true);
       });
     });
 
@@ -964,6 +1155,45 @@ describe('Auth Middleware', () => {
           allowedDriveIds: [],
         };
         expect(isSessionAuthResult(mcpResult)).toBe(false);
+      });
+    });
+
+    describe('isOAuthAuthResult', () => {
+      it('returns true for an OAuth result', () => {
+        const oauthResult = {
+          userId: 'test',
+          role: 'user' as const,
+          tokenVersion: 0,
+          adminRoleVersion: 0,
+          tokenType: 'oauth' as const,
+          tokenId: 'oauth-token-id',
+          scopes: { account: true, offlineAccess: false, drives: new Map() },
+          driveScopes: [],
+          allowedDriveIds: [],
+        };
+        expect(isOAuthAuthResult(oauthResult)).toBe(true);
+      });
+
+      it('returns false for session/mcp results', () => {
+        const sessionResult = {
+          userId: 'test',
+          role: 'user' as const,
+          tokenVersion: 0,
+          adminRoleVersion: 0,
+          tokenType: 'session' as const,
+          sessionId: 'test-session-id',
+        };
+        const mcpResult = {
+          userId: 'test',
+          role: 'user' as const,
+          tokenVersion: 0,
+          adminRoleVersion: 0,
+          tokenType: 'mcp' as const,
+          tokenId: 'token-id',
+          allowedDriveIds: [],
+        };
+        expect(isOAuthAuthResult(sessionResult)).toBe(false);
+        expect(isOAuthAuthResult(mcpResult)).toBe(false);
       });
     });
   });

--- a/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
@@ -84,6 +84,7 @@ import {
   getAllowedDriveIds,
   type MCPAuthResult,
   type SessionAuthResult,
+  type OAuthAuthResult,
 } from '../index';
 
 describe('MCP Scope Enforcement', () => {
@@ -124,6 +125,30 @@ describe('MCP Scope Enforcement', () => {
     sessionId: 'session-xyz',
   });
 
+  const createScopedOAuthAuth = (allowedDriveIds: string[]): OAuthAuthResult => ({
+    tokenType: 'oauth',
+    userId: 'user-123',
+    role: 'user',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    tokenId: 'oauth-token-abc',
+    scopes: { account: false, offlineAccess: false, drives: new Map() },
+    driveScopes: allowedDriveIds.map((driveId) => ({ driveId, role: null, customRoleId: null })),
+    allowedDriveIds,
+  });
+
+  const createAccountScopedOAuthAuth = (): OAuthAuthResult => ({
+    tokenType: 'oauth',
+    userId: 'user-123',
+    role: 'user',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    tokenId: 'oauth-token-abc',
+    scopes: { account: true, offlineAccess: false, drives: new Map() },
+    driveScopes: [],
+    allowedDriveIds: [],
+  });
+
   // ===========================================================================
   // 1. getAllowedDriveIds
   // ===========================================================================
@@ -143,6 +168,19 @@ describe('MCP Scope Enforcement', () => {
 
     it('given scoped MCP auth, should return the allowed drive IDs', () => {
       const auth = createScopedMCPAuth(['drive-1', 'drive-2']);
+      const result = getAllowedDriveIds(auth);
+
+      expect(result).toEqual(['drive-1', 'drive-2']);
+    });
+
+    it('given account-scoped OAuth auth, should return empty array (full access, like an unscoped MCP token)', () => {
+      const result = getAllowedDriveIds(createAccountScopedOAuthAuth());
+
+      expect(result).toEqual([]);
+    });
+
+    it('given drive-scoped OAuth auth, should return the allowed drive IDs', () => {
+      const auth = createScopedOAuthAuth(['drive-1', 'drive-2']);
       const result = getAllowedDriveIds(auth);
 
       expect(result).toEqual(['drive-1', 'drive-2']);
@@ -175,6 +213,27 @@ describe('MCP Scope Enforcement', () => {
 
     it('given scoped MCP token, should deny access to out-of-scope drive', () => {
       const auth = createScopedMCPAuth(['drive-1']);
+      const result = checkMCPDriveScope(auth, 'drive-other');
+
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(403);
+    });
+
+    it('given account-scoped OAuth token, should allow access to any drive (full access)', () => {
+      const result = checkMCPDriveScope(createAccountScopedOAuthAuth(), 'any-drive');
+
+      expect(result).toBeNull();
+    });
+
+    it('given drive-scoped OAuth token, should allow access to an in-scope drive — scope narrowing bites', () => {
+      const auth = createScopedOAuthAuth(['drive-1', 'drive-2']);
+      const result = checkMCPDriveScope(auth, 'drive-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('given drive-scoped OAuth token, should deny access to an out-of-scope drive with 403 — scope narrowing bites', () => {
+      const auth = createScopedOAuthAuth(['drive-1']);
       const result = checkMCPDriveScope(auth, 'drive-other');
 
       expect(result).not.toBeNull();

--- a/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
+++ b/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
@@ -19,10 +19,16 @@ vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
   getAppDriveAccessLevel: vi.fn(),
   getAppAccessiblePagesInDrive: vi.fn(),
   hasAppDriveMembership: vi.fn(),
+  getScopedAccessLevel: vi.fn(),
+  getScopedDriveMembership: vi.fn(),
+  getScopedDriveAccessLevel: vi.fn(),
+  getScopedAccessiblePagesInDrive: vi.fn(),
+  hasScopedDriveMembership: vi.fn(),
 }));
 
 import {
   isScopedMCPAuth,
+  isScopedOAuthAuth,
   getPrincipalAccessLevel,
   canPrincipalViewPage,
   canPrincipalEditPage,
@@ -54,6 +60,10 @@ import {
   getAppDriveMembership,
   getAppAccessiblePagesInDrive,
   hasAppDriveMembership,
+  getScopedAccessLevel,
+  getScopedDriveMembership,
+  getScopedAccessiblePagesInDrive,
+  hasScopedDriveMembership,
 } from '@pagespace/lib/permissions/app-permissions';
 
 const USER_ID = 'user_aaaaaaaaaaaaaaaaaaaaaa';
@@ -66,6 +76,18 @@ const sessionAuth: AuthResult = { ...base, userId: USER_ID, tokenType: 'session'
 const unscopedMcpAuth: AuthResult = { ...base, userId: USER_ID, tokenType: 'mcp', tokenId: TOKEN_ID, allowedDriveIds: [] };
 const scopedMcpAuth: AuthResult = { ...base, userId: USER_ID, tokenType: 'mcp', tokenId: TOKEN_ID, allowedDriveIds: [DRIVE_ID] };
 
+const DRIVE_SCOPES = [{ driveId: DRIVE_ID, role: null, customRoleId: null }];
+const accountOAuthAuth: AuthResult = {
+  ...base, userId: USER_ID, tokenType: 'oauth', tokenId: TOKEN_ID,
+  scopes: { account: true, offlineAccess: false, drives: new Map() },
+  driveScopes: [], allowedDriveIds: [],
+};
+const scopedOAuthAuth: AuthResult = {
+  ...base, userId: USER_ID, tokenType: 'oauth', tokenId: TOKEN_ID,
+  scopes: { account: false, offlineAccess: false, drives: new Map([[DRIVE_ID, { kind: 'drive' as const, driveId: DRIVE_ID, role: { kind: 'inherit' as const } }]]) },
+  driveScopes: DRIVE_SCOPES, allowedDriveIds: [DRIVE_ID],
+};
+
 const FULL = { canView: true, canEdit: true, canShare: true, canDelete: true };
 const VIEW_ONLY = { canView: true, canEdit: false, canShare: false, canDelete: false };
 
@@ -74,6 +96,21 @@ describe('isScopedMCPAuth', () => {
     expect(isScopedMCPAuth(sessionAuth)).toBe(false);
     expect(isScopedMCPAuth(unscopedMcpAuth)).toBe(false);
     expect(isScopedMCPAuth(scopedMcpAuth)).toBe(true);
+  });
+
+  it('is false for OAuth auth (even drive-scoped)', () => {
+    expect(isScopedMCPAuth(accountOAuthAuth)).toBe(false);
+    expect(isScopedMCPAuth(scopedOAuthAuth)).toBe(false);
+  });
+});
+
+describe('isScopedOAuthAuth', () => {
+  it('is true only for OAuth auth without the account scope', () => {
+    expect(isScopedOAuthAuth(sessionAuth)).toBe(false);
+    expect(isScopedOAuthAuth(unscopedMcpAuth)).toBe(false);
+    expect(isScopedOAuthAuth(scopedMcpAuth)).toBe(false);
+    expect(isScopedOAuthAuth(accountOAuthAuth)).toBe(false);
+    expect(isScopedOAuthAuth(scopedOAuthAuth)).toBe(true);
   });
 });
 
@@ -131,6 +168,34 @@ describe('dispatch matrix — page-level checks', () => {
     expect(await canPrincipalSharePage(scopedMcpAuth, PAGE_ID)).toBe(true);
     expect(canUserDeletePage).not.toHaveBeenCalled();
     expect(canUserSharePage).not.toHaveBeenCalled();
+  });
+
+  it('getPrincipalAccessLevel: drive-scoped OAuth token → scoped path with driveScopes+userId, indistinguishable from a scoped MCP token', async () => {
+    vi.mocked(getScopedAccessLevel).mockResolvedValue(VIEW_ONLY);
+    expect(await getPrincipalAccessLevel(scopedOAuthAuth, PAGE_ID)).toEqual(VIEW_ONLY);
+    expect(getScopedAccessLevel).toHaveBeenCalledWith(DRIVE_SCOPES, USER_ID, PAGE_ID);
+    expect(getUserAccessLevel).not.toHaveBeenCalled();
+    expect(getAppAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('getPrincipalAccessLevel: account-scoped OAuth token → user path (full-user credential, like an unscoped MCP token)', async () => {
+    vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+    expect(await getPrincipalAccessLevel(accountOAuthAuth, PAGE_ID)).toEqual(FULL);
+    expect(getUserAccessLevel).toHaveBeenCalledWith(USER_ID, PAGE_ID);
+    expect(getScopedAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('canPrincipalEditPage: scoped OAuth MEMBER-equivalent denied even though the user could edit', async () => {
+    vi.mocked(getScopedAccessLevel).mockResolvedValue(VIEW_ONLY);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    expect(await canPrincipalEditPage(scopedOAuthAuth, PAGE_ID)).toBe(false);
+    expect(canUserEditPage).not.toHaveBeenCalled();
+  });
+
+  it('canPrincipalDeletePage / canPrincipalSharePage: scoped OAuth token keyed to scoped-app flags', async () => {
+    vi.mocked(getScopedAccessLevel).mockResolvedValue({ ...FULL, canDelete: false, canShare: true });
+    expect(await canPrincipalDeletePage(scopedOAuthAuth, PAGE_ID)).toBe(false);
+    expect(await canPrincipalSharePage(scopedOAuthAuth, PAGE_ID)).toBe(true);
   });
 });
 
@@ -203,6 +268,55 @@ describe('dispatch matrix — drive-level checks', () => {
     await getPrincipalAccessiblePagesInDrive(sessionAuth, DRIVE_ID);
     expect(getUserAccessiblePagesInDriveWithDetails).toHaveBeenCalledWith(USER_ID, DRIVE_ID);
   });
+
+  it('isPrincipalDriveMember: drive-scoped OAuth token → scoped membership via driveScopes+userId', async () => {
+    vi.mocked(hasScopedDriveMembership).mockResolvedValue(true);
+    expect(await isPrincipalDriveMember(scopedOAuthAuth, DRIVE_ID)).toBe(true);
+    expect(hasScopedDriveMembership).toHaveBeenCalledWith(DRIVE_SCOPES, USER_ID, DRIVE_ID);
+    expect(isUserDriveMember).not.toHaveBeenCalled();
+  });
+
+  it('getPrincipalDriveAccess: account-scoped OAuth token → user access (full-user credential)', async () => {
+    vi.mocked(getUserDriveAccess).mockResolvedValue(true);
+    expect(await getPrincipalDriveAccess(accountOAuthAuth, DRIVE_ID)).toBe(true);
+    expect(getUserDriveAccess).toHaveBeenCalledWith(USER_ID, DRIVE_ID);
+  });
+
+  it('isPrincipalDriveOwnerOrAdmin: scoped OAuth token with explicit ADMIN role → true; MEMBER → false', async () => {
+    vi.mocked(getScopedDriveMembership).mockReturnValue({ role: 'MEMBER', customRoleId: null });
+    vi.mocked(isDriveOwnerOrAdmin).mockResolvedValue(true); // owning user IS admin — must not leak through
+    expect(await isPrincipalDriveOwnerOrAdmin(scopedOAuthAuth, DRIVE_ID)).toBe(false);
+    expect(isDriveOwnerOrAdmin).not.toHaveBeenCalled();
+
+    vi.mocked(getScopedDriveMembership).mockReturnValue({ role: 'ADMIN', customRoleId: null });
+    expect(await isPrincipalDriveOwnerOrAdmin(scopedOAuthAuth, DRIVE_ID)).toBe(true);
+  });
+
+  it('isPrincipalDriveOwnerOrAdmin: INHERITED OAuth scope row (role null) uses the owner\'s own authority', async () => {
+    vi.mocked(getScopedDriveMembership).mockReturnValue({ role: null, customRoleId: null });
+    vi.mocked(isDriveOwnerOrAdmin).mockResolvedValue(true);
+    expect(await isPrincipalDriveOwnerOrAdmin(scopedOAuthAuth, DRIVE_ID)).toBe(true);
+    expect(isDriveOwnerOrAdmin).toHaveBeenCalledWith(USER_ID, DRIVE_ID);
+  });
+
+  it('isPrincipalDriveOwnerOrAdmin: no matching OAuth scope row → false (no user fallback)', async () => {
+    vi.mocked(getScopedDriveMembership).mockReturnValue(null);
+    vi.mocked(isDriveOwnerOrAdmin).mockResolvedValue(true);
+    expect(await isPrincipalDriveOwnerOrAdmin(scopedOAuthAuth, DRIVE_ID)).toBe(false);
+    expect(isDriveOwnerOrAdmin).not.toHaveBeenCalled();
+  });
+
+  it('getPrincipalDriveIds: drive-scoped OAuth token → its allowedDriveIds, NOT the user drive list', async () => {
+    vi.mocked(getDriveIdsForUser).mockResolvedValue(['other-drive']);
+    expect(await getPrincipalDriveIds(scopedOAuthAuth)).toEqual([DRIVE_ID]);
+    expect(getDriveIdsForUser).not.toHaveBeenCalled();
+  });
+
+  it('getPrincipalAccessiblePagesInDrive: drive-scoped OAuth token dispatches to getScopedAccessiblePagesInDrive', async () => {
+    vi.mocked(getScopedAccessiblePagesInDrive).mockResolvedValue([]);
+    await getPrincipalAccessiblePagesInDrive(scopedOAuthAuth, DRIVE_ID);
+    expect(getScopedAccessiblePagesInDrive).toHaveBeenCalledWith(DRIVE_SCOPES, USER_ID, DRIVE_ID);
+  });
 });
 
 describe('getPrincipalBatchPagePermissions', () => {
@@ -230,5 +344,24 @@ describe('getPrincipalBatchPagePermissions', () => {
     const result = await getPrincipalBatchPagePermissions(scopedMcpAuth, []);
     expect(result.size).toBe(0);
     expect(getAppAccessiblePagesInDrive).not.toHaveBeenCalled();
+  });
+
+  it('drive-scoped OAuth token → resolves via getScopedAccessiblePagesInDrive, denying everything else', async () => {
+    vi.mocked(getScopedAccessiblePagesInDrive).mockResolvedValue([
+      { id: PAGE_ID, title: 'A', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false, permissions: VIEW_ONLY },
+    ]);
+
+    const result = await getPrincipalBatchPagePermissions(scopedOAuthAuth, [PAGE_ID, 'page_outside']);
+    expect(result.get(PAGE_ID)).toEqual(VIEW_ONLY);
+    expect(result.get('page_outside')).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+    expect(getScopedAccessiblePagesInDrive).toHaveBeenCalledWith(DRIVE_SCOPES, USER_ID, DRIVE_ID);
+    expect(getBatchPagePermissions).not.toHaveBeenCalled();
+  });
+
+  it('account-scoped OAuth token → user batch path (full-user credential)', async () => {
+    const expected = new Map([[PAGE_ID, FULL]]);
+    vi.mocked(getBatchPagePermissions).mockResolvedValue(expected);
+    expect(await getPrincipalBatchPagePermissions(accountOAuthAuth, [PAGE_ID])).toBe(expected);
+    expect(getBatchPagePermissions).toHaveBeenCalledWith(USER_ID, [PAGE_ID]);
   });
 });

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -2,8 +2,11 @@ import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
 import { eq, and, isNull } from '@pagespace/db/operators'
 import { mcpTokens } from '@pagespace/db/schema/auth';
+import { oauthAccessTokens } from '@pagespace/db/schema/oauth';
 import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { findOAuthAccessTokenByValue } from '@pagespace/lib/auth/token-lookup';
+import { parseScopeList, scopeSetToDriveScopes, type ScopeSet, type DriveScopeRow } from '@pagespace/lib/auth/oauth/scopes';
 import { EnforcedAuthContext } from '@pagespace/lib/permissions/enforced-context';
 import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';
@@ -11,8 +14,9 @@ import { getSessionFromCookies } from './cookie-config';
 const BEARER_PREFIX = 'Bearer ';
 const MCP_TOKEN_PREFIX = 'mcp_';
 const SESSION_TOKEN_PREFIX = 'ps_sess_';
+const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
 
-export type TokenType = 'mcp' | 'session';
+export type TokenType = 'mcp' | 'session' | 'oauth';
 
 interface BaseAuthDetails {
   userId: string;
@@ -36,7 +40,21 @@ export interface SessionAuthResult extends BaseAuthDetails {
   sessionId: string;
 }
 
-export type AuthResult = MCPAuthResult | SessionAuthResult;
+interface OAuthAuthDetails extends BaseAuthDetails {
+  tokenId: string;
+  scopes: ScopeSet;
+  // Bridge to the mcp_token_drives-shaped capability model (ADR 0002 Decision 2).
+  driveScopes: DriveScopeRow[];
+  // Drive IDs this token is scoped to. Empty array means access to ALL drives
+  // (the `account` scope) — same convention as MCPAuthDetails.allowedDriveIds.
+  allowedDriveIds: string[];
+}
+
+export interface OAuthAuthResult extends OAuthAuthDetails {
+  tokenType: 'oauth';
+}
+
+export type AuthResult = MCPAuthResult | SessionAuthResult | OAuthAuthResult;
 
 export interface AuthError {
   error: NextResponse;
@@ -153,6 +171,72 @@ export async function validateMCPToken(token: string): Promise<MCPAuthDetails | 
   }
 }
 
+export async function validateOAuthAccessToken(token: string): Promise<OAuthAuthDetails | null> {
+  try {
+    if (!token || !token.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+      return null;
+    }
+
+    const record = await findOAuthAccessTokenByValue(token);
+    if (!record) {
+      return null;
+    }
+
+    const user = record.user;
+
+    // Revoke on sight, mirroring the mcp_token_user_suspended handling above.
+    if (user.suspendedAt) {
+      logSecurityEvent('unauthorized', {
+        reason: 'oauth_token_user_suspended',
+        userId: record.userId,
+        tokenId: record.id,
+        authType: 'oauth',
+        action: 'revoke_and_deny',
+      });
+
+      await db
+        .update(oauthAccessTokens)
+        .set({ revokedAt: new Date(), revokedReason: 'user_suspended' })
+        .where(eq(oauthAccessTokens.id, record.id));
+
+      return null;
+    }
+
+    if (record.expiresAt.getTime() <= Date.now()) {
+      return null;
+    }
+
+    // Stale token: the user's tokenVersion moved on (password change/global
+    // logout) since this access token was minted — mirrors device-auth-utils.
+    if (record.tokenVersion !== user.tokenVersion) {
+      return null;
+    }
+
+    const parsed = parseScopeList(record.scopes.join(' '));
+    if (!parsed.ok) {
+      // Fail closed: corrupt/unparseable stored scope data must never resolve.
+      return null;
+    }
+
+    const driveScopes = scopeSetToDriveScopes(parsed.scopes);
+    const allowedDriveIds = parsed.scopes.account ? [] : driveScopes.map((scope) => scope.driveId);
+
+    return {
+      userId: record.userId,
+      role: user.role as 'user' | 'admin',
+      tokenVersion: user.tokenVersion,
+      adminRoleVersion: user.adminRoleVersion,
+      tokenId: record.id,
+      scopes: parsed.scopes,
+      driveScopes,
+      allowedDriveIds,
+    };
+  } catch (error) {
+    console.error('validateOAuthAccessToken error', error);
+    return null;
+  }
+}
+
 export async function validateSessionToken(token: string): Promise<SessionClaims | null> {
   try {
     if (!token) {
@@ -185,6 +269,28 @@ export async function authenticateMCPRequest(request: Request): Promise<Authenti
     ...mcpDetails,
     tokenType: 'mcp',
   } satisfies MCPAuthResult;
+}
+
+export async function authenticateOAuthRequest(request: Request): Promise<AuthenticationResult> {
+  const token = getBearerToken(request);
+
+  if (!token || !token.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+    return {
+      error: unauthorized('OAuth access token required'),
+    };
+  }
+
+  const oauthDetails = await validateOAuthAccessToken(token);
+  if (!oauthDetails) {
+    return {
+      error: unauthorized('Invalid OAuth access token'),
+    };
+  }
+
+  return {
+    ...oauthDetails,
+    tokenType: 'oauth',
+  } satisfies OAuthAuthResult;
 }
 
 export async function authenticateSessionRequest(request: Request): Promise<AuthenticationResult> {
@@ -262,6 +368,10 @@ export function isSessionAuthResult(result: AuthenticationResult): result is Ses
   return !('error' in result) && result.tokenType === 'session';
 }
 
+export function isOAuthAuthResult(result: AuthenticationResult): result is OAuthAuthResult {
+  return !('error' in result) && result.tokenType === 'oauth';
+}
+
 export async function authenticateRequestWithOptions(
   request: Request,
   options: AuthenticateOptions,
@@ -278,6 +388,7 @@ export async function authenticateRequestWithOptions(
   const allowedTypes = new Set(allow);
   const allowMCP = allowedTypes.has('mcp');
   const allowSession = allowedTypes.has('session');
+  const allowOAuth = allowedTypes.has('oauth');
 
   const bearerToken = getBearerToken(request);
 
@@ -290,12 +401,23 @@ export async function authenticateRequestWithOptions(
     return authenticateMCPRequest(request);
   }
 
+  if (bearerToken?.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+    if (!allowOAuth) {
+      return {
+        error: unauthorized('OAuth tokens are not permitted for this endpoint'),
+      };
+    }
+    return authenticateOAuthRequest(request);
+  }
+
   let authResult: AuthenticationResult;
 
   if (allowSession) {
     authResult = await authenticateSessionRequest(request);
   } else if (allowMCP) {
     authResult = await authenticateMCPRequest(request);
+  } else if (allowOAuth) {
+    authResult = await authenticateOAuthRequest(request);
   } else {
     return {
       error: unauthorized('No authentication methods permitted for this endpoint', 500),
@@ -442,6 +564,9 @@ export async function authenticateWithEnforcedContext(
 export function getAllowedDriveIds(auth: AuthResult): string[] {
   if (isMCPAuthResult(auth)) {
     return auth.allowedDriveIds;
+  }
+  if (isOAuthAuthResult(auth)) {
+    return auth.allowedDriveIds; // Empty for the `account` scope = full access
   }
   return []; // Session auth = full access
 }

--- a/apps/web/src/lib/auth/principal-permissions.ts
+++ b/apps/web/src/lib/auth/principal-permissions.ts
@@ -1,9 +1,11 @@
 /**
  * Principal-aware permission dispatch.
  *
- * A request principal is either a user (session auth, or an unscoped MCP token
- * acting as its owning user) or an "app member" (a drive-scoped MCP token with
- * an mcp_token_drives row per drive).
+ * A request principal is either a user (session auth, an unscoped MCP token,
+ * or an account-scoped OAuth token acting as its owning user) or an "app
+ * member" (a drive-scoped MCP token with an mcp_token_drives row per drive,
+ * or a drive-scoped OAuth access token carrying an equivalent DriveScopeRow[]
+ * — see ADR 0002 Decision 2).
  *
  * Model: a key is the user it belongs to, narrowed by scope, optionally
  * weakened by an explicit role. Scope rows default to role NULL = INHERIT (the
@@ -37,8 +39,12 @@ import {
   getAppDriveMembership,
   getAppAccessiblePagesInDrive,
   hasAppDriveMembership,
+  getScopedAccessLevel,
+  getScopedDriveMembership,
+  getScopedAccessiblePagesInDrive,
+  hasScopedDriveMembership,
 } from '@pagespace/lib/permissions/app-permissions';
-import { isMCPAuthResult, type AuthResult, type MCPAuthResult } from './index';
+import { isMCPAuthResult, isOAuthAuthResult, type AuthResult, type MCPAuthResult, type OAuthAuthResult } from './index';
 
 /**
  * A scoped MCP token acts as an app member (its allowedDriveIds are exactly its
@@ -48,6 +54,15 @@ export function isScopedMCPAuth(auth: AuthResult): auth is MCPAuthResult {
   return isMCPAuthResult(auth) && auth.allowedDriveIds.length > 0;
 }
 
+/**
+ * A drive-scoped OAuth access token (any scope short of `account`) acts as an
+ * app member, exactly like a scoped MCP token — an account-scoped OAuth token
+ * is a full-user credential and acts as the user instead.
+ */
+export function isScopedOAuthAuth(auth: AuthResult): auth is OAuthAuthResult {
+  return isOAuthAuthResult(auth) && !auth.scopes.account;
+}
+
 export async function getPrincipalAccessLevel(
   auth: AuthResult,
   pageId: string,
@@ -55,12 +70,19 @@ export async function getPrincipalAccessLevel(
   if (isScopedMCPAuth(auth)) {
     return getAppAccessLevel(auth.tokenId, pageId);
   }
+  if (isScopedOAuthAuth(auth)) {
+    return getScopedAccessLevel(auth.driveScopes, auth.userId, pageId);
+  }
   return getUserAccessLevel(auth.userId, pageId);
 }
 
 export async function canPrincipalViewPage(auth: AuthResult, pageId: string): Promise<boolean> {
   if (isScopedMCPAuth(auth)) {
     const level = await getAppAccessLevel(auth.tokenId, pageId);
+    return level?.canView ?? false;
+  }
+  if (isScopedOAuthAuth(auth)) {
+    const level = await getScopedAccessLevel(auth.driveScopes, auth.userId, pageId);
     return level?.canView ?? false;
   }
   return canUserViewPage(auth.userId, pageId);
@@ -71,12 +93,20 @@ export async function canPrincipalEditPage(auth: AuthResult, pageId: string): Pr
     const level = await getAppAccessLevel(auth.tokenId, pageId);
     return level?.canEdit ?? false;
   }
+  if (isScopedOAuthAuth(auth)) {
+    const level = await getScopedAccessLevel(auth.driveScopes, auth.userId, pageId);
+    return level?.canEdit ?? false;
+  }
   return canUserEditPage(auth.userId, pageId);
 }
 
 export async function canPrincipalDeletePage(auth: AuthResult, pageId: string): Promise<boolean> {
   if (isScopedMCPAuth(auth)) {
     const level = await getAppAccessLevel(auth.tokenId, pageId);
+    return level?.canDelete ?? false;
+  }
+  if (isScopedOAuthAuth(auth)) {
+    const level = await getScopedAccessLevel(auth.driveScopes, auth.userId, pageId);
     return level?.canDelete ?? false;
   }
   return canUserDeletePage(auth.userId, pageId);
@@ -87,6 +117,10 @@ export async function canPrincipalSharePage(auth: AuthResult, pageId: string): P
     const level = await getAppAccessLevel(auth.tokenId, pageId);
     return level?.canShare ?? false;
   }
+  if (isScopedOAuthAuth(auth)) {
+    const level = await getScopedAccessLevel(auth.driveScopes, auth.userId, pageId);
+    return level?.canShare ?? false;
+  }
   return canUserSharePage(auth.userId, pageId);
 }
 
@@ -94,12 +128,18 @@ export async function isPrincipalDriveMember(auth: AuthResult, driveId: string):
   if (isScopedMCPAuth(auth)) {
     return hasAppDriveMembership(auth.tokenId, driveId);
   }
+  if (isScopedOAuthAuth(auth)) {
+    return hasScopedDriveMembership(auth.driveScopes, auth.userId, driveId);
+  }
   return isUserDriveMember(auth.userId, driveId);
 }
 
 export async function getPrincipalDriveAccess(auth: AuthResult, driveId: string): Promise<boolean> {
   if (isScopedMCPAuth(auth)) {
     return hasAppDriveMembership(auth.tokenId, driveId);
+  }
+  if (isScopedOAuthAuth(auth)) {
+    return hasScopedDriveMembership(auth.driveScopes, auth.userId, driveId);
   }
   return getUserDriveAccess(auth.userId, driveId);
 }
@@ -112,6 +152,12 @@ export async function isPrincipalDriveOwnerOrAdmin(auth: AuthResult, driveId: st
     if (membership.role === null) return isDriveOwnerOrAdmin(auth.userId, driveId);
     return membership.role === 'OWNER' || membership.role === 'ADMIN';
   }
+  if (isScopedOAuthAuth(auth)) {
+    const membership = getScopedDriveMembership(auth.driveScopes, driveId);
+    if (!membership) return false;
+    if (membership.role === null) return isDriveOwnerOrAdmin(auth.userId, driveId);
+    return membership.role === 'ADMIN';
+  }
   return isDriveOwnerOrAdmin(auth.userId, driveId);
 }
 
@@ -121,6 +167,9 @@ export async function isPrincipalDriveOwnerOrAdmin(auth: AuthResult, driveId: st
  */
 export async function getPrincipalDriveIds(auth: AuthResult): Promise<string[]> {
   if (isScopedMCPAuth(auth)) {
+    return auth.allowedDriveIds;
+  }
+  if (isScopedOAuthAuth(auth)) {
     return auth.allowedDriveIds;
   }
   return getDriveIdsForUser(auth.userId);
@@ -134,6 +183,9 @@ export async function getPrincipalAccessiblePagesInDrive(
   if (isScopedMCPAuth(auth)) {
     return getAppAccessiblePagesInDrive(auth.tokenId, driveId);
   }
+  if (isScopedOAuthAuth(auth)) {
+    return getScopedAccessiblePagesInDrive(auth.driveScopes, auth.userId, driveId);
+  }
   return getUserAccessiblePagesInDriveWithDetails(auth.userId, driveId);
 }
 
@@ -146,7 +198,7 @@ export async function getPrincipalBatchPagePermissions(
   auth: AuthResult,
   pageIds: string[],
 ): Promise<Map<string, PermissionLevel>> {
-  if (!isScopedMCPAuth(auth)) {
+  if (!isScopedMCPAuth(auth) && !isScopedOAuthAuth(auth)) {
     return getBatchPagePermissions(auth.userId, pageIds);
   }
 
@@ -162,7 +214,9 @@ export async function getPrincipalBatchPagePermissions(
   // drives stay denied.
   const requested = new Set(pageIds);
   for (const driveId of auth.allowedDriveIds) {
-    const accessible = await getAppAccessiblePagesInDrive(auth.tokenId, driveId);
+    const accessible = isScopedMCPAuth(auth)
+      ? await getAppAccessiblePagesInDrive(auth.tokenId, driveId)
+      : await getScopedAccessiblePagesInDrive((auth as OAuthAuthResult).driveScopes, auth.userId, driveId);
     for (const page of accessible) {
       if (requested.has(page.id)) {
         results.set(page.id, { ...page.permissions });

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.revoke.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.revoke.test.ts
@@ -1,0 +1,124 @@
+/**
+ * RFC 7009 token revocation (task qyqgrjbvntpsdh578k0yiwgr).
+ *
+ * revokeOAuthToken never distinguishes "not found" from "found and revoked" —
+ * the route layer always returns 200 regardless of what happens here. These
+ * tests instead assert the correct DB side-effect occurred: a refresh token
+ * revokes its whole family; an access token revokes only itself.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const H = vi.hoisted(() => ({
+  oauthRefreshTokens: {
+    __table: 'refresh',
+    id: 'rt.id',
+    tokenHash: 'rt.tokenHash',
+    clientId: 'rt.clientId',
+    familyId: 'rt.familyId',
+    revokedAt: 'rt.revokedAt',
+  } as Record<string, unknown>,
+  oauthAccessTokens: {
+    __table: 'access',
+    id: 'at.id',
+    tokenHash: 'at.tokenHash',
+    clientId: 'at.clientId',
+    familyId: 'at.familyId',
+    revokedAt: 'at.revokedAt',
+  } as Record<string, unknown>,
+}));
+
+vi.mock('@pagespace/db/schema/oauth', () => ({
+  oauthRefreshTokens: H.oauthRefreshTokens,
+  oauthAccessTokens: H.oauthAccessTokens,
+  oauthClients: {},
+  oauthAuthorizationCodes: {},
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'users.id' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
+  and: vi.fn((...args: unknown[]) => ({ _and: args })),
+  isNull: vi.fn((a: unknown) => ({ _isNull: a })),
+}));
+
+const selectMock = vi.fn();
+const updateMock = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+
+import { revokeOAuthToken } from '../oauth-repository';
+
+const CLIENT_DB_ID = 'client-db-id-1';
+const NOW = new Date('2026-01-01T00:00:00Z');
+
+function stubSelectResult(rows: unknown[]) {
+  return { from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }) };
+}
+
+function stubUpdateChain() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  updateMock.mockReturnValue({ set });
+  return { set, where };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('revokeOAuthToken — refresh token', () => {
+  it('revokes the whole family when a matching refresh token is found', async () => {
+    selectMock.mockReturnValueOnce(stubSelectResult([{ familyId: 'family-1' }]));
+    const { set } = stubUpdateChain();
+
+    await revokeOAuthToken({ token: 'ps_rt_' + 'a'.repeat(43), clientDbId: CLIENT_DB_ID, now: NOW });
+
+    expect(updateMock).toHaveBeenCalledWith(H.oauthRefreshTokens);
+    expect(updateMock).toHaveBeenCalledWith(H.oauthAccessTokens);
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ revokedAt: NOW }));
+  });
+
+  it('no-ops when the refresh token is unknown/foreign (no matching client-scoped row)', async () => {
+    selectMock.mockReturnValueOnce(stubSelectResult([]));
+
+    await revokeOAuthToken({ token: 'ps_rt_' + 'b'.repeat(43), clientDbId: CLIENT_DB_ID, now: NOW });
+
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('revokeOAuthToken — access token', () => {
+  it('revokes only the single access token, not its family', async () => {
+    const { set, where } = stubUpdateChain();
+
+    await revokeOAuthToken({ token: 'ps_at_' + 'a'.repeat(43), clientDbId: CLIENT_DB_ID, now: NOW });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith(H.oauthAccessTokens);
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ revokedAt: NOW }));
+    expect(where).toHaveBeenCalled();
+  });
+});
+
+describe('revokeOAuthToken — unknown token format', () => {
+  it('no-ops for a token with neither ps_at_ nor ps_rt_ prefix (foreign/garbage — no oracle upstream)', async () => {
+    await revokeOAuthToken({ token: 'mcp_some-token', clientDbId: CLIENT_DB_ID, now: NOW });
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('no-ops for an empty token', async () => {
+    await revokeOAuthToken({ token: '', clientDbId: CLIENT_DB_ID, now: NOW });
+
+    expect(selectMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -208,6 +208,61 @@ export async function exchangeAuthorizationCode(
   });
 }
 
+export interface RevokeOAuthTokenInput {
+  /** Raw token from the revocation request; hashed before any lookup. */
+  token: string;
+  /** Resolved `oauth_clients.id` for the request's client_id — a token issued
+   * to a different client is indistinguishable from an unknown token: the
+   * update's WHERE clause simply matches nothing (no oracle). */
+  clientDbId: string;
+  now: Date;
+}
+
+const OAUTH_REFRESH_TOKEN_PREFIX = 'ps_rt_';
+const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
+
+/**
+ * RFC 7009 revocation (task qyqgrjbvntpsdh578k0yiwgr). A refresh token
+ * revokes its whole family (reusing `revokeTokenFamily`, the same helper the
+ * reuse-detection paths above use); an access token revokes only itself. An
+ * unknown token, a foreign token (different client), an already-revoked
+ * token, or a token in neither opaque format is a silent no-op — the route
+ * layer always returns 200 regardless, so nothing here needs to report which
+ * case occurred.
+ */
+export async function revokeOAuthToken(input: RevokeOAuthTokenInput): Promise<void> {
+  const tokenHash = hashToken(input.token);
+
+  if (input.token.startsWith(OAUTH_REFRESH_TOKEN_PREFIX)) {
+    const rows = await db
+      .select({ familyId: oauthRefreshTokens.familyId })
+      .from(oauthRefreshTokens)
+      .where(and(eq(oauthRefreshTokens.tokenHash, tokenHash), eq(oauthRefreshTokens.clientId, input.clientDbId)));
+
+    const row = rows[0];
+    if (row) {
+      await revokeTokenFamily(db, row.familyId, input.now, 'client_revoked');
+    }
+    return;
+  }
+
+  if (input.token.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+    await db
+      .update(oauthAccessTokens)
+      .set({ revokedAt: input.now, revokedReason: 'client_revoked' })
+      .where(
+        and(
+          eq(oauthAccessTokens.tokenHash, tokenHash),
+          eq(oauthAccessTokens.clientId, input.clientDbId),
+          isNull(oauthAccessTokens.revokedAt),
+        ),
+      );
+    return;
+  }
+
+  // Neither opaque format — foreign/garbage token, no-op (no oracle upstream).
+}
+
 export interface RefreshTokenGrantInput {
   /** Raw refresh token from the token request; hashed before any lookup. */
   refreshToken: string;

--- a/packages/lib/src/auth/__tests__/token-lookup.test.ts
+++ b/packages/lib/src/auth/__tests__/token-lookup.test.ts
@@ -8,6 +8,7 @@ vi.mock('@pagespace/db/db', () => ({
   db: {
     query: {
       mcpTokens: { findFirst: vi.fn() },
+      oauthAccessTokens: { findFirst: vi.fn() },
     },
   },
 }));
@@ -17,13 +18,19 @@ vi.mock('@pagespace/db/schema/auth', () => ({
     revokedAt: 'revokedAt',
   },
 }));
+vi.mock('@pagespace/db/schema/oauth', () => ({
+  oauthAccessTokens: {
+    tokenHash: 'oauthAccessTokens.tokenHash',
+    revokedAt: 'oauthAccessTokens.revokedAt',
+  },
+}));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   isNull: vi.fn(),
 }));
 
-import { findMCPTokenByValue } from '../token-lookup';
+import { findMCPTokenByValue, findOAuthAccessTokenByValue } from '../token-lookup';
 import { db } from '@pagespace/db/db';
 
 describe('token-lookup', () => {
@@ -80,6 +87,60 @@ describe('token-lookup', () => {
       vi.mocked(db.query.mcpTokens.findFirst).mockResolvedValue(undefined as never);
 
       const result = await findMCPTokenByValue('mcp_nonexistent-token');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findOAuthAccessTokenByValue', () => {
+    it('should return null for empty input', async () => {
+      const result = await findOAuthAccessTokenByValue('');
+      expect(result).toBeNull();
+      expect(db.query.oauthAccessTokens.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('should return null for non-string input', async () => {
+      const result = await findOAuthAccessTokenByValue(null as unknown as string);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for token without ps_at_ prefix', async () => {
+      const result = await findOAuthAccessTokenByValue('mcp_some-token');
+      expect(result).toBeNull();
+      expect(db.query.oauthAccessTokens.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('should look up token by hash when prefix is correct', async () => {
+      const mockRecord = {
+        id: 'oauth-token-1',
+        userId: 'user-1',
+        tokenHash: 'hash123',
+        tokenPrefix: 'ps_at_abc',
+        familyId: 'family-1',
+        scopes: ['account'],
+        tokenVersion: 1,
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000),
+        revokedAt: null,
+        user: { id: 'user-1', tokenVersion: 1, role: 'user', adminRoleVersion: 0, suspendedAt: null },
+      };
+      vi.mocked(db.query.oauthAccessTokens.findFirst).mockResolvedValue(mockRecord as never);
+
+      const result = await findOAuthAccessTokenByValue('ps_at_some-valid-token');
+      expect(result).toEqual(mockRecord);
+      expect(db.query.oauthAccessTokens.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          with: expect.objectContaining({
+            user: expect.objectContaining({
+              columns: { id: true, tokenVersion: true, role: true, adminRoleVersion: true, suspendedAt: true },
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should return null when no matching token found', async () => {
+      vi.mocked(db.query.oauthAccessTokens.findFirst).mockResolvedValue(undefined as never);
+
+      const result = await findOAuthAccessTokenByValue('ps_at_nonexistent-token');
       expect(result).toBeNull();
     });
   });

--- a/packages/lib/src/auth/token-lookup.ts
+++ b/packages/lib/src/auth/token-lookup.ts
@@ -10,9 +10,11 @@
 import { db } from '@pagespace/db/db';
 import { eq, and, isNull } from '@pagespace/db/operators';
 import { mcpTokens } from '@pagespace/db/schema/auth';
+import { oauthAccessTokens } from '@pagespace/db/schema/oauth';
 import { hashToken } from './token-utils';
 
 const MCP_TOKEN_PREFIX = 'mcp_';
+const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
 
 /**
  * MCP token record with user relation
@@ -75,4 +77,67 @@ export async function findMCPTokenByValue(
   });
 
   return (record ?? null) as MCPTokenRecord | null;
+}
+
+/**
+ * OAuth 2.1 access token record with user relation (ADR 0003 §3.1-3.2).
+ */
+export interface OAuthAccessTokenRecord {
+  id: string;
+  userId: string;
+  scopes: string[];
+  tokenVersion: number;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  user: {
+    id: string;
+    tokenVersion: number;
+    role: string;
+    adminRoleVersion: number;
+    suspendedAt: Date | null;
+  };
+}
+
+/**
+ * Find an OAuth access token by its hash value.
+ *
+ * Security: Only looks up by hash - plaintext tokens are never stored or
+ * compared. Only searches for non-revoked tokens (revokedAt IS NULL); expiry
+ * and suspended-user rejection are the caller's job (mirrors findMCPTokenByValue).
+ *
+ * @param tokenValue - The raw OAuth access token value (must start with 'ps_at_')
+ * @returns The token record with user relation, or null if not found/revoked
+ */
+export async function findOAuthAccessTokenByValue(
+  tokenValue: string
+): Promise<OAuthAccessTokenRecord | null> {
+  if (!tokenValue || typeof tokenValue !== 'string') {
+    return null;
+  }
+
+  if (!tokenValue.startsWith(OAUTH_ACCESS_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const tokenHash = hashToken(tokenValue);
+
+  const record = await db.query.oauthAccessTokens.findFirst({
+    where: and(
+      eq(oauthAccessTokens.tokenHash, tokenHash),
+      isNull(oauthAccessTokens.revokedAt)
+    ),
+    with: {
+      user: {
+        columns: {
+          id: true,
+          tokenVersion: true,
+          role: true,
+          adminRoleVersion: true,
+          suspendedAt: true,
+        },
+      },
+    },
+  });
+
+  return (record ?? null) as OAuthAccessTokenRecord | null;
 }

--- a/packages/lib/src/permissions/__tests__/app-permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/app-permissions.test.ts
@@ -42,7 +42,13 @@ import {
   getAppDriveAccessLevel,
   getAppAccessiblePagesInDrive,
   resolveExplicitAppRoleAccess,
+  getScopedAccessLevel,
+  hasScopedDriveMembership,
+  getScopedDriveMembership,
+  getScopedDriveAccessLevel,
+  getScopedAccessiblePagesInDrive,
 } from '../app-permissions';
+import type { DriveScopeRow } from '../../auth/oauth/scopes';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import {
@@ -389,5 +395,165 @@ describe('getAppAccessiblePagesInDrive', () => {
     const result = await getAppAccessiblePagesInDrive(TOKEN_ID, DRIVE_ID);
     expect(result).toHaveLength(1);
     expect(result[0].permissions).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getScopedAccessLevel / hasScopedDriveMembership / getScopedDriveAccessLevel /
+// getScopedAccessiblePagesInDrive — the OAuth-token entry points (task 10).
+// Membership comes from an in-memory DriveScopeRow[] (scopeSetToDriveScopes
+// output), NOT a DB join — no mcp_token_drives row exists for an OAuth
+// access token. These must reuse the exact same resolver
+// (resolveExplicitAppRoleAccess) and DB helpers (fetchPageTarget,
+// fetchCustomRolePermissions, getUserAccessLevel) as the MCP-token path, so
+// an OAuth token with drive-narrowed scope is indistinguishable in capability
+// from an equivalent scoped MCP token.
+// ---------------------------------------------------------------------------
+
+const scopeRow = (driveId: string, role: 'ADMIN' | 'MEMBER' | null, customRoleId: string | null = null): DriveScopeRow => ({
+  driveId,
+  role,
+  customRoleId,
+});
+
+describe('getScopedAccessLevel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when no drive-scope row matches the target drive', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: false, type: 'DOCUMENT' }]));
+
+    expect(await getScopedAccessLevel([scopeRow('other-drive', null)], OWNER_ID, PAGE_ID)).toBeNull();
+    expect(getUserAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('INHERIT (role null) → delegates to the owning user\'s access, same as the MCP path', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: false, type: 'DOCUMENT' }]));
+    vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+
+    expect(await getScopedAccessLevel([scopeRow(DRIVE_ID, null)], OWNER_ID, PAGE_ID)).toEqual(FULL);
+    expect(getUserAccessLevel).toHaveBeenCalledWith(OWNER_ID, PAGE_ID);
+  });
+
+  it('explicit MEMBER on a CHANNEL → canEdit true, identical to the MCP-token resolver', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: false, type: 'CHANNEL' }]));
+
+    expect(await getScopedAccessLevel([scopeRow(DRIVE_ID, 'MEMBER')], OWNER_ID, PAGE_ID)).toEqual({ ...VIEW_ONLY, canEdit: true });
+    expect(getUserAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('explicit ADMIN on a private page → full (parity with a scoped MCP ADMIN token)', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: true, type: 'DOCUMENT' }]));
+
+    expect(await getScopedAccessLevel([scopeRow(DRIVE_ID, 'ADMIN')], OWNER_ID, PAGE_ID)).toEqual(FULL);
+  });
+
+  it('custom role: per-page grant wins, canDelete forced false', async () => {
+    const perms = { [PAGE_ID]: { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: false, type: 'DOCUMENT' }]))
+      .mockReturnValueOnce(stubSelect([{ permissions: perms, driveWidePermissions: null }]));
+
+    const result = await getScopedAccessLevel([scopeRow(DRIVE_ID, 'MEMBER', CUSTOM_ROLE_ID)], OWNER_ID, PAGE_ID);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+});
+
+describe('hasScopedDriveMembership', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('false when no scope row matches the drive', async () => {
+    expect(await hasScopedDriveMembership([scopeRow('other-drive', null)], OWNER_ID, DRIVE_ID)).toBe(false);
+  });
+
+  it('explicit role row → true regardless of owner membership', async () => {
+    expect(await hasScopedDriveMembership([scopeRow(DRIVE_ID, 'MEMBER')], OWNER_ID, DRIVE_ID)).toBe(true);
+    expect(isUserDriveMember).not.toHaveBeenCalled();
+  });
+
+  it('inherit row counts ONLY while the owner still has drive access', async () => {
+    vi.mocked(isUserDriveMember).mockResolvedValue(true);
+    expect(await hasScopedDriveMembership([scopeRow(DRIVE_ID, null)], OWNER_ID, DRIVE_ID)).toBe(true);
+    expect(isUserDriveMember).toHaveBeenCalledWith(OWNER_ID, DRIVE_ID);
+  });
+
+  it('DANGLING inherit row (owner removed) → false', async () => {
+    vi.mocked(isUserDriveMember).mockResolvedValue(false);
+    expect(await hasScopedDriveMembership([scopeRow(DRIVE_ID, null)], OWNER_ID, DRIVE_ID)).toBe(false);
+  });
+});
+
+describe('getScopedDriveMembership', () => {
+  it('returns nullable role + customRoleId for a matching row', () => {
+    expect(getScopedDriveMembership([scopeRow(DRIVE_ID, 'ADMIN', null)], DRIVE_ID)).toEqual({
+      role: 'ADMIN', customRoleId: null,
+    });
+  });
+
+  it('returns null when no row matches', () => {
+    expect(getScopedDriveMembership([scopeRow('other-drive', null)], DRIVE_ID)).toBeNull();
+  });
+});
+
+describe('getScopedDriveAccessLevel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('null when no scope row matches the drive', async () => {
+    expect(await getScopedDriveAccessLevel([scopeRow('other-drive', null)], OWNER_ID, DRIVE_ID)).toBeNull();
+  });
+
+  it('INHERIT → owner\'s drive-root access via getUserAccessLevel', async () => {
+    vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+    expect(await getScopedDriveAccessLevel([scopeRow(DRIVE_ID, null)], OWNER_ID, DRIVE_ID)).toEqual(FULL);
+    expect(getUserAccessLevel).toHaveBeenCalledWith(OWNER_ID, DRIVE_ID);
+  });
+
+  it('explicit MEMBER → view+edit (no delete/share)', async () => {
+    expect(await getScopedDriveAccessLevel([scopeRow(DRIVE_ID, 'MEMBER')], OWNER_ID, DRIVE_ID)).toEqual({
+      canView: true, canEdit: true, canShare: false, canDelete: false,
+    });
+  });
+
+  it('explicit ADMIN → full', async () => {
+    expect(await getScopedDriveAccessLevel([scopeRow(DRIVE_ID, 'ADMIN')], OWNER_ID, DRIVE_ID)).toEqual(FULL);
+  });
+});
+
+describe('getScopedAccessiblePagesInDrive', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns [] when no scope row matches the drive', async () => {
+    expect(await getScopedAccessiblePagesInDrive([scopeRow('other-drive', null)], OWNER_ID, DRIVE_ID)).toEqual([]);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('INHERIT → exactly the owner\'s accessible set', async () => {
+    const ownerSet = [
+      { id: 'p1', title: 'A', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false, permissions: FULL },
+    ];
+    vi.mocked(getUserAccessiblePagesInDriveWithDetails).mockResolvedValue(ownerSet);
+
+    expect(await getScopedAccessiblePagesInDrive([scopeRow(DRIVE_ID, null)], OWNER_ID, DRIVE_ID)).toBe(ownerSet);
+    expect(getUserAccessiblePagesInDriveWithDetails).toHaveBeenCalledWith(OWNER_ID, DRIVE_ID);
+  });
+
+  it('explicit plain MEMBER: non-private pages, channels editable — same body as the MCP path', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelectList([
+      { id: 'doc', title: 'Doc', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false },
+      { id: 'chan', title: 'General', type: 'CHANNEL', parentId: null, position: 1, isTrashed: false },
+    ]));
+
+    const result = await getScopedAccessiblePagesInDrive([scopeRow(DRIVE_ID, 'MEMBER')], OWNER_ID, DRIVE_ID);
+    expect(result.find((p) => p.id === 'doc')?.permissions).toEqual(VIEW_ONLY);
+    expect(result.find((p) => p.id === 'chan')?.permissions).toEqual({ ...VIEW_ONLY, canEdit: true });
+  });
+
+  it('explicit ADMIN: every page, full access', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelectList([
+      { id: 'p1', title: 'A', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false },
+    ]));
+
+    const result = await getScopedAccessiblePagesInDrive([scopeRow(DRIVE_ID, 'ADMIN')], OWNER_ID, DRIVE_ID);
+    expect(result).toHaveLength(1);
+    expect(result[0].permissions).toEqual(FULL);
   });
 });

--- a/packages/lib/src/permissions/app-permissions.ts
+++ b/packages/lib/src/permissions/app-permissions.ts
@@ -10,6 +10,7 @@ import {
 } from './permissions';
 import { fetchCustomRolePermissions, resolveCustomRolePermissions, type CustomRolePerms, type PagePerm } from './membership-queries';
 import type { PermissionLevel, PageWithPermissions } from './permissions';
+import type { DriveScopeRow } from '../auth/oauth/scopes';
 
 /**
  * App-member permission resolution for MCP tokens.
@@ -56,7 +57,7 @@ interface PageTarget {
   isDriveRoot: boolean;
 }
 
-async function fetchPageTarget(targetPageId: string): Promise<PageTarget> {
+export async function fetchPageTarget(targetPageId: string): Promise<PageTarget> {
   const rows = await db
     .select({ driveId: pages.driveId, isPrivate: pages.isPrivate, type: pages.type })
     .from(pages)
@@ -222,7 +223,22 @@ export async function getAppAccessiblePagesInDrive(
 ): Promise<PageWithPermissions[]> {
   const membership = await fetchAppMembershipContext(tokenId, driveId);
   if (!membership) return [];
+  return resolveAccessiblePagesForMembership(membership, driveId);
+}
 
+/**
+ * Shared body for {@link getAppAccessiblePagesInDrive} (MCP token, membership
+ * sourced from a `mcp_token_drives` DB row) and
+ * {@link getScopedAccessiblePagesInDrive} (OAuth token, membership sourced
+ * from a parsed `ScopeSet` — no DB row exists for it). Both entry points
+ * resolve membership their own way, then defer to this one body so the
+ * listing logic (drive-wide fallback, per-page overrides, etc.) is never
+ * duplicated between token types.
+ */
+async function resolveAccessiblePagesForMembership(
+  membership: AppMembershipContext,
+  driveId: string,
+): Promise<PageWithPermissions[]> {
   if (membership.role === null) {
     return getUserAccessiblePagesInDriveWithDetails(membership.ownerUserId, driveId);
   }
@@ -344,4 +360,114 @@ export async function getAppAccessiblePagesInDrive(
     ...p,
     permissions: { canView: true, canEdit: p.type === 'CHANNEL', canShare: false, canDelete: false },
   }));
+}
+
+// ---------------------------------------------------------------------------
+// OAuth-token entry points (Phase 1 task 10, ADR 0002 Decision 2).
+//
+// An OAuth access token's drive scope is a parsed `ScopeSet`, bridged to
+// `DriveScopeRow[]` by `scopeSetToDriveScopes` — the exact `mcp_token_drives`
+// row shape, but there is no DB row: the token id has no corresponding
+// `mcp_token_drives` foreign key (that table's `tokenId` FK only points at
+// `mcp_tokens`). These entry points source membership from the in-memory
+// array instead of a DB join, then defer to the SAME resolver
+// (`resolveExplicitAppRoleAccess`) and DB helpers (`fetchPageTarget`,
+// `fetchCustomRolePermissions`, `getUserAccessLevel`) the MCP-token path
+// uses, so a drive-narrowed OAuth token is indistinguishable in capability
+// from an equivalent scoped MCP token.
+// ---------------------------------------------------------------------------
+
+function findScopeRow(driveScopes: DriveScopeRow[], driveId: string): DriveScopeRow | null {
+  return driveScopes.find((row) => row.driveId === driveId) ?? null;
+}
+
+export async function getScopedAccessLevel(
+  driveScopes: DriveScopeRow[],
+  ownerUserId: string,
+  targetPageId: string,
+): Promise<PermissionLevel | null> {
+  const target = await fetchPageTarget(targetPageId);
+  const row = findScopeRow(driveScopes, target.driveId);
+  if (!row) return null;
+
+  if (row.role === null) {
+    return getUserAccessLevel(ownerUserId, targetPageId);
+  }
+
+  const customRole = row.customRoleId
+    ? await fetchCustomRolePermissions(row.customRoleId, target.driveId)
+    : null;
+
+  return resolveExplicitAppRoleAccess({
+    role: row.role,
+    customRole,
+    customRoleUnresolved: !!row.customRoleId && !customRole,
+    targetPageId,
+    pageType: target.pageType,
+    isPrivate: target.isPrivate,
+    isDriveRoot: target.isDriveRoot,
+  });
+}
+
+/**
+ * Whether the scope has usable access to the drive. An inherit row counts
+ * only while its OWNER still has drive access — mirrors hasAppDriveMembership.
+ */
+export async function hasScopedDriveMembership(
+  driveScopes: DriveScopeRow[],
+  ownerUserId: string,
+  driveId: string,
+): Promise<boolean> {
+  const row = findScopeRow(driveScopes, driveId);
+  if (!row) return false;
+  if (row.role === null) return isUserDriveMember(ownerUserId, driveId);
+  return true;
+}
+
+/** Pure array lookup — no DB, unlike getAppDriveMembership. */
+export function getScopedDriveMembership(
+  driveScopes: DriveScopeRow[],
+  driveId: string,
+): { role: 'ADMIN' | 'MEMBER' | null; customRoleId: string | null } | null {
+  const row = findScopeRow(driveScopes, driveId);
+  if (!row) return null;
+  return { role: row.role, customRoleId: row.customRoleId };
+}
+
+/**
+ * Drive-level access. Inherit → the owner's drive-root access (user rule);
+ * explicit → user drive-root parity: any membership gets view+edit, ADMIN
+ * adds share+delete. Mirrors getAppDriveAccessLevel (OAuth's grammar has no
+ * OWNER role — scopeSetToDriveScopes only ever emits 'ADMIN' | 'MEMBER' | null).
+ */
+export async function getScopedDriveAccessLevel(
+  driveScopes: DriveScopeRow[],
+  ownerUserId: string,
+  driveId: string,
+): Promise<PermissionLevel | null> {
+  const row = findScopeRow(driveScopes, driveId);
+  if (!row) return null;
+
+  if (row.role === null) {
+    return getUserAccessLevel(ownerUserId, driveId);
+  }
+
+  const isAdminLike = row.role === 'ADMIN';
+  return { canView: true, canEdit: true, canShare: isAdminLike, canDelete: isAdminLike };
+}
+
+/**
+ * All pages in a drive visible to the OAuth-scoped principal. Delegates to
+ * the same body getAppAccessiblePagesInDrive uses once membership is resolved.
+ */
+export async function getScopedAccessiblePagesInDrive(
+  driveScopes: DriveScopeRow[],
+  ownerUserId: string,
+  driveId: string,
+): Promise<PageWithPermissions[]> {
+  const row = findScopeRow(driveScopes, driveId);
+  if (!row) return [];
+
+  const membership: AppMembershipContext = { role: row.role, customRoleId: row.customRoleId, ownerUserId };
+  return resolveAccessiblePagesForMembership(membership, driveId);
 }


### PR DESCRIPTION
## Summary
- Phase 1 task 10 (the keystone task): OAuth access tokens now work as a first-class `authenticateRequest` token type, on par with `mcp_*` tokens.
- New `POST /api/oauth/revoke` (RFC 7009): refresh token revokes its whole family; access token revokes just itself; unknown/foreign/already-revoked tokens always return 200 empty body (no oracle).
- `apps/web/src/lib/auth/index.ts` extended with a new `'oauth'` `TokenType`: `validateOAuthAccessToken` does hash lookup, expiry check, tokenVersion-staleness check, and suspended-user revoke-on-sight (mirrors `mcp_token_user_suspended` exactly). Wired into `authenticateRequestWithOptions` and `getAllowedDriveIds`, so `checkMCPDriveScope`/`checkMCPPageScope`/`filterDrivesByMCPScope` work for OAuth tokens with zero new logic.
- `packages/lib/permissions/app-permissions.ts` gained `getScopedAccessLevel`/`hasScopedDriveMembership`/`getScopedDriveMembership`/`getScopedDriveAccessLevel`/`getScopedAccessiblePagesInDrive` — these adapt an OAuth token's `DriveScopeRow[]` (no `mcp_token_drives` row exists for it) into the exact same `resolveExplicitAppRoleAccess` resolution the MCP-token path already uses. No new permission logic.
- `principal-permissions.ts` gained `isScopedOAuthAuth`, dispatching every principal helper so a drive-narrowed OAuth token is indistinguishable in capability from an equivalent scoped MCP token; an account-scoped OAuth token acts as the full user (like an unscoped MCP token).
- `GET /api/drives/[driveId]` now accepts OAuth access tokens, proving the integration end-to-end on a real protected route (in-scope 200, out-of-scope 403, expired/revoked/suspended 401).

## Test plan
- [x] `bun run --filter 'web' typecheck` — green
- [x] `bun run --filter 'web' lint` — green (pre-existing warnings only)
- [x] `bun run test:unit` — green; 3 pre-existing failures (admin-role-version, message grouping midnight edge case, activity-tools) confirmed identical on clean `pu/cli-login` HEAD via `git stash` — local Postgres role config issue, unrelated to this change
- [x] `bun run test:security` — green; 7 pre-existing failures confirmed identical on clean HEAD (same local-DB-role environment issue)
- [x] RED commit (`394564f45`) confirmed failing before GREEN commit (`4a79fe0ee`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LC7L9jsDudoJ1wYMLqbc53