### PR TITLE
cli: update docs & changelog (Phase 6 task 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable user-facing changes to PageSpace are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- **`pagespace` CLI** — install `@pagespace/cli`, run `pagespace login`, and use verbs like
+  `pagespace drives list`, `pagespace pages read`, `pagespace search text`, and `pagespace tasks
+  create` without hand-minting a token first.
+- **CLI login** — `pagespace login` opens a browser for an OAuth login with PKCE; `pagespace login
+  --device` covers machines with no browser (CI, remote boxes). Both replace copying a token out of
+  Settings by hand as the primary way for a person to authenticate.
+- **`pagespace tokens create` / `list` / `revoke`** — mint and manage scoped agent/CI tokens from
+  the terminal, the same tokens Settings > MCP already creates.
+- **`@pagespace/sdk`** — a typed TypeScript client (`PageSpaceClient`) for the PageSpace API,
+  covering drives, pages, roles, tasks, agents, conversations, exports, tokens, search, activity,
+  and channels.
+- **`pagespace mcp`** — a stdio MCP server generated from the same operation registry as the CLI
+  and SDK, so Claude Desktop, Claude Code, Cursor, and other MCP clients get a tool surface that
+  can't drift from what the CLI itself supports.
+
+### Changed
+
+- The MCP integration docs and the Settings > MCP page now lead with `pagespace login` for
+  personal use, keeping token creation for agents, CI, and drive-scoped access.
+
+### Deprecated
+
+- The standalone `pagespace-mcp` npm package is deprecated in favor of `pagespace mcp` (part of
+  `@pagespace/cli`). It keeps working exactly as before — same tools, same env vars — and now
+  prints a one-line migration notice to stderr. See the
+  [migration guide](packages/cli/docs/migrating-from-pagespace-mcp.md).

--- a/apps/marketing/src/app/docs/integrations/mcp/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/mcp/page.tsx
@@ -3,49 +3,73 @@ import { createMetadata } from "@/lib/metadata";
 
 export const metadata = createMetadata({
   title: "MCP Integration",
-  description: "Connect AI tools like Claude Desktop, Claude Code, and Cursor to PageSpace via the Model Context Protocol. Create tokens, configure servers, and wire up external clients.",
+  description: "Connect AI tools like Claude Desktop, Claude Code, and Cursor to PageSpace via the Model Context Protocol. Log in with the pagespace CLI, or use a scoped token for agents and CI.",
   path: "/docs/integrations/mcp",
-  keywords: ["MCP", "Model Context Protocol", "AI integration", "Claude", "Cursor", "API tokens"],
+  keywords: ["MCP", "Model Context Protocol", "AI integration", "Claude", "Cursor", "API tokens", "pagespace CLI"],
 });
 
 const content = `
 # MCP Integration
 
-PageSpace speaks the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) — an open standard for giving AI tools access to external data and actions. The companion \`pagespace-mcp\` npm package runs locally as an MCP server and lets tools like Claude Desktop, Claude Code, and Cursor read and write your PageSpace workspace.
+PageSpace speaks the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) — an open standard for giving AI tools access to external data and actions. The \`pagespace\` CLI runs \`pagespace mcp\`, a local MCP server that lets tools like Claude Desktop, Claude Code, and Cursor read and write your PageSpace workspace.
 
 \`\`\`
-AI tool (MCP client)  →  pagespace-mcp (MCP server)  →  PageSpace API
+AI tool (MCP client)  →  pagespace mcp (MCP server)  →  PageSpace API
                                                          ↓
                                                     Your workspace
 \`\`\`
 
-Tokens authenticate as your user. Every operation runs with your permissions; drive-scoped tokens restrict access further.
+Every operation runs with the permissions of whoever (or whatever) authenticated — a human via \`pagespace login\`, or a scoped token for an agent or CI job.
 
-## Step 1: Create an MCP token
+## Step 1: Install the CLI and authenticate
 
-1. Open **Settings > MCP** in PageSpace.
-2. Click **Create Token** and give it a name.
-3. Copy the token. It starts with \`mcp_\` and is shown **once** — only a SHA3-256 hash is stored server-side.
-4. Optionally scope the token to specific drives, and give it a role. A scoped token joins those drives as an **app** — it appears on each drive's member list, and its access is governed by the role you give it there. Scoped tokens cannot create new drives.
+\`\`\`bash
+npm install -g @pagespace/cli
+pagespace login
+\`\`\`
+
+\`pagespace login\` opens a browser, completes an OAuth login, and stores the credential locally — \`pagespace mcp\` picks it up automatically, no token to copy or paste.
+
+**Agents, CI, and service accounts** don't have a browser to log in with. Mint a scoped token instead, either from the CLI or from **Settings > MCP**:
+
+\`\`\`bash
+pagespace tokens create --name "Claude Desktop" --drive <driveId>
+\`\`\`
+
+This prints a token starting with \`mcp_\`, shown **once** — only a SHA3-256 hash is stored server-side. Scope it to specific drives and it joins those drives as an **app** on the member list, governed by the role you give it there; scoped tokens cannot create new drives.
 
 ## Step 2: Configure your AI tool
 
-The config format follows the standard MCP \`mcpServers\` schema:
+Logged in with \`pagespace login\`? No token needed in the config — \`pagespace mcp\` reads your stored login:
 
 \`\`\`json
 {
   "mcpServers": {
     "pagespace": {
-      "command": "npx",
-      "args": ["-y", "pagespace-mcp@latest"],
+      "command": "pagespace",
+      "args": ["mcp"]
+    }
+  }
+}
+\`\`\`
+
+Using a scoped token instead (agents, CI, headless):
+
+\`\`\`json
+{
+  "mcpServers": {
+    "pagespace": {
+      "command": "pagespace",
+      "args": ["mcp"],
       "env": {
-        "PAGESPACE_API_URL": "https://pagespace.ai",
-        "PAGESPACE_AUTH_TOKEN": "mcp_your_token_here"
+        "PAGESPACE_TOKEN": "mcp_your_token_here"
       }
     }
   }
 }
 \`\`\`
+
+\`PAGESPACE_API_URL\` overrides the default \`https://pagespace.ai\` host for self-hosted instances.
 
 ### Claude Desktop
 
@@ -56,10 +80,8 @@ Edit \`claude_desktop_config.json\`:
 ### Claude Code
 
 \`\`\`bash
-claude mcp add pagespace -- npx -y pagespace-mcp@latest
+claude mcp add pagespace -- pagespace mcp
 \`\`\`
-
-Then set \`PAGESPACE_API_URL\` and \`PAGESPACE_AUTH_TOKEN\` in your environment.
 
 ### Cursor
 
@@ -67,7 +89,7 @@ Then set \`PAGESPACE_API_URL\` and \`PAGESPACE_AUTH_TOKEN\` in your environment.
 
 ## Step 3: Capabilities
 
-Once connected, \`pagespace-mcp\` exposes tools that wrap the PageSpace API. The exact tool list ships with the npm package and evolves independently; the [pagespace-mcp README](https://www.npmjs.com/package/pagespace-mcp) is the authoritative reference.
+\`pagespace mcp\` generates its tool list mechanically from the same operation registry that powers the \`pagespace\` CLI and \`@pagespace/sdk\`, so the tool surface can't drift from what the CLI itself supports.
 
 At a minimum the server covers:
 
@@ -87,10 +109,10 @@ Every tool respects the caller's permissions. If you cannot view a page in the w
 
 ## Use an agent as an OpenAI-compatible model
 
-The same MCP token also unlocks an **OpenAI-compatible API**, so any tool that speaks the OpenAI Chat Completions format can talk to one of your PageSpace agents as if it were a model.
+Any token also unlocks an **OpenAI-compatible API**, so any tool that speaks the OpenAI Chat Completions format can talk to one of your PageSpace agents as if it were a model.
 
 - **Base URL** — \`https://pagespace.ai/api/v1\`
-- **API key** — your MCP token (\`mcp_...\`)
+- **API key** — your token (\`mcp_...\`)
 - **Model** — \`ps-agent://<pageId>\`, the id of the AI Chat page you want to run. Copy it from the agent's settings tab.
 
 \`\`\`bash
@@ -108,21 +130,25 @@ The agent replies with its own system prompt and tools, and runs those tools ser
 
 ## Token security
 
-- **Scoped access** — restrict a token to specific drives at creation.
-- **Instant revocation** — revoke from **Settings > MCP** to cut a token off immediately.
+- **Scoped access** — restrict a token to specific drives at creation, from the CLI (\`pagespace tokens create --drive <id>\`) or **Settings > MCP**.
+- **Instant revocation** — \`pagespace tokens revoke <tokenId>\`, or revoke from **Settings > MCP**, cuts a token off immediately.
 - **Audit logging** — token create/revoke/use events land in the audit log with the token identifier.
 - **Hash-only storage** — the database stores a SHA3-256 hash, never the raw token. Losing a token means creating a new one.
 - **No automatic expiry** — tokens live until revoked. Rotate on whatever cadence fits your risk model.
 
 ## Troubleshooting
 
-**Token rejected**: confirm it hasn't been revoked in **Settings > MCP** and that it starts with \`mcp_\`.
+**Token rejected**: confirm it hasn't been revoked (\`pagespace tokens list\` or **Settings > MCP**) and that it starts with \`mcp_\`.
 
-**Connection refused**: check \`PAGESPACE_API_URL\` is correct and reachable from the machine running the MCP server.
+**Connection refused**: check \`PAGESPACE_API_URL\` (or \`--host\`) is correct and reachable from the machine running \`pagespace mcp\`.
 
-**Permission denied**: MCP inherits your user permissions. If you lost access to a drive, the token stops seeing it too.
+**Permission denied**: MCP inherits the caller's permissions. If you lost access to a drive, the token or login stops seeing it too.
 
-**Server fails to start**: run \`npx -y pagespace-mcp@latest --help\` to confirm the package installs.
+**Server fails to start**: run \`pagespace whoami\` to confirm you're authenticated, and \`pagespace --version\` to confirm the CLI installed correctly.
+
+## Using the older \`pagespace-mcp\` package?
+
+\`pagespace-mcp\` still works — it now prints a one-line deprecation notice to stderr pointing at the migration guide in the [\`@pagespace/cli\` repository](https://github.com/2witstudios/PageSpace/blob/master/packages/cli/docs/migrating-from-pagespace-mcp.md). Move to \`@pagespace/cli\` on your own schedule; the tool surface is unchanged, only how you install and authenticate it is.
 `;
 
 export default function MCPPage() {

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -297,16 +297,16 @@ export default function MCPSettingsView() {
     const config = {
       mcpServers: {
         "pagespace": {
-          command: "npx",
-          args: ["-y", "pagespace-mcp@latest"],
+          command: "pagespace",
+          args: ["mcp"],
           env: {
             PAGESPACE_API_URL: "https://pagespace.ai",
-            PAGESPACE_AUTH_TOKEN: token
+            PAGESPACE_TOKEN: token
           }
         }
       }
     };
-    
+
     return JSON.stringify(config, null, 2);
   };
 
@@ -344,8 +344,11 @@ export default function MCPSettingsView() {
         </Button>
         <h1 className="text-3xl font-bold mb-6">MCP Integration</h1>
         <p className="mb-8 text-muted-foreground">
-          Create and manage MCP (Model Context Protocol) tokens for Claude Code and Claude Desktop integration.
-          These tokens allow external tools to read and edit your documents.
+          Connect Claude Code, Claude Desktop, and other MCP clients to PageSpace. For your own
+          machine, the <code className="rounded bg-muted px-1">pagespace</code> CLI&apos;s{' '}
+          <code className="rounded bg-muted px-1">pagespace login</code> is the fastest path — no
+          token to copy. The tokens below are for agents, CI, and service accounts, or whenever you
+          want access scoped to specific drives.
         </p>
       </div>
 
@@ -573,23 +576,27 @@ export default function MCPSettingsView() {
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="space-y-2">
-            <p className="text-sm font-medium">1. Install the MCP server</p>
+            <p className="text-sm font-medium">1. Install the pagespace CLI</p>
             <div className="relative">
               <pre className="rounded-lg bg-muted p-3 overflow-x-auto">
-                <code className="font-mono text-sm">npm install -g pagespace-mcp@latest</code>
+                <code className="font-mono text-sm">npm install -g @pagespace/cli</code>
               </pre>
               <Button
                 size="sm"
                 variant="outline"
                 className="absolute top-2 right-2"
                 onClick={() => {
-                  navigator.clipboard.writeText("npm install -g pagespace-mcp@latest");
+                  navigator.clipboard.writeText("npm install -g @pagespace/cli");
                   toast.success("Command copied to clipboard");
                 }}
               >
                 <Copy className="h-3 w-3" />
               </Button>
             </div>
+            <p className="text-xs text-muted-foreground">
+              This installs <code className="rounded bg-muted px-1">pagespace mcp</code>, which the
+              config below points at.
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,23 +4,139 @@ The `pagespace` command-line client — a thin verb layer over `@pagespace/sdk`.
 replaces hand-minted `mcp_*` tokens with a real OAuth 2.1 credential; `pagespace tokens create`
 mints scoped agent tokens from the terminal instead of Settings → MCP.
 
-**Pure core, effects at the edges**: `parseArgv` turns `process.argv` into a typed `CommandIntent`
-(or a typed `UsageError`) with no I/O. `resolveConfig` applies the fixed precedence — `--token`/
-`--host` flags > `PAGESPACE_TOKEN`/`PAGESPACE_API_URL` env > stored profile credential > defaults
-(`https://pagespace.ai`) — as a pure function over plain data. The router matches a `CommandIntent`
-against a static route table and dispatches to a handler; handlers receive an injected
-`{ sdk, stdout, stderr, env, credentialStore }` context and never touch `process.*` directly. Only
-`src/bin.ts` reads `process.argv`/`process.env`/`process.stdout`/`process.exitCode`.
+## Install
 
-**Exit codes** (fixed contract, every command tests against it): `0` success, `1` API/runtime
-error, `2` usage error.
+```bash
+npm install -g @pagespace/cli
+# or, without installing: npx @pagespace/cli whoami
+```
+
+This installs two commands: `pagespace` and `pagespace-mcp` (a bridge alias — see
+[Migrating from `pagespace-mcp`](docs/migrating-from-pagespace-mcp.md)).
+
+## Quickstart
+
+```bash
+# 1. Log in — opens a browser, completes an OAuth 2.1 + PKCE flow, stores the credential locally
+pagespace login
+
+# 2. Confirm it worked
+pagespace whoami
+
+# 3. Run a command
+pagespace drives list
+```
+
+No browser on this machine (CI, a remote box, a container)? Use the device flow instead:
+
+```bash
+pagespace login --device
+```
+
+This prints a short code and a verification URL — approve it from any browser, and the CLI polls
+until the login completes.
+
+## Auth
+
+- **`pagespace login [--host <url>] [--yes]`** — loopback + PKCE browser login. Stores the
+  credential for `--host` (default `https://pagespace.ai`).
+- **`pagespace login --device`** — device-authorization flow for headless machines.
+- **`pagespace logout [--host <url>] [--all] [--force]`** — clears the stored credential for one
+  host, or every host with `--all`.
+- **`pagespace whoami [--json]`** — prints the identity the current credential resolves to.
+- **`pagespace tokens create --name <name> [--drive <id> [--role member|admin|<roleId>]]...`** —
+  mints a scoped `mcp_*` token (the credential to use for agents, CI, and service accounts, since
+  `pagespace login` needs a browser). `pagespace tokens list [--json]` and
+  `pagespace tokens revoke <tokenId>` manage existing ones.
+
+### Credential precedence
+
+Every command resolves auth and host the same way:
+
+```
+--token / --host flag  >  PAGESPACE_TOKEN / PAGESPACE_API_URL env  >  stored `pagespace login` credential  >  default host (https://pagespace.ai)
+```
+
+The legacy `PAGESPACE_AUTH_TOKEN` env var (from the old `pagespace-mcp` package) still works — it
+fills the `PAGESPACE_TOKEN` slot when that variable isn't set, with a one-line stderr deprecation
+notice. Prefer `PAGESPACE_TOKEN` going forward.
+
+## Command reference
+
+Every command follows `pagespace <resource> <verb> [args] [flags]`.
+
+| Resource | Verbs |
+|---|---|
+| `drives` | `list [--all]`, `create <name>`, `rename <driveId> <name>`, `trash <driveId> [--yes]`, `restore <driveId>` |
+| `pages` | `list --drive <id> [parentId]`, `tree --drive <id> [parentId]`, `read-details <pageId>`, `create <title> <type> [parentId] --drive <id>`, `rename <pageId> <title>`, `move <pageId> <newParentId\|root> <position>`, `trash <pageId> [--all] [--yes]`, `restore <pageId>`, `read <pageId> [--start N] [--end M] [--raw]`, `replace-lines <pageId> --start N [--end M] [--file <path>]`, `export <pageId> --format md\|csv --out <path\|->` |
+| `sheets` | `edit-cells <pageId> [--json-input <json>]` |
+| `trash` | `list --drive <id>` |
+| `tasks` | `list <taskListPageId>`, `create <pageId> --title <title> [--priority low\|medium\|high] [--status <slug>] [--due <date>] [--assignee <userId>]`, `update <pageId> <taskId> [--status <slug>] [--title <title>] [--priority ...] [--due <date>]`, `delete <pageId> <taskId> [--yes]`, `reorder <pageId> <taskId> <position>`, `statuses <taskListPageId>`, `create-status <pageId> --name <name> --color <color> --group todo\|in_progress\|done`, `assigned` |
+| `search` | `text <query> [--drive <id>\|--all-drives] [--max-results <n>]`, `regex <pattern> --drive <id> [--in content\|title\|both]`, `glob <pattern> --drive <id>` |
+| `agents` | `list --drive <id>\|--all-drives`, `ask <agentPageId> <message> [--conversation-id <id>] [--context <text>]`, `config <agentPageId> --set <key>=<value>` |
+| `models` | `list` |
+| `activity` | `<driveId>` |
+| `channels` | `send <channelId> <message>` |
+| `tokens` | `create --name <name> [--drive <id>]`, `list`, `revoke <tokenId>` |
+
+Every command supports `--json` (machine-readable output on stdout, nothing else) and `--host
+<url>` / `--token <token>` (override the resolved config for that one call).
+
+## `pagespace mcp`
+
+Runs a stdio MCP server generated from the same operation registry the SDK and CLI use — the
+entire tool surface derives from one source, so it can't drift from `pagespace`'s own commands.
+Auth resolves through the same precedence as every other command; there's no separate MCP auth
+path.
+
+```json
+{
+  "mcpServers": {
+    "pagespace": {
+      "command": "pagespace",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Coming from the standalone `pagespace-mcp` npm package? See
+[Migrating from `pagespace-mcp`](docs/migrating-from-pagespace-mcp.md) — nothing breaks today,
+and the bin alias bridges old configs with zero changes beyond a deprecation notice on stderr.
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `PAGESPACE_TOKEN` | Bearer credential, same precedence slot as `--token`. |
+| `PAGESPACE_API_URL` | API host, same precedence slot as `--host`. Defaults to `https://pagespace.ai`. |
+| `PAGESPACE_AUTH_TOKEN` | Deprecated alias for `PAGESPACE_TOKEN`, kept for `pagespace-mcp` compatibility. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. |
+| `1` | API or runtime error (network failure, server error, authentication rejected). |
+| `2` | Usage error (bad flags, unknown command). |
+
+## Design notes
+
+**Pure core, effects at the edges**: `parseArgv` turns `process.argv` into a typed `CommandIntent`
+(or a typed `UsageError`) with no I/O. `resolveConfig` applies the precedence above as a pure
+function over plain data. The router matches a `CommandIntent` against a static route table and
+dispatches to a handler; handlers receive an injected `{ sdk, stdout, stderr, env,
+credentialStore }` context and never touch `process.*` directly. Only `src/bin.ts` reads
+`process.argv`/`process.env`/`process.stdout`/`process.exitCode`.
 
 **Zero trust**: no token is ever printed — not in output, not in a usage-error message, not in a
 log. `--json` mode writes nothing to stdout but the JSON payload itself.
 
-The credential store (OS keychain + chmod-0600 file fallback) lands in Phase 4 task 2; this
-package currently ships a `NullCredentialStore` placeholder so the handler contract doesn't change
-shape when the real store arrives.
+The credential store is the OS keychain with a chmod-0600 file fallback.
 
-See PageSpace page `ea07mt5jvw0flihsbjce1iv9` (epic architecture + non-negotiables) and phase page
-`ntr8palcnmkih8kiy33qo717` (Phase 4 security law) for the binding decisions this package follows.
+## See also
+
+- [`@pagespace/sdk`](../sdk/README.md) — the typed client this CLI is a verb layer over.
+- [Migrating from `pagespace-mcp`](docs/migrating-from-pagespace-mcp.md).
+- PageSpace page `ea07mt5jvw0flihsbjce1iv9` (epic architecture + non-negotiables) and phase page
+  `ntr8palcnmkih8kiy33qo717` (Phase 4 security law) for the binding decisions this package follows.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -11,12 +11,137 @@ directly, so unit tests never touch the network.
 **Zero trust end-to-end**: every server response is zod-validated against its output schema, and
 no code path in this package may ever log token material.
 
+## Install
+
+```bash
+npm install @pagespace/sdk
+# or: bun add @pagespace/sdk
+```
+
+## Quickstart
+
+```ts
+import { PageSpaceClient, StaticTokenProvider } from '@pagespace/sdk';
+
+const client = new PageSpaceClient({
+  baseUrl: 'https://pagespace.ai',
+  auth: new StaticTokenProvider(process.env.PAGESPACE_TOKEN!),
+});
+
+const drives = await client.drives.list({});
+console.log(drives.map((d) => d.name));
+```
+
+Get a token by running `pagespace tokens create --name "my script"` with the
+[`pagespace` CLI](../cli/README.md), or by minting one in **Settings > MCP** in the app.
+
+## Auth providers
+
+`PageSpaceClient` takes any `AuthProvider` (`{ getAccessToken(): Promise<string>; invalidate(): void }`):
+
+- **`StaticTokenProvider(token: string)`** — wraps a fixed credential (an `mcp_*` token or
+  `PAGESPACE_TOKEN`). Never refreshes; once the server rejects it, every subsequent call fails
+  closed rather than retrying the same rejected token.
+
+  ```ts
+  import { StaticTokenProvider } from '@pagespace/sdk';
+  const auth = new StaticTokenProvider(process.env.PAGESPACE_TOKEN!);
+  ```
+
+- **`OAuthTokenProvider(options)`** — manages a refreshable OAuth 2.1 credential (what
+  `pagespace login` stores). Takes `{ initialTokens, refreshAccessToken, now?, skewMs?,
+  onTokensUpdated? }` and refreshes automatically once the access token is within `skewMs`
+  (default 60s) of `accessExpiresAt`.
+
+  ```ts
+  import { OAuthTokenProvider } from '@pagespace/sdk';
+
+  const auth = new OAuthTokenProvider({
+    initialTokens: storedTokens, // { accessToken, accessExpiresAt, refreshToken, refreshExpiresAt }
+    refreshAccessToken: (refreshToken) => exchangeRefreshToken(refreshToken),
+    onTokensUpdated: (tokens) => saveTokens(tokens),
+  });
+  ```
+
+## The operation registry
+
+Every domain method comes from the same registry entry shape (`defineOperation`), so the SDK
+method, the CLI verb, and the `pagespace mcp` tool for a given operation always agree on inputs
+and outputs:
+
+```ts
+import { defineOperation } from '@pagespace/sdk';
+import { z } from 'zod';
+
+const getWidget = defineOperation({
+  name: 'widgets.get',
+  method: 'GET',
+  path: '/api/widgets/:widgetId',
+  inputSchema: z.object({ widgetId: z.string() }),
+  outputSchema: z.object({ id: z.string(), label: z.string() }),
+  description: 'Get a widget.',
+});
+```
+
+Every registered operation is also reachable through the fully-typed escape hatch
+`client.invoke(op, input)`, which preserves that operation's own input/output types regardless of
+whether it has a generated namespace method.
+
+## Resource namespaces
+
+`PageSpaceClient` exposes one generated method per registered operation, grouped by domain
+namespace. One example per namespace:
+
+| Namespace | Example call |
+|---|---|
+| `client.drives` | `client.drives.list({})` |
+| `client.pages` | `client.pages.create({ driveId, title, type: 'DOCUMENT' })` |
+| `client.roles` | `client.roles.setPagePermissions({ driveId, roleId, permissionsPatch })` |
+| `client.tasks` | `client.tasks.create({ pageId, title })` |
+| `client.agents` | `client.agents.ask({ agentId, question })` |
+| `client.conversations` | `client.conversations.read({ agentId, conversationId })` |
+| `client.export` | `client.export.pageMarkdown({ pageId })` |
+| `client.tokens` | `client.tokens.create({ name })` |
+| `client.search` | `client.search.glob({ driveId, pattern })` |
+| `client.activity` | `client.activity.get({ driveId })` |
+| `client.channels` | `client.channels.send({ pageId, content })` |
+
+A handful of operations (calendar, collaborators, commands, drive members, workflows) are
+registered and reachable via `pagespace mcp`, but don't yet have a generated namespace method —
+call them with `client.invoke(op, input)` using the operation exported from
+`@pagespace/sdk`'s `operations/*` modules.
+
+## Errors
+
+Every failure is a typed subclass of `PageSpaceError` (`AuthenticationError`, `ValidationError`,
+`NotFoundError`, `PermissionDeniedError`, `RateLimitError`, `ServerError`, `NetworkError`,
+`TimeoutError`, `IncompatibleServerError`, `ResponseValidationError`), each with a matching
+`is*Error()` type guard:
+
+```ts
+import { isRateLimitError } from '@pagespace/sdk';
+
+try {
+  await client.pages.create({ driveId, title: 'Notes' });
+} catch (error) {
+  if (isRateLimitError(error)) {
+    // error.retryAfterMs is set when the server sent one
+  }
+  throw error;
+}
+```
+
+## Server version compatibility
+
 `PageSpaceClient` enforces the [ADR 0001](../../docs/adr/0001-sdk-api-versioning.md) handshake:
 every 2xx response is checked, lazily and once per client instance, against the SDK's compiled-in
 `MIN_SERVER_API_VERSION`, and an incompatible server fails closed with `IncompatibleServerError`
-(opt out only via the explicit `skipVersionCheck: true`). The repo-level assertion
-`MIN_SERVER_API_VERSION <= API_CONTRACT_VERSION` is still deferred until
-`packages/lib/src/api-contract-version.ts` exists (Phase 1/7).
+(opt out only via the explicit `skipVersionCheck: true`).
 
-See PageSpace page `ea07mt5jvw0flihsbjce1iv9` (epic architecture + non-negotiables) and
-`docs/adr/` for the binding decisions this package follows.
+## See also
+
+- [`@pagespace/cli`](../cli/README.md) — `pagespace login`, verbs over this SDK, and `pagespace mcp`.
+- [Migrating from `pagespace-mcp`](../cli/docs/migrating-from-pagespace-mcp.md) — if you're moving
+  off the standalone MCP server.
+- PageSpace page `ea07mt5jvw0flihsbjce1iv9` (epic architecture + non-negotiables) and `docs/adr/`
+  for the binding decisions this package follows.


### PR DESCRIPTION
## Summary
Final task of Phase 6 (MCP Adapter & Migration) of the PageSpace SDK/CLI/OAuth epic — docs & changelog for the now-feature-complete surface (OAuth 2.1 login, `@pagespace/sdk`, `pagespace` CLI, `pagespace mcp`).

- `packages/sdk/README.md` — install, quickstart, auth providers (`StaticTokenProvider`/`OAuthTokenProvider`), operation registry, one verified example call per resource namespace, error taxonomy, server-version handshake.
- `packages/cli/README.md` — install, quickstart (login → whoami → first command), full `pagespace <resource> <verb>` grammar table, `pagespace mcp`, `tokens create/list/revoke`, env vars, exit codes.
- `apps/marketing/src/app/docs/integrations/mcp/page.tsx` — rewritten around `pagespace login` + `pagespace mcp` as the primary path, scoped tokens (`pagespace tokens create` or Settings > MCP) for agents/CI, `pagespace-mcp` marked deprecated with a link to the migration guide.
- Settings > MCP UI (`MCPSettingsView.tsx`) — points personal users at `pagespace login` first, keeps token management as the scoped-credential surface, updates the quick-setup install command and generated config to `pagespace mcp` / `PAGESPACE_TOKEN`.
- `CHANGELOG.md` — new file (none existed before), Keep-a-Changelog format, `Unreleased` entry covering the OAuth provider, `@pagespace/sdk`, the `pagespace` CLI, and the MCP adapter + `pagespace-mcp` deprecation.

Every command, flag, and namespace documented was grepped against the merged source (`run.ts` `ROUTES`, `client.ts` `DEFAULT_OPERATIONS_MAP`, each operation's real input schema) — three initially-wrong SDK example calls (`agents.ask`, `conversations.read`, `roles.setPagePermissions`, `channels.send` field names) were caught this way and fixed. The SDK README's code snippets were also typechecked directly against the built `@pagespace/sdk` package (not just read).

## Test plan
- [x] `bun run lint` — green
- [x] `bun run --filter 'web' typecheck` — green
- [x] `bun run --filter 'marketing' build` — green (57/57 static pages, including the rewritten MCP doc page)
- [x] `bun run --filter '@pagespace/cli' typecheck && test` — green (651 tests)
- [x] Every SDK README snippet typechecked against `packages/sdk/dist` via a scratch file compiled with the CLI's `tsconfig.json`
- [x] CLI command grammar cross-checked line-by-line against `packages/cli/src/run.ts`'s `ROUTES` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UH6bFR9pE67ioDQHX8cZCd