### PR TITLE
feat(sdk): server-side API version contract (ADR 0001 D1/D2) + composed SDK<->server test

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -122,7 +122,8 @@ export async function middleware(req: NextRequest) {
       pathname === '/api/memory/cron' ||
       pathname === '/api/pulse/cron' ||
       pathname === '/api/integrations/zoom/webhook' ||
-      pathname === '/api/health'
+      pathname === '/api/health' ||
+      pathname === '/api/version'
     ) {
       const { response } = createSecureResponse(isProduction, req, { isAPIRoute });
       return response;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -128,6 +128,7 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@pagespace/sdk": "workspace:*",
     "@capacitor/app": "^7.1.1",
     "@capacitor/browser": "^7.0.3",
     "@capacitor/core": "^7.0.0",

--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -33,6 +33,7 @@ const AUDIT_CALL_PATTERN =
 const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   // --- Public/unauthenticated endpoints (no user context to audit) ---
   ['health', 'Infrastructure health probe, no auth or user data'],
+  ['version', 'ADR 0001 D2 public handshake endpoint, no auth or user data, constant response'],
   ['compiled-css', 'Static CSS compilation, no user context'],
   ['contact', 'Public contact form, no authenticated user'],
   ['avatar/[userId]/[filename]', 'Public asset serving, no auth required'],

--- a/apps/web/src/app/api/version/__tests__/route.test.ts
+++ b/apps/web/src/app/api/version/__tests__/route.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
+import { GET } from '../route';
+
+describe('GET /api/version (ADR 0001 D2 — eager-handshake target)', () => {
+  it('responds 200 with { service, apiVersion } equal to API_CONTRACT_VERSION', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ service: 'pagespace-web', apiVersion: API_CONTRACT_VERSION });
+  });
+
+  it('does not cache the handshake response', async () => {
+    const response = await GET();
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store, no-cache, must-revalidate');
+  });
+});

--- a/apps/web/src/app/api/version/__tests__/version-sdk-contract.test.ts
+++ b/apps/web/src/app/api/version/__tests__/version-sdk-contract.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The composed CLI->server contract test the epic lacked (ADR 0001, plan
+ * section W3): every prior SDK version-check test feeds `checkServerCompatibility`
+ * plain fixture values, and every prior server header test reads
+ * `response.headers.get(...)` directly — neither exercises the two wired
+ * together. This test constructs a real `PageSpaceClient` (no
+ * `skipVersionCheck`) and drives it against the actual `GET /api/version`
+ * route handler and the actual `applySecurityHeaders` seam
+ * (`@/middleware/security-headers`, ADR 0001 D2) that stamps
+ * `X-PageSpace-API-Version` on real `/api/*` responses. If either side of
+ * the contract drifts — the header stops being emitted, or the SDK's
+ * compatibility check regresses — this is the test that fails.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { NextResponse } from 'next/server';
+import {
+  defineOperation,
+  isIncompatibleServerError,
+  PageSpaceClient,
+  type AuthProvider,
+} from '@pagespace/sdk';
+import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
+import { applySecurityHeaders } from '@/middleware/security-headers';
+import { GET } from '../route';
+
+const getVersion = defineOperation({
+  name: 'version.get',
+  method: 'GET',
+  path: '/api/version',
+  inputSchema: z.object({}),
+  outputSchema: z.object({ service: z.string(), apiVersion: z.string() }),
+  description: 'ADR 0001 D2 eager-handshake endpoint.',
+});
+
+function fakeAuth(): AuthProvider {
+  return { getAccessToken: vi.fn(async () => 'token-1'), invalidate: vi.fn() };
+}
+
+function makeClient(fetchImpl: typeof fetch): PageSpaceClient {
+  return new PageSpaceClient({
+    baseUrl: 'https://pagespace.ai',
+    auth: fakeAuth(),
+    jitter: () => 0,
+    timeoutMs: 1000,
+    fetch: fetchImpl,
+  });
+}
+
+describe('SDK <-> server assembled version contract', () => {
+  it('succeeds with no IncompatibleServerError when the real route handler response is stamped by the real applySecurityHeaders seam', async () => {
+    const fetchImpl = (async () => {
+      const response = await GET();
+      applySecurityHeaders(response as unknown as NextResponse, {
+        nonce: 'test-nonce',
+        isProduction: false,
+        isAPIRoute: true,
+      });
+      return response;
+    }) as unknown as typeof fetch;
+
+    const client = makeClient(fetchImpl);
+
+    await expect(client.invoke(getVersion, {})).resolves.toEqual({
+      service: 'pagespace-web',
+      apiVersion: API_CONTRACT_VERSION,
+    });
+  });
+
+  it('regression guard: the real route handler response WITHOUT the header stamp throws IncompatibleServerError', async () => {
+    const fetchImpl = (async () => GET()) as unknown as typeof fetch;
+    const client = makeClient(fetchImpl);
+
+    const error = await client.invoke(getVersion, {}).catch((e: unknown) => e);
+    expect(isIncompatibleServerError(error)).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/version/route.ts
+++ b/apps/web/src/app/api/version/route.ts
@@ -1,0 +1,13 @@
+import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
+
+/**
+ * Public, DB-free handshake endpoint (ADR 0001 D2, docs/adr/0001-sdk-api-versioning.md).
+ * The eager-handshake target — SDK/CLI clients call this before any operation
+ * to render a compatibility verdict without waiting on a first real request.
+ */
+export async function GET(): Promise<Response> {
+  return Response.json(
+    { service: 'pagespace-web', apiVersion: API_CONTRACT_VERSION },
+    { headers: { 'Cache-Control': 'no-store, no-cache, must-revalidate' } },
+  );
+}

--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextResponse } from 'next/server';
+import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
 import {
   generateNonce,
   buildCSPPolicy,
@@ -313,6 +314,14 @@ describe('Security Headers', () => {
 
       expect(response.headers.has('Cross-Origin-Embedder-Policy')).toBe(false);
     });
+
+    it('stamps X-PageSpace-API-Version on the 2xx pass-through path (ADR 0001 D2/D7#10)', () => {
+      const response = NextResponse.next();
+
+      applySecurityHeaders(response, { nonce: 'test', isProduction: false, isAPIRoute: true });
+
+      expect(response.headers.get('X-PageSpace-API-Version')).toBe(API_CONTRACT_VERSION);
+    });
   });
 
   describe('createSecureResponse', () => {
@@ -419,6 +428,12 @@ describe('Security Headers', () => {
       const response = createSecureErrorResponse('Error', 500, false);
 
       expect(response.headers.get('Strict-Transport-Security')).toBeNull();
+    });
+
+    it('stamps X-PageSpace-API-Version on the 401/403 early-rejection path (ADR 0001 D2/D7#10)', () => {
+      const response = createSecureErrorResponse({ error: 'Authentication required' }, 401);
+
+      expect(response.headers.get('X-PageSpace-API-Version')).toBe(API_CONTRACT_VERSION);
     });
   });
 

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
 
 export const NONCE_HEADER = 'x-nonce';
 
@@ -46,6 +47,7 @@ const ERROR_RESPONSE_HEADERS: Record<string, string> = {
   'X-Content-Type-Options': 'nosniff',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
   'Permissions-Policy': PERMISSIONS_POLICY,
+  'X-PageSpace-API-Version': API_CONTRACT_VERSION,
 };
 
 export const createSecureErrorResponse = (
@@ -155,6 +157,7 @@ export const applySecurityHeaders = (
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Permissions-Policy', PERMISSIONS_POLICY);
+  response.headers.set('X-PageSpace-API-Version', API_CONTRACT_VERSION);
   // COEP 'credentialless' is set for all page routes except Stripe-dependent
   // paths (/settings/plan, /settings/billing) where it blocks Stripe.js loading
   // via no-cors without Cross-Origin-Resource-Policy headers.

--- a/bun.lock
+++ b/bun.lock
@@ -442,6 +442,7 @@
         "@capgo/capacitor-social-login": "^7.0.5",
         "@eslint/eslintrc": "^3",
         "@next/eslint-plugin-next": "15.5.18",
+        "@pagespace/sdk": "workspace:*",
         "@tailwindcss/postcss": "^4",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^20",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,6 +12,11 @@
     "lint": "eslint src"
   },
   "exports": {
+    "./api-contract-version": {
+      "types": "./dist/api-contract-version.d.ts",
+      "import": "./dist/api-contract-version.js",
+      "require": "./dist/api-contract-version.js"
+    },
     "./client-safe": {
       "types": "./dist/client-safe.d.ts",
       "import": "./dist/client-safe.js",

--- a/packages/lib/src/api-contract-version.ts
+++ b/packages/lib/src/api-contract-version.ts
@@ -1,0 +1,7 @@
+/**
+ * The server's API contract version (ADR 0001 D1, docs/adr/0001-sdk-api-versioning.md).
+ * Versions the operation registry contract — not the app, not the deploy
+ * artifact. Hand-maintained; bumped only by PRs that change the contract.
+ * Never derive this from npm_package_version, git tags, or image tags.
+ */
+export const API_CONTRACT_VERSION = '1.0.0';

--- a/packages/sdk/src/__tests__/api-contract-guard.test.ts
+++ b/packages/sdk/src/__tests__/api-contract-guard.test.ts
@@ -1,0 +1,44 @@
+/**
+ * ADR 0001 D3 (docs/adr/0001-sdk-api-versioning.md) — the SDK pins its own
+ * MIN_SERVER_API_VERSION and never imports the server's live
+ * API_CONTRACT_VERSION. This guards both halves of that decision: the
+ * SDK's floor must never demand a future server, and the SDK source must
+ * stay decoupled from the server tree it will be published independently
+ * of.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
+import { MIN_SERVER_API_VERSION, compareApiVersions, parseApiVersion } from '../version.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = resolve(__dirname, '..');
+
+function listNonTestSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return listNonTestSourceFiles(full);
+    if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) return [full];
+    return [];
+  });
+}
+
+describe('ADR 0001 D3 — SDK/server version decoupling', () => {
+  it('D7.11 — MIN_SERVER_API_VERSION never exceeds API_CONTRACT_VERSION', () => {
+    const min = parseApiVersion(MIN_SERVER_API_VERSION);
+    const contract = parseApiVersion(API_CONTRACT_VERSION);
+    expect(min).not.toBeNull();
+    expect(contract).not.toBeNull();
+    expect(compareApiVersions(min!, contract!)).toBeLessThanOrEqual(0);
+  });
+
+  it('the SDK source never imports the server\'s api-contract-version module (D3: decoupled from @pagespace/lib)', () => {
+    const offenders = listNonTestSourceFiles(SRC_ROOT).filter((file) => {
+      const content = readFileSync(file, 'utf-8');
+      return /from\s+['"].*api-contract-version['"]/.test(content);
+    });
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Post-review remediation for the SDK/CLI/OAuth epic — workstream **W3**, blocker **B1**.

`@pagespace/sdk` requires an `X-PageSpace-API-Version` header on the first 2xx response and fails closed (`IncompatibleServerError('missing-header')`) when absent — but no server route or middleware emitted it. Every CLI/MCP command would throw on its first successful response. All unit suites passed only because SDK tests inject the header into fixtures; the composed contract was never exercised. This PR implements ADR 0001 D1/D2 exactly and adds the missing composed test.

- `packages/lib/src/api-contract-version.ts` — hand-maintained `API_CONTRACT_VERSION = '1.0.0'` (+ `package.json` exports entry, per project law for new subpath modules)
- `apps/web/src/middleware/security-headers.ts` — stamps `X-PageSpace-API-Version` in **both** central seams: `applySecurityHeaders` (2xx pass-through) and `ERROR_RESPONSE_HEADERS` (401/403 early-rejection). Missing either leaves a response class non-compliant (ADR fact 7).
- `GET /api/version` — public, DB-free eager-handshake endpoint (ADR D2), added to the middleware public-route allowlist.
- ADR D3 guard test — `MIN_SERVER_API_VERSION <= API_CONTRACT_VERSION`, and asserts the SDK source never imports the server's live constant (decoupling per D3).
- **The missing leaf**: a composed SDK↔server integration test (`apps/web/src/app/api/version/__tests__/version-sdk-contract.test.ts`) that drives a real `PageSpaceClient` (no `skipVersionCheck`) against the real `GET /api/version` route handler and the real `applySecurityHeaders` seam — asserting success with the header present, and `IncompatibleServerError` without it. This is the assembled-system smoke test the epic's unit suites lacked.

Also: adds `@pagespace/sdk` as a devDependency of `apps/web` (needed for the composed test), and exempts `/api/version` from the `security-audit-coverage` gate (same justification as `/api/health`: public infra probe, no user data).

## Test plan

- [x] `bun run --filter '@pagespace/lib' typecheck && test` — 278 files / 6220 tests pass
- [x] `bun run --filter 'web' typecheck && lint` — clean except 3 pre-existing unrelated errors in `page-agents/consult` tests (predate this branch, untouched by this PR)
- [x] `bun run --filter '@pagespace/sdk' typecheck && test` — 34 files / 719 tests pass
- [x] Full `apps/web` vitest run — only 3 pre-existing failures remain (DB-dependent `admin-role-version`/`activity-tools` tests requiring a real Postgres role; a pre-existing midnight-boundary flake in `grouping.test.ts`) — none touched by this PR
- [x] New tests: `security-headers.test.ts` (+2), `api/version/route.test.ts` (+2), `version-sdk-contract.test.ts` (+2), `api-contract-guard.test.ts` (+2, sdk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019N1sdgHCExqwUS7VR5wv3h