### PR TITLE
cli: implement agents & activity verbs (Phase 5 task 5)

### DIFF
--- a/packages/cli/src/commands/__tests__/activity.test.ts
+++ b/packages/cli/src/commands/__tests__/activity.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, activityHandler, parseArgv } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const ACTIVITY_RESULT = {
+  activities: [
+    {
+      id: 'a1',
+      timestamp: '2026-07-01T12:00:00.000Z',
+      userId: 'u1',
+      actorEmail: 'ada@example.com',
+      actorDisplayName: 'Ada',
+      isAiGenerated: false,
+      aiProvider: null,
+      aiModel: null,
+      aiConversationId: null,
+      operation: 'update',
+      resourceType: 'page' as const,
+      resourceId: 'p1',
+      resourceTitle: 'Design Doc',
+      driveId: 'd1',
+      pageId: 'p1',
+      contentSnapshot: null,
+      contentFormat: null,
+      contentRef: null,
+      contentSize: null,
+      rollbackFromActivityId: null,
+      rollbackSourceOperation: null,
+      rollbackSourceTimestamp: null,
+      rollbackSourceTitle: null,
+      updatedFields: null,
+      previousValues: null,
+      newValues: null,
+      metadata: null,
+      streamId: null,
+      streamSeq: null,
+      changeGroupId: null,
+      changeGroupType: null,
+      stateHashBefore: null,
+      stateHashAfter: null,
+      dataCategory: null,
+      legalBasis: null,
+      retentionPolicy: null,
+      recipients: null,
+      isArchived: false,
+      chainSeq: 1,
+      previousLogHash: null,
+      logHash: null,
+      chainSeed: null,
+      user: { id: 'u1', name: 'Ada', email: 'ada@example.com', image: null },
+    },
+  ],
+  pagination: { total: 1, limit: 50, offset: 0, hasMore: false },
+};
+
+describe('activityHandler', () => {
+  it('exits 2 with a usage error when driveId is missing', async () => {
+    const get = vi.fn(async () => ACTIVITY_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ activity: { get } }) });
+
+    const code = await activityHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('calls activity.get with context "drive" + the given driveId', async () => {
+    const get = vi.fn(async () => ACTIVITY_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ activity: { get } }) });
+
+    const code = await activityHandler(ctx, commandIntent(['d1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(get).toHaveBeenCalledWith({ context: 'drive', driveId: 'd1' });
+  });
+
+  it('exits 2 with a usage error given extra positional args', async () => {
+    const get = vi.fn(async () => ACTIVITY_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ activity: { get } }) });
+
+    const code = await activityHandler(ctx, commandIntent(['d1', 'extra']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('renders a timestamped one-line-per-entry feed', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ activity: { get: async () => ACTIVITY_RESULT } }) });
+
+    await activityHandler(ctx, commandIntent(['d1']));
+
+    expect(stdout.lines.join('')).toBe('2026-07-01T12:00:00.000Z  ada@example.com  update page:p1\n');
+  });
+
+  it('renders "No activity." when the feed is empty', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({
+      stdout,
+      sdk: fakeSdk({ activity: { get: async () => ({ activities: [], pagination: { total: 0, limit: 50, offset: 0, hasMore: false } }) } }),
+    });
+
+    await activityHandler(ctx, commandIntent(['d1']));
+
+    expect(stdout.lines.join('')).toBe('No activity.\n');
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ activity: { get: async () => ACTIVITY_RESULT } }) });
+
+    const code = await activityHandler(ctx, commandIntent(['d1', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(ACTIVITY_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const get = vi.fn(async () => {
+      throw new Error('Drive not found');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ activity: { get } }) });
+
+    const code = await activityHandler(ctx, commandIntent(['d1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Drive not found');
+  });
+});

--- a/packages/cli/src/commands/__tests__/agents.test.ts
+++ b/packages/cli/src/commands/__tests__/agents.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  EXIT_RUNTIME_ERROR,
+  EXIT_SUCCESS,
+  EXIT_USAGE_ERROR,
+  agentsAskHandler,
+  agentsConfigHandler,
+  agentsListHandler,
+  modelsListHandler,
+  parseArgv,
+} from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { TimeoutError } from '@pagespace/sdk';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const DRIVE_AGENT = {
+  id: 'ag1',
+  title: 'Support Bot',
+  parentId: 'root',
+  position: 0,
+  aiProvider: 'anthropic',
+  aiModel: 'claude-sonnet-5',
+  hasWelcomeMessage: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  hasSystemPrompt: true,
+};
+
+const LIST_RESULT = {
+  success: true as const,
+  driveId: 'd1',
+  driveName: 'Engineering',
+  driveSlug: 'engineering',
+  agents: [DRIVE_AGENT],
+  count: 1,
+  summary: 'Found 1 agent',
+  stats: { totalInDrive: 1, accessible: 1, withSystemPrompt: 1, withTools: 0 },
+  nextSteps: [],
+};
+
+const MULTI_DRIVE_AGENT = { ...DRIVE_AGENT, driveId: 'd1', driveName: 'Engineering', driveSlug: 'engineering' };
+
+const MULTI_DRIVE_LIST_RESULT = {
+  success: true as const,
+  totalCount: 1,
+  driveCount: 1,
+  summary: 'Found 1 agent across 1 drive',
+  stats: { accessibleDrives: 1, totalAgents: 1, withSystemPrompt: 1, withTools: 0, averageAgentsPerDrive: 1 },
+  nextSteps: [],
+  agents: [MULTI_DRIVE_AGENT],
+};
+
+const ASK_RESULT = {
+  success: true as const,
+  agent: { id: 'ag1', title: 'Support Bot', systemPrompt: 'Be helpful.', provider: 'anthropic', model: 'claude-sonnet-5', enabledToolsCount: 2 },
+  question: 'What is the refund policy?',
+  response: 'Refunds are processed within 5 business days.',
+  context: null,
+  conversationId: 'conv1',
+  metadata: {
+    conversationLength: 2,
+    toolsAvailable: 2,
+    provider: 'anthropic',
+    model: 'claude-sonnet-5',
+    responseLength: 44,
+    timestamp: '2026-01-01T00:00:00.000Z',
+  },
+  summary: 'Consulted agent Support Bot',
+  nextSteps: [],
+};
+
+const UPDATE_CONFIG_RESULT = {
+  success: true as const,
+  id: 'ag1',
+  title: 'Support Bot',
+  type: 'AI_CHAT' as const,
+  message: 'Updated',
+  summary: 'Updated 1 field',
+  updatedFields: ['aiModel'],
+  agentConfig: {
+    systemPrompt: 'Be helpful.',
+    enabledToolsCount: 2,
+    enabledTools: ['search'],
+    aiProvider: 'anthropic',
+    aiModel: 'claude-sonnet-5',
+    hasSystemPrompt: true,
+    toolExposureMode: 'upfront' as const,
+  },
+  stats: { pageType: 'AI_CHAT' as const, updatedFields: 1, configuredTools: 1, hasSystemPrompt: true },
+  nextSteps: [],
+};
+
+const MODELS_RESULT = {
+  providers: [
+    {
+      provider: 'anthropic',
+      name: 'Anthropic',
+      dynamic: false,
+      models: [
+        { id: 'claude-sonnet-5', displayName: 'Claude Sonnet 5', provider: 'anthropic', free: false },
+        { id: 'claude-haiku-4-5', displayName: 'Claude Haiku 4.5', provider: 'anthropic', free: true, contextWindow: 200000 },
+      ],
+    },
+  ],
+  defaultProvider: 'anthropic',
+  defaultModel: 'claude-sonnet-5',
+};
+
+// ---------------------------------------------------------------------------
+// agents list -> agents.list / agents.listMultiDrive
+// ---------------------------------------------------------------------------
+
+describe('agentsListHandler', () => {
+  it('exits 2 with a usage error when neither --drive nor --all-drives is given', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { list } }) });
+
+    const code = await agentsListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 when both --drive and --all-drives are given (mutually exclusive)', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { list } }) });
+
+    const code = await agentsListHandler(ctx, commandIntent(['--drive', 'd1', '--all-drives']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('calls agents.list with the given driveId', async () => {
+    const list = vi.fn(async () => LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { list } }) });
+
+    const code = await agentsListHandler(ctx, commandIntent(['--drive', 'd1']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(list).toHaveBeenCalledWith({ driveId: 'd1' });
+  });
+
+  it('calls agents.listMultiDrive when --all-drives is given', async () => {
+    const listMultiDrive = vi.fn(async () => MULTI_DRIVE_LIST_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { listMultiDrive } }) });
+
+    const code = await agentsListHandler(ctx, commandIntent(['--all-drives']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(listMultiDrive).toHaveBeenCalledWith({});
+  });
+
+  it('renders one line per agent for a single drive', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { list: async () => LIST_RESULT } }) });
+
+    await agentsListHandler(ctx, commandIntent(['--drive', 'd1']));
+
+    expect(stdout.lines.join('')).toBe('ag1  Support Bot  [anthropic/claude-sonnet-5]\n');
+  });
+
+  it('renders drive-prefixed lines across drives for --all-drives', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { listMultiDrive: async () => MULTI_DRIVE_LIST_RESULT } }) });
+
+    await agentsListHandler(ctx, commandIntent(['--all-drives']));
+
+    expect(stdout.lines.join('')).toBe('engineering:ag1  Support Bot  [anthropic/claude-sonnet-5]\n');
+  });
+
+  it('renders "No agents." when the drive has none', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { list: async () => ({ ...LIST_RESULT, agents: [] }) } }) });
+
+    await agentsListHandler(ctx, commandIntent(['--drive', 'd1']));
+
+    expect(stdout.lines.join('')).toBe('No agents.\n');
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { list: async () => LIST_RESULT } }) });
+
+    const code = await agentsListHandler(ctx, commandIntent(['--drive', 'd1', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(LIST_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const list = vi.fn(async () => {
+      throw new Error('Drive not found');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ agents: { list } }) });
+
+    const code = await agentsListHandler(ctx, commandIntent(['--drive', 'd1']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Drive not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agents ask -> agents.ask
+// ---------------------------------------------------------------------------
+
+describe('agentsAskHandler', () => {
+  it('exits 2 with a usage error when the message is missing', async () => {
+    const ask = vi.fn(async () => ASK_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { ask } }) });
+
+    const code = await agentsAskHandler(ctx, commandIntent(['ag1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(ask).not.toHaveBeenCalled();
+  });
+
+  it('calls agents.ask with agentId + question', async () => {
+    const ask = vi.fn(async () => ASK_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { ask } }) });
+
+    const code = await agentsAskHandler(ctx, commandIntent(['ag1', 'What is the refund policy?']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(ask).toHaveBeenCalledWith({ agentId: 'ag1', question: 'What is the refund policy?', context: undefined, conversationId: undefined });
+  });
+
+  it('passes --conversation-id and --context through', async () => {
+    const ask = vi.fn(async () => ASK_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { ask } }) });
+
+    await agentsAskHandler(ctx, commandIntent(['ag1', 'follow up', '--conversation-id', 'conv1', '--context', 'ticket #42']));
+
+    expect(ask).toHaveBeenCalledWith({ agentId: 'ag1', question: 'follow up', context: 'ticket #42', conversationId: 'conv1' });
+  });
+
+  it('renders the plain-text response (agents.ask has no parts array — a flat response string)', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { ask: async () => ASK_RESULT } }) });
+
+    await agentsAskHandler(ctx, commandIntent(['ag1', 'What is the refund policy?']));
+
+    expect(stdout.lines.join('')).toBe('Refunds are processed within 5 business days.\n\n(conversationId: conv1)\n');
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { ask: async () => ASK_RESULT } }) });
+
+    const code = await agentsAskHandler(ctx, commandIntent(['ag1', 'q', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(ASK_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on a non-timeout API failure', async () => {
+    const stderr = createRecordingSink();
+    const ask = vi.fn(async () => {
+      throw new Error('Agent not found');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ agents: { ask } }) });
+
+    const code = await agentsAskHandler(ctx, commandIntent(['ag1', 'q']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Agent not found');
+  });
+
+  it('renders an honest "may still have run" message on timeout, never auto-retrying', async () => {
+    const stderr = createRecordingSink();
+    const ask = vi.fn(async () => {
+      throw new TimeoutError('timed out');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ agents: { ask } }) });
+
+    const code = await agentsAskHandler(ctx, commandIntent(['ag1', 'q']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(ask).toHaveBeenCalledTimes(1);
+    expect(stderr.lines.join('')).toContain('may still be running');
+    expect(stderr.lines.join('')).not.toContain('undefined');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agents config -> agents.updateConfig
+// ---------------------------------------------------------------------------
+
+describe('agentsConfigHandler', () => {
+  it('exits 2 with a usage error when agentPageId is missing', async () => {
+    const updateConfig = vi.fn(async () => UPDATE_CONFIG_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    const code = await agentsConfigHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when no --set flag is given', async () => {
+    const updateConfig = vi.fn(async () => UPDATE_CONFIG_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    const code = await agentsConfigHandler(ctx, commandIntent(['ag1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('maps a single --set key=value to the matching updateConfig field', async () => {
+    const updateConfig = vi.fn(async () => UPDATE_CONFIG_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    const code = await agentsConfigHandler(ctx, commandIntent(['ag1', '--set', 'aiModel=claude-sonnet-5']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(updateConfig).toHaveBeenCalledWith({ agentId: 'ag1', aiModel: 'claude-sonnet-5' });
+  });
+
+  it('merges repeated --set flags and JSON-coerces non-string values', async () => {
+    const updateConfig = vi.fn(async () => UPDATE_CONFIG_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    await agentsConfigHandler(
+      ctx,
+      commandIntent([
+        'ag1',
+        '--set',
+        'aiModel=claude-sonnet-5',
+        '--set',
+        'enabledTools=["search","glob"]',
+        '--set',
+        'visibleToGlobalAssistant=true',
+      ]),
+    );
+
+    expect(updateConfig).toHaveBeenCalledWith({
+      agentId: 'ag1',
+      aiModel: 'claude-sonnet-5',
+      enabledTools: ['search', 'glob'],
+      visibleToGlobalAssistant: true,
+    });
+  });
+
+  it('does not maintain its own key allowlist — forwards an unrecognized --set key as-is and lets the server/schema reject it', async () => {
+    const updateConfig = vi.fn(async () => UPDATE_CONFIG_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    await agentsConfigHandler(ctx, commandIntent(['ag1', '--set', 'notARealField=x']));
+
+    expect(updateConfig).toHaveBeenCalledWith({ agentId: 'ag1', notARealField: 'x' });
+  });
+
+  it('exits 2 for a malformed --set value with no "="', async () => {
+    const updateConfig = vi.fn(async () => UPDATE_CONFIG_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    const code = await agentsConfigHandler(ctx, commandIntent(['ag1', '--set', 'aiModel']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { updateConfig: async () => UPDATE_CONFIG_RESULT } }) });
+
+    const code = await agentsConfigHandler(ctx, commandIntent(['ag1', '--set', 'aiModel=claude-sonnet-5', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(UPDATE_CONFIG_RESULT);
+  });
+
+  it("exits 1 and renders the server's validation error verbatim", async () => {
+    const stderr = createRecordingSink();
+    const updateConfig = vi.fn(async () => {
+      throw new Error('No updatable field provided');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ agents: { updateConfig } }) });
+
+    const code = await agentsConfigHandler(ctx, commandIntent(['ag1', '--set', 'notARealField=x']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('No updatable field provided');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// models list -> agents.listModels
+// ---------------------------------------------------------------------------
+
+describe('modelsListHandler', () => {
+  it('exits 2 with a usage error given any positional args', async () => {
+    const listModels = vi.fn(async () => MODELS_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { listModels } }) });
+
+    const code = await modelsListHandler(ctx, commandIntent(['extra']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(listModels).not.toHaveBeenCalled();
+  });
+
+  it('calls agents.listModels with no arguments', async () => {
+    const listModels = vi.fn(async () => MODELS_RESULT);
+    const ctx = createFakeContext({ sdk: fakeSdk({ agents: { listModels } }) });
+
+    const code = await modelsListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(listModels).toHaveBeenCalledWith({});
+  });
+
+  it('renders one line per model, grouped by provider, marking free models', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { listModels: async () => MODELS_RESULT } }) });
+
+    await modelsListHandler(ctx, commandIntent([]));
+
+    expect(stdout.lines.join('')).toBe(
+      'anthropic:claude-sonnet-5  Claude Sonnet 5\nanthropic:claude-haiku-4-5  Claude Haiku 4.5  [free]\n',
+    );
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ agents: { listModels: async () => MODELS_RESULT } }) });
+
+    const code = await modelsListHandler(ctx, commandIntent(['--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(MODELS_RESULT);
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const listModels = vi.fn(async () => {
+      throw new Error('Service unavailable');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ agents: { listModels } }) });
+
+    const code = await modelsListHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Service unavailable');
+  });
+});

--- a/packages/cli/src/commands/__tests__/channels.test.ts
+++ b/packages/cli/src/commands/__tests__/channels.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, channelsSendHandler, parseArgv } from '@pagespace/cli';
+import type { CommandIntent } from '@pagespace/cli';
+import { createFakeContext, createRecordingSink, fakeSdk } from '../../__tests__/fake-context.js';
+
+function commandIntent(argv: string[]): CommandIntent {
+  const intent = parseArgv(['__cmd__', ...argv]);
+  if (intent.kind !== 'command') throw new Error('expected command');
+  return { ...intent, args: intent.args.slice(1) };
+}
+
+const SENT_MESSAGE = {
+  id: 'm1',
+  content: 'hello team',
+  createdAt: '2026-07-01T12:00:00.000Z',
+  pageId: 'ch1',
+  userId: 'u1',
+  fileId: null,
+  attachmentMeta: null,
+  isActive: true,
+  editedAt: null,
+  aiMeta: null,
+  parentId: null,
+  replyCount: 0,
+  lastReplyAt: null,
+  mirroredFromId: null,
+  quotedMessageId: null,
+  user: { id: 'u1', name: 'Ada', image: null },
+  file: null,
+  reactions: [],
+  mirroredFrom: null,
+};
+
+describe('channelsSendHandler', () => {
+  it('exits 2 with a usage error when the message is missing', async () => {
+    const send = vi.fn(async () => SENT_MESSAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ channels: { send } }) });
+
+    const code = await channelsSendHandler(ctx, commandIntent(['ch1']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 with a usage error when the channelId is missing', async () => {
+    const send = vi.fn(async () => SENT_MESSAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ channels: { send } }) });
+
+    const code = await channelsSendHandler(ctx, commandIntent([]));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('calls channels.send with pageId + content for the given argv', async () => {
+    const send = vi.fn(async () => SENT_MESSAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ channels: { send } }) });
+
+    const code = await channelsSendHandler(ctx, commandIntent(['ch1', 'hello team']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(send).toHaveBeenCalledWith({ pageId: 'ch1', content: 'hello team' });
+  });
+
+  it('exits 2 with a usage error given more than one message token (must be shell-quoted)', async () => {
+    const send = vi.fn(async () => SENT_MESSAGE);
+    const ctx = createFakeContext({ sdk: fakeSdk({ channels: { send } }) });
+
+    const code = await channelsSendHandler(ctx, commandIntent(['ch1', 'hello', 'team']));
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('--json emits exactly the SDK response and nothing else on stdout', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ channels: { send: async () => SENT_MESSAGE } }) });
+
+    const code = await channelsSendHandler(ctx, commandIntent(['ch1', 'hello team', '--json']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(stdout.lines.join(''))).toEqual(SENT_MESSAGE);
+  });
+
+  it('renders a confirmation line in human mode', async () => {
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, sdk: fakeSdk({ channels: { send: async () => SENT_MESSAGE } }) });
+
+    await channelsSendHandler(ctx, commandIntent(['ch1', 'hello team']));
+
+    expect(stdout.lines.join('')).toBe('Sent message m1 to ch1.\n');
+  });
+
+  it('exits 1 and surfaces the server error on API failure', async () => {
+    const stderr = createRecordingSink();
+    const send = vi.fn(async () => {
+      throw new Error('Channel not found');
+    });
+    const ctx = createFakeContext({ stderr, sdk: fakeSdk({ channels: { send } }) });
+
+    const code = await channelsSendHandler(ctx, commandIntent(['ch1', 'hi']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    expect(stderr.lines.join('')).toContain('Channel not found');
+  });
+});

--- a/packages/cli/src/commands/activity.ts
+++ b/packages/cli/src/commands/activity.ts
@@ -1,0 +1,39 @@
+/**
+ * `pagespace activity <driveId>` (Phase 5 task 5). Thin projection over the
+ * `activity.get` SDK operation (Phase 3 task 9 defined it; this task wires it
+ * onto the client facade — see `@pagespace/sdk`'s `client.ts`), scoped to a
+ * single drive's activity feed (`context: 'drive'`).
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+type ActivityResult = Awaited<ReturnType<PageSpaceClient['activity']['get']>>;
+
+/** Pure: no I/O. */
+export function renderActivity(value: ActivityResult): string {
+  if (value.activities.length === 0) return 'No activity.\n';
+  return `${value.activities
+    .map((entry) => `${entry.timestamp}  ${entry.actorEmail}  ${entry.operation} ${entry.resourceType}:${entry.resourceId}`)
+    .join('\n')}\n`;
+}
+
+export const activityHandler: CommandHandler = async (ctx, intent) => {
+  const [driveId, ...extra] = intent.args;
+  if (!driveId || extra.length > 0) {
+    ctx.stderr.write('Usage: pagespace activity <driveId> [--json]\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.activity.get({ context: 'drive', driveId }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  ctx.stdout.write(renderActivity(result.value));
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,0 +1,286 @@
+/**
+ * `pagespace agents list|ask|config` and `pagespace models list` (Phase 5
+ * task 5). Thin projections over the `agents.*` SDK operations (Phase 3 task
+ * 5; already wired onto the client facade before this task) — this module
+ * adds no SDK surface, only argv parsing and result rendering.
+ *
+ * `agents.ask`'s output has a flat `response: string` field, not an AI SDK
+ * `parts` array (`operations/agents.ts`'s `askAgentOutputSchema`) — same
+ * "route truth over an assumed shape" idiom `operations/channels.ts`
+ * documents for channel messages. Human-mode rendering prints that string
+ * directly; there is no non-text part to summarize. `agents.ask` is also
+ * non-idempotent (a retried consult would double-execute the agent), so a
+ * timeout is never retried — it renders an honest "may still have run"
+ * message instead.
+ *
+ * `agents config --set k=v` intentionally keeps no allowlist of valid keys:
+ * it forwards whatever `--set` pairs the caller gives straight onto
+ * `agents.updateConfig`'s input object. An unrecognized key either gets
+ * stripped by that operation's zod schema before the network call, or — if
+ * every `--set` key given is unrecognized — the route itself 400s ("no
+ * updatable field"), which `callSdk` already surfaces verbatim. Either way
+ * the schema/server is the one source of truth for valid keys, never a
+ * second CLI-side list that could drift from it.
+ */
+import type { PageSpaceClient } from '@pagespace/sdk';
+import { isTimeoutError } from '@pagespace/sdk';
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { extractDriveFlag } from './drive-flag.js';
+import { callSdk } from './sdk-error.js';
+
+type AgentsListResult = Awaited<ReturnType<PageSpaceClient['agents']['list']>>;
+type AgentsMultiDriveListResult = Awaited<ReturnType<PageSpaceClient['agents']['listMultiDrive']>>;
+type UpdateAgentConfigInput = Parameters<PageSpaceClient['agents']['updateConfig']>[0];
+type ModelsListResult = Awaited<ReturnType<PageSpaceClient['agents']['listModels']>>;
+
+// ---------------------------------------------------------------------------
+// agents list -> agents.list / agents.listMultiDrive
+// ---------------------------------------------------------------------------
+
+/** Pure: no I/O. */
+export function renderAgentsList(value: AgentsListResult): string {
+  if (value.agents.length === 0) return 'No agents.\n';
+  return `${value.agents.map((agent) => `${agent.id}  ${agent.title ?? '(untitled)'}  [${agent.aiProvider}/${agent.aiModel}]`).join('\n')}\n`;
+}
+
+/** Pure: no I/O. */
+export function renderAgentsMultiDriveList(value: AgentsMultiDriveListResult): string {
+  const agents = value.agents ?? value.agentsByDrive?.flatMap((entry) => entry.agents) ?? [];
+  if (agents.length === 0) return 'No agents.\n';
+  return `${agents.map((agent) => `${agent.driveSlug}:${agent.id}  ${agent.title ?? '(untitled)'}  [${agent.aiProvider}/${agent.aiModel}]`).join('\n')}\n`;
+}
+
+/** Pure: no I/O. Consumes a lone `--all-drives` boolean flag, passing everything else through in `rest`. */
+function extractAllDrivesFlag(args: readonly string[]): { readonly allDrives: boolean; readonly rest: readonly string[] } {
+  const rest: string[] = [];
+  let allDrives = false;
+  for (const token of args) {
+    if (token === '--all-drives') {
+      allDrives = true;
+      continue;
+    }
+    rest.push(token);
+  }
+  return { allDrives, rest };
+}
+
+export const agentsListHandler: CommandHandler = async (ctx, intent) => {
+  const usage = 'Usage: pagespace agents list --drive <driveId> | --all-drives [--json]\n';
+
+  const driveExtracted = extractDriveFlag(intent.args);
+  if (!driveExtracted.ok) {
+    ctx.stderr.write(`${driveExtracted.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const { allDrives, rest } = extractAllDrivesFlag(driveExtracted.rest);
+  if (rest.length > 0) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const driveId = driveExtracted.driveId;
+  if (driveId !== undefined && allDrives) {
+    ctx.stderr.write('Flags --drive and --all-drives are mutually exclusive.\n');
+    return EXIT_USAGE_ERROR;
+  }
+  if (driveId === undefined && !allDrives) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  if (allDrives) {
+    const result = await callSdk(ctx.stderr, () => ctx.sdk.agents.listMultiDrive({}));
+    if (!result.ok) return EXIT_RUNTIME_ERROR;
+    if (intent.flags.json) {
+      ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+      return EXIT_SUCCESS;
+    }
+    ctx.stdout.write(renderAgentsMultiDriveList(result.value));
+    return EXIT_SUCCESS;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.agents.list({ driveId: driveId as string }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+  ctx.stdout.write(renderAgentsList(result.value));
+  return EXIT_SUCCESS;
+};
+
+// ---------------------------------------------------------------------------
+// agents ask -> agents.ask
+// ---------------------------------------------------------------------------
+
+type FlagScanResult =
+  | { readonly ok: true; readonly values: ReadonlyMap<string, string>; readonly rest: readonly string[] }
+  | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. Consumes any of `flags`' value-taking tokens, passing everything else through in `rest`. */
+function scanValueFlags(args: readonly string[], flags: readonly string[]): FlagScanResult {
+  const values = new Map<string, string>();
+  const rest: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i] as string;
+    if (flags.includes(token)) {
+      const value = args[i + 1];
+      if (value === undefined) return { ok: false, message: `Flag ${token} requires a value.` };
+      values.set(token, value);
+      i += 2;
+      continue;
+    }
+    rest.push(token);
+    i += 1;
+  }
+  return { ok: true, values, rest };
+}
+
+export const agentsAskHandler: CommandHandler = async (ctx, intent) => {
+  const usage = 'Usage: pagespace agents ask <agentPageId> <message> [--conversation-id <id>] [--context <text>]\n';
+
+  const scanned = scanValueFlags(intent.args, ['--conversation-id', '--context']);
+  if (!scanned.ok) {
+    ctx.stderr.write(`${scanned.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const [agentId, question, ...extra] = scanned.rest;
+  if (!agentId || !question || extra.length > 0) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  let result: Awaited<ReturnType<PageSpaceClient['agents']['ask']>>;
+  try {
+    result = await ctx.sdk.agents.ask({
+      agentId,
+      question,
+      context: scanned.values.get('--context'),
+      conversationId: scanned.values.get('--conversation-id'),
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      ctx.stderr.write(
+        `Request to agent ${agentId} timed out — it may still be running. This call is never automatically retried (retrying would risk double-executing a non-idempotent request); check the agent's conversation history before asking again.\n`,
+      );
+      return EXIT_RUNTIME_ERROR;
+    }
+    ctx.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    return EXIT_RUNTIME_ERROR;
+  }
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result)}\n`);
+    return EXIT_SUCCESS;
+  }
+  ctx.stdout.write(`${result.response}\n\n(conversationId: ${result.conversationId})\n`);
+  return EXIT_SUCCESS;
+};
+
+// ---------------------------------------------------------------------------
+// agents config -> agents.updateConfig
+// ---------------------------------------------------------------------------
+
+/** Pure: no I/O. `--set`-style value coercion — JSON first (numbers/booleans/arrays/null), raw string otherwise. */
+function coerceSetValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+type SetFlagsResult =
+  | { readonly ok: true; readonly values: ReadonlyMap<string, unknown>; readonly rest: readonly string[] }
+  | { readonly ok: false; readonly message: string };
+
+/** Pure: no I/O. Merges every repeated `--set key=value` pair; anything else passes through in `rest`. */
+function extractSetFlags(args: readonly string[]): SetFlagsResult {
+  const values = new Map<string, unknown>();
+  const rest: string[] = [];
+  let i = 0;
+  while (i < args.length) {
+    const token = args[i] as string;
+    if (token === '--set') {
+      const pair = args[i + 1];
+      if (pair === undefined) return { ok: false, message: 'Flag --set requires a value in the form key=value.' };
+      const eq = pair.indexOf('=');
+      if (eq <= 0) return { ok: false, message: `Invalid --set value "${pair}": expected key=value.` };
+      values.set(pair.slice(0, eq), coerceSetValue(pair.slice(eq + 1)));
+      i += 2;
+      continue;
+    }
+    rest.push(token);
+    i += 1;
+  }
+  return { ok: true, values, rest };
+}
+
+export const agentsConfigHandler: CommandHandler = async (ctx, intent) => {
+  const usage = 'Usage: pagespace agents config <agentPageId> --set <key>=<value> [--set <key>=<value> ...]\n';
+
+  const [agentId, ...rest0] = intent.args;
+  if (!agentId) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const parsed = extractSetFlags(rest0);
+  if (!parsed.ok) {
+    ctx.stderr.write(`${parsed.message}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.rest.length > 0) {
+    ctx.stderr.write(`Unknown argument: ${parsed.rest[0]}\n`);
+    return EXIT_USAGE_ERROR;
+  }
+  if (parsed.values.size === 0) {
+    ctx.stderr.write(usage);
+    return EXIT_USAGE_ERROR;
+  }
+
+  const input = { agentId, ...Object.fromEntries(parsed.values) } as UpdateAgentConfigInput;
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.agents.updateConfig(input));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+  ctx.stdout.write(`Updated agent ${result.value.id}: ${result.value.updatedFields.join(', ')}\n`);
+  return EXIT_SUCCESS;
+};
+
+// ---------------------------------------------------------------------------
+// models list -> agents.listModels
+// ---------------------------------------------------------------------------
+
+/** Pure: no I/O. */
+export function renderModelsList(value: ModelsListResult): string {
+  const lines = value.providers.flatMap((provider) =>
+    provider.models.map((model) => `${provider.provider}:${model.id}  ${model.displayName}${model.free ? '  [free]' : ''}`),
+  );
+  if (lines.length === 0) return 'No models.\n';
+  return `${lines.join('\n')}\n`;
+}
+
+export const modelsListHandler: CommandHandler = async (ctx, intent) => {
+  if (intent.args.length > 0) {
+    ctx.stderr.write('Usage: pagespace models list [--json]\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.agents.listModels({}));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+  ctx.stdout.write(renderModelsList(result.value));
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/commands/channels.ts
+++ b/packages/cli/src/commands/channels.ts
@@ -1,0 +1,30 @@
+/**
+ * `pagespace channels send <channelId> <message>` (Phase 5 task 5). Thin
+ * projection over `channels.sendMessage` (Phase 3 task 9 defined it; this
+ * task wires it onto the client facade — see `@pagespace/sdk`'s `client.ts`).
+ * `<message>` is a single argv token, same convention `search text`'s query
+ * follows — a multi-word message must be shell-quoted by the caller, never
+ * silently rejoined here.
+ */
+import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../exit-codes.js';
+import type { CommandHandler } from '../router/router.js';
+import { callSdk } from './sdk-error.js';
+
+export const channelsSendHandler: CommandHandler = async (ctx, intent) => {
+  const [channelId, message, ...extra] = intent.args;
+  if (!channelId || !message || extra.length > 0) {
+    ctx.stderr.write('Usage: pagespace channels send <channelId> <message>\n');
+    return EXIT_USAGE_ERROR;
+  }
+
+  const result = await callSdk(ctx.stderr, () => ctx.sdk.channels.send({ pageId: channelId, content: message }));
+  if (!result.ok) return EXIT_RUNTIME_ERROR;
+
+  if (intent.flags.json) {
+    ctx.stdout.write(`${JSON.stringify(result.value)}\n`);
+    return EXIT_SUCCESS;
+  }
+
+  ctx.stdout.write(`Sent message ${result.value.id} to ${channelId}.\n`);
+  return EXIT_SUCCESS;
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -89,6 +89,22 @@ export {
   searchTextHandler,
 } from './commands/search.js';
 
+// Agents, models & activity/channels verbs (Phase 5 task 5) — thin
+// projections over the `agents.*`/`activity.*`/`channels.*` SDK operations
+// (this same task wires the activity/channels namespaces onto the client
+// facade — see `@pagespace/sdk`'s `client.ts`).
+export {
+  agentsAskHandler,
+  agentsConfigHandler,
+  agentsListHandler,
+  modelsListHandler,
+  renderAgentsList,
+  renderAgentsMultiDriveList,
+  renderModelsList,
+} from './commands/agents.js';
+export { activityHandler, renderActivity } from './commands/activity.js';
+export { channelsSendHandler } from './commands/channels.js';
+
 // Tasks verbs (Phase 5 task 3) — thin projections over the `tasks.*` SDK
 // operations (and, for list/statuses, the already-wired `pages.read`
 // TASK_LIST branch).

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -11,6 +11,9 @@ import { createDiscoverMetadata } from './auth/discover.js';
 import { resolveEnvToken } from './auth/legacy-token-env.js';
 import { createRefreshAccessToken } from './auth/silent-refresh.js';
 import { resolveAuth } from './auth/resolve.js';
+import { activityHandler } from './commands/activity.js';
+import { agentsAskHandler, agentsConfigHandler, agentsListHandler, modelsListHandler } from './commands/agents.js';
+import { channelsSendHandler } from './commands/channels.js';
 import {
   drivesCreateHandler,
   drivesListHandler,
@@ -109,6 +112,12 @@ const ROUTES: readonly Route[] = [
   { path: ['search', 'text'], handler: searchTextHandler },
   { path: ['search', 'regex'], handler: searchRegexHandler },
   { path: ['search', 'glob'], handler: searchGlobHandler },
+  { path: ['agents', 'list'], handler: agentsListHandler },
+  { path: ['agents', 'ask'], handler: agentsAskHandler },
+  { path: ['agents', 'config'], handler: agentsConfigHandler },
+  { path: ['models', 'list'], handler: modelsListHandler },
+  { path: ['activity'], handler: activityHandler },
+  { path: ['channels', 'send'], handler: channelsSendHandler },
 ];
 
 /**

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -439,4 +439,43 @@ describe('PageSpaceClient — registry-derived namespaces', () => {
     await expect(client.search.regex({ driveId: 'd1', pattern: 'TODO' })).resolves.toEqual(regexFixture);
     await expect(client.search.multiDrive({ searchQuery: 'quarterly report' })).resolves.toEqual(multiDriveFixture);
   });
+
+  it('exposes the activity & channels namespaces (Phase 5 task 5 wired the facade; Phase 3 task 9 defined the operations)', async () => {
+    const activityFixture = {
+      activities: [],
+      pagination: { total: 0, limit: 50, offset: 0, hasMore: false },
+    };
+    const sendFixture = {
+      id: 'm1',
+      content: 'hi',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      pageId: 'ch1',
+      userId: 'u1',
+      fileId: null,
+      attachmentMeta: null,
+      isActive: true,
+      editedAt: null,
+      aiMeta: null,
+      parentId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      mirroredFromId: null,
+      quotedMessageId: null,
+      user: { id: 'u1', name: 'Ada', image: null },
+      file: null,
+      reactions: [],
+      mirroredFrom: null,
+    };
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/api/activities')) return jsonResponse(200, activityFixture);
+      return jsonResponse(200, sendFixture);
+    });
+    const client = makeClient({ fetch: fetchMock });
+
+    expect(typeof client.activity.get).toBe('function');
+    expect(typeof client.channels.send).toBe('function');
+
+    await expect(client.activity.get({})).resolves.toEqual(activityFixture);
+    await expect(client.channels.send({ pageId: 'ch1', content: 'hi' })).resolves.toEqual(sendFixture);
+  });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -37,7 +37,9 @@ import {
   type ValidationIssue,
 } from './errors.js';
 import type { AuthProvider } from './auth/provider.js';
+import { getActivity } from './operations/activity.js';
 import { askAgent, listAgents, listModels, multiDriveListAgents, updateAgentConfig } from './operations/agents.js';
+import { sendChannelMessage } from './operations/channels.js';
 import { listConversations, readConversation } from './operations/conversations.js';
 import { createDrive, listDrives, renameDrive, restoreDrive, trashDrive, updateDriveContext } from './operations/drives.js';
 import {
@@ -151,6 +153,12 @@ const DEFAULT_OPERATIONS_MAP = {
     glob: globSearch,
     regex: regexSearch,
     multiDrive: multiDriveSearch,
+  },
+  activity: {
+    get: getActivity,
+  },
+  channels: {
+    send: sendChannelMessage,
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Wires the SDK facade's `activity`/`channels` namespaces onto `PageSpaceClient` — `activity.get` and `channels.sendMessage` were defined in Phase 3 task 9 but never wired onto the client (SDK facade gap called out in this task's ground truth).
- Adds thin CLI verbs on top, per Phase 5's law (argv parse -> one SDK call -> render, SDK/stdout/stderr injected):
  - `agents list --drive <id> | --all-drives [--json]` -> `agents.list` / `agents.listMultiDrive`
  - `agents ask <agentPageId> <message> [--conversation-id <id>] [--context <text>]` -> `agents.ask`; a timeout renders an honest "may still have run" message instead of auto-retrying (POST is non-idempotent — a retry would double-execute the consult)
  - `agents config <agentPageId> --set k=v [--set k=v ...]` -> `agents.updateConfig`; forwards `--set` pairs with no client-side key allowlist, so the operation's zod schema / server route stays the single source of truth for valid keys
  - `models list [--json]` -> `agents.listModels`
  - `activity <driveId> [--json]` -> `activity.get` (`context: 'drive'`)
  - `channels send <channelId> <message> [--json]` -> `channels.sendMessage`
- `agents.ask`'s output is a flat `response: string`, not an AI SDK `parts` array — documented in the new module the same way `operations/channels.ts` documents its own route-truth-over-assumed-shape discrepancy; human-mode rendering prints that string directly.

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck && bun run --filter '@pagespace/sdk' test` (716 tests)
- [x] `bun run --filter '@pagespace/cli' typecheck && bun run --filter '@pagespace/cli' test` (651 tests, including the 101-test single-auth-path structural check)
- [x] RED commit (failing command + client-facade tests) landed before the GREEN implementation commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01BUS47KPbZizQ4JW5v6bQKd