### PR TITLE
Phase 7 · zero-trust security audit — SDK/CLI/OAuth epic

### DIFF
--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -242,6 +242,8 @@ const DEVICE_POLL_ERROR_BODY: Record<Exclude<Awaited<ReturnType<typeof pollDevic
   slow_down: { error: 'slow_down' },
   expired_token: { error: 'expired_token' },
   access_denied: { error: 'access_denied' },
+  // Constant-shape with not_found/expired/etc — no oracle on account status.
+  user_suspended: INVALID_GRANT,
 };
 
 async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
@@ -98,6 +98,7 @@ let insertedDeviceRows: Record<string, unknown>[] = [];
 let refreshRows: TokenRow[] = [];
 let accessRows: TokenRow[] = [];
 let userTokenVersion = 0;
+let userSuspendedAt: Date | null = null;
 let lockChain: Promise<unknown> = Promise.resolve();
 
 function makeTx() {
@@ -106,7 +107,7 @@ function makeTx() {
       from: (table: unknown) => ({
         where: (predicate: Predicate) => {
           if (table === usersTable) {
-            return Promise.resolve([{ tokenVersion: userTokenVersion }]);
+            return Promise.resolve([{ tokenVersion: userTokenVersion, suspendedAt: userSuspendedAt }]);
           }
           const matches = deviceRow && evalPredicate(predicate, deviceRow as unknown as Record<string, unknown>);
           const rows = matches ? [{ ...deviceRow }] : [];
@@ -214,6 +215,7 @@ beforeEach(() => {
   refreshRows = [];
   accessRows = [];
   userTokenVersion = 0;
+  userSuspendedAt = null;
   lockChain = Promise.resolve();
 });
 
@@ -328,6 +330,17 @@ describe('pollDeviceToken', () => {
     seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, lastPolledAt: null });
     await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
     expect(deviceRow?.lastPolledAt).toBeNull();
+  });
+
+  it('rejects and mints no tokens for an approved device code whose user is suspended (zero-trust audit finding)', async () => {
+    seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['account'] });
+    userSuspendedAt = new Date();
+
+    const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+    expect(result).toEqual({ outcome: 'user_suspended' });
+    expect(refreshRows).toHaveLength(0);
+    expect(accessRows).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.exchange.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.exchange.test.ts
@@ -121,6 +121,7 @@ let codeRow: CodeRow | null = null;
 let refreshRows: TokenRow[] = [];
 let accessRows: TokenRow[] = [];
 let userTokenVersion = 0;
+let userSuspendedAt: Date | null = null;
 let lockChain: Promise<unknown> = Promise.resolve();
 
 function makeTx() {
@@ -129,7 +130,7 @@ function makeTx() {
       from: (table: unknown) => ({
         where: (predicate: Predicate) => {
           if (table === usersTable) {
-            return Promise.resolve([{ tokenVersion: userTokenVersion }]);
+            return Promise.resolve([{ tokenVersion: userTokenVersion, suspendedAt: userSuspendedAt }]);
           }
           const matches = codeRow && evalPredicate(predicate, codeRow as unknown as Record<string, unknown>);
           const rows = matches ? [{ ...codeRow }] : [];
@@ -205,6 +206,7 @@ beforeEach(() => {
   refreshRows = [];
   accessRows = [];
   userTokenVersion = 0;
+  userSuspendedAt = null;
   lockChain = Promise.resolve();
 });
 
@@ -320,6 +322,27 @@ describe('exchangeAuthorizationCode — rejections', () => {
     });
 
     expect(result).toEqual({ outcome: 'rejected', decision: { status: 'pkce_failed' } });
+  });
+});
+
+describe('exchangeAuthorizationCode — suspended user (zero-trust audit finding)', () => {
+  it('rejects the exchange and mints no tokens when the code owner is suspended', async () => {
+    seedCodeRow();
+    userSuspendedAt = new Date();
+
+    const result = await exchangeAuthorizationCode({
+      code: CODE,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+      clientDbId: CLIENT_DB_ID,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'user_suspended' });
+    expect(refreshRows).toHaveLength(0);
+    expect(accessRows).toHaveLength(0);
+    // Single-use still holds: the code is consumed, not left replayable.
+    expect(codeRow?.consumedAt).not.toBeNull();
   });
 });
 

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
@@ -26,10 +26,11 @@ const H = vi.hoisted(() => ({
     string,
     unknown
   >,
+  usersTable: { __table: 'users', id: 'users.id' } as Record<string, unknown>,
   state: { dbTransactionImpl: null as null | ((cb: (tx: unknown) => unknown) => unknown) },
 }));
 
-const { oauthRefreshTokens, oauthAccessTokens } = H;
+const { oauthRefreshTokens, oauthAccessTokens, usersTable } = H;
 
 vi.mock('@pagespace/db/schema/oauth', () => ({
   oauthRefreshTokens: H.oauthRefreshTokens,
@@ -38,7 +39,7 @@ vi.mock('@pagespace/db/schema/oauth', () => ({
   oauthAuthorizationCodes: {},
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
-  users: { __table: 'users', id: 'users.id' },
+  users: H.usersTable,
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
@@ -94,13 +95,17 @@ interface AccessRow {
 
 let refreshRows: RefreshRow[] = [];
 let accessRows: AccessRow[] = [];
+let userSuspendedAt: Date | null = null;
 let lockChain: Promise<unknown> = Promise.resolve();
 
 function makeTx() {
   return {
     select: () => ({
-      from: () => ({
+      from: (table: unknown) => ({
         where: (predicate: Predicate) => {
+          if (table === usersTable) {
+            return Promise.resolve([{ suspendedAt: userSuspendedAt }]);
+          }
           const matches = refreshRows.filter((r) => evalPredicate(predicate, r as unknown as Record<string, unknown>));
           const p = Promise.resolve(matches) as Promise<RefreshRow[]> & { for: (mode: string) => Promise<RefreshRow[]> };
           p.for = () => p;
@@ -174,6 +179,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   refreshRows = [];
   accessRows = [];
+  userSuspendedAt = null;
   lockChain = Promise.resolve();
 });
 
@@ -305,6 +311,45 @@ describe('refreshTokenGrant — reuse detection: the theft scenario end-to-end',
       now: new Date(Date.now() + 61_000),
     });
     expect(legitimateRetry).toEqual({ outcome: 'invalid_grant' });
+  });
+});
+
+describe('refreshTokenGrant — suspended user (zero-trust audit finding)', () => {
+  it('rejects the grant and revokes the whole family when the owning user is suspended, mirroring mcp-token suspension handling', async () => {
+    seedRefreshRow();
+    userSuspendedAt = new Date();
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_grant' });
+    // No fresh pair minted for a suspended user's refresh attempt.
+    expect(refreshRows).toHaveLength(1);
+    expect(accessRows).toHaveLength(0);
+    // The family is dead, not merely denied this once — a second attempt
+    // (even after "unsuspension" edits the row back) must not somehow still
+    // work off a family we left alive.
+    expect(refreshRows[0].revokedAt).not.toBeNull();
+    expect(refreshRows[0].revokedReason).toBe('user_suspended');
+  });
+
+  it('does not mint or rotate anything for a suspended user even under concurrent refresh attempts', async () => {
+    seedRefreshRow();
+    userSuspendedAt = new Date();
+
+    const [first, second] = await Promise.all([
+      refreshTokenGrant({ refreshToken: REFRESH_TOKEN, clientDbId: CLIENT_DB_ID, requestedScope: null, now: new Date() }),
+      refreshTokenGrant({ refreshToken: REFRESH_TOKEN, clientDbId: CLIENT_DB_ID, requestedScope: null, now: new Date() }),
+    ]);
+
+    expect(first).toEqual({ outcome: 'invalid_grant' });
+    expect(second).toEqual({ outcome: 'invalid_grant' });
+    expect(refreshRows).toHaveLength(1);
+    expect(accessRows).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -97,6 +97,7 @@ export interface ExchangeAuthorizationCodeInput {
 export type ExchangeAuthorizationCodeResult =
   | { outcome: 'not_found' }
   | { outcome: 'rejected'; decision: Exclude<CodeExchangeDecision, { status: 'ok' }> }
+  | { outcome: 'user_suspended' }
   | { outcome: 'ok'; userId: string; scopes: string[]; tokens: IssuedTokenPair };
 
 async function revokeTokenFamily(
@@ -178,8 +179,23 @@ export async function exchangeAuthorizationCode(
       return { outcome: 'rejected', decision };
     }
 
-    const userRows = await tx.select({ tokenVersion: users.tokenVersion }).from(users).where(eq(users.id, row.userId));
+    const userRows = await tx
+      .select({ tokenVersion: users.tokenVersion, suspendedAt: users.suspendedAt })
+      .from(users)
+      .where(eq(users.id, row.userId));
     const tokenVersion = userRows[0]?.tokenVersion ?? 0;
+
+    // Zero trust, mirrors mcp-token suspension handling: a suspended user's
+    // authorization code is single-use dead (consumed below) but mints no
+    // tokens at all — never hand out a family that would only be dead on
+    // first use.
+    if (userRows[0]?.suspendedAt) {
+      await tx
+        .update(oauthAuthorizationCodes)
+        .set({ consumedAt: input.now })
+        .where(eq(oauthAuthorizationCodes.id, row.id));
+      return { outcome: 'user_suspended' };
+    }
 
     const tokens = issueInitialTokenPair(input.now);
 
@@ -348,6 +364,20 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
       return { outcome: 'invalid_grant' };
     }
 
+    // Zero trust, mirrors mcp-token suspension handling: a suspended user's
+    // refresh token is not just denied THIS rotation — the whole family is
+    // killed outright, the same way an MCP token is revoked on sight, rather
+    // than left alive to keep minting access tokens that only die on first
+    // use (constant-shape: same invalid_grant a reused/expired token gets).
+    const userRows = await tx
+      .select({ suspendedAt: users.suspendedAt })
+      .from(users)
+      .where(eq(users.id, row.userId));
+    if (userRows[0]?.suspendedAt) {
+      await revokeTokenFamily(tx, row.familyId, input.now, 'user_suspended');
+      return { outcome: 'invalid_grant' };
+    }
+
     let scopes = row.scopes;
     if (input.requestedScope !== null) {
       const requested = parseScopeList(input.requestedScope);
@@ -468,6 +498,7 @@ export type PollDeviceTokenResult =
   | { outcome: 'slow_down' }
   | { outcome: 'expired_token' }
   | { outcome: 'access_denied' }
+  | { outcome: 'user_suspended' }
   | { outcome: 'ok'; userId: string; scopes: string[]; tokens: IssuedTokenPair };
 
 /**
@@ -524,10 +555,16 @@ export async function pollDeviceToken(input: PollDeviceTokenInput): Promise<Poll
     }
 
     const userRows = await tx
-      .select({ tokenVersion: users.tokenVersion })
+      .select({ tokenVersion: users.tokenVersion, suspendedAt: users.suspendedAt })
       .from(users)
       .where(eq(users.id, decision.grant.userId));
     const tokenVersion = userRows[0]?.tokenVersion ?? 0;
+
+    // Zero trust, mirrors mcp-token suspension handling: an approved device
+    // code whose user is suspended mints no tokens at all.
+    if (userRows[0]?.suspendedAt) {
+      return { outcome: 'user_suspended' };
+    }
 
     const tokens = issueInitialTokenPair(input.now);
 

--- a/packages/lib/src/auth/oauth/__tests__/clients.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/clients.test.ts
@@ -71,4 +71,32 @@ describe('validateRedirectUri', () => {
     const bareClient = { clientId: 'x', name: 'X', type: 'public' as const, redirectUris: [], allowedGrantTypes: [], firstParty: false };
     expect(validateRedirectUri(bareClient, 'http://127.0.0.1:1/callback')).toBe(false);
   });
+
+  it('zero-trust audit: alternate loopback IP encodings (decimal/octal/short-form) still resolve to the exact registered host, not a bypass', () => {
+    // The WHATWG URL parser normalizes every one of these into the literal
+    // "127.0.0.1" before validateRedirectUri ever compares hostnames — so
+    // there is no alternate representation that is BOTH accepted here AND
+    // distinct from the registered loopback literal.
+    expect(validateRedirectUri(client, 'http://2130706433/callback')).toBe(true); // decimal
+    expect(validateRedirectUri(client, 'http://0177.0.0.1/callback')).toBe(true); // octal
+    expect(validateRedirectUri(client, 'http://127.1/callback')).toBe(true); // short-form
+  });
+
+  it('zero-trust audit: expanded/alternate IPv6 loopback literals still normalize to [::1]', () => {
+    expect(validateRedirectUri(client, 'http://[0:0:0:0:0:0:0:1]/callback')).toBe(true);
+    expect(validateRedirectUri(client, 'http://[::0:1]/callback')).toBe(true);
+  });
+
+  it('zero-trust audit: a dot-segment path-traversal probe cannot smuggle an unregistered path past the exact-match check', () => {
+    // The URL parser resolves ".." during parsing itself (before this
+    // function ever sees a pathname), so this collapses to "/secret", which
+    // is exactly matched against and rejected the same as any other
+    // unregistered path.
+    expect(validateRedirectUri(client, 'http://127.0.0.1:5000/callback/../secret')).toBe(false);
+    expect(validateRedirectUri(client, 'http://127.0.0.1:5000/callback/../../evil')).toBe(false);
+  });
+
+  it('zero-trust audit: an encoded dot-segment (literal %2e%2e, never decoded into a path separator) is rejected as an unregistered path', () => {
+    expect(validateRedirectUri(client, 'http://127.0.0.1:5000/callback%2e%2e/evil')).toBe(false);
+  });
 });

--- a/scripts/test-security.sh
+++ b/scripts/test-security.sh
@@ -44,6 +44,31 @@ run_test_suite() {
     fi
 }
 
+# Some packages (@pagespace/cli, @pagespace/sdk) wire a `pretest: bun run
+# build` hook (tsc must run before vitest sees the compiled dist types).
+# `bun run --filter <pkg> test -- <args>` forwards trailing args to EVERY
+# script in that chain, including pretest — so `-- src --reporter=dot` reaches
+# `tsc` as stray positional args and it refuses to build ("Unknown compiler
+# option '--reporter=dot'"), failing the suite before vitest ever runs a
+# single test. Building explicitly first, then invoking vitest directly
+# (bypassing the `test` npm-script's arg-forwarding entirely), avoids that.
+run_full_package_suite() {
+    local name="$1"
+    local pkg_dir="$2"
+
+    TOTAL=$((TOTAL + 1))
+    echo -e "${YELLOW}▶ Running: ${name}${NC}"
+
+    if (cd "$pkg_dir" && bun run build && bunx vitest run src --reporter=dot) 2>&1; then
+        echo -e "${GREEN}✓ ${name} passed${NC}"
+        echo ""
+    else
+        echo -e "${RED}✗ ${name} failed${NC}"
+        echo ""
+        FAILED=$((FAILED + 1))
+    fi
+}
+
 # =============================================================================
 # Core Security Module Tests (packages/lib/src/security)
 # =============================================================================
@@ -169,6 +194,40 @@ echo "💾 Database Transaction Security"
 echo "---------------------------------"
 
 run_test_suite "Auth Transactions (Race Conditions)" "@pagespace/db" "src/transactions/__tests__/auth-transactions.test.ts"
+
+# =============================================================================
+# OAuth 2.1 Provider, SDK, CLI & MCP Adapter (SDK/CLI/OAuth epic — Phase 7
+# zero-trust audit). Whole-package runs for @pagespace/cli and @pagespace/sdk
+# are deliberate, not lazy: virtually every file in both packages is auth
+# surface (credential storage, token exchange/rotation, the MCP adapter's
+# error-formatting boundary) and the epic is still under active development —
+# a per-file allowlist here would silently stop covering new auth code the
+# moment a task added a file without also editing this script. Directory-glob
+# runs for the oauth pure logic and API routes make new files under those
+# directories covered automatically for the same reason.
+# =============================================================================
+echo "🔑 OAuth 2.1 Provider (packages/lib/src/auth/oauth — PKCE, scopes, code/device/refresh lifecycle, redirect_uri, clients)"
+echo "-----------------------------------------------------------------------------------------------------------------------"
+
+run_test_suite "OAuth Provider Pure Logic (PKCE/scopes/code-lifecycle/refresh-rotation/clients/user-code/authorize-request/consent/metadata)" "@pagespace/lib" "src/auth/oauth"
+
+echo "🔑 OAuth 2.1 Provider API Routes & Repository (apps/web — authorize/token/device/revoke, atomic grant persistence)"
+echo "---------------------------------------------------------------------------------------------------------------"
+
+run_test_suite "OAuth API Routes (authorize/token/device_authorization/revoke + hardening sweep)" "web" "src/app/api/oauth"
+run_test_suite "OAuth Repository (atomic code exchange/refresh rotation/device poll persistence)" "web" "src/lib/repositories/__tests__/oauth-repository"
+run_test_suite "OAuth Scope Narrowing (principal-permissions dispatch, drive-scoped MCP/OAuth token enforcement)" "web" "src/lib/auth/__tests__/principal-permissions.test.ts"
+run_test_suite "OAuth Scope Enforcement (mcp-scope-enforcement, drive-scope 403 boundary)" "web" "src/lib/auth/__tests__/mcp-scope-enforcement.test.ts"
+
+echo "🔑 pagespace CLI (packages/cli — login/device-login, credential store, auth precedence, tokens, mcp adapter)"
+echo "----------------------------------------------------------------------------------------------------------"
+
+run_full_package_suite "pagespace CLI (full package — every command authenticates through the same precedence resolver)" "packages/cli"
+
+echo "🔑 pagespace SDK (packages/sdk — auth providers, error classification, operation registry)"
+echo "--------------------------------------------------------------------------------------------"
+
+run_full_package_suite "pagespace SDK (full package — StaticTokenProvider/OAuthTokenProvider, typed error hierarchy)" "packages/sdk"
 
 # =============================================================================
 # Security Audit Coverage Gate


### PR DESCRIPTION
## Summary

Adversarial zero-trust security audit of the OAuth 2.1 provider, `@pagespace/sdk`, `pagespace` CLI, and MCP adapter (epic `ea07mt5jvw0flihsbjce1iv9`, Phase 7 task 1). Full findings table with evidence: [PageSpace audit page](https://pagespace.ai) `l18k2qa9g990ht6kzl2wfiaa`.

**Method:** attempted every attack on the Phase 7 checklist against real code (tests, not thought experiments) — PKCE downgrade, code/refresh-token reuse, redirect_uri bypass, open-redirect, device-code brute force, scope escalation, suspended-user tokens, secrets-in-logs, CLI loopback binding, non-TTY prompting, tokens-in-argv. One real finding, fixed; everything else held and got a new or existing regression test as evidence.

- **F1 (fixed):** suspended users could keep rotating OAuth refresh tokens / exchanging authorization codes / polling approved device codes indefinitely — none of the three grant paths checked `users.suspendedAt`, unlike the access-token-validation layer (which already revoked on sight, mirroring mcp-token suspension). `refreshTokenGrant` now revokes the whole family; `exchangeAuthorizationCode`/`pollDeviceToken` now deny minting outright (constant-shape, no oracle).
- **Held, newly probed:** redirect_uri validation survives alternate-IP-encoding and dot-segment path-traversal bypass attempts (WHATWG URL normalization collapses every alternate form before comparison) — 4 new regression tests.
- **`test:security` extended:** had zero coverage of the entire SDK/CLI/OAuth epic surface. Added OAuth pure logic, OAuth API routes/repository, OAuth scope narrowing/enforcement, and full `@pagespace/cli`/`@pagespace/sdk` package runs — all green. Also fixed a latent runner bug where `pretest: bun run build` hooks broke on forwarded trailing args.

## Test plan
- [x] RED tests confirmed failing against pre-fix code (3 files, 5 tests) for F1
- [x] GREEN after fix — `oauth-repository.{refresh,exchange,device}.test.ts` all pass (44 tests)
- [x] `bun run --filter '@pagespace/lib' typecheck && test` — green (6198 tests)
- [x] `bun run --filter 'web' typecheck && lint` — green
- [x] `bun run test:security` — all new suites green; 7 pre-existing unrelated failures documented as out-of-scope on the audit page (deleted test files predating this epic, vitest-config-excluded integration tests, one DB-role-provisioning test)
- [x] No `any`, no unused imports, bun only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018byTbsVGEr3u7sQ9QzMLbi