### PR TITLE
sdk: wire full client facade — 9 unwired namespaces (Phase 7 hardening)

### DIFF
--- a/packages/sdk/src/__tests__/client-facade-completeness.test.ts
+++ b/packages/sdk/src/__tests__/client-facade-completeness.test.ts
@@ -2,24 +2,39 @@
  * Structural completeness gate (Phase 7 hardening): every operation defined
  * anywhere under `operations/` must be reachable through exactly one
  * `client.<namespace>.<method>()` facade method. The operation universe is
- * discovered mechanically (directory scan + duck-typed `Operation` filter),
- * never a hand-maintained list — a new operations file or a new operation
- * added to an existing file is picked up automatically, so it can't go
- * silently unwired the way the `calendar` namespace previously did.
+ * discovered mechanically (`import.meta.glob` + duck-typed `Operation`
+ * filter), never a hand-maintained list — a new operations file or a new
+ * operation added to an existing file is picked up automatically, so it
+ * can't go silently unwired the way 9 whole namespaces previously did.
+ * Wiring is checked via `listWiredOperations()` (client.ts) rather than by
+ * guessing a namespace/method key from the operation's own name, since the
+ * facade doesn't guarantee that convention (e.g. `channels.send` wires
+ * `channels.sendMessage`).
  */
 import { describe, expect, it } from 'vitest';
-import type { AuthProvider } from '../auth/provider.js';
-import { PageSpaceClient } from '../client.js';
+import { listWiredOperations } from '../client.js';
 import type { Operation } from '../registry/define.js';
 import { createRegistry } from '../registry/registry.js';
 
 /**
- * `import.meta.glob` is Vite's statically-analyzable enumeration of every
- * sibling module under `operations/` (one level deep — `__tests__/*.test.ts`
- * lives in a subdirectory the pattern doesn't reach). Eager so the modules
- * are already evaluated; no runtime `fs`/dynamic-import-by-string needed.
+ * `import.meta.glob` (Vite/vitest) isn't in the package's `ImportMeta` type —
+ * this package has no `vite/client` types reference (it's a library, not a
+ * Vite app) — so the single method this test needs is declared locally
+ * rather than pulling in vite's own (much wider) ambient types.
  */
-const OPERATION_MODULES = import.meta.glob('../operations/*.ts', { eager: true }) as Record<string, Record<string, unknown>>;
+declare global {
+  interface ImportMeta {
+    glob(pattern: string, options: { eager: true }): Record<string, Record<string, unknown>>;
+  }
+}
+
+/**
+ * Vite's statically-analyzable enumeration of every sibling module under
+ * `operations/` (one level deep — `__tests__/*.test.ts` lives in a
+ * subdirectory the pattern doesn't reach). Eager so the modules are already
+ * evaluated; no runtime `fs`/dynamic-import-by-string needed.
+ */
+const OPERATION_MODULES = import.meta.glob('../operations/*.ts', { eager: true });
 
 function isOperation(value: unknown): value is Operation {
   if (typeof value !== 'object' || value === null) return false;
@@ -47,42 +62,26 @@ function loadAllOperations(): Operation[] {
   return ops;
 }
 
-function fakeAuth(): AuthProvider {
-  return {
-    getAccessToken: async () => 'token',
-    invalidate: () => {},
-  };
-}
-
 describe('PageSpaceClient facade — structural completeness', () => {
-  it('exposes every registry operation through exactly one client namespace method', () => {
+  it('wires every registry operation into exactly one client namespace method', () => {
     const allOps = loadAllOperations();
     // Guards the test itself: a duplicate operation name is a registry bug independent of wiring.
     const registry = createRegistry(allOps);
     expect(registry.all.length).toBeGreaterThan(0);
 
-    const client = new PageSpaceClient({
-      baseUrl: 'https://pagespace.ai',
-      auth: fakeAuth(),
-      skipVersionCheck: true,
-    });
-    const clientAsRecord = client as unknown as Record<string, unknown>;
-
-    const unwired: string[] = [];
-    for (const op of registry.all) {
-      const dotIndex = op.name.indexOf('.');
-      const namespace = dotIndex === -1 ? op.name : op.name.slice(0, dotIndex);
-      const method = dotIndex === -1 ? '' : op.name.slice(dotIndex + 1);
-
-      const namespaceObj = clientAsRecord[namespace];
-      const fn =
-        namespaceObj && typeof namespaceObj === 'object' ? (namespaceObj as Record<string, unknown>)[method] : undefined;
-
-      if (typeof fn !== 'function') {
-        unwired.push(op.name);
-      }
+    // Membership by the operation's own name, not by guessing a namespace/method
+    // key from it — the facade is free to expose an operation under a shorter
+    // method name than its registry name (e.g. `channels.send` for the
+    // `channels.sendMessage` operation, to match an already-shipped CLI verb).
+    const wiredCounts = new Map<string, number>();
+    for (const op of listWiredOperations()) {
+      wiredCounts.set(op.name, (wiredCounts.get(op.name) ?? 0) + 1);
     }
 
+    const unwired = registry.all.filter((op) => !wiredCounts.has(op.name)).map((op) => op.name);
+    const duplicatelyWired = [...wiredCounts.entries()].filter(([, count]) => count > 1).map(([name]) => name);
+
     expect(unwired).toEqual([]);
+    expect(duplicatelyWired).toEqual([]);
   });
 });

--- a/packages/sdk/src/__tests__/client-facade-completeness.test.ts
+++ b/packages/sdk/src/__tests__/client-facade-completeness.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Structural completeness gate (Phase 7 hardening): every operation defined
+ * anywhere under `operations/` must be reachable through exactly one
+ * `client.<namespace>.<method>()` facade method. The operation universe is
+ * discovered mechanically (directory scan + duck-typed `Operation` filter),
+ * never a hand-maintained list — a new operations file or a new operation
+ * added to an existing file is picked up automatically, so it can't go
+ * silently unwired the way the `calendar` namespace previously did.
+ */
+import { describe, expect, it } from 'vitest';
+import type { AuthProvider } from '../auth/provider.js';
+import { PageSpaceClient } from '../client.js';
+import type { Operation } from '../registry/define.js';
+import { createRegistry } from '../registry/registry.js';
+
+/**
+ * `import.meta.glob` is Vite's statically-analyzable enumeration of every
+ * sibling module under `operations/` (one level deep — `__tests__/*.test.ts`
+ * lives in a subdirectory the pattern doesn't reach). Eager so the modules
+ * are already evaluated; no runtime `fs`/dynamic-import-by-string needed.
+ */
+const OPERATION_MODULES = import.meta.glob('../operations/*.ts', { eager: true }) as Record<string, Record<string, unknown>>;
+
+function isOperation(value: unknown): value is Operation {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  const inputSchema = candidate.inputSchema as { safeParse?: unknown } | undefined;
+  const outputSchema = candidate.outputSchema as { safeParse?: unknown } | undefined;
+  return (
+    typeof candidate.name === 'string' &&
+    typeof candidate.method === 'string' &&
+    typeof candidate.path === 'string' &&
+    typeof candidate.description === 'string' &&
+    typeof inputSchema?.safeParse === 'function' &&
+    typeof outputSchema?.safeParse === 'function'
+  );
+}
+
+/** Every `Operation`-shaped export across every module in `operations/` — the full registry universe. */
+function loadAllOperations(): Operation[] {
+  const ops: Operation[] = [];
+  for (const mod of Object.values(OPERATION_MODULES)) {
+    for (const exported of Object.values(mod)) {
+      if (isOperation(exported)) ops.push(exported);
+    }
+  }
+  return ops;
+}
+
+function fakeAuth(): AuthProvider {
+  return {
+    getAccessToken: async () => 'token',
+    invalidate: () => {},
+  };
+}
+
+describe('PageSpaceClient facade — structural completeness', () => {
+  it('exposes every registry operation through exactly one client namespace method', () => {
+    const allOps = loadAllOperations();
+    // Guards the test itself: a duplicate operation name is a registry bug independent of wiring.
+    const registry = createRegistry(allOps);
+    expect(registry.all.length).toBeGreaterThan(0);
+
+    const client = new PageSpaceClient({
+      baseUrl: 'https://pagespace.ai',
+      auth: fakeAuth(),
+      skipVersionCheck: true,
+    });
+    const clientAsRecord = client as unknown as Record<string, unknown>;
+
+    const unwired: string[] = [];
+    for (const op of registry.all) {
+      const dotIndex = op.name.indexOf('.');
+      const namespace = dotIndex === -1 ? op.name : op.name.slice(0, dotIndex);
+      const method = dotIndex === -1 ? '' : op.name.slice(dotIndex + 1);
+
+      const namespaceObj = clientAsRecord[namespace];
+      const fn =
+        namespaceObj && typeof namespaceObj === 'object' ? (namespaceObj as Record<string, unknown>)[method] : undefined;
+
+      if (typeof fn !== 'function') {
+        unwired.push(op.name);
+      }
+    }
+
+    expect(unwired).toEqual([]);
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -39,7 +39,21 @@ import {
 import type { AuthProvider } from './auth/provider.js';
 import { getActivity } from './operations/activity.js';
 import { askAgent, listAgents, listModels, multiDriveListAgents, updateAgentConfig } from './operations/agents.js';
-import { sendChannelMessage } from './operations/channels.js';
+import {
+  createCalendarEvent,
+  deleteCalendarEvent,
+  deleteCalendarTrigger,
+  getCalendarEvent,
+  inviteCalendarAttendees,
+  listCalendarEvents,
+  removeCalendarAttendee,
+  rsvpCalendarEvent,
+  setCalendarTrigger,
+  updateCalendarEvent,
+} from './operations/calendar.js';
+import { deleteChannelMessage, sendChannelMessage } from './operations/channels.js';
+import { listCollaborators } from './operations/collaborators.js';
+import { createCommand, deleteCommand, listCommands, updateCommand } from './operations/commands.js';
 import { listConversations, readConversation } from './operations/conversations.js';
 import { createDrive, listDrives, renameDrive, restoreDrive, trashDrive, updateDriveContext } from './operations/drives.js';
 import {
@@ -54,6 +68,7 @@ import {
 } from './operations/pages.js';
 import { deleteLines, editSheetCells, insertLines, readDocument, replaceLines } from './operations/documents.js';
 import { exportPageMarkdown, exportSheetCsv } from './operations/export.js';
+import { listDriveMembers } from './operations/members.js';
 import {
   createDriveRole,
   deleteDriveRole,
@@ -76,6 +91,7 @@ import {
 } from './operations/tasks.js';
 import { createMcpToken, listMcpTokens, revokeMcpToken } from './operations/mcp-tokens.js';
 import { globSearch, multiDriveSearch, regexSearch } from './operations/search.js';
+import { createWorkflow, deleteWorkflow, listWorkflows, updateWorkflow } from './operations/workflows.js';
 import type { Operation } from './registry/define.js';
 import { createRegistry, type OperationRegistry } from './registry/registry.js';
 import { buildRequest } from './transport/build-request.js';
@@ -159,6 +175,37 @@ const DEFAULT_OPERATIONS_MAP = {
   },
   channels: {
     send: sendChannelMessage,
+    delete: deleteChannelMessage,
+  },
+  calendar: {
+    list: listCalendarEvents,
+    get: getCalendarEvent,
+    create: createCalendarEvent,
+    update: updateCalendarEvent,
+    delete: deleteCalendarEvent,
+    rsvp: rsvpCalendarEvent,
+    inviteAttendees: inviteCalendarAttendees,
+    removeAttendee: removeCalendarAttendee,
+    setTrigger: setCalendarTrigger,
+    deleteTrigger: deleteCalendarTrigger,
+  },
+  collaborators: {
+    list: listCollaborators,
+  },
+  commands: {
+    list: listCommands,
+    create: createCommand,
+    update: updateCommand,
+    delete: deleteCommand,
+  },
+  members: {
+    list: listDriveMembers,
+  },
+  workflows: {
+    list: listWorkflows,
+    create: createWorkflow,
+    update: updateWorkflow,
+    delete: deleteWorkflow,
   },
 } as const;
 
@@ -208,6 +255,16 @@ function delay(ms: number): Promise<void> {
 
 function flattenOperations(map: OperationsMap): Operation[] {
   return Object.values(map).flatMap((methods) => Object.values(methods));
+}
+
+/**
+ * Every operation actually wired into the facade, across every namespace —
+ * the structural-completeness regression gate (`client-facade-completeness.test.ts`)
+ * diffs this against the full operation registry so a new operation left out
+ * of `DEFAULT_OPERATIONS_MAP` fails the suite instead of going unnoticed.
+ */
+export function listWiredOperations(): readonly Operation[] {
+  return flattenOperations(DEFAULT_OPERATIONS_MAP);
 }
 
 function buildNamespaces(


### PR DESCRIPTION
## Summary
- Phase 5 (`ea07mt5jvw0flihsbjce1iv9`) found the SDK client facade (`packages/sdk/src/client.ts` `DEFAULT_OPERATIONS_MAP`) systematically incomplete — the task was scoped to `calendar`, but a mechanical audit surfaced 9 entirely-unwired namespaces at the time this branch was cut.
- **Rebased onto current `pu/cli-login`** (merged Phase 5/6/7 work in the interim already wired `drives` (full), `export`, `search`, `activity`, `channels.send`, and a new `tokens` namespace for CLI verbs that shipped in the meantime). The conflict was resolved by keeping every existing namespace/method exactly as-is (so already-shipped CLI verbs — `ctx.sdk.search.*`, `ctx.sdk.channels.send`, `ctx.sdk.export.*`, `ctx.sdk.activity.get` — keep working unchanged) and layering in only what was still missing.
- **RED**: `packages/sdk/src/__tests__/client-facade-completeness.test.ts` mechanically discovers every `Operation`-shaped export under `operations/*.ts` (via `import.meta.glob`, no hardcoded list) and asserts each operation's own registry `name` is wired into the facade *somewhere* (checked by name membership against a new `listWiredOperations()` export from `client.ts`, not by guessing a namespace/method key — the facade already uses shorter method names than the registry name in places, e.g. `channels.send` for the `channels.sendMessage` operation, to match a shipped CLI verb).
- **GREEN**: wired the remaining namespaces — `calendar` (10 ops), `collaborators`, `commands`, `members`, `workflows` — plus `channels.delete` (`deleteChannelMessage`, previously missing alongside the already-wired `send`).
- `computeFreeSlots` (calendar.ts) intentionally stays unwired — it's a documented pure helper over `calendar.list`'s output, not a registry operation (`check_calendar_availability` isn't a network op).
- The completeness test is a permanent regression gate: any future operation added to `operations/*.ts` without a matching facade entry fails the suite immediately, by construction (no hand-maintained op list to fall out of sync).

## Outcome
Final unwired-list the completeness test drove (all now wired):
- `calendar.{list,get,create,update,delete,rsvp,inviteAttendees,removeAttendee,setTrigger,deleteTrigger}`
- `collaborators.list`
- `commands.{list,create,update,delete}`
- `members.list`
- `workflows.{list,create,update,delete}`
- `channels.deleteMessage` (wired as `channels.delete`, alongside the pre-existing `channels.send`)

Already wired pre-rebase (kept unchanged): `drives.*` (full), `pages.*`, `roles.*`, `tasks.*`, `agents.*`, `conversations.*`, `export.*`, `search.*`, `activity.get`, `channels.send`, `tokens.*`.

## Test plan
- [x] `bun run --filter '@pagespace/sdk' typecheck` — green
- [x] `bun run --filter '@pagespace/sdk' test` — 717/717 passing (33 test files), including the completeness gate
- [x] `bun run --filter '@pagespace/cli' typecheck` — green
- [x] `bun run --filter '@pagespace/cli' test` — 651/651 passing (53 test files) — confirms Phase 5 CLI verbs are intact after the rebase
- [x] `gh pr view` — `mergeStateStatus: CLEAN`, `mergeable: MERGEABLE`

https://claude.ai/code/session_016TFt59ehq6EmR7E1fTtwcG