### PR TITLE
cli: implement tasks verbs (Phase 5 task 3)

### DIFF
--- a/packages/cli/src/commands/__tests__/tasks.test.ts
+++ b/packages/cli/src/commands/__tests__/tasks.test.ts
@@ -1,0 +1,556 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EXIT_RUNTIME_ERROR,
+  EXIT_SUCCESS,
+  EXIT_USAGE_ERROR,
+  parseArgv,
+  tasksAssignedHandler,
+  tasksCreateHandler,
+  tasksCreateStatusHandler,
+  tasksDeleteHandler,
+  tasksListHandler,
+  tasksReorderHandler,
+  tasksStatusesHandler,
+  tasksUpdateHandler,
+} from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const USER_REF = { id: 'user_1', name: 'Ada', image: null };
+
+const TASK = {
+  id: 'task_1',
+  userId: 'user_1',
+  assigneeId: null,
+  assigneeAgentId: null,
+  pageId: 'pg_list_1',
+  status: 'in_progress',
+  priority: 'medium' as const,
+  position: 0,
+  dueDate: null,
+  metadata: null,
+  completedAt: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  assignee: null,
+  assigneeAgent: null,
+  user: USER_REF,
+  page: { id: 'pg_task_1', title: 'RED — write tests' },
+  assignees: [],
+  title: 'RED — write tests',
+};
+
+const TASK_LIST_ITEM = {
+  id: 'task_1',
+  title: 'RED — write tests',
+  status: 'in_progress',
+  priority: 'medium' as const,
+  assigneeId: null,
+  assigneeAgentId: null,
+  dueDate: null,
+  position: 0,
+  completedAt: null,
+  pageId: 'pg_task_1',
+  assignee: null,
+  assigneeAgent: null,
+  assignees: [],
+  hasContent: false,
+  subTaskCount: 0,
+  subTaskCompletedCount: 0,
+};
+
+const TASK_LIST_READ_RESULT = {
+  pageId: 'pg_list_1',
+  pageTitle: 'Sprint Board',
+  pageType: 'TASK_LIST' as const,
+  taskListId: 'tl_1',
+  parentTaskList: null,
+  totalLines: 1,
+  numberedLines: ['   1 | # Sprint Board'],
+  content: '# Sprint Board',
+  tasks: [TASK_LIST_ITEM],
+  availableStatuses: [
+    { slug: 'pending', label: 'To Do', group: 'todo', position: 0, color: null },
+    { slug: 'in_progress', label: 'In Progress', group: 'in_progress', position: 1, color: null },
+    { slug: 'completed', label: 'Done', group: 'done', position: 2, color: null },
+  ],
+  progress: { total: 1, percentage: 0, byGroup: { todo: 0, in_progress: 1, done: 0 }, bySlug: { in_progress: 1 } },
+};
+
+const GENERIC_READ_RESULT = {
+  pageId: 'pg_doc_1',
+  pageTitle: 'Not a task list',
+  totalLines: 1,
+  numberedLines: ['   1 | hello'],
+  content: 'hello',
+};
+
+const ASSIGNED_RESULT = {
+  tasks: [
+    {
+      ...TASK,
+      driveId: 'drv_1',
+      taskListPageId: 'pg_list_1',
+      taskListPageTitle: 'Sprint Board',
+      statusGroup: 'in_progress' as const,
+      statusLabel: 'In Progress',
+      statusColor: '#00f',
+      page: { id: 'pg_task_1', title: 'RED — write tests', isTrashed: false, parentId: 'pg_list_1' },
+    },
+  ],
+  statusConfigsByTaskList: {},
+  pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+};
+
+describe('tasksListHandler', () => {
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const read = vi.fn(async () => TASK_LIST_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await tasksListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('calls pages.read with the given pageId', async () => {
+    const read = vi.fn(async () => TASK_LIST_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await tasksListHandler(ctx, commandIntent(['pg_list_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(read).toHaveBeenCalledWith({ operation: 'read', pageId: 'pg_list_1' });
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => TASK_LIST_READ_RESULT } }) });
+
+    await tasksListHandler(ctx, commandIntent(['pg_list_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(TASK_LIST_READ_RESULT);
+  });
+
+  it('renders task ids, statuses, and progress in human mode', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => TASK_LIST_READ_RESULT } }) });
+
+    await tasksListHandler(ctx, commandIntent(['pg_list_1']));
+
+    const output = stdout.lines.join('');
+    expect(output).toContain('task_1');
+    expect(output).toContain('in_progress');
+    expect(output).toMatch(/progress/i);
+  });
+
+  it('errors when the page is not a TASK_LIST, without touching stdout', async () => {
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ pages: { read: async () => GENERIC_READ_RESULT } }) });
+
+    const code = await tasksListHandler(ctx, commandIntent(['pg_doc_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toMatch(/not a task list/i);
+  });
+});
+
+describe('tasksStatusesHandler', () => {
+  it('exits 2 with a usage error when pageId is missing', async () => {
+    const read = vi.fn(async () => TASK_LIST_READ_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ pages: { read } }) });
+
+    const code = await tasksStatusesHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => TASK_LIST_READ_RESULT } }) });
+
+    await tasksStatusesHandler(ctx, commandIntent(['pg_list_1', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(TASK_LIST_READ_RESULT);
+  });
+
+  it('renders every available status slug and group in human mode', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ pages: { read: async () => TASK_LIST_READ_RESULT } }) });
+
+    await tasksStatusesHandler(ctx, commandIntent(['pg_list_1']));
+
+    const output = stdout.lines.join('');
+    expect(output).toContain('pending');
+    expect(output).toContain('in_progress');
+    expect(output).toContain('completed');
+  });
+
+  it('errors when the page is not a TASK_LIST', async () => {
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ pages: { read: async () => GENERIC_READ_RESULT } }) });
+
+    const code = await tasksStatusesHandler(ctx, commandIntent(['pg_doc_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toMatch(/not a task list/i);
+  });
+});
+
+describe('tasksCreateHandler', () => {
+  it('requires pageId and --title', async () => {
+    const create = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { create } }) });
+
+    const code = await tasksCreateHandler(ctx, commandIntent(['pg_list_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('calls tasks.create with only the flags given', async () => {
+    const create = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { create } }) });
+
+    const code = await tasksCreateHandler(ctx, commandIntent(['pg_list_1', '--title', 'Ship it']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(create).toHaveBeenCalledWith({
+      pageId: 'pg_list_1',
+      title: 'Ship it',
+      priority: undefined,
+      status: undefined,
+      dueDate: undefined,
+      assigneeId: undefined,
+    });
+  });
+
+  it('maps every optional flag through to the SDK call', async () => {
+    const create = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { create } }) });
+
+    await tasksCreateHandler(
+      ctx,
+      commandIntent([
+        'pg_list_1',
+        '--title',
+        'Ship it',
+        '--priority',
+        'high',
+        '--status',
+        'in_progress',
+        '--due',
+        '2026-02-01',
+        '--assignee',
+        'user_2',
+      ]),
+    );
+
+    expect(create).toHaveBeenCalledWith({
+      pageId: 'pg_list_1',
+      title: 'Ship it',
+      priority: 'high',
+      status: 'in_progress',
+      dueDate: '2026-02-01',
+      assigneeId: 'user_2',
+    });
+  });
+
+  it('rejects an invalid --priority as a usage error without calling the SDK', async () => {
+    const create = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { create } }) });
+
+    const code = await tasksCreateHandler(ctx, commandIntent(['pg_list_1', '--title', 'Ship it', '--priority', 'urgent']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ tasks: { create: async () => TASK } }) });
+
+    await tasksCreateHandler(ctx, commandIntent(['pg_list_1', '--title', 'Ship it', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(TASK);
+  });
+});
+
+describe('tasksUpdateHandler', () => {
+  it('requires pageId and taskId', async () => {
+    const update = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { update } }) });
+
+    const code = await tasksUpdateHandler(ctx, commandIntent(['pg_list_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('maps every update flag combo through to the SDK call', async () => {
+    const update = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { update } }) });
+
+    await tasksUpdateHandler(
+      ctx,
+      commandIntent(['pg_list_1', 'task_1', '--status', 'completed', '--title', 'Renamed', '--priority', 'low', '--due', '2026-03-01']),
+    );
+
+    expect(update).toHaveBeenCalledWith({
+      pageId: 'pg_list_1',
+      taskId: 'task_1',
+      title: 'Renamed',
+      status: 'completed',
+      priority: 'low',
+      dueDate: '2026-03-01',
+    });
+  });
+
+  it('passes undefined for flags not given', async () => {
+    const update = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { update } }) });
+
+    await tasksUpdateHandler(ctx, commandIntent(['pg_list_1', 'task_1', '--status', 'completed']));
+
+    expect(update).toHaveBeenCalledWith({
+      pageId: 'pg_list_1',
+      taskId: 'task_1',
+      title: undefined,
+      status: 'completed',
+      priority: undefined,
+      dueDate: undefined,
+    });
+  });
+
+  it('rejects an invalid --priority as a usage error without calling the SDK', async () => {
+    const update = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { update } }) });
+
+    const code = await tasksUpdateHandler(ctx, commandIntent(['pg_list_1', 'task_1', '--priority', 'urgent']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('renders the server container-gating rejection message verbatim, exit 1', async () => {
+    const gateMessage = 'Cannot complete task: sub-tasks incomplete (2 of 5 remaining)';
+    const update = vi.fn(async () => {
+      throw new Error(gateMessage);
+    });
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ tasks: { update } }) });
+
+    const code = await tasksUpdateHandler(ctx, commandIntent(['pg_list_1', 'task_1', '--status', 'completed']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain(gateMessage);
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ tasks: { update: async () => TASK } }) });
+
+    await tasksUpdateHandler(ctx, commandIntent(['pg_list_1', 'task_1', '--status', 'completed', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(TASK);
+  });
+});
+
+describe('tasksDeleteHandler (destructive)', () => {
+  it('with --yes in a non-TTY session: deletes without prompting', async () => {
+    const del = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => 'irrelevant');
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { delete: del } }), isTTY: false, prompt });
+
+    const code = await tasksDeleteHandler(ctx, commandIntent(['pg_list_1', 'task_1', '--yes']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(prompt).not.toHaveBeenCalled();
+    expect(del).toHaveBeenCalledWith({ pageId: 'pg_list_1', taskId: 'task_1' });
+  });
+
+  it('fails closed in a non-TTY session without --yes, never calling delete', async () => {
+    const del = vi.fn(async () => ({ success: true }));
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { delete: del } }), isTTY: false, stderr });
+
+    const code = await tasksDeleteHandler(ctx, commandIntent(['pg_list_1', 'task_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(del).not.toHaveBeenCalled();
+    expect(stderr.lines.join('')).toMatch(/--yes/);
+  });
+
+  it('in a TTY session without --yes, prompts and deletes on an affirmative answer', async () => {
+    const del = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => 'y');
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { delete: del } }), isTTY: true, prompt });
+
+    const code = await tasksDeleteHandler(ctx, commandIntent(['pg_list_1', 'task_1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(prompt).toHaveBeenCalled();
+    expect(del).toHaveBeenCalledWith({ pageId: 'pg_list_1', taskId: 'task_1' });
+  });
+
+  it('in a TTY session without --yes, refuses on a declined answer', async () => {
+    const del = vi.fn(async () => ({ success: true }));
+    const prompt = vi.fn(async () => 'n');
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { delete: del } }), isTTY: true, prompt });
+
+    const code = await tasksDeleteHandler(ctx, commandIntent(['pg_list_1', 'task_1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when taskId is missing', async () => {
+    const del = vi.fn(async () => ({ success: true }));
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { delete: del } }) });
+
+    const code = await tasksDeleteHandler(ctx, commandIntent(['pg_list_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(del).not.toHaveBeenCalled();
+  });
+});
+
+describe('tasksReorderHandler', () => {
+  it('calls tasks.reorder with pageId, taskId, and a numeric position', async () => {
+    const reorder = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { reorder } }) });
+
+    const code = await tasksReorderHandler(ctx, commandIntent(['pg_list_1', 'task_1', '2']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(reorder).toHaveBeenCalledWith({ pageId: 'pg_list_1', taskId: 'task_1', position: 2 });
+  });
+
+  it('exits 2 with a usage error for a non-numeric position, never calling the SDK', async () => {
+    const reorder = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { reorder } }) });
+
+    const code = await tasksReorderHandler(ctx, commandIntent(['pg_list_1', 'task_1', 'not-a-number']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(reorder).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when position is missing', async () => {
+    const reorder = vi.fn(async () => TASK);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { reorder } }) });
+
+    const code = await tasksReorderHandler(ctx, commandIntent(['pg_list_1', 'task_1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(reorder).not.toHaveBeenCalled();
+  });
+});
+
+describe('tasksCreateStatusHandler', () => {
+  const STATUS_CONFIG = {
+    id: 'status_1',
+    taskListId: 'tl_1',
+    name: 'Blocked',
+    slug: 'blocked',
+    color: '#f00',
+    group: 'in_progress' as const,
+    position: 3,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('requires --name, --color, and --group', async () => {
+    const createStatus = vi.fn(async () => STATUS_CONFIG);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { createStatus } }) });
+
+    const code = await tasksCreateStatusHandler(ctx, commandIntent(['pg_list_1', '--name', 'Blocked']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(createStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid --group as a usage error without calling the SDK', async () => {
+    const createStatus = vi.fn(async () => STATUS_CONFIG);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { createStatus } }) });
+
+    const code = await tasksCreateStatusHandler(
+      ctx,
+      commandIntent(['pg_list_1', '--name', 'Blocked', '--color', '#f00', '--group', 'not-a-group']),
+    );
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(createStatus).not.toHaveBeenCalled();
+  });
+
+  it('calls tasks.createStatus with the given fields', async () => {
+    const createStatus = vi.fn(async () => STATUS_CONFIG);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { createStatus } }) });
+
+    const code = await tasksCreateStatusHandler(
+      ctx,
+      commandIntent(['pg_list_1', '--name', 'Blocked', '--color', '#f00', '--group', 'in_progress', '--position', '3']),
+    );
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(createStatus).toHaveBeenCalledWith({ pageId: 'pg_list_1', name: 'Blocked', color: '#f00', group: 'in_progress', position: 3 });
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ tasks: { createStatus: async () => STATUS_CONFIG } }) });
+
+    await tasksCreateStatusHandler(ctx, commandIntent(['pg_list_1', '--name', 'Blocked', '--color', '#f00', '--group', 'in_progress', '--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(STATUS_CONFIG);
+  });
+});
+
+describe('tasksAssignedHandler', () => {
+  it('calls tasks.getAssigned with no filters', async () => {
+    const getAssigned = vi.fn(async () => ASSIGNED_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ tasks: { getAssigned } }) });
+
+    const code = await tasksAssignedHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(getAssigned).toHaveBeenCalledWith({});
+  });
+
+  it('--json emits exactly the SDK response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ tasks: { getAssigned: async () => ASSIGNED_RESULT } }) });
+
+    await tasksAssignedHandler(ctx, commandIntent(['--json']));
+
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(ASSIGNED_RESULT);
+  });
+
+  it('renders assigned tasks in human mode', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ tasks: { getAssigned: async () => ASSIGNED_RESULT } }) });
+
+    await tasksAssignedHandler(ctx, commandIntent([]));
+
+    const output = stdout.lines.join('');
+    expect(output).toContain('task_1');
+    expect(output).toContain('RED — write tests');
+  });
+
+  it('renders a friendly message when there are no assigned tasks', async () => {
+    const stdout = createRecordingSink();
+    const empty = { ...ASSIGNED_RESULT, tasks: [] };
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ tasks: { getAssigned: async () => empty } }) });
+
+    await tasksAssignedHandler(ctx, commandIntent([]));
+
+    expect(stdout.lines.join('')).toMatch(/no assigned tasks/i);
+  });
+});

--- a/packages/cli/src/commands/tasks.ts
+++ b/packages/cli/src/commands/tasks.ts
@@ -1,0 +1,412 @@
+/**
+ * `pagespace tasks list|create|update|delete|reorder|statuses|create-status|assigned`
+ * (Phase 5 task 3). Thin projections over the `tasks.*` SDK operations —
+ * every underlying operation (`create`, `update`, `delete`, `reorder`,
+ * `createStatus`, `getAssigned`) was already defined and wired on the client
+ * facade by Phase 3 task 4, so this module adds no SDK surface, only argv
+ * parsing and result rendering.
+ *
+ * `list`/`statuses` have no dedicated SDK operation of their own — both are
+ * thin views over `pages.read`'s TASK_LIST branch (already wired by Phase 3
+ * task 2), which is the exact payload `read_page` on a TASK_LIST page
+ * returns: tasks, availableStatuses, and progress in one call. `--json`
+ * always emits that whole raw response for either verb (same rule the
+ * merged `pages`/`trash` verbs follow: `--json` is never a filtered subset
+ * of what human mode chooses to render).
+ *
+ * `update`'s container-gating rejection (server blocks completing a parent
+ * with open sub-tasks) needs no special handling here: `callSdk` already
+ * writes the caught error's `.message` to stderr unmodified, which *is*
+ * "render that message faithfully" — the server's own text already embeds
+ * the pending/total counts. `classifyTaskCompletionGate` (SDK) exists for
+ * callers that need to branch on the gate programmatically; this command
+ * doesn't need to.
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { priorityEnum, statusGroupEnum } from '@pagespace/sdk';
+import { confirmationFailureMessage, confirmDestructive } from '../confirm.js';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+type PagesReadResult = Awaited<ReturnType<PageSpaceClient['pages']['read']>>;
+type TaskListRead = Extract<PagesReadResult, { pageType: 'TASK_LIST' }>;
+
+/** Pure: no I/O. */
+export function renderTasksList(value: TaskListRead): string {
+  const lines = value.tasks.map((task) => `[${task.status}] ${task.id}  ${task.title}  (priority: ${task.priority})`);
+  lines.push(`Progress: ${value.progress.percentage}% (${value.progress.total} tasks)`);
+  return `${lines.join('\n')}\n`;
+}
+
+/** Pure: no I/O. */
+export function renderTaskStatuses(value: TaskListRead): string {
+  if (value.availableStatuses.length === 0) {
+    return 'No statuses.\n';
+  }
+  return `${value.availableStatuses.map((status) => `${status.slug}  ${status.label}  [${status.group}]`).join('\n')}\n`;
+}
+
+export const tasksListHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId] = intent.args;
+  if (!pageId || intent.args.length > 1) {
+    ctx.stderr.write('Usage: pagespace tasks list <taskListPageId>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.read({ operation: 'read', pageId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  if (result.value.pageType !== 'TASK_LIST') {
+    ctx.stderr.write(`Page ${pageId} is not a task list.\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  ctx.stdout.write(renderTasksList(result.value));
+  return EXIT_SUCCESS;
+};
+
+export const tasksStatusesHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId] = intent.args;
+  if (!pageId || intent.args.length > 1) {
+    ctx.stderr.write('Usage: pagespace tasks statuses <taskListPageId>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.pages.read({ operation: 'read', pageId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  if (result.value.pageType !== 'TASK_LIST') {
+    ctx.stderr.write(`Page ${pageId} is not a task list.\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  ctx.stdout.write(renderTaskStatuses(result.value));
+  return EXIT_SUCCESS;
+};
+
+type FlagScanResult =
+  | { readonly ok: true; readonly values: ReadonlyMap<string, string>; readonly rest: readonly string[] }
+  | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. Consumes any of `flags`' value-taking tokens, passing everything else through in `rest`. */
+function scanValueFlags(args: readonly string[], flags: readonly string[]): FlagScanResult {
+  const values = new Map<string, string>();
+  const rest: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i] as string;
+    if (flags.includes(token)) {
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: `Flag ${token} requires a value.` };
+      values.set(token, value);
+      i += 2;
+      continue;
+    }
+    rest.push(token);
+    i += 1;
+  }
+  return { ok: true, values, rest };
+}
+
+export interface TaskCreateFlags {
+  readonly title: string | undefined;
+  readonly status: string | undefined;
+  readonly priority: string | undefined;
+  readonly due: string | undefined;
+  readonly assignee: string | undefined;
+  readonly rest: readonly string[];
+}
+export type ExtractTaskCreateFlagsResult = ({ readonly ok: true } & TaskCreateFlags) | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. */
+export function extractTaskCreateFlags(args: readonly string[]): ExtractTaskCreateFlagsResult {
+  const scanned = scanValueFlags(args, ['--title', '--status', '--priority', '--due', '--assignee']);
+  if (!scanned.ok) return scanned;
+  return {
+    ok: true,
+    title: scanned.values.get('--title'),
+    status: scanned.values.get('--status'),
+    priority: scanned.values.get('--priority'),
+    due: scanned.values.get('--due'),
+    assignee: scanned.values.get('--assignee'),
+    rest: scanned.rest,
+  };
+}
+
+export interface TaskUpdateFlags {
+  readonly title: string | undefined;
+  readonly status: string | undefined;
+  readonly priority: string | undefined;
+  readonly due: string | undefined;
+  readonly rest: readonly string[];
+}
+export type ExtractTaskUpdateFlagsResult = ({ readonly ok: true } & TaskUpdateFlags) | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. Deliberately excludes `--assignee` — this task's spec scopes `update` to status/title/priority/due. */
+export function extractTaskUpdateFlags(args: readonly string[]): ExtractTaskUpdateFlagsResult {
+  const scanned = scanValueFlags(args, ['--title', '--status', '--priority', '--due']);
+  if (!scanned.ok) return scanned;
+  return {
+    ok: true,
+    title: scanned.values.get('--title'),
+    status: scanned.values.get('--status'),
+    priority: scanned.values.get('--priority'),
+    due: scanned.values.get('--due'),
+    rest: scanned.rest,
+  };
+}
+
+export interface TaskStatusCreateFlags {
+  readonly name: string | undefined;
+  readonly color: string | undefined;
+  readonly group: string | undefined;
+  readonly position: string | undefined;
+  readonly rest: readonly string[];
+}
+export type ExtractTaskStatusCreateFlagsResult =
+  | ({ readonly ok: true } & TaskStatusCreateFlags)
+  | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. */
+export function extractTaskStatusCreateFlags(args: readonly string[]): ExtractTaskStatusCreateFlagsResult {
+  const scanned = scanValueFlags(args, ['--name', '--color', '--group', '--position']);
+  if (!scanned.ok) return scanned;
+  return {
+    ok: true,
+    name: scanned.values.get('--name'),
+    color: scanned.values.get('--color'),
+    group: scanned.values.get('--group'),
+    position: scanned.values.get('--position'),
+    rest: scanned.rest,
+  };
+}
+
+export const tasksCreateHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, ...rest0] = intent.args;
+  const usage =
+    'Usage: pagespace tasks create <pageId> --title <title> [--priority low|medium|high] [--status <slug>] [--due <date>] [--assignee <userId>]\n';
+  if (!pageId) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = extractTaskCreateFlags(rest0);
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.rest.length > 0) {
+    ctx.stderr.write(`Unknown argument: ${parsed.rest[0]}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (!parsed.title) {
+    ctx.stderr.write('Flag --title is required.\n');
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.priority !== undefined && !priorityEnum.safeParse(parsed.priority).success) {
+    ctx.stderr.write(`Invalid --priority "${parsed.priority}". Expected one of: ${priorityEnum.options.join(', ')}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.tasks.create({
+      pageId,
+      title: parsed.title as string,
+      priority: parsed.priority as 'low' | 'medium' | 'high' | undefined,
+      status: parsed.status,
+      dueDate: parsed.due,
+      assigneeId: parsed.assignee,
+    }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Created task ${result.value.id}  ${result.value.title}  [${result.value.status}]\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const tasksUpdateHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, taskId, ...rest0] = intent.args;
+  const usage = 'Usage: pagespace tasks update <pageId> <taskId> [--status <slug>] [--title <title>] [--priority low|medium|high] [--due <date>]\n';
+  if (!pageId || !taskId) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = extractTaskUpdateFlags(rest0);
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.rest.length > 0) {
+    ctx.stderr.write(`Unknown argument: ${parsed.rest[0]}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.priority !== undefined && !priorityEnum.safeParse(parsed.priority).success) {
+    ctx.stderr.write(`Invalid --priority "${parsed.priority}". Expected one of: ${priorityEnum.options.join(', ')}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.tasks.update({
+      pageId,
+      taskId,
+      title: parsed.title,
+      status: parsed.status,
+      priority: parsed.priority as 'low' | 'medium' | 'high' | undefined,
+      dueDate: parsed.due,
+    }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Updated task ${result.value.id}  ${result.value.title}  [${result.value.status}]\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const tasksDeleteHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, taskId] = intent.args;
+  if (!pageId || !taskId) {
+    ctx.stderr.write('Usage: pagespace tasks delete <pageId> <taskId> [--yes]\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const confirmation = await confirmDestructive(`Delete task ${taskId}? [y/N] `, {
+    isTTY: ctx.isTTY,
+    yes: intent.flags.yes,
+    prompt: ctx.prompt,
+  });
+  if (!confirmation.ok) {
+    ctx.stderr.write(`${confirmationFailureMessage(confirmation)}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.tasks.delete({ pageId, taskId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Deleted task ${taskId}.\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const tasksReorderHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, taskId, rawPosition] = intent.args;
+  if (!pageId || !taskId || rawPosition === undefined || intent.args.length > 3) {
+    ctx.stderr.write('Usage: pagespace tasks reorder <pageId> <taskId> <position>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const position = Number(rawPosition);
+  if (!Number.isFinite(position)) {
+    ctx.stderr.write(`Invalid position "${rawPosition}": must be a finite number.\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.tasks.reorder({ pageId, taskId, position }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Reordered task ${result.value.id} to position ${result.value.position}.\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const tasksCreateStatusHandler: CommandHandler = async (ctx, intent) => {
+  const [pageId, ...rest0] = intent.args;
+  const usage = 'Usage: pagespace tasks create-status <pageId> --name <name> --color <color> --group todo|in_progress|done [--position N]\n';
+  if (!pageId) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = extractTaskStatusCreateFlags(rest0);
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.rest.length > 0) {
+    ctx.stderr.write(`Unknown argument: ${parsed.rest[0]}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (!parsed.name || !parsed.color || !parsed.group) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+  if (!statusGroupEnum.safeParse(parsed.group).success) {
+    ctx.stderr.write(`Invalid --group "${parsed.group}". Expected one of: ${statusGroupEnum.options.join(', ')}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  let position: number | undefined;
+  if (parsed.position !== undefined) {
+    position = Number(parsed.position);
+    if (!Number.isFinite(position)) {
+      ctx.stderr.write(`Invalid --position "${parsed.position}": must be a finite number.\n`);
+      return EXIT_USAGE_ERROR;
+    }
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.tasks.createStatus({
+      pageId,
+      name: parsed.name as string,
+      color: parsed.color as string,
+      group: parsed.group as 'todo' | 'in_progress' | 'done',
+      position,
+    }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+  } else {
+    ctx.stdout.write(`Created status ${result.value.slug}  ${result.value.name}  [${result.value.group}]\n`);
+  }
+  return EXIT_SUCCESS;
+};
+
+export const tasksAssignedHandler: CommandHandler = async (ctx, intent) => {
+  if (intent.args.length > 0) {
+    ctx.stderr.write('Usage: pagespace tasks assigned [--json]\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.tasks.getAssigned({}));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  if (result.value.tasks.length === 0) {
+    ctx.stdout.write('No assigned tasks.\n');
+    return EXIT_SUCCESS;
+  }
+  ctx.stdout.write(
+    `${result.value.tasks.map((task) => `[${task.statusLabel}] ${task.id}  ${task.title}  (priority: ${task.priority})`).join('\n')}\n`,
+  );
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,6 +77,33 @@ export {
 } from './commands/pages.js';
 export { renderTrashTree, trashListHandler } from './commands/trash.js';
 
+// Tasks verbs (Phase 5 task 3) — thin projections over the `tasks.*` SDK
+// operations (and, for list/statuses, the already-wired `pages.read`
+// TASK_LIST branch).
+export {
+  extractTaskCreateFlags,
+  extractTaskStatusCreateFlags,
+  extractTaskUpdateFlags,
+  renderTasksList,
+  renderTaskStatuses,
+  tasksAssignedHandler,
+  tasksCreateHandler,
+  tasksCreateStatusHandler,
+  tasksDeleteHandler,
+  tasksListHandler,
+  tasksReorderHandler,
+  tasksStatusesHandler,
+  tasksUpdateHandler,
+} from './commands/tasks.js';
+export type {
+  ExtractTaskCreateFlagsResult,
+  ExtractTaskStatusCreateFlagsResult,
+  ExtractTaskUpdateFlagsResult,
+  TaskCreateFlags,
+  TaskStatusCreateFlags,
+  TaskUpdateFlags,
+} from './commands/tasks.js';
+
 // Content & export verbs (Phase 5 task 2) — thin projections over the
 // documents/export SDK operations.
 export {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -36,6 +36,16 @@ import {
   pagesTreeHandler,
 } from './commands/pages.js';
 import { sheetsEditCellsHandler } from './commands/sheets.js';
+import {
+  tasksAssignedHandler,
+  tasksCreateHandler,
+  tasksCreateStatusHandler,
+  tasksDeleteHandler,
+  tasksListHandler,
+  tasksReorderHandler,
+  tasksStatusesHandler,
+  tasksUpdateHandler,
+} from './commands/tasks.js';
 import { trashListHandler } from './commands/trash.js';
 import { versionHandler } from './commands/version.js';
 import { whoamiHandler } from './commands/whoami.js';
@@ -87,6 +97,14 @@ const ROUTES: readonly Route[] = [
   { path: ['pages', 'export'], handler: pagesExportHandler },
   { path: ['sheets', 'edit-cells'], handler: sheetsEditCellsHandler },
   { path: ['trash', 'list'], handler: trashListHandler },
+  { path: ['tasks', 'list'], handler: tasksListHandler },
+  { path: ['tasks', 'create'], handler: tasksCreateHandler },
+  { path: ['tasks', 'update'], handler: tasksUpdateHandler },
+  { path: ['tasks', 'delete'], handler: tasksDeleteHandler },
+  { path: ['tasks', 'reorder'], handler: tasksReorderHandler },
+  { path: ['tasks', 'statuses'], handler: tasksStatusesHandler },
+  { path: ['tasks', 'create-status'], handler: tasksCreateStatusHandler },
+  { path: ['tasks', 'assigned'], handler: tasksAssignedHandler },
 ];
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -166,8 +166,10 @@ export {
   deleteTask,
   deleteTaskTrigger,
   getAssignedTasks,
+  priorityEnum,
   reorderTask,
   setTaskTrigger,
+  statusGroupEnum,
   updateTask,
 } from './operations/tasks.js';
 export type { TaskCompletionGatedError } from './operations/tasks.js';

--- a/packages/sdk/src/operations/tasks.ts
+++ b/packages/sdk/src/operations/tasks.ts
@@ -20,8 +20,10 @@ import { z } from 'zod';
 import { defineOperation } from '../registry/define.js';
 import { HttpError, isHttpError } from '../errors.js';
 
-const priorityEnum = z.enum(['low', 'medium', 'high']);
-const statusGroupEnum = z.enum(['todo', 'in_progress', 'done']);
+/** Exported (unlike status slugs, which are per-list and server-owned) so CLI verbs can validate `--priority` without a second, drifting allowlist. */
+export const priorityEnum = z.enum(['low', 'medium', 'high']);
+/** Exported for the same reason as `priorityEnum` — `tasks create-status --group` validates against this, not a duplicated literal. */
+export const statusGroupEnum = z.enum(['todo', 'in_progress', 'done']);
 const triggerTypeEnum = z.enum(['due_date', 'completion']);
 
 const userRefSchema = z


### PR DESCRIPTION
## Summary
- Adds `pagespace tasks list|create|update|delete|reorder|statuses|create-status|assigned` — thin projections over the `tasks.*` SDK operations. All underlying operations (`create`, `update`, `delete`, `reorder`, `createStatus`, `getAssigned`) were already defined and wired on the client facade by Phase 3 task 4 — no SDK facade gap found.
- `list`/`statuses` have no dedicated operation; both reuse the already-wired `pages.read` TASK_LIST branch (tasks + availableStatuses + progress in one call — the exact `read_page` payload for a TASK_LIST page). `--json` always emits that whole raw response.
- `update`'s container-gating rejection (server blocks completing a parent with open sub-tasks) needs no special-case code — `callSdk` already surfaces the caught error's message verbatim.
- Exports `priorityEnum`/`statusGroupEnum` from `@pagespace/sdk` (mirrors the existing `pageTypeSchema` precedent) so `tasks create`/`create-status` can validate `--priority`/`--group` client-side without a second, drifting allowlist. Status *slugs* stay server-validated per the phase law (list-specific, no client allowlist).

## Test plan
- [x] RED commit: 36 failing tests in `packages/cli/src/commands/__tests__/tasks.test.ts` (argv→SDK-call matrix, every update flag combo, `--json` exactness, destructive delete confirmation, gating-rejection rendering)
- [x] GREEN commit: implementation, all tests pass
- [x] `bun run --filter '@pagespace/sdk' typecheck && test` — 714 passed
- [x] `bun run --filter '@pagespace/cli' typecheck && test` — 558 passed (incl. the 36 new + `single-auth-path.test.ts` auto-covering the new command file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kz2Q5pSeEjLi8wdbh7KvvG