### PR TITLE
fix(notifications): drop dead type guards, fix nested-button a11y

### DIFF
--- a/apps/web/src/components/notifications/NotificationToast.tsx
+++ b/apps/web/src/components/notifications/NotificationToast.tsx
@@ -23,29 +23,28 @@ export function NotificationToast({ notification, onSelect, onDismiss }: Notific
     <article
       data-testid="notification-toast"
       data-notification-type={notification.type}
-      role="button"
-      tabIndex={0}
-      aria-label={`${notification.title}. ${notification.message}`}
-      onClick={onSelect}
-      onKeyDown={(event) => {
-        if (event.target !== event.currentTarget) return;
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          onSelect();
-        }
-      }}
       className={cn(
         'group relative flex w-[380px] max-w-[calc(100vw-2rem)] items-start gap-3',
         'rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-lg',
-        'cursor-pointer transition-colors hover:bg-accent hover:text-accent-foreground',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        'transition-colors hover:bg-accent hover:text-accent-foreground',
       )}
     >
+      {/* Full-card activation target, painted below the dismiss button so it
+          doesn't capture the corner clicks — avoids nesting a <button> inside
+          a role="button" element while keeping the whole card clickable. */}
+      <button
+        type="button"
+        data-testid="notification-toast-select"
+        aria-label={`${notification.title}. ${notification.message}`}
+        onClick={onSelect}
+        className="absolute inset-0 z-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+
       <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
         <Icon className="size-4" aria-hidden />
       </div>
 
-      <div className="min-w-0 flex-1 pr-6">
+      <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-semibold leading-5 text-foreground">
           {notification.title}
         </p>
@@ -68,11 +67,8 @@ export function NotificationToast({ notification, onSelect, onDismiss }: Notific
       <button
         type="button"
         aria-label="Dismiss notification"
-        className="absolute right-2 top-2 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-70 hover:bg-accent hover:text-accent-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        onClick={(event) => {
-          event.stopPropagation();
-          onDismiss();
-        }}
+        className="relative z-10 flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-70 hover:bg-accent hover:text-accent-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={onDismiss}
       >
         <X className="size-3.5" aria-hidden />
       </button>

--- a/apps/web/src/components/notifications/__tests__/NotificationToast.test.tsx
+++ b/apps/web/src/components/notifications/__tests__/NotificationToast.test.tsx
@@ -70,24 +70,10 @@ describe('NotificationToast', () => {
     expect(screen.queryByText(/^by /)).not.toBeInTheDocument();
   });
 
-  it('invokes onSelect when clicked', () => {
+  it('invokes onSelect when the card is clicked', () => {
     const onSelect = vi.fn();
     render(<NotificationToast notification={build()} onSelect={onSelect} onDismiss={vi.fn()} />);
-    fireEvent.click(screen.getByTestId('notification-toast'));
-    expect(onSelect).toHaveBeenCalledTimes(1);
-  });
-
-  it('invokes onSelect on Enter keypress', () => {
-    const onSelect = vi.fn();
-    render(<NotificationToast notification={build()} onSelect={onSelect} onDismiss={vi.fn()} />);
-    fireEvent.keyDown(screen.getByTestId('notification-toast'), { key: 'Enter' });
-    expect(onSelect).toHaveBeenCalledTimes(1);
-  });
-
-  it('invokes onSelect on Space keypress', () => {
-    const onSelect = vi.fn();
-    render(<NotificationToast notification={build()} onSelect={onSelect} onDismiss={vi.fn()} />);
-    fireEvent.keyDown(screen.getByTestId('notification-toast'), { key: ' ' });
+    fireEvent.click(screen.getByTestId('notification-toast-select'));
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
@@ -100,11 +86,10 @@ describe('NotificationToast', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it('does not invoke onSelect when Enter is pressed on the nested dismiss button (bubbled event)', () => {
-    const onSelect = vi.fn();
-    render(<NotificationToast notification={build()} onSelect={onSelect} onDismiss={vi.fn()} />);
+  it('does not nest the dismiss button inside the card activation button', () => {
+    render(<NotificationToast notification={build()} onSelect={vi.fn()} onDismiss={vi.fn()} />);
+    const selectButton = screen.getByTestId('notification-toast-select');
     const dismissButton = screen.getByRole('button', { name: /dismiss notification/i });
-    fireEvent.keyDown(dismissButton, { key: 'Enter', bubbles: true });
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(selectButton).not.toContainElement(dismissButton);
   });
 });

--- a/packages/lib/src/notifications/__tests__/guards.test.ts
+++ b/packages/lib/src/notifications/__tests__/guards.test.ts
@@ -11,8 +11,6 @@ import {
   isDriveInvited,
   isDriveJoined,
   isDriveRoleChanged,
-  isMention,
-  isTaskAssigned,
   hasMetadataField,
 } from '../guards';
 import type { LegacyNotification } from '../types';
@@ -361,66 +359,6 @@ describe('isDriveRoleChanged', () => {
   it('returns false when metadata is missing driveName key', () => {
     const n = base({ type: 'DRIVE_ROLE_CHANGED', metadata: { previousRole: 'MEMBER' } });
     expect(isDriveRoleChanged(n)).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// isMention
-// ---------------------------------------------------------------------------
-describe('isMention', () => {
-  it('returns true for matching type with mentionerName key', () => {
-    const n = base({ type: 'MENTION', metadata: { mentionerName: 'Jane', pageTitle: 'Roadmap', pageType: 'DOCUMENT' } });
-    expect(isMention(n)).toBe(true);
-  });
-
-  it('returns false for wrong type', () => {
-    const n = base({ type: 'TASK_ASSIGNED', metadata: { mentionerName: 'Jane' } });
-    expect(isMention(n)).toBe(false);
-  });
-
-  it('returns false when metadata is undefined', () => {
-    const n = base({ type: 'MENTION', metadata: undefined });
-    expect(isMention(n)).toBe(false);
-  });
-
-  it('returns false when metadata is null', () => {
-    const n = base({ type: 'MENTION', metadata: null as unknown as undefined });
-    expect(isMention(n)).toBe(false);
-  });
-
-  it('returns false when metadata is missing mentionerName key', () => {
-    const n = base({ type: 'MENTION', metadata: { pageTitle: 'Roadmap' } });
-    expect(isMention(n)).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// isTaskAssigned
-// ---------------------------------------------------------------------------
-describe('isTaskAssigned', () => {
-  it('returns true for matching type with taskId key', () => {
-    const n = base({ type: 'TASK_ASSIGNED', metadata: { taskId: 't1', taskTitle: 'Ship it', assignerName: 'Jane' } });
-    expect(isTaskAssigned(n)).toBe(true);
-  });
-
-  it('returns false for wrong type', () => {
-    const n = base({ type: 'MENTION', metadata: { taskId: 't1' } });
-    expect(isTaskAssigned(n)).toBe(false);
-  });
-
-  it('returns false when metadata is undefined', () => {
-    const n = base({ type: 'TASK_ASSIGNED', metadata: undefined });
-    expect(isTaskAssigned(n)).toBe(false);
-  });
-
-  it('returns false when metadata is null', () => {
-    const n = base({ type: 'TASK_ASSIGNED', metadata: null as unknown as undefined });
-    expect(isTaskAssigned(n)).toBe(false);
-  });
-
-  it('returns false when metadata is missing taskId key', () => {
-    const n = base({ type: 'TASK_ASSIGNED', metadata: { taskTitle: 'Ship it' } });
-    expect(isTaskAssigned(n)).toBe(false);
   });
 });
 

--- a/packages/lib/src/notifications/guards.ts
+++ b/packages/lib/src/notifications/guards.ts
@@ -12,8 +12,6 @@ import type {
   DriveInvitedNotification,
   DriveJoinedNotification,
   DriveRoleChangedNotification,
-  MentionNotification,
-  TaskAssignedNotification,
   LegacyNotification,
 } from './types';
 
@@ -119,26 +117,6 @@ export function isDriveRoleChanged(
     notification.metadata != null &&
     typeof notification.metadata === 'object' &&
     'driveName' in notification.metadata;
-}
-
-// Mention guard
-export function isMention(
-  notification: Notification | LegacyNotification
-): notification is MentionNotification {
-  return notification.type === 'MENTION' &&
-    notification.metadata != null &&
-    typeof notification.metadata === 'object' &&
-    'mentionerName' in notification.metadata;
-}
-
-// Task assignment guard
-export function isTaskAssigned(
-  notification: Notification | LegacyNotification
-): notification is TaskAssignedNotification {
-  return notification.type === 'TASK_ASSIGNED' &&
-    notification.metadata != null &&
-    typeof notification.metadata === 'object' &&
-    'taskId' in notification.metadata;
 }
 
 // Helper to check if a notification has a specific metadata field


### PR DESCRIPTION
## Summary
Follow-up from the review of #1785 (Discord/Slack-style toast preference tier). Two minor findings, no functional/behavioral change to the feature itself:

- **Dead code**: `isMention` / `isTaskAssigned` were added to `packages/lib/src/notifications/guards.ts` alongside the toast feature but nothing calls them — `toast-eligible-types.ts` and `resolve-destination.ts` both do their own inline `notification.type === 'MENTION'` checks. Removed the two guards and their tests.
- **A11y**: `NotificationToast` nested a real `<button>` (dismiss) inside a `role="button"` `<article>` — invalid ARIA widget nesting, and required a manual `onKeyDown` handler to make the outer div keyboard-accessible in the first place. Restructured to a "stretched button" pattern: a full-card `<button>` handles select, painted below the dismiss button in stacking order (`z-0` vs `z-10`) so dismiss clicks still resolve correctly. The two actions are now siblings, not nested, and keyboard activation is native (no custom key handling needed).

## Test plan
- [x] `bun run --filter web typecheck` — clean
- [x] `bun run --filter '@pagespace/lib' typecheck` — clean
- [x] `eslint` on both changed source files — clean
- [x] `vitest run` on `NotificationToast.test.tsx`, `guards.test.ts`, `useNotificationToasts.test.tsx`, `NotificationItem.test.tsx` — all passing (updated the two tests that exercised the old nested-keydown behavior; added a regression test asserting the dismiss button is not a descendant of the select button)