### PR TITLE
oauth: rate limiting & audit logging hardening sweep (Phase 1 task 11)

### DIFF
--- a/apps/web/src/app/api/oauth/__tests__/hardening.test.ts
+++ b/apps/web/src/app/api/oauth/__tests__/hardening.test.ts
@@ -1,0 +1,88 @@
+/**
+ * OAuth Hardening Sweep (Phase 1 task sff4q8l3hbgm15aiqz29dl0t)
+ *
+ * Structural enforcement: every route file under api/oauth must wire BOTH a
+ * distributed rate limiter and audit logging. Unlike the app-wide security
+ * audit coverage gate (`api/__tests__/security-audit-coverage.test.ts`),
+ * this surface has no allowlist — the whole point of a hardening sweep is
+ * that a future OAuth endpoint cannot ship unprotected, not even
+ * provisionally. Enumeration is dynamic (readdirSync), so a newly added
+ * route.ts file is covered automatically without editing this test.
+ */
+
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+const OAUTH_API_DIR = join(__dirname, '..');
+
+const RATE_LIMIT_PATTERN = /checkDistributedRateLimit\(/;
+const RATE_LIMIT_IMPORT_PATTERN = /from ['"]@pagespace\/lib\/security\/distributed-rate-limit['"]/;
+const AUDIT_CALL_PATTERN = /auditRequest\(/;
+const AUDIT_IMPORT_PATTERN = /from ['"]@pagespace\/lib\/audit\/audit-log['"]/;
+
+function collectRouteFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry === 'node_modules' || entry === '.next' || entry === '__tests__') continue;
+    if (statSync(full).isDirectory()) {
+      results.push(...collectRouteFiles(full));
+    } else if (entry === 'route.ts') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function toLogicalPath(absolutePath: string): string {
+  const relative = absolutePath.replace(OAUTH_API_DIR + '/', '');
+  return relative.replace(/\/route\.ts$/, '');
+}
+
+describe('OAuth hardening sweep', () => {
+  const routeFiles = collectRouteFiles(OAUTH_API_DIR);
+  const routes = routeFiles.map((f) => ({ path: toLogicalPath(f), file: f, content: readFileSync(f, 'utf-8') }));
+
+  it('discovers the full OAuth route surface (sanity check against a silently-empty glob)', () => {
+    expect(routes.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('every OAuth route wires a distributed rate limiter — no endpoint ships unprotected', () => {
+    const violations = routes.filter(
+      (r) => !RATE_LIMIT_PATTERN.test(r.content) || !RATE_LIMIT_IMPORT_PATTERN.test(r.content),
+    );
+
+    expect(violations.map((v) => v.path)).toEqual([]);
+  });
+
+  it('every OAuth route emits audit events for security-relevant outcomes', () => {
+    const violations = routes.filter(
+      (r) => !AUDIT_CALL_PATTERN.test(r.content) || !AUDIT_IMPORT_PATTERN.test(r.content),
+    );
+
+    expect(violations.map((v) => v.path)).toEqual([]);
+  });
+
+  it('never logs raw token, code, or user-code material inside an audit call\'s details', () => {
+    // A crude but effective guard: the `details` object literal passed to
+    // auditRequest must never reference the route's raw secret-holding
+    // variables (only clientId/oauthEvent/outcome-shaped summaries).
+    const FORBIDDEN_IN_AUDIT_DETAILS = [/token:\s*[a-zA-Z]/, /code:\s*[a-zA-Z]/, /userCode:\s*[a-zA-Z]/];
+    const violations: string[] = [];
+
+    for (const route of routes) {
+      const auditCalls = route.content.match(/auditRequest\([^;]*?\}\s*\)/gs) ?? [];
+      for (const call of auditCalls) {
+        for (const pattern of FORBIDDEN_IN_AUDIT_DETAILS) {
+          if (pattern.test(call)) {
+            violations.push(`${route.path}: ${call.slice(0, 80)}...`);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
@@ -10,6 +10,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: (result: unknown) => !!result && typeof result === 'object' && 'error' in (result as object),
+  getClientIP: vi.fn().mockReturnValue('203.0.113.9'),
+}));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: { OAUTH_AUTHORIZE: { maxAttempts: 20, windowMs: 300_000, progressiveDelay: false } },
 }));
 
 vi.mock('@/lib/repositories/oauth-repository', () => ({
@@ -32,10 +39,12 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { createAuthorizationCode } from '@/lib/repositories/oauth-repository';
 
 const REDIRECT_URI = 'http://127.0.0.1:51234/callback';
 const CODE_CHALLENGE = 'a'.repeat(43);
+const ALLOWED = { allowed: true, attemptsRemaining: 19 };
 
 function authorizeUrl(overrides: Record<string, string | undefined> = {}): string {
   const params: Record<string, string> = {
@@ -65,6 +74,40 @@ function getRequest(overrides: Record<string, string | undefined> = {}): Request
 
 beforeEach(() => {
   vi.clearAllMocks();
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('GET /api/oauth/authorize — per-IP rate limiting', () => {
+  it('blocks with 429 when the per-IP limit is exceeded, never checking auth', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-authorize:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await GET(getRequest() as never);
+
+    expect(res.status).toBe(429);
+    expect(authenticateRequestWithOptions).not.toHaveBeenCalled();
+  });
+
+  it('audits the rate-limit trip', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-authorize:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    await GET(getRequest() as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited' }),
+    );
+  });
+
+  it('checks the IP dimension keyed by client IP', async () => {
+    await GET(getRequest({ client_id: 'evil-client' }) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('ip:203.0.113.9'))).toBe(true);
+  });
 });
 
 describe('GET /api/oauth/authorize — open-redirect guard', () => {
@@ -181,6 +224,62 @@ describe('POST /api/oauth/authorize — consent CSRF', () => {
     const res = await POST(postRequest(approvalBody) as never);
     expect(res.status).toBe(403);
     expect(vi.mocked(createAuthorizationCode)).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/authorize — per-user/per-client rate limiting', () => {
+  beforeEach(() => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      tokenType: 'session',
+      userId: 'user-1',
+      role: 'user',
+      tokenVersion: 0,
+      adminRoleVersion: 0,
+      sessionId: 'sess-1',
+    } as never);
+  });
+
+  it('blocks with 429 when the per-user limit is exceeded, never minting a code', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-authorize:user:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(postRequest(approvalBody) as never);
+
+    expect(res.status).toBe(429);
+    expect(vi.mocked(createAuthorizationCode)).not.toHaveBeenCalled();
+  });
+
+  it('blocks with 429 when the per-client limit is exceeded, never minting a code', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-authorize:client:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(postRequest(approvalBody) as never);
+
+    expect(res.status).toBe(429);
+    expect(vi.mocked(createAuthorizationCode)).not.toHaveBeenCalled();
+  });
+
+  it('checks both the user and client dimensions', async () => {
+    await POST(postRequest(approvalBody) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('user:user-1'))).toBe(true);
+    expect(keys.some((k) => k.includes('client:pagespace-cli'))).toBe(true);
+  });
+
+  it('audits the rate-limit trip', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-authorize:user:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    await POST(postRequest(approvalBody) as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited', userId: 'user-1' }),
+    );
   });
 });
 

--- a/apps/web/src/app/api/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/oauth/authorize/route.ts
@@ -18,7 +18,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
 import {
   validateAuthorizeRequest,
   type AuthorizeRequestParams,
@@ -31,6 +31,11 @@ import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
 import { ensureOAuthClientRow, createAuthorizationCode } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
+
+function rateLimitedResponse(retryAfter: number): NextResponse {
+  return NextResponse.json({ error: 'rate_limited', retryAfter }, { status: 429 });
+}
 
 function extractParams(searchParams: URLSearchParams): AuthorizeRequestParams {
   return {
@@ -60,6 +65,16 @@ function buildRedirectWithParams(redirectUri: string, params: Record<string, str
 }
 
 export async function GET(req: NextRequest) {
+  // Per-IP only: GET is the unauthenticated entry point (no session yet) and
+  // is the open-redirect reconnaissance surface (probing client_id /
+  // redirect_uri combinations), so IP is the only identity available.
+  const ip = getClientIP(req);
+  const ipLimit = await checkDistributedRateLimit(`oauth-authorize:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_AUTHORIZE);
+  if (!ipLimit.allowed) {
+    auditRequest(req, { eventType: 'security.rate.limited', details: { oauthEvent: 'authorize_rate_limited' } });
+    return rateLimitedResponse(ipLimit.retryAfter ?? 0);
+  }
+
   const { searchParams, search } = new URL(req.url);
   const params = extractParams(searchParams);
   const client = params.clientId ? getRegisteredClient(params.clientId) : null;
@@ -110,6 +125,23 @@ export async function POST(req: NextRequest) {
     body = approvalSchema.parse(await req.json());
   } catch {
     return NextResponse.json({ error: 'invalid_request' }, { status: 400 });
+  }
+
+  // Consent decisions have real identity (session user + claimed client_id),
+  // so rate-limit both dimensions: per-user blunts rapid grant/deny cycling
+  // by one compromised session; per-client blunts a malicious client
+  // hammering consent across many victim sessions.
+  const [userLimit, clientLimit] = await Promise.all([
+    checkDistributedRateLimit(`oauth-authorize:user:${auth.userId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_AUTHORIZE),
+    checkDistributedRateLimit(`oauth-authorize:client:${body.clientId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_AUTHORIZE),
+  ]);
+  if (!userLimit.allowed || !clientLimit.allowed) {
+    auditRequest(req, {
+      eventType: 'security.rate.limited',
+      userId: auth.userId,
+      details: { clientId: body.clientId, oauthEvent: 'authorize_rate_limited' },
+    });
+    return rateLimitedResponse(Math.max(userLimit.retryAfter ?? 0, clientLimit.retryAfter ?? 0));
   }
 
   const params: AuthorizeRequestParams = {

--- a/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
@@ -16,7 +16,18 @@ vi.mock('@/lib/repositories/oauth-repository', () => ({
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('203.0.113.13'),
+}));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: { OAUTH_DEVICE_INIT: { maxAttempts: 10, windowMs: 300_000, progressiveDelay: false } },
+}));
+
 import { POST } from '../route';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const CLIENT_ID = 'pagespace-cli';
 const CLIENT_DB_ID = 'client-db-id-1';
@@ -33,10 +44,50 @@ function deviceAuthRequest(fields: Record<string, string | undefined>, contentTy
   });
 }
 
+const ALLOWED = { allowed: true, attemptsRemaining: 9 };
+
 beforeEach(() => {
   vi.clearAllMocks();
   ensureOAuthClientRow.mockResolvedValue(CLIENT_DB_ID);
   createDeviceAuthorization.mockResolvedValue(undefined);
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('POST /api/oauth/device_authorization — per-IP rate limiting', () => {
+  it('blocks with 429 when the per-IP limit is exceeded, never persisting a device code', async () => {
+    checkDistributedRateLimit.mockResolvedValue({ allowed: false, retryAfter: 300 });
+
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(429);
+    expect(createDeviceAuthorization).not.toHaveBeenCalled();
+  });
+
+  it('sets Cache-Control: no-store on the rate-limited response', async () => {
+    checkDistributedRateLimit.mockResolvedValue({ allowed: false, retryAfter: 300 });
+
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('checks the IP dimension keyed by client IP', async () => {
+    await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('ip:203.0.113.13'))).toBe(true);
+  });
+
+  it('audits the rate-limit trip', async () => {
+    checkDistributedRateLimit.mockResolvedValue({ allowed: false, retryAfter: 300 });
+
+    await POST(deviceAuthRequest({ client_id: CLIENT_ID }) as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited' }),
+    );
+  });
 });
 
 describe('POST /api/oauth/device_authorization — form-encoding enforcement', () => {

--- a/apps/web/src/app/api/oauth/device_authorization/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/route.ts
@@ -8,6 +8,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
+import { getClientIP } from '@/lib/auth';
 import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
 import { parseScopeList, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
 import { generateUserCode, normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
@@ -15,6 +16,7 @@ import { generateToken, hashToken } from '@pagespace/lib/auth/token-utils';
 import { DEVICE_CODE_TTL_SECONDS, DEVICE_CODE_POLL_INTERVAL_SECONDS } from '@pagespace/lib/auth/oauth/code-lifecycle';
 import { ensureOAuthClientRow, createDeviceAuthorization } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 
 function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
   return NextResponse.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
@@ -24,6 +26,16 @@ export async function POST(req: NextRequest) {
   const contentType = req.headers.get('content-type') ?? '';
   if (!contentType.toLowerCase().includes('application/x-www-form-urlencoded')) {
     return noStoreJson({ error: 'invalid_request' }, 400);
+  }
+
+  // Per-IP only: unauthenticated by protocol design (the CLI has no session
+  // yet), so IP is the only identity available. Bounds mass device/user-code
+  // minting that would exhaust the short user-code space or flood the table.
+  const ip = getClientIP(req);
+  const ipLimit = await checkDistributedRateLimit(`oauth-device-init:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_DEVICE_INIT);
+  if (!ipLimit.allowed) {
+    auditRequest(req, { eventType: 'security.rate.limited', details: { oauthEvent: 'device_authorization_rate_limited' } });
+    return noStoreJson({ error: 'rate_limited', retryAfter: ipLimit.retryAfter ?? 0 }, 429);
   }
 
   const form = new URLSearchParams(await req.text());

--- a/apps/web/src/app/api/oauth/revoke/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/revoke/__tests__/route.test.ts
@@ -22,6 +22,16 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
 
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('203.0.113.15'),
+}));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: { OAUTH_REVOKE: { maxAttempts: 20, windowMs: 300_000, progressiveDelay: false } },
+}));
+
 import { POST } from '../route';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
@@ -40,10 +50,58 @@ function revokeRequest(fields: Record<string, string | undefined>, contentType =
   });
 }
 
+const ALLOWED = { allowed: true, attemptsRemaining: 19 };
+
 beforeEach(() => {
   vi.clearAllMocks();
   ensureOAuthClientRow.mockResolvedValue(CLIENT_DB_ID);
   revokeOAuthToken.mockResolvedValue(undefined);
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('POST /api/oauth/revoke — per-IP/per-client rate limiting', () => {
+  it('blocks with 429 when the per-IP limit is exceeded, never calling the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-revoke:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(revokeRequest({ token: 'ps_at_' + 'a'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(429);
+    expect(revokeOAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('blocks with 429 when the per-client limit is exceeded, never calling the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-revoke:client:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(revokeRequest({ token: 'ps_at_' + 'a'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(res.status).toBe(429);
+    expect(revokeOAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('checks both the IP and client dimensions', async () => {
+    await POST(revokeRequest({ token: 'ps_at_' + 'a'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('ip:203.0.113.15'))).toBe(true);
+    expect(keys.some((k) => k.includes(`client:${CLIENT_ID}`))).toBe(true);
+  });
+
+  it('audits the rate-limit trip', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-revoke:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    await POST(revokeRequest({ token: 'ps_at_' + 'a'.repeat(43), client_id: CLIENT_ID }) as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited' }),
+    );
+  });
 });
 
 describe('POST /api/oauth/revoke — form-encoding enforcement', () => {

--- a/apps/web/src/app/api/oauth/revoke/route.ts
+++ b/apps/web/src/app/api/oauth/revoke/route.ts
@@ -15,9 +15,11 @@
  * rejections.
  */
 import { NextRequest, NextResponse } from 'next/server';
+import { getClientIP } from '@/lib/auth';
 import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
 import { ensureOAuthClientRow, revokeOAuthToken } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 
 function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
   return NextResponse.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
@@ -41,6 +43,22 @@ export async function POST(req: NextRequest) {
 
   if (!token || !clientId) {
     return noStoreJson(INVALID_REQUEST, 400);
+  }
+
+  // Unauthenticated by protocol (RFC 7009 forbids an oracle on outcome, so
+  // there's no credential to gate on) — per-IP + per-claimed-client is the
+  // only defense against endpoint flooding.
+  const ip = getClientIP(req);
+  const [ipLimit, clientLimit] = await Promise.all([
+    checkDistributedRateLimit(`oauth-revoke:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_REVOKE),
+    checkDistributedRateLimit(`oauth-revoke:client:${clientId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_REVOKE),
+  ]);
+  if (!ipLimit.allowed || !clientLimit.allowed) {
+    auditRequest(req, {
+      eventType: 'security.rate.limited',
+      details: { clientId, oauthEvent: 'revoke_rate_limited' },
+    });
+    return noStoreJson({ error: 'rate_limited', retryAfter: Math.max(ipLimit.retryAfter ?? 0, clientLimit.retryAfter ?? 0) }, 429);
   }
 
   const client = getRegisteredClient(clientId);

--- a/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
@@ -24,7 +24,21 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
 
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('203.0.113.11'),
+}));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: {
+    OAUTH_TOKEN_EXCHANGE: { maxAttempts: 10, windowMs: 300_000, progressiveDelay: true },
+    OAUTH_DEVICE_POLL: { maxAttempts: 100, windowMs: 300_000, progressiveDelay: false },
+  },
+}));
+
 import { POST } from '../route';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const REDIRECT_URI = 'http://127.0.0.1:51234/callback';
 const CLIENT_ID = 'pagespace-cli';
@@ -62,9 +76,76 @@ const okTokens = {
   familyExpiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
 };
 
+const ALLOWED = { allowed: true, attemptsRemaining: 9 };
+
 beforeEach(() => {
   vi.clearAllMocks();
   ensureOAuthClientRow.mockResolvedValue(CLIENT_DB_ID);
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('POST /api/oauth/token — authorization_code grant, rate limiting', () => {
+  it('blocks with 429 when the per-IP limit is exceeded, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:exchange:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(validFields()) as never);
+
+    expect(res.status).toBe(429);
+    expect(exchangeAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('blocks with 429 when the per-client limit is exceeded, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:exchange:client:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(validFields()) as never);
+
+    expect(res.status).toBe(429);
+    expect(exchangeAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('checks both the IP and client dimensions', async () => {
+    exchangeAuthorizationCode.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: okTokens,
+    });
+
+    await POST(tokenRequest(validFields()) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('ip:203.0.113.11'))).toBe(true);
+    expect(keys.some((k) => k.includes(`client:${CLIENT_ID}`))).toBe(true);
+  });
+
+  it('sets Cache-Control: no-store on the rate-limited response', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:exchange:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(validFields()) as never);
+
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('audits the rate-limit trip without leaking token/code material', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:exchange:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    await POST(tokenRequest(validFields()) as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited' }),
+    );
+    const call = vi.mocked(auditRequest).mock.calls[0][1] as { details?: Record<string, unknown> };
+    expect(JSON.stringify(call.details ?? {})).not.toContain('raw-code-value');
+  });
 });
 
 describe('POST /api/oauth/token — form-encoding enforcement', () => {
@@ -370,6 +451,30 @@ describe('POST /api/oauth/token — refresh_token grant, constant-shape failures
   });
 });
 
+describe('POST /api/oauth/token — refresh_token grant, rate limiting', () => {
+  it('blocks with 429 when the per-IP limit is exceeded, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:exchange:ip:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(refreshFields()) as never);
+
+    expect(res.status).toBe(429);
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('blocks with 429 when the per-client limit is exceeded, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:exchange:client:') ? { allowed: false, retryAfter: 300 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(refreshFields()) as never);
+
+    expect(res.status).toBe(429);
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+});
+
 describe('POST /api/oauth/token — unsupported grant_type', () => {
   it('rejects an unrecognized grant_type', async () => {
     const res = await POST(tokenRequest({ grant_type: 'client_credentials' }) as never);
@@ -482,5 +587,54 @@ describe('POST /api/oauth/token — device_code grant, RFC 8628 §3.5 poll outco
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_request' });
     expect(pollDeviceToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/token — device_code grant, endpoint-level rate limiting', () => {
+  it('responds with the RFC 8628 slow_down contract (not a generic 429) when the endpoint-level limit trips, never reaching the repository', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:device_poll:ip:') ? { allowed: false, retryAfter: 30 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(deviceFields()) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'slow_down' });
+    expect(pollDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('blocks when the per-client limit trips', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:device_poll:client:') ? { allowed: false, retryAfter: 30 } : ALLOWED,
+    );
+
+    const res = await POST(tokenRequest(deviceFields()) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'slow_down' });
+  });
+
+  it('checks both the IP and client dimensions, distinct from the exchange-grant keys', async () => {
+    pollDeviceToken.mockResolvedValue({ outcome: 'authorization_pending' });
+
+    await POST(tokenRequest(deviceFields()) as never);
+
+    const keys = checkDistributedRateLimit.mock.calls.map((c) => c[0] as string);
+    expect(keys.some((k) => k.includes('device_poll:ip:203.0.113.11'))).toBe(true);
+    expect(keys.some((k) => k.includes(`device_poll:client:${CLIENT_ID}`))).toBe(true);
+    expect(keys.every((k) => !k.startsWith('oauth-token:exchange:'))).toBe(true);
+  });
+
+  it('audits the rate-limit trip', async () => {
+    checkDistributedRateLimit.mockImplementation(async (key: string) =>
+      key.startsWith('oauth-token:device_poll:ip:') ? { allowed: false, retryAfter: 30 } : ALLOWED,
+    );
+
+    await POST(tokenRequest(deviceFields()) as never);
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'security.rate.limited' }),
+    );
   });
 });

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -28,6 +28,7 @@
  * device_code falls back to the shared invalid_grant.
  */
 import { NextRequest, NextResponse } from 'next/server';
+import { getClientIP } from '@/lib/auth';
 import { getRegisteredClient, type RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
 import { ACCESS_TOKEN_TTL_SECONDS } from '@pagespace/lib/auth/oauth/issue-tokens';
 import {
@@ -37,6 +38,7 @@ import {
   pollDeviceToken,
 } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 
 function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
   return NextResponse.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
@@ -45,6 +47,52 @@ function noStoreJson(body: Record<string, unknown>, status: number): NextRespons
 const INVALID_REQUEST = { error: 'invalid_request' };
 const INVALID_GRANT = { error: 'invalid_grant' };
 const INVALID_SCOPE = { error: 'invalid_scope' };
+
+/**
+ * authorization_code + refresh_token grants both present a high-entropy
+ * secret exactly once per legitimate use — real traffic is rare, so a tight
+ * per-IP + per-client limit blunts brute-forcing a code/refresh token.
+ * Returns a generic 429 (no oracle: rate-limiting isn't a credential-guessing
+ * signal, unlike the grant's own invalid_grant/invalid_scope split).
+ */
+async function checkTokenExchangeRateLimit(req: NextRequest, clientId: string): Promise<NextResponse | null> {
+  const ip = getClientIP(req);
+  const [ipLimit, clientLimit] = await Promise.all([
+    checkDistributedRateLimit(`oauth-token:exchange:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_TOKEN_EXCHANGE),
+    checkDistributedRateLimit(`oauth-token:exchange:client:${clientId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_TOKEN_EXCHANGE),
+  ]);
+  if (ipLimit.allowed && clientLimit.allowed) return null;
+
+  auditRequest(req, {
+    eventType: 'security.rate.limited',
+    details: { clientId, oauthEvent: 'token_exchange_rate_limited' },
+  });
+  return noStoreJson({ error: 'rate_limited', retryAfter: Math.max(ipLimit.retryAfter ?? 0, clientLimit.retryAfter ?? 0) }, 429);
+}
+
+/**
+ * device_code polling is a distinct risk profile: RFC 8628 legitimate
+ * traffic is ~1 poll per pollIntervalSeconds from a single flow, already
+ * throttled per-device-code by decideDevicePoll's own slow_down. This is an
+ * endpoint-level backstop against a client ignoring slow_down or scanning
+ * device codes wholesale — set generous enough to never trip on real
+ * traffic. Responds with the RFC 8628 slow_down contract, not a bare 429,
+ * so a compliant polling client backs off instead of erroring out.
+ */
+async function checkDevicePollRateLimit(req: NextRequest, clientId: string): Promise<NextResponse | null> {
+  const ip = getClientIP(req);
+  const [ipLimit, clientLimit] = await Promise.all([
+    checkDistributedRateLimit(`oauth-token:device_poll:ip:${ip}`, DISTRIBUTED_RATE_LIMITS.OAUTH_DEVICE_POLL),
+    checkDistributedRateLimit(`oauth-token:device_poll:client:${clientId}`, DISTRIBUTED_RATE_LIMITS.OAUTH_DEVICE_POLL),
+  ]);
+  if (ipLimit.allowed && clientLimit.allowed) return null;
+
+  auditRequest(req, {
+    eventType: 'security.rate.limited',
+    details: { clientId, oauthEvent: 'device_poll_rate_limited' },
+  });
+  return noStoreJson({ error: 'slow_down' }, 400);
+}
 
 type ResolvedClient = { client: RegisteredClient; clientDbId: string };
 type ClientResolution = ResolvedClient | { rejection: NextResponse };
@@ -82,6 +130,9 @@ async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchPar
   if (!code || !redirectUri || !clientId || !codeVerifier) {
     return noStoreJson(INVALID_REQUEST, 400);
   }
+
+  const rateLimited = await checkTokenExchangeRateLimit(req, clientId);
+  if (rateLimited) return rateLimited;
 
   const resolved = await resolveClient(form, clientId);
   if ('rejection' in resolved) return resolved.rejection;
@@ -128,6 +179,9 @@ async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams):
   if (!refreshToken || !clientId) {
     return noStoreJson(INVALID_REQUEST, 400);
   }
+
+  const rateLimited = await checkTokenExchangeRateLimit(req, clientId);
+  if (rateLimited) return rateLimited;
 
   const resolved = await resolveClient(form, clientId);
   if ('rejection' in resolved) return resolved.rejection;
@@ -197,6 +251,9 @@ async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): P
   if (!deviceCode || !clientId) {
     return noStoreJson(INVALID_REQUEST, 400);
   }
+
+  const rateLimited = await checkDevicePollRateLimit(req, clientId);
+  if (rateLimited) return rateLimited;
 
   const resolved = await resolveClient(form, clientId);
   if ('rejection' in resolved) return resolved.rejection;

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -615,6 +615,53 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 15 * 60 * 1000,
     progressiveDelay: false,
   },
+  // OAuth /authorize: GET is the unauthenticated client_id/redirect_uri
+  // probing surface (open-redirect reconnaissance); POST is the session-gated
+  // consent decision. Generous enough for a human clicking through the flow
+  // more than once, tight enough to blunt scripted enumeration.
+  OAUTH_AUTHORIZE: {
+    maxAttempts: 20,
+    windowMs: 5 * 60 * 1000,
+    blockDurationMs: 5 * 60 * 1000,
+    progressiveDelay: false,
+  },
+  // OAuth /token authorization_code + refresh_token grants: each presents a
+  // high-entropy secret exactly once per legitimate grant, so real traffic is
+  // rare. Tight + progressive to blunt brute-forcing a code/refresh token.
+  OAUTH_TOKEN_EXCHANGE: {
+    maxAttempts: 10,
+    windowMs: 5 * 60 * 1000,
+    blockDurationMs: 5 * 60 * 1000,
+    progressiveDelay: true,
+  },
+  // OAuth /token device_code polling: RFC 8628 expects ~1 poll per
+  // pollIntervalSeconds (5s) from a single legitimate flow — that's already
+  // throttled by decideDevicePoll's own per-record slow_down. This is an
+  // endpoint-level backstop against a client ignoring slow_down or scanning
+  // device codes wholesale, so it sits above single-flow polling volume.
+  OAUTH_DEVICE_POLL: {
+    maxAttempts: 100,
+    windowMs: 5 * 60 * 1000,
+    blockDurationMs: 60 * 1000,
+    progressiveDelay: false,
+  },
+  // OAuth /device_authorization: unauthenticated device/user-code minting.
+  // Limits mass code generation that would exhaust the short user-code space
+  // or flood the device_authorizations table.
+  OAUTH_DEVICE_INIT: {
+    maxAttempts: 10,
+    windowMs: 5 * 60 * 1000,
+    blockDurationMs: 5 * 60 * 1000,
+    progressiveDelay: false,
+  },
+  // OAuth /revoke: unauthenticated by design (RFC 7009 forbids an oracle on
+  // outcome), so rate limiting is the only defense against endpoint flooding.
+  OAUTH_REVOKE: {
+    maxAttempts: 20,
+    windowMs: 5 * 60 * 1000,
+    blockDurationMs: 5 * 60 * 1000,
+    progressiveDelay: false,
+  },
 } as const;
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Final task of Phase 1 (OAuth 2.1 Authorization Server) — a hardening sweep adding rate limiting across the whole OAuth surface. Audit logging was already comprehensive from tasks 5–10 (issued/rotated/revoked/granted/denied all emit `auditRequest`); this PR closes the rate-limiting gap and adds a structural sweep test so a future OAuth endpoint can't ship unprotected.

- **`/api/oauth/authorize`**: per-IP on GET (unauthenticated, the open-redirect probing surface); per-user + per-client on the POST consent decision.
- **`/api/oauth/token`**: per-IP + per-client on `authorization_code` and `refresh_token` grants (`OAUTH_TOKEN_EXCHANGE` — high-entropy secret presented once, so real traffic is rare); a separate, more generous per-IP + per-client bucket on `device_code` polling (`OAUTH_DEVICE_POLL`) that sits above legitimate RFC 8628 poll volume — already throttled per-device-code by `decideDevicePoll`'s own `slow_down` — and responds with the `slow_down` JSON contract (not a bare 429) so a compliant polling client backs off correctly.
- **`/api/oauth/device_authorization`**: per-IP (unauthenticated device/user-code minting; bounds user-code-space exhaustion).
- **`/api/oauth/revoke`**: per-IP + per-client (RFC 7009 forbids an oracle on outcome, so rate limiting is the only defense against endpoint flooding).
- `/device_authorization/verify` and `/decision` already had per-IP + per-session rate limiting from task 9 — unchanged.

Every rate-limit trip emits `security.rate.limited` with `clientId`/`oauthEvent` only — never token, code, or user-code material.

New `DISTRIBUTED_RATE_LIMITS` entries: `OAUTH_AUTHORIZE`, `OAUTH_TOKEN_EXCHANGE`, `OAUTH_DEVICE_POLL`, `OAUTH_DEVICE_INIT`, `OAUTH_REVOKE` — each dimensioned and justified in a code comment per the task spec.

Adds `apps/web/src/app/api/oauth/__tests__/hardening.test.ts`: dynamically enumerates every `route.ts` under `api/oauth` and asserts each wires both `checkDistributedRateLimit` and `auditRequest` — structural enforcement so a future endpoint can't ship unprotected.

## Test plan

- [x] RED: 25 new tests added across the 4 route test files + sweep test, confirmed failing before implementation
- [x] GREEN: all 119 OAuth route tests passing after wiring rate limits
- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bun run --filter 'web' lint` — clean (pre-existing warnings only, unrelated files)
- [x] `bun run test:unit` — 10851/10867 passing; 16 pre-existing failures are DB-integration tests needing a `test` Postgres role only present in CI (admin-role-version, unrelated grouping/activity-tools tests) — none touch OAuth
- [x] `bun run test:security` — 36/43 suites passing; 7 pre-existing failures are the same DB-integration category (Session Service, Device Auth Utilities, Permissions, Login/Signup/Mobile Login routes, Admin Role Versioning) — none touch OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVBxH6ymALML6Kqcpm5U19