### PR TITLE
fix(oauth): W4 security remediation — P1a/P1b, offline_access gating, tokenVersion, grant-type enforcement

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
+  isScopedOAuthAuth: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
@@ -60,7 +61,7 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 }));
 
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
 import { logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 
 describe('/api/auth/mcp-tokens', () => {
@@ -76,6 +77,7 @@ describe('/api/auth/mcp-tokens', () => {
       sessionId: 'test-session-id',
     } as never);
     vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isScopedOAuthAuth).mockReturnValue(false);
 
     // Default repository mocks
     vi.mocked(sessionRepository.createMcpTokenWithDriveScopes).mockResolvedValue({

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
+  isScopedOAuthAuth: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
@@ -59,7 +60,7 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 
 import { DELETE, PATCH } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
@@ -67,6 +68,28 @@ import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service'
 const createContext = (tokenId = 'token-123') => ({
   params: Promise.resolve({ tokenId }),
 });
+
+const DRIVE_SCOPED_OAUTH = {
+  userId: 'test-user-id',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  tokenType: 'oauth',
+  tokenId: 'oauth-token-1',
+  scopes: { account: false, offlineAccess: false, drives: new Map([['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }]]) },
+  driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
+  allowedDriveIds: ['drive-1'],
+};
+
+function mockIsScopedOAuthAuth(): void {
+  vi.mocked(isScopedOAuthAuth).mockImplementation(
+    (auth: unknown) =>
+      !!auth &&
+      typeof auth === 'object' &&
+      (auth as { tokenType?: string }).tokenType === 'oauth' &&
+      !(auth as { scopes?: { account?: boolean } }).scopes?.account
+  );
+}
 
 describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
   beforeEach(() => {
@@ -83,6 +106,7 @@ describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
     vi.mocked(isAuthError).mockImplementation(
       (result: unknown) => result != null && typeof result === 'object' && 'error' in result
     );
+    mockIsScopedOAuthAuth();
 
     vi.mocked(getActorInfo).mockResolvedValue({ actorEmail: 'test@example.com' } as never);
 
@@ -122,6 +146,20 @@ describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
       request,
       expect.objectContaining({ allow: expect.arrayContaining(['oauth']) })
     );
+  });
+
+  it('P1a: rejects a drive-scoped OAuth token, never reaching the repository', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': 'valid-csrf-token' },
+    });
+
+    const response = await DELETE(request, createContext());
+
+    expect(response.status).toBe(403);
+    expect(sessionRepository.revokeMcpToken).not.toHaveBeenCalled();
   });
 
   it('returns 404 when token not found', async () => {
@@ -196,6 +234,7 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
       sessionId: 'test-session-id',
     } as never);
     vi.mocked(isAuthError).mockReturnValue(false);
+    mockIsScopedOAuthAuth();
     vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockResolvedValue({
       id: 'token-123',
       name: 'My Token',
@@ -220,6 +259,24 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
       invalidCustomRoles: [],
       unauthorizedCustomRoles: [],
     });
+  });
+
+  it('P1a: rejects a drive-scoped OAuth token, never reaching the repository', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+    const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+      method: 'PATCH',
+      headers: {
+        Cookie: 'ps_session=valid-token',
+        'X-CSRF-Token': 'valid-csrf-token',
+      },
+      body: JSON.stringify({ drives: [{ id: 'drive-1' }] }),
+    });
+
+    const response = await PATCH(request, createContext());
+
+    expect(response.status).toBe(403);
+    expect(sessionRepository.updateMcpTokenDriveScopes).not.toHaveBeenCalled();
   });
 
   it('returns 404 when token not found', async () => {

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -29,6 +29,17 @@ const updateTokenScopesSchema = z.object({
   message: 'Provide drives or driveIds',
 });
 
+// A drive-scoped OAuth token acts as an app member for that drive only (ADR
+// 0002 Decision 2) — it must never manage the full mcp_* credential surface.
+// Only a full-user credential (session, or an account-scoped OAuth token) may
+// reach this route.
+function rejectScopedOAuth(auth: Parameters<typeof isScopedOAuthAuth>[0]): NextResponse | null {
+  if (isScopedOAuthAuth(auth)) {
+    return NextResponse.json({ error: 'insufficient_scope' }, { status: 403 });
+  }
+  return null;
+}
+
 // DELETE: Revoke an MCP token
 export async function DELETE(
   req: NextRequest,
@@ -36,6 +47,8 @@ export async function DELETE(
 ) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
   if (isAuthError(auth)) return auth.error;
+  const scopeRejection = rejectScopedOAuth(auth);
+  if (scopeRejection) return scopeRejection;
   const userId = auth.userId;
 
   const { tokenId } = await context.params;
@@ -74,6 +87,8 @@ export async function PATCH(
 ) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
   if (isAuthError(auth)) return auth.error;
+  const scopeRejection = rejectScopedOAuth(auth);
+  if (scopeRejection) return scopeRejection;
   const userId = auth.userId;
 
   const { tokenId } = await context.params;

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { normalizeDriveScopes } from '@pagespace/lib/auth/mcp-token-scopes';
 import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
+import { rejectScopedOAuth } from '../scope-guard';
 
 // 'oauth' lets the pagespace CLI (`pagespace tokens revoke`) authenticate
 // with an OAuth access token instead of a session cookie — see the sibling
@@ -28,17 +29,6 @@ const updateTokenScopesSchema = z.object({
 }).refine(d => d.drives !== undefined || d.driveIds !== undefined, {
   message: 'Provide drives or driveIds',
 });
-
-// A drive-scoped OAuth token acts as an app member for that drive only (ADR
-// 0002 Decision 2) — it must never manage the full mcp_* credential surface.
-// Only a full-user credential (session, or an account-scoped OAuth token) may
-// reach this route.
-function rejectScopedOAuth(auth: Parameters<typeof isScopedOAuthAuth>[0]): NextResponse | null {
-  if (isScopedOAuthAuth(auth)) {
-    return NextResponse.json({ error: 'insufficient_scope' }, { status: 403 });
-  }
-  return null;
-}
 
 // DELETE: Revoke an MCP token
 export async function DELETE(

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
+  isScopedOAuthAuth: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -73,11 +74,35 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 
 import { POST, GET } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
+
+const DRIVE_SCOPED_OAUTH = {
+  userId: 'test-user-id',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  tokenType: 'oauth',
+  tokenId: 'oauth-token-1',
+  scopes: { account: false, offlineAccess: false, drives: new Map([['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }]]) },
+  driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
+  allowedDriveIds: ['drive-1'],
+};
+
+const ACCOUNT_SCOPED_OAUTH = {
+  userId: 'test-user-id',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  tokenType: 'oauth',
+  tokenId: 'oauth-token-2',
+  scopes: { account: true, offlineAccess: false, drives: new Map() },
+  driveScopes: [],
+  allowedDriveIds: [],
+};
 
 describe('/api/auth/mcp-tokens (additional coverage)', () => {
   beforeEach(() => {
@@ -93,6 +118,13 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
     } as never);
     vi.mocked(isAuthError).mockImplementation(
       (result: unknown) => result != null && typeof result === 'object' && 'error' in result
+    );
+    vi.mocked(isScopedOAuthAuth).mockImplementation(
+      (auth: unknown) =>
+        !!auth &&
+        typeof auth === 'object' &&
+        (auth as { tokenType?: string }).tokenType === 'oauth' &&
+        !(auth as { scopes?: { account?: boolean } }).scopes?.account
     );
 
     // Default mocks that need re-setup after resetAllMocks
@@ -152,6 +184,49 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
 
         const response = await POST(request);
         expect(response.status).toBe(401);
+      });
+    });
+
+    describe('P1a — OAuth account-scope enforcement (a drive-scoped OAuth token must not mint an unscoped MCP token)', () => {
+      it('rejects a drive-scoped OAuth token, never reaching the repository', async () => {
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+        const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'My Token' }),
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(403);
+        expect(sessionRepository.createMcpTokenWithDriveScopes).not.toHaveBeenCalled();
+      });
+
+      it('allows an account-scoped OAuth token', async () => {
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(ACCOUNT_SCOPED_OAUTH as never);
+
+        const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'My Token' }),
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(200);
+      });
+
+      it('leaves session auth unaffected', async () => {
+        const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'My Token' }),
+        });
+
+        const response = await POST(request);
+
+        expect(response.status).toBe(200);
       });
     });
 
@@ -368,6 +443,27 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
 
         const response = await GET(request);
         expect(response.status).toBe(401);
+      });
+    });
+
+    describe('P1a — OAuth account-scope enforcement (a drive-scoped OAuth token must not list all MCP tokens)', () => {
+      it('rejects a drive-scoped OAuth token, never reaching the repository', async () => {
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+        const request = new NextRequest('http://localhost/api/auth/mcp-tokens', { method: 'GET' });
+        const response = await GET(request);
+
+        expect(response.status).toBe(403);
+        expect(sessionRepository.findUserMcpTokensWithDrives).not.toHaveBeenCalled();
+      });
+
+      it('allows an account-scoped OAuth token', async () => {
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(ACCOUNT_SCOPED_OAUTH as never);
+
+        const request = new NextRequest('http://localhost/api/auth/mcp-tokens', { method: 'GET' });
+        const response = await GET(request);
+
+        expect(response.status).toBe(200);
       });
     });
 

--- a/apps/web/src/app/api/auth/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { z } from 'zod/v4';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -7,6 +7,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
 import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
+import { rejectScopedOAuth } from './scope-guard';
 
 // 'oauth' lets the pagespace CLI (which never holds a session cookie —
 // `pagespace tokens create/list` authenticates with an OAuth access token
@@ -29,17 +30,6 @@ const createTokenSchema = z.object({
     customRoleId: z.string().optional(),
   })).optional(),
 }).refine(d => !(d.drives && d.driveIds), { message: 'Provide drives or driveIds, not both' });
-
-// A drive-scoped OAuth token acts as an app member for that drive only (ADR
-// 0002 Decision 2) — it must never mint, list, or manage the full mcp_*
-// credential surface. Only a full-user credential (session, or an
-// account-scoped OAuth token) may reach this route.
-function rejectScopedOAuth(auth: Parameters<typeof isScopedOAuthAuth>[0]): NextResponse | null {
-  if (isScopedOAuthAuth(auth)) {
-    return NextResponse.json({ error: 'insufficient_scope' }, { status: 403 });
-  }
-  return null;
-}
 
 // POST: Create a new MCP token
 export async function POST(req: NextRequest) {

--- a/apps/web/src/app/api/auth/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { z } from 'zod/v4';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -30,10 +30,23 @@ const createTokenSchema = z.object({
   })).optional(),
 }).refine(d => !(d.drives && d.driveIds), { message: 'Provide drives or driveIds, not both' });
 
+// A drive-scoped OAuth token acts as an app member for that drive only (ADR
+// 0002 Decision 2) — it must never mint, list, or manage the full mcp_*
+// credential surface. Only a full-user credential (session, or an
+// account-scoped OAuth token) may reach this route.
+function rejectScopedOAuth(auth: Parameters<typeof isScopedOAuthAuth>[0]): NextResponse | null {
+  if (isScopedOAuthAuth(auth)) {
+    return NextResponse.json({ error: 'insufficient_scope' }, { status: 403 });
+  }
+  return null;
+}
+
 // POST: Create a new MCP token
 export async function POST(req: NextRequest) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
+  const scopeRejection = rejectScopedOAuth(auth);
+  if (scopeRejection) return scopeRejection;
   const userId = auth.userId;
 
   try {
@@ -128,6 +141,8 @@ export async function POST(req: NextRequest) {
 export async function GET(req: NextRequest) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS_READ);
   if (isAuthError(auth)) return auth.error;
+  const scopeRejection = rejectScopedOAuth(auth);
+  if (scopeRejection) return scopeRejection;
   const userId = auth.userId;
 
   try {

--- a/apps/web/src/app/api/auth/mcp-tokens/scope-guard.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/scope-guard.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { isScopedOAuthAuth } from '@/lib/auth';
+
+/**
+ * A drive-scoped OAuth token acts as an app member for that drive only (ADR
+ * 0002 Decision 2) — it must never mint, list, revoke, or manage the full
+ * mcp_* credential surface. Only a full-user credential (session, or an
+ * account-scoped OAuth token) may reach these routes. Shared by
+ * `mcp-tokens/route.ts` and `mcp-tokens/[tokenId]/route.ts`.
+ */
+export function rejectScopedOAuth(auth: Parameters<typeof isScopedOAuthAuth>[0]): NextResponse | null {
+  if (isScopedOAuthAuth(auth)) {
+    return NextResponse.json({ error: 'insufficient_scope' }, { status: 403 });
+  }
+  return null;
+}

--- a/apps/web/src/app/api/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/oauth/authorize/route.ts
@@ -24,11 +24,10 @@ import {
   type AuthorizeRequestParams,
 } from '@pagespace/lib/auth/oauth/authorize-request';
 import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
-import { checkGrantAuthority, formatScopeSet, type GrantAuthority } from '@pagespace/lib/auth/oauth/scopes';
+import { checkGrantAuthority, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
 import { AUTHORIZATION_CODE_TTL_SECONDS } from '@pagespace/lib/auth/oauth/code-lifecycle';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
-import { getDriveAccess } from '@pagespace/lib/services/drive-service';
-import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
+import { resolveGrantAuthority } from '@/lib/auth/oauth-grant-authority';
 import { ensureOAuthClientRow, createAuthorizationCode } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
@@ -180,23 +179,7 @@ export async function POST(req: NextRequest) {
   // Decision 2). Any violation rejects the entire request — no partial grant,
   // uniform `invalid_scope` (no oracle distinguishing "no access" from "role
   // not grantable" on an endpoint reachable pre-consent by arbitrary clients).
-  const authorityMap = new Map<string, GrantAuthority extends ReadonlyMap<string, infer V> ? V : never>();
-  for (const [driveId, scope] of result.scopes.drives) {
-    const access = await getDriveAccess(driveId, auth.userId);
-    const ownCustomRoleId = await getMemberCustomRoleId(driveId, auth.userId);
-    const customRoleOk =
-      scope.role.kind === 'custom' ? await customRoleBelongsToDrive(scope.role.customRoleId, driveId) : true;
-
-    authorityMap.set(driveId, {
-      isOwner: access.isOwner,
-      isMember: access.isMember,
-      isAdmin: access.isAdmin,
-      ownCustomRoleId,
-      roleBelongsToDrive: () => customRoleOk,
-    });
-  }
-
-  const authority = checkGrantAuthority(result.scopes, authorityMap);
+  const authority = checkGrantAuthority(result.scopes, await resolveGrantAuthority(result.scopes, auth.userId));
   if (!authority.ok) {
     return NextResponse.json({
       redirectUri: buildRedirectWithParams(result.redirectUri, { error: 'invalid_scope', state: result.state }),

--- a/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
@@ -22,11 +22,25 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
 }));
 
 const recordDeviceApproval = vi.fn();
+const verifyDeviceUserCode = vi.fn();
 vi.mock('@/lib/repositories/oauth-repository', () => ({
   recordDeviceApproval: (...args: unknown[]) => recordDeviceApproval(...args),
+  verifyDeviceUserCode: (...args: unknown[]) => verifyDeviceUserCode(...args),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+const getDriveAccess = vi.fn();
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getDriveAccess: (...args: unknown[]) => getDriveAccess(...args),
+}));
+
+const getMemberCustomRoleId = vi.fn();
+const customRoleBelongsToDrive = vi.fn();
+vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
+  getMemberCustomRoleId: (...args: unknown[]) => getMemberCustomRoleId(...args),
+  customRoleBelongsToDrive: (...args: unknown[]) => customRoleBelongsToDrive(...args),
+}));
 
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
@@ -54,6 +68,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(authenticateRequestWithOptions).mockResolvedValue(AUTHENTICATED as never);
   checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+  // Default: the presented user code isn't found by the read-only scope
+  // lookup — most tests below exercise deny/rate-limit/not-found paths that
+  // never need it, and recordDeviceApproval independently re-validates.
+  verifyDeviceUserCode.mockResolvedValue({ outcome: 'not_found' });
+  getDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' });
+  getMemberCustomRoleId.mockResolvedValue(null);
+  customRoleBelongsToDrive.mockResolvedValue(true);
 });
 
 describe('POST /api/oauth/device_authorization/decision — CSRF/session gate', () => {
@@ -167,5 +188,53 @@ describe('POST /api/oauth/device_authorization/decision — outcomes', () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_request' });
     expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/oauth/device_authorization/decision — P1b: grant-authority check before approval', () => {
+  it('rejects approving a scope the user cannot grant (e.g. drive:admin without admin/owner authority), never recording approval', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['drive:abc12345:admin'] });
+    getDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false, isMember: true, role: 'MEMBER' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_scope' });
+    expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+
+  it('rejects approving a drive the user has no access to at all', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['drive:abc12345'] });
+    getDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false, isMember: false, role: null });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_scope' });
+    expect(recordDeviceApproval).not.toHaveBeenCalled();
+  });
+
+  it('allows approving a scope the user has authority to grant', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['drive:abc12345:member'] });
+    getDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' });
+    recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, action: 'approved' });
+    expect(recordDeviceApproval).toHaveBeenCalled();
+  });
+
+  it('does not run the authority check for a deny decision', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['drive:abc12345:admin'] });
+    getDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false, isMember: false, role: null });
+    recordDeviceApproval.mockResolvedValue({ outcome: 'denied' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'deny' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, action: 'denied' });
+    expect(recordDeviceApproval).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
@@ -214,6 +214,19 @@ describe('POST /api/oauth/device_authorization/decision — P1b: grant-authority
     expect(recordDeviceApproval).not.toHaveBeenCalled();
   });
 
+  it('allows approving a device code that requested NO scope at all (vacuous authority pass, matching device_authorization/route.ts allowing an empty scope) — regression guard', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: [] });
+    recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, action: 'approved' });
+    expect(recordDeviceApproval).toHaveBeenCalled();
+    // Nothing to authorize, so no drive-access lookups should even run.
+    expect(getDriveAccess).not.toHaveBeenCalled();
+  });
+
   it('allows approving a scope the user has authority to grant', async () => {
     verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['drive:abc12345:member'] });
     getDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' });

--- a/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
@@ -4,13 +4,23 @@
  * the user code from scratch — never trusts an earlier /verify call — then
  * records the decision via `decideDeviceApproval` (task 4, not
  * reimplemented).
+ *
+ * Approval additionally enforces the SAME grant-authority caps the
+ * authorization-code consent screen enforces (ADR 0002 Decision 2, P1b): the
+ * device code's requested scopes are re-checked against the approving user's
+ * actual drive access immediately before `recordDeviceApproval`, so a user
+ * cannot approve a scope (e.g. `drive:<id>:admin`) they have no authority to
+ * grant. A code that can't be looked up here is left to `recordDeviceApproval`
+ * to reject on its own terms (not_found/expired/already_settled).
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
-import { recordDeviceApproval } from '@/lib/repositories/oauth-repository';
+import { parseScopeList, checkGrantAuthority } from '@pagespace/lib/auth/oauth/scopes';
+import { resolveGrantAuthority } from '@/lib/auth/oauth-grant-authority';
+import { recordDeviceApproval, verifyDeviceUserCode } from '@/lib/repositories/oauth-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const bodySchema = z.object({
@@ -46,6 +56,25 @@ export async function POST(req: NextRequest) {
   }
 
   const normalized = normalizeUserCode(body.userCode);
+
+  if (body.action === 'approve') {
+    const lookup = await verifyDeviceUserCode({ userCode: normalized, now: new Date() });
+    if (lookup.outcome === 'ok') {
+      const parsed = parseScopeList(lookup.scopes.join(' '));
+      const authority =
+        parsed.ok && checkGrantAuthority(parsed.scopes, await resolveGrantAuthority(parsed.scopes, auth.userId));
+
+      if (!authority || !authority.ok) {
+        auditRequest(req, {
+          eventType: 'authz.access.denied',
+          userId: auth.userId,
+          details: { oauthEvent: 'device_decision_scope_denied' },
+        });
+        return NextResponse.json({ error: 'invalid_scope' }, { status: 400 });
+      }
+    }
+  }
+
   const result = await recordDeviceApproval({
     userCode: normalized,
     action: body.action,

--- a/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
@@ -59,7 +59,13 @@ export async function POST(req: NextRequest) {
 
   if (body.action === 'approve') {
     const lookup = await verifyDeviceUserCode({ userCode: normalized, now: new Date() });
-    if (lookup.outcome === 'ok') {
+    // An empty scope list is a legitimate device-authorization request
+    // (device_authorization/route.ts leaves `scopes: []` when the initial
+    // POST omits `scope` entirely) — nothing to authorize, so skip straight
+    // to recordDeviceApproval. `parseScopeList` rejects an empty string
+    // outright (`empty_scope`), which is correct for the wire-level `scope`
+    // grammar but would wrongly block approval of this valid empty case.
+    if (lookup.outcome === 'ok' && lookup.scopes.length > 0) {
       const parsed = parseScopeList(lookup.scopes.join(' '));
       const authority =
         parsed.ok && checkGrantAuthority(parsed.scopes, await resolveGrantAuthority(parsed.scopes, auth.userId));

--- a/apps/web/src/app/api/oauth/token/__tests__/grant-type-enforcement.test.ts
+++ b/apps/web/src/app/api/oauth/token/__tests__/grant-type-enforcement.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `RegisteredClient.allowedGrantTypes` (`packages/lib/src/auth/oauth/clients.ts:19`)
+ * is defined but was never enforced at the token endpoint — any registered
+ * client could use any grant regardless of its declared allow-list. This
+ * suite mocks the static client registry with a deliberately restricted
+ * client (unlike the real first-party CLI, which allows all three) to
+ * exercise the enforcement in isolation from `route.test.ts`, which relies on
+ * the real (unrestricted) registry throughout.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const RESTRICTED_CLIENT_ID = 'restricted-client';
+const RESTRICTED_CLIENT = {
+  clientId: RESTRICTED_CLIENT_ID,
+  name: 'Restricted Client',
+  type: 'public' as const,
+  redirectUris: ['http://127.0.0.1/callback'],
+  allowedGrantTypes: ['authorization_code'] as const,
+  firstParty: false,
+};
+
+vi.mock('@pagespace/lib/auth/oauth/clients', () => ({
+  getRegisteredClient: (clientId: string) => (clientId === RESTRICTED_CLIENT_ID ? RESTRICTED_CLIENT : null),
+}));
+
+const ensureOAuthClientRow = vi.fn();
+const exchangeAuthorizationCode = vi.fn();
+const refreshTokenGrant = vi.fn();
+const pollDeviceToken = vi.fn();
+vi.mock('@/lib/repositories/oauth-repository', () => ({
+  ensureOAuthClientRow: (...args: unknown[]) => ensureOAuthClientRow(...args),
+  exchangeAuthorizationCode: (...args: unknown[]) => exchangeAuthorizationCode(...args),
+  refreshTokenGrant: (...args: unknown[]) => refreshTokenGrant(...args),
+  pollDeviceToken: (...args: unknown[]) => pollDeviceToken(...args),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ getClientIP: vi.fn().mockReturnValue('203.0.113.11') }));
+
+const checkDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => checkDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: {
+    OAUTH_TOKEN_EXCHANGE: { maxAttempts: 10, windowMs: 300_000, progressiveDelay: true },
+    OAUTH_DEVICE_POLL: { maxAttempts: 100, windowMs: 300_000, progressiveDelay: false },
+  },
+}));
+
+import { POST } from '../route';
+
+const ALLOWED = { allowed: true, attemptsRemaining: 9 };
+
+function tokenRequest(fields: Record<string, string | undefined>): Request {
+  const body = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) body.set(key, value);
+  }
+  return new Request('http://web.local/api/oauth/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureOAuthClientRow.mockResolvedValue('restricted-client-db-id');
+  checkDistributedRateLimit.mockResolvedValue(ALLOWED);
+});
+
+describe('POST /api/oauth/token — allowedGrantTypes enforcement', () => {
+  it('rejects a refresh_token grant for a client whose allowedGrantTypes excludes it, never calling the repository', async () => {
+    const res = await POST(
+      tokenRequest({
+        grant_type: 'refresh_token',
+        refresh_token: 'raw-refresh-token-value',
+        client_id: RESTRICTED_CLIENT_ID,
+      }) as never,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_grant' });
+    expect(refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('rejects a device_code grant for a client whose allowedGrantTypes excludes it, never calling the repository', async () => {
+    const res = await POST(
+      tokenRequest({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'raw-device-code-value',
+        client_id: RESTRICTED_CLIENT_ID,
+      }) as never,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_grant' });
+    expect(pollDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('allows the grant type the client IS registered for', async () => {
+    exchangeAuthorizationCode.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: {
+        accessToken: 'ps_at_' + 'a'.repeat(43),
+        refreshToken: undefined,
+        accessExpiresAt: new Date(Date.now() + 15 * 60 * 1000),
+        familyId: 'family-1',
+        familyExpiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const res = await POST(
+      tokenRequest({
+        grant_type: 'authorization_code',
+        code: 'raw-code-value',
+        redirect_uri: 'http://127.0.0.1/callback',
+        client_id: RESTRICTED_CLIENT_ID,
+        code_verifier: 'a'.repeat(43),
+      }) as never,
+    );
+
+    expect(res.status).toBe(200);
+    expect(exchangeAuthorizationCode).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/token/__tests__/route.test.ts
@@ -231,6 +231,59 @@ describe('POST /api/oauth/token — happy path', () => {
   });
 });
 
+describe('POST /api/oauth/token — F1: refresh_token omitted from the response when offline_access was not granted', () => {
+  it('authorization_code grant: no refresh_token key at all in an access-only response', async () => {
+    exchangeAuthorizationCode.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: { ...okTokens, refreshToken: undefined },
+    });
+
+    const res = await POST(tokenRequest(validFields()) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      access_token: okTokens.accessToken,
+      token_type: 'Bearer',
+      expires_in: 15 * 60,
+      scope: 'account',
+    });
+    expect('refresh_token' in body).toBe(false);
+  });
+
+  it('refresh_token grant: no refresh_token key at all when the rotated pair is access-only', async () => {
+    refreshTokenGrant.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: { ...okTokens, refreshToken: undefined },
+    });
+
+    const res = await POST(tokenRequest(refreshFields()) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect('refresh_token' in body).toBe(false);
+  });
+
+  it('device_code grant: no refresh_token key at all when the device grant is access-only', async () => {
+    pollDeviceToken.mockResolvedValue({
+      outcome: 'ok',
+      userId: 'user-1',
+      scopes: ['account'],
+      tokens: { ...okTokens, refreshToken: undefined },
+    });
+
+    const res = await POST(tokenRequest(deviceFields()) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect('refresh_token' in body).toBe(false);
+  });
+});
+
 describe('POST /api/oauth/token — constant-shape failures (no oracle)', () => {
   const CONSTANT_BODY = { error: 'invalid_grant' };
 

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -30,7 +30,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getClientIP } from '@/lib/auth';
 import { getRegisteredClient, type RegisteredClient } from '@pagespace/lib/auth/oauth/clients';
-import { ACCESS_TOKEN_TTL_SECONDS } from '@pagespace/lib/auth/oauth/issue-tokens';
+import { ACCESS_TOKEN_TTL_SECONDS, type IssuedTokenPair } from '@pagespace/lib/auth/oauth/issue-tokens';
 import {
   ensureOAuthClientRow,
   exchangeAuthorizationCode,
@@ -42,6 +42,22 @@ import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/l
 
 function noStoreJson(body: Record<string, unknown>, status: number): NextResponse {
   return NextResponse.json(body, { status, headers: { 'Cache-Control': 'no-store' } });
+}
+
+/**
+ * RFC 6749 §5.1 success body for all three grants. `refresh_token` is
+ * `undefined` whenever F1 (ADR 0003, offline_access gating) minted an
+ * access-only pair — `JSON.stringify` drops `undefined`-valued keys, so the
+ * field is absent from the wire response entirely, not merely null.
+ */
+function tokenSuccessBody(tokens: IssuedTokenPair, scopes: string[]): Record<string, unknown> {
+  return {
+    access_token: tokens.accessToken,
+    token_type: 'Bearer',
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    refresh_token: tokens.refreshToken,
+    scope: scopes.join(' '),
+  };
 }
 
 const INVALID_REQUEST = { error: 'invalid_request' };
@@ -98,14 +114,20 @@ type ResolvedClient = { client: RegisteredClient; clientDbId: string };
 type ClientResolution = ResolvedClient | { rejection: NextResponse };
 
 /**
- * Resolve and validate the requesting client — shared by both grants.
- * Unknown client_id and a public client presenting a client_secret are the
- * SAME two rejections (`invalid_grant` / `invalid_request`) either grant
- * produces; one guard, not two divergent copies.
+ * Resolve and validate the requesting client — shared by all three grants.
+ * Unknown client_id, a public client presenting a client_secret, and a grant
+ * type outside the client's `allowedGrantTypes` (defined but previously
+ * unenforced, `clients.ts:19`) all collapse to the SAME rejections
+ * (`invalid_grant` / `invalid_request`) every grant produces; one guard, not
+ * divergent copies per grant handler.
  */
-async function resolveClient(form: URLSearchParams, clientId: string): Promise<ClientResolution> {
+async function resolveClient(form: URLSearchParams, clientId: string, grantType: string): Promise<ClientResolution> {
   const client = getRegisteredClient(clientId);
   if (!client) {
+    return { rejection: noStoreJson(INVALID_GRANT, 400) };
+  }
+
+  if (!client.allowedGrantTypes.includes(grantType)) {
     return { rejection: noStoreJson(INVALID_GRANT, 400) };
   }
 
@@ -134,7 +156,7 @@ async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchPar
   const rateLimited = await checkTokenExchangeRateLimit(req, clientId);
   if (rateLimited) return rateLimited;
 
-  const resolved = await resolveClient(form, clientId);
+  const resolved = await resolveClient(form, clientId, 'authorization_code');
   if ('rejection' in resolved) return resolved.rejection;
   const { client, clientDbId } = resolved;
 
@@ -160,16 +182,7 @@ async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchPar
     details: { clientId: client.clientId, oauthEvent: 'code_exchange' },
   });
 
-  return noStoreJson(
-    {
-      access_token: result.tokens.accessToken,
-      token_type: 'Bearer',
-      expires_in: ACCESS_TOKEN_TTL_SECONDS,
-      refresh_token: result.tokens.refreshToken,
-      scope: result.scopes.join(' '),
-    },
-    200,
-  );
+  return noStoreJson(tokenSuccessBody(result.tokens, result.scopes), 200);
 }
 
 async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
@@ -183,7 +196,7 @@ async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams):
   const rateLimited = await checkTokenExchangeRateLimit(req, clientId);
   if (rateLimited) return rateLimited;
 
-  const resolved = await resolveClient(form, clientId);
+  const resolved = await resolveClient(form, clientId, 'refresh_token');
   if ('rejection' in resolved) return resolved.rejection;
   const { client, clientDbId } = resolved;
 
@@ -216,16 +229,7 @@ async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams):
     details: { clientId: client.clientId, oauthEvent: 'refresh_rotated' },
   });
 
-  return noStoreJson(
-    {
-      access_token: result.tokens.accessToken,
-      token_type: 'Bearer',
-      expires_in: ACCESS_TOKEN_TTL_SECONDS,
-      refresh_token: result.tokens.refreshToken,
-      scope: result.scopes.join(' '),
-    },
-    200,
-  );
+  return noStoreJson(tokenSuccessBody(result.tokens, result.scopes), 200);
 }
 
 /**
@@ -257,7 +261,7 @@ async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): P
   const rateLimited = await checkDevicePollRateLimit(req, clientId);
   if (rateLimited) return rateLimited;
 
-  const resolved = await resolveClient(form, clientId);
+  const resolved = await resolveClient(form, clientId, 'urn:ietf:params:oauth:grant-type:device_code');
   if ('rejection' in resolved) return resolved.rejection;
   const { client, clientDbId } = resolved;
 
@@ -277,16 +281,7 @@ async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): P
     details: { clientId: client.clientId, oauthEvent: 'device_poll_granted' },
   });
 
-  return noStoreJson(
-    {
-      access_token: result.tokens.accessToken,
-      token_type: 'Bearer',
-      expires_in: ACCESS_TOKEN_TTL_SECONDS,
-      refresh_token: result.tokens.refreshToken,
-      scope: result.scopes.join(' '),
-    },
-    200,
-  );
+  return noStoreJson(tokenSuccessBody(result.tokens, result.scopes), 200);
 }
 
 export async function POST(req: NextRequest) {

--- a/apps/web/src/lib/auth/__tests__/oauth-grant-authority.test.ts
+++ b/apps/web/src/lib/auth/__tests__/oauth-grant-authority.test.ts
@@ -1,0 +1,114 @@
+/**
+ * resolveGrantAuthority (extracted from the authorize/route.ts consent
+ * check, ADR 0002 Decision 2, reused by the device-decision P1b check).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const getDriveAccess = vi.fn();
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getDriveAccess: (...args: unknown[]) => getDriveAccess(...args),
+}));
+
+const getMemberCustomRoleId = vi.fn();
+const customRoleBelongsToDrive = vi.fn();
+vi.mock('@pagespace/lib/permissions/membership-queries', () => ({
+  getMemberCustomRoleId: (...args: unknown[]) => getMemberCustomRoleId(...args),
+  customRoleBelongsToDrive: (...args: unknown[]) => customRoleBelongsToDrive(...args),
+}));
+
+import { resolveGrantAuthority } from '../oauth-grant-authority';
+import type { ScopeSet } from '@pagespace/lib/auth/oauth/scopes';
+
+function scopeSet(drives: Array<[string, ScopeSet['drives'] extends ReadonlyMap<string, infer V> ? V : never]>): ScopeSet {
+  return { account: false, offlineAccess: false, drives: new Map(drives) };
+}
+
+const USER_ID = 'user-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' });
+  getMemberCustomRoleId.mockResolvedValue(null);
+  customRoleBelongsToDrive.mockResolvedValue(true);
+});
+
+describe('resolveGrantAuthority', () => {
+  it('resolves authority for a single drive scope', async () => {
+    const scopes = scopeSet([['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }]]);
+
+    const authority = await resolveGrantAuthority(scopes, USER_ID);
+
+    expect(authority.size).toBe(1);
+    expect(authority.get('drive-1')).toMatchObject({ isOwner: true, isAdmin: true, isMember: true });
+    expect(getDriveAccess).toHaveBeenCalledWith('drive-1', USER_ID);
+  });
+
+  it('resolves authority for every drive in a multi-drive scope set', async () => {
+    const scopes = scopeSet([
+      ['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }],
+      ['drive-2', { kind: 'drive', driveId: 'drive-2', role: { kind: 'admin' } }],
+      ['drive-3', { kind: 'drive', driveId: 'drive-3', role: { kind: 'member' } }],
+    ]);
+
+    const authority = await resolveGrantAuthority(scopes, USER_ID);
+
+    expect(authority.size).toBe(3);
+    expect(getDriveAccess).toHaveBeenCalledTimes(3);
+    expect(getDriveAccess).toHaveBeenCalledWith('drive-1', USER_ID);
+    expect(getDriveAccess).toHaveBeenCalledWith('drive-2', USER_ID);
+    expect(getDriveAccess).toHaveBeenCalledWith('drive-3', USER_ID);
+  });
+
+  it('only checks customRoleBelongsToDrive for a custom-role scope, not for inherit/admin/member', async () => {
+    const scopes = scopeSet([
+      ['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }],
+      ['drive-2', { kind: 'drive', driveId: 'drive-2', role: { kind: 'custom', customRoleId: 'role-x' } }],
+    ]);
+
+    await resolveGrantAuthority(scopes, USER_ID);
+
+    expect(customRoleBelongsToDrive).toHaveBeenCalledTimes(1);
+    expect(customRoleBelongsToDrive).toHaveBeenCalledWith('role-x', 'drive-2');
+  });
+
+  it("wires roleBelongsToDrive() to customRoleBelongsToDrive's resolved value for a custom-role scope", async () => {
+    customRoleBelongsToDrive.mockResolvedValue(false);
+    const scopes = scopeSet([['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'custom', customRoleId: 'role-x' } }]]);
+
+    const authority = await resolveGrantAuthority(scopes, USER_ID);
+
+    expect(authority.get('drive-1')?.roleBelongsToDrive('role-x')).toBe(false);
+  });
+
+  it('returns an empty map for a scope set with no drive scopes, without calling any lookup', async () => {
+    const scopes = scopeSet([]);
+
+    const authority = await resolveGrantAuthority(scopes, USER_ID);
+
+    expect(authority.size).toBe(0);
+    expect(getDriveAccess).not.toHaveBeenCalled();
+  });
+
+  it('resolves per-drive lookups concurrently, not serialized one drive at a time', async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    getDriveAccess.mockImplementation(async () => {
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      concurrent -= 1;
+      return { isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' };
+    });
+
+    const scopes = scopeSet([
+      ['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }],
+      ['drive-2', { kind: 'drive', driveId: 'drive-2', role: { kind: 'inherit' } }],
+      ['drive-3', { kind: 'drive', driveId: 'drive-3', role: { kind: 'inherit' } }],
+    ]);
+
+    await resolveGrantAuthority(scopes, USER_ID);
+
+    // Serialized (for-of + await one drive at a time) would never exceed 1.
+    expect(maxConcurrent).toBeGreaterThan(1);
+  });
+});

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -709,6 +709,7 @@ export function checkMCPCreateScope(
 // Re-export from other auth modules
 export {
   isScopedMCPAuth,
+  isScopedOAuthAuth,
   getPrincipalAccessLevel,
   canPrincipalViewPage,
   canPrincipalEditPage,

--- a/apps/web/src/lib/auth/oauth-grant-authority.ts
+++ b/apps/web/src/lib/auth/oauth-grant-authority.ts
@@ -1,0 +1,33 @@
+/**
+ * Consent-time / device-decision grant-authority resolution (ADR 0002
+ * Decision 2). Shared by the authorization-code consent screen
+ * (`/api/oauth/authorize`) and the device-authorization approval decision
+ * (`/api/oauth/device_authorization/decision`) — both mint a grant from
+ * user-approved scopes and must enforce the exact same authority caps before
+ * doing so, so the DB-backed lookup lives in one place and both routes hand
+ * the result straight to the pure `checkGrantAuthority`.
+ */
+import type { ScopeSet, GrantAuthority } from '@pagespace/lib/auth/oauth/scopes';
+import { getDriveAccess } from '@pagespace/lib/services/drive-service';
+import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
+
+export async function resolveGrantAuthority(scopes: ScopeSet, userId: string): Promise<GrantAuthority> {
+  const authorityMap = new Map<string, GrantAuthority extends ReadonlyMap<string, infer V> ? V : never>();
+
+  for (const [driveId, scope] of scopes.drives) {
+    const access = await getDriveAccess(driveId, userId);
+    const ownCustomRoleId = await getMemberCustomRoleId(driveId, userId);
+    const customRoleOk =
+      scope.role.kind === 'custom' ? await customRoleBelongsToDrive(scope.role.customRoleId, driveId) : true;
+
+    authorityMap.set(driveId, {
+      isOwner: access.isOwner,
+      isMember: access.isMember,
+      isAdmin: access.isAdmin,
+      ownCustomRoleId,
+      roleBelongsToDrive: () => customRoleOk,
+    });
+  }
+
+  return authorityMap;
+}

--- a/apps/web/src/lib/auth/oauth-grant-authority.ts
+++ b/apps/web/src/lib/auth/oauth-grant-authority.ts
@@ -12,22 +12,26 @@ import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { customRoleBelongsToDrive, getMemberCustomRoleId } from '@pagespace/lib/permissions/membership-queries';
 
 export async function resolveGrantAuthority(scopes: ScopeSet, userId: string): Promise<GrantAuthority> {
-  const authorityMap = new Map<string, GrantAuthority extends ReadonlyMap<string, infer V> ? V : never>();
+  const entries = await Promise.all(
+    Array.from(scopes.drives, async ([driveId, scope]) => {
+      const [access, ownCustomRoleId, customRoleOk] = await Promise.all([
+        getDriveAccess(driveId, userId),
+        getMemberCustomRoleId(driveId, userId),
+        scope.role.kind === 'custom' ? customRoleBelongsToDrive(scope.role.customRoleId, driveId) : Promise.resolve(true),
+      ]);
 
-  for (const [driveId, scope] of scopes.drives) {
-    const access = await getDriveAccess(driveId, userId);
-    const ownCustomRoleId = await getMemberCustomRoleId(driveId, userId);
-    const customRoleOk =
-      scope.role.kind === 'custom' ? await customRoleBelongsToDrive(scope.role.customRoleId, driveId) : true;
+      return [
+        driveId,
+        {
+          isOwner: access.isOwner,
+          isMember: access.isMember,
+          isAdmin: access.isAdmin,
+          ownCustomRoleId,
+          roleBelongsToDrive: () => customRoleOk,
+        },
+      ] as const;
+    }),
+  );
 
-    authorityMap.set(driveId, {
-      isOwner: access.isOwner,
-      isMember: access.isMember,
-      isAdmin: access.isAdmin,
-      ownCustomRoleId,
-      roleBelongsToDrive: () => customRoleOk,
-    });
-  }
-
-  return authorityMap;
+  return new Map(entries);
 }

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
@@ -323,7 +323,7 @@ describe('pollDeviceToken', () => {
     expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
     expect(refreshRows).toHaveLength(1);
     expect(accessRows).toHaveLength(1);
-    expect(refreshRows[0].tokenHash).toBe(hashToken(result.tokens.refreshToken));
+    expect(refreshRows[0].tokenHash).toBe(hashToken(result.tokens.refreshToken!));
   });
 
   it('does not persist lastPolledAt for an already-settled (approved) record', async () => {
@@ -341,6 +341,32 @@ describe('pollDeviceToken', () => {
     expect(result).toEqual({ outcome: 'user_suspended' });
     expect(refreshRows).toHaveLength(0);
     expect(accessRows).toHaveLength(0);
+  });
+
+  describe('F1 — refresh token gated on offline_access', () => {
+    it('mints an access-only grant (no refresh row, no refresh_token) when offline_access was not requested', async () => {
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['account'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result.outcome).toBe('ok');
+      if (result.outcome !== 'ok') throw new Error('unreachable');
+      expect(result.tokens.accessToken).toMatch(/^ps_at_/);
+      expect(result.tokens.refreshToken).toBeUndefined();
+      expect(refreshRows).toHaveLength(0);
+      expect(accessRows).toHaveLength(1);
+    });
+
+    it('mints a refresh token when offline_access was requested', async () => {
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['account', 'offline_access'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result.outcome).toBe('ok');
+      if (result.outcome !== 'ok') throw new Error('unreachable');
+      expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
+      expect(refreshRows).toHaveLength(1);
+    });
   });
 });
 

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.exchange.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.exchange.test.ts
@@ -189,7 +189,10 @@ function seedCodeRow(overrides: Partial<CodeRow> = {}): void {
     codeHash: hashToken(CODE),
     clientId: CLIENT_DB_ID,
     userId: USER_ID,
-    scopes: ['account'],
+    // offline_access included by default so the pre-existing happy-path
+    // fixtures below exercise refresh-token issuance as before; the F1 gate
+    // tests further down explicitly override this to exercise access-only.
+    scopes: ['account', 'offline_access'],
     redirectUri: REDIRECT_URI,
     codeChallenge: deriveCodeChallenge(CODE_VERIFIER),
     codeChallengeMethod: 'S256',
@@ -225,7 +228,7 @@ describe('exchangeAuthorizationCode — happy path', () => {
     expect(result.outcome).toBe('ok');
     if (result.outcome !== 'ok') throw new Error('unreachable');
     expect(result.userId).toBe(USER_ID);
-    expect(result.scopes).toEqual(['account']);
+    expect(result.scopes).toEqual(['account', 'offline_access']);
     expect(result.tokens.accessToken).toMatch(/^ps_at_/);
     expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
 
@@ -233,7 +236,7 @@ describe('exchangeAuthorizationCode — happy path', () => {
     expect(codeRow?.issuedFamilyId).toBe(result.tokens.familyId);
     expect(refreshRows).toHaveLength(1);
     expect(accessRows).toHaveLength(1);
-    expect(refreshRows[0].tokenHash).toBe(hashToken(result.tokens.refreshToken));
+    expect(refreshRows[0].tokenHash).toBe(hashToken(result.tokens.refreshToken!));
     expect(accessRows[0].tokenHash).toBe(hashToken(result.tokens.accessToken));
   });
 
@@ -409,6 +412,46 @@ describe('exchangeAuthorizationCode — atomic single-use consumption under a ra
     expect(refreshRows[0].revokedAt).not.toBeNull();
     expect(accessRows[0].revokedAt).not.toBeNull();
     // No new tokens were minted for the replay.
+    expect(refreshRows).toHaveLength(1);
+    expect(accessRows).toHaveLength(1);
+  });
+});
+
+describe('exchangeAuthorizationCode — F1: refresh token gated on offline_access', () => {
+  it('mints an access-only grant (no refresh row, no refresh_token) when offline_access was not requested', async () => {
+    seedCodeRow({ scopes: ['account'] });
+
+    const result = await exchangeAuthorizationCode({
+      code: CODE,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+      clientDbId: CLIENT_DB_ID,
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.tokens.accessToken).toMatch(/^ps_at_/);
+    expect(result.tokens.refreshToken).toBeUndefined();
+    expect(refreshRows).toHaveLength(0);
+    expect(accessRows).toHaveLength(1);
+    expect(codeRow?.issuedFamilyId).toBe(result.tokens.familyId);
+  });
+
+  it('mints a refresh token when offline_access was requested', async () => {
+    seedCodeRow({ scopes: ['account', 'offline_access'] });
+
+    const result = await exchangeAuthorizationCode({
+      code: CODE,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+      clientDbId: CLIENT_DB_ID,
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
     expect(refreshRows).toHaveLength(1);
     expect(accessRows).toHaveLength(1);
   });

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
@@ -447,7 +447,7 @@ describe('refreshTokenGrant — F1: refresh token gated on offline_access', () =
     expect(accessRows[0].scopes).toEqual(['account']);
   });
 
-  it('a terminal (access-only) rotation still marks replacedByTokenId non-null, so a benign in-window retry is NOT mistaken for reuse (Codex P2)', async () => {
+  it('a terminal (access-only) rotation still records revokedReason "rotated" (honest null replacedByTokenId), so a benign in-window retry is NOT mistaken for reuse (Codex P2)', async () => {
     seedRefreshRow({ scopes: ['account', 'offline_access'] });
 
     const result = await refreshTokenGrant({
@@ -458,12 +458,15 @@ describe('refreshTokenGrant — F1: refresh token gated on offline_access', () =
     });
 
     expect(result.outcome).toBe('ok');
-    // decideRefreshRotation's grace-window branch only applies when
-    // replacedByTokenId !== null — without a marker here, ANY presentation of
-    // this now-revoked token (even a benign dropped-connection retry inside
-    // the 30s window) falls straight through to reuse_detected and revokes
-    // the whole family, including the access token this call just issued.
-    expect(refreshRows[0].replacedByTokenId).not.toBeNull();
+    // decideRefreshRotation's grace-window branch keys off revokedReason ===
+    // 'rotated' (not replacedByTokenId, which is honestly null here — there
+    // really is no next refresh row for a terminal rotation). Without this,
+    // ANY presentation of this now-revoked token (even a benign
+    // dropped-connection retry inside the 30s window) would fall straight
+    // through to reuse_detected and revoke the whole family, including the
+    // access token this call just issued.
+    expect(refreshRows[0].revokedReason).toBe('rotated');
+    expect(refreshRows[0].replacedByTokenId).toBeNull();
   });
 
   it('a benign duplicate/retry within the grace window on a terminal rotation does NOT revoke the family (Codex P2)', async () => {

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
@@ -447,6 +447,58 @@ describe('refreshTokenGrant — F1: refresh token gated on offline_access', () =
     expect(accessRows[0].scopes).toEqual(['account']);
   });
 
+  it('a terminal (access-only) rotation still marks replacedByTokenId non-null, so a benign in-window retry is NOT mistaken for reuse (Codex P2)', async () => {
+    seedRefreshRow({ scopes: ['account', 'offline_access'] });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: 'account',
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    // decideRefreshRotation's grace-window branch only applies when
+    // replacedByTokenId !== null — without a marker here, ANY presentation of
+    // this now-revoked token (even a benign dropped-connection retry inside
+    // the 30s window) falls straight through to reuse_detected and revokes
+    // the whole family, including the access token this call just issued.
+    expect(refreshRows[0].replacedByTokenId).not.toBeNull();
+  });
+
+  it('a benign duplicate/retry within the grace window on a terminal rotation does NOT revoke the family (Codex P2)', async () => {
+    seedRefreshRow({ scopes: ['account', 'offline_access'] });
+
+    const t0 = new Date();
+    const first = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: 'account', // drops offline_access -> terminal, access-only
+      now: t0,
+    });
+    expect(first.outcome).toBe('ok');
+    if (first.outcome !== 'ok') throw new Error('unreachable');
+    expect(first.tokens.refreshToken).toBeUndefined();
+
+    // A benign duplicate/retry (e.g. a dropped-connection retry) presents the
+    // SAME (now-revoked) old token again, within the 30s grace window.
+    const retryNow = new Date(t0.getTime() + 5_000);
+    const retry = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: 'account',
+      now: retryNow,
+    });
+
+    // The retry itself still fails — there's no grace cache to replay from
+    // (deferred infra, same as the non-terminal case) — but critically the
+    // family must NOT be revoked: the access token from the first
+    // (successful) response must remain valid.
+    expect(retry).toEqual({ outcome: 'invalid_grant' });
+    expect(accessRows).toHaveLength(1);
+    expect(accessRows[0].revokedAt).toBeFalsy();
+  });
+
   it('keeps minting a refresh token across rotation while offline_access remains granted', async () => {
     seedRefreshRow({ scopes: ['account', 'offline_access'] });
 

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.refresh.test.ts
@@ -96,6 +96,7 @@ interface AccessRow {
 let refreshRows: RefreshRow[] = [];
 let accessRows: AccessRow[] = [];
 let userSuspendedAt: Date | null = null;
+let userTokenVersion = 0;
 let lockChain: Promise<unknown> = Promise.resolve();
 
 function makeTx() {
@@ -104,7 +105,7 @@ function makeTx() {
       from: (table: unknown) => ({
         where: (predicate: Predicate) => {
           if (table === usersTable) {
-            return Promise.resolve([{ suspendedAt: userSuspendedAt }]);
+            return Promise.resolve([{ suspendedAt: userSuspendedAt, tokenVersion: userTokenVersion }]);
           }
           const matches = refreshRows.filter((r) => evalPredicate(predicate, r as unknown as Record<string, unknown>));
           const p = Promise.resolve(matches) as Promise<RefreshRow[]> & { for: (mode: string) => Promise<RefreshRow[]> };
@@ -162,7 +163,11 @@ function seedRefreshRow(overrides: Partial<RefreshRow> = {}): RefreshRow {
     clientId: CLIENT_DB_ID,
     familyId: FAMILY_ID,
     userId: USER_ID,
-    scopes: ['account'],
+    // offline_access included by default: a stored refresh-token row only
+    // ever exists because offline_access was granted at issuance, so the
+    // pre-existing rotation fixtures below keep exercising that path; the F1
+    // gate tests further down explicitly narrow it away.
+    scopes: ['account', 'offline_access'],
     tokenVersion: 0,
     expiresAt: new Date(Date.now() + 30 * DAY),
     familyExpiresAt: new Date(Date.now() + 90 * DAY),
@@ -180,6 +185,7 @@ beforeEach(() => {
   refreshRows = [];
   accessRows = [];
   userSuspendedAt = null;
+  userTokenVersion = 0;
   lockChain = Promise.resolve();
 });
 
@@ -205,7 +211,7 @@ describe('refreshTokenGrant — happy path', () => {
     expect(refreshRows[0].replacedByTokenId).not.toBeNull();
     expect(refreshRows).toHaveLength(2);
     expect(accessRows).toHaveLength(1);
-    expect(refreshRows[1].tokenHash).toBe(hashToken(result.tokens.refreshToken));
+    expect(refreshRows[1].tokenHash).toBe(hashToken(result.tokens.refreshToken!));
     expect(refreshRows[1].familyId).toBe(FAMILY_ID);
   });
 
@@ -299,13 +305,13 @@ describe('refreshTokenGrant — reuse detection: the theft scenario end-to-end',
     expect(attackerAttempt).toEqual({ outcome: 'invalid_grant' });
 
     // The entire family is dead: the legitimate client's brand-new refresh token is also revoked.
-    const legitimateNewRow = refreshRows.find((r) => r.tokenHash === hashToken(legitimate.tokens.refreshToken));
+    const legitimateNewRow = refreshRows.find((r) => r.tokenHash === hashToken(legitimate.tokens.refreshToken!));
     expect(legitimateNewRow?.revokedAt).not.toBeNull();
     expect(accessRows.every((r) => r.revokedAt !== null)).toBe(true);
 
     // Locked out: the legitimate client can no longer refresh with its (now-revoked) new token either.
     const legitimateRetry = await refreshTokenGrant({
-      refreshToken: legitimate.tokens.refreshToken,
+      refreshToken: legitimate.tokens.refreshToken!,
       clientDbId: CLIENT_DB_ID,
       requestedScope: null,
       now: new Date(Date.now() + 61_000),
@@ -355,20 +361,24 @@ describe('refreshTokenGrant — suspended user (zero-trust audit finding)', () =
 
 describe('refreshTokenGrant — scope narrowing', () => {
   it('narrows scope on request and persists only the narrowed set on the new tokens', async () => {
-    seedRefreshRow({ scopes: ['account', 'offline_access'] });
+    // Keep offline_access in the narrowed request so this test's focus (only
+    // the narrowed set is persisted) stays independent of the F1 gate, which
+    // has its own dedicated tests below. `account` and `drive:*` scopes are
+    // mutually exclusive by grammar, so narrow among drive scopes instead.
+    seedRefreshRow({ scopes: ['offline_access', 'drive:abc12345', 'drive:xyz98765'] });
 
     const result = await refreshTokenGrant({
       refreshToken: REFRESH_TOKEN,
       clientDbId: CLIENT_DB_ID,
-      requestedScope: 'account',
+      requestedScope: 'offline_access drive:abc12345',
       now: new Date(),
     });
 
     expect(result.outcome).toBe('ok');
     if (result.outcome !== 'ok') throw new Error('unreachable');
-    expect(result.scopes).toEqual(['account']);
-    expect(refreshRows[1].scopes).toEqual(['account']);
-    expect(accessRows[0].scopes).toEqual(['account']);
+    expect(result.scopes).toEqual(['offline_access', 'drive:abc12345']);
+    expect(refreshRows[1].scopes).toEqual(['offline_access', 'drive:abc12345']);
+    expect(accessRows[0].scopes).toEqual(['offline_access', 'drive:abc12345']);
   });
 
   it('rejects any scope escalation attempt with invalid_scope', async () => {
@@ -404,10 +414,87 @@ describe('refreshTokenGrant — concurrent refresh yields exactly one winner', (
     // rejection must not revoke the winner's brand-new pair.
     const winner = first.outcome === 'ok' ? first : second;
     if (winner.outcome !== 'ok') throw new Error('unreachable');
-    const winnerRow = refreshRows.find((r) => r.tokenHash === hashToken(winner.tokens.refreshToken));
+    const winnerRow = refreshRows.find((r) => r.tokenHash === hashToken(winner.tokens.refreshToken!));
     expect(winnerRow?.revokedAt).toBeFalsy();
 
     expect(refreshRows).toHaveLength(2);
     expect(accessRows).toHaveLength(1);
+  });
+});
+
+describe('refreshTokenGrant — F1: refresh token gated on offline_access', () => {
+  it('narrowing the request scope to drop offline_access ends the family: rotated pair is access-only', async () => {
+    seedRefreshRow({ scopes: ['account', 'offline_access'] });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: 'account',
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.scopes).toEqual(['account']);
+    expect(result.tokens.refreshToken).toBeUndefined();
+    expect(result.tokens.accessToken).toMatch(/^ps_at_/);
+    // The presented token is still revoked (rotation always consumes it),
+    // but no new refresh row is inserted since the narrowed set has no
+    // offline_access to carry forward.
+    expect(refreshRows).toHaveLength(1);
+    expect(refreshRows[0].revokedAt).not.toBeNull();
+    expect(accessRows).toHaveLength(1);
+    expect(accessRows[0].scopes).toEqual(['account']);
+  });
+
+  it('keeps minting a refresh token across rotation while offline_access remains granted', async () => {
+    seedRefreshRow({ scopes: ['account', 'offline_access'] });
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
+    if (result.outcome !== 'ok') throw new Error('unreachable');
+    expect(result.tokens.refreshToken).toMatch(/^ps_rt_/);
+    expect(refreshRows).toHaveLength(2);
+  });
+});
+
+describe('refreshTokenGrant — tokenVersion mismatch (global logout, ADR 0003 §6-§7)', () => {
+  it('refuses a refresh whose snapshot tokenVersion no longer matches the user, WITHOUT revoking the family (logout ≠ theft)', async () => {
+    seedRefreshRow({ tokenVersion: 1 });
+    userTokenVersion = 2;
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result).toEqual({ outcome: 'invalid_grant' });
+    // Family untouched: not revoked, no new tokens minted, but the presented
+    // token itself is also left alone (this is not a rotation, and not theft).
+    expect(refreshRows).toHaveLength(1);
+    expect(refreshRows[0].revokedAt).toBeNull();
+    expect(accessRows).toHaveLength(0);
+  });
+
+  it('allows the refresh when the snapshot tokenVersion matches the user', async () => {
+    seedRefreshRow({ tokenVersion: 2 });
+    userTokenVersion = 2;
+
+    const result = await refreshTokenGrant({
+      refreshToken: REFRESH_TOKEN,
+      clientDbId: CLIENT_DB_ID,
+      requestedScope: null,
+      now: new Date(),
+    });
+
+    expect(result.outcome).toBe('ok');
   });
 });

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -197,24 +197,30 @@ export async function exchangeAuthorizationCode(
       return { outcome: 'user_suspended' };
     }
 
-    const tokens = issueInitialTokenPair(input.now);
+    // F1 (ADR 0003, OIDC-standard): a refresh token is only minted when the
+    // granted scope set includes offline_access — otherwise this is an
+    // access-only grant.
+    const offlineAccess = row.scopes.includes('offline_access');
+    const tokens = issueInitialTokenPair(input.now, offlineAccess);
 
     await tx
       .update(oauthAuthorizationCodes)
       .set({ consumedAt: input.now, issuedFamilyId: tokens.familyId })
       .where(eq(oauthAuthorizationCodes.id, row.id));
 
-    await tx.insert(oauthRefreshTokens).values({
-      tokenHash: tokens.refreshTokenHash,
-      tokenPrefix: tokens.refreshTokenPrefix,
-      familyId: tokens.familyId,
-      clientId: input.clientDbId,
-      userId: row.userId,
-      scopes: row.scopes,
-      tokenVersion,
-      expiresAt: tokens.refreshExpiresAt,
-      familyExpiresAt: tokens.familyExpiresAt,
-    });
+    if (tokens.refreshToken !== undefined) {
+      await tx.insert(oauthRefreshTokens).values({
+        tokenHash: tokens.refreshTokenHash,
+        tokenPrefix: tokens.refreshTokenPrefix,
+        familyId: tokens.familyId,
+        clientId: input.clientDbId,
+        userId: row.userId,
+        scopes: row.scopes,
+        tokenVersion,
+        expiresAt: tokens.refreshExpiresAt,
+        familyExpiresAt: tokens.familyExpiresAt,
+      });
+    }
 
     await tx.insert(oauthAccessTokens).values({
       tokenHash: tokens.accessTokenHash,
@@ -340,13 +346,24 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
       return { outcome: 'invalid_grant' };
     }
 
+    // Fetched up front (not just for the suspension check below): the
+    // decision itself needs the user's CURRENT tokenVersion to detect a
+    // global "logout all devices" that happened since this token's snapshot.
+    const userRows = await tx
+      .select({ suspendedAt: users.suspendedAt, tokenVersion: users.tokenVersion })
+      .from(users)
+      .where(eq(users.id, row.userId));
+    const currentTokenVersion = userRows[0]?.tokenVersion ?? 0;
+
     const decision = decideRefreshRotation(
       {
         expiresAt: row.expiresAt,
         familyExpiresAt: row.familyExpiresAt,
         revokedAt: row.revokedAt,
         replacedByTokenId: row.replacedByTokenId,
+        tokenVersion: row.tokenVersion,
       },
+      currentTokenVersion,
       input.now,
       false,
     );
@@ -369,10 +386,6 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
     // killed outright, the same way an MCP token is revoked on sight, rather
     // than left alive to keep minting access tokens that only die on first
     // use (constant-shape: same invalid_grant a reused/expired token gets).
-    const userRows = await tx
-      .select({ suspendedAt: users.suspendedAt })
-      .from(users)
-      .where(eq(users.id, row.userId));
     if (userRows[0]?.suspendedAt) {
       await revokeTokenFamily(tx, row.familyId, input.now, 'user_suspended');
       return { outcome: 'invalid_grant' };
@@ -388,26 +401,32 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
       scopes = formatScopeSet(requested.scopes).split(' ');
     }
 
-    const newRefreshId = createId();
-    const tokens = issueRotatedTokenPair(input.now, row.familyId, row.familyExpiresAt);
+    // F1 (ADR 0003, OIDC-standard): a client that narrows scope to drop
+    // offline_access ends the refresh chain here — the rotated pair is
+    // access-only and there is nothing left to replace the presented token.
+    const offlineAccess = scopes.includes('offline_access');
+    const newRefreshId = offlineAccess ? createId() : null;
+    const tokens = issueRotatedTokenPair(input.now, row.familyId, row.familyExpiresAt, offlineAccess);
 
     await tx
       .update(oauthRefreshTokens)
       .set({ revokedAt: input.now, revokedReason: 'rotated', replacedByTokenId: newRefreshId })
       .where(eq(oauthRefreshTokens.id, row.id));
 
-    await tx.insert(oauthRefreshTokens).values({
-      id: newRefreshId,
-      tokenHash: tokens.refreshTokenHash,
-      tokenPrefix: tokens.refreshTokenPrefix,
-      familyId: tokens.familyId,
-      clientId: input.clientDbId,
-      userId: row.userId,
-      scopes,
-      tokenVersion: row.tokenVersion,
-      expiresAt: tokens.refreshExpiresAt,
-      familyExpiresAt: tokens.familyExpiresAt,
-    });
+    if (tokens.refreshToken !== undefined && newRefreshId !== null) {
+      await tx.insert(oauthRefreshTokens).values({
+        id: newRefreshId,
+        tokenHash: tokens.refreshTokenHash,
+        tokenPrefix: tokens.refreshTokenPrefix,
+        familyId: tokens.familyId,
+        clientId: input.clientDbId,
+        userId: row.userId,
+        scopes,
+        tokenVersion: row.tokenVersion,
+        expiresAt: tokens.refreshExpiresAt,
+        familyExpiresAt: tokens.familyExpiresAt,
+      });
+    }
 
     await tx.insert(oauthAccessTokens).values({
       tokenHash: tokens.accessTokenHash,
@@ -566,19 +585,23 @@ export async function pollDeviceToken(input: PollDeviceTokenInput): Promise<Poll
       return { outcome: 'user_suspended' };
     }
 
-    const tokens = issueInitialTokenPair(input.now);
+    // F1 (ADR 0003, OIDC-standard): access-only unless offline_access was granted.
+    const offlineAccess = decision.grant.scopes.includes('offline_access');
+    const tokens = issueInitialTokenPair(input.now, offlineAccess);
 
-    await tx.insert(oauthRefreshTokens).values({
-      tokenHash: tokens.refreshTokenHash,
-      tokenPrefix: tokens.refreshTokenPrefix,
-      familyId: tokens.familyId,
-      clientId: input.clientDbId,
-      userId: decision.grant.userId,
-      scopes: decision.grant.scopes,
-      tokenVersion,
-      expiresAt: tokens.refreshExpiresAt,
-      familyExpiresAt: tokens.familyExpiresAt,
-    });
+    if (tokens.refreshToken !== undefined) {
+      await tx.insert(oauthRefreshTokens).values({
+        tokenHash: tokens.refreshTokenHash,
+        tokenPrefix: tokens.refreshTokenPrefix,
+        familyId: tokens.familyId,
+        clientId: input.clientDbId,
+        userId: decision.grant.userId,
+        scopes: decision.grant.scopes,
+        tokenVersion,
+        expiresAt: tokens.refreshExpiresAt,
+        familyExpiresAt: tokens.familyExpiresAt,
+      });
+    }
 
     await tx.insert(oauthAccessTokens).values({
       tokenHash: tokens.accessTokenHash,

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -292,14 +292,6 @@ export async function revokeOAuthToken(input: RevokeOAuthTokenInput): Promise<vo
   // Neither opaque format — foreign/garbage token, no-op (no oracle upstream).
 }
 
-/**
- * Sentinel for `oauthRefreshTokens.replacedByTokenId` on a terminal (F1
- * access-only) rotation — never dereferenced/joined against, only read back
- * as a plain `!== null` check by `decideRefreshRotation`'s grace-window
- * branch (`refresh-rotation.ts`). See `refreshTokenGrant` below.
- */
-const TERMINAL_ROTATION_MARKER = 'terminal-access-only-rotation';
-
 export interface RefreshTokenGrantInput {
   /** Raw refresh token from the token request; hashed before any lookup. */
   refreshToken: string;
@@ -343,7 +335,7 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
         familyExpiresAt: oauthRefreshTokens.familyExpiresAt,
         familyId: oauthRefreshTokens.familyId,
         revokedAt: oauthRefreshTokens.revokedAt,
-        replacedByTokenId: oauthRefreshTokens.replacedByTokenId,
+        revokedReason: oauthRefreshTokens.revokedReason,
       })
       .from(oauthRefreshTokens)
       .where(and(eq(oauthRefreshTokens.tokenHash, tokenHash), eq(oauthRefreshTokens.clientId, input.clientDbId)))
@@ -368,7 +360,7 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
         expiresAt: row.expiresAt,
         familyExpiresAt: row.familyExpiresAt,
         revokedAt: row.revokedAt,
-        replacedByTokenId: row.replacedByTokenId,
+        revokedReason: row.revokedReason,
         tokenVersion: row.tokenVersion,
       },
       currentTokenVersion,
@@ -416,17 +408,14 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
     const newRefreshId = offlineAccess ? createId() : null;
     const tokens = issueRotatedTokenPair(input.now, row.familyId, row.familyExpiresAt, offlineAccess);
 
-    // decideRefreshRotation's grace-window branch only fires when
-    // replacedByTokenId !== null (it's the signal "this row died via a
-    // legitimate rotation", distinct from a straight reuse/family
-    // revocation). A terminal (access-only) rotation has no next refresh row
-    // to point to, but a benign in-window retry (dropped connection, same as
-    // any other rotation) must still land on grace_cache_miss rather than
-    // reuse_detected — so mark it with a non-dereferenced sentinel instead of
-    // leaving it null.
+    // decideRefreshRotation's grace-window branch keys off revokedReason ===
+    // 'rotated' (not replacedByTokenId) precisely so a terminal (access-only)
+    // rotation — no next refresh row to point to — still lands a benign
+    // in-window retry on grace_cache_miss rather than reuse_detected.
+    // replacedByTokenId stays an honest null for a terminal rotation.
     await tx
       .update(oauthRefreshTokens)
-      .set({ revokedAt: input.now, revokedReason: 'rotated', replacedByTokenId: newRefreshId ?? TERMINAL_ROTATION_MARKER })
+      .set({ revokedAt: input.now, revokedReason: 'rotated', replacedByTokenId: newRefreshId })
       .where(eq(oauthRefreshTokens.id, row.id));
 
     if (tokens.refreshToken !== undefined && newRefreshId !== null) {

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -292,6 +292,14 @@ export async function revokeOAuthToken(input: RevokeOAuthTokenInput): Promise<vo
   // Neither opaque format — foreign/garbage token, no-op (no oracle upstream).
 }
 
+/**
+ * Sentinel for `oauthRefreshTokens.replacedByTokenId` on a terminal (F1
+ * access-only) rotation — never dereferenced/joined against, only read back
+ * as a plain `!== null` check by `decideRefreshRotation`'s grace-window
+ * branch (`refresh-rotation.ts`). See `refreshTokenGrant` below.
+ */
+const TERMINAL_ROTATION_MARKER = 'terminal-access-only-rotation';
+
 export interface RefreshTokenGrantInput {
   /** Raw refresh token from the token request; hashed before any lookup. */
   refreshToken: string;
@@ -408,9 +416,17 @@ export async function refreshTokenGrant(input: RefreshTokenGrantInput): Promise<
     const newRefreshId = offlineAccess ? createId() : null;
     const tokens = issueRotatedTokenPair(input.now, row.familyId, row.familyExpiresAt, offlineAccess);
 
+    // decideRefreshRotation's grace-window branch only fires when
+    // replacedByTokenId !== null (it's the signal "this row died via a
+    // legitimate rotation", distinct from a straight reuse/family
+    // revocation). A terminal (access-only) rotation has no next refresh row
+    // to point to, but a benign in-window retry (dropped connection, same as
+    // any other rotation) must still land on grace_cache_miss rather than
+    // reuse_detected — so mark it with a non-dereferenced sentinel instead of
+    // leaving it null.
     await tx
       .update(oauthRefreshTokens)
-      .set({ revokedAt: input.now, revokedReason: 'rotated', replacedByTokenId: newRefreshId })
+      .set({ revokedAt: input.now, revokedReason: 'rotated', replacedByTokenId: newRefreshId ?? TERMINAL_ROTATION_MARKER })
       .where(eq(oauthRefreshTokens.id, row.id));
 
     if (tokens.refreshToken !== undefined && newRefreshId !== null) {

--- a/docs/adr/0003-cli-credential-model.md
+++ b/docs/adr/0003-cli-credential-model.md
@@ -89,6 +89,20 @@ The `client_id` for the first-party CLI, redirect-URI rules for the loopback cal
 
 ## 3. Decision D2 — Token format, lifetimes, rotation (the exact contract)
 
+**F1 (post-review amendment) — refresh issuance is gated on `offline_access`.**
+A refresh token (`ps_rt_*`) is minted — at initial issuance (`authorization_code`
+or `device_code` grant) or at rotation (`refresh_token` grant) — **only** when
+the granted scope set includes the `offline_access` scope (OIDC-standard); a
+grant without it is access-token-only, and the token response omits
+`refresh_token` entirely rather than sending a token nobody asked to keep
+alive. `pagespace login` always requests `account offline_access`
+(`packages/cli/src/commands/login.ts` `DEFAULT_LOGIN_SCOPE`), so the CLI's
+normal login flow is unaffected and always receives a refresh token. A client
+that narrows scope on a `refresh_token` grant (RFC 6749 §6) to drop
+`offline_access` gets one final access-only pair and ends the refresh chain —
+the presented token is still consumed (rotation semantics), but there is
+nothing left to rotate into on a subsequent call.
+
 ### 3.1 Format and storage at rest (server)
 
 - Access token: **`ps_at_*`**; refresh token: **`ps_rt_*`**. Both opaque, 32 bytes base64url entropy via `generateOpaqueToken` — `TokenType` union and the `isValidTokenFormat` regex are extended with `at|rt` (`packages/lib/src/auth/opaque-tokens.ts:10,32`). No JWTs, no embedded claims — all context (user, client, scopes, family, expiry) lives in DB rows keyed by SHA3-256 hash (`token-utils.ts:42-44`), plaintext never stored, raw value returned exactly once at issuance. `tokenPrefix` (first 12 chars) stored for debugging only (`token-utils.ts:47-59`).

--- a/packages/lib/src/auth/oauth/__tests__/issue-tokens.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/issue-tokens.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import {
   issuedTokenLifetimes,
   issueInitialTokenPair,
+  issueRotatedTokenPair,
   ACCESS_TOKEN_TTL_SECONDS,
   REFRESH_TOKEN_TTL_SECONDS,
   REFRESH_TOKEN_FAMILY_TTL_SECONDS,
@@ -51,17 +52,17 @@ describe('issuedTokenLifetimes', () => {
 });
 
 describe('issueInitialTokenPair', () => {
-  it('mints ps_at_*/ps_rt_* tokens that pass the opaque-token format gate', () => {
-    const pair = issueInitialTokenPair(new Date());
+  it('mints ps_at_*/ps_rt_* tokens that pass the opaque-token format gate when offline_access is granted', () => {
+    const pair = issueInitialTokenPair(new Date(), true);
 
     expect(isValidTokenFormat(pair.accessToken)).toBe(true);
-    expect(isValidTokenFormat(pair.refreshToken)).toBe(true);
+    expect(isValidTokenFormat(pair.refreshToken!)).toBe(true);
     expect(getTokenType(pair.accessToken)).toBe('at');
-    expect(getTokenType(pair.refreshToken)).toBe('rt');
+    expect(getTokenType(pair.refreshToken!)).toBe('rt');
   });
 
   it('never returns the raw token as its own hash', () => {
-    const pair = issueInitialTokenPair(new Date());
+    const pair = issueInitialTokenPair(new Date(), true);
 
     expect(pair.accessTokenHash).not.toBe(pair.accessToken);
     expect(pair.refreshTokenHash).not.toBe(pair.refreshToken);
@@ -71,20 +72,61 @@ describe('issueInitialTokenPair', () => {
 
   it('fixes familyExpiresAt at 90 days from now and clamps refresh accordingly', () => {
     const now = new Date('2026-01-01T00:00:00Z');
-    const pair = issueInitialTokenPair(now);
+    const pair = issueInitialTokenPair(now, true);
 
     expect(pair.familyExpiresAt.getTime()).toBe(now.getTime() + REFRESH_TOKEN_FAMILY_TTL_SECONDS * 1000);
-    expect(pair.refreshExpiresAt.getTime()).toBe(now.getTime() + REFRESH_TOKEN_TTL_SECONDS * 1000);
+    expect(pair.refreshExpiresAt!.getTime()).toBe(now.getTime() + REFRESH_TOKEN_TTL_SECONDS * 1000);
     expect(pair.accessExpiresAt.getTime()).toBe(now.getTime() + ACCESS_TOKEN_TTL_SECONDS * 1000);
   });
 
   it('generates a fresh familyId and fresh tokens on every call (never reused)', () => {
     const now = new Date();
-    const first = issueInitialTokenPair(now);
-    const second = issueInitialTokenPair(now);
+    const first = issueInitialTokenPair(now, true);
+    const second = issueInitialTokenPair(now, true);
 
     expect(first.familyId).not.toBe(second.familyId);
     expect(first.accessToken).not.toBe(second.accessToken);
     expect(first.refreshToken).not.toBe(second.refreshToken);
+  });
+
+  describe('F1 — refresh token gated on offline_access', () => {
+    it('mints no refresh token at all when offline_access was not granted', () => {
+      const pair = issueInitialTokenPair(new Date(), false);
+
+      expect(pair.refreshToken).toBeUndefined();
+      expect(pair.refreshTokenHash).toBeUndefined();
+      expect(pair.refreshTokenPrefix).toBeUndefined();
+      expect(pair.refreshExpiresAt).toBeUndefined();
+    });
+
+    it('still mints a valid access token and family metadata when offline_access is absent', () => {
+      const now = new Date('2026-01-01T00:00:00Z');
+      const pair = issueInitialTokenPair(now, false);
+
+      expect(isValidTokenFormat(pair.accessToken)).toBe(true);
+      expect(pair.familyId).toBeTruthy();
+      expect(pair.familyExpiresAt.getTime()).toBe(now.getTime() + REFRESH_TOKEN_FAMILY_TTL_SECONDS * 1000);
+    });
+  });
+});
+
+describe('issueRotatedTokenPair — F1 refresh token gated on offline_access', () => {
+  it('mints a refresh token when offline_access is granted', () => {
+    const now = new Date();
+    const pair = issueRotatedTokenPair(now, 'family-1', new Date(now.getTime() + 1000), true);
+
+    expect(isValidTokenFormat(pair.refreshToken!)).toBe(true);
+    expect(pair.familyId).toBe('family-1');
+  });
+
+  it('mints no refresh token when offline_access is not granted', () => {
+    const now = new Date();
+    const pair = issueRotatedTokenPair(now, 'family-1', new Date(now.getTime() + 1000), false);
+
+    expect(pair.refreshToken).toBeUndefined();
+    expect(pair.refreshTokenHash).toBeUndefined();
+    expect(pair.refreshTokenPrefix).toBeUndefined();
+    expect(pair.refreshExpiresAt).toBeUndefined();
+    expect(isValidTokenFormat(pair.accessToken)).toBe(true);
   });
 });

--- a/packages/lib/src/auth/oauth/__tests__/refresh-rotation.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/refresh-rotation.test.ts
@@ -2,7 +2,8 @@
  * Pure refresh-token rotation decision (ADR 0003 §3.3-3.4, §6-§7; Phase 1
  * task 8, RED sub-task qa0870vw0zz27x14n1vluv6z). No DB, no clock, no
  * randomness — every case below hand-builds a `RefreshTokenRecord` and an
- * injected `now`/`graceCacheHit` and asserts the resulting decision.
+ * injected `userTokenVersion`/`now`/`graceCacheHit` and asserts the resulting
+ * decision.
  */
 import { describe, it, expect } from 'vitest';
 import { decideRefreshRotation, REFRESH_GRACE_WINDOW_MS, type RefreshTokenRecord } from '../refresh-rotation';
@@ -16,14 +17,15 @@ function liveRecord(overrides: Partial<RefreshTokenRecord> = {}): RefreshTokenRe
     familyExpiresAt: new Date(Date.now() + 90 * DAY),
     revokedAt: null,
     replacedByTokenId: null,
+    tokenVersion: 0,
     ...overrides,
   };
 }
 
 describe('decideRefreshRotation — happy path', () => {
-  it('rotates a live, unexpired, unrevoked token', () => {
+  it('rotates a live, unexpired, unrevoked token whose tokenVersion matches the user', () => {
     const now = new Date();
-    const decision = decideRefreshRotation(liveRecord(), now, false);
+    const decision = decideRefreshRotation(liveRecord(), 0, now, false);
     expect(decision).toEqual({ ok: true, action: 'rotate' });
   });
 });
@@ -32,13 +34,13 @@ describe('decideRefreshRotation — expiry', () => {
   it('exactly-at per-token expiry fails closed as expired', () => {
     const now = new Date(2026, 0, 1, 0, 0, 0);
     const record = liveRecord({ expiresAt: now, familyExpiresAt: new Date(now.getTime() + DAY) });
-    expect(decideRefreshRotation(record, now, false)).toEqual({ ok: false, reason: 'expired', revokeFamily: false });
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({ ok: false, reason: 'expired', revokeFamily: false });
   });
 
   it('past per-token expiry is expired', () => {
     const now = new Date();
     const record = liveRecord({ expiresAt: new Date(now.getTime() - 1000) });
-    expect(decideRefreshRotation(record, now, false)).toEqual({ ok: false, reason: 'expired', revokeFamily: false });
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({ ok: false, reason: 'expired', revokeFamily: false });
   });
 
   it('family_expired takes precedence over the per-token TTL (absolute cap wins)', () => {
@@ -47,7 +49,7 @@ describe('decideRefreshRotation — expiry', () => {
       familyExpiresAt: new Date(now.getTime() - 1000),
       expiresAt: new Date(now.getTime() + DAY), // per-token TTL not yet reached
     });
-    expect(decideRefreshRotation(record, now, false)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({
       ok: false,
       reason: 'family_expired',
       revokeFamily: false,
@@ -57,7 +59,7 @@ describe('decideRefreshRotation — expiry', () => {
   it('exactly-at family expiry fails closed as family_expired', () => {
     const now = new Date(2026, 0, 1, 0, 0, 0);
     const record = liveRecord({ familyExpiresAt: now });
-    expect(decideRefreshRotation(record, now, false)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({
       ok: false,
       reason: 'family_expired',
       revokeFamily: false,
@@ -71,7 +73,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     const now = new Date(revokedAt.getTime() + 29_000);
     const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
 
-    expect(decideRefreshRotation(record, now, true)).toEqual({ ok: true, action: 'grace-replay' });
+    expect(decideRefreshRotation(record, 0, now, true)).toEqual({ ok: true, action: 'grace-replay' });
   });
 
   it('same inputs with graceCacheHit false → grace_cache_miss (NOT theft — family untouched)', () => {
@@ -79,7 +81,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     const now = new Date(revokedAt.getTime() + 29_000);
     const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
 
-    expect(decideRefreshRotation(record, now, false)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({
       ok: false,
       reason: 'grace_cache_miss',
       revokeFamily: false,
@@ -91,7 +93,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     const now = new Date(revokedAt.getTime() + 31_000);
     const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
 
-    expect(decideRefreshRotation(record, now, true)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, true)).toEqual({
       ok: false,
       reason: 'reuse_detected',
       revokeFamily: true,
@@ -103,7 +105,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     const now = new Date(revokedAt.getTime() + 31_000);
     const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
 
-    expect(decideRefreshRotation(record, now, false)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({
       ok: false,
       reason: 'reuse_detected',
       revokeFamily: true,
@@ -115,7 +117,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     const now = new Date(revokedAt.getTime() + REFRESH_GRACE_WINDOW_MS);
     const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
 
-    expect(decideRefreshRotation(record, now, true)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, true)).toEqual({
       ok: false,
       reason: 'reuse_detected',
       revokeFamily: true,
@@ -127,7 +129,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     const now = new Date(revokedAt.getTime() + 1_000);
     const record = liveRecord({ revokedAt, replacedByTokenId: null });
 
-    expect(decideRefreshRotation(record, now, true)).toEqual({
+    expect(decideRefreshRotation(record, 0, now, true)).toEqual({
       ok: false,
       reason: 'reuse_detected',
       revokeFamily: true,
@@ -137,14 +139,46 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
   it('the theft scenario end-to-end: legitimate client rotates, then an attacker replays the stolen pre-rotation token outside the grace window — reuse_detected, family dies', () => {
     // Legitimate client's rotation revoked the old token at t0.
     const t0 = new Date();
-    const legitimateRotation = decideRefreshRotation(liveRecord({ revokedAt: null }), t0, false);
+    const legitimateRotation = decideRefreshRotation(liveRecord({ revokedAt: null }), 0, t0, false);
     expect(legitimateRotation).toEqual({ ok: true, action: 'rotate' });
 
     // Attacker replays the now-revoked, rotated-away token well after the grace window.
     const attackerNow = new Date(t0.getTime() + 60_000);
     const stolenRecord = liveRecord({ revokedAt: t0, replacedByTokenId: 'legit-next-token-id' });
-    const attackerDecision = decideRefreshRotation(stolenRecord, attackerNow, false);
+    const attackerDecision = decideRefreshRotation(stolenRecord, 0, attackerNow, false);
 
     expect(attackerDecision).toEqual({ ok: false, reason: 'reuse_detected', revokeFamily: true });
+  });
+});
+
+describe('decideRefreshRotation — tokenVersion mismatch (global logout, ADR 0003 §6-§7)', () => {
+  it('refuses a live, unexpired, unrevoked token whose snapshot tokenVersion no longer matches the user — WITHOUT revoking the family (logout ≠ theft)', () => {
+    const now = new Date();
+    const record = liveRecord({ tokenVersion: 1 });
+
+    expect(decideRefreshRotation(record, 2, now, false)).toEqual({
+      ok: false,
+      reason: 'version_mismatch',
+      revokeFamily: false,
+    });
+  });
+
+  it('a matching tokenVersion still rotates normally', () => {
+    const now = new Date();
+    const record = liveRecord({ tokenVersion: 3 });
+
+    expect(decideRefreshRotation(record, 3, now, false)).toEqual({ ok: true, action: 'rotate' });
+  });
+
+  it('reuse detection still takes precedence over a version mismatch (revocation checked first)', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 60_000);
+    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id', tokenVersion: 1 });
+
+    expect(decideRefreshRotation(record, 2, now, false)).toEqual({
+      ok: false,
+      reason: 'reuse_detected',
+      revokeFamily: true,
+    });
   });
 });

--- a/packages/lib/src/auth/oauth/__tests__/refresh-rotation.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/refresh-rotation.test.ts
@@ -16,7 +16,7 @@ function liveRecord(overrides: Partial<RefreshTokenRecord> = {}): RefreshTokenRe
     expiresAt: new Date(Date.now() + 30 * DAY),
     familyExpiresAt: new Date(Date.now() + 90 * DAY),
     revokedAt: null,
-    replacedByTokenId: null,
+    revokedReason: null,
     tokenVersion: 0,
     ...overrides,
   };
@@ -68,10 +68,10 @@ describe('decideRefreshRotation — expiry', () => {
 });
 
 describe('decideRefreshRotation — reuse detection, grace window, grace-cache miss (ADR 0003 §7.3)', () => {
-  it('29s after revocation, replacedByTokenId set, graceCacheHit true → grace-replay', () => {
+  it('29s after revocation, revokedReason "rotated", graceCacheHit true → grace-replay', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + 29_000);
-    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated' });
 
     expect(decideRefreshRotation(record, 0, now, true)).toEqual({ ok: true, action: 'grace-replay' });
   });
@@ -79,7 +79,22 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
   it('same inputs with graceCacheHit false → grace_cache_miss (NOT theft — family untouched)', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + 29_000);
-    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated' });
+
+    expect(decideRefreshRotation(record, 0, now, false)).toEqual({
+      ok: false,
+      reason: 'grace_cache_miss',
+      revokeFamily: false,
+    });
+  });
+
+  it('a TERMINAL rotation (F1: offline_access dropped, no next refresh token minted) still grants grace — revokedReason is "rotated" regardless of whether a replacement was minted', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 5_000);
+    // A terminal rotation revokes the presented token for the SAME reason
+    // ('rotated') as any other rotation — it just doesn't mint a next
+    // refresh token. The grace-window branch must not require one.
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated' });
 
     expect(decideRefreshRotation(record, 0, now, false)).toEqual({
       ok: false,
@@ -91,7 +106,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
   it('31s after revocation (outside the 30s window), graceCacheHit true → reuse_detected regardless', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + 31_000);
-    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated' });
 
     expect(decideRefreshRotation(record, 0, now, true)).toEqual({
       ok: false,
@@ -103,7 +118,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
   it('31s after revocation, graceCacheHit false → reuse_detected (same as true — cache state never overrides an out-of-window reuse)', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + 31_000);
-    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated' });
 
     expect(decideRefreshRotation(record, 0, now, false)).toEqual({
       ok: false,
@@ -115,7 +130,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
   it('exactly at the 30s boundary is treated as OUTSIDE the window (fail closed) → reuse_detected', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + REFRESH_GRACE_WINDOW_MS);
-    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id' });
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated' });
 
     expect(decideRefreshRotation(record, 0, now, true)).toEqual({
       ok: false,
@@ -124,10 +139,22 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
     });
   });
 
-  it('revoked with no replacedByTokenId (e.g. already family-revoked) is reuse_detected even within 30s — no legitimate replacement to replay', () => {
+  it('revoked for reuse_detected (e.g. already family-revoked) is reuse_detected even within 30s — no legitimate rotation to explain the duplicate', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + 1_000);
-    const record = liveRecord({ revokedAt, replacedByTokenId: null });
+    const record = liveRecord({ revokedAt, revokedReason: 'reuse_detected' });
+
+    expect(decideRefreshRotation(record, 0, now, true)).toEqual({
+      ok: false,
+      reason: 'reuse_detected',
+      revokeFamily: true,
+    });
+  });
+
+  it('revoked for user_suspended is reuse_detected even within 30s — suspension is not a benign rotation', () => {
+    const revokedAt = new Date();
+    const now = new Date(revokedAt.getTime() + 1_000);
+    const record = liveRecord({ revokedAt, revokedReason: 'user_suspended' });
 
     expect(decideRefreshRotation(record, 0, now, true)).toEqual({
       ok: false,
@@ -144,7 +171,7 @@ describe('decideRefreshRotation — reuse detection, grace window, grace-cache m
 
     // Attacker replays the now-revoked, rotated-away token well after the grace window.
     const attackerNow = new Date(t0.getTime() + 60_000);
-    const stolenRecord = liveRecord({ revokedAt: t0, replacedByTokenId: 'legit-next-token-id' });
+    const stolenRecord = liveRecord({ revokedAt: t0, revokedReason: 'rotated' });
     const attackerDecision = decideRefreshRotation(stolenRecord, 0, attackerNow, false);
 
     expect(attackerDecision).toEqual({ ok: false, reason: 'reuse_detected', revokeFamily: true });
@@ -173,7 +200,7 @@ describe('decideRefreshRotation — tokenVersion mismatch (global logout, ADR 00
   it('reuse detection still takes precedence over a version mismatch (revocation checked first)', () => {
     const revokedAt = new Date();
     const now = new Date(revokedAt.getTime() + 60_000);
-    const record = liveRecord({ revokedAt, replacedByTokenId: 'next-token-id', tokenVersion: 1 });
+    const record = liveRecord({ revokedAt, revokedReason: 'rotated', tokenVersion: 1 });
 
     expect(decideRefreshRotation(record, 2, now, false)).toEqual({
       ok: false,

--- a/packages/lib/src/auth/oauth/issue-tokens.ts
+++ b/packages/lib/src/auth/oauth/issue-tokens.ts
@@ -40,32 +40,43 @@ export function issuedTokenLifetimes(now: Date, familyExpiresAt: Date): IssuedTo
   return { accessExpiresAt, refreshExpiresAt };
 }
 
-export interface IssuedTokenPair {
+/**
+ * The refresh-token fields are a discriminated union rather than plain
+ * optionals: `offline_access` gating (F1) means a caller must not be able to
+ * read `refreshTokenHash` etc. after only checking `refreshToken`, so
+ * narrowing on `refreshToken !== undefined` narrows the whole branch.
+ */
+export type IssuedTokenPair = {
   accessToken: string;
   accessTokenHash: string;
   accessTokenPrefix: string;
   accessExpiresAt: Date;
-  refreshToken: string;
-  refreshTokenHash: string;
-  refreshTokenPrefix: string;
-  refreshExpiresAt: Date;
   familyId: string;
   familyExpiresAt: Date;
-}
+} & (
+  | { refreshToken: string; refreshTokenHash: string; refreshTokenPrefix: string; refreshExpiresAt: Date }
+  | { refreshToken?: undefined; refreshTokenHash?: undefined; refreshTokenPrefix?: undefined; refreshExpiresAt?: undefined }
+);
 
 /**
  * Mint the initial token pair for a brand-new refresh-token family — the
  * authorization_code grant always starts a family, it never rotates one.
  * `familyExpiresAt` is fixed here, at first issuance, and is never extended
  * (ADR 0003 §3.2-3.3): every later rotation clamps its refresh TTL against
- * this same absolute boundary.
+ * this same absolute boundary. `offlineAccess` gates refresh-token minting
+ * (F1, OIDC-standard, ADR 0003): without it, only an access token is issued.
  */
-export function issueInitialTokenPair(now: Date): IssuedTokenPair {
+export function issueInitialTokenPair(now: Date, offlineAccess: boolean): IssuedTokenPair {
   const familyId = createId();
   const familyExpiresAt = new Date(now.getTime() + REFRESH_TOKEN_FAMILY_TTL_SECONDS * 1000);
   const { accessExpiresAt, refreshExpiresAt } = issuedTokenLifetimes(now, familyExpiresAt);
 
   const access = generateOpaqueToken('at');
+
+  if (!offlineAccess) {
+    return { accessToken: access.token, accessTokenHash: access.tokenHash, accessTokenPrefix: access.tokenPrefix, accessExpiresAt, familyId, familyExpiresAt };
+  }
+
   const refresh = generateOpaqueToken('rt');
 
   return {
@@ -87,12 +98,25 @@ export function issueInitialTokenPair(now: Date): IssuedTokenPair {
  * ADR 0003 §3.3). `familyId`/`familyExpiresAt` are carried over unchanged
  * from the presented token's record — only the authorization_code grant
  * starts a new family; rotation clamps its refresh TTL against the family's
- * original absolute boundary, never resets it.
+ * original absolute boundary, never resets it. `offlineAccess` gates
+ * refresh-token minting the same way `issueInitialTokenPair` does (F1) — a
+ * client that narrows scope to drop `offline_access` mid-rotation gets an
+ * access-only pair and no further refresh token.
  */
-export function issueRotatedTokenPair(now: Date, familyId: string, familyExpiresAt: Date): IssuedTokenPair {
+export function issueRotatedTokenPair(
+  now: Date,
+  familyId: string,
+  familyExpiresAt: Date,
+  offlineAccess: boolean,
+): IssuedTokenPair {
   const { accessExpiresAt, refreshExpiresAt } = issuedTokenLifetimes(now, familyExpiresAt);
 
   const access = generateOpaqueToken('at');
+
+  if (!offlineAccess) {
+    return { accessToken: access.token, accessTokenHash: access.tokenHash, accessTokenPrefix: access.tokenPrefix, accessExpiresAt, familyId, familyExpiresAt };
+  }
+
   const refresh = generateOpaqueToken('rt');
 
   return {

--- a/packages/lib/src/auth/oauth/refresh-rotation.ts
+++ b/packages/lib/src/auth/oauth/refresh-rotation.ts
@@ -24,8 +24,16 @@ export interface RefreshTokenRecord {
   familyExpiresAt: Date;
   /** Set the moment this token is rotated away or revoked; null while live. */
   revokedAt: Date | null;
-  /** The token this one was rotated into, if any. */
-  replacedByTokenId: string | null;
+  /**
+   * Why this token was revoked. `'rotated'` means a legitimate single-use
+   * rotation consumed it — true even for a terminal, access-only rotation
+   * (F1: `offline_access` dropped, no next refresh token minted) — so an
+   * in-window duplicate presentation is a benign race (grace-replay /
+   * grace_cache_miss), never reuse. Any other reason (`'reuse_detected'`,
+   * `'user_suspended'`, `'client_revoked'`, `'code_reuse'`) has no benign
+   * explanation for a duplicate presentation.
+   */
+  revokedReason: string | null;
   /** The user's `tokenVersion` snapshotted at this token's issuance/rotation. */
   tokenVersion: number;
 }
@@ -49,15 +57,17 @@ export type RefreshRotationDecision =
  *
  * Precedence (each a distinct security posture, most specific first):
  *  1. Already revoked (`revokedAt` set) is checked first — a revoked token
- *     with a replacement wired up (`replacedByTokenId`) fired from a prior
- *     rotation, not a manual/family revocation:
+ *     revoked BY a legitimate rotation (`revokedReason === 'rotated'`,
+ *     regardless of whether that rotation minted a next refresh token or
+ *     was terminal/access-only, F1):
  *       - inside the 30s grace window: a benign concurrent-refresh replay if
  *         the cache still has the pair (`grace-replay`), or an infra gap if
  *         it doesn't (`grace_cache_miss` — family is NOT revoked, this is
  *         not attacker behavior).
- *       - outside the window, or with no replacement to replay (e.g. the
- *         token was revoked by a family-wide reuse revocation, not a
- *         rotation): reuse — revoke the entire family.
+ *       - outside the window, or revoked for any OTHER reason (e.g. a
+ *         family-wide reuse revocation, suspension, or manual revocation —
+ *         no benign explanation for a duplicate presentation): reuse —
+ *         revoke the entire family.
  *  2. family_expired — the absolute 90-day cap wins over a still-live
  *     per-token TTL; it is fixed at first issuance and never extended.
  *  3. expired — the per-token 30-day TTL.
@@ -76,7 +86,7 @@ export function decideRefreshRotation(
     const elapsedSinceRevocation = now.getTime() - record.revokedAt.getTime();
     const withinGraceWindow = elapsedSinceRevocation < REFRESH_GRACE_WINDOW_MS;
 
-    if (withinGraceWindow && record.replacedByTokenId !== null) {
+    if (withinGraceWindow && record.revokedReason === 'rotated') {
       return graceCacheHit
         ? { ok: true, action: 'grace-replay' }
         : { ok: false, reason: 'grace_cache_miss', revokeFamily: false };

--- a/packages/lib/src/auth/oauth/refresh-rotation.ts
+++ b/packages/lib/src/auth/oauth/refresh-rotation.ts
@@ -26,6 +26,8 @@ export interface RefreshTokenRecord {
   revokedAt: Date | null;
   /** The token this one was rotated into, if any. */
   replacedByTokenId: string | null;
+  /** The user's `tokenVersion` snapshotted at this token's issuance/rotation. */
+  tokenVersion: number;
 }
 
 export type RefreshRotationDecision =
@@ -36,7 +38,11 @@ export type RefreshRotationDecision =
   | { ok: false; reason: 'expired' | 'family_expired'; revokeFamily: false }
   /** In-window but the cache lost the pair — an infra gap, not theft. */
   | { ok: false; reason: 'grace_cache_miss'; revokeFamily: false }
-  | { ok: false; reason: 'reuse_detected'; revokeFamily: true };
+  | { ok: false; reason: 'reuse_detected'; revokeFamily: true }
+  /** The user's tokenVersion has advanced since this token was issued (a
+   *  global "logout all devices") — refuse, but the family is NOT revoked:
+   *  this is not attacker behavior. */
+  | { ok: false; reason: 'version_mismatch'; revokeFamily: false };
 
 /**
  * Decide what a presented refresh token means right now.
@@ -55,10 +61,14 @@ export type RefreshRotationDecision =
  *  2. family_expired — the absolute 90-day cap wins over a still-live
  *     per-token TTL; it is fixed at first issuance and never extended.
  *  3. expired — the per-token 30-day TTL.
- *  4. otherwise — rotate: issue a fresh pair, revoke the presented token.
+ *  4. version_mismatch — the user's tokenVersion has advanced since this
+ *     token's snapshot (a global "logout all devices"). Refused, but the
+ *     family is left alone: this is an intentional logout, not theft.
+ *  5. otherwise — rotate: issue a fresh pair, revoke the presented token.
  */
 export function decideRefreshRotation(
   record: RefreshTokenRecord,
+  userTokenVersion: number,
   now: Date,
   graceCacheHit: boolean,
 ): RefreshRotationDecision {
@@ -81,6 +91,10 @@ export function decideRefreshRotation(
 
   if (now.getTime() >= record.expiresAt.getTime()) {
     return { ok: false, reason: 'expired', revokeFamily: false };
+  }
+
+  if (record.tokenVersion !== userTokenVersion) {
+    return { ok: false, reason: 'version_mismatch', revokeFamily: false };
   }
 
   return { ok: true, action: 'rotate' };


### PR DESCRIPTION
## Summary

Post-review remediation for the SDK/CLI/OAuth epic (plan `unified-churning-metcalfe.md` §W4, epic page `ea07mt5jvw0flihsbjce1iv9`). Five fixes, each done TDD (RED then GREEN):

- **P1a — mcp-tokens escalation**: a drive-scoped OAuth access token could mint an *unscoped* (full-access) MCP token via `POST/GET /api/auth/mcp-tokens` and its `[tokenId]` sibling (`DELETE`/`PATCH`). Now requires an account-scoped OAuth token (or session) across all four handlers, reusing the existing `isScopedOAuthAuth` helper (previously only wired for permission dispatch, now also re-exported from `@/lib/auth`).
- **P1b — device decision scope check**: approving a device-authorization user code never validated the device code's requested scopes against the approving user's actual drive authority, letting a user approve a scope (e.g. `drive:<id>:admin`) they can't grant. Extracted the authorize/route.ts consent-authority I/O into a shared `apps/web/src/lib/auth/oauth-grant-authority.ts` helper and reused it (with the existing pure `checkGrantAuthority`) in the device decision route, before `recordDeviceApproval`.
- **F1 — gate refresh on `offline_access`**: `issueInitialTokenPair`/`issueRotatedTokenPair` now mint a refresh token only when the granted scope set includes `offline_access` (OIDC-standard) — `IssuedTokenPair` becomes a discriminated union so an access-only grant can't accidentally read refresh-token fields. All three `oauth-repository.ts` call sites (auth-code exchange, refresh rotation, device poll) mint/persist a refresh token conditionally; the token endpoint's response omits `refresh_token` entirely otherwise. `pagespace login` already requests `offline_access` by default, so the CLI is unaffected. ADR 0003 updated.
- **tokenVersion global logout**: `decideRefreshRotation` gained a `userTokenVersion` parameter and `version_mismatch` outcome — a refresh token whose snapshotted `tokenVersion` no longer matches the user (a global "logout all devices") is refused **without** family revocation, since a logout isn't theft.
- **allowedGrantTypes enforcement**: the token endpoint now enforces `RegisteredClient.allowedGrantTypes` (defined in `clients.ts` but never checked) in the shared `resolveClient` path for all three grants.

### Post-review convergence (Codex + proactive 8-angle self-review)

Two bugs found by **Codex** and independently by one of the self-review angles, both fixed with regression tests:

- **Terminal-rotation grace-window bug**: when a `refresh_token` grant narrows scope to drop `offline_access` (the F1 gate above), the rotated pair is access-only. The first fix attempt (a `TERMINAL_ROTATION_MARKER` sentinel in `replacedByTokenId`) worked but was itself flagged by the self-review as an architecture smell — smuggling a magic string into a column meant to reference another token row. **Redesigned**: `decideRefreshRotation`'s grace-window branch now keys off the already-existing `revokedReason === 'rotated'` field instead; `replacedByTokenId` stays an honest `null` for a terminal rotation. Same bug fixed, no new sentinel concept.
- **Empty-scope device-approval regression**: `/oauth/authorize` requires a non-empty `scope` param, but `device_authorization`'s initial POST explicitly allows an empty one (`scopes: []`). The new P1b authority check reused `parseScopeList`, which fails closed on an empty string — permanently blocking approval of any legitimately scope-less device code. Fixed: the authority check now only runs when the device code requested at least one scope; an empty scope list is a vacuous pass straight to `recordDeviceApproval`, matching prior behavior.

Also from the self-review: parallelized `resolveGrantAuthority`'s per-drive-scope DB lookups (was serializing N drives × 3 lookups each on the human-facing consent/device-approval click path — now `Promise.all` throughout, with a new dedicated test file including a concurrency assertion), and deduplicated a byte-for-byte-identical `rejectScopedOAuth` guard that had drifted into two sibling route files into `apps/web/src/app/api/auth/mcp-tokens/scope-guard.ts`.

**Considered and deliberately deferred** (no live bug, documented for the record): CLI/SDK zod schemas assume `refresh_token` is always a string — currently unreachable since the CLI always requests `offline_access` and never narrows scope on refresh; a hypothetical future ordering interaction between the new `version_mismatch` check and the (currently unused) user-suspension check — no code path sets `suspendedAt` today; a pre-existing, unrelated edge case where an explicit-but-empty `scope=` param on refresh is rejected rather than treated as "keep everything"; a pre-existing (not introduced by this PR) unbounded-scope-count DoS amplification vector on `/oauth/authorize`'s consent check, now also reachable via device-decision — out of this remediation's scope; further deduplication of `oauth-repository.ts`'s three near-identical token-insert call sites — marginal benefit on already-correct, fully-tested code.

## Test plan
- [x] `bun run --filter '@pagespace/lib' typecheck && test` — 6229 tests green
- [x] `bun run --filter 'web' typecheck && lint` — green
- [x] `bun run test:security` — 43/50 suites green; the remaining 7 are a pre-existing ledger (stale test-glob paths reporting "no test files found" for Session Service/Device Auth Utilities/Permissions/Login/Signup/Mobile-Login Route, plus one DB-dependent test needing a live Postgres role) verified present on `pu/cli-login` before this branch via `git stash` comparison — none touch OAuth/MCP-token code
- [x] RED→GREEN for every item, including the post-review fixes: new/updated tests in `mcp-tokens` route tests, `device_authorization/decision` route tests (incl. the empty-scope regression guard), `issue-tokens`/`refresh-rotation` unit tests (incl. the terminal-rotation grace-window scenario), `oauth-repository.*.test.ts`, a new `token/__tests__/grant-type-enforcement.test.ts`, and a new `oauth-grant-authority.test.ts`
- [x] Both Codex findings replied to with commit-level evidence; not resolved (left open for reviewer verification per convergence-loop policy)
- [x] No merge conflicts with `pu/cli-login` (0 behind, currently 3 ahead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLZCXrUYeogjFDqCPaxjoq
