### PR TITLE
cli: implement drives & pages verbs (Phase 5 task 1)

### DIFF
--- a/packages/cli/src/__tests__/confirm.test.ts
+++ b/packages/cli/src/__tests__/confirm.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { confirmationFailureMessage, confirmDestructive, isYes } from '@pagespace/cli';
+
+describe('isYes', () => {
+  it('accepts y/yes case-insensitively, with surrounding whitespace', () => {
+    expect(isYes('y')).toBe(true);
+    expect(isYes('Y')).toBe(true);
+    expect(isYes('yes')).toBe(true);
+    expect(isYes('YES')).toBe(true);
+    expect(isYes('  yes  ')).toBe(true);
+  });
+
+  it('rejects anything else', () => {
+    expect(isYes('')).toBe(false);
+    expect(isYes('n')).toBe(false);
+    expect(isYes('no')).toBe(false);
+    expect(isYes('yep')).toBe(false);
+  });
+});
+
+describe('confirmDestructive', () => {
+  it('succeeds immediately with --yes, never prompting', async () => {
+    let prompted = false;
+    const result = await confirmDestructive('Trash it?', {
+      isTTY: false,
+      yes: true,
+      prompt: async () => {
+        prompted = true;
+        return 'yes';
+      },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(prompted).toBe(false);
+  });
+
+  it('fails closed in a non-TTY session without --yes, never prompting', async () => {
+    let prompted = false;
+    const result = await confirmDestructive('Trash it?', {
+      isTTY: false,
+      yes: false,
+      prompt: async () => {
+        prompted = true;
+        return 'yes';
+      },
+    });
+    expect(result).toEqual({ ok: false, reason: 'non_tty_missing_yes' });
+    expect(prompted).toBe(false);
+  });
+
+  it('prompts in a TTY session without --yes and succeeds on an affirmative answer', async () => {
+    const result = await confirmDestructive('Trash it?', {
+      isTTY: true,
+      yes: false,
+      prompt: async () => 'yes',
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('prompts in a TTY session without --yes and fails on a declined answer', async () => {
+    const result = await confirmDestructive('Trash it?', {
+      isTTY: true,
+      yes: false,
+      prompt: async () => 'no',
+    });
+    expect(result).toEqual({ ok: false, reason: 'declined' });
+  });
+
+  it('supports a custom affirmative predicate (e.g. typed confirmation name)', async () => {
+    const result = await confirmDestructive('Type the drive name to confirm:', {
+      isTTY: true,
+      yes: false,
+      prompt: async () => 'My Drive',
+      isAffirmative: (answer) => answer === 'My Drive',
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('passes the exact message through to prompt', async () => {
+    let seen: string | undefined;
+    await confirmDestructive('Trash "Foo"?', {
+      isTTY: true,
+      yes: false,
+      prompt: async (message) => {
+        seen = message;
+        return 'yes';
+      },
+    });
+    expect(seen).toBe('Trash "Foo"?');
+  });
+});
+
+describe('confirmationFailureMessage', () => {
+  it('gives a --yes-pointing message for a non-TTY refusal', () => {
+    expect(confirmationFailureMessage({ ok: false, reason: 'non_tty_missing_yes' })).toMatch(/--yes/);
+  });
+
+  it('gives an abort message for a declined interactive confirmation', () => {
+    expect(confirmationFailureMessage({ ok: false, reason: 'declined' })).toMatch(/abort/i);
+  });
+});

--- a/packages/cli/src/__tests__/fake-context.ts
+++ b/packages/cli/src/__tests__/fake-context.ts
@@ -38,6 +38,19 @@ export function createFakeContext(overrides: Partial<HandlerContext> = {}): Hand
     stderr: createRecordingSink(),
     env: {},
     credentialStore: createFakeCredentialStore(),
+    isTTY: false,
+    prompt: async () => '',
     ...overrides,
   };
+}
+
+/**
+ * Casts a plain object stubbing only the namespace methods a command actually
+ * calls into a `PageSpaceClient` — the class has private fields, so no object
+ * literal is structurally assignable without this. Command tests build the
+ * minimal shape they need (e.g. `{ drives: { list: async () => [...] } }`)
+ * and pass the result as `createFakeContext({ sdk: fakeSdk(...) })`.
+ */
+export function fakeSdk(shape: Record<string, unknown>): PageSpaceClient {
+  return shape as unknown as PageSpaceClient;
 }

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -5,6 +5,7 @@
  * injected, so it can be unit-tested without a real process.
  */
 import process from 'node:process';
+import * as readline from 'node:readline/promises';
 import { createCredentialStore } from './credentials/store.js';
 import type { OutputSink } from './handler-context.js';
 import { run } from './run.js';
@@ -12,12 +13,23 @@ import { run } from './run.js';
 const stdout: OutputSink = { write: (chunk) => { process.stdout.write(chunk); } };
 const stderr: OutputSink = { write: (chunk) => { process.stderr.write(chunk); } };
 
+async function prompt(message: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(message);
+  } finally {
+    rl.close();
+  }
+}
+
 run({
   argv: process.argv.slice(2),
   env: process.env,
   stdout,
   stderr,
   credentialStore: createCredentialStore({ stderr }),
+  isTTY: process.stdin.isTTY === true,
+  prompt,
 })
   .then((code) => {
     process.exitCode = code;

--- a/packages/cli/src/commands/__tests__/drive-flag.test.ts
+++ b/packages/cli/src/commands/__tests__/drive-flag.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { extractDriveFlag } from '../drive-flag.js';
+
+describe('extractDriveFlag (pure)', () => {
+  it('returns driveId undefined and rest unchanged when --drive is absent', () => {
+    expect(extractDriveFlag(['pg_parent'])).toEqual({ ok: true, driveId: undefined, rest: ['pg_parent'] });
+  });
+
+  it('extracts --drive and its value, leaving the rest in order', () => {
+    expect(extractDriveFlag(['pg_parent', '--drive', 'drv_1'])).toEqual({ ok: true, driveId: 'drv_1', rest: ['pg_parent'] });
+  });
+
+  it('extracts --drive when it leads, leaving trailing positionals intact', () => {
+    expect(extractDriveFlag(['--drive', 'drv_1', 'RFC-1', 'DOCUMENT'])).toEqual({
+      ok: true,
+      driveId: 'drv_1',
+      rest: ['RFC-1', 'DOCUMENT'],
+    });
+  });
+
+  it('extracts --drive from the middle of other positionals', () => {
+    expect(extractDriveFlag(['RFC-1', '--drive', 'drv_1', 'DOCUMENT'])).toEqual({
+      ok: true,
+      driveId: 'drv_1',
+      rest: ['RFC-1', 'DOCUMENT'],
+    });
+  });
+
+  it('fails closed with a usage message when --drive has no value', () => {
+    expect(extractDriveFlag(['--drive'])).toEqual({ ok: false, message: 'Flag --drive requires a value.' });
+  });
+
+  it('is a pure function: identical input produces a deep-equal result', () => {
+    const args = ['pg_parent', '--drive', 'drv_1'];
+    expect(extractDriveFlag(args)).toEqual(extractDriveFlag(args));
+  });
+});

--- a/packages/cli/src/commands/__tests__/drives.test.ts
+++ b/packages/cli/src/commands/__tests__/drives.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  drivesCreateHandler,
+  drivesListHandler,
+  drivesRenameHandler,
+  drivesRestoreHandler,
+  drivesTrashHandler,
+  EXIT_RUNTIME_ERROR,
+  EXIT_SUCCESS,
+  EXIT_USAGE_ERROR,
+  parseArgv,
+} from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+const DRIVE = {
+  id: 'drv_1',
+  name: 'Engineering',
+  slug: 'engineering',
+  ownerId: 'user_1',
+  kind: 'STANDARD' as const,
+  isTrashed: false,
+  trashedAt: null,
+  drivePrompt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  isOwned: true,
+  role: 'OWNER' as const,
+  lastAccessedAt: null,
+  homePageId: null,
+};
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(argv);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return intent;
+}
+
+describe('drivesListHandler', () => {
+  it('calls drives.list with includeTrash undefined by default', async () => {
+    const list = vi.fn(async () => [DRIVE]);
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { list } }) });
+
+    const code = await drivesListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(list).toHaveBeenCalledWith({ includeTrash: undefined });
+  });
+
+  it('maps --all to includeTrash: true', async () => {
+    const list = vi.fn(async () => [DRIVE]);
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { list } }) });
+
+    await drivesListHandler(ctx, commandIntent(['--all']));
+
+    expect(list).toHaveBeenCalledWith({ includeTrash: true });
+  });
+
+  it('renders human-readable output including id and name', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ drives: { list: async () => [DRIVE] } }) });
+
+    await drivesListHandler(ctx, commandIntent([]));
+
+    const output = stdout.lines.join('');
+    expect(output).toContain(DRIVE.id);
+    expect(output).toContain(DRIVE.name);
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ drives: { list: async () => [DRIVE] } }) });
+
+    const code = await drivesListHandler(ctx, commandIntent(['--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual([DRIVE]);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({
+      stderr,
+      sdk: fakeSdk({
+        drives: {
+          list: async () => {
+            throw new Error('permission denied');
+          },
+        },
+      }),
+    });
+
+    const code = await drivesListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('permission denied');
+  });
+});
+
+describe('drivesCreateHandler', () => {
+  it('calls drives.create with the given name', async () => {
+    const create = vi.fn(async () => DRIVE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { create } }) });
+
+    const code = await drivesCreateHandler(ctx, commandIntent(['Engineering']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(create).toHaveBeenCalledWith({ name: 'Engineering' });
+  });
+
+  it('exits 2 with a usage error and never calls the SDK when name is missing', async () => {
+    const create = vi.fn(async () => DRIVE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { create } }) });
+
+    const code = await drivesCreateHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ drives: { create: async () => DRIVE } }) });
+
+    await drivesCreateHandler(ctx, commandIntent(['Engineering', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(DRIVE);
+  });
+});
+
+describe('drivesRenameHandler', () => {
+  it('calls drives.rename with driveId and name', async () => {
+    const rename = vi.fn(async () => ({ ...DRIVE, name: 'New Name' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { rename } }) });
+
+    const code = await drivesRenameHandler(ctx, commandIntent(['drv_1', 'New Name']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(rename).toHaveBeenCalledWith({ driveId: 'drv_1', name: 'New Name' });
+  });
+
+  it('exits 2 with a usage error when args are missing, never calling the SDK', async () => {
+    const rename = vi.fn(async () => DRIVE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { rename } }) });
+
+    const code = await drivesRenameHandler(ctx, commandIntent(['drv_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('drivesTrashHandler (destructive)', () => {
+  function ctxWith(overrides: { list?: () => Promise<unknown>; trash?: () => Promise<unknown> }, extra: Partial<Parameters<typeof createFakeContext>[0]> = {}) {
+    return createFakeContext({
+      sdk: fakeSdk({
+        drives: {
+          list: overrides.list ?? (async () => [DRIVE]),
+          trash: overrides.trash ?? (async () => ({ success: true })),
+        },
+      }),
+      ...extra,
+    });
+  }
+
+  it('with --yes in a non-TTY session: looks up the drive, then trashes without prompting', async () => {
+    const list = vi.fn(async () => [DRIVE]);
+    const trash = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => 'irrelevant');
+    const ctx = ctxWith({ list, trash }, { isTTY: false, prompt });
+
+    const code = await drivesTrashHandler(ctx, commandIntent(['drv_1', '--yes']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(list).toHaveBeenCalledWith({});
+    expect(prompt).not.toHaveBeenCalled();
+    expect(trash).toHaveBeenCalledWith({ driveId: 'drv_1', confirmDriveName: 'Engineering' });
+  });
+
+  it('fails closed in a non-TTY session without --yes, never calling trash', async () => {
+    const trash = vi.fn(async () => ({ success: true }));
+    const stderr = createRecordingSink();
+    const ctx = ctxWith({ trash }, { isTTY: false, stderr });
+
+    const code = await drivesTrashHandler(ctx, commandIntent(['drv_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+    expect(stderr.lines.join('')).toMatch(/--yes/);
+  });
+
+  it('in a TTY session without --yes, prompts to type the drive name and trashes on a correct answer', async () => {
+    const trash = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => 'Engineering');
+    const ctx = ctxWith({ trash }, { isTTY: true, prompt });
+
+    const code = await drivesTrashHandler(ctx, commandIntent(['drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(prompt).toHaveBeenCalledWith(expect.stringContaining('Engineering'));
+    expect(trash).toHaveBeenCalledWith({ driveId: 'drv_1', confirmDriveName: 'Engineering' });
+  });
+
+  it('in a TTY session without --yes, refuses to trash when the typed name does not match', async () => {
+    const trash = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => 'wrong name');
+    const stderr = createRecordingSink();
+    const ctx = ctxWith({ trash }, { isTTY: true, prompt, stderr });
+
+    const code = await drivesTrashHandler(ctx, commandIntent(['drv_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+  });
+
+  it('exits 1 without calling trash when the drive is not found in drives.list', async () => {
+    const trash = vi.fn(async () => ({ success: true }));
+    const stderr = createRecordingSink();
+    const ctx = ctxWith({ list: async () => [], trash }, { isTTY: false, stderr });
+
+    const code = await drivesTrashHandler(ctx, commandIntent(['drv_missing', '--yes']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+    expect(stderr.lines.join('')).toContain('drv_missing');
+  });
+
+  it('exits 2 with a usage error when driveId is missing', async () => {
+    const trash = vi.fn(async () => ({ success: true }));
+    const ctx = ctxWith({ trash });
+
+    const code = await drivesTrashHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+  });
+});
+
+describe('drivesRestoreHandler', () => {
+  it('calls drives.restore with driveId (not destructive: no confirmation needed)', async () => {
+    const restore = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => '');
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { restore } }), isTTY: true, prompt });
+
+    const code = await drivesRestoreHandler(ctx, commandIntent(['drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(restore).toHaveBeenCalledWith({ driveId: 'drv_1' });
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when driveId is missing', async () => {
+    const restore = vi.fn(async () => ({ success: true }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ drives: { restore } }) });
+
+    const code = await drivesRestoreHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(restore).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/__tests__/pages.test.ts
+++ b/packages/cli/src/commands/__tests__/pages.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EXIT_RUNTIME_ERROR,
+  EXIT_SUCCESS,
+  EXIT_USAGE_ERROR,
+  pagesCreateHandler,
+  pagesListHandler,
+  pagesMoveHandler,
+  pagesReadDetailsHandler,
+  pagesRenameHandler,
+  pagesRestoreHandler,
+  pagesTrashHandler,
+  pagesTreeHandler,
+  parseArgv,
+} from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+/**
+ * Mirrors what the router hands a handler: `parseArgv` only passes an
+ * unrecognized flag (e.g. `--drive`) through into `args` once at least one
+ * positional token has been seen (there is no command yet to hand it to
+ * otherwise) — in real usage that's always true by the time a handler runs,
+ * since the resource/verb path segments precede it. `__cmd__` stands in for
+ * that already-stripped path prefix and is sliced back off below.
+ */
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const LIST_RESULT = {
+  mode: 'ls' as const,
+  driveName: 'Engineering',
+  driveSlug: 'engineering',
+  location: '/engineering',
+  breadcrumb: [],
+  pages: [
+    { id: 'pg_root_1', title: 'Design Docs', type: 'FOLDER' as const, hasChildren: true, isTaskLinked: false },
+    { id: 'pg_nested_1', title: 'RFC-1', type: 'DOCUMENT' as const, hasChildren: false, isTaskLinked: false },
+  ],
+  count: 2,
+  totalInDrive: 2,
+};
+
+const DIRECT_RESULT = {
+  ...LIST_RESULT,
+  pages: [{ id: 'pg_root_1', title: 'Design Docs', type: 'FOLDER' as const, hasChildren: true, isTaskLinked: false }],
+  count: 1,
+};
+
+const PAGE = {
+  id: 'pg_1',
+  title: 'RFC-1',
+  type: 'DOCUMENT' as const,
+  content: null,
+  contentMode: 'markdown' as const,
+  parentId: null,
+  driveId: 'drv_1',
+  position: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  revision: 1,
+  stateHash: null,
+  isTrashed: false,
+  trashedAt: null,
+  aiProvider: null,
+  aiModel: null,
+  systemPrompt: null,
+  enabledTools: null,
+  isPaginated: null,
+};
+
+describe('pagesListHandler', () => {
+  it('requires --drive: exits 2 and never calls the SDK without it', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { list } }) });
+
+    const code = await pagesListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('calls pages.list with driveId and optional parentId', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { list } }) });
+
+    const code = await pagesListHandler(ctx, commandIntent(['pg_parent', '--drive', 'drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(list).toHaveBeenCalledWith({ driveId: 'drv_1', parentId: 'pg_parent', ls: true });
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { list: async () => LIST_RESULT } }) });
+
+    await pagesListHandler(ctx, commandIntent(['--drive', 'drv_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(LIST_RESULT);
+  });
+
+  it('renders type and id for each page in human mode', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { list: async () => LIST_RESULT } }) });
+
+    await pagesListHandler(ctx, commandIntent(['--drive', 'drv_1']));
+
+    const output = stdout.lines.join('');
+    expect(output).toContain('FOLDER');
+    expect(output).toContain('pg_root_1');
+    expect(output).toContain('DOCUMENT');
+    expect(output).toContain('pg_nested_1');
+  });
+});
+
+describe('pagesTreeHandler', () => {
+  it('requires --drive: exits 2 and never calls the SDK without it', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { list } }) });
+
+    const code = await pagesTreeHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('--json makes exactly one recursive call and emits exactly its raw response', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { list } }) });
+
+    const code = await pagesTreeHandler(ctx, commandIntent(['--drive', 'drv_1', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledWith({ driveId: 'drv_1', parentId: undefined, recursive: true, ls: true });
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(LIST_RESULT);
+  });
+
+  it('human mode fetches both recursive and direct listings and indents nested pages', async () => {
+    const list = vi.fn(async (input: { recursive?: boolean }) => (input.recursive ? LIST_RESULT : DIRECT_RESULT));
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { list } }) });
+
+    const code = await pagesTreeHandler(ctx, commandIntent(['--drive', 'drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list).toHaveBeenCalledWith({ driveId: 'drv_1', parentId: undefined, recursive: true, ls: true });
+    expect(list).toHaveBeenCalledWith({ driveId: 'drv_1', parentId: undefined, recursive: false, ls: true });
+
+    const lines = stdout.lines.join('').split('\n').filter(Boolean);
+    const rootLine = lines.find((line) => line.includes('pg_root_1'));
+    const nestedLine = lines.find((line) => line.includes('pg_nested_1'));
+    expect(rootLine).toBeDefined();
+    expect(nestedLine).toBeDefined();
+    expect(nestedLine!.length - nestedLine!.trimStart().length).toBeGreaterThan(rootLine!.length - rootLine!.trimStart().length);
+  });
+});
+
+describe('pagesReadDetailsHandler', () => {
+  it('calls pages.details with pageId', async () => {
+    const details = vi.fn(async () => ({ ...PAGE, children: [], messages: [] }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { details } }) });
+
+    const code = await pagesReadDetailsHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(details).toHaveBeenCalledWith({ pageId: 'pg_1' });
+  });
+
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const details = vi.fn(async () => ({ ...PAGE, children: [], messages: [] }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { details } }) });
+
+    const code = await pagesReadDetailsHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(details).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const value = { ...PAGE, children: [], messages: [] };
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { details: async () => value } }) });
+
+    await pagesReadDetailsHandler(ctx, commandIntent(['pg_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(value);
+  });
+});
+
+describe('pagesCreateHandler', () => {
+  it('requires --drive, title, and type', async () => {
+    const create = vi.fn(async () => PAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { create } }) });
+
+    const code = await pagesCreateHandler(ctx, commandIntent(['Title Only']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid page type as a usage error without calling the SDK', async () => {
+    const create = vi.fn(async () => PAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { create } }) });
+
+    const code = await pagesCreateHandler(ctx, commandIntent(['RFC-1', 'NOT_A_TYPE', '--drive', 'drv_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('calls pages.create with driveId, title, type, and null parentId by default', async () => {
+    const create = vi.fn(async () => PAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { create } }) });
+
+    const code = await pagesCreateHandler(ctx, commandIntent(['RFC-1', 'DOCUMENT', '--drive', 'drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(create).toHaveBeenCalledWith({ driveId: 'drv_1', title: 'RFC-1', type: 'DOCUMENT', parentId: null });
+  });
+
+  it('passes an explicit parentId through when given', async () => {
+    const create = vi.fn(async () => PAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { create } }) });
+
+    await pagesCreateHandler(ctx, commandIntent(['RFC-1', 'DOCUMENT', 'pg_parent', '--drive', 'drv_1']));
+
+    expect(create).toHaveBeenCalledWith({ driveId: 'drv_1', title: 'RFC-1', type: 'DOCUMENT', parentId: 'pg_parent' });
+  });
+});
+
+describe('pagesRenameHandler', () => {
+  it('calls pages.rename with pageId and title', async () => {
+    const rename = vi.fn(async () => PAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { rename } }) });
+
+    const code = await pagesRenameHandler(ctx, commandIntent(['pg_1', 'New Title']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(rename).toHaveBeenCalledWith({ pageId: 'pg_1', title: 'New Title' });
+  });
+
+  it('exits 2 with a usage error when args are missing', async () => {
+    const rename = vi.fn(async () => PAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { rename } }) });
+
+    const code = await pagesRenameHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('pagesMoveHandler', () => {
+  it('calls pages.move with pageId, newParentId, and newPosition', async () => {
+    const move = vi.fn(async () => ({ message: 'moved' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { move } }) });
+
+    const code = await pagesMoveHandler(ctx, commandIntent(['pg_1', 'pg_parent', '3']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(move).toHaveBeenCalledWith({ pageId: 'pg_1', newParentId: 'pg_parent', newPosition: 3 });
+  });
+
+  it('maps the "root" keyword newParentId to null', async () => {
+    const move = vi.fn(async () => ({ message: 'moved' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { move } }) });
+
+    await pagesMoveHandler(ctx, commandIntent(['pg_1', 'root', '0']));
+
+    expect(move).toHaveBeenCalledWith({ pageId: 'pg_1', newParentId: null, newPosition: 0 });
+  });
+
+  it('exits 2 with a usage error for a non-numeric position, never calling the SDK', async () => {
+    const move = vi.fn(async () => ({ message: 'moved' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { move } }) });
+
+    const code = await pagesMoveHandler(ctx, commandIntent(['pg_1', 'pg_parent', 'not-a-number']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(move).not.toHaveBeenCalled();
+  });
+});
+
+describe('pagesTrashHandler (destructive)', () => {
+  it('with --yes in a non-TTY session: trashes without prompting, trash_children defaults false', async () => {
+    const trash = vi.fn(async () => ({ message: 'trashed' }));
+    const prompt = vi.fn(async () => 'irrelevant');
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { trash } }), isTTY: false, prompt });
+
+    const code = await pagesTrashHandler(ctx, commandIntent(['pg_1', '--yes']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(trash).toHaveBeenCalledWith({ pageId: 'pg_1', trash_children: false });
+  });
+
+  it('maps --all to trash_children: true', async () => {
+    const trash = vi.fn(async () => ({ message: 'trashed' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { trash } }), isTTY: false });
+
+    await pagesTrashHandler(ctx, commandIntent(['pg_1', '--yes', '--all']));
+
+    expect(trash).toHaveBeenCalledWith({ pageId: 'pg_1', trash_children: true });
+  });
+
+  it('fails closed in a non-TTY session without --yes, never calling trash', async () => {
+    const trash = vi.fn(async () => ({ message: 'trashed' }));
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { trash } }), isTTY: false, stderr });
+
+    const code = await pagesTrashHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+    expect(stderr.lines.join('')).toMatch(/--yes/);
+  });
+
+  it('in a TTY session without --yes, prompts and trashes on an affirmative answer', async () => {
+    const trash = vi.fn(async () => ({ message: 'trashed' }));
+    const prompt = vi.fn(async () => 'y');
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { trash } }), isTTY: true, prompt });
+
+    const code = await pagesTrashHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(prompt).toHaveBeenCalled();
+    expect(trash).toHaveBeenCalledWith({ pageId: 'pg_1', trash_children: false });
+  });
+
+  it('in a TTY session without --yes, refuses on a declined answer', async () => {
+    const trash = vi.fn(async () => ({ message: 'trashed' }));
+    const prompt = vi.fn(async () => 'n');
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { trash } }), isTTY: true, prompt });
+
+    const code = await pagesTrashHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const trash = vi.fn(async () => ({ message: 'trashed' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { trash } }) });
+
+    const code = await pagesTrashHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(trash).not.toHaveBeenCalled();
+  });
+});
+
+describe('pagesRestoreHandler', () => {
+  it('calls pages.restore with pageId (not destructive: no confirmation needed)', async () => {
+    const restore = vi.fn(async () => ({ message: 'restored' }));
+    const prompt = vi.fn(async () => '');
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { restore } }), isTTY: true, prompt });
+
+    const code = await pagesRestoreHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(restore).toHaveBeenCalledWith({ pageId: 'pg_1' });
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const restore = vi.fn(async () => ({ message: 'restored' }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { restore } }) });
+
+    const code = await pagesRestoreHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(restore).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/__tests__/render.test.ts
+++ b/packages/cli/src/commands/__tests__/render.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { renderDrive, renderDrivesList, renderPage, renderPagesList, renderPagesTree, renderTrashTree } from '@pagespace/cli';
+
+describe('renderDrivesList (pure)', () => {
+  it('renders "No drives." for an empty list', () => {
+    expect(renderDrivesList([])).toBe('No drives.\n');
+  });
+
+  it('renders one stable line per drive with id, name, kind, and role', () => {
+    const output = renderDrivesList([
+      { id: 'drv_1', name: 'Engineering', kind: 'STANDARD', role: 'OWNER' } as never,
+    ]);
+    expect(output).toBe('drv_1  Engineering  [STANDARD] (OWNER)\n');
+  });
+});
+
+describe('renderDrive (pure)', () => {
+  it('renders id and name on one line', () => {
+    expect(renderDrive({ id: 'drv_1', name: 'Engineering' })).toBe('drv_1  Engineering\n');
+  });
+});
+
+describe('renderPagesList (pure)', () => {
+  it('renders "No pages." for an empty list', () => {
+    expect(
+      renderPagesList({ mode: 'ls', driveName: 'D', driveSlug: 'd', location: '/', breadcrumb: [], pages: [], count: 0, totalInDrive: 0 } as never),
+    ).toBe('No pages.\n');
+  });
+
+  it('renders one stable line per page with type, id, and title', () => {
+    const output = renderPagesList({
+      mode: 'ls',
+      driveName: 'D',
+      driveSlug: 'd',
+      location: '/',
+      breadcrumb: [],
+      pages: [{ id: 'pg_1', title: 'RFC-1', type: 'DOCUMENT', hasChildren: false, isTaskLinked: false }],
+      count: 1,
+      totalInDrive: 1,
+    } as never);
+    expect(output).toBe('DOCUMENT  pg_1  RFC-1\n');
+  });
+
+  it('falls back to "(untitled)" for a null title', () => {
+    const output = renderPagesList({
+      mode: 'ls',
+      driveName: 'D',
+      driveSlug: 'd',
+      location: '/',
+      breadcrumb: [],
+      pages: [{ id: 'pg_1', title: null, type: 'FOLDER', hasChildren: false, isTaskLinked: false }],
+      count: 1,
+      totalInDrive: 1,
+    } as never);
+    expect(output).toContain('(untitled)');
+  });
+});
+
+describe('renderPagesTree (pure)', () => {
+  const RESULT = {
+    mode: 'ls' as const,
+    driveName: 'D',
+    driveSlug: 'd',
+    location: '/',
+    breadcrumb: [],
+    pages: [
+      { id: 'pg_root', title: 'Root Folder', type: 'FOLDER' as const, hasChildren: true, isTaskLinked: false },
+      { id: 'pg_child', title: 'Child Doc', type: 'DOCUMENT' as const, hasChildren: false, isTaskLinked: false },
+    ],
+    count: 2,
+    totalInDrive: 2,
+  };
+
+  it('renders "No pages." for an empty result', () => {
+    expect(renderPagesTree({ ...RESULT, pages: [] }, new Set())).toBe('No pages.\n');
+  });
+
+  it('indents an id absent from rootIds, and does not indent one present in it', () => {
+    const output = renderPagesTree(RESULT, new Set(['pg_root']));
+    const lines = output.split('\n').filter(Boolean);
+    expect(lines[0]).toBe('FOLDER  pg_root  Root Folder');
+    expect(lines[1]).toBe('  DOCUMENT  pg_child  Child Doc');
+  });
+});
+
+describe('renderPage (pure)', () => {
+  it('renders type, id, and title', () => {
+    expect(renderPage({ id: 'pg_1', title: 'RFC-1', type: 'DOCUMENT' } as never)).toBe('DOCUMENT  pg_1  RFC-1\n');
+  });
+
+  it('falls back to "(untitled)" for a null title', () => {
+    expect(renderPage({ id: 'pg_1', title: null, type: 'DOCUMENT' } as never)).toContain('(untitled)');
+  });
+});
+
+describe('renderTrashTree (pure)', () => {
+  it('renders nothing for an empty tree', () => {
+    expect(renderTrashTree([])).toBe('');
+  });
+
+  it('indents children strictly deeper than their parent, by true depth', () => {
+    const output = renderTrashTree([
+      {
+        id: 'pg_1',
+        title: 'Old Folder',
+        type: 'FOLDER',
+        children: [{ id: 'pg_2', title: 'Old Doc', type: 'DOCUMENT', children: [] }],
+      },
+    ] as never);
+    const lines = output.split('\n').filter(Boolean);
+    expect(lines[0]).toBe('FOLDER  pg_1  Old Folder');
+    expect(lines[1]).toBe('  DOCUMENT  pg_2  Old Doc');
+  });
+});

--- a/packages/cli/src/commands/__tests__/trash.test.ts
+++ b/packages/cli/src/commands/__tests__/trash.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, parseArgv, trashListHandler } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+/**
+ * Mirrors what the router hands a handler: `parseArgv` only passes an
+ * unrecognized flag (e.g. `--drive`) through into `args` once at least one
+ * positional token has been seen — in real usage that's always true by the
+ * time a handler runs, since the resource/verb path precedes it. `__cmd__`
+ * stands in for that already-stripped prefix and is sliced back off below.
+ */
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const TRASH_TREE = [
+  {
+    id: 'pg_1',
+    title: 'Old Folder',
+    type: 'FOLDER' as const,
+    children: [{ id: 'pg_2', title: 'Old Doc', type: 'DOCUMENT' as const, children: [] }],
+  },
+];
+
+describe('trashListHandler', () => {
+  it('requires --drive: exits 2 and never calls the SDK without it', async () => {
+    const listTrash = vi.fn(async () => TRASH_TREE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { listTrash } }) });
+
+    const code = await trashListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(listTrash).not.toHaveBeenCalled();
+  });
+
+  it('calls pages.listTrash with driveId', async () => {
+    const listTrash = vi.fn(async () => TRASH_TREE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { listTrash } }) });
+
+    const code = await trashListHandler(ctx, commandIntent(['--drive', 'drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(listTrash).toHaveBeenCalledWith({ driveId: 'drv_1' });
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { listTrash: async () => TRASH_TREE } }) });
+
+    await trashListHandler(ctx, commandIntent(['--drive', 'drv_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(TRASH_TREE);
+  });
+
+  it('renders the true nested depth in human mode (child indented deeper than parent)', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { listTrash: async () => TRASH_TREE } }) });
+
+    await trashListHandler(ctx, commandIntent(['--drive', 'drv_1']));
+
+    const lines = stdout.lines.join('').split('\n').filter(Boolean);
+    const parentLine = lines.find((line) => line.includes('pg_1'));
+    const childLine = lines.find((line) => line.includes('pg_2'));
+    expect(parentLine).toBeDefined();
+    expect(childLine).toBeDefined();
+    expect(childLine!.length - childLine!.trimStart().length).toBeGreaterThan(parentLine!.length - parentLine!.trimStart().length);
+  });
+
+  it('reports an empty trash plainly', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { listTrash: async () => [] } }) });
+
+    const code = await trashListHandler(ctx, commandIntent(['--drive', 'drv_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(stdout.lines.join('')).toMatch(/empty/i);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({
+      stderr,
+      sdk: fakeSdk({
+        pages: {
+          listTrash: async () => {
+            throw new Error('drive not found');
+          },
+        },
+      }),
+    });
+
+    const code = await trashListHandler(ctx, commandIntent(['--drive', 'drv_missing']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('drive not found');
+  });
+});

--- a/packages/cli/src/commands/drive-flag.ts
+++ b/packages/cli/src/commands/drive-flag.ts
@@ -1,0 +1,33 @@
+/**
+ * Local `--drive <id>` extraction for `pages`/`trash` verbs. `--drive` is
+ * NOT a global flag (`tokens create`'s pre-existing, merged `--drive`/`--role`
+ * pairs are repeatable and command-specific, parsed the same way from
+ * `CommandIntent.args` — see `tokens/args.ts`) — `parseArgv` only extracts
+ * `--json`/`--yes`/`--host`/`--token`/etc. and passes everything else
+ * through into `args` verbatim once a command path has started. Each
+ * resource command owning a `--drive` flag interprets it itself, the same
+ * way `tokens create` interprets its own `--name`/`--role`.
+ */
+export type ExtractDriveFlagResult =
+  | { readonly ok: true; readonly driveId: string | undefined; readonly rest: readonly string[] }
+  | { readonly ok: false; readonly message: string };
+
+export function extractDriveFlag(args: readonly string[]): ExtractDriveFlagResult {
+  const rest: string[] = [];
+  let driveId: string | undefined;
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--drive') {
+      const value = args[i + 1];
+      if (value === undefined) {
+        return { ok: false, message: 'Flag --drive requires a value.' };
+      }
+      driveId = value;
+      i += 2;
+      continue;
+    }
+    rest.push(args[i]);
+    i += 1;
+  }
+  return { ok: true, driveId, rest };
+}

--- a/packages/cli/src/commands/drives.ts
+++ b/packages/cli/src/commands/drives.ts
@@ -1,0 +1,147 @@
+/**
+ * `pagespace drives list|create|rename|trash|restore` (Phase 5 task 1).
+ * Thin projections over the `drives.*` SDK operations — argv parsing and
+ * result rendering are pure; `ctx.sdk` is the only I/O edge each handler
+ * touches directly (destructive `trash` also reads `ctx.isTTY`/`ctx.prompt`
+ * via the shared confirmation gate).
+ *
+ * `drives trash` requires typing the drive's own name to confirm (matching
+ * `assertDriveNameConfirmed`'s client-side guardrail — the route itself
+ * trashes unconditionally, per inventory D11) rather than a plain yes/no,
+ * since trashing a drive takes every page in it down too. `--yes` skips the
+ * name prompt entirely and confirms with the drive's actual (already-known)
+ * name.
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { assertDriveNameConfirmed } from '@pagespace/sdk';
+import { confirmationFailureMessage, confirmDestructive } from '../confirm.js';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+type DriveSummary = Awaited<ReturnType<PageSpaceClient['drives']['list']>>[number];
+/** `create` and `rename`/`trash` return different (but overlapping) drive shapes — only id/name are rendered. */
+interface DriveIdentity {
+  readonly id: string;
+  readonly name: string;
+}
+
+/** Pure: no I/O. */
+export function renderDrivesList(drives: readonly DriveSummary[]): string {
+  if (drives.length === 0) {
+    return 'No drives.\n';
+  }
+  return drives.map((drive) => `${drive.id}  ${drive.name}  [${drive.kind}] (${drive.role})\n`).join('');
+}
+
+/** Pure: no I/O. */
+export function renderDrive(drive: DriveIdentity): string {
+  return `${drive.id}  ${drive.name}\n`;
+}
+
+export const drivesListHandler: CommandHandler = async (ctx, intent) => {
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.drives.list({ includeTrash: intent.flags.all || undefined }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(renderDrivesList(result.value));
+  }
+  return EXIT_SUCCESS;
+};
+
+export const drivesCreateHandler: CommandHandler = async (ctx, intent) => {
+  const [name] = intent.args;
+  if (!name) {
+    ctx.stderr.write('Usage: pagespace drives create <name>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.drives.create({ name }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Created drive ${renderDrive(result.value)}`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const drivesRenameHandler: CommandHandler = async (ctx, intent) => {
+  const [driveId, name] = intent.args;
+  if (!driveId || !name || intent.args.length > 2) {
+    ctx.stderr.write('Usage: pagespace drives rename <driveId> <name>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.drives.rename({ driveId, name }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Renamed drive to ${renderDrive(result.value)}`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const drivesTrashHandler: CommandHandler = async (ctx, intent) => {
+  const [driveId] = intent.args;
+  if (!driveId) {
+    ctx.stderr.write('Usage: pagespace drives trash <driveId> [--yes]\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const found = await callSdk(ctx.stderr, () => ctx.sdk.drives.list({}));
+  if (!found.ok) return EXIT_RUNTIME_ERROR;
+
+  const drive = found.value.find((candidate) => candidate.id === driveId);
+  if (!drive) {
+    ctx.stderr.write(`Drive not found or not accessible: ${driveId}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  const confirmation = await confirmDestructive(
+    `Type the drive name "${drive.name}" to confirm trashing it (all its pages will be trashed too): `,
+    {
+      isTTY: ctx.isTTY,
+      yes: intent.flags.yes,
+      prompt: ctx.prompt,
+      isAffirmative: (answer) => assertDriveNameConfirmed(drive.name, answer.trim()).ok,
+    },
+  );
+  if (!confirmation.ok) {
+    ctx.stderr.write(`${confirmationFailureMessage(confirmation)}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.drives.trash({ driveId, confirmDriveName: drive.name }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Trashed drive ${drive.name} (${driveId}).\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const drivesRestoreHandler: CommandHandler = async (ctx, intent) => {
+  const [driveId] = intent.args;
+  if (!driveId) {
+    ctx.stderr.write('Usage: pagespace drives restore <driveId>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.drives.restore({ driveId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Restored drive ${driveId}.\n`);
+  }
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/commands/pages.ts
+++ b/packages/cli/src/commands/pages.ts
@@ -1,0 +1,251 @@
+/**
+ * `pagespace pages list|tree|read-details|create|rename|move|trash|restore`
+ * (Phase 5 task 1). Thin projections over the `pages.*` SDK operations.
+ *
+ * `pages tree`: `pages.list`'s ls-mode response (Phase 3) is a flat,
+ * preorder-DFS array of `{id, type, hasChildren}` with no `parentId`/depth
+ * field, so a single recursive call cannot be unambiguously re-nested
+ * (two different trees can produce the identical flat sequence). `--json`
+ * stays a single `recursive: true` call — exactly the raw SDK response, per
+ * law. Human mode additionally fetches the non-recursive listing at the
+ * same location (same operation, one more call) purely to know which ids
+ * are direct children, giving an honest two-level indent (root vs. nested)
+ * instead of a fabricated deeper hierarchy the wire data can't support.
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { pageTypeSchema } from '@pagespace/sdk';
+import { confirmationFailureMessage, confirmDestructive } from '../confirm.js';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { extractDriveFlag } from './drive-flag.js';
+import { callSdk } from './sdk-error.js';
+
+type PagesListResult = Awaited<ReturnType<PageSpaceClient['pages']['list']>>;
+type PagesListEntry = PagesListResult['pages'][number];
+type PageRecord = Awaited<ReturnType<PageSpaceClient['pages']['create']>>;
+
+/** Pure: no I/O. */
+export function renderPagesList(result: PagesListResult): string {
+  if (result.pages.length === 0) {
+    return 'No pages.\n';
+  }
+  return result.pages.map((page) => `${page.type}  ${page.id}  ${page.title ?? '(untitled)'}\n`).join('');
+}
+
+/** Pure: no I/O. Two-level indent (root vs. nested) — see module doc comment for why. */
+export function renderPagesTree(recursive: PagesListResult, rootIds: ReadonlySet<string>): string {
+  if (recursive.pages.length === 0) {
+    return 'No pages.\n';
+  }
+  return recursive.pages
+    .map((page: PagesListEntry) => {
+      const indent = rootIds.has(page.id) ? '' : '  ';
+      return `${indent}${page.type}  ${page.id}  ${page.title ?? '(untitled)'}\n`;
+    })
+    .join('');
+}
+
+/** Pure: no I/O. */
+export function renderPage(page: PageRecord): string {
+  return `${page.type}  ${page.id}  ${page.title ?? '(untitled)'}\n`;
+}
+
+export const pagesListHandler: CommandHandler = async (ctx, intent) => {
+  const extracted = extractDriveFlag(intent.args);
+  if (!extracted.ok) {
+    ctx.stderr.write(`${extracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (!extracted.driveId) {
+    ctx.stderr.write('Usage: pagespace pages list --drive <driveId> [parentId]\n');
+    return EXIT_USAGE_ERROR;
+  }
+  const [parentId] = extracted.rest;
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.list({ driveId: extracted.driveId as string, parentId, ls: true }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(renderPagesList(result.value));
+  }
+  return EXIT_SUCCESS;
+};
+
+export const pagesTreeHandler: CommandHandler = async (ctx, intent) => {
+  const extracted = extractDriveFlag(intent.args);
+  if (!extracted.ok) {
+    ctx.stderr.write(`${extracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (!extracted.driveId) {
+    ctx.stderr.write('Usage: pagespace pages tree --drive <driveId> [parentId]\n');
+    return EXIT_USAGE_ERROR;
+  }
+  const [parentId] = extracted.rest;
+  const driveId = extracted.driveId;
+
+  const recursive = await callSdk(ctx.stderr, () => ctx.sdk.pages.list({ driveId, parentId, recursive: true, ls: true }));
+  if (!recursive.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(recursive.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  const direct = await callSdk(ctx.stderr, () => ctx.sdk.pages.list({ driveId, parentId, recursive: false, ls: true }));
+  if (!direct.ok) return EXIT_RUNTIME_ERROR;
+
+  const rootIds = new Set(direct.value.pages.map((page) => page.id));
+  ctx.stdout.write(renderPagesTree(recursive.value, rootIds));
+  return EXIT_SUCCESS;
+};
+
+export const pagesReadDetailsHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId] = intent.args;
+  if (!pageId) {
+    ctx.stderr.write('Usage: pagespace pages read-details <pageId>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.details({ pageId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    const page = result.value;
+    ctx.stdout.write(`${page.type}  ${page.id}  ${page.title ?? '(untitled)'}\n`);
+    ctx.stdout.write(`Children: ${page.children.length}, Messages: ${page.messages.length}\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const pagesCreateHandler: CommandHandler = async (ctx, intent) => {
+  const extracted = extractDriveFlag(intent.args);
+  if (!extracted.ok) {
+    ctx.stderr.write(`${extracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  const usage = 'Usage: pagespace pages create <title> <type> [parentId] --drive <driveId>\n';
+  if (!extracted.driveId) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+  const [title, rawType, parentId] = extracted.rest;
+  if (!title || !rawType) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsedType = pageTypeSchema.safeParse(rawType);
+  if (!parsedType.success) {
+    ctx.stderr.write(`Invalid page type "${rawType}". Expected one of: ${pageTypeSchema.options.join(', ')}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.pages.create({ driveId: extracted.driveId as string, title, type: parsedType.data, parentId: parentId ?? null }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Created page ${renderPage(result.value)}`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const pagesRenameHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, title] = intent.args;
+  if (!pageId || !title || intent.args.length > 2) {
+    ctx.stderr.write('Usage: pagespace pages rename <pageId> <title>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.rename({ pageId, title }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Renamed page ${renderPage(result.value)}`);
+  }
+  return EXIT_SUCCESS;
+};
+
+/** Literal keyword for "move to drive root" — a leading `-` would be misparsed as a flag by `parseArgv`. */
+const ROOT_PARENT_KEYWORD = 'root';
+
+export const pagesMoveHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, rawNewParentId, rawNewPosition] = intent.args;
+  if (!pageId || rawNewParentId === undefined || rawNewPosition === undefined) {
+    ctx.stderr.write(`Usage: pagespace pages move <pageId> <newParentId|${ROOT_PARENT_KEYWORD}> <newPosition>\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const newPosition = Number(rawNewPosition);
+  if (!Number.isFinite(newPosition)) {
+    ctx.stderr.write(`Invalid newPosition "${rawNewPosition}": must be a finite number.\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const newParentId = rawNewParentId === ROOT_PARENT_KEYWORD ? null : rawNewParentId;
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.move({ pageId, newParentId, newPosition }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`${result.value.message}\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const pagesTrashHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId] = intent.args;
+  if (!pageId) {
+    ctx.stderr.write('Usage: pagespace pages trash <pageId> [--all] [--yes]\n');
+    return EXIT_USAGE_ERROR;
+  }
+  const trashChildren = intent.flags.all;
+
+  const confirmation = await confirmDestructive(
+    `Trash page ${pageId}${trashChildren ? ' and all its children' : ''}? [y/N] `,
+    { isTTY: ctx.isTTY, yes: intent.flags.yes, prompt: ctx.prompt },
+  );
+  if (!confirmation.ok) {
+    ctx.stderr.write(`${confirmationFailureMessage(confirmation)}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.trash({ pageId, trash_children: trashChildren }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`${result.value.message}\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const pagesRestoreHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId] = intent.args;
+  if (!pageId) {
+    ctx.stderr.write('Usage: pagespace pages restore <pageId>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.restore({ pageId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`${result.value.message}\n`);
+  }
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/commands/sdk-error.ts
+++ b/packages/cli/src/commands/sdk-error.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared "call the SDK, surface the server's own error honestly" wrapper
+ * every drives/pages/trash verb uses (Phase 5 task 1) — one place that
+ * decides exit code 1 vs. rethrow, so no command hand-rolls its own
+ * try/catch/format triple.
+ */
+import type { OutputSink } from '../handler-context.js';
+
+export type SdkCallResult<T> = { readonly ok: true; readonly value: T } | { readonly ok: false };
+
+export async function callSdk<T>(stderr: OutputSink, fn: () => Promise<T>): Promise<SdkCallResult<T>> {
+  try {
+    return { ok: true, value: await fn() };
+  } catch (error) {
+    stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return { ok: false };
+  }
+}

--- a/packages/cli/src/commands/trash.ts
+++ b/packages/cli/src/commands/trash.ts
@@ -1,0 +1,45 @@
+/**
+ * `pagespace trash list --drive <id>` (Phase 5 task 1) — a thin projection
+ * over `pages.listTrash`, exposed under its own `trash` resource per the
+ * phase task's explicit grammar rather than as a `pages` sub-verb. Unlike
+ * `pages.list`'s ls-mode, this operation's response is a genuine nested tree
+ * (each node carries real `children`), so — unlike `pages tree` — human-mode
+ * rendering here can indent by true depth with zero ambiguity.
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { extractDriveFlag } from './drive-flag.js';
+import { callSdk } from './sdk-error.js';
+
+type TrashNode = Awaited<ReturnType<PageSpaceClient['pages']['listTrash']>>[number];
+
+/** Pure: no I/O. Renders the real trash tree, indenting by true depth. */
+export function renderTrashTree(nodes: readonly TrashNode[], depth = 0): string {
+  const indent = '  '.repeat(depth);
+  return nodes
+    .map((node) => `${indent}${node.type}  ${node.id}  ${node.title ?? '(untitled)'}\n${renderTrashTree(node.children as TrashNode[], depth + 1)}`)
+    .join('');
+}
+
+export const trashListHandler: CommandHandler = async (ctx, intent) => {
+  const extracted = extractDriveFlag(intent.args);
+  if (!extracted.ok) {
+    ctx.stderr.write(`${extracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (!extracted.driveId) {
+    ctx.stderr.write('Usage: pagespace trash list --drive <driveId>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.listTrash({ driveId: extracted.driveId as string }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(result.value.length === 0 ? 'Trash is empty.\n' : renderTrashTree(result.value));
+  }
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/confirm.ts
+++ b/packages/cli/src/confirm.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared destructive-verb confirmation gate (Phase 5 task 1 law): `--yes`
+ * always skips the prompt; a non-TTY invocation without `--yes` fails closed
+ * without ever prompting (never hangs waiting on stdin in CI); a TTY
+ * invocation without `--yes` prompts and requires an affirmative answer.
+ *
+ * `isAffirmative` is injected per-call so callers needing a stronger gate
+ * (e.g. "type the drive's name") can supply their own answer predicate
+ * instead of the plain yes/no default.
+ */
+export type ConfirmOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: 'non_tty_missing_yes' | 'declined' };
+
+export interface ConfirmDestructiveOptions {
+  readonly isTTY: boolean;
+  readonly yes: boolean;
+  readonly prompt: (message: string) => Promise<string>;
+  readonly isAffirmative?: (answer: string) => boolean;
+}
+
+/** Pure: no I/O, total. */
+export function isYes(answer: string): boolean {
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+export async function confirmDestructive(message: string, options: ConfirmDestructiveOptions): Promise<ConfirmOutcome> {
+  if (options.yes) {
+    return { ok: true };
+  }
+  if (!options.isTTY) {
+    return { ok: false, reason: 'non_tty_missing_yes' };
+  }
+  const answer = await options.prompt(message);
+  const isAffirmative = options.isAffirmative ?? isYes;
+  return isAffirmative(answer) ? { ok: true } : { ok: false, reason: 'declined' };
+}
+
+export function confirmationFailureMessage(outcome: Extract<ConfirmOutcome, { ok: false }>): string {
+  return outcome.reason === 'non_tty_missing_yes'
+    ? 'Refusing to proceed without confirmation in a non-interactive session. Re-run with --yes.'
+    : 'Aborted: not confirmed.';
+}

--- a/packages/cli/src/handler-context.ts
+++ b/packages/cli/src/handler-context.ts
@@ -13,4 +13,8 @@ export interface HandlerContext {
   readonly stderr: OutputSink;
   readonly env: Readonly<Record<string, string | undefined>>;
   readonly credentialStore: CredentialStore;
+  /** Whether stdin is an interactive terminal — governs the fail-closed rule for destructive verbs. */
+  readonly isTTY: boolean;
+  /** Writes `message` and reads one line of interactive input. Never called when `isTTY` is false. */
+  readonly prompt: (message: string) => Promise<string>;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,12 @@ export type { CommandHandler, Route, RouteResolution } from './router/router.js'
 // Handler context — what every command handler receives instead of `process.*`.
 export type { HandlerContext, OutputSink } from './handler-context.js';
 
+// Destructive-verb confirmation gate (Phase 5 task 1) — shared by every
+// `trash` verb: --yes short-circuits, non-TTY without it fails closed,
+// TTY without it prompts via the injected `HandlerContext.prompt`.
+export { confirmationFailureMessage, confirmDestructive, isYes } from './confirm.js';
+export type { ConfirmDestructiveOptions, ConfirmOutcome } from './confirm.js';
+
 // Multi-host credential store (keychain + 0600 file fallback) — Phase 4 task 2.
 export { CompositeCredentialStore, createCredentialStore } from './credentials/store.js';
 export type { CredentialStore, CreateCredentialStoreOptions } from './credentials/store.js';
@@ -44,6 +50,32 @@ export type { ExitCode } from './exit-codes.js';
 // Built-in commands.
 export { helpHandler } from './commands/help.js';
 export { CLI_VERSION, versionHandler } from './commands/version.js';
+
+// Drives & pages verbs (Phase 5 task 1) — thin projections over the
+// `drives.*`/`pages.*` SDK operations.
+export {
+  drivesCreateHandler,
+  drivesListHandler,
+  drivesRenameHandler,
+  drivesRestoreHandler,
+  drivesTrashHandler,
+  renderDrive,
+  renderDrivesList,
+} from './commands/drives.js';
+export {
+  pagesCreateHandler,
+  pagesListHandler,
+  pagesMoveHandler,
+  pagesReadDetailsHandler,
+  pagesRenameHandler,
+  pagesRestoreHandler,
+  pagesTrashHandler,
+  pagesTreeHandler,
+  renderPage,
+  renderPagesList,
+  renderPagesTree,
+} from './commands/pages.js';
+export { renderTrashTree, trashListHandler } from './commands/trash.js';
 export {
   createLoginHandler,
   DEFAULT_LOGIN_SCOPE,

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -11,11 +11,29 @@ import { createDiscoverMetadata } from './auth/discover.js';
 import { resolveEnvToken } from './auth/legacy-token-env.js';
 import { createRefreshAccessToken } from './auth/silent-refresh.js';
 import { resolveAuth } from './auth/resolve.js';
+import {
+  drivesCreateHandler,
+  drivesListHandler,
+  drivesRenameHandler,
+  drivesRestoreHandler,
+  drivesTrashHandler,
+} from './commands/drives.js';
 import { helpHandler } from './commands/help.js';
 import { loginHandler } from './commands/login.js';
 import { loginDeviceHandler } from './commands/login-device.js';
 import { logoutHandler } from './commands/logout.js';
 import { mcpHandler } from './commands/mcp.js';
+import {
+  pagesCreateHandler,
+  pagesListHandler,
+  pagesMoveHandler,
+  pagesReadDetailsHandler,
+  pagesRenameHandler,
+  pagesRestoreHandler,
+  pagesTrashHandler,
+  pagesTreeHandler,
+} from './commands/pages.js';
+import { trashListHandler } from './commands/trash.js';
 import { versionHandler } from './commands/version.js';
 import { whoamiHandler } from './commands/whoami.js';
 import { tokensCreateHandler } from './commands/tokens/create.js';
@@ -33,6 +51,10 @@ export interface RunDependencies {
   readonly stdout: OutputSink;
   readonly stderr: OutputSink;
   readonly credentialStore: CredentialStore;
+  /** Defaults to `false` (fail-closed) when omitted — only `bin.ts` knows the real terminal state. */
+  readonly isTTY?: boolean;
+  /** Defaults to a function that never resolves truthily when omitted; only called when `isTTY` is true. */
+  readonly prompt?: (message: string) => Promise<string>;
 }
 
 const ROUTES: readonly Route[] = [
@@ -44,6 +66,20 @@ const ROUTES: readonly Route[] = [
   { path: ['tokens', 'list'], handler: tokensListHandler },
   { path: ['tokens', 'revoke'], handler: tokensRevokeHandler },
   { path: ['mcp'], handler: mcpHandler },
+  { path: ['drives', 'list'], handler: drivesListHandler },
+  { path: ['drives', 'create'], handler: drivesCreateHandler },
+  { path: ['drives', 'rename'], handler: drivesRenameHandler },
+  { path: ['drives', 'trash'], handler: drivesTrashHandler },
+  { path: ['drives', 'restore'], handler: drivesRestoreHandler },
+  { path: ['pages', 'list'], handler: pagesListHandler },
+  { path: ['pages', 'tree'], handler: pagesTreeHandler },
+  { path: ['pages', 'read-details'], handler: pagesReadDetailsHandler },
+  { path: ['pages', 'create'], handler: pagesCreateHandler },
+  { path: ['pages', 'rename'], handler: pagesRenameHandler },
+  { path: ['pages', 'move'], handler: pagesMoveHandler },
+  { path: ['pages', 'trash'], handler: pagesTrashHandler },
+  { path: ['pages', 'restore'], handler: pagesRestoreHandler },
+  { path: ['trash', 'list'], handler: trashListHandler },
 ];
 
 /**
@@ -98,6 +134,8 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
     stderr: deps.stderr,
     env: deps.env,
     credentialStore: deps.credentialStore,
+    isTTY: deps.isTTY ?? false,
+    prompt: deps.prompt ?? (async () => ''),
   };
 
   if (parsed.flags.version) {

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -352,6 +352,17 @@ describe('PageSpaceClient — registry-derived namespaces', () => {
     expect(page.id).toBe('p1');
   });
 
+  it('exposes every drives.* operation defined in operations/drives.ts, not just list (regression: only .list was wired)', () => {
+    const client = makeClient({ fetch: vi.fn() });
+
+    expect(typeof client.drives.list).toBe('function');
+    expect(typeof client.drives.create).toBe('function');
+    expect(typeof client.drives.rename).toBe('function');
+    expect(typeof client.drives.updateContext).toBe('function');
+    expect(typeof client.drives.trash).toBe('function');
+    expect(typeof client.drives.restore).toBe('function');
+  });
+
   it('exposes the Phase 3 agents & conversations namespaces', () => {
     const client = makeClient({ fetch: vi.fn() });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -39,7 +39,7 @@ import {
 import type { AuthProvider } from './auth/provider.js';
 import { askAgent, listAgents, listModels, multiDriveListAgents, updateAgentConfig } from './operations/agents.js';
 import { listConversations, readConversation } from './operations/conversations.js';
-import { listDrives } from './operations/drives.js';
+import { createDrive, listDrives, renameDrive, restoreDrive, trashDrive, updateDriveContext } from './operations/drives.js';
 import {
   createPage,
   getPageDetails,
@@ -82,7 +82,14 @@ import { computeBackoff, DEFAULT_RETRY_POLICY, isIdempotentMethod, type Jitter, 
 import { checkServerCompatibility, MIN_SERVER_API_VERSION } from './version.js';
 
 const DEFAULT_OPERATIONS_MAP = {
-  drives: { list: listDrives },
+  drives: {
+    list: listDrives,
+    create: createDrive,
+    rename: renameDrive,
+    updateContext: updateDriveContext,
+    trash: trashDrive,
+    restore: restoreDrive,
+  },
   pages: {
     list: listPages,
     listTrash: listTrash,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -129,6 +129,7 @@ export {
   listPages,
   listTrash,
   movePage,
+  pageTypeSchema,
   renamePage,
   restorePage,
   trashPage,


### PR DESCRIPTION
## Summary
- Adds `pagespace drives list|create|rename|trash|restore` and `pagespace pages list|tree|read-details|create|rename|move|trash|restore`, plus `pagespace trash list`, as thin projections over the SDK's `drives.*`/`pages.*` operations.
- SDK: wires `drives.create/rename/trash/restore` into `PageSpaceClient`'s operations map (only `.list` was wired before); exports `pageTypeSchema`.
- CLI: adds a `--drive` value flag to `parseArgv`; adds `isTTY`/`prompt` to `HandlerContext` (optional on `RunDependencies`, defaulted in `run()` so Phase 4's existing tests are untouched) so destructive verbs can gate on a real TTY; wires `bin.ts` to `process.stdin.isTTY` + a `readline`-based prompt.
- New `confirm.ts`: shared `confirmDestructive` gate — `--yes` always skips the prompt, non-TTY without it fails closed without ever touching stdin, TTY without it prompts and requires an affirmative answer.
- `drives trash` requires typing the drive's own name (via the SDK's `assertDriveNameConfirmed` client-side guardrail) rather than a plain yes/no, since it cascades to every page in the drive.
- `pages tree`: `pages.list`'s ls-mode response has no `parentId`/depth, so a single recursive call can't be unambiguously re-nested (documented in the module). `--json` stays exactly the raw single-call SDK response; human mode additionally fetches the non-recursive listing (same op, one more call) to give an honest two-level indent instead of a fabricated hierarchy.
- `trash list` renders true nested depth, since `pages.listTrash`'s response is a genuine tree (unlike `pages.list`).

## Test plan
- [x] `bun run --filter '@pagespace/cli' typecheck` — green
- [x] `bun run --filter '@pagespace/cli' test` — green (361 tests)
- [x] `bun run --filter '@pagespace/sdk' typecheck && test` — green (702 tests, unaffected)
- [x] Single-auth-path structural test still passes for all new command modules (no direct client construction, no raw `process.env`/`PAGESPACE_TOKEN` reads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFwsZWq5Z24CSA2DaLAomC