### PR TITLE
cli: implement tool-surface parity gate vs v5.2.2 (Phase 6 task 2)

### DIFF
--- a/packages/cli/src/mcp/__tests__/fixtures/README.md
+++ b/packages/cli/src/mcp/__tests__/fixtures/README.md
@@ -1,0 +1,64 @@
+# v5.2.2-tools.json — derivation
+
+The parity contract for Phase 6 task 2 (`docs/sdk/operations-inventory.md`,
+task page `l07x7hy9c30vr0io3ov3se2t`) is the OLD `pagespace-mcp` MCP server
+**at its `v5.2.2` git tag** — not its current HEAD. The tool's own repo
+(`/Users/jono/production/pagespace-mcp`) has kept moving since (it's at
+5.2.6 as of this writing: `chore: bump to 5.2.6`), adding tools the v5.2.2
+contract never had. Pinning to the tag, not HEAD, is what makes this fixture
+a stable, auditable ground truth instead of a moving target.
+
+## How `v5.2.2-tools.json` was generated
+
+1. `cd /Users/jono/production/pagespace-mcp && git show v5.2.2:src/tools.js > /tmp/v522-tools.mjs`
+   — extracts `src/tools.js` as it existed at the `v5.2.2` tag (commit
+   `93ee576`, "chore: bump to 5.2.2"), without touching the working tree.
+2. `bun run extract-v5.2.2-tools.mjs /tmp/v522-tools.mjs > v5.2.2-tools.json`
+   (the script in this directory) — mechanically imports that file as an ES
+   module and maps every entry in its exported `tools` array to
+   `{ name, required }`, where `required` is `inputSchema.required ?? []`.
+   No hand-transcription; the fixture is exactly what `tools.js` declared.
+
+Result: **67 tools**, matching `docs/sdk/operations-inventory.md`'s
+"Tool count: 67 registered tools" line — the doc's own inventory was written
+against this same `v5.2.2` snapshot (its "Sources of truth" section cites
+package.json `5.2.3`, but the note there flags the version string as a
+`server.js` reporting quirk (D13); tag `v5.2.2`'s `tools.js` is what was
+actually walked).
+
+## Why not just read the current `pagespace-mcp` repo at test time
+
+- **Auditability**: a git tag is immutable; importing the live repo at test
+  time would make the parity gate's pass/fail depend on whatever that
+  external repo happens to contain when the test runs — silently drifting
+  ground truth is exactly the failure mode this gate exists to prevent.
+  See `s5kfa3mc4boyjqrsfzvwocx4` (Phase 6 law): "commit the extracted list
+  as a fixture."
+- **No runtime dependency** on a second, unversioned local checkout existing
+  at a specific path on whatever machine runs the test suite.
+
+## Known delta: v5.2.2 → current `pagespace-mcp` HEAD (5.2.6)
+
+`git diff v5.2.2 HEAD -- src/tools.js` (in the `pagespace-mcp` repo) shows
+exactly 3 tools added since v5.2.2, none removed and no `required` fields
+changed on any of the 67 tools that already existed at v5.2.2:
+
+| Tool added after v5.2.2 | Status against the current SDK registry |
+|---|---|
+| `insert_lines` | Already covered — `pages.insertLines` |
+| `delete_lines` | Already covered — `pages.deleteLines` |
+| `set_home_page` | **Not covered** — no corresponding operation exists in `packages/sdk/src/operations/`. Out of scope for *this* v5.2.2-pinned gate (task 2's contract is v5.2.2, not 5.2.6), but worth a follow-up ticket before `pagespace-mcp` is fully retired, since a live 5.2.6 install has a capability this SDK doesn't yet expose. |
+
+## Regenerating
+
+```
+cd /Users/jono/production/pagespace-mcp
+git show v5.2.2:src/tools.js > /tmp/v522-tools.mjs
+cd -
+bun run packages/cli/src/mcp/__tests__/fixtures/extract-v5.2.2-tools.mjs /tmp/v522-tools.mjs \
+  > packages/cli/src/mcp/__tests__/fixtures/v5.2.2-tools.json
+```
+
+Only re-run this if the `v5.2.2` tag itself is ever amended (it shouldn't
+be — tags are supposed to be immutable) or if a future phase deliberately
+re-pins the parity contract to a newer tag.

--- a/packages/cli/src/mcp/__tests__/fixtures/extract-v5.2.2-tools.mjs
+++ b/packages/cli/src/mcp/__tests__/fixtures/extract-v5.2.2-tools.mjs
@@ -1,0 +1,27 @@
+// Regenerates v5.2.2-tools.json — see README.md in this directory for the
+// full derivation story. Run from anywhere with:
+//
+//   bun run packages/cli/src/mcp/__tests__/fixtures/extract-v5.2.2-tools.mjs \
+//     /path/to/pagespace-mcp/src/tools.js > v5.2.2-tools.json
+//
+// The input file must be `src/tools.js` checked out AT the `v5.2.2` git tag
+// of https://github.com/2witstudios/pagespace-mcp (or any working tree
+// pinned there via `git show v5.2.2:src/tools.js > tools.js`) — never the
+// tool's current HEAD, which has moved on since (see README.md).
+//
+// This does NOT import the old repo at runtime for the parity test itself;
+// it is a one-time (or re-run-on-demand) generator whose output is the
+// committed, auditable fixture the test actually reads.
+const toolsPath = process.argv[2];
+if (!toolsPath) {
+  console.error('Usage: bun run extract-v5.2.2-tools.mjs <path-to-v5.2.2-tools.js>');
+  process.exit(1);
+}
+const { tools } = await import(toolsPath);
+
+const extracted = tools.map((tool) => ({
+  name: tool.name,
+  required: tool.inputSchema.required ?? [],
+}));
+
+console.log(JSON.stringify(extracted, null, 2));

--- a/packages/cli/src/mcp/__tests__/fixtures/v5.2.2-parity-map.ts
+++ b/packages/cli/src/mcp/__tests__/fixtures/v5.2.2-parity-map.ts
@@ -1,0 +1,212 @@
+/**
+ * Parity map: v5.2.2 `pagespace-mcp` tool name -> current SDK operation name
+ * (Phase 6 task 2). This is the one place a rename/reshape/drop is allowed
+ * to exist without failing the parity test in `../v5.2.2-parity.test.ts` —
+ * every entry here must cite a reason (a `docs/sdk/operations-inventory.md`
+ * `D#` row where one exists), never a silent skip.
+ *
+ * Every one of the 67 tools in `fixtures/v5.2.2-tools.json` must appear in
+ * EXACTLY one of `TOOL_NAME_ALIASES` or `DROPPED_TOOLS` — the test asserts
+ * this partition is total and disjoint, so an unmapped tool fails loudly
+ * naming itself, not silently passing or silently skipping.
+ */
+
+/** How a single v5.2.2-required field maps onto the new operation's input schema. */
+export type FieldMapping =
+  /** Field name is unchanged. */
+  | { readonly kind: 'same' }
+  /** Field was renamed; `to` is the new property name. */
+  | { readonly kind: 'renamed'; readonly to: string; readonly reason: string }
+  /** Field no longer exists anywhere and needs none — verified decorative/never read server-side. */
+  | { readonly kind: 'dropped'; readonly reason: string }
+  /** Field's old flat value is now supplied inside a differently-shaped new field named `into`. */
+  | { readonly kind: 'reshaped'; readonly into: string; readonly reason: string };
+
+export interface ToolMapping {
+  /** The current SDK operation name (`Operation.name`, dotted namespace) this old tool maps to. */
+  readonly opName: string;
+  /**
+   * Per-required-field overrides, keyed by the OLD tool's field name. Any
+   * v5.2.2-required field not listed here defaults to `SAME` (name
+   * unchanged). Only list fields that actually need a non-`same` mapping.
+   */
+  readonly fields?: Readonly<Record<string, FieldMapping>>;
+}
+
+/**
+ * The 66 v5.2.2 tools that map onto a live operation in the current SDK
+ * registry (`packages/sdk/src/operations/*.ts`, assembled by
+ * `buildOperationRegistry` in `../../serve.ts`).
+ */
+export const TOOL_NAME_ALIASES: Readonly<Record<string, ToolMapping>> = {
+  // ── Drives ──────────────────────────────────────────────────────────────
+  list_drives: { opName: 'drives.list' },
+  create_drive: { opName: 'drives.create' },
+  rename_drive: { opName: 'drives.rename' },
+  update_drive_context: { opName: 'drives.updateContext' },
+  trash_drive: { opName: 'drives.trash' },
+  restore_drive: { opName: 'drives.restore' },
+
+  // ── Page listing & trash listing ────────────────────────────────────────
+  // `driveSlug` was tool-layer-only decoration — the route never read it
+  // (pages.ts `listPages`/`listTrash` doc comments; operations-inventory.md
+  // §2.2 "driveSlug is a tool-layer nicety the route never reads").
+  list_pages: {
+    opName: 'pages.list',
+    fields: { driveSlug: { kind: 'dropped', reason: 'decorative only — route never reads driveSlug (inventory §2.2)' } },
+  },
+  list_trash: {
+    opName: 'pages.listTrash',
+    fields: { driveSlug: { kind: 'dropped', reason: 'decorative only — route never reads driveSlug (inventory §2.2)' } },
+  },
+
+  // ── Page read & metadata ────────────────────────────────────────────────
+  read_page: { opName: 'pages.read' },
+  get_page_details: { opName: 'pages.details' },
+
+  // ── Page write ───────────────────────────────────────────────────────────
+  create_page: { opName: 'pages.create' },
+  rename_page: { opName: 'pages.rename' },
+  // D-note (pages.ts `movePage` doc): wire body is `{pageId, newParentId,
+  // newPosition}` — `position` renamed to match the route's own field name.
+  move_page: {
+    opName: 'pages.move',
+    fields: { position: { kind: 'renamed', to: 'newPosition', reason: 'wire body field is newPosition, matching pages/reorder route exactly' } },
+  },
+  replace_lines: { opName: 'pages.replaceLines' },
+  trash_page: { opName: 'pages.trash' },
+  restore_page: { opName: 'pages.restore' },
+  edit_sheet_cells: { opName: 'pages.editCells' },
+
+  // ── Task management ──────────────────────────────────────────────────────
+  create_task: { opName: 'tasks.create' },
+  update_task: { opName: 'tasks.update' },
+  delete_task: { opName: 'tasks.delete' },
+  reorder_task: { opName: 'tasks.reorder' },
+  create_task_status: { opName: 'tasks.createStatus' },
+  get_assigned_tasks: { opName: 'tasks.getAssigned' },
+
+  // ── Search ───────────────────────────────────────────────────────────────
+  regex_search: { opName: 'search.regex' },
+  glob_search: { opName: 'search.glob' },
+  multi_drive_search: { opName: 'search.multiDrive' },
+
+  // ── AI agents & models ───────────────────────────────────────────────────
+  // `agentPath` was decorative on every old agent tool — verified never sent
+  // to any route (agents.ts module doc: "agentPath from every old tool's
+  // input was decorative — verified never sent to any route").
+  update_agent_config: {
+    opName: 'agents.updateConfig',
+    fields: { agentPath: { kind: 'dropped', reason: 'decorative only — never sent to any route (agents.ts module doc)' } },
+  },
+  list_agents: { opName: 'agents.list' },
+  multi_drive_list_agents: { opName: 'agents.listMultiDrive' },
+  ask_agent: {
+    opName: 'agents.ask',
+    fields: { agentPath: { kind: 'dropped', reason: 'decorative only — never sent to any route (agents.ts module doc)' } },
+  },
+  list_models: { opName: 'agents.listModels' },
+
+  // ── Calendar ─────────────────────────────────────────────────────────────
+  list_calendar_events: { opName: 'calendar.list' },
+  get_calendar_event: { opName: 'calendar.get' },
+  create_calendar_event: { opName: 'calendar.create' },
+  update_calendar_event: { opName: 'calendar.update' },
+  delete_calendar_event: { opName: 'calendar.delete' },
+  rsvp_calendar_event: { opName: 'calendar.rsvp' },
+  invite_calendar_attendees: { opName: 'calendar.inviteAttendees' },
+  // D6: the route reads the target user exclusively from `?userId=`
+  // (defaulting to the caller when absent) — the operation's field is named
+  // `userId` to match the route, not the old tool's `targetUserId`.
+  remove_calendar_attendee: {
+    opName: 'calendar.removeAttendee',
+    fields: { targetUserId: { kind: 'renamed', to: 'userId', reason: 'D6 — route reads ?userId=, not a targetUserId body field' } },
+  },
+
+  // ── Slash commands ───────────────────────────────────────────────────────
+  list_commands: { opName: 'commands.list' },
+  create_command: { opName: 'commands.create' },
+  update_command: { opName: 'commands.update' },
+  delete_command: { opName: 'commands.delete' },
+
+  // ── Role management ──────────────────────────────────────────────────────
+  list_drive_roles: { opName: 'roles.list' },
+  get_drive_role: { opName: 'roles.get' },
+  create_drive_role: { opName: 'roles.create' },
+  update_drive_role: { opName: 'roles.update' },
+  delete_drive_role: { opName: 'roles.delete' },
+  // roles.ts module doc: fix #1765 replaced the flat single-page
+  // {pageId, canView, canEdit, canShare} shape with a server-side
+  // read-merge-write `permissionsPatch: Record<pageId, PagePerm>` map, so a
+  // single SDK call can never wipe another page's grant. `pageId` (the only
+  // v5.2.2-*required* field affected — canView/canEdit/canShare were
+  // optional flags there) is absorbed into `permissionsPatch`'s keys.
+  set_role_page_permissions: {
+    opName: 'roles.setPagePermissions',
+    fields: { pageId: { kind: 'reshaped', into: 'permissionsPatch', reason: 'fix #1765 — per-page read-merge-write patch, pageId becomes a dynamic key' } },
+  },
+  set_role_drive_wide_permissions: { opName: 'roles.setDriveWidePermissions' },
+  remove_role_page_permissions: {
+    opName: 'roles.removePagePermissions',
+    fields: { pageId: { kind: 'reshaped', into: 'permissionsPatch', reason: 'fix #1765 — per-page read-merge-write patch, pageId becomes a dynamic key' } },
+  },
+
+  // ── Agent triggers ───────────────────────────────────────────────────────
+  // calendar.ts operations use `eventId` throughout (matching every other
+  // calendar.* operation) instead of the old trigger tools' one-off
+  // `calendarEventId`.
+  set_calendar_trigger: {
+    opName: 'calendar.setTrigger',
+    fields: { calendarEventId: { kind: 'renamed', to: 'eventId', reason: 'aligned with every other calendar.* operation\'s eventId field' } },
+  },
+  delete_calendar_trigger: {
+    opName: 'calendar.deleteTrigger',
+    fields: { calendarEventId: { kind: 'renamed', to: 'eventId', reason: 'aligned with every other calendar.* operation\'s eventId field' } },
+  },
+  set_task_trigger: { opName: 'tasks.setTrigger' },
+  delete_task_trigger: { opName: 'tasks.deleteTrigger' },
+
+  // ── Scheduled workflows ──────────────────────────────────────────────────
+  list_workflows: { opName: 'workflows.list' },
+  create_workflow: { opName: 'workflows.create' },
+  update_workflow: { opName: 'workflows.update' },
+  delete_workflow: { opName: 'workflows.delete' },
+
+  // ── Members & collaborators ──────────────────────────────────────────────
+  list_drive_members: { opName: 'members.list' },
+  list_collaborators: { opName: 'collaborators.list' },
+
+  // ── Conversations, channels & activity ───────────────────────────────────
+  list_conversations: { opName: 'conversations.list' },
+  read_conversation: { opName: 'conversations.read' },
+  send_channel_message: { opName: 'channels.sendMessage' },
+  delete_channel_message: { opName: 'channels.deleteMessage' },
+  get_activity: { opName: 'activity.get' },
+};
+
+export interface DroppedToolEntry {
+  /** Why this v5.2.2 tool has no corresponding MCP tool today. Must reference the operations-inventory.md D# row when one exists. */
+  readonly reason: string;
+}
+
+/**
+ * v5.2.2 tools with NO corresponding operation in the current registry, by
+ * deliberate design (not an oversight) — reviewable, greppable, one entry
+ * per tool, every entry with a reason.
+ */
+export const DROPPED_TOOLS: Readonly<Record<string, DroppedToolEntry>> = {
+  // D4 (operations-inventory.md): the old tool hit the exact same route as
+  // list_calendar_events (GET /api/calendar/events) and computed free/busy
+  // gaps client-side over the response. The registry models that as
+  // `computeFreeSlots(events, range)`, a pure function over
+  // `calendar.list`'s output (packages/sdk/src/operations/calendar.ts) —
+  // there is no `calendar.checkAvailability` operation and therefore no MCP
+  // tool. Reachable capability: call `calendar.list` (`list_calendar_events`)
+  // then compute free slots over its `events` array (the same math
+  // `computeFreeSlots` runs, exported for any caller that wants it — though,
+  // unlike the old tool, it is not itself callable as an MCP tool).
+  check_calendar_availability: {
+    reason:
+      'D4 — collapsed into computeFreeSlots(events, range), a pure function over calendar.list\'s output; not registered as its own operation, so no MCP tool exists for it',
+  },
+};

--- a/packages/cli/src/mcp/__tests__/fixtures/v5.2.2-tools.json
+++ b/packages/cli/src/mcp/__tests__/fixtures/v5.2.2-tools.json
@@ -1,0 +1,443 @@
+[
+  {
+    "name": "list_drives",
+    "required": []
+  },
+  {
+    "name": "create_drive",
+    "required": [
+      "name"
+    ]
+  },
+  {
+    "name": "rename_drive",
+    "required": [
+      "driveId",
+      "name"
+    ]
+  },
+  {
+    "name": "update_drive_context",
+    "required": [
+      "driveId",
+      "drivePrompt"
+    ]
+  },
+  {
+    "name": "list_pages",
+    "required": [
+      "driveSlug",
+      "driveId"
+    ]
+  },
+  {
+    "name": "list_trash",
+    "required": [
+      "driveSlug",
+      "driveId"
+    ]
+  },
+  {
+    "name": "read_page",
+    "required": [
+      "pageId"
+    ]
+  },
+  {
+    "name": "get_page_details",
+    "required": [
+      "pageId"
+    ]
+  },
+  {
+    "name": "create_page",
+    "required": [
+      "driveId",
+      "title",
+      "type"
+    ]
+  },
+  {
+    "name": "rename_page",
+    "required": [
+      "pageId",
+      "title"
+    ]
+  },
+  {
+    "name": "move_page",
+    "required": [
+      "pageId",
+      "position"
+    ]
+  },
+  {
+    "name": "replace_lines",
+    "required": [
+      "pageId",
+      "startLine",
+      "content"
+    ]
+  },
+  {
+    "name": "trash_page",
+    "required": [
+      "pageId"
+    ]
+  },
+  {
+    "name": "trash_drive",
+    "required": [
+      "driveId",
+      "confirmDriveName"
+    ]
+  },
+  {
+    "name": "restore_page",
+    "required": [
+      "pageId"
+    ]
+  },
+  {
+    "name": "restore_drive",
+    "required": [
+      "driveId"
+    ]
+  },
+  {
+    "name": "edit_sheet_cells",
+    "required": [
+      "pageId",
+      "cells"
+    ]
+  },
+  {
+    "name": "create_task",
+    "required": [
+      "pageId",
+      "title"
+    ]
+  },
+  {
+    "name": "update_task",
+    "required": [
+      "pageId",
+      "taskId"
+    ]
+  },
+  {
+    "name": "delete_task",
+    "required": [
+      "pageId",
+      "taskId"
+    ]
+  },
+  {
+    "name": "reorder_task",
+    "required": [
+      "pageId",
+      "taskId",
+      "position"
+    ]
+  },
+  {
+    "name": "create_task_status",
+    "required": [
+      "pageId",
+      "name",
+      "color",
+      "group"
+    ]
+  },
+  {
+    "name": "get_assigned_tasks",
+    "required": []
+  },
+  {
+    "name": "regex_search",
+    "required": [
+      "driveId",
+      "pattern"
+    ]
+  },
+  {
+    "name": "glob_search",
+    "required": [
+      "driveId",
+      "pattern"
+    ]
+  },
+  {
+    "name": "multi_drive_search",
+    "required": [
+      "searchQuery"
+    ]
+  },
+  {
+    "name": "update_agent_config",
+    "required": [
+      "agentPath",
+      "agentId"
+    ]
+  },
+  {
+    "name": "list_agents",
+    "required": [
+      "driveId"
+    ]
+  },
+  {
+    "name": "multi_drive_list_agents",
+    "required": []
+  },
+  {
+    "name": "ask_agent",
+    "required": [
+      "agentPath",
+      "agentId",
+      "question"
+    ]
+  },
+  {
+    "name": "list_calendar_events",
+    "required": [
+      "startDate",
+      "endDate"
+    ]
+  },
+  {
+    "name": "get_calendar_event",
+    "required": [
+      "eventId"
+    ]
+  },
+  {
+    "name": "check_calendar_availability",
+    "required": [
+      "startDate",
+      "endDate"
+    ]
+  },
+  {
+    "name": "create_calendar_event",
+    "required": [
+      "title",
+      "startAt",
+      "endAt"
+    ]
+  },
+  {
+    "name": "update_calendar_event",
+    "required": [
+      "eventId"
+    ]
+  },
+  {
+    "name": "delete_calendar_event",
+    "required": [
+      "eventId"
+    ]
+  },
+  {
+    "name": "rsvp_calendar_event",
+    "required": [
+      "eventId",
+      "status"
+    ]
+  },
+  {
+    "name": "invite_calendar_attendees",
+    "required": [
+      "eventId",
+      "userIds"
+    ]
+  },
+  {
+    "name": "remove_calendar_attendee",
+    "required": [
+      "eventId",
+      "targetUserId"
+    ]
+  },
+  {
+    "name": "list_commands",
+    "required": []
+  },
+  {
+    "name": "create_command",
+    "required": [
+      "trigger",
+      "description",
+      "entryPageId"
+    ]
+  },
+  {
+    "name": "update_command",
+    "required": [
+      "commandId"
+    ]
+  },
+  {
+    "name": "delete_command",
+    "required": [
+      "commandId"
+    ]
+  },
+  {
+    "name": "list_drive_roles",
+    "required": [
+      "driveId"
+    ]
+  },
+  {
+    "name": "get_drive_role",
+    "required": [
+      "driveId",
+      "roleId"
+    ]
+  },
+  {
+    "name": "create_drive_role",
+    "required": [
+      "driveId",
+      "name"
+    ]
+  },
+  {
+    "name": "update_drive_role",
+    "required": [
+      "driveId",
+      "roleId"
+    ]
+  },
+  {
+    "name": "delete_drive_role",
+    "required": [
+      "driveId",
+      "roleId"
+    ]
+  },
+  {
+    "name": "set_role_page_permissions",
+    "required": [
+      "driveId",
+      "roleId",
+      "pageId"
+    ]
+  },
+  {
+    "name": "set_role_drive_wide_permissions",
+    "required": [
+      "driveId",
+      "roleId"
+    ]
+  },
+  {
+    "name": "remove_role_page_permissions",
+    "required": [
+      "driveId",
+      "roleId",
+      "pageId"
+    ]
+  },
+  {
+    "name": "set_calendar_trigger",
+    "required": [
+      "calendarEventId",
+      "agentPageId"
+    ]
+  },
+  {
+    "name": "delete_calendar_trigger",
+    "required": [
+      "calendarEventId"
+    ]
+  },
+  {
+    "name": "set_task_trigger",
+    "required": [
+      "taskId",
+      "triggerType",
+      "agentPageId"
+    ]
+  },
+  {
+    "name": "delete_task_trigger",
+    "required": [
+      "taskId",
+      "triggerType"
+    ]
+  },
+  {
+    "name": "list_workflows",
+    "required": [
+      "driveId"
+    ]
+  },
+  {
+    "name": "create_workflow",
+    "required": [
+      "driveId",
+      "name",
+      "cronExpression",
+      "agentPageId"
+    ]
+  },
+  {
+    "name": "update_workflow",
+    "required": [
+      "workflowId"
+    ]
+  },
+  {
+    "name": "delete_workflow",
+    "required": [
+      "workflowId"
+    ]
+  },
+  {
+    "name": "list_drive_members",
+    "required": [
+      "driveId"
+    ]
+  },
+  {
+    "name": "list_collaborators",
+    "required": []
+  },
+  {
+    "name": "list_models",
+    "required": []
+  },
+  {
+    "name": "list_conversations",
+    "required": [
+      "agentId"
+    ]
+  },
+  {
+    "name": "read_conversation",
+    "required": [
+      "agentId",
+      "conversationId"
+    ]
+  },
+  {
+    "name": "send_channel_message",
+    "required": [
+      "pageId",
+      "content"
+    ]
+  },
+  {
+    "name": "delete_channel_message",
+    "required": [
+      "pageId",
+      "messageId"
+    ]
+  },
+  {
+    "name": "get_activity",
+    "required": []
+  }
+]

--- a/packages/cli/src/mcp/__tests__/v5.2.2-parity.test.ts
+++ b/packages/cli/src/mcp/__tests__/v5.2.2-parity.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tool-surface parity gate vs pagespace-mcp v5.2.2 (Phase 6 task 2).
+ *
+ * This is the epic's honesty mechanism: it enumerates every tool
+ * `pagespace-mcp` had at its v5.2.2 tag (`fixtures/v5.2.2-tools.json`, see
+ * `fixtures/README.md` for exactly how that fixture was derived) and fails
+ * loudly if the generated MCP surface (`buildOperationRegistry` +
+ * `operationToMcpTool`, the same pipeline `pagespace mcp` serves over stdio)
+ * is missing any of those tools or any of their v5.2.2-required input
+ * fields. Renames/reshapes/drops are only permitted via the explicit,
+ * commented map in `fixtures/v5.2.2-parity-map.ts` — never a silent skip.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { listOperations } from '@pagespace/sdk';
+import { buildOperationRegistry } from '../serve.js';
+import { operationToMcpTool, type McpToolDefinition } from '../tool-convert.js';
+import { DROPPED_TOOLS, TOOL_NAME_ALIASES, type FieldMapping } from './fixtures/v5.2.2-parity-map.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface V522Tool {
+  readonly name: string;
+  readonly required: readonly string[];
+}
+
+const fixtureTools: readonly V522Tool[] = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures/v5.2.2-tools.json'), 'utf-8'),
+);
+
+const inventoryDoc = readFileSync(
+  join(__dirname, '../../../../../docs/sdk/operations-inventory.md'),
+  'utf-8',
+);
+
+function generatedSurface(): ReadonlyMap<string, McpToolDefinition & { readonly propertyNames: ReadonlySet<string> }> {
+  const registry = buildOperationRegistry();
+  const tools = listOperations(registry).map(operationToMcpTool);
+  const byName = new Map<string, McpToolDefinition & { readonly propertyNames: ReadonlySet<string> }>();
+  for (const tool of tools) {
+    const properties = (tool.inputSchema as { properties?: Record<string, unknown> }).properties ?? {};
+    byName.set(tool.name, { ...tool, propertyNames: new Set(Object.keys(properties)) });
+  }
+  return byName;
+}
+
+/** Resolves what property name(s) an old-tool required field should appear as in the new schema, or null if the field was intentionally dropped. */
+function resolveExpectedField(fieldMapping: FieldMapping | undefined, oldField: string): string | null {
+  const mapping = fieldMapping ?? { kind: 'same' as const };
+  switch (mapping.kind) {
+    case 'same':
+      return oldField;
+    case 'renamed':
+      return mapping.to;
+    case 'reshaped':
+      return mapping.into;
+    case 'dropped':
+      return null;
+  }
+}
+
+describe('v5.2.2 tool-surface parity gate', () => {
+  it('fixture has exactly 67 tools, matching operations-inventory.md\'s stated count', () => {
+    const match = inventoryDoc.match(/Tool count:\s*\*{0,2}(\d+)\s*registered tools/);
+    expect(match, 'expected to find "Tool count: N registered tools" in operations-inventory.md').not.toBeNull();
+    const inventoryCount = Number(match?.[1]);
+    expect(
+      fixtureTools.length,
+      `fixture has ${fixtureTools.length} tools but operations-inventory.md declares ${inventoryCount} — name the delta before changing either`,
+    ).toBe(inventoryCount);
+  });
+
+  it('every fixture tool is mapped in EXACTLY one of TOOL_NAME_ALIASES or DROPPED_TOOLS (total, disjoint partition)', () => {
+    const unmapped: string[] = [];
+    const mappedTwice: string[] = [];
+    for (const tool of fixtureTools) {
+      const inAliases = tool.name in TOOL_NAME_ALIASES;
+      const inDropped = tool.name in DROPPED_TOOLS;
+      if (!inAliases && !inDropped) unmapped.push(tool.name);
+      if (inAliases && inDropped) mappedTwice.push(tool.name);
+    }
+    expect(unmapped, `v5.2.2 tools with no mapping at all — add each to TOOL_NAME_ALIASES or DROPPED_TOOLS: ${unmapped.join(', ')}`).toEqual([]);
+    expect(mappedTwice, `v5.2.2 tools mapped in BOTH tables (ambiguous): ${mappedTwice.join(', ')}`).toEqual([]);
+  });
+
+  it('every DROPPED_TOOLS entry carries a non-empty reason', () => {
+    for (const [name, entry] of Object.entries(DROPPED_TOOLS)) {
+      expect(entry.reason.length, `DROPPED_TOOLS.${name} must have a reason string`).toBeGreaterThan(10);
+    }
+  });
+
+  it('every aliased v5.2.2 tool has a live MCP tool at its mapped operation name', () => {
+    const surface = generatedSurface();
+    const missing: string[] = [];
+    for (const tool of fixtureTools) {
+      const mapping = TOOL_NAME_ALIASES[tool.name];
+      if (!mapping) continue; // covered by the partition test above (dropped, or a real gap already failing there)
+      if (!surface.has(mapping.opName)) {
+        missing.push(`${tool.name} -> ${mapping.opName} (not found in generated MCP surface)`);
+      }
+    }
+    expect(missing, `missing tools in the generated MCP surface:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  it('every v5.2.2-required field of every aliased tool is present (by name or documented alias) in the generated schema', () => {
+    const surface = generatedSurface();
+    const problems: string[] = [];
+
+    for (const tool of fixtureTools) {
+      const mapping = TOOL_NAME_ALIASES[tool.name];
+      if (!mapping) continue;
+
+      const generated = surface.get(mapping.opName);
+      if (!generated) continue; // already reported by the previous test
+
+      for (const oldField of tool.required) {
+        const expected = resolveExpectedField(mapping.fields?.[oldField], oldField);
+        if (expected === null) continue; // explicitly, reason-documented drop
+
+        if (!generated.propertyNames.has(expected)) {
+          problems.push(
+            `${tool.name}.${oldField} -> expected "${expected}" as a property of "${mapping.opName}", but it is absent. ` +
+              `Generated properties: [${[...generated.propertyNames].join(', ')}]`,
+          );
+        }
+      }
+    }
+
+    expect(problems, `required-field parity gaps:\n${problems.join('\n')}`).toEqual([]);
+  });
+
+  it('every DROPPED_TOOLS entry names a real, still-nonexistent gap (guards against a stale allowlist)', () => {
+    const surface = generatedSurface();
+    // None of these should coincidentally already exist under their own old
+    // snake_case name or an obvious dotted equivalent — if one does, the
+    // drop entry is stale and should move to TOOL_NAME_ALIASES instead.
+    for (const name of Object.keys(DROPPED_TOOLS)) {
+      expect(surface.has(name), `DROPPED_TOOLS.${name} exists verbatim in the generated surface — move it to TOOL_NAME_ALIASES`).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the mechanical tool-surface parity gate between `pagespace-mcp`'s **v5.2.2** git tag (67 tools) and the generated MCP surface (`buildOperationRegistry` + `operationToMcpTool`, Phase 6 task 1's adapter).
- `fixtures/v5.2.2-tools.json`: 67 tools (name + required fields), mechanically extracted via `git show v5.2.2:src/tools.js` in `pagespace-mcp` — never hand-transcribed, never imported from that repo at test time. `fixtures/README.md` documents the exact derivation and the known v5.2.2→5.2.6 delta (3 tools added since v5.2.2: `insert_lines`/`delete_lines` already covered by `pages.insertLines`/`pages.deleteLines`; `set_home_page` genuinely uncovered but out of scope for this v5.2.2-pinned gate).
- `fixtures/v5.2.2-parity-map.ts`: explicit, commented `TOOL_NAME_ALIASES` (old snake_case → new dotted `Operation.name`) and `DROPPED_TOOLS` allowlist. Every rename/reshape/drop cites a reason, referencing the Phase 0 inventory's D-register where applicable (D6 for `remove_calendar_attendee`'s field rename, D4 for the one dropped tool).
- `v5.2.2-parity.test.ts` asserts: fixture count matches `operations-inventory.md`'s stated tool count; every fixture tool is mapped in exactly one of the alias/dropped tables (total, disjoint partition — an unmapped tool fails loudly, by name); every aliased tool exists in the generated surface; every v5.2.2-required field is present (by name or documented alias); every dropped-tool reason is non-empty; no dropped tool coincidentally already exists verbatim (stale-allowlist guard).

## Result
**GREEN immediately.** The current SDK registry already covers every v5.2.2 tool and required field once the one documented D4 divergence is accounted for:
- `check_calendar_availability` has no corresponding MCP tool — it was intentionally collapsed into `computeFreeSlots(events, range)`, a pure function over `calendar.list`'s output (Phase 3's own documented D4 resolution), not a second network operation. Allowlisted with reason, not silently dropped.

No real SDK/registry gaps were found requiring a Phase 3 follow-up.

## Test plan
- [x] `bun run --filter '@pagespace/cli' typecheck` — passes
- [x] `bun run --filter '@pagespace/cli' test` — 360/360 passed (6 new parity tests + all existing suites green)
- [x] Verified `extract-v5.2.2-tools.mjs`'s output byte-for-byte matches the committed fixture (regeneration is reproducible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Chiu2NMMGEhdws5KuFRz9w