### PR TITLE
cli: implement pagespace mcp stdio server (Phase 6 task 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -465,6 +465,7 @@
         "pagespace": "./dist/bin.js",
       },
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@napi-rs/keyring": "^1.3.0",
         "@pagespace/lib": "workspace:*",
         "@pagespace/sdk": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
     "@pagespace/lib": "workspace:*",
     "@pagespace/sdk": "workspace:*",

--- a/packages/cli/src/__tests__/run.test.ts
+++ b/packages/cli/src/__tests__/run.test.ts
@@ -90,4 +90,20 @@ describe('run', () => {
     expect(deps.stderr.lines).toEqual([]);
     expect(deleteCalls).toBe(0);
   });
+
+  it('"mcp" is not auth-exempt: fails closed with an actionable message and zero credentials', async () => {
+    const deps = makeDeps(['mcp']);
+    const code = await run(deps);
+    expect(code).not.toBe(EXIT_SUCCESS);
+    expect(deps.stderr.lines.join('')).toMatch(/pagespace login|PAGESPACE_TOKEN/);
+  });
+
+  it('folds the legacy PAGESPACE_AUTH_TOKEN env var into the single auth-resolution path with a deprecation notice, never echoing the token', async () => {
+    const deps = makeDeps(['whoami'], { PAGESPACE_AUTH_TOKEN: 'ps_legacy_secret_value' });
+    await run(deps);
+    const stderrText = deps.stderr.lines.join('');
+    expect(stderrText).toMatch(/PAGESPACE_AUTH_TOKEN/);
+    expect(stderrText).toMatch(/PAGESPACE_TOKEN/);
+    expect(stderrText).not.toContain('ps_legacy_secret_value');
+  });
 });

--- a/packages/cli/src/auth/__tests__/legacy-token-env.test.ts
+++ b/packages/cli/src/auth/__tests__/legacy-token-env.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEnvToken } from '../legacy-token-env.js';
+
+describe('resolveEnvToken — pure legacy PAGESPACE_AUTH_TOKEN fallback', () => {
+  it('uses PAGESPACE_TOKEN when present, with no deprecation notice', () => {
+    const result = resolveEnvToken({ PAGESPACE_TOKEN: 'ps_new' });
+    expect(result).toEqual({ token: 'ps_new', deprecationNotice: null });
+  });
+
+  it('falls back to the legacy PAGESPACE_AUTH_TOKEN var when PAGESPACE_TOKEN is absent, with a deprecation notice', () => {
+    const result = resolveEnvToken({ PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
+    expect(result.token).toBe('ps_legacy');
+    expect(result.deprecationNotice).toMatch(/PAGESPACE_AUTH_TOKEN/);
+    expect(result.deprecationNotice).toMatch(/PAGESPACE_TOKEN/);
+  });
+
+  it('prefers PAGESPACE_TOKEN over the legacy var when both are present, with no notice', () => {
+    const result = resolveEnvToken({ PAGESPACE_TOKEN: 'ps_new', PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
+    expect(result).toEqual({ token: 'ps_new', deprecationNotice: null });
+  });
+
+  it('treats a whitespace-only PAGESPACE_TOKEN as absent and falls back to the legacy var', () => {
+    const result = resolveEnvToken({ PAGESPACE_TOKEN: '   ', PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
+    expect(result.token).toBe('ps_legacy');
+  });
+
+  it('treats a whitespace-only legacy var as absent too', () => {
+    const result = resolveEnvToken({ PAGESPACE_AUTH_TOKEN: '   ' });
+    expect(result).toEqual({ token: undefined, deprecationNotice: null });
+  });
+
+  it('returns no token and no notice when neither var is set', () => {
+    const result = resolveEnvToken({});
+    expect(result).toEqual({ token: undefined, deprecationNotice: null });
+  });
+
+  it('never echoes the legacy token value inside the deprecation notice', () => {
+    const result = resolveEnvToken({ PAGESPACE_AUTH_TOKEN: 'ps_super_secret_value' });
+    expect(result.deprecationNotice).not.toContain('ps_super_secret_value');
+  });
+});

--- a/packages/cli/src/auth/legacy-token-env.ts
+++ b/packages/cli/src/auth/legacy-token-env.ts
@@ -1,0 +1,43 @@
+/**
+ * Legacy credential env var support (Phase 6 task 1). The old standalone
+ * `pagespace-mcp` server read its bearer token from `PAGESPACE_AUTH_TOKEN`
+ * (`config.js`). The CLI's own `PAGESPACE_TOKEN` (Phase 4 task 7) always
+ * takes precedence — this only fills `PAGESPACE_TOKEN`'s precedence slot
+ * when it is itself absent (or blank), so existing `npx pagespace-mcp`
+ * configs (and `pagespace mcp`, which shares this same resolver via
+ * `run.ts` — no second, un-audited auth path) keep authenticating with zero
+ * config change beyond eventually switching to `PAGESPACE_TOKEN` or
+ * `pagespace login`. Pure: no I/O, never echoes the token value itself in
+ * the deprecation notice.
+ */
+const LEGACY_TOKEN_ENV_VAR = 'PAGESPACE_AUTH_TOKEN';
+const TOKEN_ENV_VAR = 'PAGESPACE_TOKEN';
+
+export interface ResolvedEnvToken {
+  readonly token: string | undefined;
+  readonly deprecationNotice: string | null;
+}
+
+function present(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function resolveEnvToken(env: Readonly<Record<string, string | undefined>>): ResolvedEnvToken {
+  const token = present(env[TOKEN_ENV_VAR]);
+  if (token !== undefined) {
+    return { token, deprecationNotice: null };
+  }
+
+  const legacy = present(env[LEGACY_TOKEN_ENV_VAR]);
+  if (legacy !== undefined) {
+    return {
+      token: legacy,
+      deprecationNotice:
+        `${LEGACY_TOKEN_ENV_VAR} is deprecated and will be removed in a future release. ` +
+        `Set ${TOKEN_ENV_VAR} instead, or run "pagespace login".`,
+    };
+  }
+
+  return { token: undefined, deprecationNotice: null };
+}

--- a/packages/cli/src/commands/__tests__/mcp.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, parseArgv } from '@pagespace/cli';
-import type { CredentialStore, HostCredential } from '@pagespace/cli';
 import { createFakeContext, createRecordingSink } from '../../__tests__/fake-context.js';
-import { createMcpHandler, resolveMcpEnvToken } from '../mcp.js';
+import { createMcpHandler } from '../mcp.js';
 
 function commandIntent(argv: string[]) {
   const intent = parseArgv(argv);
@@ -12,128 +11,50 @@ function commandIntent(argv: string[]) {
   return intent;
 }
 
-function fakeStore(initial: Map<string, HostCredential> = new Map()): CredentialStore {
-  return {
-    get: async (host) => initial.get(host) ?? null,
-    set: async (host, credential) => {
-      initial.set(host, credential);
-    },
-    delete: async (host) => {
-      initial.delete(host);
-    },
-    list: async () => [...initial.entries()].map(([host, credential]) => ({ host, tokenPrefix: credential.refreshToken.slice(0, 12) })),
-  };
-}
-
-function baseDeps(store: CredentialStore, transport: ReturnType<typeof InMemoryTransport.createLinkedPair>[0]) {
-  return {
-    createCredentialStore: () => store,
-    discoverMetadata: async () => ({ tokenEndpoint: 'https://pagespace.ai/api/oauth/token' }),
-    createRefreshAccessToken: () => async () => ({
-      accessToken: 'ps_at_fresh',
-      accessExpiresAt: Date.now() + 900_000,
-      refreshToken: 'ps_rt_rotated',
-      refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
-    }),
-    createTransport: () => transport,
-    now: () => Date.parse('2026-07-03T00:00:00.000Z'),
-  };
-}
-
-describe('resolveMcpEnvToken — pure legacy-env-var fallback', () => {
-  it('uses PAGESPACE_TOKEN when present, with no deprecation notice', () => {
-    const result = resolveMcpEnvToken({ PAGESPACE_TOKEN: 'ps_new' });
-    expect(result).toEqual({ token: 'ps_new', deprecationNotice: null });
-  });
-
-  it('falls back to the legacy PAGESPACE_AUTH_TOKEN var when PAGESPACE_TOKEN is absent, with a deprecation notice', () => {
-    const result = resolveMcpEnvToken({ PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
-    expect(result.token).toBe('ps_legacy');
-    expect(result.deprecationNotice).toMatch(/PAGESPACE_AUTH_TOKEN/);
-    expect(result.deprecationNotice).toMatch(/PAGESPACE_TOKEN/);
-  });
-
-  it('prefers PAGESPACE_TOKEN over the legacy var when both are present, with no notice', () => {
-    const result = resolveMcpEnvToken({ PAGESPACE_TOKEN: 'ps_new', PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
-    expect(result).toEqual({ token: 'ps_new', deprecationNotice: null });
-  });
-
-  it('treats a whitespace-only PAGESPACE_TOKEN as absent and falls back to the legacy var', () => {
-    const result = resolveMcpEnvToken({ PAGESPACE_TOKEN: '   ', PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
-    expect(result.token).toBe('ps_legacy');
-  });
-
-  it('returns no token and no notice when neither var is set', () => {
-    const result = resolveMcpEnvToken({});
-    expect(result).toEqual({ token: undefined, deprecationNotice: null });
-  });
-
-  it('never echoes the legacy token value inside the deprecation notice', () => {
-    const result = resolveMcpEnvToken({ PAGESPACE_AUTH_TOKEN: 'ps_super_secret_value' });
-    expect(result.deprecationNotice).not.toContain('ps_super_secret_value');
-  });
-});
-
-describe('createMcpHandler — auth precedence + fail-closed + stdio wiring', () => {
-  it('fails closed with EXIT_RUNTIME_ERROR and an actionable message when no credential source is available', async () => {
-    const [serverTransport] = InMemoryTransport.createLinkedPair();
-    const handler = createMcpHandler(baseDeps(fakeStore(), serverTransport));
+describe('createMcpHandler — thin stdio wiring over ctx.sdk', () => {
+  it('connects to the injected transport and serves the full registry (client can list every tool)', async () => {
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler({ createTransport: () => serverTransport });
 
     const stderr = createRecordingSink();
     const ctx = createFakeContext({ stderr, env: {} });
-    const code = await handler(ctx, commandIntent(['mcp']));
-
-    expect(code).toBe(EXIT_RUNTIME_ERROR);
-    expect(stderr.lines.join('')).toMatch(/pagespace login|PAGESPACE_TOKEN/);
-  });
-
-  it('writes the legacy-env deprecation notice to stderr (never stdout) and never leaks the token value', async () => {
-    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
-    const handler = createMcpHandler(baseDeps(fakeStore(), serverTransport));
-
-    const stdout = createRecordingSink();
-    const stderr = createRecordingSink();
-    const ctx = createFakeContext({ stdout, stderr, env: { PAGESPACE_AUTH_TOKEN: 'ps_legacy_secret' } });
-
     const client = new Client({ name: 'test-client', version: '0.0.0' });
+
     const [code] = await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
-
-    expect(code).toBe(EXIT_SUCCESS);
-    expect(stderr.lines.join('')).toMatch(/PAGESPACE_AUTH_TOKEN/);
-    expect(stdout.lines.join('')).toBe('');
-    expect([...stdout.lines, ...stderr.lines].join('')).not.toContain('ps_legacy_secret');
-  });
-
-  it('an explicit --token flag takes precedence and serves a working MCP server over the injected transport', async () => {
-    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
-    const handler = createMcpHandler(baseDeps(fakeStore(), serverTransport));
-
-    const ctx = createFakeContext({ env: {} });
-    const client = new Client({ name: 'test-client', version: '0.0.0' });
-    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp', '--token', 'ps_flag_token'])), client.connect(clientTransport)]);
 
     expect(code).toBe(EXIT_SUCCESS);
     const { tools } = await client.listTools();
     expect(tools.length).toBeGreaterThan(60);
   });
 
-  it('succeeds from a stored profile credential (silent refresh) when no flag/env token is present', async () => {
-    const store = fakeStore(
-      new Map([
-        [
-          'https://pagespace.ai',
-          { refreshToken: 'ps_rt', clientId: 'pagespace-cli', scopes: ['account'], createdAt: '2026-01-01T00:00:00.000Z' } as HostCredential,
-        ],
-      ]),
-    );
+  it('writes a startup diagnostic to stderr only (never stdout)', async () => {
     const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
-    const handler = createMcpHandler(baseDeps(store, serverTransport));
+    const handler = createMcpHandler({ createTransport: () => serverTransport });
 
-    const ctx = createFakeContext({ env: {} });
+    const stdout = createRecordingSink();
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stdout, stderr, env: {} });
     const client = new Client({ name: 'test-client', version: '0.0.0' });
-    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
 
-    expect(code).toBe(EXIT_SUCCESS);
-    expect((await store.get('https://pagespace.ai'))?.refreshToken).toBe('ps_rt_rotated');
+    await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
+
+    expect(stdout.lines).toEqual([]);
+    expect(stderr.lines.join('')).toContain('pagespace mcp');
+  });
+
+  it('returns EXIT_RUNTIME_ERROR and a clean message (no stack trace) when the transport fails to connect', async () => {
+    const handler = createMcpHandler({
+      createTransport: () => {
+        throw new Error('port already in use');
+      },
+    });
+
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, env: {} });
+    const code = await handler(ctx, commandIntent(['mcp']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('port already in use');
+    expect(stderr.lines.join('')).not.toMatch(/at .*:\d+:\d+/);
   });
 });

--- a/packages/cli/src/commands/__tests__/mcp.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, parseArgv } from '@pagespace/cli';
+import type { CredentialStore, HostCredential } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink } from '../../__tests__/fake-context.js';
+import { createMcpHandler, resolveMcpEnvToken } from '../mcp.js';
+
+function commandIntent(argv: string[]) {
+  const intent = parseArgv(argv);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return intent;
+}
+
+function fakeStore(initial: Map<string, HostCredential> = new Map()): CredentialStore {
+  return {
+    get: async (host) => initial.get(host) ?? null,
+    set: async (host, credential) => {
+      initial.set(host, credential);
+    },
+    delete: async (host) => {
+      initial.delete(host);
+    },
+    list: async () => [...initial.entries()].map(([host, credential]) => ({ host, tokenPrefix: credential.refreshToken.slice(0, 12) })),
+  };
+}
+
+function baseDeps(store: CredentialStore, transport: ReturnType<typeof InMemoryTransport.createLinkedPair>[0]) {
+  return {
+    createCredentialStore: () => store,
+    discoverMetadata: async () => ({ tokenEndpoint: 'https://pagespace.ai/api/oauth/token' }),
+    createRefreshAccessToken: () => async () => ({
+      accessToken: 'ps_at_fresh',
+      accessExpiresAt: Date.now() + 900_000,
+      refreshToken: 'ps_rt_rotated',
+      refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    }),
+    createTransport: () => transport,
+    now: () => Date.parse('2026-07-03T00:00:00.000Z'),
+  };
+}
+
+describe('resolveMcpEnvToken — pure legacy-env-var fallback', () => {
+  it('uses PAGESPACE_TOKEN when present, with no deprecation notice', () => {
+    const result = resolveMcpEnvToken({ PAGESPACE_TOKEN: 'ps_new' });
+    expect(result).toEqual({ token: 'ps_new', deprecationNotice: null });
+  });
+
+  it('falls back to the legacy PAGESPACE_AUTH_TOKEN var when PAGESPACE_TOKEN is absent, with a deprecation notice', () => {
+    const result = resolveMcpEnvToken({ PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
+    expect(result.token).toBe('ps_legacy');
+    expect(result.deprecationNotice).toMatch(/PAGESPACE_AUTH_TOKEN/);
+    expect(result.deprecationNotice).toMatch(/PAGESPACE_TOKEN/);
+  });
+
+  it('prefers PAGESPACE_TOKEN over the legacy var when both are present, with no notice', () => {
+    const result = resolveMcpEnvToken({ PAGESPACE_TOKEN: 'ps_new', PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
+    expect(result).toEqual({ token: 'ps_new', deprecationNotice: null });
+  });
+
+  it('treats a whitespace-only PAGESPACE_TOKEN as absent and falls back to the legacy var', () => {
+    const result = resolveMcpEnvToken({ PAGESPACE_TOKEN: '   ', PAGESPACE_AUTH_TOKEN: 'ps_legacy' });
+    expect(result.token).toBe('ps_legacy');
+  });
+
+  it('returns no token and no notice when neither var is set', () => {
+    const result = resolveMcpEnvToken({});
+    expect(result).toEqual({ token: undefined, deprecationNotice: null });
+  });
+
+  it('never echoes the legacy token value inside the deprecation notice', () => {
+    const result = resolveMcpEnvToken({ PAGESPACE_AUTH_TOKEN: 'ps_super_secret_value' });
+    expect(result.deprecationNotice).not.toContain('ps_super_secret_value');
+  });
+});
+
+describe('createMcpHandler — auth precedence + fail-closed + stdio wiring', () => {
+  it('fails closed with EXIT_RUNTIME_ERROR and an actionable message when no credential source is available', async () => {
+    const [serverTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler(baseDeps(fakeStore(), serverTransport));
+
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, env: {} });
+    const code = await handler(ctx, commandIntent(['mcp']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toMatch(/pagespace login|PAGESPACE_TOKEN/);
+  });
+
+  it('writes the legacy-env deprecation notice to stderr (never stdout) and never leaks the token value', async () => {
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler(baseDeps(fakeStore(), serverTransport));
+
+    const stdout = createRecordingSink();
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stdout, stderr, env: { PAGESPACE_AUTH_TOKEN: 'ps_legacy_secret' } });
+
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(stderr.lines.join('')).toMatch(/PAGESPACE_AUTH_TOKEN/);
+    expect(stdout.lines.join('')).toBe('');
+    expect([...stdout.lines, ...stderr.lines].join('')).not.toContain('ps_legacy_secret');
+  });
+
+  it('an explicit --token flag takes precedence and serves a working MCP server over the injected transport', async () => {
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler(baseDeps(fakeStore(), serverTransport));
+
+    const ctx = createFakeContext({ env: {} });
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp', '--token', 'ps_flag_token'])), client.connect(clientTransport)]);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(60);
+  });
+
+  it('succeeds from a stored profile credential (silent refresh) when no flag/env token is present', async () => {
+    const store = fakeStore(
+      new Map([
+        [
+          'https://pagespace.ai',
+          { refreshToken: 'ps_rt', clientId: 'pagespace-cli', scopes: ['account'], createdAt: '2026-01-01T00:00:00.000Z' } as HostCredential,
+        ],
+      ]),
+    );
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const handler = createMcpHandler(baseDeps(store, serverTransport));
+
+    const ctx = createFakeContext({ env: {} });
+    const client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [code] = await Promise.all([handler(ctx, commandIntent(['mcp'])), client.connect(clientTransport)]);
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect((await store.get('https://pagespace.ai'))?.refreshToken).toBe('ps_rt_rotated');
+  });
+});

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -9,6 +9,7 @@ const USAGE_LINES = [
   '  login     Log in via the browser (loopback + PKCE)',
   '  logout    Revoke and remove a stored credential',
   '  whoami    Show the currently authenticated identity',
+  '  mcp       Serve the full operation registry as an MCP stdio server',
   '',
   'Global flags:',
   '  --json          Emit machine-readable JSON on stdout only',

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,41 @@
+/**
+ * `pagespace mcp` (Phase 6 task 1) — serves the full operation registry as
+ * an MCP stdio server. Authenticates exactly like every other command:
+ * ONLY through `ctx.sdk`, built once by `run.ts`'s resolver (Phase 4 task 7
+ * precedence, extended with the legacy credential env var support in
+ * `auth/legacy-token-env.ts` — so existing `npx pagespace-mcp` configs keep
+ * working). This file never constructs its own client and never reads a
+ * credential env var itself — see `commands/__tests__/single-auth-path.test.ts`,
+ * which enforces that structurally across every command module.
+ */
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { buildOperationRegistry, createMcpServer } from '../mcp/serve.js';
+
+export interface McpHandlerDeps {
+  readonly createTransport: () => Transport;
+}
+
+export function createMcpHandler(deps: McpHandlerDeps): CommandHandler {
+  return async (ctx) => {
+    const registry = buildOperationRegistry();
+    const server = createMcpServer({ registry, sdk: ctx.sdk });
+
+    ctx.stderr.write(`pagespace mcp: serving ${registry.all.length} tools over stdio\n`);
+
+    try {
+      await server.connect(deps.createTransport());
+    } catch (error) {
+      ctx.stderr.write(`Failed to start MCP server: ${error instanceof Error ? error.message : String(error)}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
+    return EXIT_SUCCESS;
+  };
+}
+
+export const mcpHandler: CommandHandler = createMcpHandler({
+  createTransport: () => new StdioServerTransport(),
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -134,6 +134,21 @@ export { tokensListHandler } from './commands/tokens/list.js';
 export { createTokensRevokeHandler, tokensRevokeHandler } from './commands/tokens/revoke.js';
 export type { RevokeHandlerDeps } from './commands/tokens/revoke.js';
 
+// Legacy `PAGESPACE_AUTH_TOKEN` env var support (Phase 6 task 1) — folded
+// into `run.ts`'s single auth-resolution path, never a second one.
+export { resolveEnvToken } from './auth/legacy-token-env.js';
+export type { ResolvedEnvToken } from './auth/legacy-token-env.js';
+
+// `pagespace mcp` — the stdio MCP adapter generated from the operation
+// registry (Phase 6 task 1). `mcp/serve.ts` walks the registry into MCP
+// tool definitions via the pure conversion in `mcp/tool-convert.ts`.
+export { operationToMcpTool, validateToolInput, formatInvalidInputResult, formatSdkErrorResult, formatSuccessResult, formatUnknownToolResult } from './mcp/tool-convert.js';
+export type { McpCallResult, McpJsonSchema, McpTextContent, McpToolAnnotations, McpToolDefinition, ValidatedToolInput } from './mcp/tool-convert.js';
+export { buildOperationRegistry, createMcpServer } from './mcp/serve.js';
+export type { CreateMcpServerOptions, McpSdkClient } from './mcp/serve.js';
+export { createMcpHandler, mcpHandler } from './commands/mcp.js';
+export type { McpHandlerDeps } from './commands/mcp.js';
+
 // Composition root.
 export { run } from './run.js';
 export type { RunDependencies } from './run.js';

--- a/packages/cli/src/mcp/__tests__/serve.test.ts
+++ b/packages/cli/src/mcp/__tests__/serve.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  AuthenticationError,
+  NotFoundError,
+  PermissionDeniedError,
+  createRegistry,
+  defineOperation,
+  getOperation,
+  listOperations,
+  type Operation,
+  type OperationRegistry,
+} from '@pagespace/sdk';
+import { z } from 'zod';
+import { buildOperationRegistry, createMcpServer } from '../serve.js';
+
+function fakeSdk(invoke: (op: Operation, input: unknown) => Promise<unknown>) {
+  return { invoke };
+}
+
+async function connectedClient(registry: OperationRegistry, invoke: (op: Operation, input: unknown) => Promise<unknown>) {
+  const server = createMcpServer({ registry, sdk: fakeSdk(invoke) });
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+describe('buildOperationRegistry — the full operation surface', () => {
+  it('contains every operation exported by the SDK, with no duplicates', () => {
+    const registry = buildOperationRegistry();
+    const names = listOperations(registry).map((op) => op.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names.length).toBeGreaterThan(60);
+  });
+
+  it('includes representative operations from every domain', () => {
+    const registry = buildOperationRegistry();
+    for (const name of ['drives.list', 'pages.replaceLines', 'tasks.create', 'agents.ask', 'calendar.list', 'search.glob', 'roles.list', 'workflows.create']) {
+      expect(getOperation(registry, name), `expected ${name} in the full registry`).toBeDefined();
+    }
+  });
+});
+
+describe('createMcpServer — list_tools completeness vs the registry', () => {
+  it('lists exactly one MCP tool per registry operation, by name', async () => {
+    const registry = buildOperationRegistry();
+    const client = await connectedClient(registry, async () => ({}));
+
+    const { tools } = await client.listTools();
+    const toolNames = tools.map((tool) => tool.name).sort();
+    const registryNames = listOperations(registry)
+      .map((op) => op.name)
+      .sort();
+
+    expect(toolNames).toEqual(registryNames);
+  });
+
+  it('every listed tool carries a non-empty description and an object inputSchema', async () => {
+    const registry = buildOperationRegistry();
+    const client = await connectedClient(registry, async () => ({}));
+
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.description, tool.name).toBeTruthy();
+      expect((tool.inputSchema as { type: string }).type).toBe('object');
+    }
+  });
+});
+
+describe('createMcpServer — call_tool round trips', () => {
+  const echoOp = defineOperation({
+    name: 'test.echo',
+    method: 'POST',
+    path: '/api/test/echo',
+    inputSchema: z.object({ message: z.string().min(1) }),
+    outputSchema: z.object({ echoed: z.string() }),
+    description: 'Echoes a message back.',
+  });
+
+  const scopedOp = defineOperation({
+    name: 'test.scoped',
+    method: 'DELETE',
+    path: '/api/test/:id',
+    inputSchema: z.object({ id: z.string() }),
+    outputSchema: z.object({ success: z.literal(true) }),
+    requiredScope: 'drive:admin',
+    description: 'A scoped destructive test operation.',
+    destructive: true,
+  });
+
+  function registryOf(...ops: readonly Operation[]) {
+    return createRegistry(ops);
+  }
+
+  it('happy path: validates input, invokes the SDK, and returns the output as content', async () => {
+    let received: unknown;
+    const client = await connectedClient(registryOf(echoOp), async (_op, input) => {
+      received = input;
+      return { echoed: (input as { message: string }).message };
+    });
+
+    const result = await client.callTool({ name: 'test.echo', arguments: { message: 'hello' } });
+    expect(received).toEqual({ message: 'hello' });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result.content)).toContain('hello');
+  });
+
+  it('invalid input: never calls the SDK, returns an MCP-conformant error result (not a protocol crash)', async () => {
+    let sdkCalled = false;
+    const client = await connectedClient(registryOf(echoOp), async () => {
+      sdkCalled = true;
+      return {};
+    });
+
+    const result = await client.callTool({ name: 'test.echo', arguments: { message: '' } });
+    expect(sdkCalled).toBe(false);
+    expect(result.isError).toBe(true);
+  });
+
+  it('unknown tool: returns an MCP-conformant error result naming the tool, never throws', async () => {
+    const client = await connectedClient(registryOf(echoOp), async () => ({}));
+    const result = await client.callTool({ name: 'does.not.exist', arguments: {} });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain('does.not.exist');
+  });
+
+  it('permission denied: the error result names the operation\'s required scope', async () => {
+    const client = await connectedClient(registryOf(scopedOp), async () => {
+      throw new PermissionDeniedError('nope', 'test.scoped');
+    });
+
+    const result = await client.callTool({ name: 'test.scoped', arguments: { id: 'x' } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toContain('drive:admin');
+  });
+
+  it('authentication failure surfaces as a distinct, actionable error result', async () => {
+    const client = await connectedClient(registryOf(echoOp), async () => {
+      throw new AuthenticationError('nope', 'test.echo');
+    });
+
+    const result = await client.callTool({ name: 'test.echo', arguments: { message: 'hi' } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/login|token/i);
+  });
+
+  it('not-found surfaces distinctly from permission-denied', async () => {
+    const client = await connectedClient(registryOf(echoOp), async () => {
+      throw new NotFoundError('nope', 'test.echo');
+    });
+
+    const result = await client.callTool({ name: 'test.echo', arguments: { message: 'hi' } });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).not.toContain('drive:admin');
+  });
+
+  it('never leaks a stack trace or token material for an unexpected thrown error', async () => {
+    const client = await connectedClient(registryOf(echoOp), async () => {
+      const err = new Error('leaked ps_supersecrettoken123');
+      err.stack = 'Error: leaked ps_supersecrettoken123\n    at handler (/app/secret.ts:1:1)';
+      throw err;
+    });
+
+    const result = await client.callTool({ name: 'test.echo', arguments: { message: 'hi' } });
+    expect(result.isError).toBe(true);
+    const text = JSON.stringify(result.content);
+    expect(text).not.toContain('ps_supersecrettoken123');
+    expect(text).not.toContain('/app/secret.ts');
+  });
+});

--- a/packages/cli/src/mcp/__tests__/tool-convert.test.ts
+++ b/packages/cli/src/mcp/__tests__/tool-convert.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  createCalendarEvent,
+  createTask,
+  defineOperation,
+  globSearch,
+  listModels,
+  replaceLines,
+  updateTask,
+  type Operation,
+} from '@pagespace/sdk';
+import {
+  formatInvalidInputResult,
+  formatSdkErrorResult,
+  formatSuccessResult,
+  formatUnknownToolResult,
+  operationToMcpTool,
+  validateToolInput,
+} from '../tool-convert.js';
+
+function jsonSchemaOf(op: Operation) {
+  return operationToMcpTool(op).inputSchema as Record<string, unknown>;
+}
+
+describe('operationToMcpTool — pure registry entry -> MCP tool conversion', () => {
+  it('carries the operation name and mandatory description straight through', () => {
+    const tool = operationToMcpTool(globSearch);
+    expect(tool.name).toBe('search.glob');
+    expect(tool.description).toBe(globSearch.description);
+    expect(tool.description.length).toBeGreaterThan(0);
+  });
+
+  it('produces a self-contained JSON Schema object with no external $ref/$schema noise', () => {
+    const schema = jsonSchemaOf(globSearch);
+    expect(schema.type).toBe('object');
+    expect(schema.$schema).toBeUndefined();
+    expect(JSON.stringify(schema)).not.toContain('$ref');
+  });
+
+  it('converts every property with its zod constraints (string/number/enum/bounds)', () => {
+    const schema = jsonSchemaOf(globSearch) as { properties: Record<string, Record<string, unknown>> };
+    expect(schema.properties.driveId).toMatchObject({ type: 'string' });
+    expect(schema.properties.pattern).toMatchObject({ type: 'string', minLength: 1 });
+    expect(schema.properties.maxResults).toMatchObject({ type: 'integer', minimum: 1, maximum: 200 });
+  });
+
+  it('marks non-optional fields required and drops optional fields from required', () => {
+    const schema = jsonSchemaOf(globSearch) as { required: string[] };
+    expect(schema.required).toContain('driveId');
+    expect(schema.required).toContain('pattern');
+    expect(schema.required).not.toContain('maxResults');
+    expect(schema.required).not.toContain('includeTypes');
+  });
+
+  it('unwraps a top-level .refine() to the underlying object schema (replaceLines)', () => {
+    const schema = jsonSchemaOf(replaceLines) as { type: string; properties: Record<string, unknown>; required: string[] };
+    expect(schema.type).toBe('object');
+    expect(schema.properties.startLine).toMatchObject({ type: 'integer', minimum: 1 });
+    expect(schema.properties.endLine).toBeDefined();
+    expect(schema.required).not.toContain('endLine');
+  });
+
+  it('unwraps a .strict().refine() object (tasks.update) the same way', () => {
+    const schema = jsonSchemaOf(updateTask) as { properties: Record<string, unknown> };
+    expect(schema.properties.pageId).toMatchObject({ type: 'string' });
+    expect(schema.properties.title).toMatchObject({ type: 'string' });
+  });
+
+  it('converts an enum field to a JSON Schema enum of the same values', () => {
+    const schema = jsonSchemaOf(createTask) as { properties: Record<string, Record<string, unknown>> };
+    expect(schema.properties.priority).toMatchObject({ enum: ['low', 'medium', 'high'] });
+  });
+
+  it('converts an array-of-object field (assigneeIds union-shaped discriminator)', () => {
+    const schema = jsonSchemaOf(createTask) as {
+      properties: { assigneeIds: { type: string; items: { properties: Record<string, unknown> } } };
+    };
+    expect(schema.properties.assigneeIds.type).toBe('array');
+    expect(schema.properties.assigneeIds.items.properties.type).toMatchObject({ enum: ['user', 'agent'] });
+    expect(schema.properties.assigneeIds.items.properties.id).toMatchObject({ type: 'string' });
+  });
+
+  it('converts a nullable().optional() field to a nullable-compatible schema', () => {
+    const schema = jsonSchemaOf(createCalendarEvent) as { properties: Record<string, unknown> };
+    // description: z.string().max(10000).nullable().optional()
+    const description = JSON.stringify(schema.properties.description);
+    expect(description).toContain('null');
+  });
+
+  it('produces {type: "object", properties: {}} for a no-input operation', () => {
+    const schema = jsonSchemaOf(listModels) as { type: string; properties: Record<string, unknown> };
+    expect(schema.type).toBe('object');
+    expect(schema.properties).toEqual({});
+  });
+
+  it('sets readOnlyHint true for GET operations and false otherwise', () => {
+    expect(operationToMcpTool(globSearch).annotations.readOnlyHint).toBe(true);
+    expect(operationToMcpTool(createTask).annotations.readOnlyHint).toBe(false);
+  });
+
+  it('sets destructiveHint from the operation\'s own destructive flag', () => {
+    const destructiveOp = defineOperation({
+      name: 'test.destroy',
+      method: 'DELETE',
+      path: '/api/test/:id',
+      inputSchema: z.object({ id: z.string() }),
+      outputSchema: z.object({ success: z.literal(true) }),
+      destructive: true,
+      description: 'Destroys a thing.',
+    });
+    expect(operationToMcpTool(destructiveOp).annotations.destructiveHint).toBe(true);
+    expect(operationToMcpTool(globSearch).annotations.destructiveHint).toBe(false);
+  });
+
+  it('is a pure function: calling it twice on the same operation yields deep-equal, independently-frozen results', () => {
+    const first = operationToMcpTool(createTask);
+    const second = operationToMcpTool(createTask);
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+  });
+});
+
+describe('validateToolInput — zod pre-flight before any network call', () => {
+  it('accepts input matching the schema and returns parsed (defaulted) data', () => {
+    const result = validateToolInput(globSearch, { driveId: 'd1', pattern: '**/*.md' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toMatchObject({ driveId: 'd1', pattern: '**/*.md' });
+    }
+  });
+
+  it('rejects input missing a required field, without throwing', () => {
+    const result = validateToolInput(globSearch, { driveId: 'd1' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues.length).toBeGreaterThan(0);
+      expect(result.issues.join(' ')).toMatch(/pattern/);
+    }
+  });
+
+  it('rejects a value that fails a numeric bound', () => {
+    const result = validateToolInput(globSearch, { driveId: 'd1', pattern: '*', maxResults: 999 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-object input (e.g. a bare string) without throwing', () => {
+    expect(() => validateToolInput(globSearch, 'not an object')).not.toThrow();
+    expect(validateToolInput(globSearch, 'not an object').ok).toBe(false);
+  });
+
+  it('rejects undefined/null input for an operation with required fields', () => {
+    expect(validateToolInput(globSearch, undefined).ok).toBe(false);
+    expect(validateToolInput(globSearch, null).ok).toBe(false);
+  });
+});
+
+describe('formatInvalidInputResult / formatUnknownToolResult — MCP-conformant error results, never a thrown protocol error', () => {
+  it('returns isError: true content mentioning the tool name and the validation issues', () => {
+    const result = formatInvalidInputResult(globSearch, ['pattern: Required']);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('search.glob');
+    expect(result.content[0]?.text).toContain('pattern: Required');
+  });
+
+  it('never includes a stack trace', () => {
+    const result = formatInvalidInputResult(globSearch, ['pattern: Required']);
+    expect(result.content[0]?.text).not.toMatch(/at .*:\d+:\d+/);
+  });
+
+  it('formatUnknownToolResult names the unrecognized tool and is an error result', () => {
+    const result = formatUnknownToolResult('not_a_real_tool');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('not_a_real_tool');
+  });
+});
+
+describe('formatSuccessResult', () => {
+  it('renders the operation output as text content, not marked as an error', () => {
+    const result = formatSuccessResult({ ok: true, id: '123' });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]?.text).toContain('123');
+  });
+});
+
+describe('formatSdkErrorResult — distinct, secret-free messages per SDK error type', () => {
+  class FakePermissionDeniedError extends Error {
+    readonly code = 'PERMISSION_DENIED' as const;
+  }
+  class FakeAuthenticationError extends Error {
+    readonly code = 'AUTHENTICATION_ERROR' as const;
+  }
+  class FakeNotFoundError extends Error {
+    readonly code = 'NOT_FOUND' as const;
+  }
+
+  const opWithScope = defineOperation({
+    name: 'test.scoped',
+    method: 'POST',
+    path: '/api/test',
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+    requiredScope: 'drive:admin',
+    description: 'A scoped test operation.',
+  });
+
+  it('names the missing scope from the registry when permission is denied', () => {
+    const result = formatSdkErrorResult(opWithScope, new FakePermissionDeniedError('nope'));
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('drive:admin');
+  });
+
+  it('maps an authentication failure to an actionable message', () => {
+    const result = formatSdkErrorResult(globSearch, new FakeAuthenticationError('nope'));
+    expect(result.content[0]?.text).toMatch(/login|PAGESPACE_TOKEN/i);
+  });
+
+  it('maps a not-found error to a distinct message from permission-denied', () => {
+    const notFound = formatSdkErrorResult(globSearch, new FakeNotFoundError('nope'));
+    const denied = formatSdkErrorResult(opWithScope, new FakePermissionDeniedError('nope'));
+    expect(notFound.content[0]?.text).not.toBe(denied.content[0]?.text);
+  });
+
+  it('never leaks a raw stack trace or the error object for an unrecognized/unexpected error', () => {
+    const weird = new Error('super secret token=ps_abc123 leaked in a stack frame');
+    weird.stack = 'Error: super secret token=ps_abc123\n    at leaky (/some/path.ts:42:1)';
+    const result = formatSdkErrorResult(globSearch, weird);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).not.toContain('ps_abc123');
+    expect(result.content[0]?.text).not.toContain('at leaky');
+    expect(result.content[0]?.text).not.toMatch(/at .*:\d+:\d+/);
+  });
+
+  it('never leaks anything for a thrown non-Error value', () => {
+    const result = formatSdkErrorResult(globSearch, 'a plain string throw with a token ps_zzz');
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).not.toContain('ps_zzz');
+  });
+});

--- a/packages/cli/src/mcp/serve.ts
+++ b/packages/cli/src/mcp/serve.ts
@@ -1,0 +1,243 @@
+/**
+ * `pagespace mcp`'s stdio server (Phase 6 task 1) — a thin shell over the
+ * operation registry. All decision logic (tool conversion, input
+ * validation, error mapping) lives in `tool-convert.ts`; this file only:
+ * (1) assembles every SDK-exported operation into one full registry, and
+ * (2) wires the low-level MCP `Server`'s `tools/list` and `tools/call`
+ * handlers to that registry.
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import {
+  askAgent,
+  createCalendarEvent,
+  createCommand,
+  createDrive,
+  createDriveRole,
+  createPage,
+  createTask,
+  createTaskStatus,
+  createWorkflow,
+  deleteCalendarEvent,
+  deleteCalendarTrigger,
+  deleteChannelMessage,
+  deleteCommand,
+  deleteDriveRole,
+  deleteLines,
+  deleteTask,
+  deleteTaskTrigger,
+  deleteWorkflow,
+  editSheetCells,
+  exportPageMarkdown,
+  exportSheetCsv,
+  getActivity,
+  getAssignedTasks,
+  getCalendarEvent,
+  getDriveRole,
+  getPageDetails,
+  globSearch,
+  insertLines,
+  inviteCalendarAttendees,
+  listAgents,
+  listCalendarEvents,
+  listCollaborators,
+  listCommands,
+  listConversations,
+  listDriveMembers,
+  listDriveRoles,
+  listDrives,
+  listModels,
+  listPages,
+  listTrash,
+  listWorkflows,
+  movePage,
+  multiDriveListAgents,
+  multiDriveSearch,
+  readConversation,
+  readDocument,
+  regexSearch,
+  removeCalendarAttendee,
+  removeRolePagePermissions,
+  renameDrive,
+  renamePage,
+  reorderTask,
+  replaceLines,
+  restoreDrive,
+  restorePage,
+  rsvpCalendarEvent,
+  sendChannelMessage,
+  setCalendarTrigger,
+  setRoleDriveWidePermissions,
+  setRolePagePermissions,
+  setTaskTrigger,
+  trashDrive,
+  trashPage,
+  updateAgentConfig,
+  updateCalendarEvent,
+  updateCommand,
+  updateDriveContext,
+  updateDriveRole,
+  updateTask,
+  updateWorkflow,
+  createRegistry,
+  getOperation,
+  listOperations,
+  type Operation,
+  type OperationRegistry,
+} from '@pagespace/sdk';
+import {
+  formatInvalidInputResult,
+  formatSdkErrorResult,
+  formatSuccessResult,
+  formatUnknownToolResult,
+  operationToMcpTool,
+  validateToolInput,
+} from './tool-convert.js';
+
+/**
+ * Every operation the SDK exports, across every domain (drives, pages,
+ * documents, roles, tasks, agents, conversations, channels, activity,
+ * calendar, search, commands, workflows, members, collaborators, export).
+ * `buildOperationRegistry` is the ONLY place this list is assembled — the
+ * MCP tool surface is derived from it mechanically (`listOperations` +
+ * `operationToMcpTool`), so drift between "operations the SDK has" and
+ * "tools MCP serves" is structurally impossible.
+ */
+const ALL_OPERATIONS: readonly Operation[] = [
+  askAgent,
+  createCalendarEvent,
+  createCommand,
+  createDrive,
+  createDriveRole,
+  createPage,
+  createTask,
+  createTaskStatus,
+  createWorkflow,
+  deleteCalendarEvent,
+  deleteCalendarTrigger,
+  deleteChannelMessage,
+  deleteCommand,
+  deleteDriveRole,
+  deleteLines,
+  deleteTask,
+  deleteTaskTrigger,
+  deleteWorkflow,
+  editSheetCells,
+  exportPageMarkdown,
+  exportSheetCsv,
+  getActivity,
+  getAssignedTasks,
+  getCalendarEvent,
+  getDriveRole,
+  getPageDetails,
+  globSearch,
+  insertLines,
+  inviteCalendarAttendees,
+  listAgents,
+  listCalendarEvents,
+  listCollaborators,
+  listCommands,
+  listConversations,
+  listDriveMembers,
+  listDriveRoles,
+  listDrives,
+  listModels,
+  listPages,
+  listTrash,
+  listWorkflows,
+  movePage,
+  multiDriveListAgents,
+  multiDriveSearch,
+  readConversation,
+  readDocument,
+  regexSearch,
+  removeCalendarAttendee,
+  removeRolePagePermissions,
+  renameDrive,
+  renamePage,
+  reorderTask,
+  replaceLines,
+  restoreDrive,
+  restorePage,
+  rsvpCalendarEvent,
+  sendChannelMessage,
+  setCalendarTrigger,
+  setRoleDriveWidePermissions,
+  setRolePagePermissions,
+  setTaskTrigger,
+  trashDrive,
+  trashPage,
+  updateAgentConfig,
+  updateCalendarEvent,
+  updateCommand,
+  updateDriveContext,
+  updateDriveRole,
+  updateTask,
+  updateWorkflow,
+];
+
+/** Pure: assembles the full operation registry. Rejects duplicate names at construction (`createRegistry`). */
+export function buildOperationRegistry(): OperationRegistry {
+  return createRegistry(ALL_OPERATIONS);
+}
+
+/**
+ * The only slice of `PageSpaceClient` this server needs. Deliberately not
+ * `Pick<PageSpaceClient, 'invoke'>`: `PageSpaceClient.invoke` is generic per
+ * call (`Operation<string, TInputSchema, TOutputSchema>` narrows its own
+ * input/output types), and every operation flowing through here is the
+ * type-erased `Operation` `listOperations` returns — a plain, non-generic
+ * shape is what a fake `invoke` in tests needs to satisfy too.
+ */
+export interface McpSdkClient {
+  invoke(op: Operation, input: unknown): Promise<unknown>;
+}
+
+export interface CreateMcpServerOptions {
+  readonly registry: OperationRegistry;
+  readonly sdk: McpSdkClient;
+  readonly serverInfo?: { readonly name: string; readonly version: string };
+}
+
+const DEFAULT_SERVER_INFO = { name: 'pagespace', version: '0.1.0' } as const;
+
+/**
+ * Wires `tools/list` and `tools/call` to `registry`. The only I/O this
+ * function's handlers perform is `sdk.invoke` — everything else (listing,
+ * validation, error formatting) delegates to the pure functions in
+ * `tool-convert.ts`.
+ */
+export function createMcpServer(options: CreateMcpServerOptions): Server {
+  const { registry, sdk } = options;
+  const server = new Server(
+    { name: options.serverInfo?.name ?? DEFAULT_SERVER_INFO.name, version: options.serverInfo?.version ?? DEFAULT_SERVER_INFO.version },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: listOperations(registry).map(operationToMcpTool),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+    const { name, arguments: rawArgs } = request.params;
+    const op = getOperation(registry, name);
+    if (!op) {
+      return formatUnknownToolResult(name) as CallToolResult;
+    }
+
+    const validated = validateToolInput(op, rawArgs ?? {});
+    if (!validated.ok) {
+      return formatInvalidInputResult(op, validated.issues) as CallToolResult;
+    }
+
+    try {
+      const output = await sdk.invoke(op, validated.data);
+      return formatSuccessResult(output) as CallToolResult;
+    } catch (error) {
+      return formatSdkErrorResult(op, error) as CallToolResult;
+    }
+  });
+
+  return server;
+}

--- a/packages/cli/src/mcp/tool-convert.ts
+++ b/packages/cli/src/mcp/tool-convert.ts
@@ -1,0 +1,164 @@
+/**
+ * registry entry -> MCP tool definition (Phase 6 task 1). PURE: no I/O, no
+ * SDK/network calls — every function here is a total, side-effect-free
+ * transform over a single `Operation` and, where relevant, an already-thrown
+ * SDK error value.
+ *
+ * JSON Schema conversion uses zod's own native `z.toJSONSchema` (zod v4),
+ * not the third-party `zod-to-json-schema` package: verified directly
+ * against zod 4.3.6 (this workspace's resolved version) that the
+ * third-party package silently returns an empty `{ $schema }` for every
+ * registry operation — it does not understand zod v4's internal schema
+ * representation. `z.toJSONSchema` was verified against every schema
+ * construct the registry actually uses: top-level and nested `.refine()`/
+ * `.strict()`, optional/nullable fields, enums, literals-with-`.default()`,
+ * arrays of objects, and string/number bounds (min/max/regex).
+ */
+import { z } from 'zod';
+import {
+  isAuthenticationError,
+  isHttpError,
+  isIncompatibleServerError,
+  isNetworkError,
+  isNotFoundError,
+  isPageSpaceError,
+  isPermissionDeniedError,
+  isRateLimitError,
+  isResponseValidationError,
+  isServerError,
+  isTimeoutError,
+  isValidationError,
+  type Operation,
+} from '@pagespace/sdk';
+
+export interface McpJsonSchema {
+  readonly type: 'object';
+  readonly [key: string]: unknown;
+}
+
+export interface McpToolAnnotations {
+  readonly readOnlyHint: boolean;
+  readonly destructiveHint: boolean;
+}
+
+export interface McpToolDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: McpJsonSchema;
+  readonly annotations: McpToolAnnotations;
+}
+
+export interface McpTextContent {
+  readonly type: 'text';
+  readonly text: string;
+}
+
+export interface McpCallResult {
+  readonly content: readonly McpTextContent[];
+  readonly isError?: boolean;
+}
+
+export type ValidatedToolInput =
+  | { readonly ok: true; readonly data: Record<string, unknown> }
+  | { readonly ok: false; readonly issues: readonly string[] };
+
+const READ_ONLY_METHODS: ReadonlySet<string> = new Set(['GET']);
+
+function textResult(text: string, isError = false): McpCallResult {
+  return isError ? { content: [{ type: 'text', text }], isError: true } : { content: [{ type: 'text', text }] };
+}
+
+/**
+ * Pure: `Operation` -> MCP tool definition. `op.description` is mandatory by
+ * registry contract (`registry/define.ts`), so this never falls back to a
+ * placeholder description.
+ */
+export function operationToMcpTool(op: Operation): McpToolDefinition {
+  const schema = z.toJSONSchema(op.inputSchema) as Record<string, unknown>;
+  const { $schema: _drop, ...rest } = schema;
+
+  return Object.freeze({
+    name: op.name,
+    description: op.description,
+    inputSchema: Object.freeze({ type: 'object', ...rest }) as McpJsonSchema,
+    annotations: Object.freeze({
+      readOnlyHint: READ_ONLY_METHODS.has(op.method),
+      destructiveHint: op.destructive === true,
+    }),
+  });
+}
+
+/** Pure: zod-validates `rawInput` against `op.inputSchema` — the mandatory pre-flight before any network call. */
+export function validateToolInput(op: Operation, rawInput: unknown): ValidatedToolInput {
+  const parsed = op.inputSchema.safeParse(rawInput);
+  if (parsed.success) {
+    return { ok: true, data: parsed.data as Record<string, unknown> };
+  }
+  return {
+    ok: false,
+    issues: parsed.error.issues.map((issue) => `${issue.path.length > 0 ? issue.path.join('.') : '(root)'}: ${issue.message}`),
+  };
+}
+
+/** Pure, MCP-conformant: invalid input is a normal tool result with `isError: true`, never a protocol-level crash. */
+export function formatInvalidInputResult(op: Operation, issues: readonly string[]): McpCallResult {
+  return textResult(`Invalid input for tool "${op.name}":\n${issues.map((issue) => `- ${issue}`).join('\n')}`, true);
+}
+
+/** Pure: an unrecognized tool name is a normal error result, never a thrown protocol error. */
+export function formatUnknownToolResult(name: string): McpCallResult {
+  return textResult(`Unknown tool: "${name}"`, true);
+}
+
+/** Pure: renders a successful operation output as MCP text content. */
+export function formatSuccessResult(output: unknown): McpCallResult {
+  return textResult(JSON.stringify(output, null, 2));
+}
+
+/**
+ * Pure: maps an SDK typed error (or anything else a call might throw) to a
+ * distinct, secret-free MCP error result. Every branch builds its message
+ * from an error's own typed fields via the SDK's realm-independent guards —
+ * never from `error.stack` or a raw dump of the error/request. The final,
+ * unrecognized-error branch is deliberately generic: it does not surface
+ * `error.message` at all, since a non-`PageSpaceError` throw could be
+ * anything (the old api.js body/token stderr-logging pattern this phase's
+ * law bans).
+ */
+export function formatSdkErrorResult(op: Operation, error: unknown): McpCallResult {
+  if (isPermissionDeniedError(error)) {
+    const scope = op.requiredScope ? ` Requires "${op.requiredScope}" scope.` : '';
+    return textResult(`Permission denied for "${op.name}".${scope}`, true);
+  }
+  if (isAuthenticationError(error)) {
+    return textResult(`Authentication failed for "${op.name}". Run "pagespace login" or set PAGESPACE_TOKEN.`, true);
+  }
+  if (isNotFoundError(error)) {
+    return textResult(`Not found: the target of "${op.name}" does not exist or is not accessible.`, true);
+  }
+  if (isValidationError(error)) {
+    return textResult(`Server rejected input for "${op.name}": ${error.message}`, true);
+  }
+  if (isRateLimitError(error)) {
+    return textResult(`Rate limited calling "${op.name}". Try again later.`, true);
+  }
+  if (isResponseValidationError(error)) {
+    return textResult(`Server response for "${op.name}" did not match the expected shape.`, true);
+  }
+  if (isIncompatibleServerError(error)) {
+    return textResult(`Server is incompatible with this client for "${op.name}".`, true);
+  }
+  if (isTimeoutError(error)) {
+    return textResult(`Timed out calling "${op.name}".`, true);
+  }
+  if (isNetworkError(error)) {
+    return textResult(`Network error calling "${op.name}".`, true);
+  }
+  if (isServerError(error) || isHttpError(error)) {
+    return textResult(`Server error calling "${op.name}": ${error.message}`, true);
+  }
+  if (isPageSpaceError(error)) {
+    return textResult(`Error calling "${op.name}": ${error.message}`, true);
+  }
+  return textResult(`Unexpected error calling "${op.name}".`, true);
+}

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -8,12 +8,14 @@ import { PageSpaceClient } from '@pagespace/sdk';
 import { parseArgv } from './argv/parse.js';
 import { buildAuthProvider, enforceAuth } from './auth/auth-context.js';
 import { createDiscoverMetadata } from './auth/discover.js';
+import { resolveEnvToken } from './auth/legacy-token-env.js';
 import { createRefreshAccessToken } from './auth/silent-refresh.js';
 import { resolveAuth } from './auth/resolve.js';
 import { helpHandler } from './commands/help.js';
 import { loginHandler } from './commands/login.js';
 import { loginDeviceHandler } from './commands/login-device.js';
 import { logoutHandler } from './commands/logout.js';
+import { mcpHandler } from './commands/mcp.js';
 import { versionHandler } from './commands/version.js';
 import { whoamiHandler } from './commands/whoami.js';
 import { tokensCreateHandler } from './commands/tokens/create.js';
@@ -41,6 +43,7 @@ const ROUTES: readonly Route[] = [
   { path: ['tokens', 'create'], handler: tokensCreateHandler },
   { path: ['tokens', 'list'], handler: tokensListHandler },
   { path: ['tokens', 'revoke'], handler: tokensRevokeHandler },
+  { path: ['mcp'], handler: mcpHandler },
 ];
 
 /**
@@ -51,7 +54,8 @@ const ROUTES: readonly Route[] = [
  * "not logged in" is a normal, graceful outcome for them, not a hard
  * failure — routing them through `enforceAuth` first would print this
  * resolver's generic message (and attempt a redundant refresh) ahead of
- * their own, more specific handling.
+ * their own, more specific handling. `mcp` is NOT exempt — it authenticates
+ * through `ctx.sdk` exactly like every other command below.
  */
 const AUTH_EXEMPT_HANDLERS = new Set([helpHandler, loginHandler, logoutHandler, whoamiHandler]);
 
@@ -68,10 +72,15 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
     profile: null,
   });
 
+  const envToken = resolveEnvToken(deps.env);
+  if (envToken.deprecationNotice) {
+    deps.stderr.write(`${envToken.deprecationNotice}\n`);
+  }
+
   const credential = await deps.credentialStore.get(host);
   const source = resolveAuth(
     { token: parsed.flags.token },
-    { PAGESPACE_TOKEN: deps.env.PAGESPACE_TOKEN },
+    { PAGESPACE_TOKEN: envToken.token },
     credential ? { [host]: credential } : {},
     host,
   );


### PR DESCRIPTION
## Summary
- `packages/cli/src/mcp/tool-convert.ts` — pure registry entry → MCP tool conversion (`operationToMcpTool`, using zod v4's native `z.toJSONSchema`), zod pre-flight input validation, and MCP-conformant result/error formatting (no stack traces, no token material, distinct messages per SDK error type — `PermissionDeniedError` names the operation's `requiredScope`).
- `packages/cli/src/mcp/serve.ts` — assembles every operation the SDK exports into one full registry (`buildOperationRegistry`) and wires the low-level MCP `Server`'s `tools/list`/`tools/call` handlers to it (`createMcpServer`) — a thin shell, all decision logic lives in `tool-convert.ts`.
- `packages/cli/src/commands/mcp.ts` — the `pagespace mcp` command. Authenticates ONLY through `ctx.sdk`, exactly like every other command (structurally enforced by the existing `single-auth-path.test.ts`) — no second, un-audited auth path.
- `packages/cli/src/auth/legacy-token-env.ts` — folds the old standalone `pagespace-mcp` server's `PAGESPACE_AUTH_TOKEN` env var into `PAGESPACE_TOKEN`'s precedence slot (Phase 4 task 7's `resolveAuth`, unchanged) only when `PAGESPACE_TOKEN` itself is absent, with a stderr deprecation notice that never echoes the token value. Wired into `run.ts`'s single auth-resolution path, so `pagespace mcp` (and every command) keeps authenticating for existing `npx pagespace-mcp` configs with zero code change beyond eventually switching to `PAGESPACE_TOKEN`/`pagespace login`.

Tool definitions are derived from the registry, never hand-written. Round-trip tested over an in-memory MCP stdio transport (`InMemoryTransport` + `Client`): `list_tools` completeness vs. the registry, `call_tool` happy/invalid-input/unknown-tool/permission-denied/auth-failure paths, and no stack traces or token material leaking into any error result.

## Test plan
- [x] `bun run --filter '@pagespace/cli' typecheck` — passes
- [x] `bun run --filter '@pagespace/cli' test` — 321 tests passed (38 new: tool-convert, serve, mcp command, legacy-token-env; plus 2 new run.ts integration tests)
- [x] RED commit (`1e5d52746`) verified failing before GREEN implementation (`8c3350539`)
- [ ] Manual smoke test of `pagespace mcp` wired into a real MCP client (Claude Desktop/Code config) — not run in this sandbox

Task: Phase 6 task 1 (taskId `bfy6q9qqw8pxk0l8ddb9ztmo`) on the PageSpace SDK/CLI/OAuth Provider epic. Base branch `pu/cli-login` per orchestration contract — do not merge; this converges with the rest of Phase 6/7 later.