### PR TITLE
cli: implement search verbs (Phase 5 task 4)

### DIFF
--- a/packages/cli/src/commands/__tests__/search.test.ts
+++ b/packages/cli/src/commands/__tests__/search.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EXIT_RUNTIME_ERROR,
+  EXIT_SUCCESS,
+  EXIT_USAGE_ERROR,
+  parseArgv,
+  searchGlobHandler,
+  searchRegexHandler,
+  searchTextHandler,
+} from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+/**
+ * Mirrors what the router hands a handler: `parseArgv` only passes an
+ * unrecognized flag (e.g. `--drive`) through into `args` once at least one
+ * positional token has been seen — `__cmd__` stands in for the
+ * already-stripped command path prefix and is sliced back off below.
+ */
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const GLOB_RESULT = {
+  success: true as const,
+  driveSlug: 'engineering',
+  pattern: '**/README*',
+  results: [
+    { pageId: 'p1', title: 'README', type: 'DOCUMENT', semanticPath: '/engineering/README', matchedOn: 'title' as const },
+  ],
+  totalResults: 1,
+  summary: 'Found 1 page matching pattern "**/README*"',
+  stats: { totalPagesScanned: 42, matchingPages: 1, documentTypes: ['DOCUMENT'], matchTypes: { path: 0, title: 1 } },
+  nextSteps: ['Use read_page with the pageId to examine content'],
+};
+
+const REGEX_RESULT = {
+  success: true as const,
+  driveSlug: 'engineering',
+  pattern: 'TODO.*urgent',
+  searchIn: 'content',
+  results: [
+    {
+      pageId: 'p1',
+      title: 'Design Doc',
+      type: 'DOCUMENT',
+      semanticPath: '/engineering/Design Doc',
+      matchingLines: [{ lineNumber: 12, content: '// TODO: urgent fix needed' }],
+      totalMatches: 1,
+    },
+  ],
+  totalResults: 1,
+  summary: 'Found 1 page matching pattern "TODO.*urgent"',
+  stats: { pagesScanned: 10, pagesWithAccess: 1, documentTypes: ['DOCUMENT'] },
+  nextSteps: ['Use read_page with the pageId to examine full content'],
+};
+
+const MULTI_DRIVE_RESULT = {
+  success: true as const,
+  searchQuery: 'quarterly report',
+  searchType: 'text',
+  results: [
+    {
+      driveId: 'd1',
+      driveName: 'Engineering',
+      driveSlug: 'engineering',
+      matches: [{ pageId: 'p1', title: 'Q3 Report', type: 'DOCUMENT', excerpt: 'quarterly report summary...' }],
+      count: 1,
+    },
+    {
+      driveId: 'd2',
+      driveName: 'Marketing',
+      driveSlug: 'marketing',
+      matches: [{ pageId: 'p2', title: 'Campaign Report', type: 'DOCUMENT', excerpt: 'quarterly report on campaign...' }],
+      count: 1,
+    },
+  ],
+  totalDrives: 2,
+  totalMatches: 2,
+  summary: 'Found 2 matches across 2 drives',
+  stats: { drivesSearched: 2, drivesWithResults: 2, totalMatches: 2 },
+  nextSteps: ['Use read_page with specific pageIds to examine content'],
+};
+
+// ---------------------------------------------------------------------------
+// search text -> search.multiDrive
+// ---------------------------------------------------------------------------
+
+describe('searchTextHandler', () => {
+  it('exits 2 with a usage error when the query is missing', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(multiDrive).not.toHaveBeenCalled();
+  });
+
+  it('calls search.multiDrive with searchType "text" and no maxResultsPerDrive by default', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['quarterly report']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(multiDrive).toHaveBeenCalledWith({ searchQuery: 'quarterly report', searchType: 'text', maxResultsPerDrive: undefined });
+  });
+
+  it('passes --max-results through as maxResultsPerDrive', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    await searchTextHandler(ctx, commandIntent(['x', '--max-results', '5']));
+
+    expect(multiDrive).toHaveBeenCalledWith({ searchQuery: 'x', searchType: 'text', maxResultsPerDrive: 5 });
+  });
+
+  it('exits 2 when --max-results is above the multi-drive bound of 50', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['x', '--max-results', '51']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(multiDrive).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when --max-results is below 1', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['x', '--max-results', '0']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(multiDrive).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when --max-results is not an integer', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['x', '--max-results', 'abc']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(multiDrive).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when both --drive and --all-drives are given (mutually exclusive)', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['x', '--drive', 'd1', '--all-drives']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(multiDrive).not.toHaveBeenCalled();
+  });
+
+  it('accepts --all-drives as a no-op flag (multi-drive search always covers accessible drives)', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['x', '--all-drives']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(multiDrive).toHaveBeenCalledWith({ searchQuery: 'x', searchType: 'text', maxResultsPerDrive: undefined });
+  });
+
+  it('renders grep-style output (driveSlug:pageId: excerpt) across all drive groups by default', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { multiDrive: async () => MULTI_DRIVE_RESULT } }) });
+
+    await searchTextHandler(ctx, commandIntent(['quarterly report']));
+
+    const output = stdout.lines.join('');
+    expect(output).toBe(
+      'engineering:p1: quarterly report summary...\nmarketing:p2: quarterly report on campaign...\n',
+    );
+  });
+
+  it('renders only the matching drive group when --drive filters the (already-fetched) response', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { multiDrive: async () => MULTI_DRIVE_RESULT } }) });
+
+    await searchTextHandler(ctx, commandIntent(['quarterly report', '--drive', 'd2']));
+
+    expect(stdout.lines.join('')).toBe('marketing:p2: quarterly report on campaign...\n');
+  });
+
+  it('--json emits exactly the unfiltered SDK response even when --drive is given', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { multiDrive: async () => MULTI_DRIVE_RESULT } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['quarterly report', '--drive', 'd2', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(MULTI_DRIVE_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const multiDrive = vi.fn(async () => {
+      throw new Error('Multi-drive search failed');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ search: { multiDrive } }) });
+
+    const code = await searchTextHandler(ctx, commandIntent(['x']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Multi-drive search failed');
+  });
+
+  it('passes a query containing shell metacharacters through verbatim, unmangled', async () => {
+    const multiDrive = vi.fn(async () => MULTI_DRIVE_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { multiDrive } }) });
+    const rawQuery = '$(rm -rf /) & echo "hi" | cat';
+
+    await searchTextHandler(ctx, commandIntent([rawQuery]));
+
+    expect(multiDrive).toHaveBeenCalledWith({ searchQuery: rawQuery, searchType: 'text', maxResultsPerDrive: undefined });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search regex -> search.regex
+// ---------------------------------------------------------------------------
+
+describe('searchRegexHandler', () => {
+  it('exits 2 with a usage error when --drive is missing', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['TODO.*urgent']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(regex).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when the pattern is missing', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['--drive', 'd1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(regex).not.toHaveBeenCalled();
+  });
+
+  it('calls search.regex with driveId + pattern for the given argv', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['TODO.*urgent', '--drive', 'd1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(regex).toHaveBeenCalledWith({ driveId: 'd1', pattern: 'TODO.*urgent', searchIn: undefined, maxResults: undefined });
+  });
+
+  it('maps --in to searchIn', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+
+    await searchRegexHandler(ctx, commandIntent(['x', '--drive', 'd1', '--in', 'both']));
+
+    expect(regex).toHaveBeenCalledWith({ driveId: 'd1', pattern: 'x', searchIn: 'both', maxResults: undefined });
+  });
+
+  it('exits 2 for an invalid --in value', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['x', '--drive', 'd1', '--in', 'everywhere']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(regex).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when --max-results is above the regex bound of 100', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['x', '--drive', 'd1', '--max-results', '101']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(regex).not.toHaveBeenCalled();
+  });
+
+  it('passes a pattern with regex metacharacters through verbatim, unmangled (no double-escaping)', async () => {
+    const regex = vi.fn(async () => REGEX_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { regex } }) });
+    const rawPattern = '\\d{4}-\\d{2}-\\d{2}.*(foo|bar)+$';
+
+    await searchRegexHandler(ctx, commandIntent([rawPattern, '--drive', 'd1']));
+
+    expect(regex).toHaveBeenCalledWith({ driveId: 'd1', pattern: rawPattern, searchIn: undefined, maxResults: undefined });
+  });
+
+  it('renders grep-style output (path:pageId:line: content) per matching line', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { regex: async () => REGEX_RESULT } }) });
+
+    await searchRegexHandler(ctx, commandIntent(['TODO.*urgent', '--drive', 'd1']));
+
+    expect(stdout.lines.join('')).toBe('/engineering/Design Doc:p1:12: // TODO: urgent fix needed\n');
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { regex: async () => REGEX_RESULT } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['TODO.*urgent', '--drive', 'd1', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(REGEX_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const regex = vi.fn(async () => {
+      throw new Error('Pattern parameter is required');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ search: { regex } }) });
+
+    const code = await searchRegexHandler(ctx, commandIntent(['x', '--drive', 'd1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Pattern parameter is required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// search glob -> search.glob
+// ---------------------------------------------------------------------------
+
+describe('searchGlobHandler', () => {
+  it('exits 2 with a usage error when --drive is missing', async () => {
+    const glob = vi.fn(async () => GLOB_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { glob } }) });
+
+    const code = await searchGlobHandler(ctx, commandIntent(['**/README*']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(glob).not.toHaveBeenCalled();
+  });
+
+  it('calls search.glob with driveId + pattern for the given argv', async () => {
+    const glob = vi.fn(async () => GLOB_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { glob } }) });
+
+    const code = await searchGlobHandler(ctx, commandIntent(['**/README*', '--drive', 'd1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(glob).toHaveBeenCalledWith({ driveId: 'd1', pattern: '**/README*', maxResults: undefined });
+  });
+
+  it('exits 2 when --max-results is above the glob bound of 200', async () => {
+    const glob = vi.fn(async () => GLOB_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { glob } }) });
+
+    const code = await searchGlobHandler(ctx, commandIntent(['*', '--drive', 'd1', '--max-results', '201']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(glob).not.toHaveBeenCalled();
+  });
+
+  it('passes a pattern with glob stars through verbatim, unmangled', async () => {
+    const glob = vi.fn(async () => GLOB_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ search: { glob } }) });
+    const rawPattern = '**/*.{md,ts}';
+
+    await searchGlobHandler(ctx, commandIntent([rawPattern, '--drive', 'd1']));
+
+    expect(glob).toHaveBeenCalledWith({ driveId: 'd1', pattern: rawPattern, maxResults: undefined });
+  });
+
+  it('renders grep-style output (path:pageId: title)', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { glob: async () => GLOB_RESULT } }) });
+
+    await searchGlobHandler(ctx, commandIntent(['**/README*', '--drive', 'd1']));
+
+    expect(stdout.lines.join('')).toBe('/engineering/README:p1: README\n');
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ search: { glob: async () => GLOB_RESULT } }) });
+
+    const code = await searchGlobHandler(ctx, commandIntent(['**/README*', '--drive', 'd1', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(GLOB_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const glob = vi.fn(async () => {
+      throw new Error('Drive not found');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ search: { glob } }) });
+
+    const code = await searchGlobHandler(ctx, commandIntent(['*', '--drive', 'd1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Drive not found');
+  });
+});

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,0 +1,231 @@
+/**
+ * `pagespace search text|regex|glob` (Phase 5 task 4). Thin projections over
+ * the `search.*` SDK operations (Phase 3 task 3; wired onto the client facade
+ * by this same task — see `@pagespace/sdk`'s `client.ts`).
+ *
+ * There is no per-drive "text" search route on the server — only
+ * `search.glob`/`search.regex` are drive-scoped; free-text search only
+ * exists as `search.multiDrive` (`searchType: 'text'`), which always
+ * enumerates every drive the caller can access and has no `driveId` input.
+ * `search text --drive <id>` therefore makes the same one multi-drive call
+ * as `--all-drives`/the no-flag default and narrows which drive's result
+ * *group* human-mode rendering shows — a pure post-call filter, not a second
+ * SDK call or a fabricated request field the server would silently ignore.
+ * `--json` always emits the untouched multi-drive response regardless of
+ * `--drive`, matching every other verb's rule that `--json` is never a
+ * filtered subset of what human mode chooses to render.
+ *
+ * Patterns/queries are taken from `intent.args` verbatim and forwarded
+ * unchanged — the server owns pattern safety (ReDoS guards, statement
+ * timeouts); this module neither sanitizes nor mangles them.
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { extractDriveFlag } from './drive-flag.js';
+import { callSdk } from './sdk-error.js';
+
+type MultiDriveSearchResult = Awaited<ReturnType<PageSpaceClient['search']['multiDrive']>>;
+type RegexSearchResult = Awaited<ReturnType<PageSpaceClient['search']['regex']>>;
+type GlobSearchResult = Awaited<ReturnType<PageSpaceClient['search']['glob']>>;
+
+type FlagScanResult =
+  | { readonly ok: true; readonly booleans: ReadonlySet<string>; readonly values: ReadonlyMap<string, string>; readonly rest: readonly string[] }
+  | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. Consumes any of `spec`'s flags (boolean or value-taking), passing everything else through in `rest` verbatim — patterns/queries are never touched. */
+function scanFlags(args: readonly string[], spec: { readonly booleanFlags: readonly string[]; readonly valueFlags: readonly string[] }): FlagScanResult {
+  const booleans = new Set<string>();
+  const values = new Map<string, string>();
+  const rest: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i] as string;
+    if (spec.booleanFlags.includes(token)) {
+      booleans.add(token);
+      i += 1;
+      continue;
+    }
+    if (spec.valueFlags.includes(token)) {
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: `Flag ${token} requires a value.` };
+      values.set(token, value);
+      i += 2;
+      continue;
+    }
+    rest.push(token);
+    i += 1;
+  }
+  return { ok: true, booleans, values, rest };
+}
+
+/** Pure: no I/O. Parses a `--max-results`-style flag value against the operation's own clamp, or reports a usage error. */
+function parseBoundedMaxResults(raw: string | undefined, flagName: string, min: number, max: number): { readonly ok: true; readonly value: number | undefined } | { readonly ok: false; readonly message: string } {
+  if (raw === undefined) return { ok: true, value: undefined };
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    return { ok: false, message: `Invalid ${flagName} "${raw}": must be an integer between ${min} and ${max}.` };
+  }
+  return { ok: true, value: parsed };
+}
+
+const SEARCH_IN_VALUES = ['content', 'title', 'both'] as const;
+type SearchIn = (typeof SEARCH_IN_VALUES)[number];
+
+/** Pure: no I/O. */
+export function renderMultiDriveSearch(value: MultiDriveSearchResult, driveId: string | undefined): string {
+  const groups = driveId === undefined ? value.results : value.results.filter((group) => group.driveId === driveId);
+  const lines = groups.flatMap((group) => group.matches.map((match) => `${group.driveSlug}:${match.pageId}: ${match.excerpt}`));
+  if (lines.length === 0) return 'No results.\n';
+  return `${lines.join('\n')}\n`;
+}
+
+/** Pure: no I/O. */
+export function renderRegexSearch(value: RegexSearchResult): string {
+  const lines = value.results.flatMap((result) =>
+    result.matchingLines.map((line) => `${result.semanticPath}:${result.pageId}:${line.lineNumber}: ${line.content}`),
+  );
+  if (lines.length === 0) return 'No results.\n';
+  return `${lines.join('\n')}\n`;
+}
+
+/** Pure: no I/O. */
+export function renderGlobSearch(value: GlobSearchResult): string {
+  if (value.results.length === 0) return 'No results.\n';
+  return `${value.results.map((result) => `${result.semanticPath}:${result.pageId}: ${result.title}`).join('\n')}\n`;
+}
+
+export const searchTextHandler: CommandHandler = async (ctx, intent) => {
+  const usage = 'Usage: pagespace search text <query> [--drive <driveId>|--all-drives] [--max-results <n>]\n';
+
+  const driveExtracted = extractDriveFlag(intent.args);
+  if (!driveExtracted.ok) {
+    ctx.stderr.write(`${driveExtracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = scanFlags(driveExtracted.rest, { booleanFlags: ['--all-drives'], valueFlags: ['--max-results'] });
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const [query, ...extra] = parsed.rest;
+  if (!query || extra.length > 0) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const driveId = driveExtracted.driveId;
+  if (driveId !== undefined && parsed.booleans.has('--all-drives')) {
+    ctx.stderr.write('Flags --drive and --all-drives are mutually exclusive.\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const maxResults = parseBoundedMaxResults(parsed.values.get('--max-results'), '--max-results', 1, 50);
+  if (!maxResults.ok) {
+    ctx.stderr.write(`${maxResults.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.search.multiDrive({ searchQuery: query, searchType: 'text', maxResultsPerDrive: maxResults.value }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  ctx.stdout.write(renderMultiDriveSearch(result.value, driveId));
+  return EXIT_SUCCESS;
+};
+
+export const searchRegexHandler: CommandHandler = async (ctx, intent) => {
+  const usage = 'Usage: pagespace search regex <pattern> --drive <driveId> [--in content|title|both] [--max-results <n>]\n';
+
+  const driveExtracted = extractDriveFlag(intent.args);
+  if (!driveExtracted.ok) {
+    ctx.stderr.write(`${driveExtracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = scanFlags(driveExtracted.rest, { booleanFlags: [], valueFlags: ['--in', '--max-results'] });
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const [pattern, ...extra] = parsed.rest;
+  const driveId = driveExtracted.driveId;
+  if (!pattern || !driveId || extra.length > 0) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const rawSearchIn = parsed.values.get('--in');
+  if (rawSearchIn !== undefined && !SEARCH_IN_VALUES.includes(rawSearchIn as SearchIn)) {
+    ctx.stderr.write(`Invalid --in "${rawSearchIn}". Expected one of: ${SEARCH_IN_VALUES.join(', ')}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const maxResults = parseBoundedMaxResults(parsed.values.get('--max-results'), '--max-results', 1, 100);
+  if (!maxResults.ok) {
+    ctx.stderr.write(`${maxResults.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () =>
+    ctx.sdk.search.regex({ driveId, pattern, searchIn: rawSearchIn as SearchIn | undefined, maxResults: maxResults.value }),
+  );
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  ctx.stdout.write(renderRegexSearch(result.value));
+  return EXIT_SUCCESS;
+};
+
+export const searchGlobHandler: CommandHandler = async (ctx, intent) => {
+  const usage = 'Usage: pagespace search glob <pattern> --drive <driveId> [--max-results <n>]\n';
+
+  const driveExtracted = extractDriveFlag(intent.args);
+  if (!driveExtracted.ok) {
+    ctx.stderr.write(`${driveExtracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = scanFlags(driveExtracted.rest, { booleanFlags: [], valueFlags: ['--max-results'] });
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const [pattern, ...extra] = parsed.rest;
+  const driveId = driveExtracted.driveId;
+  if (!pattern || !driveId || extra.length > 0) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const maxResults = parseBoundedMaxResults(parsed.values.get('--max-results'), '--max-results', 1, 200);
+  if (!maxResults.ok) {
+    ctx.stderr.write(`${maxResults.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.search.glob({ driveId, pattern, maxResults: maxResults.value }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  ctx.stdout.write(renderGlobSearch(result.value));
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -77,6 +77,18 @@ export {
 } from './commands/pages.js';
 export { renderTrashTree, trashListHandler } from './commands/trash.js';
 
+// Search verbs (Phase 5 task 4) — thin projections over the `search.*` SDK
+// operations (glob/regex are drive-scoped; text is the multi-drive op with
+// searchType: 'text').
+export {
+  renderGlobSearch,
+  renderMultiDriveSearch,
+  renderRegexSearch,
+  searchGlobHandler,
+  searchRegexHandler,
+  searchTextHandler,
+} from './commands/search.js';
+
 // Tasks verbs (Phase 5 task 3) — thin projections over the `tasks.*` SDK
 // operations (and, for list/statuses, the already-wired `pages.read`
 // TASK_LIST branch).

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -25,6 +25,7 @@ import { loginHandler } from './commands/login.js';
 import { loginDeviceHandler } from './commands/login-device.js';
 import { logoutHandler } from './commands/logout.js';
 import { mcpHandler } from './commands/mcp.js';
+import { searchGlobHandler, searchRegexHandler, searchTextHandler } from './commands/search.js';
 import {
   pagesCreateHandler,
   pagesListHandler,
@@ -105,6 +106,9 @@ const ROUTES: readonly Route[] = [
   { path: ['tasks', 'statuses'], handler: tasksStatusesHandler },
   { path: ['tasks', 'create-status'], handler: tasksCreateStatusHandler },
   { path: ['tasks', 'assigned'], handler: tasksAssignedHandler },
+  { path: ['search', 'text'], handler: searchTextHandler },
+  { path: ['search', 'regex'], handler: searchRegexHandler },
+  { path: ['search', 'glob'], handler: searchGlobHandler },
 ];
 
 /**

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -390,4 +390,53 @@ describe('PageSpaceClient — registry-derived namespaces', () => {
     await expect(client.export.pageMarkdown({ pageId: 'p1' })).resolves.toBe('# Hello');
     await expect(client.export.sheetCsv({ pageId: 'p1' })).resolves.toBe('a,b\n1,2');
   });
+
+  it('exposes the search namespace (Phase 3 task 3 defined the operations; the facade never wired them)', async () => {
+    const globFixture = {
+      success: true,
+      driveSlug: 'engineering',
+      pattern: '**/README*',
+      results: [],
+      totalResults: 0,
+      summary: 'Found 0 pages matching pattern "**/README*"',
+      stats: { totalPagesScanned: 0, matchingPages: 0, documentTypes: [], matchTypes: { path: 0, title: 0 } },
+      nextSteps: [],
+    };
+    const regexFixture = {
+      success: true,
+      driveSlug: 'engineering',
+      pattern: 'TODO',
+      searchIn: 'content',
+      results: [],
+      totalResults: 0,
+      summary: 'Found 0 pages matching pattern "TODO"',
+      stats: { pagesScanned: 0, pagesWithAccess: 0, documentTypes: [] },
+      nextSteps: [],
+    };
+    const multiDriveFixture = {
+      success: true,
+      searchQuery: 'quarterly report',
+      searchType: 'text',
+      results: [],
+      totalDrives: 0,
+      totalMatches: 0,
+      summary: 'Found 0 matches across 0 drives',
+      stats: { drivesSearched: 0, drivesWithResults: 0, totalMatches: 0 },
+      nextSteps: [],
+    };
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/search/glob')) return jsonResponse(200, globFixture);
+      if (url.includes('/search/regex')) return jsonResponse(200, regexFixture);
+      return jsonResponse(200, multiDriveFixture);
+    });
+    const client = makeClient({ fetch: fetchMock });
+
+    expect(typeof client.search.glob).toBe('function');
+    expect(typeof client.search.regex).toBe('function');
+    expect(typeof client.search.multiDrive).toBe('function');
+
+    await expect(client.search.glob({ driveId: 'd1', pattern: '**/README*' })).resolves.toEqual(globFixture);
+    await expect(client.search.regex({ driveId: 'd1', pattern: 'TODO' })).resolves.toEqual(regexFixture);
+    await expect(client.search.multiDrive({ searchQuery: 'quarterly report' })).resolves.toEqual(multiDriveFixture);
+  });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -73,6 +73,7 @@ import {
   updateTask,
 } from './operations/tasks.js';
 import { createMcpToken, listMcpTokens, revokeMcpToken } from './operations/mcp-tokens.js';
+import { globSearch, multiDriveSearch, regexSearch } from './operations/search.js';
 import type { Operation } from './registry/define.js';
 import { createRegistry, type OperationRegistry } from './registry/registry.js';
 import { buildRequest } from './transport/build-request.js';
@@ -145,6 +146,11 @@ const DEFAULT_OPERATIONS_MAP = {
     create: createMcpToken,
     list: listMcpTokens,
     revoke: revokeMcpToken,
+  },
+  search: {
+    glob: globSearch,
+    regex: regexSearch,
+    multiDrive: multiDriveSearch,
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Closes the known SDK facade gap: `DEFAULT_OPERATIONS_MAP` never wired a `search` namespace onto `PageSpaceClient` even though `operations/search.ts` already defined `glob`/`regex`/`multiDrive` (Phase 3 task 3) — same shape as the export-namespace gap Phase 3 task 10 left behind. `client.search.{glob,regex,multiDrive}` now exist, mirroring the operation names exactly (no invented method names).
- Implements `pagespace search text|regex|glob` as thin projections over those SDK operations:
  - `search text <query> [--drive <id>|--all-drives] [--max-results <n>]` → `search.multiDrive` (`searchType: 'text'`). No per-drive text-search route exists on the server, so `--drive` doesn't change the request — it narrows which drive's result group human-mode rendering shows (pure post-call filter). `--json` always emits the untouched multi-drive response regardless of `--drive`.
  - `search regex <pattern> --drive <id> [--in content|title|both] [--max-results <n>]` → `search.regex`.
  - `search glob <pattern> --drive <id> [--max-results <n>]` → `search.glob`.
- `--max-results` is validated client-side against each operation's own clamp (50/100/200) before any network call, exiting 2 on an out-of-bounds value.
- Patterns/queries flow from argv straight into the SDK call — no escaping, sanitizing, or double-encoding.

## TDD
- RED commit: 30 CLI command tests (argv→call matrix, `--drive`/`--all-drives` mutual exclusion, bounds validation, regex/glob metacharacter fidelity, grep-style rendering, `--json` purity) + the client-facade regression test for the `search` namespace gap — all failing.
- GREEN commit: wires `client.ts` + implements `packages/cli/src/commands/search.ts` + registers routes in `run.ts`/`index.ts` — all tests pass.

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck` — pass
- [x] `bun run --filter '@pagespace/sdk' test` — 715/715 pass
- [x] `bun run --filter '@pagespace/cli' typecheck` — pass
- [x] `bun run --filter '@pagespace/cli' test` — 593/593 pass (includes `single-auth-path.test.ts` auto-checking the new `search.ts` module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm9dDdg4xTG36KXmpzzGWJ