### PR TITLE
feat(mcp): edit-scopes UI for MCP token drive access (T4)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -260,6 +260,7 @@ export default function MCPSettingsView() {
   const [newDriveRoles, setNewDriveRoles] = useState<Record<string, DriveRoleSelection>>({});
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [editingTokenId, setEditingTokenId] = useState<string | null>(null);
+  const [editingTokenWasUnscoped, setEditingTokenWasUnscoped] = useState(false);
   const [editSelectedDriveIds, setEditSelectedDriveIds] = useState<string[]>([]);
   const [editDriveRoles, setEditDriveRoles] = useState<Record<string, DriveRoleSelection>>({});
   const [editingScopes, setEditingScopes] = useState(false);
@@ -422,6 +423,7 @@ export default function MCPSettingsView() {
 
   const openEditDialog = (token: MCPToken) => {
     setEditingTokenId(token.id);
+    setEditingTokenWasUnscoped(!token.isScoped);
     setEditSelectedDriveIds(token.driveScopes.map(scope => scope.id));
     const roles: Record<string, DriveRoleSelection> = {};
     token.driveScopes.forEach(scope => {
@@ -447,6 +449,17 @@ export default function MCPSettingsView() {
   const updateTokenScopes = async () => {
     if (!editingTokenId) return;
 
+    // This token currently has access to ALL drives (unscoped). Saving with no
+    // drives selected would silently convert it to a NO-access token instead of
+    // preserving all-drives access — require explicit confirmation for that case.
+    if (editingTokenWasUnscoped && editSelectedDriveIds.length === 0) {
+      const confirmed = window.confirm(
+        'This token currently has access to ALL your drives. Saving with no drives ' +
+        'selected will restrict it to NO drives, not leave it unrestricted. Continue?'
+      );
+      if (!confirmed) return;
+    }
+
     setEditingScopes(true);
     try {
       const driveScopesPayload = editSelectedDriveIds.map(id => {
@@ -470,6 +483,7 @@ export default function MCPSettingsView() {
       ));
       setEditDialogOpen(false);
       setEditingTokenId(null);
+      setEditingTokenWasUnscoped(false);
       setEditSelectedDriveIds([]);
       setEditDriveRoles({});
       toast.success('Token scopes updated successfully');
@@ -792,6 +806,7 @@ export default function MCPSettingsView() {
           setEditDialogOpen(open);
           if (!open) {
             setEditingTokenId(null);
+            setEditingTokenWasUnscoped(false);
             setEditSelectedDriveIds([]);
             setEditDriveRoles({});
           }
@@ -811,7 +826,9 @@ export default function MCPSettingsView() {
               </div>
               <p className="text-sm text-muted-foreground">
                 {editSelectedDriveIds.length === 0
-                  ? 'This token will have access to 0 drives.'
+                  ? editingTokenWasUnscoped
+                    ? 'This token currently has access to ALL your drives. Selecting none and saving will restrict it to NO drives, not leave it unrestricted.'
+                    : 'This token will have access to 0 drives.'
                   : `This token will only have access to ${editSelectedDriveIds.length} selected drive${editSelectedDriveIds.length === 1 ? '' : 's'}.`}
               </p>
 

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -107,14 +107,20 @@ function DriveRoleSelect({
   roles: DriveRoleOption[] | undefined;
   onChange: (driveId: string, value: string) => void;
 }) {
+  const currentValue = selectValueForRole(selection);
+  // Always render the currently-selected option even if the caller's ceiling would
+  // otherwise hide it (e.g. Admin was granted earlier while the caller had a higher
+  // role and they've since been downgraded to Member) — otherwise Radix Select shows
+  // a blank trigger instead of the token's actual, still-in-effect scope.
+  const showAdmin = callerRole !== 'MEMBER' || currentValue === ADMIN_VALUE;
   return (
-    <Select value={selectValueForRole(selection)} onValueChange={(value) => onChange(driveId, value)}>
+    <Select value={currentValue} onValueChange={(value) => onChange(driveId, value)}>
       <SelectTrigger className="h-8 text-xs w-full" aria-label={`Role for ${driveName}`}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
         <SelectItem value={INHERIT_VALUE}>Inherit my access</SelectItem>
-        {callerRole !== 'MEMBER' && <SelectItem value={ADMIN_VALUE}>Admin</SelectItem>}
+        {showAdmin && <SelectItem value={ADMIN_VALUE}>Admin</SelectItem>}
         <SelectItem value={MEMBER_VALUE}>Member</SelectItem>
         {roles && roles.length > 0 && (
           <>
@@ -771,7 +777,9 @@ export default function MCPSettingsView() {
                     {token.driveScopes && token.driveScopes.length > 0 && (
                       <div className="text-xs text-muted-foreground">
                         Access: {token.driveScopes.map(d => {
-                          const roleLabel = d.role === 'ADMIN' ? 'Admin' : d.customRoleName || null;
+                          const roleLabel = d.role === 'ADMIN'
+                            ? 'Admin'
+                            : d.customRoleName || (d.role === 'MEMBER' ? 'Member' : null);
                           return roleLabel ? `${d.name} (${roleLabel})` : d.name;
                         }).join(', ')}
                       </div>

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -1,12 +1,20 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   Dialog,
   DialogContent,
@@ -21,15 +29,18 @@ import {
   AlertDescription,
 } from '@/components/ui/alert';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Trash2, Copy, Plus, Eye, EyeOff, Key, Terminal, Check, Download, AlertTriangle, ArrowLeft, Shield, Code2 } from 'lucide-react';
+import { Trash2, Copy, Plus, Eye, EyeOff, Key, Terminal, Check, Download, AlertTriangle, ArrowLeft, Shield, Code2, Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import { useRouter } from 'next/navigation';
-import { post, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 interface DriveScope {
   id: string;
   name: string;
+  role: 'ADMIN' | 'MEMBER' | null;
+  customRoleId?: string | null;
+  customRoleName?: string | null;
 }
 
 interface MCPToken {
@@ -49,6 +60,73 @@ interface Drive {
   id: string;
   name: string;
   slug: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+}
+
+interface DriveRoleOption {
+  id: string;
+  name: string;
+  color?: string | null;
+}
+
+interface DriveRoleSelection {
+  role: 'ADMIN' | 'MEMBER' | null;
+  customRoleId?: string | null;
+}
+
+const INHERIT_VALUE = 'INHERIT';
+const ADMIN_VALUE = 'ADMIN';
+const MEMBER_VALUE = 'MEMBER';
+
+function selectValueForRole(selection: DriveRoleSelection | undefined): string {
+  if (!selection || selection.role === null) return INHERIT_VALUE;
+  if (selection.role === 'ADMIN') return ADMIN_VALUE;
+  if (selection.customRoleId) return selection.customRoleId;
+  return MEMBER_VALUE;
+}
+
+function roleSelectionFromValue(value: string): DriveRoleSelection {
+  if (value === INHERIT_VALUE) return { role: null, customRoleId: null };
+  if (value === ADMIN_VALUE) return { role: 'ADMIN', customRoleId: null };
+  if (value === MEMBER_VALUE) return { role: 'MEMBER', customRoleId: null };
+  return { role: 'MEMBER', customRoleId: value };
+}
+
+function DriveRoleSelect({
+  driveId,
+  driveName,
+  callerRole,
+  selection,
+  roles,
+  onChange,
+}: {
+  driveId: string;
+  driveName: string;
+  callerRole: 'OWNER' | 'ADMIN' | 'MEMBER';
+  selection: DriveRoleSelection | undefined;
+  roles: DriveRoleOption[] | undefined;
+  onChange: (driveId: string, value: string) => void;
+}) {
+  return (
+    <Select value={selectValueForRole(selection)} onValueChange={(value) => onChange(driveId, value)}>
+      <SelectTrigger className="h-8 text-xs w-full" aria-label={`Role for ${driveName}`}>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={INHERIT_VALUE}>Inherit my access</SelectItem>
+        {callerRole !== 'MEMBER' && <SelectItem value={ADMIN_VALUE}>Admin</SelectItem>}
+        <SelectItem value={MEMBER_VALUE}>Member</SelectItem>
+        {roles && roles.length > 0 && (
+          <>
+            <SelectSeparator />
+            {roles.map((role) => (
+              <SelectItem key={role.id} value={role.id}>{role.name}</SelectItem>
+            ))}
+          </>
+        )}
+      </SelectContent>
+    </Select>
+  );
 }
 
 function CopyButton({ text, label }: { text: string; label?: string }) {
@@ -179,6 +257,14 @@ export default function MCPSettingsView() {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [newTokenName, setNewTokenName] = useState('');
   const [selectedDriveIds, setSelectedDriveIds] = useState<string[]>([]);
+  const [newDriveRoles, setNewDriveRoles] = useState<Record<string, DriveRoleSelection>>({});
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [editingTokenId, setEditingTokenId] = useState<string | null>(null);
+  const [editSelectedDriveIds, setEditSelectedDriveIds] = useState<string[]>([]);
+  const [editDriveRoles, setEditDriveRoles] = useState<Record<string, DriveRoleSelection>>({});
+  const [editingScopes, setEditingScopes] = useState(false);
+  const [driveRolesByDriveId, setDriveRolesByDriveId] = useState<Record<string, DriveRoleOption[]>>({});
+  const loadedRoleDriveIdsRef = useRef<Set<string>>(new Set());
   const [newToken, setNewToken] = useState<NewToken | null>(null);
   const [showNewToken, setShowNewToken] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -189,6 +275,28 @@ export default function MCPSettingsView() {
     loadTokens();
     loadDrives();
   }, []);
+
+  const ensureDriveRolesLoaded = async (driveId: string) => {
+    if (loadedRoleDriveIdsRef.current.has(driveId)) return;
+    loadedRoleDriveIdsRef.current.add(driveId);
+    try {
+      const response = await fetchWithAuth(`/api/drives/${driveId}/roles`);
+      if (response.ok) {
+        const { roles } = await response.json();
+        setDriveRolesByDriveId(prev => ({
+          ...prev,
+          [driveId]: (roles as { id: string; name: string; color: string | null }[]).map(role => ({
+            id: role.id,
+            name: role.name,
+            color: role.color,
+          })),
+        }));
+      }
+    } catch (error) {
+      console.error('Error loading drive roles:', error);
+      loadedRoleDriveIdsRef.current.delete(driveId);
+    }
+  };
 
   const loadTokens = async () => {
     try {
@@ -220,6 +328,25 @@ export default function MCPSettingsView() {
     }
   };
 
+  const buildDriveScopes = (
+    driveIds: string[],
+    roleSelections: Record<string, DriveRoleSelection>
+  ): DriveScope[] =>
+    driveIds.map(id => {
+      const drive = drives.find(d => d.id === id);
+      const selection = roleSelections[id] ?? { role: null, customRoleId: null };
+      const customRole = selection.customRoleId
+        ? driveRolesByDriveId[id]?.find(r => r.id === selection.customRoleId)
+        : undefined;
+      return {
+        id,
+        name: drive?.name || 'Unknown',
+        role: selection.role,
+        customRoleId: selection.customRoleId ?? null,
+        customRoleName: customRole?.name ?? null,
+      };
+    });
+
   const createToken = async () => {
     if (!newTokenName.trim()) {
       toast.error('Please enter a name for the token');
@@ -228,9 +355,15 @@ export default function MCPSettingsView() {
 
     setCreating(true);
     try {
-      const payload: { name: string; driveIds?: string[] } = { name: newTokenName.trim() };
+      const payload: {
+        name: string;
+        drives?: { id: string; role: 'ADMIN' | 'MEMBER' | null; customRoleId?: string }[];
+      } = { name: newTokenName.trim() };
       if (selectedDriveIds.length > 0) {
-        payload.driveIds = selectedDriveIds;
+        payload.drives = selectedDriveIds.map(id => {
+          const selection = newDriveRoles[id] ?? { role: null, customRoleId: null };
+          return { id, role: selection.role, customRoleId: selection.customRoleId ?? undefined };
+        });
       }
 
       const token = await post<NewToken>('/api/auth/mcp-tokens', payload);
@@ -239,10 +372,7 @@ export default function MCPSettingsView() {
       const tokenWithScopes: MCPToken = {
         ...token,
         isScoped: selectedDriveIds.length > 0,
-        driveScopes: selectedDriveIds.map(id => {
-          const drive = drives.find(d => d.id === id);
-          return { id, name: drive?.name || 'Unknown' };
-        }),
+        driveScopes: buildDriveScopes(selectedDriveIds, newDriveRoles),
       };
 
       setNewToken(token);
@@ -254,6 +384,7 @@ export default function MCPSettingsView() {
       }
       setNewTokenName('');
       setSelectedDriveIds([]);
+      setNewDriveRoles({});
       setCreateDialogOpen(false);
       setShowNewToken(true);
       toast.success('MCP token created successfully');
@@ -266,11 +397,15 @@ export default function MCPSettingsView() {
   };
 
   const toggleDriveSelection = (driveId: string) => {
-    setSelectedDriveIds(prev =>
-      prev.includes(driveId)
-        ? prev.filter(id => id !== driveId)
-        : [...prev, driveId]
-    );
+    setSelectedDriveIds(prev => {
+      if (prev.includes(driveId)) return prev.filter(id => id !== driveId);
+      ensureDriveRolesLoaded(driveId);
+      return [...prev, driveId];
+    });
+  };
+
+  const setNewDriveRole = (driveId: string, value: string) => {
+    setNewDriveRoles(prev => ({ ...prev, [driveId]: roleSelectionFromValue(value) }));
   };
 
   const deleteToken = async (tokenId: string) => {
@@ -282,6 +417,67 @@ export default function MCPSettingsView() {
     } catch (error) {
       console.error('Error deleting MCP token:', error);
       toast.error(error instanceof Error ? error.message : 'Failed to delete token');
+    }
+  };
+
+  const openEditDialog = (token: MCPToken) => {
+    setEditingTokenId(token.id);
+    setEditSelectedDriveIds(token.driveScopes.map(scope => scope.id));
+    const roles: Record<string, DriveRoleSelection> = {};
+    token.driveScopes.forEach(scope => {
+      roles[scope.id] = { role: scope.role, customRoleId: scope.customRoleId ?? null };
+      ensureDriveRolesLoaded(scope.id);
+    });
+    setEditDriveRoles(roles);
+    setEditDialogOpen(true);
+  };
+
+  const toggleEditDriveSelection = (driveId: string) => {
+    setEditSelectedDriveIds(prev => {
+      if (prev.includes(driveId)) return prev.filter(id => id !== driveId);
+      ensureDriveRolesLoaded(driveId);
+      return [...prev, driveId];
+    });
+  };
+
+  const setEditDriveRole = (driveId: string, value: string) => {
+    setEditDriveRoles(prev => ({ ...prev, [driveId]: roleSelectionFromValue(value) }));
+  };
+
+  const updateTokenScopes = async () => {
+    if (!editingTokenId) return;
+
+    setEditingScopes(true);
+    try {
+      const driveScopesPayload = editSelectedDriveIds.map(id => {
+        const selection = editDriveRoles[id] ?? { role: null, customRoleId: null };
+        return { id, role: selection.role, customRoleId: selection.customRoleId ?? undefined };
+      });
+
+      await patch<{ id: string; name: string; driveScopes: { id: string; name: string }[] }>(
+        `/api/auth/mcp-tokens/${editingTokenId}`,
+        { drives: driveScopesPayload }
+      );
+
+      // PATCH always sends an explicit drives array, so the token is always scoped
+      // afterward (even [] means "scoped to zero drives", not "unscoped") — unlike
+      // createToken()'s conditional isScoped, which reflects an omitted drives field.
+      const nextDriveScopes = buildDriveScopes(editSelectedDriveIds, editDriveRoles);
+      setTokens(prev => prev.map(t =>
+        t.id === editingTokenId
+          ? { ...t, driveScopes: nextDriveScopes, isScoped: true }
+          : t
+      ));
+      setEditDialogOpen(false);
+      setEditingTokenId(null);
+      setEditSelectedDriveIds([]);
+      setEditDriveRoles({});
+      toast.success('Token scopes updated successfully');
+    } catch (error) {
+      console.error('Error updating MCP token scopes:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to update token scopes');
+    } finally {
+      setEditingScopes(false);
     }
   };
 
@@ -410,6 +606,7 @@ export default function MCPSettingsView() {
               if (!open) {
                 setNewTokenName('');
                 setSelectedDriveIds([]);
+                setNewDriveRoles({});
               }
             }}>
             <DialogTrigger asChild>
@@ -454,20 +651,34 @@ export default function MCPSettingsView() {
                   </p>
 
                   {drives.length > 0 && (
-                    <div className="border rounded-md p-3 max-h-48 overflow-y-auto space-y-2">
+                    <div className="border rounded-md p-3 max-h-64 overflow-y-auto space-y-3">
                       {drives.map((drive) => (
-                        <div key={drive.id} className="flex items-center space-x-2">
-                          <Checkbox
-                            id={`drive-${drive.id}`}
-                            checked={selectedDriveIds.includes(drive.id)}
-                            onCheckedChange={() => toggleDriveSelection(drive.id)}
-                          />
-                          <label
-                            htmlFor={`drive-${drive.id}`}
-                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                          >
-                            {drive.name}
-                          </label>
+                        <div key={drive.id} className="space-y-1">
+                          <div className="flex items-center space-x-2">
+                            <Checkbox
+                              id={`drive-${drive.id}`}
+                              checked={selectedDriveIds.includes(drive.id)}
+                              onCheckedChange={() => toggleDriveSelection(drive.id)}
+                            />
+                            <label
+                              htmlFor={`drive-${drive.id}`}
+                              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1"
+                            >
+                              {drive.name}
+                            </label>
+                          </div>
+                          {selectedDriveIds.includes(drive.id) && (
+                            <div className="pl-6">
+                              <DriveRoleSelect
+                                driveId={drive.id}
+                                driveName={drive.name}
+                                callerRole={drive.role}
+                                selection={newDriveRoles[drive.id]}
+                                roles={driveRolesByDriveId[drive.id]}
+                                onChange={setNewDriveRole}
+                              />
+                            </div>
+                          )}
                         </div>
                       ))}
                     </div>
@@ -478,7 +689,10 @@ export default function MCPSettingsView() {
                       variant="ghost"
                       size="sm"
                       className="text-xs"
-                      onClick={() => setSelectedDriveIds([])}
+                      onClick={() => {
+                        setSelectedDriveIds([]);
+                        setNewDriveRoles({});
+                      }}
                     >
                       Clear selection (allow all drives)
                     </Button>
@@ -542,23 +756,124 @@ export default function MCPSettingsView() {
                     </div>
                     {token.driveScopes && token.driveScopes.length > 0 && (
                       <div className="text-xs text-muted-foreground">
-                        Access: {token.driveScopes.map(d => d.name).join(', ')}
+                        Access: {token.driveScopes.map(d => {
+                          const roleLabel = d.role === 'ADMIN' ? 'Admin' : d.customRoleName || null;
+                          return roleLabel ? `${d.name} (${roleLabel})` : d.name;
+                        }).join(', ')}
                       </div>
                     )}
                   </div>
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    onClick={() => deleteToken(token.id)}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      aria-label="Edit token scopes"
+                      onClick={() => openEditDialog(token)}
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => deleteToken(token.id)}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </div>
                 </div>
               </Card>
             ))}
           </div>
         )}
       </section>
+
+      {/* Edit Token Scopes */}
+      <Dialog open={editDialogOpen} onOpenChange={(open) => {
+          setEditDialogOpen(open);
+          if (!open) {
+            setEditingTokenId(null);
+            setEditSelectedDriveIds([]);
+            setEditDriveRoles({});
+          }
+        }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit Token Drive Scopes</DialogTitle>
+            <DialogDescription>
+              Change which drives this token can access.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Shield className="h-4 w-4 text-muted-foreground" />
+                <Label>Drive Access Scope</Label>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {editSelectedDriveIds.length === 0
+                  ? 'This token will have access to 0 drives.'
+                  : `This token will only have access to ${editSelectedDriveIds.length} selected drive${editSelectedDriveIds.length === 1 ? '' : 's'}.`}
+              </p>
+
+              {drives.length > 0 && (
+                <div className="border rounded-md p-3 max-h-64 overflow-y-auto space-y-3">
+                  {drives.map((drive) => (
+                    <div key={drive.id} className="space-y-1">
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id={`edit-drive-${drive.id}`}
+                          checked={editSelectedDriveIds.includes(drive.id)}
+                          onCheckedChange={() => toggleEditDriveSelection(drive.id)}
+                        />
+                        <label
+                          htmlFor={`edit-drive-${drive.id}`}
+                          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1"
+                        >
+                          {drive.name}
+                        </label>
+                      </div>
+                      {editSelectedDriveIds.includes(drive.id) && (
+                        <div className="pl-6">
+                          <DriveRoleSelect
+                            driveId={drive.id}
+                            driveName={drive.name}
+                            callerRole={drive.role}
+                            selection={editDriveRoles[drive.id]}
+                            roles={driveRolesByDriveId[drive.id]}
+                            onChange={setEditDriveRole}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {editSelectedDriveIds.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-xs"
+                  onClick={() => {
+                    setEditSelectedDriveIds([]);
+                    setEditDriveRoles({});
+                  }}
+                >
+                  Clear selection (revoke all access)
+                </Button>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={updateTokenScopes} disabled={editingScopes}>
+              {editingScopes ? "Saving..." : "Save Changes"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Quick Setup */}
       <Card>

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
@@ -191,6 +191,22 @@ describe('MCPSettingsView — edit token drive scopes', () => {
     expect(screen.queryByRole('option', { name: /^admin$/i })).not.toBeInTheDocument();
   });
 
+  it('still shows Admin as the current value on a Member-ceiling drive if it was already granted', async () => {
+    // Edge case: Admin was granted while the caller had higher access, and they've
+    // since been downgraded to Member on that drive. The scope is still in effect
+    // server-side, so the picker must reflect it rather than showing a blank trigger.
+    await renderView(
+      [{ ...tokenA(), driveScopes: [{ id: DRIVE_MEMBER_ONLY.id, name: DRIVE_MEMBER_ONLY.name, role: 'ADMIN', customRoleId: null, customRoleName: null }] }],
+      [DRIVE_MEMBER_ONLY]
+    );
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+
+    const roleSelect = screen.getByRole('combobox', { name: /role for drive three/i });
+    expect(roleSelect).toHaveTextContent(/^admin$/i);
+  });
+
   it('lists the drive’s custom roles (fetched from /api/drives/:id/roles) and submits the chosen customRoleId', async () => {
     patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
     await renderView();
@@ -238,6 +254,20 @@ describe('MCPSettingsView — edit token drive scopes', () => {
     await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
 
     await waitFor(() => expect(within(getCardFor('Token A')).getByText(/Access:/)).toHaveTextContent('Drive One (Admin)'));
+  });
+
+  it('labels an explicit Member scope distinctly from inherit in the row summary', async () => {
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await selectRoleOption('drive one', /^member$/i);
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    // Distinguishes an explicit Member downgrade from the default "inherit my access"
+    // (role: null), which renders with no suffix at all.
+    await waitFor(() => expect(within(getCardFor('Token A')).getByText(/Access:/)).toHaveTextContent('Drive One (Member)'));
   });
 
   it('on rejection keeps the dialog open, toasts an error, and leaves token state unchanged', async () => {

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const fetchWithAuthMock = vi.fn();
+const postMock = vi.fn();
+const patchMock = vi.fn();
+const delMock = vi.fn();
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+  post: (...args: unknown[]) => postMock(...args),
+  patch: (...args: unknown[]) => patchMock(...args),
+  del: (...args: unknown[]) => delMock(...args),
+}));
+
+import MCPSettingsView from '../MCPSettingsView';
+import { toast } from 'sonner';
+
+// jsdom doesn't implement these; Radix Select's pointer-interaction internals need them.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+const DRIVE_ONE = { id: 'drive-1', name: 'Drive One', slug: 'drive-one', role: 'OWNER' as const };
+const DRIVE_TWO = { id: 'drive-2', name: 'Drive Two', slug: 'drive-two', role: 'OWNER' as const };
+const DRIVE_MEMBER_ONLY = { id: 'drive-3', name: 'Drive Three', slug: 'drive-three', role: 'MEMBER' as const };
+
+const CUSTOM_ROLE = { id: 'role-support', name: 'Support', color: 'blue' };
+
+const tokenA = () => ({
+  id: 'token-1',
+  name: 'Token A',
+  lastUsed: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  isScoped: true,
+  driveScopes: [{ id: DRIVE_ONE.id, name: DRIVE_ONE.name, role: null, customRoleId: null, customRoleName: null }],
+});
+
+const tokenB = () => ({
+  id: 'token-2',
+  name: 'Token B',
+  lastUsed: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  isScoped: true,
+  driveScopes: [{ id: DRIVE_TWO.id, name: DRIVE_TWO.name, role: null, customRoleId: null, customRoleName: null }],
+});
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const cannedFetch = (tokens: unknown[], drives: unknown[] = [DRIVE_ONE, DRIVE_TWO]) =>
+  fetchWithAuthMock.mockImplementation(async (...args: unknown[]) => {
+    const url = String(args[0]);
+    if (url.startsWith('/api/auth/mcp-tokens')) {
+      return jsonResponse(tokens);
+    }
+    if (/\/api\/drives\/[^/]+\/roles$/.test(url)) {
+      return jsonResponse({ roles: [CUSTOM_ROLE] });
+    }
+    if (url.startsWith('/api/drives')) {
+      return jsonResponse(drives);
+    }
+    return jsonResponse({});
+  });
+
+const renderView = async (tokens: unknown[] = [tokenA(), tokenB()], drives: unknown[] = [DRIVE_ONE, DRIVE_TWO]) => {
+  cannedFetch(tokens, drives);
+  render(<MCPSettingsView />);
+  await waitFor(() => expect(screen.getByText('Token A')).toBeInTheDocument());
+};
+
+const getCardFor = (tokenName: string) =>
+  screen.getByText(tokenName).closest('.p-4') as HTMLElement;
+
+// Radix Select portals its listbox to document.body, as a sibling of the Dialog's
+// own portal — not a descendant — so options must be queried at the document level.
+const selectRoleOption = async (driveLabel: string, optionName: RegExp) => {
+  await userEvent.click(screen.getByRole('combobox', { name: new RegExp(`role for ${driveLabel}`, 'i') }));
+  await userEvent.click(await screen.findByRole('option', { name: optionName }));
+};
+
+describe('MCPSettingsView — edit token drive scopes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an edit-scopes button per token row alongside delete', async () => {
+    await renderView();
+
+    const cardA = getCardFor('Token A');
+    expect(within(cardA).getByRole('button', { name: /edit token scopes/i })).toBeInTheDocument();
+    expect(within(cardA).getAllByRole('button')).toHaveLength(2); // edit + delete
+  });
+
+  it('pre-checks boxes matching the token’s current drive scopes when opened', async () => {
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    expect(within(dialog).getByLabelText('Drive One')).toBeChecked();
+    expect(within(dialog).getByLabelText('Drive Two')).not.toBeChecked();
+  });
+
+  it('shows a role select (defaulting to inherit) for each checked drive', async () => {
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+
+    const roleSelect = within(dialog).getByRole('combobox', { name: /role for drive one/i });
+    expect(roleSelect).toHaveTextContent(/inherit/i);
+    // Drive Two isn't checked, so it has no role select yet.
+    expect(within(dialog).queryByRole('combobox', { name: /role for drive two/i })).not.toBeInTheDocument();
+  });
+
+  it('submits the updated drives array (role + customRoleId) via patch, including the explicit empty-array case', async () => {
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await userEvent.click(within(dialog).getByLabelText('Drive Two'));
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(patchMock).toHaveBeenCalledWith('/api/auth/mcp-tokens/token-1', {
+        drives: [
+          { id: DRIVE_ONE.id, role: null, customRoleId: undefined },
+          { id: DRIVE_TWO.id, role: null, customRoleId: undefined },
+        ],
+      })
+    );
+
+    // Clearing all selections submits an explicit empty array, not an omitted field.
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog2 = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await userEvent.click(within(dialog2).getByRole('button', { name: /clear selection/i }));
+    await userEvent.click(within(dialog2).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(patchMock).toHaveBeenCalledWith('/api/auth/mcp-tokens/token-1', { drives: [] })
+    );
+  });
+
+  it('lets the caller pick Admin for a drive they own, and sends it in the PATCH body', async () => {
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+
+    await selectRoleOption('drive one', /^admin$/i);
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(patchMock).toHaveBeenCalledWith('/api/auth/mcp-tokens/token-1', {
+        drives: [{ id: DRIVE_ONE.id, role: 'ADMIN', customRoleId: undefined }],
+      })
+    );
+  });
+
+  it('hides the Admin option for a drive where the caller is only a Member', async () => {
+    await renderView([{ ...tokenA(), driveScopes: [{ id: DRIVE_MEMBER_ONLY.id, name: DRIVE_MEMBER_ONLY.name, role: null, customRoleId: null, customRoleName: null }] }], [DRIVE_MEMBER_ONLY]);
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+
+    await userEvent.click(screen.getByRole('combobox', { name: /role for drive three/i }));
+    expect(await screen.findByRole('option', { name: /^member$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^admin$/i })).not.toBeInTheDocument();
+  });
+
+  it('lists the drive’s custom roles (fetched from /api/drives/:id/roles) and submits the chosen customRoleId', async () => {
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+
+    await waitFor(() => expect(fetchWithAuthMock).toHaveBeenCalledWith(`/api/drives/${DRIVE_ONE.id}/roles`));
+    await selectRoleOption('drive one', /support/i);
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(patchMock).toHaveBeenCalledWith('/api/auth/mcp-tokens/token-1', {
+        drives: [{ id: DRIVE_ONE.id, role: 'MEMBER', customRoleId: CUSTOM_ROLE.id }],
+      })
+    );
+  });
+
+  it('on success closes the dialog, toasts, and updates the row without a refetch', async () => {
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+    fetchWithAuthMock.mockClear();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await userEvent.click(within(dialog).getByLabelText('Drive Two'));
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/scopes updated/i)));
+    expect(screen.queryByRole('dialog', { name: /edit token drive scopes/i })).not.toBeInTheDocument();
+    expect(within(getCardFor('Token A')).getByText(/Access:/)).toHaveTextContent('Drive One, Drive Two');
+
+    // No refetch of the token list happened — the row updated locally, not from a refetch.
+    const refetchCalls = fetchWithAuthMock.mock.calls.filter(([url]) => String(url).startsWith('/api/auth/mcp-tokens'));
+    expect(refetchCalls).toHaveLength(0);
+  });
+
+  it('shows an Admin badge in the row summary once a drive scope is granted Admin', async () => {
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await selectRoleOption('drive one', /^admin$/i);
+    await userEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(within(getCardFor('Token A')).getByText(/Access:/)).toHaveTextContent('Drive One (Admin)'));
+  });
+
+  it('on rejection keeps the dialog open, toasts an error, and leaves token state unchanged', async () => {
+    patchMock.mockRejectedValueOnce(new Error('Some drives are not accessible'));
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await userEvent.click(within(dialog).getByLabelText('Drive Two'));
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Some drives are not accessible'));
+    expect(screen.getByRole('dialog', { name: /edit token drive scopes/i })).toBeInTheDocument();
+    expect(within(getCardFor('Token A')).getByText(/Access:/)).toHaveTextContent('Drive One');
+  });
+
+  it('editing token A does not affect token B’s checkbox state', async () => {
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    let dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await userEvent.click(within(dialog).getByLabelText('Drive Two'));
+    expect(within(dialog).getByLabelText('Drive One')).toBeChecked();
+    expect(within(dialog).getByLabelText('Drive Two')).toBeChecked();
+    await userEvent.click(within(dialog).getByRole('button', { name: /cancel/i }));
+
+    await userEvent.click(within(getCardFor('Token B')).getByRole('button', { name: /edit token scopes/i }));
+    dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    expect(within(dialog).getByLabelText('Drive One')).not.toBeChecked();
+    expect(within(dialog).getByLabelText('Drive Two')).toBeChecked();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/__tests__/MCPSettingsView.test.tsx
@@ -52,6 +52,15 @@ const tokenB = () => ({
   driveScopes: [{ id: DRIVE_TWO.id, name: DRIVE_TWO.name, role: null, customRoleId: null, customRoleName: null }],
 });
 
+const unscopedToken = () => ({
+  id: 'token-unscoped',
+  name: 'All-Drives Token',
+  lastUsed: null,
+  createdAt: '2026-01-01T00:00:00Z',
+  isScoped: false,
+  driveScopes: [],
+});
+
 const jsonResponse = (body: unknown) =>
   new Response(JSON.stringify(body), {
     status: 200,
@@ -76,7 +85,7 @@ const cannedFetch = (tokens: unknown[], drives: unknown[] = [DRIVE_ONE, DRIVE_TW
 const renderView = async (tokens: unknown[] = [tokenA(), tokenB()], drives: unknown[] = [DRIVE_ONE, DRIVE_TWO]) => {
   cannedFetch(tokens, drives);
   render(<MCPSettingsView />);
-  await waitFor(() => expect(screen.getByText('Token A')).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByRole('heading', { name: 'Your Tokens' })).toBeInTheDocument());
 };
 
 const getCardFor = (tokenName: string) =>
@@ -243,6 +252,46 @@ describe('MCPSettingsView — edit token drive scopes', () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Some drives are not accessible'));
     expect(screen.getByRole('dialog', { name: /edit token drive scopes/i })).toBeInTheDocument();
     expect(within(getCardFor('Token A')).getByText(/Access:/)).toHaveTextContent('Drive One');
+  });
+
+  it('warns before silently converting an unscoped (all-drives) token to zero access', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await renderView([unscopedToken()]);
+
+    await userEvent.click(within(getCardFor('All-Drives Token')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    expect(dialog).toHaveTextContent(/currently has access to all your drives/i);
+
+    // Pressing Save with nothing selected must prompt for confirmation before
+    // silently downgrading an all-drives token to a zero-drive token.
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringMatching(/ALL your drives/));
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog', { name: /edit token drive scopes/i })).toBeInTheDocument();
+
+    // Confirming proceeds with the explicit empty-array revoke.
+    confirmSpy.mockReturnValue(true);
+    patchMock.mockResolvedValueOnce({ id: 'token-unscoped', name: 'All-Drives Token', driveScopes: [] });
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(patchMock).toHaveBeenCalledWith('/api/auth/mcp-tokens/token-unscoped', { drives: [] })
+    );
+    confirmSpy.mockRestore();
+  });
+
+  it('does not prompt for confirmation when saving an already-scoped token with a non-empty selection', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    patchMock.mockResolvedValueOnce({ id: 'token-1', name: 'Token A', driveScopes: [] });
+    await renderView();
+
+    await userEvent.click(within(getCardFor('Token A')).getByRole('button', { name: /edit token scopes/i }));
+    const dialog = await screen.findByRole('dialog', { name: /edit token drive scopes/i });
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(patchMock).toHaveBeenCalled());
+    expect(confirmSpy).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 
   it('editing token A does not affect token B’s checkbox state', async () => {

--- a/apps/web/src/lib/repositories/session-repository.ts
+++ b/apps/web/src/lib/repositories/session-repository.ts
@@ -111,10 +111,13 @@ export const sessionRepository = {
       },
       with: {
         driveScopes: {
-          columns: { driveId: true },
+          columns: { driveId: true, role: true, customRoleId: true },
           with: {
             drive: {
               columns: { id: true, name: true },
+            },
+            customRole: {
+              columns: { id: true, name: true, color: true },
             },
           },
         },
@@ -132,6 +135,9 @@ export const sessionRepository = {
         .map((scope) => ({
           id: scope.drive.id,
           name: scope.drive.name,
+          role: scope.role,
+          customRoleId: scope.customRoleId,
+          customRoleName: scope.customRole?.name ?? null,
         })),
     }));
   },


### PR DESCRIPTION
## Summary

Closes out the "Edit MCP Token Drive Scopes (Post-Creation)" epic's last remaining task (T4). PR #1745 shipped the backend-only `PATCH /api/auth/mcp-tokens/[tokenId]` endpoint with its own description explicitly deferring the UI: *"Frontend UI — separate PR. The API is ready for the frontend team to wire up."*

- Adds an **edit-scopes** action to each token row in `MCPSettingsView.tsx`, opening a dialog wired to the PATCH endpoint via the existing `patch()` auth-fetch helper. Local token state updates in place on success (no refetch).
- Adds a **per-drive role picker** (Inherit / Admin / Member / custom role) to both the create and edit dialogs, matching the value-encoding pattern already used by `AppMemberRow.tsx`. The Admin option is hidden for drives where the caller's own role is `MEMBER` (unless that drive's scope already has Admin in effect — see below), mirroring `validateDriveScopeAccess`'s server-side rule. Custom roles are fetched lazily from `GET /api/drives/:id/roles`.
- `session-repository.ts`'s `findUserMcpTokensWithDrives` now also selects `role`/`customRoleId` (+ the custom role's name) per drive scope, so the edit dialog can correctly prefill a token's existing scopes.
- Both create and edit flows now submit the richer `drives: [{id, role, customRoleId}]` shape instead of the legacy `driveIds`-only shape.

### Follow-up fixes (post-review)

- **Fixed a real bug** flagged by review (chatgpt-codex-connector, P2): opening the edit dialog for an unscoped ("all drives") token seeds zero selected drives; saving without any change used to silently send `drives: []` and mark the token scoped — converting all-drives access into no-access. Now requires an explicit `window.confirm()` before that specific conversion, and the dialog copy warns about it up front.
- Proactive self-review caught two more small correctness/clarity gaps: the Admin option could become invisible-but-still-in-effect if a caller's own drive role was later downgraded (now always shown when it's the current value), and an explicit `MEMBER` scope was visually indistinguishable from `inherit` in the row summary (now labeled `(Member)`).

## Test plan

- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bunx eslint` on all changed files — clean
- [x] `MCPSettingsView.test.tsx` (15 tests) covering: edit dialog rendering, drive-scope pre-checking, role-select defaults, Admin-hiding for Member-only drives (and its current-value exception), custom-role fetch/selection, the unscoped-token confirm guard, Member-vs-inherit labeling, success/error paths, and per-token dialog-state isolation — all passing
- [x] Existing `mcp-tokens` backend route tests (45 tests) + broader `drives`/`repositories` regression suite (865 tests) — all passing, no regressions
- [x] CI (`Lint & TypeScript Check`, `Unit Tests`) green on the latest commit
- [ ] Manual browser verification not done this session (not running locally) — recommend clicking through create → edit → role change → save, and the unscoped-token confirm prompt, on a real token before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018cTthjpC1vuCpgN15jqQn5