### PR TITLE
Add Upgrade CTA to usage page + View usage link from Buy Credits

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-continuity.test.ts
@@ -19,7 +19,6 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
-  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/recent-history-ordering.test.ts
@@ -19,7 +19,6 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
-  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/step-cap-parity.test.ts
@@ -19,7 +19,6 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
   getAllowedDriveIds: vi.fn(() => []),
   canPrincipalViewPage: vi.fn().mockResolvedValue(true),
-  isScopedMCPAuth: vi.fn(() => false),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/components/billing/BuyCreditsButton.tsx
+++ b/apps/web/src/components/billing/BuyCreditsButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -49,6 +49,7 @@ export function BuyCreditsButton({
   label = 'Buy credits',
 }: BuyCreditsButtonProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const { showBilling } = useBillingVisibility();
   const { balance } = useCreditBalance();
   const [loadingKey, setLoadingKey] = useState<string | null>(null);
@@ -110,7 +111,18 @@ export function BuyCreditsButton({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuLabel>Add credits</DropdownMenuLabel>
+          <div className="flex items-center justify-between px-2 py-1.5">
+            <DropdownMenuLabel className="p-0">Add credits</DropdownMenuLabel>
+            {pathname !== '/settings/usage' && (
+              <button
+                type="button"
+                onClick={() => router.push('/settings/usage')}
+                className="text-xs text-muted-foreground hover:underline"
+              >
+                View usage →
+              </button>
+            )}
+          </div>
           <DropdownMenuSeparator />
           {CREDIT_PACK_LIST.map((pack) => (
             <DropdownMenuItem

--- a/apps/web/src/components/billing/BuyCreditsButton.tsx
+++ b/apps/web/src/components/billing/BuyCreditsButton.tsx
@@ -111,7 +111,12 @@ export function BuyCreditsButton({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <div className="flex items-center justify-between px-2 py-1.5">
+          {/* Plain content (not a DropdownMenuItem), same reasoning as the custom-amount
+              block below: stop keydown propagation so Radix typeahead doesn't hijack it. */}
+          <div
+            className="flex items-center justify-between px-2 py-1.5"
+            onKeyDown={(e) => e.stopPropagation()}
+          >
             <DropdownMenuLabel className="p-0">Add credits</DropdownMenuLabel>
             {pathname !== '/settings/usage' && (
               <button

--- a/apps/web/src/components/billing/CreditBalanceCard.tsx
+++ b/apps/web/src/components/billing/CreditBalanceCard.tsx
@@ -7,6 +7,7 @@ import { Coins } from 'lucide-react';
 import { useCreditBalance } from '@/hooks/useCreditBalance';
 import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 import { BuyCreditsButton } from '@/components/billing/BuyCreditsButton';
+import { UpgradeTierButton } from '@/components/billing/UpgradeTierButton';
 import { formatCreditCount, formatCreditCountSigned } from '@/lib/subscription/credits';
 
 /**
@@ -24,6 +25,7 @@ export function CreditBalanceCard() {
   }
 
   const renewDate = balance?.monthly.periodEnd ? new Date(balance.monthly.periodEnd) : null;
+  const isFree = balance?.subscriptionTier === 'free';
 
   return (
     <Card>
@@ -95,7 +97,10 @@ export function CreditBalanceCard() {
                 )}
               </div>
             </div>
-            {showBilling && <BuyCreditsButton variant="default" size="default" />}
+            <div className="flex items-center gap-2">
+              <UpgradeTierButton isFree={isFree} className="flex" />
+              {showBilling && <BuyCreditsButton variant="default" size="default" />}
+            </div>
           </div>
         ) : null}
       </CardContent>

--- a/apps/web/src/components/billing/UpgradeTierButton.tsx
+++ b/apps/web/src/components/billing/UpgradeTierButton.tsx
@@ -3,10 +3,13 @@
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { PLANS } from '@/lib/subscription/plans';
+import { cn } from '@/lib/utils';
 
 interface UpgradeTierButtonProps {
   /** Whether the current user is on the free tier — the only tier this CTA targets. */
   isFree: boolean;
+  /** Merged over the default classes — e.g. to drop the navbar's `hidden sm:flex` collapsing on a full-width surface. */
+  className?: string;
 }
 
 const UpgradeIcon = PLANS.pro.icon;
@@ -19,7 +22,7 @@ const UpgradeIcon = PLANS.pro.icon;
  * billingEnabled, so a second useCreditBalance() instance here would just add a
  * redundant SWR/socket subscription for data the parent already has.
  */
-export function UpgradeTierButton({ isFree }: UpgradeTierButtonProps) {
+export function UpgradeTierButton({ isFree, className }: UpgradeTierButtonProps) {
   const router = useRouter();
 
   if (!isFree) return null;
@@ -29,7 +32,10 @@ export function UpgradeTierButton({ isFree }: UpgradeTierButtonProps) {
       variant="outline"
       size="sm"
       onClick={() => router.push('/settings/plan')}
-      className="hidden sm:flex items-center gap-1.5 border-primary/30 text-primary hover:bg-primary/10"
+      className={cn(
+        'hidden sm:flex items-center gap-1.5 border-primary/30 text-primary hover:bg-primary/10',
+        className,
+      )}
     >
       <UpgradeIcon className="h-4 w-4" />
       Upgrade

--- a/apps/web/src/components/billing/UpgradeTierButton.tsx
+++ b/apps/web/src/components/billing/UpgradeTierButton.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { PLANS } from '@/lib/subscription/plans';
 import { cn } from '@/lib/utils';
+import { useBillingVisibility } from '@/hooks/useBillingVisibility';
 
 interface UpgradeTierButtonProps {
   /** Whether the current user is on the free tier — the only tier this CTA targets. */
@@ -15,17 +16,23 @@ interface UpgradeTierButtonProps {
 const UpgradeIcon = PLANS.pro.icon;
 
 /**
- * Navbar CTA driving free-tier users toward a paid plan — buying credits alone
- * doesn't unlock premium models, so this sits next to "Buy credits" as the other
- * half of the upsell. Takes tier as a prop rather than fetching its own balance:
- * its sole caller (CreditBalance) already holds it after resolving showBilling/
- * billingEnabled, so a second useCreditBalance() instance here would just add a
- * redundant SWR/socket subscription for data the parent already has.
+ * CTA driving free-tier users toward a paid plan — buying credits alone doesn't
+ * unlock premium models, so this sits next to "Buy credits" as the other half of
+ * the upsell. Takes tier as a prop rather than fetching its own balance: callers
+ * (CreditBalance, CreditBalanceCard) already hold it after resolving billingEnabled,
+ * so a second useCreditBalance() instance here would just add a redundant
+ * SWR/socket subscription for data the parent already has. Billing *visibility*
+ * (iOS Capacitor / billing-disabled deployments) is still self-checked here via
+ * the cheap, subscription-free useBillingVisibility() — this button routes to
+ * /settings/plan, a billing surface that must stay hidden wherever BuyCreditsButton
+ * already self-hides, and every caller should be able to render it unconditionally
+ * without separately remembering to wrap it in `showBilling && ...`.
  */
 export function UpgradeTierButton({ isFree, className }: UpgradeTierButtonProps) {
   const router = useRouter();
+  const { showBilling } = useBillingVisibility();
 
-  if (!isFree) return null;
+  if (!showBilling || !isFree) return null;
 
   return (
     <Button


### PR DESCRIPTION
## Summary
Follow-up to #1807, which added an "Upgrade" navbar button and a free-tier nudge inside the "Buy credits" dropdown, but missed two things:

- **`/settings/usage`** never got the same Upgrade treatment — arguably the highest-intent page for it, since a free-tier user is already looking at their credit consumption there.
- **`BuyCreditsButton`'s dropdown** had no fast path back to the fuller usage/billing page. The navbar's direct-buy dropdown is kept as-is (fast checkout is worth it), this just adds a way to jump to usage details from wherever the button appears.

Changes:
- `UpgradeTierButton` now takes an optional `className`, so it can be reused outside the navbar without the `hidden sm:flex` responsive collapsing that only made sense there. It also now self-checks `useBillingVisibility()` internally (cheap, subscription-free) so every caller — including the already-merged navbar usage — is automatically hidden on iOS/billing-disabled deployments, without needing to remember to wrap it externally.
- `CreditBalanceCard` (the `/settings/usage` credit card) now renders the same Upgrade button next to Buy credits, gated on `subscriptionTier === 'free'`.
- `BuyCreditsButton`'s dropdown now has a "View usage →" link next to its "Add credits" label — shown everywhere it's rendered (navbar, chat out-of-credits banner, `CreditBalanceCard`) except when already on `/settings/usage`, where it'd be a no-op.

Also includes an unrelated one-line fix: `master`'s own CI was red (`ci / Lint & TypeScript Check`) due to a duplicate `isScopedMCPAuth` mock property across 3 consult-route test files, introduced by a recent unrelated merge. Fixed here since it otherwise blocks this branch's own CI.

## Review rounds
- Codex (P2) and CodeRabbit both independently caught that `UpgradeTierButton` rendered unconditionally on `/settings/usage` regardless of billing visibility — fixed by moving the check into the component itself; Codex re-reviewed the fix and confirmed no remaining issues.
- Ran an additional proactive review pass; fixed a minor Radix-typeahead keydown-propagation inconsistency, and documented reasoning for a few other findings left as intentional (see PR comments).

## Test plan
- [x] `bun run --filter web typecheck` — clean
- [x] `bunx vitest run` on the touched + previously-broken suites — 98/98 passing
- [x] All CI checks green (lint/typecheck, unit tests)
- [ ] Manual QA: free-tier user sees Upgrade button on `/settings/usage`; "View usage →" appears in the navbar/chat-banner dropdowns and navigates correctly; link is absent when opening "Buy credits" from `/settings/usage` itself; Upgrade button is absent on iOS/billing-disabled builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMHC57n9S4xGkrNKSmssRx