### PR TITLE
cli: implement content & export verbs (Phase 5 task 2)

### DIFF
--- a/packages/cli/src/commands/__tests__/content.test.ts
+++ b/packages/cli/src/commands/__tests__/content.test.ts
@@ -36,7 +36,7 @@ describe('pagesReadHandler', () => {
     const code = await pagesReadHandler(ctx, commandIntent(['pg_1']));
 
     expect(code).toBe(EXIT_SUCCESS);
-    expect(read).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: undefined, endLine: undefined });
+    expect(read).toHaveBeenCalledWith({ operation: 'read', pageId: 'pg_1', startLine: undefined, endLine: undefined });
   });
 
   it('passes --start/--end through as a numeric range', async () => {
@@ -46,7 +46,7 @@ describe('pagesReadHandler', () => {
     const code = await pagesReadHandler(ctx, commandIntent(['pg_1', '--start', '2', '--end', '5']));
 
     expect(code).toBe(EXIT_SUCCESS);
-    expect(read).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: 2, endLine: 5 });
+    expect(read).toHaveBeenCalledWith({ operation: 'read', pageId: 'pg_1', startLine: 2, endLine: 5 });
   });
 
   it('rejects an out-of-order range as a usage error before any network call', async () => {
@@ -153,7 +153,7 @@ describe('createPagesReplaceLinesHandler', () => {
 
     expect(code).toBe(EXIT_SUCCESS);
     expect(readFile).not.toHaveBeenCalled();
-    expect(replaceLines).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: 2, endLine: undefined, content: 'replacement text\n\n' });
+    expect(replaceLines).toHaveBeenCalledWith({ operation: 'replace', pageId: 'pg_1', startLine: 2, endLine: undefined, content: 'replacement text\n\n' });
   });
 
   it('reads content from --file when given, byte-exact, never touching stdin', async () => {
@@ -168,7 +168,7 @@ describe('createPagesReplaceLinesHandler', () => {
     expect(code).toBe(EXIT_SUCCESS);
     expect(readStdin).not.toHaveBeenCalled();
     expect(readFile).toHaveBeenCalledWith('/tmp/new.md');
-    expect(replaceLines).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: 2, endLine: 3, content: 'content of /tmp/new.md' });
+    expect(replaceLines).toHaveBeenCalledWith({ operation: 'replace', pageId: 'pg_1', startLine: 2, endLine: 3, content: 'content of /tmp/new.md' });
   });
 
   it('--json emits exactly the SDK response', async () => {

--- a/packages/cli/src/commands/__tests__/content.test.ts
+++ b/packages/cli/src/commands/__tests__/content.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, parseArgv } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+import { createPagesReplaceLinesHandler, pagesReadHandler } from '../content.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const GENERIC_READ_RESULT = {
+  pageId: 'pg_1',
+  pageTitle: 'RFC-1',
+  totalLines: 2,
+  numberedLines: ['   1 | line one', '   2 | line two'],
+  content: 'line one\nline two',
+};
+
+describe('pagesReadHandler', () => {
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const read = vi.fn(async () => GENERIC_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await pagesReadHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('calls pages.read with pageId only when no range is given', async () => {
+    const read = vi.fn(async () => GENERIC_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await pagesReadHandler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(read).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: undefined, endLine: undefined });
+  });
+
+  it('passes --start/--end through as a numeric range', async () => {
+    const read = vi.fn(async () => GENERIC_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await pagesReadHandler(ctx, commandIntent(['pg_1', '--start', '2', '--end', '5']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(read).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: 2, endLine: 5 });
+  });
+
+  it('rejects an out-of-order range as a usage error before any network call', async () => {
+    const read = vi.fn(async () => GENERIC_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await pagesReadHandler(ctx, commandIntent(['pg_1', '--start', '5', '--end', '2']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-integer --start as a usage error before any network call', async () => {
+    const read = vi.fn(async () => GENERIC_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await pagesReadHandler(ctx, commandIntent(['pg_1', '--start', 'nope']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => GENERIC_READ_RESULT } }) });
+
+    await pagesReadHandler(ctx, commandIntent(['pg_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(GENERIC_READ_RESULT);
+  });
+
+  it('human mode renders numbered lines', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => GENERIC_READ_RESULT } }) });
+
+    await pagesReadHandler(ctx, commandIntent(['pg_1']));
+
+    const output = stdout.lines.join('');
+    expect(output).toContain('1 | line one');
+    expect(output).toContain('2 | line two');
+  });
+
+  it('--raw prints exactly the content field, unnumbered', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => GENERIC_READ_RESULT } }) });
+
+    await pagesReadHandler(ctx, commandIntent(['pg_1', '--raw']));
+
+    expect(stdout.lines.join('')).toBe('line one\nline two');
+  });
+});
+
+describe('createPagesReplaceLinesHandler', () => {
+  it('exits 2 with a usage error when pageId is missing, never reading input', async () => {
+    const replaceLines = vi.fn(async () => ({ pageId: 'pg_1', pageTitle: null, totalLines: 2, numberedLines: [], operation: 'replace' as const, affectedLines: '1-2' }));
+    const readStdin = vi.fn(async () => 'new content');
+    const readFile = vi.fn(async () => 'file content');
+    const handler = createPagesReplaceLinesHandler({ readStdin, readFile });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { replaceLines } }) });
+
+    const code = await handler(ctx, commandIntent(['--start', '1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(readStdin).not.toHaveBeenCalled();
+    expect(replaceLines).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when --start is missing, before reading any input', async () => {
+    const replaceLines = vi.fn(async () => ({ pageId: 'pg_1', pageTitle: null, totalLines: 2, numberedLines: [], operation: 'replace' as const, affectedLines: '1' }));
+    const readStdin = vi.fn(async () => 'new content');
+    const readFile = vi.fn(async () => 'file content');
+    const handler = createPagesReplaceLinesHandler({ readStdin, readFile });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { replaceLines } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(readStdin).not.toHaveBeenCalled();
+    expect(replaceLines).not.toHaveBeenCalled();
+  });
+
+  it('rejects an out-of-order range as a usage error before reading any input', async () => {
+    const replaceLines = vi.fn(async () => ({ pageId: 'pg_1', pageTitle: null, totalLines: 2, numberedLines: [], operation: 'replace' as const, affectedLines: '1' }));
+    const readStdin = vi.fn(async () => 'new content');
+    const readFile = vi.fn(async () => 'file content');
+    const handler = createPagesReplaceLinesHandler({ readStdin, readFile });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { replaceLines } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--start', '5', '--end', '2']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(readStdin).not.toHaveBeenCalled();
+    expect(replaceLines).not.toHaveBeenCalled();
+  });
+
+  it('reads content from stdin by default and passes it through byte-exact, including trailing newlines', async () => {
+    const replaceLines = vi.fn(async () => ({ pageId: 'pg_1', pageTitle: null, totalLines: 3, numberedLines: [], operation: 'replace' as const, affectedLines: '2' }));
+    const readStdin = vi.fn(async () => 'replacement text\n\n');
+    const readFile = vi.fn(async () => 'unused');
+    const handler = createPagesReplaceLinesHandler({ readStdin, readFile });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { replaceLines } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--start', '2']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(readFile).not.toHaveBeenCalled();
+    expect(replaceLines).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: 2, endLine: undefined, content: 'replacement text\n\n' });
+  });
+
+  it('reads content from --file when given, byte-exact, never touching stdin', async () => {
+    const replaceLines = vi.fn(async () => ({ pageId: 'pg_1', pageTitle: null, totalLines: 3, numberedLines: [], operation: 'replace' as const, affectedLines: '2-3' }));
+    const readStdin = vi.fn(async () => 'should not be used');
+    const readFile = vi.fn(async (path: string) => `content of ${path}`);
+    const handler = createPagesReplaceLinesHandler({ readStdin, readFile });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { replaceLines } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--start', '2', '--end', '3', '--file', '/tmp/new.md']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(readStdin).not.toHaveBeenCalled();
+    expect(readFile).toHaveBeenCalledWith('/tmp/new.md');
+    expect(replaceLines).toHaveBeenCalledWith({ pageId: 'pg_1', startLine: 2, endLine: 3, content: 'content of /tmp/new.md' });
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const value = { pageId: 'pg_1', pageTitle: 'RFC-1', totalLines: 3, numberedLines: ['   1 | a'], operation: 'replace' as const, affectedLines: '1' };
+    const stdout = createRecordingSink();
+    const handler = createPagesReplaceLinesHandler({ readStdin: async () => 'a', readFile: async () => 'a' });
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { replaceLines: async () => value } }) });
+
+    await handler(ctx, commandIntent(['pg_1', '--start', '1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(value);
+  });
+
+  it('surfaces an SDK failure as a runtime error', async () => {
+    const replaceLines = vi.fn(async () => {
+      throw new Error('409 revision conflict');
+    });
+    const stderr = createRecordingSink();
+    const handler = createPagesReplaceLinesHandler({ readStdin: async () => 'a', readFile: async () => 'a' });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ pages: { replaceLines } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--start', '1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('409 revision conflict');
+  });
+});

--- a/packages/cli/src/commands/__tests__/export.test.ts
+++ b/packages/cli/src/commands/__tests__/export.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, parseArgv } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+import { createPagesExportHandler } from '../export.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+function fakeDeps(overrides: Partial<{ fileExists: (path: string) => Promise<boolean>; writeFile: (path: string, content: string) => Promise<void> }> = {}) {
+  return {
+    fileExists: vi.fn(async () => false),
+    writeFile: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('createPagesExportHandler', () => {
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const pageMarkdown = vi.fn(async () => '# doc');
+    const deps = fakeDeps();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['--format', 'md', '--out', '-']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(pageMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error for an invalid --format, never calling the SDK', async () => {
+    const pageMarkdown = vi.fn(async () => '# doc');
+    const deps = fakeDeps();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'pdf', '--out', '-']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(pageMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when --out is missing', async () => {
+    const pageMarkdown = vi.fn(async () => '# doc');
+    const deps = fakeDeps();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'md']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(pageMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('--format md calls export.pageMarkdown and "-" writes the raw text to stdout, nothing else', async () => {
+    const pageMarkdown = vi.fn(async () => '# Hello World');
+    const sheetCsv = vi.fn(async () => 'a,b');
+    const deps = fakeDeps();
+    const stdout = createRecordingSink();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ export: { pageMarkdown, sheetCsv } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'md', '--out', '-']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(pageMarkdown).toHaveBeenCalledWith({ pageId: 'pg_1' });
+    expect(sheetCsv).not.toHaveBeenCalled();
+    expect(stdout.lines.join('')).toBe('# Hello World');
+  });
+
+  it('--format csv calls export.sheetCsv', async () => {
+    const pageMarkdown = vi.fn(async () => '# Hello World');
+    const sheetCsv = vi.fn(async () => 'a,b\n1,2');
+    const deps = fakeDeps();
+    const stdout = createRecordingSink();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ export: { pageMarkdown, sheetCsv } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'csv', '--out', '-']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(sheetCsv).toHaveBeenCalledWith({ pageId: 'pg_1' });
+    expect(pageMarkdown).not.toHaveBeenCalled();
+    expect(stdout.lines.join('')).toBe('a,b\n1,2');
+  });
+
+  it('writes to a file path when --out is not "-", and prints nothing raw to stdout', async () => {
+    const pageMarkdown = vi.fn(async () => '# Hello World');
+    const deps = fakeDeps({ fileExists: vi.fn(async () => false) });
+    const stdout = createRecordingSink();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'md', '--out', '/tmp/doc.md']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(deps.writeFile).toHaveBeenCalledWith('/tmp/doc.md', '# Hello World');
+    expect(stdout.lines.join('')).not.toContain('# Hello World');
+  });
+
+  it('refuses to overwrite an existing file without --force, never calling the SDK', async () => {
+    const pageMarkdown = vi.fn(async () => '# Hello World');
+    const deps = fakeDeps({ fileExists: vi.fn(async () => true) });
+    const stderr = createRecordingSink();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'md', '--out', '/tmp/doc.md']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(pageMarkdown).not.toHaveBeenCalled();
+    expect(deps.writeFile).not.toHaveBeenCalled();
+    expect(stderr.lines.join('')).toMatch(/--force/);
+  });
+
+  it('overwrites an existing file when --force is given', async () => {
+    const pageMarkdown = vi.fn(async () => '# Hello World');
+    const deps = fakeDeps({ fileExists: vi.fn(async () => true) });
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'md', '--out', '/tmp/doc.md', '--force']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(pageMarkdown).toHaveBeenCalledWith({ pageId: 'pg_1' });
+    expect(deps.writeFile).toHaveBeenCalledWith('/tmp/doc.md', '# Hello World');
+  });
+
+  it('surfaces an SDK failure as a runtime error', async () => {
+    const pageMarkdown = vi.fn(async () => {
+      throw new Error('Markdown export is only available for DOCUMENT pages');
+    });
+    const deps = fakeDeps();
+    const stderr = createRecordingSink();
+    const handler = createPagesExportHandler(deps);
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ export: { pageMarkdown } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--format', 'md', '--out', '-']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Markdown export is only available for DOCUMENT pages');
+  });
+});

--- a/packages/cli/src/commands/__tests__/sheets.test.ts
+++ b/packages/cli/src/commands/__tests__/sheets.test.ts
@@ -42,7 +42,7 @@ describe('createSheetsEditCellsHandler', () => {
     const code = await handler(ctx, commandIntent(['pg_1']));
 
     expect(code).toBe(EXIT_SUCCESS);
-    expect(editCells).toHaveBeenCalledWith({ pageId: 'pg_1', cells: [{ address: 'A1', value: '5' }] });
+    expect(editCells).toHaveBeenCalledWith({ operation: 'edit-cells', pageId: 'pg_1', cells: [{ address: 'A1', value: '5' }] });
   });
 
   it('reads cells from --json-input when given, never touching stdin', async () => {
@@ -55,7 +55,7 @@ describe('createSheetsEditCellsHandler', () => {
 
     expect(code).toBe(EXIT_SUCCESS);
     expect(readStdin).not.toHaveBeenCalled();
-    expect(editCells).toHaveBeenCalledWith({ pageId: 'pg_1', cells: [{ address: 'B2', value: '7' }] });
+    expect(editCells).toHaveBeenCalledWith({ operation: 'edit-cells', pageId: 'pg_1', cells: [{ address: 'B2', value: '7' }] });
   });
 
   it('rejects malformed JSON input as a usage error before any network call', async () => {

--- a/packages/cli/src/commands/__tests__/sheets.test.ts
+++ b/packages/cli/src/commands/__tests__/sheets.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, parseArgv } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+import { createSheetsEditCellsHandler } from '../sheets.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const EDIT_RESULT = {
+  pageId: 'pg_1',
+  pageTitle: 'Budget',
+  cellsUpdated: 1,
+  operation: 'edit-cells' as const,
+  stats: { valuesSet: 1, formulasSet: 0, cellsCleared: 0, sheetDimensions: { rows: 10, columns: 10 } },
+  updatedCells: [{ address: 'A1', type: 'value' as const }],
+};
+
+describe('createSheetsEditCellsHandler', () => {
+  it('exits 2 with a usage error when pageId is missing, never reading input', async () => {
+    const editCells = vi.fn(async () => EDIT_RESULT);
+    const readStdin = vi.fn(async () => '[]');
+    const handler = createSheetsEditCellsHandler({ readStdin });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { editCells } }) });
+
+    const code = await handler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(readStdin).not.toHaveBeenCalled();
+    expect(editCells).not.toHaveBeenCalled();
+  });
+
+  it('reads cells from stdin by default and passes them through to pages.editCells', async () => {
+    const editCells = vi.fn(async () => EDIT_RESULT);
+    const readStdin = vi.fn(async () => '[{"address":"A1","value":"5"}]');
+    const handler = createSheetsEditCellsHandler({ readStdin });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { editCells } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(editCells).toHaveBeenCalledWith({ pageId: 'pg_1', cells: [{ address: 'A1', value: '5' }] });
+  });
+
+  it('reads cells from --json-input when given, never touching stdin', async () => {
+    const editCells = vi.fn(async () => EDIT_RESULT);
+    const readStdin = vi.fn(async () => 'should not be used');
+    const handler = createSheetsEditCellsHandler({ readStdin });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { editCells } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1', '--json-input', '[{"address":"B2","value":"7"}]']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(readStdin).not.toHaveBeenCalled();
+    expect(editCells).toHaveBeenCalledWith({ pageId: 'pg_1', cells: [{ address: 'B2', value: '7' }] });
+  });
+
+  it('rejects malformed JSON input as a usage error before any network call', async () => {
+    const editCells = vi.fn(async () => EDIT_RESULT);
+    const handler = createSheetsEditCellsHandler({ readStdin: async () => 'not json' });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { editCells } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(editCells).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-array JSON input as a usage error before any network call', async () => {
+    const editCells = vi.fn(async () => EDIT_RESULT);
+    const handler = createSheetsEditCellsHandler({ readStdin: async () => '{"address":"A1","value":"5"}' });
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { editCells } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(editCells).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const handler = createSheetsEditCellsHandler({ readStdin: async () => '[{"address":"A1","value":"5"}]' });
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { editCells: async () => EDIT_RESULT } }) });
+
+    await handler(ctx, commandIntent(['pg_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(EDIT_RESULT);
+  });
+
+  it('surfaces an SDK failure as a runtime error', async () => {
+    const editCells = vi.fn(async () => {
+      throw new Error('Invalid A1-style cell address');
+    });
+    const stderr = createRecordingSink();
+    const handler = createSheetsEditCellsHandler({ readStdin: async () => '[{"address":"A1","value":"5"}]' });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ pages: { editCells } }) });
+
+    const code = await handler(ctx, commandIntent(['pg_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Invalid A1-style cell address');
+  });
+});

--- a/packages/cli/src/commands/content.ts
+++ b/packages/cli/src/commands/content.ts
@@ -1,0 +1,200 @@
+/**
+ * `pagespace pages read|replace-lines` (Phase 5 task 2). Thin projections
+ * over the `pages.read`/`pages.replaceLines` SDK operations (documents
+ * namespace, already wired on the client by Phase 3 task 2).
+ *
+ * `--start`/`--end` and `--file` are not part of the global argv grammar
+ * (`parseArgv` only extracts `--json`/`--yes`/`--host`/etc.), so each is
+ * extracted locally from `CommandIntent.args` the same way `extractDriveFlag`
+ * handles `--drive` — a small composable scanner that consumes what it
+ * understands and passes the remainder through `rest`.
+ *
+ * Range validation (1-based, `end >= start`) happens here as a usage error
+ * (exit 2) before any SDK call, even though the SDK's own zod schema would
+ * eventually reject the same input — that rejection surfaces as a runtime
+ * error (exit 1) via `callSdk`, which is the wrong exit code for a malformed
+ * command.
+ *
+ * `replaceLines`' content is read byte-exact from stdin or `--file` (no
+ * trim, no injected trailing newline) and passed straight through to the
+ * SDK — the coding-harness hot path depends on trailing-newline fidelity
+ * surviving a read -> replace -> read round trip.
+ */
+import process from 'node:process';
+import { readFile } from 'node:fs/promises';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+interface RangeFlagsResult {
+  readonly ok: true;
+  readonly startLine: number | undefined;
+  readonly endLine: number | undefined;
+  readonly rest: readonly string[];
+}
+interface RangeFlagsError {
+  readonly ok: false;
+  readonly message: string;
+}
+
+/** Pure: no I/O. Consumes `--start`/`--end`, passes everything else through in `rest`. */
+export function extractLineRangeFlags(args: readonly string[]): RangeFlagsResult | RangeFlagsError {
+  let startLine: number | undefined;
+  let endLine: number | undefined;
+  const rest: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--start' || args[i] === '--end') {
+      const flag = args[i] as '--start' | '--end';
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: `Flag ${flag} requires a value.` };
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        return { ok: false, message: `Invalid ${flag} "${value}": must be an integer >= 1.` };
+      }
+      if (flag === '--start') startLine = parsed;
+      else endLine = parsed;
+      i += 2;
+      continue;
+    }
+    rest.push(args[i] as string);
+    i += 1;
+  }
+  if (startLine !== undefined && endLine !== undefined && endLine < startLine) {
+    return { ok: false, message: `--end (${endLine}) must be >= --start (${startLine}).` };
+  }
+  return { ok: true, startLine, endLine, rest };
+}
+
+/** Pure: no I/O. */
+function extractRawFlag(args: readonly string[]): { readonly raw: boolean; readonly rest: readonly string[] } {
+  const rest: string[] = [];
+  let raw = false;
+  for (const arg of args) {
+    if (arg === '--raw') raw = true;
+    else rest.push(arg);
+  }
+  return { raw, rest };
+}
+
+/** Pure: no I/O. */
+function extractFileFlag(
+  args: readonly string[],
+): { readonly ok: true; readonly filePath: string | undefined; readonly rest: readonly string[] } | { readonly ok: false; readonly message: string } {
+  const rest: string[] = [];
+  let filePath: string | undefined;
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--file') {
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: 'Flag --file requires a value.' };
+      filePath = value;
+      i += 2;
+      continue;
+    }
+    rest.push(args[i] as string);
+    i += 1;
+  }
+  return { ok: true, filePath, rest };
+}
+
+export const pagesReadHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, ...rest0] = intent.args;
+  if (!pageId) {
+    ctx.stderr.write('Usage: pagespace pages read <pageId> [--start N] [--end M] [--raw]\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const { raw, rest: rest1 } = extractRawFlag(rest0);
+  const range = extractLineRangeFlags(rest1);
+  if (!range.ok) {
+    ctx.stderr.write(`${range.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (range.rest.length > 0) {
+    ctx.stderr.write(`Unknown argument: ${range.rest[0]}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.pages.read({ operation: 'read', pageId, startLine: range.startLine, endLine: range.endLine }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else if ('content' in result.value) {
+    ctx.stdout.write(raw ? result.value.content : `${result.value.numberedLines.join('\n')}\n`);
+  } else {
+    // A FILE page not yet in `completed` status has no text content to read.
+    ctx.stdout.write(`${result.value.message ?? result.value.error ?? `No readable content (status: ${result.value.status}).`}\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export interface ContentSourceDeps {
+  readonly readStdin: () => Promise<string>;
+  readonly readFile: (path: string) => Promise<string>;
+}
+
+export function createPagesReplaceLinesHandler(deps: ContentSourceDeps): CommandHandler {
+  return async (ctx, intent) => {
+    const [pageId, ...rest0] = intent.args;
+    if (!pageId) {
+      ctx.stderr.write('Usage: pagespace pages replace-lines <pageId> --start N [--end M] [--file <path>]\n');
+      return EXIT_USAGE_ERROR;
+    }
+
+    const fileFlag = extractFileFlag(rest0);
+    if (!fileFlag.ok) {
+      ctx.stderr.write(`${fileFlag.message}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    const range = extractLineRangeFlags(fileFlag.rest);
+    if (!range.ok) {
+      ctx.stderr.write(`${range.message}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    if (range.rest.length > 0) {
+      ctx.stderr.write(`Unknown argument: ${range.rest[0]}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    if (range.startLine === undefined) {
+      ctx.stderr.write('Flag --start is required.\n');
+      return EXIT_USAGE_ERROR;
+    }
+
+    let content: string;
+    try {
+      content = fileFlag.filePath !== undefined ? await deps.readFile(fileFlag.filePath) : await deps.readStdin();
+    } catch (error) {
+      ctx.stderr.write(`Failed to read input: ${error instanceof Error ? error.message : String(error)}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
+    const result = await callSdk(ctx.stderr, () =>
+      ctx.sdk.pages.replaceLines({ operation: 'replace', pageId, startLine: range.startLine as number, endLine: range.endLine, content }),
+    );
+    if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+    if (intent.flags.json) {
+      ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    } else {
+      ctx.stdout.write(`Replaced line(s) ${result.value.affectedLines} in ${pageId} (${result.value.totalLines} lines total)\n`);
+    }
+    return EXIT_SUCCESS;
+  };
+}
+
+async function readStdinToString(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+export const pagesReplaceLinesHandler: CommandHandler = createPagesReplaceLinesHandler({
+  readStdin: readStdinToString,
+  readFile: (path) => readFile(path, 'utf-8'),
+});

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -1,0 +1,127 @@
+/**
+ * `pagespace pages export` (Phase 5 task 2). Thin projection over the
+ * `export.pageMarkdown`/`export.sheetCsv` SDK operations (Phase 3 task 10;
+ * this task also fixed the client facade gap — see `packages/sdk/src/client.ts`).
+ *
+ * Both operations are `textResponse: true` — the SDK response is already
+ * the raw exported text, not a JSON envelope. `--out -` writes that text
+ * verbatim to stdout (nothing else on stdout in that mode), regardless of
+ * `--json`: wrapping already-raw text in a JSON string would defeat the
+ * point of piping it. Writing to a file refuses to silently overwrite an
+ * existing path — `--force` is the only opt-out, checked before the SDK
+ * call so a doomed write never costs a network round trip.
+ */
+import { access, writeFile as writeFileToDisk } from 'node:fs/promises';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+const FORMATS = ['md', 'csv'] as const;
+type ExportFormat = (typeof FORMATS)[number];
+
+/** Pure: no I/O. */
+function extractExportFlags(
+  args: readonly string[],
+):
+  | { readonly ok: true; readonly format: string | undefined; readonly out: string | undefined; readonly rest: readonly string[] }
+  | { readonly ok: false; readonly message: string } {
+  const rest: string[] = [];
+  let format: string | undefined;
+  let out: string | undefined;
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--format' || args[i] === '--out') {
+      const flag = args[i] as '--format' | '--out';
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: `Flag ${flag} requires a value.` };
+      if (flag === '--format') format = value;
+      else out = value;
+      i += 2;
+      continue;
+    }
+    rest.push(args[i] as string);
+    i += 1;
+  }
+  return { ok: true, format, out, rest };
+}
+
+export interface PagesExportDeps {
+  readonly fileExists: (path: string) => Promise<boolean>;
+  readonly writeFile: (path: string, content: string) => Promise<void>;
+}
+
+export function createPagesExportHandler(deps: PagesExportDeps): CommandHandler {
+  return async (ctx, intent) => {
+    const [pageId, ...rest0] = intent.args;
+    if (!pageId) {
+      ctx.stderr.write('Usage: pagespace pages export <pageId> --format md|csv --out <path|-> [--force]\n');
+      return EXIT_USAGE_ERROR;
+    }
+
+    const parsed = extractExportFlags(rest0);
+    if (!parsed.ok) {
+      ctx.stderr.write(`${parsed.message}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    if (parsed.rest.length > 0) {
+      ctx.stderr.write(`Unknown argument: ${parsed.rest[0]}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    if (!parsed.format || !FORMATS.includes(parsed.format as ExportFormat)) {
+      ctx.stderr.write(`Flag --format is required and must be one of: ${FORMATS.join(', ')}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    if (!parsed.out) {
+      ctx.stderr.write('Flag --out is required (a file path, or "-" for stdout).\n');
+      return EXIT_USAGE_ERROR;
+    }
+    const format = parsed.format as ExportFormat;
+    const out = parsed.out;
+
+    if (out !== '-' && !intent.flags.force) {
+      const exists = await deps.fileExists(out);
+      if (exists) {
+        ctx.stderr.write(`Refusing to overwrite existing file "${out}" without --force.\n`);
+        return EXIT_RUNTIME_ERROR;
+      }
+    }
+
+    const result = await callSdk(ctx.stderr, () =>
+      format === 'md' ? ctx.sdk.export.pageMarkdown({ pageId }) : ctx.sdk.export.sheetCsv({ pageId }),
+    );
+    if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+    if (out === '-') {
+      ctx.stdout.write(result.value);
+      return EXIT_SUCCESS;
+    }
+
+    try {
+      await deps.writeFile(out, result.value);
+    } catch (error) {
+      ctx.stderr.write(`Failed to write "${out}": ${error instanceof Error ? error.message : String(error)}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
+    if (intent.flags.json) {
+      ctx.stdout.write(`${JSON.stringify({ pageId, format, path: out, bytes: Buffer.byteLength(result.value) })}\n`);
+    } else {
+      ctx.stdout.write(`Exported ${pageId} as ${format} to ${out}\n`);
+    }
+    return EXIT_SUCCESS;
+  };
+}
+
+async function fileExistsOnDisk(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const pagesExportHandler: CommandHandler = createPagesExportHandler({
+  fileExists: fileExistsOnDisk,
+  writeFile: (path, content) => writeFileToDisk(path, content, 'utf-8'),
+});

--- a/packages/cli/src/commands/sheets.ts
+++ b/packages/cli/src/commands/sheets.ts
@@ -1,0 +1,104 @@
+/**
+ * `pagespace sheets edit-cells` (Phase 5 task 2). Thin projection over the
+ * `pages.editCells` SDK operation (documents namespace, Phase 3 task 2) —
+ * grouped under a `sheets` CLI resource per this task's spec even though the
+ * SDK models it as a `pages.*` method, since a SHEET page's content-editing
+ * surface is the natural CLI-facing grouping for this verb.
+ *
+ * Cell addresses/values are JSON, given via `--json-input` or stdin.
+ * Malformed JSON or a non-array shape is a usage error (exit 2) before any
+ * network call; the per-cell address/value shape is left to the SDK's own
+ * zod validation (surfaced as a runtime error via `callSdk`), matching how
+ * every other thin verb defers business-shape checks to the server/SDK.
+ */
+import process from 'node:process';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+/** Pure: no I/O. */
+function extractJsonInputFlag(
+  args: readonly string[],
+): { readonly ok: true; readonly jsonInput: string | undefined; readonly rest: readonly string[] } | { readonly ok: false; readonly message: string } {
+  const rest: string[] = [];
+  let jsonInput: string | undefined;
+  let i = 0;
+  while (i < args.length) {
+    if (args[i] === '--json-input') {
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: 'Flag --json-input requires a value.' };
+      jsonInput = value;
+      i += 2;
+      continue;
+    }
+    rest.push(args[i] as string);
+    i += 1;
+  }
+  return { ok: true, jsonInput, rest };
+}
+
+export interface SheetsEditCellsDeps {
+  readonly readStdin: () => Promise<string>;
+}
+
+export function createSheetsEditCellsHandler(deps: SheetsEditCellsDeps): CommandHandler {
+  return async (ctx, intent) => {
+    const [pageId, ...rest0] = intent.args;
+    if (!pageId) {
+      ctx.stderr.write('Usage: pagespace sheets edit-cells <pageId> [--json-input <json>]\n');
+      return EXIT_USAGE_ERROR;
+    }
+
+    const inputFlag = extractJsonInputFlag(rest0);
+    if (!inputFlag.ok) {
+      ctx.stderr.write(`${inputFlag.message}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+    if (inputFlag.rest.length > 0) {
+      ctx.stderr.write(`Unknown argument: ${inputFlag.rest[0]}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+
+    let raw: string;
+    try {
+      raw = inputFlag.jsonInput !== undefined ? inputFlag.jsonInput : await deps.readStdin();
+    } catch (error) {
+      ctx.stderr.write(`Failed to read input: ${error instanceof Error ? error.message : String(error)}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
+    let cells: unknown;
+    try {
+      cells = JSON.parse(raw);
+    } catch {
+      ctx.stderr.write('Invalid JSON in --json-input/stdin.\n');
+      return EXIT_USAGE_ERROR;
+    }
+    if (!Array.isArray(cells)) {
+      ctx.stderr.write('Input must be a JSON array of {address, value} cells.\n');
+      return EXIT_USAGE_ERROR;
+    }
+
+    const result = await callSdk(ctx.stderr, () =>
+      ctx.sdk.pages.editCells({ operation: 'edit-cells', pageId, cells: cells as Array<{ address: string; value: string }> }),
+    );
+    if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+    if (intent.flags.json) {
+      ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    } else {
+      ctx.stdout.write(`Updated ${result.value.cellsUpdated} cell(s) in ${pageId}.\n`);
+    }
+    return EXIT_SUCCESS;
+  };
+}
+
+async function readStdinToString(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+export const sheetsEditCellsHandler: CommandHandler = createSheetsEditCellsHandler({ readStdin: readStdinToString });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -76,6 +76,20 @@ export {
   renderPagesTree,
 } from './commands/pages.js';
 export { renderTrashTree, trashListHandler } from './commands/trash.js';
+
+// Content & export verbs (Phase 5 task 2) — thin projections over the
+// documents/export SDK operations.
+export {
+  createPagesReplaceLinesHandler,
+  extractLineRangeFlags,
+  pagesReadHandler,
+  pagesReplaceLinesHandler,
+} from './commands/content.js';
+export type { ContentSourceDeps } from './commands/content.js';
+export { createSheetsEditCellsHandler, sheetsEditCellsHandler } from './commands/sheets.js';
+export type { SheetsEditCellsDeps } from './commands/sheets.js';
+export { createPagesExportHandler, pagesExportHandler } from './commands/export.js';
+export type { PagesExportDeps } from './commands/export.js';
 export {
   createLoginHandler,
   DEFAULT_LOGIN_SCOPE,

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -18,6 +18,8 @@ import {
   drivesRestoreHandler,
   drivesTrashHandler,
 } from './commands/drives.js';
+import { pagesReadHandler, pagesReplaceLinesHandler } from './commands/content.js';
+import { pagesExportHandler } from './commands/export.js';
 import { helpHandler } from './commands/help.js';
 import { loginHandler } from './commands/login.js';
 import { loginDeviceHandler } from './commands/login-device.js';
@@ -33,6 +35,7 @@ import {
   pagesTrashHandler,
   pagesTreeHandler,
 } from './commands/pages.js';
+import { sheetsEditCellsHandler } from './commands/sheets.js';
 import { trashListHandler } from './commands/trash.js';
 import { versionHandler } from './commands/version.js';
 import { whoamiHandler } from './commands/whoami.js';
@@ -79,6 +82,10 @@ const ROUTES: readonly Route[] = [
   { path: ['pages', 'move'], handler: pagesMoveHandler },
   { path: ['pages', 'trash'], handler: pagesTrashHandler },
   { path: ['pages', 'restore'], handler: pagesRestoreHandler },
+  { path: ['pages', 'read'], handler: pagesReadHandler },
+  { path: ['pages', 'replace-lines'], handler: pagesReplaceLinesHandler },
+  { path: ['pages', 'export'], handler: pagesExportHandler },
+  { path: ['sheets', 'edit-cells'], handler: sheetsEditCellsHandler },
   { path: ['trash', 'list'], handler: trashListHandler },
 ];
 

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -374,4 +374,20 @@ describe('PageSpaceClient — registry-derived namespaces', () => {
     expect(typeof client.conversations.list).toBe('function');
     expect(typeof client.conversations.read).toBe('function');
   });
+
+  it('exposes the export namespace (Phase 3 task 10 defined the operations; the facade never wired them)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/export/markdown')) {
+        return new Response('# Hello', { status: 200, headers: { 'X-PageSpace-API-Version': API_VERSION, 'Content-Type': 'text/markdown' } });
+      }
+      return new Response('a,b\n1,2', { status: 200, headers: { 'X-PageSpace-API-Version': API_VERSION, 'Content-Type': 'text/csv' } });
+    });
+    const client = makeClient({ fetch: fetchMock });
+
+    expect(typeof client.export.pageMarkdown).toBe('function');
+    expect(typeof client.export.sheetCsv).toBe('function');
+
+    await expect(client.export.pageMarkdown({ pageId: 'p1' })).resolves.toBe('# Hello');
+    await expect(client.export.sheetCsv({ pageId: 'p1' })).resolves.toBe('a,b\n1,2');
+  });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -51,6 +51,7 @@ import {
   trashPage,
 } from './operations/pages.js';
 import { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
+import { exportPageMarkdown, exportSheetCsv } from './operations/export.js';
 import {
   createDriveRole,
   deleteDriveRole,
@@ -135,6 +136,10 @@ const DEFAULT_OPERATIONS_MAP = {
   conversations: {
     list: listConversations,
     read: readConversation,
+  },
+  export: {
+    pageMarkdown: exportPageMarkdown,
+    sheetCsv: exportSheetCsv,
   },
   tokens: {
     create: createMcpToken,


### PR DESCRIPTION
## Summary
- **SDK facade gap fix**: `packages/sdk/src/client.ts` `DEFAULT_OPERATIONS_MAP` had no `export` namespace even though `operations/export.ts` (Phase 3 task 10) defined `exportPageMarkdown`/`exportSheetCsv`. Wired both onto `client.export.pageMarkdown`/`client.export.sheetCsv`, plus a client test asserting the namespace is exposed and both calls resolve their raw text response.
- `pagespace pages read <id> [--start N] [--end M] [--raw]` — thin projection over `pages.read` (documents namespace, already wired). Human mode renders the already-numbered lines; `--raw` prints the unnumbered `content` field for piping. A not-yet-processed FILE page (no `content`/`numberedLines`) falls back to its status message.
- `pagespace pages replace-lines <id> --start N [--end M] [--file <path>]` — content from stdin or `--file`, passed through byte-exact (no trim, no injected newline) to `pages.replaceLines`.
- `pagespace sheets edit-cells <id> [--json-input <json>]` — cells from stdin or `--json-input`; malformed JSON or a non-array shape is a usage error (exit 2) before any network call. Per-cell address/value validation is left to the SDK's own zod schema.
- `pagespace pages export <id> --format md|csv --out <path|-> [--force]` — `-` streams the raw exported text to stdout verbatim (nothing else on stdout, regardless of `--json`, since the SDK response for these ops is already plain text); a file target refuses to silently overwrite without `--force`, checked before the SDK call.
- 1-based range validation (`read`/`replace-lines`) is enforced as a usage error (exit 2) *before* any SDK call — the SDK's own zod schema would eventually reject the same malformed range, but that surfaces as a runtime error (exit 1) via `callSdk`, the wrong exit code for a syntax problem.

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` — 32/32 files, 714/714 tests
- [x] `bun run --filter '@pagespace/cli' typecheck && bun run --filter '@pagespace/cli' test` — 47/47 files, 510/510 tests (includes the `single-auth-path` structural check over the three new command files)
- [x] TDD: RED commit (`3a647d390`) with all new tests failing against nonexistent modules, then GREEN commit (`b2cb346bb`) implementing against them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvENVyobNVfCU21rAZd911