### PR TITLE
cli: scaffold @pagespace/cli package (Phase 4 task 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -458,6 +458,16 @@
         "typescript": "^5",
       },
     },
+    "packages/cli": {
+      "name": "@pagespace/cli",
+      "version": "0.1.0",
+      "bin": {
+        "pagespace": "./dist/bin.js",
+      },
+      "dependencies": {
+        "@pagespace/sdk": "workspace:*",
+      },
+    },
     "packages/db": {
       "name": "@pagespace/db",
       "version": "0.1.0",
@@ -1191,6 +1201,8 @@
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.16.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qnjQhjHI4TDL3hkidZyEmQRK43w2NHl6TP5Rnt/0XxYuLdEgx/1yzShhYidyqWzdnhGhSPTM/WVP2mK66XLegA=="],
 
     "@pagespace/android": ["@pagespace/android@workspace:apps/android"],
+
+    "@pagespace/cli": ["@pagespace/cli@workspace:packages/cli"],
 
     "@pagespace/db": ["@pagespace/db@workspace:packages/db"],
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,26 @@
+# @pagespace/cli
+
+The `pagespace` command-line client — a thin verb layer over `@pagespace/sdk`. `pagespace login`
+replaces hand-minted `mcp_*` tokens with a real OAuth 2.1 credential; `pagespace tokens create`
+mints scoped agent tokens from the terminal instead of Settings → MCP.
+
+**Pure core, effects at the edges**: `parseArgv` turns `process.argv` into a typed `CommandIntent`
+(or a typed `UsageError`) with no I/O. `resolveConfig` applies the fixed precedence — `--token`/
+`--host` flags > `PAGESPACE_TOKEN`/`PAGESPACE_API_URL` env > stored profile credential > defaults
+(`https://pagespace.ai`) — as a pure function over plain data. The router matches a `CommandIntent`
+against a static route table and dispatches to a handler; handlers receive an injected
+`{ sdk, stdout, stderr, env, credentialStore }` context and never touch `process.*` directly. Only
+`src/bin.ts` reads `process.argv`/`process.env`/`process.stdout`/`process.exitCode`.
+
+**Exit codes** (fixed contract, every command tests against it): `0` success, `1` API/runtime
+error, `2` usage error.
+
+**Zero trust**: no token is ever printed — not in output, not in a usage-error message, not in a
+log. `--json` mode writes nothing to stdout but the JSON payload itself.
+
+The credential store (OS keychain + chmod-0600 file fallback) lands in Phase 4 task 2; this
+package currently ships a `NullCredentialStore` placeholder so the handler contract doesn't change
+shape when the real store arrives.
+
+See PageSpace page `ea07mt5jvw0flihsbjce1iv9` (epic architecture + non-negotiables) and phase page
+`ntr8palcnmkih8kiy33qo717` (Phase 4 security law) for the binding decisions this package follows.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pagespace/cli",
+  "version": "0.1.0",
+  "license": "UNLICENSED",
+  "type": "module",
+  "sideEffects": false,
+  "bin": {
+    "pagespace": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && chmod +x dist/bin.js",
+    "pretypecheck": "bun run build",
+    "typecheck": "tsc --noEmit",
+    "pretest": "bun run build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@pagespace/sdk": "workspace:*"
+  }
+}

--- a/packages/cli/src/__tests__/fake-context.ts
+++ b/packages/cli/src/__tests__/fake-context.ts
@@ -1,0 +1,24 @@
+import { PageSpaceClient, StaticTokenProvider } from '@pagespace/sdk';
+import type { HandlerContext, OutputSink } from '@pagespace/cli';
+import { NullCredentialStore } from '@pagespace/cli';
+
+export function createRecordingSink(): OutputSink & { readonly lines: string[] } {
+  const lines: string[] = [];
+  return {
+    lines,
+    write(chunk: string) {
+      lines.push(chunk);
+    },
+  };
+}
+
+export function createFakeContext(overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    sdk: new PageSpaceClient({ baseUrl: 'https://pagespace.ai', auth: new StaticTokenProvider('test-token') }),
+    stdout: createRecordingSink(),
+    stderr: createRecordingSink(),
+    env: {},
+    credentialStore: new NullCredentialStore(),
+    ...overrides,
+  };
+}

--- a/packages/cli/src/__tests__/run.test.ts
+++ b/packages/cli/src/__tests__/run.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { CLI_VERSION, EXIT_SUCCESS, EXIT_USAGE_ERROR, NullCredentialStore, run } from '@pagespace/cli';
+import type { RunDependencies } from '@pagespace/cli';
+import { createRecordingSink } from './fake-context.js';
+
+function makeDeps(argv: string[], env: Record<string, string | undefined> = {}): RunDependencies & {
+  stdout: ReturnType<typeof createRecordingSink>;
+  stderr: ReturnType<typeof createRecordingSink>;
+} {
+  return {
+    argv,
+    env,
+    stdout: createRecordingSink(),
+    stderr: createRecordingSink(),
+    credentialStore: new NullCredentialStore(),
+  };
+}
+
+describe('run', () => {
+  it('exits 0 and prints usage for "help"', async () => {
+    const deps = makeDeps(['help']);
+    const code = await run(deps);
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(deps.stdout.lines.join('')).toContain('pagespace');
+  });
+
+  it('exits 0 for --version and reports CLI_VERSION', async () => {
+    const deps = makeDeps(['--version']);
+    const code = await run(deps);
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(deps.stdout.lines.join('')).toContain(CLI_VERSION);
+  });
+
+  it('exits 2 for an unknown command', async () => {
+    const deps = makeDeps(['nope']);
+    const code = await run(deps);
+    expect(code).toBe(EXIT_USAGE_ERROR);
+  });
+
+  it('exits 2 when no command is given at all', async () => {
+    const deps = makeDeps([]);
+    const code = await run(deps);
+    expect(code).toBe(EXIT_USAGE_ERROR);
+  });
+
+  it('exits 2 for an unknown flag and never writes it to stdout', async () => {
+    const deps = makeDeps(['--bogus']);
+    const code = await run(deps);
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(deps.stdout.lines).toEqual([]);
+  });
+
+  it('never prints a supplied --token value anywhere, even on a usage error', async () => {
+    const deps = makeDeps(['--token', 'super-secret-value', '--bogus']);
+    await run(deps);
+    expect(deps.stdout.lines.join('')).not.toContain('super-secret-value');
+    expect(deps.stderr.lines.join('')).not.toContain('super-secret-value');
+  });
+
+  it('emits ONLY valid JSON on stdout for "help --json"', async () => {
+    const deps = makeDeps(['help', '--json']);
+    await run(deps);
+    const written = deps.stdout.lines.join('');
+    expect(() => JSON.parse(written)).not.toThrow();
+  });
+
+  it('reads the credential store exactly once per invocation', async () => {
+    let readCalls = 0;
+    const store = {
+      async read() {
+        readCalls += 1;
+        return null;
+      },
+      async write() {},
+      async clear() {},
+    };
+    const deps = { ...makeDeps(['help']), credentialStore: store };
+    await run(deps);
+    expect(readCalls).toBe(1);
+  });
+});

--- a/packages/cli/src/__tests__/scaffold.test.ts
+++ b/packages/cli/src/__tests__/scaffold.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { CLI_VERSION } from '@pagespace/cli';
+
+interface PackageManifest {
+  name?: string;
+  bin?: Record<string, string>;
+  exports?: unknown;
+  files?: string[];
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'),
+) as PackageManifest;
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+describe('@pagespace/cli package scaffold', () => {
+  it('is named @pagespace/cli', () => {
+    expect(packageJson.name).toBe('@pagespace/cli');
+  });
+
+  it('declares the pagespace bin pointing at dist/bin.js', () => {
+    expect(packageJson.bin).toEqual({ pagespace: './dist/bin.js' });
+  });
+
+  it('ships an exports map for programmatic (non-bin) consumers', () => {
+    expect(packageJson.exports).toBeDefined();
+  });
+
+  it('only ships dist/ in the published package', () => {
+    expect(packageJson.files).toEqual(['dist']);
+  });
+
+  it('depends on @pagespace/sdk as a workspace dependency', () => {
+    expect(packageJson.dependencies).toMatchObject({ '@pagespace/sdk': 'workspace:*' });
+  });
+
+  it('declares build, typecheck, and test scripts for turbo/bun --filter', () => {
+    expect(packageJson.scripts).toMatchObject({
+      build: expect.any(String),
+      typecheck: expect.any(String),
+      test: expect.any(String),
+    });
+  });
+
+  it('is importable by its published package name and exports a semver CLI_VERSION', () => {
+    expect(typeof CLI_VERSION).toBe('string');
+    expect(CLI_VERSION).toMatch(SEMVER);
+  });
+});

--- a/packages/cli/src/argv/__tests__/parse.test.ts
+++ b/packages/cli/src/argv/__tests__/parse.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgv } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+
+function expectCommand(result: ReturnType<typeof parseArgv>): asserts result is CommandIntent {
+  expect(result.kind).toBe('command');
+}
+
+describe('parseArgv', () => {
+  it('parses a bare invocation with no args and all-default flags', () => {
+    const result = parseArgv([]);
+    expectCommand(result);
+    expect(result.args).toEqual([]);
+    expect(result.flags).toEqual({
+      json: false,
+      host: undefined,
+      token: undefined,
+      yes: false,
+      help: false,
+      version: false,
+    });
+  });
+
+  it('parses a single-word command', () => {
+    const result = parseArgv(['help']);
+    expectCommand(result);
+    expect(result.args).toEqual(['help']);
+  });
+
+  it('parses a multi-segment command path', () => {
+    const result = parseArgv(['tokens', 'create']);
+    expectCommand(result);
+    expect(result.args).toEqual(['tokens', 'create']);
+  });
+
+  it('parses --json as a boolean flag', () => {
+    const result = parseArgv(['help', '--json']);
+    expectCommand(result);
+    expect(result.flags.json).toBe(true);
+  });
+
+  it('parses --yes as a boolean flag', () => {
+    const result = parseArgv(['--yes']);
+    expectCommand(result);
+    expect(result.flags.yes).toBe(true);
+  });
+
+  it('parses --help as a boolean flag', () => {
+    const result = parseArgv(['--help']);
+    expectCommand(result);
+    expect(result.flags.help).toBe(true);
+  });
+
+  it('parses --version as a boolean flag', () => {
+    const result = parseArgv(['--version']);
+    expectCommand(result);
+    expect(result.flags.version).toBe(true);
+  });
+
+  it('parses --host with its value', () => {
+    const result = parseArgv(['--host', 'https://selfhosted.example']);
+    expectCommand(result);
+    expect(result.flags.host).toBe('https://selfhosted.example');
+  });
+
+  it('parses --token with its value', () => {
+    const result = parseArgv(['--token', 'ps_sess_abc123']);
+    expectCommand(result);
+    expect(result.flags.token).toBe('ps_sess_abc123');
+  });
+
+  it('parses flags interleaved before and after the command', () => {
+    const result = parseArgv(['--json', 'tokens', 'create', '--yes']);
+    expectCommand(result);
+    expect(result.args).toEqual(['tokens', 'create']);
+    expect(result.flags.json).toBe(true);
+    expect(result.flags.yes).toBe(true);
+  });
+
+  it('rejects an unknown flag as a usage error', () => {
+    const result = parseArgv(['--bogus']);
+    expect(result).toEqual({ kind: 'usage-error', message: 'Unknown flag: --bogus' });
+  });
+
+  it('rejects --host with a missing value as a usage error', () => {
+    const result = parseArgv(['--host']);
+    expect(result.kind).toBe('usage-error');
+  });
+
+  it('rejects --token with a missing value as a usage error', () => {
+    const result = parseArgv(['--token']);
+    expect(result.kind).toBe('usage-error');
+  });
+
+  it('rejects --host followed immediately by another flag as a missing value', () => {
+    const result = parseArgv(['--host', '--json']);
+    expect(result.kind).toBe('usage-error');
+  });
+
+  it('never echoes a supplied token value back in a usage error message', () => {
+    const result = parseArgv(['--token', 'super-secret-value', '--bogus']);
+    expect(JSON.stringify(result)).not.toContain('super-secret-value');
+  });
+
+  it('is a pure function: identical input produces a deep-equal result', () => {
+    const argv = ['--json', 'tokens', 'create', '--yes'];
+    expect(parseArgv(argv)).toEqual(parseArgv(argv));
+  });
+});

--- a/packages/cli/src/argv/parse.ts
+++ b/packages/cli/src/argv/parse.ts
@@ -1,0 +1,81 @@
+/**
+ * parseArgv — the CLI's pure grammar (Phase 4 task 1). Turns raw argv tokens
+ * into a typed `CommandIntent` or a typed `UsageError`; never touches
+ * `process.*`, never throws. Command-tree validity (does "tokens create"
+ * resolve to a handler?) is the router's job, not this function's — parseArgv
+ * only understands the fixed global-flag grammar every command shares.
+ *
+ * Zero trust: a rejected flag's value is never echoed back in the error
+ * message, only the flag name — the value may be a secret (`--token`).
+ */
+
+export interface ParsedFlags {
+  readonly json: boolean;
+  readonly host: string | undefined;
+  readonly token: string | undefined;
+  readonly yes: boolean;
+  readonly help: boolean;
+  readonly version: boolean;
+}
+
+export interface CommandIntent {
+  readonly kind: 'command';
+  /** Positional tokens in order: the command path followed by any command-specific args. */
+  readonly args: readonly string[];
+  readonly flags: ParsedFlags;
+}
+
+export interface UsageError {
+  readonly kind: 'usage-error';
+  readonly message: string;
+}
+
+export type ParseResult = CommandIntent | UsageError;
+
+const VALUE_FLAGS = new Set(['--host', '--token']);
+const BOOLEAN_FLAGS = new Set(['--json', '--yes', '--help', '--version']);
+
+export function parseArgv(argv: readonly string[]): ParseResult {
+  let json = false;
+  let host: string | undefined;
+  let token: string | undefined;
+  let yes = false;
+  let help = false;
+  let version = false;
+  const args: string[] = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const current = argv[i];
+
+    if (VALUE_FLAGS.has(current)) {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith('-')) {
+        return { kind: 'usage-error', message: `Flag ${current} requires a value.` };
+      }
+      if (current === '--host') host = value;
+      else token = value;
+      i += 1;
+      continue;
+    }
+
+    if (BOOLEAN_FLAGS.has(current)) {
+      if (current === '--json') json = true;
+      else if (current === '--yes') yes = true;
+      else if (current === '--help') help = true;
+      else version = true;
+      continue;
+    }
+
+    if (current.startsWith('-')) {
+      return { kind: 'usage-error', message: `Unknown flag: ${current}` };
+    }
+
+    args.push(current);
+  }
+
+  return {
+    kind: 'command',
+    args,
+    flags: { json, host, token, yes, help, version },
+  };
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * The one file allowed to touch `process.*`. Everything else — parsing,
+ * config resolution, routing, handlers — is pure or takes its effects
+ * injected, so it can be unit-tested without a real process.
+ */
+import process from 'node:process';
+import { NullCredentialStore } from './credential-store.js';
+import type { OutputSink } from './handler-context.js';
+import { run } from './run.js';
+
+const stdout: OutputSink = { write: (chunk) => { process.stdout.write(chunk); } };
+const stderr: OutputSink = { write: (chunk) => { process.stderr.write(chunk); } };
+
+run({
+  argv: process.argv.slice(2),
+  env: process.env,
+  stdout,
+  stderr,
+  credentialStore: new NullCredentialStore(),
+})
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error: unknown) => {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });

--- a/packages/cli/src/commands/__tests__/help.test.ts
+++ b/packages/cli/src/commands/__tests__/help.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { EXIT_SUCCESS, helpHandler, parseArgv } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink } from '../../__tests__/fake-context.js';
+
+describe('helpHandler', () => {
+  it('writes human-readable usage to stdout and exits 0', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout });
+    const intent = parseArgv(['help']);
+    if (intent.kind !== 'command') throw new Error('expected command');
+
+    const code = await helpHandler(ctx, intent);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(stdout.lines.join('')).toContain('pagespace');
+  });
+
+  it('emits ONLY JSON on stdout when --json is set', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout });
+    const intent = parseArgv(['help', '--json']);
+    if (intent.kind !== 'command') throw new Error('expected command');
+
+    await helpHandler(ctx, intent);
+
+    const written = stdout.lines.join('');
+    expect(() => JSON.parse(written)).not.toThrow();
+  });
+
+  it('never writes to stderr on success', async () => {
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr });
+    const intent = parseArgv(['help']);
+    if (intent.kind !== 'command') throw new Error('expected command');
+
+    await helpHandler(ctx, intent);
+
+    expect(stderr.lines).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/__tests__/version.test.ts
+++ b/packages/cli/src/commands/__tests__/version.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { CLI_VERSION, EXIT_SUCCESS, parseArgv, versionHandler } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink } from '../../__tests__/fake-context.js';
+
+describe('versionHandler', () => {
+  it('writes the CLI version to stdout and exits 0', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout });
+    const intent = parseArgv(['--version']);
+    if (intent.kind !== 'command') throw new Error('expected command');
+
+    const code = await versionHandler(ctx, intent);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(stdout.lines.join('')).toContain(CLI_VERSION);
+  });
+
+  it('emits ONLY JSON on stdout when --json is set', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout });
+    const intent = parseArgv(['--version', '--json']);
+    if (intent.kind !== 'command') throw new Error('expected command');
+
+    await versionHandler(ctx, intent);
+
+    const written = stdout.lines.join('');
+    const parsed = JSON.parse(written) as { version: string };
+    expect(parsed.version).toBe(CLI_VERSION);
+  });
+});

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -1,0 +1,26 @@
+import { EXIT_SUCCESS } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+
+const USAGE_LINES = [
+  'pagespace <command> [flags]',
+  '',
+  'Commands:',
+  '  help      Show this help message',
+  '',
+  'Global flags:',
+  '  --json          Emit machine-readable JSON on stdout only',
+  '  --host <url>    Override the API host',
+  '  --token <tok>   Override the credential',
+  '  --yes           Assume yes to confirmation prompts',
+  '  --help          Show help',
+  '  --version       Show the CLI version',
+];
+
+export const helpHandler: CommandHandler = async (ctx, intent) => {
+  if (intent.flags.json) {
+    ctx.stdout.write(JSON.stringify({ usage: USAGE_LINES }));
+  } else {
+    ctx.stdout.write(`${USAGE_LINES.join('\n')}\n`);
+  }
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,0 +1,15 @@
+import { SDK_VERSION } from '@pagespace/sdk';
+import { EXIT_SUCCESS } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+
+/** @pagespace/cli npm package version — keep in sync with package.json. */
+export const CLI_VERSION = '0.1.0';
+
+export const versionHandler: CommandHandler = async (ctx, intent) => {
+  if (intent.flags.json) {
+    ctx.stdout.write(JSON.stringify({ version: CLI_VERSION, sdkVersion: SDK_VERSION }));
+  } else {
+    ctx.stdout.write(`pagespace/${CLI_VERSION} (sdk ${SDK_VERSION})\n`);
+  }
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/config/__tests__/resolve.test.ts
+++ b/packages/cli/src/config/__tests__/resolve.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_HOST, resolveConfig } from '@pagespace/cli';
+
+describe('resolveConfig', () => {
+  it('defaults to https://pagespace.ai when nothing else is provided', () => {
+    const config = resolveConfig({ flags: {}, env: {}, profile: null });
+    expect(config.host).toBe(DEFAULT_HOST);
+    expect(config.host).toBe('https://pagespace.ai');
+    expect(config.token).toBeUndefined();
+  });
+
+  it('prefers the profile file over defaults', () => {
+    const config = resolveConfig({
+      flags: {},
+      env: {},
+      profile: { host: 'https://from-profile.example', token: 'ps_sess_profile' },
+    });
+    expect(config.host).toBe('https://from-profile.example');
+    expect(config.token).toBe('ps_sess_profile');
+  });
+
+  it('prefers env over the profile file', () => {
+    const config = resolveConfig({
+      flags: {},
+      env: { PAGESPACE_API_URL: 'https://from-env.example', PAGESPACE_TOKEN: 'ps_sess_env' },
+      profile: { host: 'https://from-profile.example', token: 'ps_sess_profile' },
+    });
+    expect(config.host).toBe('https://from-env.example');
+    expect(config.token).toBe('ps_sess_env');
+  });
+
+  it('prefers flags over env and the profile file', () => {
+    const config = resolveConfig({
+      flags: { host: 'https://from-flag.example', token: 'ps_sess_flag' },
+      env: { PAGESPACE_API_URL: 'https://from-env.example', PAGESPACE_TOKEN: 'ps_sess_env' },
+      profile: { host: 'https://from-profile.example', token: 'ps_sess_profile' },
+    });
+    expect(config.host).toBe('https://from-flag.example');
+    expect(config.token).toBe('ps_sess_flag');
+  });
+
+  it('falls through per-field independently (flag host, env token)', () => {
+    const config = resolveConfig({
+      flags: { host: 'https://from-flag.example' },
+      env: { PAGESPACE_TOKEN: 'ps_sess_env' },
+      profile: { host: 'https://from-profile.example', token: 'ps_sess_profile' },
+    });
+    expect(config.host).toBe('https://from-flag.example');
+    expect(config.token).toBe('ps_sess_env');
+  });
+
+  it('is a pure function', () => {
+    const sources = {
+      flags: { host: 'https://a.example' },
+      env: { PAGESPACE_TOKEN: 't' },
+      profile: null,
+    };
+    expect(resolveConfig(sources)).toEqual(resolveConfig(sources));
+  });
+});

--- a/packages/cli/src/config/resolve.ts
+++ b/packages/cli/src/config/resolve.ts
@@ -1,0 +1,44 @@
+/**
+ * resolveConfig — the pure config precedence resolver (Phase 4 task 1 /
+ * Phase 4 intro "Auth precedence"): `--token`/`--host` flags > `PAGESPACE_TOKEN`/
+ * `PAGESPACE_API_URL` env > stored profile credential > defaults. Each field
+ * (host, token) falls through the chain independently.
+ *
+ * `https://pagespace.ai` is the confirmed canonical API origin — already the
+ * fixture host in every `@pagespace/sdk` transport test
+ * (packages/sdk/src/transport/__tests__/build-request.test.ts).
+ */
+
+export const DEFAULT_HOST = 'https://pagespace.ai';
+
+export interface ConfigFlags {
+  readonly host?: string;
+  readonly token?: string;
+}
+
+export interface ConfigEnv {
+  readonly PAGESPACE_TOKEN?: string;
+  readonly PAGESPACE_API_URL?: string;
+}
+
+export interface ConfigProfile {
+  readonly host?: string;
+  readonly token?: string;
+}
+
+export interface ConfigSources {
+  readonly flags: ConfigFlags;
+  readonly env: ConfigEnv;
+  readonly profile: ConfigProfile | null;
+}
+
+export interface ResolvedConfig {
+  readonly host: string;
+  readonly token: string | undefined;
+}
+
+export function resolveConfig(sources: ConfigSources): ResolvedConfig {
+  const host = sources.flags.host ?? sources.env.PAGESPACE_API_URL ?? sources.profile?.host ?? DEFAULT_HOST;
+  const token = sources.flags.token ?? sources.env.PAGESPACE_TOKEN ?? sources.profile?.token ?? undefined;
+  return { host, token };
+}

--- a/packages/cli/src/credential-store.ts
+++ b/packages/cli/src/credential-store.ts
@@ -1,0 +1,27 @@
+/**
+ * CredentialStore — placeholder pending Phase 4 task 2 (OS keychain + chmod
+ * 0600 file fallback). The interface is fixed now so the router/handler
+ * contract (`HandlerContext.credentialStore`) never has to change shape when
+ * the real store lands.
+ */
+export interface StoredProfile {
+  readonly host: string;
+  readonly token: string;
+}
+
+export interface CredentialStore {
+  read(): Promise<StoredProfile | null>;
+  write(profile: StoredProfile): Promise<void>;
+  clear(): Promise<void>;
+}
+
+/** Always empty — no persisted credential. Swapped for the real store in task 2. */
+export class NullCredentialStore implements CredentialStore {
+  async read(): Promise<StoredProfile | null> {
+    return null;
+  }
+
+  async write(): Promise<void> {}
+
+  async clear(): Promise<void> {}
+}

--- a/packages/cli/src/exit-codes.ts
+++ b/packages/cli/src/exit-codes.ts
@@ -1,0 +1,6 @@
+/** Fixed CLI exit code contract (Phase 4 task 1) — every future command tests against this. */
+export const EXIT_SUCCESS = 0;
+export const EXIT_RUNTIME_ERROR = 1;
+export const EXIT_USAGE_ERROR = 2;
+
+export type ExitCode = typeof EXIT_SUCCESS | typeof EXIT_RUNTIME_ERROR | typeof EXIT_USAGE_ERROR;

--- a/packages/cli/src/handler-context.ts
+++ b/packages/cli/src/handler-context.ts
@@ -1,0 +1,16 @@
+import type { PageSpaceClient } from '@pagespace/sdk';
+import type { CredentialStore } from './credential-store.js';
+
+/** Minimal write sink handlers use instead of touching `process.stdout`/`process.stderr` directly. */
+export interface OutputSink {
+  write(chunk: string): void;
+}
+
+/** Everything a command handler needs, injected — no handler reads `process.*` directly. */
+export interface HandlerContext {
+  readonly sdk: PageSpaceClient;
+  readonly stdout: OutputSink;
+  readonly stderr: OutputSink;
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly credentialStore: CredentialStore;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,30 @@
+// argv grammar — the pure entry point every command's tests parse through.
+export { parseArgv } from './argv/parse.js';
+export type { CommandIntent, ParsedFlags, ParseResult, UsageError } from './argv/parse.js';
+
+// Config precedence resolver (flags > env > profile > defaults).
+export { DEFAULT_HOST, resolveConfig } from './config/resolve.js';
+export type { ConfigEnv, ConfigFlags, ConfigProfile, ConfigSources, ResolvedConfig } from './config/resolve.js';
+
+// Router — resolves a parsed command path to a handler.
+export { resolveRoute } from './router/router.js';
+export type { CommandHandler, Route, RouteResolution } from './router/router.js';
+
+// Handler context — what every command handler receives instead of `process.*`.
+export type { HandlerContext, OutputSink } from './handler-context.js';
+
+// Credential store — placeholder pending Phase 4 task 2.
+export { NullCredentialStore } from './credential-store.js';
+export type { CredentialStore, StoredProfile } from './credential-store.js';
+
+// Fixed exit code contract.
+export { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from './exit-codes.js';
+export type { ExitCode } from './exit-codes.js';
+
+// Built-in commands.
+export { helpHandler } from './commands/help.js';
+export { CLI_VERSION, versionHandler } from './commands/version.js';
+
+// Composition root.
+export { run } from './run.js';
+export type { RunDependencies } from './run.js';

--- a/packages/cli/src/router/__tests__/router.test.ts
+++ b/packages/cli/src/router/__tests__/router.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveRoute } from '@pagespace/cli';
+import type { Route } from '@pagespace/cli';
+
+function route(path: string[]): Route {
+  return { path, handler: vi.fn(async () => 0) };
+}
+
+describe('resolveRoute', () => {
+  it('matches a single-segment route', () => {
+    const help = route(['help']);
+    const result = resolveRoute([help], ['help']);
+    expect(result).toEqual({ kind: 'match', route: help, rest: [] });
+  });
+
+  it('matches a multi-segment route and returns trailing args as rest', () => {
+    const tokensCreate = route(['tokens', 'create']);
+    const result = resolveRoute([tokensCreate], ['tokens', 'create', '--extra']);
+    expect(result).toEqual({ kind: 'match', route: tokensCreate, rest: ['--extra'] });
+  });
+
+  it('prefers the longest matching path when routes overlap', () => {
+    const tokens = route(['tokens']);
+    const tokensCreate = route(['tokens', 'create']);
+    const result = resolveRoute([tokens, tokensCreate], ['tokens', 'create']);
+    expect(result).toEqual({ kind: 'match', route: tokensCreate, rest: [] });
+  });
+
+  it('returns a usage error for an unknown command', () => {
+    const result = resolveRoute([route(['help'])], ['nope']);
+    expect(result).toEqual({ kind: 'usage-error', message: 'Unknown command: nope' });
+  });
+
+  it('returns a usage error when no args are given', () => {
+    const result = resolveRoute([route(['help'])], []);
+    expect(result.kind).toBe('usage-error');
+  });
+});

--- a/packages/cli/src/router/__tests__/router.test.ts
+++ b/packages/cli/src/router/__tests__/router.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveRoute } from '@pagespace/cli';
-import type { Route } from '@pagespace/cli';
+import { EXIT_SUCCESS, resolveRoute } from '@pagespace/cli';
+import type { ExitCode, Route } from '@pagespace/cli';
 
 function route(path: string[]): Route {
-  return { path, handler: vi.fn(async () => 0) };
+  return { path, handler: vi.fn(async (): Promise<ExitCode> => EXIT_SUCCESS) };
 }
 
 describe('resolveRoute', () => {

--- a/packages/cli/src/router/router.ts
+++ b/packages/cli/src/router/router.ts
@@ -1,0 +1,35 @@
+/**
+ * Router — resolves a parsed `CommandIntent.args` path against a static route
+ * table. Longest-prefix match so a route like `['tokens']` and a more
+ * specific `['tokens', 'create']` can coexist; unmatched args are a typed
+ * usage error, never a thrown exception.
+ */
+import type { CommandIntent } from '../argv/parse.js';
+import type { ExitCode } from '../exit-codes.js';
+import type { HandlerContext } from '../handler-context.js';
+
+export type CommandHandler = (ctx: HandlerContext, intent: CommandIntent) => Promise<ExitCode>;
+
+export interface Route {
+  readonly path: readonly string[];
+  readonly handler: CommandHandler;
+}
+
+export type RouteResolution =
+  | { readonly kind: 'match'; readonly route: Route; readonly rest: readonly string[] }
+  | { readonly kind: 'usage-error'; readonly message: string };
+
+export function resolveRoute(routes: readonly Route[], args: readonly string[]): RouteResolution {
+  if (args.length === 0) {
+    return { kind: 'usage-error', message: 'No command given. Run "pagespace help" to see available commands.' };
+  }
+
+  const byLongestPathFirst = [...routes].sort((a, b) => b.path.length - a.path.length);
+  for (const route of byLongestPathFirst) {
+    if (route.path.length > 0 && route.path.length <= args.length && route.path.every((segment, i) => segment === args[i])) {
+      return { kind: 'match', route, rest: args.slice(route.path.length) };
+    }
+  }
+
+  return { kind: 'usage-error', message: `Unknown command: ${args.join(' ')}` };
+}

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,0 +1,63 @@
+/**
+ * run() — the composition root. Takes argv/env/stdout/stderr/credentialStore
+ * as plain injected values (no `process.*` reference anywhere in this file)
+ * and returns an exit code; `bin.ts` is the only caller that touches the
+ * real process.
+ */
+import { PageSpaceClient, StaticTokenProvider } from '@pagespace/sdk';
+import { parseArgv } from './argv/parse.js';
+import { helpHandler } from './commands/help.js';
+import { versionHandler } from './commands/version.js';
+import { resolveConfig } from './config/resolve.js';
+import type { CredentialStore } from './credential-store.js';
+import { EXIT_USAGE_ERROR, type ExitCode } from './exit-codes.js';
+import type { HandlerContext, OutputSink } from './handler-context.js';
+import { resolveRoute, type Route } from './router/router.js';
+
+export interface RunDependencies {
+  readonly argv: readonly string[];
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly stdout: OutputSink;
+  readonly stderr: OutputSink;
+  readonly credentialStore: CredentialStore;
+}
+
+const ROUTES: readonly Route[] = [{ path: ['help'], handler: helpHandler }];
+
+export async function run(deps: RunDependencies): Promise<ExitCode> {
+  const parsed = parseArgv(deps.argv);
+  if (parsed.kind === 'usage-error') {
+    deps.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const profile = await deps.credentialStore.read();
+  const config = resolveConfig({
+    flags: { host: parsed.flags.host, token: parsed.flags.token },
+    env: { PAGESPACE_TOKEN: deps.env.PAGESPACE_TOKEN, PAGESPACE_API_URL: deps.env.PAGESPACE_API_URL },
+    profile,
+  });
+
+  const ctx: HandlerContext = {
+    sdk: new PageSpaceClient({ baseUrl: config.host, auth: new StaticTokenProvider(config.token ?? '') }),
+    stdout: deps.stdout,
+    stderr: deps.stderr,
+    env: deps.env,
+    credentialStore: deps.credentialStore,
+  };
+
+  if (parsed.flags.version) {
+    return versionHandler(ctx, parsed);
+  }
+  if (parsed.flags.help && parsed.args.length === 0) {
+    return helpHandler(ctx, parsed);
+  }
+
+  const resolution = resolveRoute(ROUTES, parsed.args);
+  if (resolution.kind === 'usage-error') {
+    deps.stderr.write(`${resolution.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  return resolution.route.handler(ctx, { ...parsed, args: resolution.rest });
+}

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/__tests__/**"]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "paths": {}
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx,js,jsx}'],
+  },
+});


### PR DESCRIPTION
## Summary
Scaffolds `packages/cli` (`@pagespace/cli`), the first task of Phase 4 — CLI Foundation & Auth. This is the router/parsing/config foundation every later CLI task (credential store, login, tokens, whoami) builds on.

- `parseArgv(argv)`: pure grammar → typed `CommandIntent` or `UsageError`. Global flags `--json`, `--host <url>`, `--token <t>`, `--yes`, `--help`, `--version`. Unknown flags / missing flag values are usage errors (exit 2), never thrown, never leak the offending value.
- `resolveConfig`: pure precedence resolver — `--token`/`--host` flags > `PAGESPACE_TOKEN`/`PAGESPACE_API_URL` env > stored profile > defaults (default host `https://pagespace.ai`, the same fixture host already used throughout `packages/sdk`'s transport tests).
- `resolveRoute`: longest-prefix match over a static route table (so a future `tokens create` can coexist with a shorter `tokens`).
- `run()`: the sole composition root — resolves config, builds a `PageSpaceClient`, dispatches through the router. `bin.ts` is the only file that touches `process.argv`/`process.env`/`process.stdout`/`process.exitCode`; every handler receives an injected `{ sdk, stdout, stderr, env, credentialStore }` context.
- `help`/`version` built-in commands — `--json` writes only the JSON payload to stdout, nothing else.
- `CredentialStore`/`NullCredentialStore`: interface fixed now so the handler contract doesn't change shape when Phase 4 task 2 lands the real OS-keychain + chmod-0600-file implementation.
- Fixed exit code contract: `0` success, `1` API/runtime error (reserved), `2` usage error.
- `package.json` (`bin: { pagespace: ./dist/bin.js }`, `exports`, `files`), `tsconfig.json`/`tsconfig.build.json`/`vitest.config.ts` following `packages/sdk`'s conventions exactly; depends on `@pagespace/sdk` (workspace).

TDD: RED commit adds the full scaffolding + 47 failing tests (fails because no `src/*.ts` implementation exists yet); GREEN commit adds the implementation until green.

## Test plan
- [x] `bun install && bun run --filter '@pagespace/cli' typecheck && bun run --filter '@pagespace/cli' test` green from a clean worktree (after building `@pagespace/db` + `@pagespace/lib` + `@pagespace/sdk` first)
- [x] `turbo typecheck --filter='@pagespace/cli...'` confirms turbo's `^build` dependency wiring builds db/lib/sdk ahead of cli automatically
- [x] Manual smoke test of the compiled binary: `pagespace help`, `pagespace --version[--json]`, unknown command/flag → exit 2, bare invocation → exit 2
- [x] Verified `dist/bin.js` is chmod +x after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Du5FGmq3itmkzt69fUrDV