### PR TITLE
cli: implement credential store (keychain + 0600 fallback) — Phase 4 task 2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -465,6 +465,7 @@
         "pagespace": "./dist/bin.js",
       },
       "dependencies": {
+        "@napi-rs/keyring": "^1.3.0",
         "@pagespace/sdk": "workspace:*",
       },
     },
@@ -1094,6 +1095,32 @@
     "@napi-rs/canvas-win32-arm64-msvc": ["@napi-rs/canvas-win32-arm64-msvc@0.1.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw=="],
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.100", "", { "os": "win32", "cpu": "x64" }, "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA=="],
+
+    "@napi-rs/keyring": ["@napi-rs/keyring@1.3.0", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.3.0", "@napi-rs/keyring-darwin-x64": "1.3.0", "@napi-rs/keyring-freebsd-x64": "1.3.0", "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0", "@napi-rs/keyring-linux-arm64-gnu": "1.3.0", "@napi-rs/keyring-linux-arm64-musl": "1.3.0", "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-musl": "1.3.0", "@napi-rs/keyring-win32-arm64-msvc": "1.3.0", "@napi-rs/keyring-win32-ia32-msvc": "1.3.0", "@napi-rs/keyring-win32-x64-msvc": "1.3.0" } }, "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA=="],
+
+    "@napi-rs/keyring-darwin-arm64": ["@napi-rs/keyring-darwin-arm64@1.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ=="],
+
+    "@napi-rs/keyring-darwin-x64": ["@napi-rs/keyring-darwin-x64@1.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw=="],
+
+    "@napi-rs/keyring-freebsd-x64": ["@napi-rs/keyring-freebsd-x64@1.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw=="],
+
+    "@napi-rs/keyring-linux-arm-gnueabihf": ["@napi-rs/keyring-linux-arm-gnueabihf@1.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ=="],
+
+    "@napi-rs/keyring-linux-arm64-gnu": ["@napi-rs/keyring-linux-arm64-gnu@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg=="],
+
+    "@napi-rs/keyring-linux-arm64-musl": ["@napi-rs/keyring-linux-arm64-musl@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw=="],
+
+    "@napi-rs/keyring-linux-riscv64-gnu": ["@napi-rs/keyring-linux-riscv64-gnu@1.3.0", "", { "os": "linux", "cpu": "none" }, "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ=="],
+
+    "@napi-rs/keyring-linux-x64-gnu": ["@napi-rs/keyring-linux-x64-gnu@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A=="],
+
+    "@napi-rs/keyring-linux-x64-musl": ["@napi-rs/keyring-linux-x64-musl@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw=="],
+
+    "@napi-rs/keyring-win32-arm64-msvc": ["@napi-rs/keyring-win32-arm64-msvc@1.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw=="],
+
+    "@napi-rs/keyring-win32-ia32-msvc": ["@napi-rs/keyring-win32-ia32-msvc@1.3.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ=="],
+
+    "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@1.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@napi-rs/keyring": "^1.3.0",
     "@pagespace/sdk": "workspace:*"
   }
 }

--- a/packages/cli/src/credentials/__tests__/fake-keychain.ts
+++ b/packages/cli/src/credentials/__tests__/fake-keychain.ts
@@ -1,0 +1,52 @@
+import type { KeychainAdapter, KeychainCredential } from '@pagespace/cli';
+
+/** In-memory `KeychainAdapter` standing in for a working OS keychain in tests. */
+export function createFakeKeychainAdapter(): KeychainAdapter & { readonly calls: string[] } {
+  const secrets = new Map<string, string>();
+  const calls: string[] = [];
+  return {
+    calls,
+    async getSecret(account: string) {
+      calls.push(`getSecret:${account}`);
+      return secrets.get(account) ?? null;
+    },
+    async setSecret(account: string, secret: string) {
+      calls.push(`setSecret:${account}`);
+      secrets.set(account, secret);
+    },
+    async deleteSecret(account: string) {
+      calls.push(`deleteSecret:${account}`);
+      secrets.delete(account);
+    },
+    async listSecrets(): Promise<readonly KeychainCredential[]> {
+      calls.push('listSecrets');
+      return [...secrets.entries()].map(([account, secret]) => ({ account, secret }));
+    },
+  };
+}
+
+/** A `KeychainAdapter` that always throws, simulating an unavailable OS keychain. */
+export function createUnavailableKeychainAdapter(message = 'no secret service running'): KeychainAdapter & {
+  readonly calls: string[];
+} {
+  const calls: string[] = [];
+  const fail = (label: string): never => {
+    calls.push(label);
+    throw new Error(message);
+  };
+  return {
+    calls,
+    async getSecret(account: string) {
+      return fail(`getSecret:${account}`);
+    },
+    async setSecret(account: string) {
+      return fail(`setSecret:${account}`);
+    },
+    async deleteSecret(account: string) {
+      return fail(`deleteSecret:${account}`);
+    },
+    async listSecrets() {
+      return fail('listSecrets');
+    },
+  };
+}

--- a/packages/cli/src/credentials/__tests__/file-store.test.ts
+++ b/packages/cli/src/credentials/__tests__/file-store.test.ts
@@ -1,0 +1,161 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FileCredentialStore, PermissionError } from '@pagespace/cli';
+import type { HostCredential } from '@pagespace/cli';
+
+const CRED_A: HostCredential = {
+  refreshToken: 'ps_rt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  clientId: 'cli-first-party',
+  scopes: ['drives:read'],
+  createdAt: '2026-07-03T00:00:00.000Z',
+};
+
+const CRED_B: HostCredential = {
+  refreshToken: 'ps_rt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  clientId: 'cli-first-party',
+  scopes: ['*'],
+  createdAt: '2026-07-03T01:00:00.000Z',
+};
+
+let root: string;
+let credentialsPath: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(join(tmpdir(), 'pagespace-cli-credstore-'));
+  credentialsPath = join(root, 'nested', 'credentials.json');
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+function mode(stat: { mode: number }): number {
+  return stat.mode & 0o777;
+}
+
+describe('FileCredentialStore', () => {
+  it('get() on a missing file returns null and creates nothing', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    expect(await store.get('pagespace.ai')).toBeNull();
+    await expect(fs.stat(credentialsPath)).rejects.toThrow();
+  });
+
+  it('list() on a missing file returns an empty array', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    expect(await store.list()).toEqual([]);
+  });
+
+  it('round-trips a single host credential', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    expect(await store.get('pagespace.ai')).toEqual(CRED_A);
+  });
+
+  it('creates the parent directory at 0700 and the file at 0600', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+
+    const dirStat = await fs.stat(join(root, 'nested'));
+    const fileStat = await fs.stat(credentialsPath);
+    expect(mode(dirStat)).toBe(0o700);
+    expect(mode(fileStat)).toBe(0o600);
+  });
+
+  it('writes atomically: no leftover temp file, valid JSON at the final path', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await store.set('pagespace.ai', CRED_B);
+
+    const entries = await fs.readdir(join(root, 'nested'));
+    expect(entries).toEqual(['credentials.json']);
+
+    const raw = await fs.readFile(credentialsPath, 'utf8');
+    expect(() => JSON.parse(raw)).not.toThrow();
+  });
+
+  it('supports multiple hosts independently', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await store.set('self-hosted.example', CRED_B);
+
+    expect(await store.get('pagespace.ai')).toEqual(CRED_A);
+    expect(await store.get('self-hosted.example')).toEqual(CRED_B);
+
+    const summaries = await store.list();
+    expect(summaries).toHaveLength(2);
+    expect(summaries.map((entry) => entry.host).sort()).toEqual(['pagespace.ai', 'self-hosted.example']);
+  });
+
+  it('delete() removes only the named host', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await store.set('self-hosted.example', CRED_B);
+
+    await store.delete('pagespace.ai');
+
+    expect(await store.get('pagespace.ai')).toBeNull();
+    expect(await store.get('self-hosted.example')).toEqual(CRED_B);
+  });
+
+  it('delete() of an unknown host is a no-op, not an error', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await expect(store.delete('unknown.example')).resolves.toBeUndefined();
+    expect(await store.get('pagespace.ai')).toEqual(CRED_A);
+  });
+
+  it('list() never includes token material, only host + prefix', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+
+    const serialized = JSON.stringify(await store.list());
+    expect(serialized).not.toContain(CRED_A.refreshToken);
+    expect(serialized).toContain('pagespace.ai');
+  });
+
+  it('refuses to read a group-readable credentials file (fail closed)', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await fs.chmod(credentialsPath, 0o640);
+
+    await expect(store.get('pagespace.ai')).rejects.toThrow(PermissionError);
+    await expect(store.list()).rejects.toThrow(PermissionError);
+  });
+
+  it('refuses to read an other-readable credentials file (fail closed)', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await fs.chmod(credentialsPath, 0o604);
+
+    await expect(store.get('pagespace.ai')).rejects.toThrow(PermissionError);
+  });
+
+  it('permission error message names the file and a chmod fix-it, no token content', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await fs.chmod(credentialsPath, 0o644);
+
+    await expect(store.get('pagespace.ai')).rejects.toThrow(/chmod 600/i);
+    try {
+      await store.get('pagespace.ai');
+      expect.unreachable();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain(credentialsPath);
+      expect(message).not.toContain(CRED_A.refreshToken);
+    }
+  });
+
+  it('re-secures a permissive parent directory on every write (floor enforced both directions)', async () => {
+    const store = new FileCredentialStore({ path: credentialsPath });
+    await store.set('pagespace.ai', CRED_A);
+    await fs.chmod(join(root, 'nested'), 0o755);
+
+    await store.set('pagespace.ai', CRED_B);
+
+    const dirStat = await fs.stat(join(root, 'nested'));
+    expect(mode(dirStat)).toBe(0o700);
+  });
+});

--- a/packages/cli/src/credentials/__tests__/serialize.test.ts
+++ b/packages/cli/src/credentials/__tests__/serialize.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CredentialsFileFormatError,
+  emptyCredentialsFile,
+  getHost,
+  isSecureMode,
+  listSummaries,
+  parseCredentialsFile,
+  parseHostCredential,
+  permissionFixItMessage,
+  removeHost,
+  serializeCredentialsFile,
+  serializeHostCredential,
+  tokenPrefix,
+  upsertHost,
+} from '@pagespace/cli';
+import type { CredentialsFile, HostCredential } from '@pagespace/cli';
+
+const CRED_A: HostCredential = {
+  refreshToken: 'ps_rt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  clientId: 'cli-first-party',
+  scopes: ['drives:read', 'drives:write'],
+  createdAt: '2026-07-03T00:00:00.000Z',
+};
+
+const CRED_B: HostCredential = {
+  refreshToken: 'ps_rt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  clientId: 'cli-first-party',
+  scopes: ['*'],
+  createdAt: '2026-07-03T01:00:00.000Z',
+};
+
+describe('emptyCredentialsFile', () => {
+  it('starts with version 1 and no hosts', () => {
+    expect(emptyCredentialsFile()).toEqual({ version: 1, hosts: {} });
+  });
+});
+
+describe('upsertHost / getHost / removeHost', () => {
+  it('is pure: does not mutate the input file', () => {
+    const file = emptyCredentialsFile();
+    const next = upsertHost(file, 'pagespace.ai', CRED_A);
+    expect(file).toEqual({ version: 1, hosts: {} });
+    expect(getHost(next, 'pagespace.ai')).toEqual(CRED_A);
+  });
+
+  it('supports multiple hosts independently', () => {
+    let file = emptyCredentialsFile();
+    file = upsertHost(file, 'pagespace.ai', CRED_A);
+    file = upsertHost(file, 'self-hosted.example', CRED_B);
+    expect(getHost(file, 'pagespace.ai')).toEqual(CRED_A);
+    expect(getHost(file, 'self-hosted.example')).toEqual(CRED_B);
+  });
+
+  it('getHost returns null for an unknown host', () => {
+    expect(getHost(emptyCredentialsFile(), 'unknown.example')).toBeNull();
+  });
+
+  it('removeHost drops only the named host, pure', () => {
+    let file = emptyCredentialsFile();
+    file = upsertHost(file, 'pagespace.ai', CRED_A);
+    file = upsertHost(file, 'self-hosted.example', CRED_B);
+    const next = removeHost(file, 'pagespace.ai');
+    expect(getHost(next, 'pagespace.ai')).toBeNull();
+    expect(getHost(next, 'self-hosted.example')).toEqual(CRED_B);
+    expect(getHost(file, 'pagespace.ai')).toEqual(CRED_A);
+  });
+
+  it('removeHost on a missing host is a no-op', () => {
+    const file = upsertHost(emptyCredentialsFile(), 'pagespace.ai', CRED_A);
+    expect(removeHost(file, 'unknown.example')).toEqual(file);
+  });
+});
+
+describe('serializeCredentialsFile / parseCredentialsFile round-trip', () => {
+  it('round-trips an empty file', () => {
+    const file = emptyCredentialsFile();
+    expect(parseCredentialsFile(serializeCredentialsFile(file))).toEqual(file);
+  });
+
+  it('round-trips a multi-host file', () => {
+    let file = emptyCredentialsFile();
+    file = upsertHost(file, 'pagespace.ai', CRED_A);
+    file = upsertHost(file, 'self-hosted.example', CRED_B);
+    expect(parseCredentialsFile(serializeCredentialsFile(file))).toEqual(file);
+  });
+
+  it('rejects invalid JSON', () => {
+    expect(() => parseCredentialsFile('{not json')).toThrow(CredentialsFileFormatError);
+  });
+
+  it('rejects an unsupported version', () => {
+    expect(() => parseCredentialsFile(JSON.stringify({ version: 99, hosts: {} }))).toThrow(
+      CredentialsFileFormatError,
+    );
+  });
+
+  it('rejects a malformed host entry (missing refreshToken)', () => {
+    const raw = JSON.stringify({
+      version: 1,
+      hosts: { 'pagespace.ai': { clientId: 'x', scopes: [], createdAt: '2026-01-01T00:00:00.000Z' } },
+    });
+    expect(() => parseCredentialsFile(raw)).toThrow(CredentialsFileFormatError);
+  });
+
+  it('rejects a host entry with non-string scopes', () => {
+    const raw = JSON.stringify({
+      version: 1,
+      hosts: {
+        'pagespace.ai': { refreshToken: 't', clientId: 'x', scopes: [1, 2], createdAt: '2026-01-01T00:00:00.000Z' },
+      },
+    });
+    expect(() => parseCredentialsFile(raw)).toThrow(CredentialsFileFormatError);
+  });
+});
+
+describe('listSummaries', () => {
+  it('exposes host + tokenPrefix only, sorted by host, never the full token', () => {
+    let file: CredentialsFile = emptyCredentialsFile();
+    file = upsertHost(file, 'self-hosted.example', CRED_B);
+    file = upsertHost(file, 'pagespace.ai', CRED_A);
+
+    const summaries = listSummaries(file);
+
+    expect(summaries).toEqual([
+      { host: 'pagespace.ai', tokenPrefix: tokenPrefix(CRED_A.refreshToken) },
+      { host: 'self-hosted.example', tokenPrefix: tokenPrefix(CRED_B.refreshToken) },
+    ]);
+
+    const serialized = JSON.stringify(summaries);
+    expect(serialized).not.toContain(CRED_A.refreshToken);
+    expect(serialized).not.toContain(CRED_B.refreshToken);
+    expect(Object.keys(summaries[0] as object).sort()).toEqual(['host', 'tokenPrefix']);
+  });
+});
+
+describe('tokenPrefix', () => {
+  it('truncates to a short, non-reversible prefix', () => {
+    const long = 'ps_rt_0123456789abcdefghijklmnopqrstuvwxyz';
+    const prefix = tokenPrefix(long);
+    expect(prefix.length).toBeLessThan(long.length);
+    expect(long.startsWith(prefix)).toBe(true);
+  });
+
+  it('never grows longer than the input', () => {
+    expect(tokenPrefix('short').length).toBeLessThanOrEqual('short'.length);
+  });
+});
+
+describe('serializeHostCredential / parseHostCredential round-trip (keychain secret encoding)', () => {
+  it('round-trips a credential', () => {
+    expect(parseHostCredential(serializeHostCredential(CRED_A))).toEqual(CRED_A);
+  });
+
+  it('rejects a malformed secret', () => {
+    expect(() => parseHostCredential('{"refreshToken":"x"}')).toThrow(CredentialsFileFormatError);
+  });
+
+  it('rejects non-JSON secrets', () => {
+    expect(() => parseHostCredential('not json at all')).toThrow(CredentialsFileFormatError);
+  });
+});
+
+describe('isSecureMode', () => {
+  it('accepts 0600 (owner read/write only)', () => {
+    expect(isSecureMode(0o600)).toBe(true);
+  });
+
+  it('accepts 0700 (owner-only directory)', () => {
+    expect(isSecureMode(0o700)).toBe(true);
+  });
+
+  it('rejects group-readable 0640', () => {
+    expect(isSecureMode(0o640)).toBe(false);
+  });
+
+  it('rejects other-readable 0604', () => {
+    expect(isSecureMode(0o604)).toBe(false);
+  });
+
+  it('rejects world-writable 0666', () => {
+    expect(isSecureMode(0o666)).toBe(false);
+  });
+});
+
+describe('permissionFixItMessage', () => {
+  it('names the offending path and a chmod fix-it, never any credential content', () => {
+    const message = permissionFixItMessage('/home/user/.pagespace/credentials.json', 0o644);
+    expect(message).toContain('/home/user/.pagespace/credentials.json');
+    expect(message.toLowerCase()).toContain('chmod 600');
+  });
+});

--- a/packages/cli/src/credentials/__tests__/store.test.ts
+++ b/packages/cli/src/credentials/__tests__/store.test.ts
@@ -1,0 +1,127 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CompositeCredentialStore, FileCredentialStore } from '@pagespace/cli';
+import type { HostCredential, OutputSink } from '@pagespace/cli';
+import { createFakeKeychainAdapter, createUnavailableKeychainAdapter } from './fake-keychain.js';
+
+const CRED_A: HostCredential = {
+  refreshToken: 'ps_rt_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  clientId: 'cli-first-party',
+  scopes: ['drives:read'],
+  createdAt: '2026-07-03T00:00:00.000Z',
+};
+
+const CRED_B: HostCredential = {
+  refreshToken: 'ps_rt_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  clientId: 'cli-first-party',
+  scopes: ['*'],
+  createdAt: '2026-07-03T01:00:00.000Z',
+};
+
+function fakeSink(): OutputSink & { readonly lines: string[] } {
+  const lines: string[] = [];
+  return { lines, write: (chunk: string) => lines.push(chunk) };
+}
+
+let root: string;
+let credentialsPath: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(join(tmpdir(), 'pagespace-cli-credstore-composite-'));
+  credentialsPath = join(root, 'credentials.json');
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe('CompositeCredentialStore — keychain available', () => {
+  it('uses the keychain and never touches the file store', async () => {
+    const keychain = createFakeKeychainAdapter();
+    const fileStore = new FileCredentialStore({ path: credentialsPath });
+    const stderr = fakeSink();
+    const store = new CompositeCredentialStore(keychain, fileStore, stderr);
+
+    await store.set('pagespace.ai', CRED_A);
+    const got = await store.get('pagespace.ai');
+
+    expect(got).toEqual(CRED_A);
+    expect(keychain.calls).toContain('setSecret:pagespace.ai');
+    await expect(fs.stat(credentialsPath)).rejects.toThrow();
+    expect(stderr.lines).toEqual([]);
+  });
+
+  it('list() never exposes token material', async () => {
+    const keychain = createFakeKeychainAdapter();
+    const store = new CompositeCredentialStore(keychain, new FileCredentialStore({ path: credentialsPath }), fakeSink());
+
+    await store.set('pagespace.ai', CRED_A);
+    await store.set('self-hosted.example', CRED_B);
+
+    const summaries = await store.list();
+    expect(summaries.map((entry) => entry.host).sort()).toEqual(['pagespace.ai', 'self-hosted.example']);
+
+    const serialized = JSON.stringify(summaries);
+    expect(serialized).not.toContain(CRED_A.refreshToken);
+    expect(serialized).not.toContain(CRED_B.refreshToken);
+  });
+
+  it('delete() removes from the keychain', async () => {
+    const keychain = createFakeKeychainAdapter();
+    const store = new CompositeCredentialStore(keychain, new FileCredentialStore({ path: credentialsPath }), fakeSink());
+
+    await store.set('pagespace.ai', CRED_A);
+    await store.delete('pagespace.ai');
+
+    expect(await store.get('pagespace.ai')).toBeNull();
+  });
+});
+
+describe('CompositeCredentialStore — keychain unavailable', () => {
+  it('degrades to the file store and prints exactly one stderr notice', async () => {
+    const keychain = createUnavailableKeychainAdapter('no secret service running');
+    const fileStore = new FileCredentialStore({ path: credentialsPath });
+    const stderr = fakeSink();
+    const store = new CompositeCredentialStore(keychain, fileStore, stderr);
+
+    await store.set('pagespace.ai', CRED_A);
+    const got = await store.get('pagespace.ai');
+    await store.list();
+
+    expect(got).toEqual(CRED_A);
+    expect(await fileStore.get('pagespace.ai')).toEqual(CRED_A);
+    expect(stderr.lines).toHaveLength(1);
+    expect(stderr.lines[0]).toMatch(/keychain unavailable/i);
+  });
+
+  it('stops calling the keychain after the first failure (degrade is sticky)', async () => {
+    const keychain = createUnavailableKeychainAdapter();
+    const store = new CompositeCredentialStore(keychain, new FileCredentialStore({ path: credentialsPath }), fakeSink());
+
+    await store.set('pagespace.ai', CRED_A);
+    await store.get('pagespace.ai');
+    await store.list();
+
+    expect(keychain.calls).toEqual(['setSecret:pagespace.ai']);
+  });
+
+  it('never crashes the caller — falls back transparently', async () => {
+    const keychain = createUnavailableKeychainAdapter();
+    const store = new CompositeCredentialStore(keychain, new FileCredentialStore({ path: credentialsPath }), fakeSink());
+
+    await expect(store.set('pagespace.ai', CRED_A)).resolves.toBeUndefined();
+    await expect(store.get('pagespace.ai')).resolves.toEqual(CRED_A);
+  });
+
+  it('never puts token material in the stderr notice', async () => {
+    const keychain = createUnavailableKeychainAdapter();
+    const stderr = fakeSink();
+    const store = new CompositeCredentialStore(keychain, new FileCredentialStore({ path: credentialsPath }), stderr);
+
+    await store.set('pagespace.ai', CRED_A);
+
+    expect(stderr.lines.join('')).not.toContain(CRED_A.refreshToken);
+  });
+});

--- a/packages/cli/src/credentials/file-store.ts
+++ b/packages/cli/src/credentials/file-store.ts
@@ -1,0 +1,106 @@
+/**
+ * File-fallback `CredentialStore` — `~/.pagespace/credentials.json`, mode 0600
+ * (parent dir 0700), written atomically (temp file + rename). Refuses to read
+ * a file with group/other permissions (fail closed) rather than silently
+ * trusting it. All (de)serialization/permission decisions are pure functions
+ * from serialize.ts; this class is the only place that touches `node:fs`.
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  emptyCredentialsFile,
+  getHost,
+  isSecureMode,
+  listSummaries,
+  parseCredentialsFile,
+  permissionFixItMessage,
+  removeHost,
+  serializeCredentialsFile,
+  upsertHost,
+} from './serialize.js';
+import type { CredentialsFile, CredentialSummary, HostCredential } from './serialize.js';
+
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PermissionError';
+  }
+}
+
+export function defaultCredentialsPath(): string {
+  return join(homedir(), '.pagespace', 'credentials.json');
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+export interface FileCredentialStoreOptions {
+  readonly path?: string;
+}
+
+export class FileCredentialStore {
+  private readonly path: string;
+
+  constructor(options: FileCredentialStoreOptions = {}) {
+    this.path = options.path ?? defaultCredentialsPath();
+  }
+
+  async get(host: string): Promise<HostCredential | null> {
+    const file = await this.readFile();
+    return getHost(file, host);
+  }
+
+  async set(host: string, credential: HostCredential): Promise<void> {
+    const file = await this.readFile();
+    await this.writeFile(upsertHost(file, host, credential));
+  }
+
+  async delete(host: string): Promise<void> {
+    const file = await this.readFile();
+    await this.writeFile(removeHost(file, host));
+  }
+
+  async list(): Promise<readonly CredentialSummary[]> {
+    return listSummaries(await this.readFile());
+  }
+
+  private async readFile(): Promise<CredentialsFile> {
+    let stat;
+    try {
+      stat = await fs.stat(this.path);
+    } catch (error) {
+      if (isErrnoException(error) && error.code === 'ENOENT') {
+        return emptyCredentialsFile();
+      }
+      throw error;
+    }
+
+    const mode = stat.mode & 0o777;
+    if (!isSecureMode(mode)) {
+      throw new PermissionError(permissionFixItMessage(this.path, mode));
+    }
+
+    const raw = await fs.readFile(this.path, 'utf8');
+    return parseCredentialsFile(raw);
+  }
+
+  private async writeFile(file: CredentialsFile): Promise<void> {
+    const dir = dirname(this.path);
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    await fs.chmod(dir, 0o700);
+
+    const serialized = serializeCredentialsFile(file);
+    const tmpPath = `${this.path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+    const handle = await fs.open(tmpPath, 'w', 0o600);
+    try {
+      await handle.writeFile(serialized, 'utf8');
+    } finally {
+      await handle.close();
+    }
+    await fs.chmod(tmpPath, 0o600);
+    await fs.rename(tmpPath, this.path);
+    await fs.chmod(this.path, 0o600);
+  }
+}

--- a/packages/cli/src/credentials/keychain.ts
+++ b/packages/cli/src/credentials/keychain.ts
@@ -1,0 +1,47 @@
+/**
+ * OS keychain adapter (macOS Keychain / libsecret / Windows Credential Manager)
+ * via `@napi-rs/keyring` — actively maintained, prebuilt per-platform binaries
+ * (no node-gyp compile step for consumers), thin wrapper over `keyring-rs`.
+ * Injected behind `KeychainAdapter` so the composite store (store.ts) and its
+ * tests never touch the native binding directly.
+ */
+import { AsyncEntry, findCredentialsAsync } from '@napi-rs/keyring';
+
+const SERVICE = 'pagespace-cli';
+
+export interface KeychainCredential {
+  readonly account: string;
+  readonly secret: string;
+}
+
+export interface KeychainAdapter {
+  getSecret(account: string): Promise<string | null>;
+  setSecret(account: string, secret: string): Promise<void>;
+  deleteSecret(account: string): Promise<void>;
+  listSecrets(): Promise<readonly KeychainCredential[]>;
+}
+
+export function createNativeKeychainAdapter(): KeychainAdapter {
+  return {
+    async getSecret(account: string): Promise<string | null> {
+      const entry = new AsyncEntry(SERVICE, account);
+      const value = await entry.getPassword();
+      return value ?? null;
+    },
+
+    async setSecret(account: string, secret: string): Promise<void> {
+      const entry = new AsyncEntry(SERVICE, account);
+      await entry.setPassword(secret);
+    },
+
+    async deleteSecret(account: string): Promise<void> {
+      const entry = new AsyncEntry(SERVICE, account);
+      await entry.deletePassword();
+    },
+
+    async listSecrets(): Promise<readonly KeychainCredential[]> {
+      const credentials = await findCredentialsAsync(SERVICE);
+      return credentials.map((credential) => ({ account: credential.account, secret: credential.password }));
+    },
+  };
+}

--- a/packages/cli/src/credentials/serialize.ts
+++ b/packages/cli/src/credentials/serialize.ts
@@ -32,53 +32,124 @@ export class CredentialsFileFormatError extends Error {
 const TOKEN_PREFIX_LENGTH = 12;
 
 export function tokenPrefix(token: string): string {
-  throw new Error('not implemented');
+  return token.slice(0, TOKEN_PREFIX_LENGTH);
 }
 
 export function emptyCredentialsFile(): CredentialsFile {
-  throw new Error('not implemented');
+  return { version: 1, hosts: {} };
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isHostCredential(value: unknown): value is HostCredential {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.refreshToken === 'string' &&
+    candidate.refreshToken.length > 0 &&
+    typeof candidate.clientId === 'string' &&
+    candidate.clientId.length > 0 &&
+    isStringArray(candidate.scopes) &&
+    typeof candidate.createdAt === 'string' &&
+    candidate.createdAt.length > 0
+  );
+}
+
+function toHostCredential(value: HostCredential): HostCredential {
+  return {
+    refreshToken: value.refreshToken,
+    clientId: value.clientId,
+    scopes: [...value.scopes],
+    createdAt: value.createdAt,
+  };
 }
 
 export function parseCredentialsFile(raw: string): CredentialsFile {
-  throw new Error('not implemented');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CredentialsFileFormatError('Credentials file is not valid JSON.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new CredentialsFileFormatError('Credentials file must contain a JSON object.');
+  }
+
+  const candidate = parsed as Record<string, unknown>;
+  if (candidate.version !== 1) {
+    throw new CredentialsFileFormatError('Unsupported or missing credentials file "version".');
+  }
+  if (typeof candidate.hosts !== 'object' || candidate.hosts === null) {
+    throw new CredentialsFileFormatError('Credentials file is missing a "hosts" object.');
+  }
+
+  const hosts: Record<string, HostCredential> = {};
+  for (const [host, value] of Object.entries(candidate.hosts as Record<string, unknown>)) {
+    if (!isHostCredential(value)) {
+      throw new CredentialsFileFormatError(`Credentials file entry for host "${host}" is malformed.`);
+    }
+    hosts[host] = toHostCredential(value);
+  }
+
+  return { version: 1, hosts };
 }
 
 export function serializeCredentialsFile(file: CredentialsFile): string {
-  throw new Error('not implemented');
+  return `${JSON.stringify(file, null, 2)}\n`;
 }
 
 export function getHost(file: CredentialsFile, host: string): HostCredential | null {
-  throw new Error('not implemented');
+  return file.hosts[host] ?? null;
 }
 
 export function upsertHost(file: CredentialsFile, host: string, credential: HostCredential): CredentialsFile {
-  throw new Error('not implemented');
+  return { version: 1, hosts: { ...file.hosts, [host]: toHostCredential(credential) } };
 }
 
 export function removeHost(file: CredentialsFile, host: string): CredentialsFile {
-  throw new Error('not implemented');
+  const hosts = { ...file.hosts };
+  delete hosts[host];
+  return { version: 1, hosts };
 }
 
 export function listSummaries(file: CredentialsFile): readonly CredentialSummary[] {
-  throw new Error('not implemented');
+  return Object.entries(file.hosts)
+    .map(([host, credential]) => ({ host, tokenPrefix: tokenPrefix(credential.refreshToken) }))
+    .sort((a, b) => a.host.localeCompare(b.host));
 }
 
 /** Encodes a single host's credential as the secret string stored in a keychain entry. */
 export function serializeHostCredential(credential: HostCredential): string {
-  throw new Error('not implemented');
+  return JSON.stringify(toHostCredential(credential));
 }
 
 export function parseHostCredential(raw: string): HostCredential {
-  throw new Error('not implemented');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CredentialsFileFormatError('Keychain secret is not valid JSON.');
+  }
+  if (!isHostCredential(parsed)) {
+    throw new CredentialsFileFormatError('Keychain secret is malformed.');
+  }
+  return toHostCredential(parsed);
 }
 
 const SECURE_MODE_MASK = 0o077;
 
 /** True iff `mode` (masked to the low 9 bits) has no group/other read/write/execute bits set. */
 export function isSecureMode(mode: number): boolean {
-  throw new Error('not implemented');
+  return (mode & SECURE_MODE_MASK) === 0;
 }
 
 export function permissionFixItMessage(path: string, mode: number): string {
-  throw new Error('not implemented');
+  const octal = (mode & 0o777).toString(8).padStart(3, '0');
+  return (
+    `Refusing to read credentials file at ${path}: mode ${octal} is readable by group/other. ` +
+    `Fix with: chmod 600 ${path}`
+  );
 }

--- a/packages/cli/src/credentials/serialize.ts
+++ b/packages/cli/src/credentials/serialize.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure (de)serialization + decision functions for the credential store.
+ * No fs/keychain I/O lives here — file-store.ts and keychain.ts are the
+ * adapters that call into these functions with data they already fetched.
+ */
+
+export interface HostCredential {
+  readonly refreshToken: string;
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+  readonly createdAt: string;
+}
+
+export interface CredentialSummary {
+  readonly host: string;
+  readonly tokenPrefix: string;
+}
+
+export interface CredentialsFile {
+  readonly version: 1;
+  readonly hosts: Readonly<Record<string, HostCredential>>;
+}
+
+export class CredentialsFileFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CredentialsFileFormatError';
+  }
+}
+
+/** Chars of a refresh token safe to show in `list()`/debug output. Never the full token. */
+const TOKEN_PREFIX_LENGTH = 12;
+
+export function tokenPrefix(token: string): string {
+  throw new Error('not implemented');
+}
+
+export function emptyCredentialsFile(): CredentialsFile {
+  throw new Error('not implemented');
+}
+
+export function parseCredentialsFile(raw: string): CredentialsFile {
+  throw new Error('not implemented');
+}
+
+export function serializeCredentialsFile(file: CredentialsFile): string {
+  throw new Error('not implemented');
+}
+
+export function getHost(file: CredentialsFile, host: string): HostCredential | null {
+  throw new Error('not implemented');
+}
+
+export function upsertHost(file: CredentialsFile, host: string, credential: HostCredential): CredentialsFile {
+  throw new Error('not implemented');
+}
+
+export function removeHost(file: CredentialsFile, host: string): CredentialsFile {
+  throw new Error('not implemented');
+}
+
+export function listSummaries(file: CredentialsFile): readonly CredentialSummary[] {
+  throw new Error('not implemented');
+}
+
+/** Encodes a single host's credential as the secret string stored in a keychain entry. */
+export function serializeHostCredential(credential: HostCredential): string {
+  throw new Error('not implemented');
+}
+
+export function parseHostCredential(raw: string): HostCredential {
+  throw new Error('not implemented');
+}
+
+const SECURE_MODE_MASK = 0o077;
+
+/** True iff `mode` (masked to the low 9 bits) has no group/other read/write/execute bits set. */
+export function isSecureMode(mode: number): boolean {
+  throw new Error('not implemented');
+}
+
+export function permissionFixItMessage(path: string, mode: number): string {
+  throw new Error('not implemented');
+}

--- a/packages/cli/src/credentials/store.ts
+++ b/packages/cli/src/credentials/store.ts
@@ -1,0 +1,116 @@
+/**
+ * The public `CredentialStore` contract (`get`/`set`/`delete`/`list` per
+ * host) plus the composite implementation: OS keychain first, degrading to
+ * the 0600 file store on the first keychain failure (headless Linux with no
+ * secret service, CI, denied Keychain access, ...). Degradation is one-way
+ * for the lifetime of the store instance and prints exactly one stderr
+ * notice — it never crashes and never silently upgrades back to keychain
+ * mid-session (that would make "where did this write go?" nondeterministic).
+ */
+import { FileCredentialStore } from './file-store.js';
+import { createNativeKeychainAdapter } from './keychain.js';
+import type { KeychainAdapter } from './keychain.js';
+import { parseHostCredential, serializeHostCredential, tokenPrefix } from './serialize.js';
+import type { CredentialSummary, HostCredential } from './serialize.js';
+
+export interface OutputSink {
+  write(chunk: string): void;
+}
+
+export interface CredentialStore {
+  get(host: string): Promise<HostCredential | null>;
+  set(host: string, credential: HostCredential): Promise<void>;
+  delete(host: string): Promise<void>;
+  list(): Promise<readonly CredentialSummary[]>;
+}
+
+const KEYCHAIN_UNAVAILABLE_NOTICE =
+  'pagespace: OS keychain unavailable, falling back to ~/.pagespace/credentials.json for credential storage';
+
+export class CompositeCredentialStore implements CredentialStore {
+  private degraded = false;
+  private noticeShown = false;
+
+  constructor(
+    private readonly keychain: KeychainAdapter,
+    private readonly fileStore: CredentialStore,
+    private readonly stderr: OutputSink,
+  ) {}
+
+  async get(host: string): Promise<HostCredential | null> {
+    return this.withFallback(
+      async () => {
+        const secret = await this.keychain.getSecret(host);
+        return secret === null ? null : parseHostCredential(secret);
+      },
+      () => this.fileStore.get(host),
+    );
+  }
+
+  async set(host: string, credential: HostCredential): Promise<void> {
+    return this.withFallback(
+      () => this.keychain.setSecret(host, serializeHostCredential(credential)),
+      () => this.fileStore.set(host, credential),
+    );
+  }
+
+  async delete(host: string): Promise<void> {
+    return this.withFallback(
+      () => this.keychain.deleteSecret(host),
+      () => this.fileStore.delete(host),
+    );
+  }
+
+  async list(): Promise<readonly CredentialSummary[]> {
+    return this.withFallback(
+      async () => {
+        const secrets = await this.keychain.listSecrets();
+        return [...secrets]
+          .map((entry) => ({
+            host: entry.account,
+            tokenPrefix: tokenPrefix(parseHostCredential(entry.secret).refreshToken),
+          }))
+          .sort((a, b) => a.host.localeCompare(b.host));
+      },
+      () => this.fileStore.list(),
+    );
+  }
+
+  private async withFallback<T>(useKeychain: () => Promise<T>, useFile: () => Promise<T>): Promise<T> {
+    if (this.degraded) {
+      return useFile();
+    }
+    try {
+      return await useKeychain();
+    } catch (error) {
+      this.degrade(error);
+      return useFile();
+    }
+  }
+
+  private degrade(error: unknown): void {
+    this.degraded = true;
+    if (!this.noticeShown) {
+      this.noticeShown = true;
+      const reason = error instanceof Error ? error.message : String(error);
+      this.stderr.write(`${KEYCHAIN_UNAVAILABLE_NOTICE} (${reason})\n`);
+    }
+  }
+}
+
+export interface CreateCredentialStoreOptions {
+  readonly credentialsPath?: string;
+  readonly keychain?: KeychainAdapter;
+  readonly stderr?: OutputSink;
+}
+
+export function createCredentialStore(options: CreateCredentialStoreOptions = {}): CredentialStore {
+  const fileStore = new FileCredentialStore({ path: options.credentialsPath });
+  const keychain = options.keychain ?? createNativeKeychainAdapter();
+  const stderr: OutputSink = options.stderr ?? {
+    write(chunk: string) {
+      process.stderr.write(chunk);
+    },
+  };
+  return new CompositeCredentialStore(keychain, fileStore, stderr);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,30 @@ export type { HandlerContext, OutputSink } from './handler-context.js';
 export { NullCredentialStore } from './credential-store.js';
 export type { CredentialStore, StoredProfile } from './credential-store.js';
 
+// Multi-host credential store (keychain + 0600 file fallback) — Phase 4 task 2.
+export { CompositeCredentialStore, createCredentialStore } from './credentials/store.js';
+export type { CredentialStore as HostCredentialStore, CreateCredentialStoreOptions } from './credentials/store.js';
+export { FileCredentialStore, PermissionError, defaultCredentialsPath } from './credentials/file-store.js';
+export type { FileCredentialStoreOptions } from './credentials/file-store.js';
+export { createNativeKeychainAdapter } from './credentials/keychain.js';
+export type { KeychainAdapter, KeychainCredential } from './credentials/keychain.js';
+export {
+  CredentialsFileFormatError,
+  emptyCredentialsFile,
+  getHost,
+  isSecureMode,
+  listSummaries,
+  parseCredentialsFile,
+  parseHostCredential,
+  permissionFixItMessage,
+  removeHost,
+  serializeCredentialsFile,
+  serializeHostCredential,
+  tokenPrefix,
+  upsertHost,
+} from './credentials/serialize.js';
+export type { CredentialSummary, CredentialsFile, HostCredential } from './credentials/serialize.js';
+
 // Fixed exit code contract.
 export { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from './exit-codes.js';
 export type { ExitCode } from './exit-codes.js';


### PR DESCRIPTION
## Summary
- Implements `interface CredentialStore { get(host)/set(host,creds)/delete(host)/list() }` in `packages/cli/src/credentials/`: pure (de)serialization + permission-mode decisions in `serialize.ts`, an atomic 0600/0700 file fallback (`file-store.ts`), an OS-keychain adapter (`keychain.ts`), and a composite store (`store.ts`) that tries the keychain first and degrades to the file fallback on first failure with a one-time stderr notice.
- Keychain library: [`@napi-rs/keyring`](https://github.com/Brooooooklyn/keyring-node) — actively maintained (napi-rs), prebuilt per-platform binaries (no node-gyp compile step for consumers), wraps `keyring-rs` (macOS Keychain / libsecret / Windows Credential Manager). Chosen over `keytar`, which has been unmaintained since 2023.
- Per-host schema exactly per ADR 0003 §3.5: `{ refreshToken, clientId, scopes, createdAt }` — access tokens are never persisted here (ephemeral, memory-only elsewhere).
- Zero-trust floor enforced both directions: writes always create dir 0700 / file 0600 (and re-assert both on every write); reads refuse (fail closed, `PermissionError` with a `chmod 600 <path>` fix-it message) any credentials file with group/other permission bits set.
- `list()` returns `{ host, tokenPrefix }` only (12-char prefix) — never token material; tests grep the serialized `list()` output and the stderr degrade notice to confirm no full refresh token ever leaks.
- TDD: RED commit (44 failing tests against stubbed pure functions) → GREEN commit (implemented `serialize.ts`; `file-store.ts`/`store.ts` were already written straight through against the stubs).
- Root barrel (`packages/cli/src/index.ts`): the new interface is exported as `HostCredentialStore` (aliased) to avoid colliding with the existing single-profile `CredentialStore`/`NullCredentialStore` placeholder in `credential-store.ts`, which is left untouched — wiring it into `HandlerContext` for a single active profile is follow-on work (likely `login`, task 3).

## Test plan
- [x] `bun run --filter '@pagespace/cli' typecheck` — green
- [x] `bun run --filter '@pagespace/cli' test` — 91/91 pass (44 new)
- [x] Pure round-trip tests for (de)serialization, multi-host independence, permission-mode decisions
- [x] Atomic-write tests (0700 dir / 0600 file, no leftover temp files, valid JSON at final path, floor re-asserted on every write)
- [x] Permissive-file rejection tests (group- and other-readable, both directions)
- [x] Keychain-available path (fake adapter) never touches the file store; keychain-unavailable path (throwing fake adapter) degrades once, one stderr notice, never crashes
- [x] No-token-in-output tests: `list()` and the degrade notice never contain the full refresh token (grepped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xCyET521oYSAUsZPX4QT7