### PR TITLE
fix(w7): live-test triage — consult conversation listing, calendar scope, task trigger echo (#1837)

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// #1837 finding #1 (hard failure) — consult-created conversations invisible
+// to GET .../conversations.
+//
+// The route persists turns via saveMessageToDatabase (chat_messages rows) but
+// never wrote a `conversations` row. list_conversations' listing query
+// (conversation-repository.ts:listConversations) LEFT JOINs against
+// `conversations` and filters on `conv."userId" = ${userId} OR conv."isShared"`.
+// With no matching row, that predicate is NULL (never true), so the
+// conversation silently drops out of every listing even though
+// read_conversation (which queries chat_messages directly) renders it fine.
+// Fix: eagerly create the conversations row, mirroring
+// apps/web/src/app/api/ai/chat/route.ts's existing pattern.
+// ============================================================================
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
+  isMCPAuthResult: vi.fn(() => false),
+  isScopedMCPAuth: vi.fn(() => false),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() },
+    ai: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })) },
+  },
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  supportsTemperature: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+const AGENT_ROW = {
+  __table: 'pages',
+  id: 'agent-1',
+  type: 'AI_CHAT',
+  title: 'Helper',
+  driveId: 'drive-1',
+  aiProvider: 'openai',
+  aiModel: 'openai/gpt-5.3-chat',
+  systemPrompt: 'You help.',
+  enabledTools: [],
+};
+const GATE_USER_ROW = { subscriptionTier: 'pro', role: 'user' };
+const DRIVE_ROW = { id: 'drive-1', name: 'Drive', slug: 'drive' };
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field: unknown, value: unknown) => ({ __eq: true, field, value })),
+  desc: vi.fn((field: unknown) => ({ __desc: true, field })),
+  and: vi.fn((...conds: unknown[]) => ({ __and: true, conds })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { __table: 'pages', id: 'id' },
+  drives: { __table: 'drives', id: 'id' },
+  chatMessages: {
+    __table: 'chatMessages',
+    pageId: 'pageId',
+    createdAt: 'createdAt',
+    conversationId: 'conversationId',
+    isActive: 'isActive',
+  },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { __table: 'users', id: 'id', subscriptionTier: 'subscriptionTier' },
+}));
+
+vi.mock('@pagespace/db/db', () => {
+  function makeBuilder() {
+    let table: { __table?: string } | undefined;
+    const builder = {
+      from: vi.fn((t: { __table?: string }) => {
+        table = t;
+        return builder;
+      }),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      then: (resolve: (v: unknown[]) => unknown, reject?: (e: unknown) => unknown) => {
+        try {
+          if (table?.__table === 'pages') return resolve([AGENT_ROW]);
+          if (table?.__table === 'users') return resolve([GATE_USER_ROW]);
+          if (table?.__table === 'drives') return resolve([DRIVE_ROW]);
+          if (table?.__table === 'chatMessages') return resolve([]);
+          return resolve([]);
+        } catch (e) {
+          return reject?.(e);
+        }
+      },
+    };
+    return builder;
+  }
+  return { db: { select: vi.fn(() => makeBuilder()) } };
+});
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {}, provider: 'openai', modelName: 'openai/gpt-5.3-chat' }),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/core/ai-tools', () => ({ pageSpaceTools: {} }));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+}));
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  DEFAULT_PROVIDER: 'openai',
+  DEFAULT_MODEL: 'openai/gpt-5.3-chat',
+  ADMIN_ONLY_PROVIDERS: new Set<string>(['glm']),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
+}));
+
+vi.mock('@/lib/ai/core/tool-utils', () => ({ mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })) }));
+vi.mock('@/lib/ai/tools/finish-tool', () => ({ finishTool: {}, FINISH_TOOL_NAME: 'finish' }));
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  saveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+const createConversation = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    createConversation: (...args: unknown[]) => createConversation(...args),
+  },
+}));
+
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({
+    text: 'answer',
+    steps: [{ text: 'answer', content: [] }],
+    totalUsage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+  }),
+  convertToModelMessages: vi.fn().mockImplementation((msgs: unknown) => msgs),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: 'user-1',
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request('https://example.com/api/ai/page-agents/consult', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('POST /api/ai/page-agents/consult — conversation listing index', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+  });
+
+  it('creates a conversations row so the conversation is listable', async () => {
+    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'New question' }));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(createConversation).toHaveBeenCalledWith(body.conversationId, 'user-1', 'agent-1');
+  });
+
+  it('creates the row for a continued conversation too (idempotent upsert)', async () => {
+    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Follow-up', conversationId: 'conv-a' }));
+    expect(response.status).toBe(200);
+
+    expect(createConversation).toHaveBeenCalledWith('conv-a', 'user-1', 'agent-1');
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
@@ -74,11 +74,6 @@ vi.mock('@pagespace/db/schema/auth', () => ({
   users: { __table: 'users', id: 'id', subscriptionTier: 'subscriptionTier' },
 }));
 
-// Mutable per-test fixture — tests reassign this to inject prior chat_messages
-// rows (including their authoring userId) for the conversationId-continuation
-// path, without touching the shared mock plumbing below.
-let CHAT_MESSAGES_RESULT: Array<{ role: string; content: string; userId: string | null }> = [];
-
 vi.mock('@pagespace/db/db', () => {
   function makeBuilder() {
     let table: { __table?: string } | undefined;
@@ -95,7 +90,7 @@ vi.mock('@pagespace/db/db', () => {
           if (table?.__table === 'pages') return resolve([AGENT_ROW]);
           if (table?.__table === 'users') return resolve([GATE_USER_ROW]);
           if (table?.__table === 'drives') return resolve([DRIVE_ROW]);
-          if (table?.__table === 'chatMessages') return resolve(CHAT_MESSAGES_RESULT);
+          if (table?.__table === 'chatMessages') return resolve([]);
           return resolve([]);
         } catch (e) {
           return reject?.(e);
@@ -187,7 +182,6 @@ describe('POST /api/ai/page-agents/consult — conversation listing index', () =
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
-    CHAT_MESSAGES_RESULT = [];
   });
 
   it('creates a conversations row so the conversation is listable', async () => {
@@ -205,31 +199,12 @@ describe('POST /api/ai/page-agents/consult — conversation listing index', () =
     expect(createConversation).toHaveBeenCalledWith('conv-a', 'user-1', 'agent-1');
   });
 
-  it('does NOT claim ownership of a supplied conversationId that belongs to a different user (Codex P2)', async () => {
-    // conv-a already has real chat_messages authored by a DIFFERENT user
-    // (the exact pre-fix "legacy conversation, no conversations row yet"
-    // shape) — the caller here ('user-1') must not be able to backfill
-    // themselves in as the owner just by supplying that ID.
-    CHAT_MESSAGES_RESULT = [
-      { role: 'user', content: 'someone else asked this', userId: 'victim-user' },
-      { role: 'assistant', content: 'answer', userId: null },
-    ];
-
-    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Hijack attempt', conversationId: 'conv-a' }));
-    expect(response.status).toBe(200);
-
-    expect(createConversation).not.toHaveBeenCalled();
-  });
-
-  it('still claims ownership when the caller authored the existing messages themselves', async () => {
-    CHAT_MESSAGES_RESULT = [
-      { role: 'user', content: 'my earlier question', userId: 'user-1' },
-      { role: 'assistant', content: 'answer', userId: null },
-    ];
-
-    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Follow-up', conversationId: 'conv-a' }));
-    expect(response.status).toBe(200);
-
-    expect(createConversation).toHaveBeenCalledWith('conv-a', 'user-1', 'agent-1');
-  });
+  // The ownership-conflict guard (a supplied conversationId must not let a
+  // different caller claim someone else's conversation — Codex P2 on #1846)
+  // now lives inside conversationRepository.createConversation itself, so
+  // every caller gets it "for free" without a call-site check. That
+  // behavior is unit-tested directly against the repository in
+  // apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts;
+  // this route always calls createConversation unconditionally (mocked
+  // above), so there's nothing conflict-specific to assert here.
 });

--- a/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/__tests__/conversation-listing-index.test.ts
@@ -74,6 +74,11 @@ vi.mock('@pagespace/db/schema/auth', () => ({
   users: { __table: 'users', id: 'id', subscriptionTier: 'subscriptionTier' },
 }));
 
+// Mutable per-test fixture — tests reassign this to inject prior chat_messages
+// rows (including their authoring userId) for the conversationId-continuation
+// path, without touching the shared mock plumbing below.
+let CHAT_MESSAGES_RESULT: Array<{ role: string; content: string; userId: string | null }> = [];
+
 vi.mock('@pagespace/db/db', () => {
   function makeBuilder() {
     let table: { __table?: string } | undefined;
@@ -90,7 +95,7 @@ vi.mock('@pagespace/db/db', () => {
           if (table?.__table === 'pages') return resolve([AGENT_ROW]);
           if (table?.__table === 'users') return resolve([GATE_USER_ROW]);
           if (table?.__table === 'drives') return resolve([DRIVE_ROW]);
-          if (table?.__table === 'chatMessages') return resolve([]);
+          if (table?.__table === 'chatMessages') return resolve(CHAT_MESSAGES_RESULT);
           return resolve([]);
         } catch (e) {
           return reject?.(e);
@@ -182,6 +187,7 @@ describe('POST /api/ai/page-agents/consult — conversation listing index', () =
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+    CHAT_MESSAGES_RESULT = [];
   });
 
   it('creates a conversations row so the conversation is listable', async () => {
@@ -193,6 +199,34 @@ describe('POST /api/ai/page-agents/consult — conversation listing index', () =
   });
 
   it('creates the row for a continued conversation too (idempotent upsert)', async () => {
+    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Follow-up', conversationId: 'conv-a' }));
+    expect(response.status).toBe(200);
+
+    expect(createConversation).toHaveBeenCalledWith('conv-a', 'user-1', 'agent-1');
+  });
+
+  it('does NOT claim ownership of a supplied conversationId that belongs to a different user (Codex P2)', async () => {
+    // conv-a already has real chat_messages authored by a DIFFERENT user
+    // (the exact pre-fix "legacy conversation, no conversations row yet"
+    // shape) — the caller here ('user-1') must not be able to backfill
+    // themselves in as the owner just by supplying that ID.
+    CHAT_MESSAGES_RESULT = [
+      { role: 'user', content: 'someone else asked this', userId: 'victim-user' },
+      { role: 'assistant', content: 'answer', userId: null },
+    ];
+
+    const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Hijack attempt', conversationId: 'conv-a' }));
+    expect(response.status).toBe(200);
+
+    expect(createConversation).not.toHaveBeenCalled();
+  });
+
+  it('still claims ownership when the caller authored the existing messages themselves', async () => {
+    CHAT_MESSAGES_RESULT = [
+      { role: 'user', content: 'my earlier question', userId: 'user-1' },
+      { role: 'assistant', content: 'answer', userId: null },
+    ];
+
     const response = await POST(makeRequest({ agentId: 'agent-1', question: 'Follow-up', conversationId: 'conv-a' }));
     expect(response.status).toBe(200);
 

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -271,14 +271,7 @@ export async function POST(request: Request) {
     // new one is minted and returned so the caller can continue it later.
     const activeConversationId: string = conversationId || createId();
 
-    // Eagerly ensure a conversations row exists so this conversation is
-    // listable via GET .../conversations, which joins against `conversations`
-    // to scope results to their owner (mirrors apps/web/src/app/api/ai/chat/route.ts).
-    // Without this, chatMessages are persisted but the conversation itself is
-    // invisible to list_conversations. Idempotent via onConflictDoNothing.
-    await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
-
-    let historyMessages: Array<{ role: string; content: string | null }>;
+    let historyMessages: Array<{ role: string; content: string | null; userId: string | null }>;
     if (conversationId) {
       // Scoped to this conversation only, in chronological order.
       historyMessages = await db
@@ -302,6 +295,25 @@ export async function POST(request: Request) {
         .orderBy(desc(chatMessages.createdAt))
         .limit(10);
       historyMessages = recentMessages.slice().reverse();
+    }
+
+    // Eagerly ensure a conversations row exists so this conversation is
+    // listable via GET .../conversations, which joins against `conversations`
+    // to scope results to their owner (mirrors apps/web/src/app/api/ai/chat/route.ts).
+    // Without this, chatMessages are persisted but the conversation itself is
+    // invisible to list_conversations. Idempotent via onConflictDoNothing —
+    // EXCEPT a caller-supplied conversationId must not be allowed to claim
+    // ownership of pre-existing history it doesn't own: a legacy conversation
+    // (real chat_messages, no conversations row yet — exactly the backfill
+    // case this fixes) could otherwise be "claimed" by any other caller who
+    // learns the ID, and ownership-gated actions elsewhere (e.g. conversation
+    // deletion) trust conversations.userId. Only backfill ownership when no
+    // existing message in this conversation belongs to a different user.
+    const hasConflictingOwner = Boolean(conversationId) && historyMessages.some(
+      (m) => m.userId !== null && m.userId !== userId
+    );
+    if (!hasConflictingOwner) {
+      await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
     }
 
     // Build conversation messages (exclude system - handled separately)

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -22,6 +22,7 @@ import { users } from '@pagespace/db/schema/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { saveMessageToDatabase } from '@/lib/ai/core/message-utils';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { createId } from '@paralleldrive/cuid2';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { isMeteringExempt } from '@pagespace/lib/ai/model-defaults';
@@ -269,6 +270,13 @@ export async function POST(request: Request) {
     // a supplied conversationId continues that exact conversation; otherwise a
     // new one is minted and returned so the caller can continue it later.
     const activeConversationId: string = conversationId || createId();
+
+    // Eagerly ensure a conversations row exists so this conversation is
+    // listable via GET .../conversations, which joins against `conversations`
+    // to scope results to their owner (mirrors apps/web/src/app/api/ai/chat/route.ts).
+    // Without this, chatMessages are persisted but the conversation itself is
+    // invisible to list_conversations. Idempotent via onConflictDoNothing.
+    await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
 
     let historyMessages: Array<{ role: string; content: string | null }>;
     if (conversationId) {

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -271,7 +271,16 @@ export async function POST(request: Request) {
     // new one is minted and returned so the caller can continue it later.
     const activeConversationId: string = conversationId || createId();
 
-    let historyMessages: Array<{ role: string; content: string | null; userId: string | null }>;
+    // Eagerly ensure a conversations row exists so this conversation is
+    // listable via GET .../conversations, which joins against `conversations`
+    // to scope results to their owner (mirrors apps/web/src/app/api/ai/chat/route.ts).
+    // Without this, chatMessages are persisted but the conversation itself is
+    // invisible to list_conversations. createConversation itself refuses to
+    // claim ownership of a supplied conversationId that already has messages
+    // from a different user (see its doc comment) — safe to call unconditionally.
+    await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
+
+    let historyMessages: Array<{ role: string; content: string | null }>;
     if (conversationId) {
       // Scoped to this conversation only, in chronological order.
       historyMessages = await db
@@ -295,25 +304,6 @@ export async function POST(request: Request) {
         .orderBy(desc(chatMessages.createdAt))
         .limit(10);
       historyMessages = recentMessages.slice().reverse();
-    }
-
-    // Eagerly ensure a conversations row exists so this conversation is
-    // listable via GET .../conversations, which joins against `conversations`
-    // to scope results to their owner (mirrors apps/web/src/app/api/ai/chat/route.ts).
-    // Without this, chatMessages are persisted but the conversation itself is
-    // invisible to list_conversations. Idempotent via onConflictDoNothing —
-    // EXCEPT a caller-supplied conversationId must not be allowed to claim
-    // ownership of pre-existing history it doesn't own: a legacy conversation
-    // (real chat_messages, no conversations row yet — exactly the backfill
-    // case this fixes) could otherwise be "claimed" by any other caller who
-    // learns the ID, and ownership-gated actions elsewhere (e.g. conversation
-    // deletion) trust conversations.userId. Only backfill ownership when no
-    // existing message in this conversation belongs to a different user.
-    const hasConflictingOwner = Boolean(conversationId) && historyMessages.some(
-      (m) => m.userId !== null && m.userId !== userId
-    );
-    if (!hasConflictingOwner) {
-      await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
     }
 
     // Build conversation messages (exclude system - handled separately)

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-access-event-scoped-creator.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-access-event-scoped-creator.test.ts
@@ -1,0 +1,126 @@
+/**
+ * #1846 Codex P2 (2nd round): a scoped MCP token can now create a personal
+ * (driveless) calendar event (calendar/events/route.ts POST fix). It must
+ * also be able to read that SAME event back via GET, or the create is a
+ * permanent dead end — but must still have no read power over a driveless
+ * event created by a DIFFERENT user. Tests canAccessEvent via the GET handler.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      calendarEvents: { findFirst: vi.fn() },
+      eventAttendees: { findFirst: vi.fn() },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => args),
+}));
+vi.mock('@pagespace/db/schema/calendar', () => ({
+  calendarEvents: {
+    id: 'id',
+    driveId: 'driveId',
+    createdById: 'createdById',
+    isTrashed: 'isTrashed',
+  },
+  eventAttendees: {
+    eventId: 'eventId',
+    userId: 'userId',
+  },
+}));
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: { calendarEventId: 'calendarEventId', status: 'status' },
+}));
+vi.mock('../../../../../../lib/ai/core/timestamp-utils', () => ({
+  isNaiveISODatetime: vi.fn(() => false),
+  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: vi.fn(),
+  isDriveOwnerOrAdmin: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/calendar-event-drive-service', () => ({
+  isUserMemberOfAnyEventDrive: vi.fn().mockResolvedValue(false),
+  getAllDriveIdsForEvent: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() } },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ audit: vi.fn(), auditRequest: vi.fn() }));
+vi.mock('../../../../../../lib/websocket/calendar-events', () => ({
+  broadcastCalendarEvent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../../../../../lib/integrations/google-calendar/push-service', () => ({
+  pushEventUpdateToGoogle: vi.fn().mockResolvedValue(undefined),
+  pushEventDeleteToGoogle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../../../../lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
+  checkMCPDriveScope: vi.fn(() => null),
+  isScopedMCPAuth: (auth: { tokenType?: string; allowedDriveIds?: string[] }) =>
+    auth?.tokenType === 'mcp' && ((auth.allowedDriveIds?.length ?? 0) > 0),
+  isPrincipalDriveMember: vi.fn(),
+  isPrincipalDriveOwnerOrAdmin: vi.fn(),
+}));
+
+import { GET } from '../route';
+import { db } from '@pagespace/db/db';
+import { authenticateRequestWithOptions } from '../../../../../../lib/auth';
+
+const CREATOR_ID = 'user_creator';
+const OUTSIDER_ID = 'user_outsider';
+const EVENT_ID = 'event_123';
+
+const mockScopedMcpAuth = (userId: string) => ({
+  userId,
+  tokenType: 'mcp' as const,
+  tokenId: 'mcp-token-1',
+  allowedDriveIds: ['drive_456'],
+});
+
+const createMockPersonalEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: EVENT_ID,
+  driveId: null,
+  createdById: CREATOR_ID,
+  visibility: 'PRIVATE' as const,
+  title: 'Personal reminder',
+  ...overrides,
+});
+
+function createGetRequest(): Request {
+  return new Request('http://localhost:3000/api/calendar/events/' + EVENT_ID, { method: 'GET' });
+}
+
+function createContext(): { params: Promise<{ eventId: string }> } {
+  return { params: Promise.resolve({ eventId: EVENT_ID }) };
+}
+
+describe('GET /api/calendar/events/[eventId] — canAccessEvent for scoped tokens on driveless events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 when a scoped MCP token reads a personal event it created itself', async () => {
+    const event = createMockPersonalEvent();
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(CREATOR_ID));
+    (db.query.calendarEvents.findFirst as Mock).mockResolvedValue(event);
+
+    const response = await GET(createGetRequest(), createContext());
+    expect(response.status).toBe(200);
+  });
+
+  it('returns 403 when a scoped MCP token tries to read a personal event created by someone else', async () => {
+    const event = createMockPersonalEvent();
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(OUTSIDER_ID));
+    (db.query.calendarEvents.findFirst as Mock).mockResolvedValue(event);
+
+    const response = await GET(createGetRequest(), createContext());
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
@@ -151,6 +151,15 @@ const mockWebAuth = (userId: string): SessionAuthResult => ({
   adminRoleVersion: 0,
 });
 
+// A drive-scoped MCP token (allowedDriveIds non-empty) — matches the
+// isScopedMCPAuth mock above (tokenType === 'mcp' && allowedDriveIds.length > 0).
+const mockScopedMcpAuth = (userId: string) => ({
+  userId,
+  tokenType: 'mcp' as const,
+  tokenId: 'mcp-token-1',
+  allowedDriveIds: [DRIVE_ID],
+});
+
 const createMockEvent = (overrides: Record<string, unknown> = {}) => ({
   id: EVENT_ID,
   driveId: DRIVE_ID,
@@ -323,5 +332,32 @@ describe('PATCH /api/calendar/events/[eventId] — canEditEvent auth policy', ()
 
     // isDriveOwnerOrAdmin should NOT be called; creator short-circuits
     expect(isDriveOwnerOrAdmin).not.toHaveBeenCalled();
+  });
+
+  // #1846 Codex P2 (2nd round): a scoped MCP token can now create a personal
+  // (driveless) event (calendar/events/route.ts fix) — it must also be able
+  // to read/edit/delete that SAME event it created, or the create is a
+  // permanent dead end. It must still have no power over a driveless event
+  // created by a DIFFERENT user.
+  it('returns 200 when a scoped MCP token edits a personal event it created itself', async () => {
+    const personalEvent = createMockEvent({ driveId: null, createdById: CREATOR_ID });
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(CREATOR_ID));
+    setupDbMocksForPatch(personalEvent);
+
+    const response = await PATCH(createPatchRequest(), createContext());
+    expect(response.status).toBe(200);
+    expect(isDriveOwnerOrAdmin).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when a scoped MCP token tries to edit a personal event created by someone else', async () => {
+    const personalEvent = createMockEvent({ driveId: null, createdById: CREATOR_ID });
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(OUTSIDER_ID));
+    (db.query.calendarEvents.findFirst as Mock).mockResolvedValue(personalEvent);
+
+    const response = await PATCH(createPatchRequest(), createContext());
+    expect(response.status).toBe(403);
+
+    const body = await response.json();
+    expect(body.error).toBe('You do not have permission to edit this event');
   });
 });

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -62,15 +62,17 @@ const updateEventSchema = z.object({
 async function canAccessEvent(auth: AuthResult, event: typeof calendarEvents.$inferSelect): Promise<boolean> {
   const userId = auth.userId;
 
-  // A drive-scoped token acts as an app member of its drives only: it gets no
-  // identity power over the owner's PERSONAL (drive-less) events.
-  if (!event.driveId && isScopedMCPAuth(auth)) {
-    return false;
-  }
-
-  // Creator always has access (identity check)
+  // Creator always has access (identity check) — including a scoped token
+  // reading back a driveless event IT created: the token still acts on
+  // behalf of its owner for a resource that belongs to that exact identity.
   if (event.createdById === userId) {
     return true;
+  }
+
+  // A drive-scoped token acts as an app member of its drives only: it gets no
+  // identity power over a DIFFERENT user's PERSONAL (drive-less) events.
+  if (!event.driveId && isScopedMCPAuth(auth)) {
+    return false;
   }
 
   // Check if user is an attendee (identity check)
@@ -96,9 +98,12 @@ async function canAccessEvent(auth: AuthResult, event: typeof calendarEvents.$in
  * Check if the principal can edit an event (only creator or drive admin)
  */
 async function canEditEvent(auth: AuthResult, event: typeof calendarEvents.$inferSelect): Promise<boolean> {
-  // Scoped tokens have no identity power over personal (drive-less) events.
-  if (!event.driveId && isScopedMCPAuth(auth)) return false;
+  // Creator always has edit access, including a scoped token editing a
+  // driveless event it created itself.
   if (event.createdById === auth.userId) return true;
+  // Scoped tokens have no identity power over a different user's personal
+  // (drive-less) events.
+  if (!event.driveId && isScopedMCPAuth(auth)) return false;
   if (event.driveId) return isPrincipalDriveOwnerOrAdmin(auth, event.driveId);
   return false;
 }

--- a/apps/web/src/app/api/calendar/events/__tests__/get-user-listing-scoped-personal-events.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/get-user-listing-scoped-personal-events.test.ts
@@ -1,0 +1,148 @@
+/**
+ * #1846 Codex P2 (2nd round): GET /api/calendar/events (context=user) must
+ * list back a personal (driveless) event that a scoped MCP token itself
+ * created (the create fix in this same PR would otherwise produce a
+ * permanently unlistable event), while still excluding a driveless event
+ * created by a DIFFERENT user (identity-scoped condition + the
+ * scoped-token cap filter must both allow the caller's own creation through).
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server');
+  return { ...actual, after: vi.fn((fn) => fn()) };
+});
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((...a: unknown[]) => ({ __op: 'eq', a })),
+  and: vi.fn((...a: unknown[]) => ({ __op: 'and', a })),
+  or: vi.fn((...a: unknown[]) => ({ __op: 'or', a })),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  inArray: vi.fn(),
+  isNull: vi.fn(() => ({ __op: 'isNull' })),
+  isNotNull: vi.fn(),
+  asc: vi.fn(),
+  desc: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/calendar', () => ({
+  calendarEvents: { id: 'id', driveId: 'driveId', createdById: 'createdById', isTrashed: 'isTrashed', visibility: 'visibility', recurrenceRule: 'recurrenceRule', startAt: 'startAt', endAt: 'endAt' },
+  eventAttendees: { eventId: 'eventId', userId: 'userId' },
+  calendarEventDrives: { eventId: 'eventId', driveId: 'driveId' },
+}));
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: { calendarEventId: 'calendarEventId' },
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id', driveId: 'driveId' } }));
+vi.mock('@pagespace/db/schema/workflow-runs', () => ({ workflowRuns: { id: 'id' } }));
+
+vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
+  upsertCalendarTriggerWorkflowInTx: vi.fn(),
+  validateCalendarAgentTrigger: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveRecipientUserIds: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/lib/websocket/calendar-events', () => ({ broadcastCalendarEvent: vi.fn() }));
+vi.mock('@/lib/integrations/google-calendar/push-service', () => ({ pushEventToGoogle: vi.fn() }));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  isNaiveISODatetime: vi.fn(() => false),
+  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
+}));
+vi.mock('@/lib/workflows/recurrence-utils', () => ({
+  expandRecurringEvents: vi.fn((events: unknown[]) => events),
+}));
+vi.mock('cron-parser', () => ({ CronExpressionParser: { parse: vi.fn() } }));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+const CREATOR_ID = 'user-creator';
+const OUTSIDER_ID = 'user-outsider';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => typeof r === 'object' && r !== null && 'error' in r),
+  checkMCPDriveScope: vi.fn(() => null),
+  checkMCPCreateScope: vi.fn(() => null),
+  isPrincipalDriveMember: vi.fn(),
+  getPrincipalDriveIds: vi.fn().mockResolvedValue([]),
+  canPrincipalViewPage: vi.fn(),
+  isScopedMCPAuth: (auth: { tokenType?: string; allowedDriveIds?: string[] }) =>
+    auth?.tokenType === 'mcp' && ((auth.allowedDriveIds?.length ?? 0) > 0),
+}));
+
+const PERSONAL_EVENT = {
+  id: 'evt-personal',
+  driveId: null,
+  createdById: CREATOR_ID,
+  visibility: 'PRIVATE',
+  isTrashed: false,
+  startAt: new Date('2026-07-04T10:00:00Z'),
+  endAt: new Date('2026-07-04T11:00:00Z'),
+  recurrenceRule: null,
+};
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      calendarEvents: { findMany: vi.fn() },
+    },
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue([]),
+      })),
+    })),
+  },
+}));
+
+import { GET } from '../route';
+import { db } from '@pagespace/db/db';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const mockScopedMcpAuth = (userId: string) => ({
+  userId,
+  tokenType: 'mcp' as const,
+  tokenId: 'mcp-token-1',
+  allowedDriveIds: ['some-other-drive'],
+});
+
+function makeGetRequest(): Request {
+  const url = new URL('http://localhost:3000/api/calendar/events');
+  url.searchParams.set('context', 'user');
+  url.searchParams.set('startDate', '2026-07-01T00:00:00Z');
+  url.searchParams.set('endDate', '2026-07-31T00:00:00Z');
+  return new Request(url.toString(), { method: 'GET' });
+}
+
+describe('GET /api/calendar/events (context=user) — scoped token + personal events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (db.query.calendarEvents.findMany as Mock).mockResolvedValue([PERSONAL_EVENT]);
+  });
+
+  it('lists a personal event a scoped MCP token created itself', async () => {
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(CREATOR_ID));
+
+    const response = await GET(makeGetRequest());
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.events.map((e: { id: string }) => e.id)).toContain('evt-personal');
+  });
+
+  it('does not leak a personal event created by a different user to a scoped MCP token', async () => {
+    // The event fixture is fixed to CREATOR_ID; a different caller querying
+    // under a scoped token must not see it even if it somehow surfaced
+    // (e.g. via the attendee branch) — the final cap filter must exclude it.
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockScopedMcpAuth(OUTSIDER_ID));
+
+    const response = await GET(makeGetRequest());
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    expect(body.events.map((e: { id: string }) => e.id)).not.toContain('evt-personal');
+  });
+});

--- a/apps/web/src/app/api/calendar/events/__tests__/post-driveless-scoped-token.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/post-driveless-scoped-token.test.ts
@@ -1,0 +1,224 @@
+/**
+ * #1837 finding #2 — a scoped MCP token creating a driveless (personal)
+ * calendar event was 403ing with "Scoped tokens cannot create new drives".
+ *
+ * checkMCPCreateScope(auth, targetDriveId) treats `targetDriveId === null` as
+ * "this call is creating a brand-new drive" (its real caller is POST
+ * /api/drives). The events route reused it as `checkMCPCreateScope(auth,
+ * data.driveId ?? null)`, so an event with NO driveId (a personal event, not a
+ * drive at all) tripped the same "cannot create new drives" guard. Personal
+ * events aren't scoped to any drive, so a scoped token should be able to
+ * create one for its own user unconditionally — the guard should only apply
+ * when a driveId is actually supplied.
+ */
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import type { SessionAuthResult } from '@/lib/auth';
+
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual<typeof import('next/server')>('next/server');
+  return { ...actual, after: vi.fn((fn) => fn()) };
+});
+
+vi.mock('@pagespace/db/db', () => {
+  const db = {
+    query: {
+      calendarEvents: { findFirst: vi.fn() },
+      eventAttendees: { findFirst: vi.fn() },
+      pages: { findFirst: vi.fn(), findMany: vi.fn() },
+    },
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue([]),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: 'evt-new' }]) })),
+    })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+    transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb({
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue([{ id: 'evt-new', startAt: new Date('2026-07-04T14:00:00Z') }]),
+        })),
+      })),
+      update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn() })) })),
+    })),
+  };
+  return { db };
+});
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => args),
+  or: vi.fn((...args: unknown[]) => args),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  inArray: vi.fn(),
+  isNull: vi.fn(),
+  asc: vi.fn(),
+  desc: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/calendar', () => ({
+  calendarEvents: { id: 'id', driveId: 'driveId', createdById: 'createdById' },
+  eventAttendees: { eventId: 'eventId', userId: 'userId' },
+}));
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: { id: 'id', workflowId: 'workflowId', calendarEventId: 'calendarEventId' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', isTrashed: 'isTrashed', driveId: 'driveId' },
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id' } }));
+vi.mock('@pagespace/db/schema/workflow-runs', () => ({ workflowRuns: { id: 'id', sourceTable: 'sourceTable', sourceId: 'sourceId' } }));
+
+vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
+  upsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'trg-1' }),
+  validateCalendarAgentTrigger: vi.fn().mockResolvedValue({ agentPageId: 'agent-1' }),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: vi.fn().mockResolvedValue(true),
+  getDriveIdsForUser: vi.fn().mockResolvedValue(['drive-1']),
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  getDriveMemberUserIds: vi.fn().mockResolvedValue(['user-1']),
+}));
+
+// Mirrors the REAL semantics of checkMCPCreateScope: null targetDriveId is
+// treated as "creating a new drive" and denied for a scoped token.
+const checkMCPCreateScope = vi.fn((_auth: unknown, targetDriveId: string | null) => {
+  if (targetDriveId === null) {
+    return new Response(
+      JSON.stringify({ error: 'Scoped tokens cannot create new drives' }),
+      { status: 403 },
+    );
+  }
+  return null;
+});
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => typeof r === 'object' && r !== null && 'error' in r),
+  checkMCPDriveScope: vi.fn(() => null),
+  checkMCPCreateScope: (...args: [unknown, string | null]) => checkMCPCreateScope(...args),
+  isScopedMCPAuth: vi.fn(() => true),
+  filterDrivesByMCPScope: vi.fn((_: unknown, ids: string[]) => ids),
+  isPrincipalDriveMember: vi.fn(async (auth: { userId: string }, driveId: string) => {
+    const { isUserDriveMember } = await import('@pagespace/lib/permissions/permissions');
+    return isUserDriveMember(auth.userId, driveId);
+  }),
+  getPrincipalDriveIds: vi.fn(async (auth: { userId: string }) => {
+    const { getDriveIdsForUser } = await import('@pagespace/lib/permissions/permissions');
+    return getDriveIdsForUser(auth.userId);
+  }),
+  canPrincipalViewPage: vi.fn(async (auth: { userId: string }, pageId: string) => {
+    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
+    return canUserViewPage(auth.userId, pageId);
+  }),
+}));
+
+vi.mock('@/lib/websocket/calendar-events', () => ({
+  broadcastCalendarEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/integrations/google-calendar/push-service', () => ({
+  pushEventToGoogle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  isNaiveISODatetime: vi.fn(() => false),
+  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: {
+      child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('cron-parser', () => ({ CronExpressionParser: { parse: vi.fn() } }));
+
+import { POST } from '../route';
+import { db } from '@pagespace/db/db';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const USER_ID = 'user-1';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: USER_ID,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'session-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost:3000/api/calendar/events', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/calendar/events — scoped token + driveless personal event', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (authenticateRequestWithOptions as Mock).mockResolvedValue(mockAuth());
+    (db.query.calendarEvents.findFirst as Mock).mockResolvedValue({
+      id: 'evt-new',
+      driveId: null,
+      createdById: USER_ID,
+      title: 'Personal event',
+      startAt: new Date('2026-07-04T14:00:00Z'),
+      endAt: new Date('2026-07-04T15:00:00Z'),
+      attendees: [],
+    });
+  });
+
+  it('does not 403 a personal (driveless) event for a scoped token', async () => {
+    const res = await POST(makeRequest({
+      title: 'Personal event',
+      startAt: '2026-07-04T14:00:00Z',
+      endAt: '2026-07-04T15:00:00Z',
+      timezone: 'UTC',
+      visibility: 'PRIVATE',
+    }));
+
+    const body = await res.json();
+    expect(body.error).not.toBe('Scoped tokens cannot create new drives');
+    expect(res.status).toBeLessThan(400);
+  });
+
+  it('still enforces drive scope when a driveId IS supplied', async () => {
+    (db.query.calendarEvents.findFirst as Mock).mockResolvedValue({
+      id: 'evt-new',
+      driveId: 'out-of-scope-drive',
+      createdById: USER_ID,
+      title: 'Drive event',
+      startAt: new Date('2026-07-04T14:00:00Z'),
+      endAt: new Date('2026-07-04T15:00:00Z'),
+      attendees: [],
+    });
+
+    await POST(makeRequest({
+      driveId: 'out-of-scope-drive',
+      title: 'Drive event',
+      startAt: '2026-07-04T14:00:00Z',
+      endAt: '2026-07-04T15:00:00Z',
+      timezone: 'UTC',
+    }));
+
+    expect(checkMCPCreateScope).toHaveBeenCalledWith(expect.anything(), 'out-of-scope-drive');
+  });
+});

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -524,9 +524,15 @@ export async function POST(request: Request) {
       ? parseNaiveDatetimeInTimezone(body.endAt, data.timezone)
       : data.endAt;
 
-    // Check MCP create scope (scoped tokens can only create in their allowed drives)
-    const createScopeError = checkMCPCreateScope(auth, data.driveId ?? null);
-    if (createScopeError) return createScopeError;
+    // Check MCP create scope (scoped tokens can only create in their allowed drives).
+    // Only applies when a driveId is actually supplied — checkMCPCreateScope treats a
+    // null targetDriveId as "creating a brand-new drive" (its real caller is POST
+    // /api/drives). A personal (driveless) event isn't scoped to any drive, so a
+    // scoped token may always create one for its own user.
+    if (data.driveId) {
+      const createScopeError = checkMCPCreateScope(auth, data.driveId);
+      if (createScopeError) return createScopeError;
+    }
 
     // Validate drive access if driveId is provided
     if (data.driveId) {

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -370,9 +370,10 @@ export async function GET(request: Request) {
     // 3. Events where user is an attendee
     const conditions = [];
 
-    // Personal events. A drive-scoped key has no identity power over the
-    // owner's PERSONAL (drive-less) events — it belongs to a workspace.
-    if (params.includePersonal && !isScopedMCPAuth(auth)) {
+    // Personal events. Identity-scoped to the caller (createdById = userId),
+    // so this is safe even for a drive-scoped token: it can only ever see its
+    // own personal events this way, never another user's.
+    if (params.includePersonal) {
       conditions.push(
         and(
           isNull(calendarEvents.driveId),
@@ -459,12 +460,19 @@ export async function GET(request: Request) {
       orderBy: [asc(calendarEvents.startAt)],
     });
 
-    // Scoped keys: the creator/attendee branches above are identity-derived and
-    // can surface events outside the key's drive universe (or personal ones).
-    // Cap the result at the principal's drives — mirrors the calendar tools.
+    // Scoped keys: the attendee branch above is identity-derived and can
+    // surface drive events outside the key's drive universe. Cap drive events
+    // at the principal's drives — mirrors the calendar tools. A driveless
+    // event the token's own user created is exempt from that cap (it has no
+    // drive to be out-of-scope of, and the token still acts on behalf of that
+    // exact identity) — but a driveless event belonging to a DIFFERENT user
+    // (reachable only via the attendee branch) stays capped out.
     const principalDriveIdSet = new Set(driveIds);
     const visibleEvents = isScopedMCPAuth(auth)
-      ? events.filter((e) => e.driveId !== null && principalDriveIdSet.has(e.driveId))
+      ? events.filter((e) =>
+          (e.driveId !== null && principalDriveIdSet.has(e.driveId)) ||
+          (e.driveId === null && e.createdById === userId)
+        )
       : events;
 
     // Annotate events with agent trigger presence

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -1215,6 +1215,37 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     }));
   });
 
+  it('#1837 finding #10 — echoes the created trigger in the response, not just the generic task block', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, dueDate: new Date('2025-06-01') });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    setupTransaction({ ...baseTask, dueDate: new Date('2025-06-01') });
+    setupRelationsLookup({ ...baseTask, dueDate: new Date('2025-06-01'), assignee: null, assigneeAgent: null, user: null, assignees: [] });
+    vi.mocked(getUserTimezone).mockResolvedValue('America/New_York');
+    vi.mocked(createTaskTriggerWorkflow).mockResolvedValueOnce({
+      workflowId: 'wf-1',
+      triggerId: 'trg-1',
+      triggerType: 'due_date',
+      nextRunAt: new Date('2025-06-01'),
+      isEnabled: true,
+    });
+
+    const response = await PATCH(createPatchRequest({
+      agentTrigger: { agentPageId: 'agent-1', prompt: 'go', triggerType: 'due_date' },
+    }), context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.agentTrigger).toEqual({
+      workflowId: 'wf-1',
+      triggerId: 'trg-1',
+      triggerType: 'due_date',
+      nextRunAt: expect.any(String),
+      isEnabled: true,
+    });
+  });
+
   it('returns 400 for a due_date agentTrigger when the task has no due date', async () => {
     setupAuth();
     setupCanEdit(true);

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -12,7 +12,7 @@ import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/pag
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
 
-import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers, createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers, createTaskTriggerWorkflow, type TaskTriggerWorkflowResult } from '@/lib/workflows/task-trigger-helpers';
 import { checkSubTasksComplete, SUBTASKS_INCOMPLETE_STATUS } from '@/lib/tasks/completion-guard';
 import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
@@ -360,7 +360,7 @@ export async function PATCH(
   }
 
   // Create the agent trigger workflow after the transaction commits, mirroring update_task.
-  let agentTriggerResult: Awaited<ReturnType<typeof createTaskTriggerWorkflow>> | undefined;
+  let agentTriggerResult: TaskTriggerWorkflowResult | undefined;
   if (normalizedAgentTrigger && taskListPage?.driveId) {
     const resolvedTimezone = typeof timezone === 'string' && timezone.trim()
       ? timezone.trim()
@@ -454,17 +454,7 @@ export async function PATCH(
   const responseBody = {
     ...taskWithRelations,
     title: responseTitle,
-    ...(agentTriggerResult
-      ? {
-          agentTrigger: {
-            workflowId: agentTriggerResult.workflowId,
-            triggerId: agentTriggerResult.triggerId,
-            triggerType: agentTriggerResult.triggerType,
-            nextRunAt: agentTriggerResult.nextRunAt,
-            isEnabled: agentTriggerResult.isEnabled,
-          },
-        }
-      : {}),
+    ...(agentTriggerResult ? { agentTrigger: agentTriggerResult } : {}),
   };
 
   // Broadcast events

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -360,11 +360,12 @@ export async function PATCH(
   }
 
   // Create the agent trigger workflow after the transaction commits, mirroring update_task.
+  let agentTriggerResult: Awaited<ReturnType<typeof createTaskTriggerWorkflow>> | undefined;
   if (normalizedAgentTrigger && taskListPage?.driveId) {
     const resolvedTimezone = typeof timezone === 'string' && timezone.trim()
       ? timezone.trim()
       : (await getUserTimezone(userId)) || 'UTC';
-    await createTaskTriggerWorkflow({
+    agentTriggerResult = await createTaskTriggerWorkflow({
       database: db,
       driveId: taskListPage.driveId,
       userId,
@@ -448,7 +449,23 @@ export async function PATCH(
     }
   }
 
-  const responseBody = { ...taskWithRelations, title: responseTitle };
+  // Surface the trigger created/updated by an inline agentTrigger — otherwise
+  // the response is indistinguishable from an update that touched no trigger.
+  const responseBody = {
+    ...taskWithRelations,
+    title: responseTitle,
+    ...(agentTriggerResult
+      ? {
+          agentTrigger: {
+            workflowId: agentTriggerResult.workflowId,
+            triggerId: agentTriggerResult.triggerId,
+            triggerType: agentTriggerResult.triggerType,
+            nextRunAt: agentTriggerResult.nextRunAt,
+            isEnabled: agentTriggerResult.isEnabled,
+          },
+        }
+      : {}),
+  };
 
   // Broadcast events
   const broadcasts: Promise<void>[] = [

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -4,7 +4,7 @@ import { eq, and, desc, asc, inArray, count, isNotNull } from '@pagespace/db/ope
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, taskAssignees } from '@pagespace/db/schema/tasks';
 import { taskTriggers } from '@pagespace/db/schema/task-triggers';
-import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { createTaskTriggerWorkflow, type TaskTriggerWorkflowResult } from '@/lib/workflows/task-trigger-helpers';
 import { DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth'
@@ -502,7 +502,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     }
 
     // Create agent trigger workflow if requested
-    let agentTriggerResult: Awaited<ReturnType<typeof createTaskTriggerWorkflow>> | undefined;
+    let agentTriggerResult: TaskTriggerWorkflowResult | undefined;
     if (agentTrigger && taskListPage.driveId) {
       agentTriggerResult = await createTaskTriggerWorkflow({
         database: tx,
@@ -608,16 +608,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     ...taskWithRelations,
     title: createdTitle,
     pageId: result.page.id,
-    ...(result.agentTriggerResult
-      ? {
-          agentTrigger: {
-            workflowId: result.agentTriggerResult.workflowId,
-            triggerId: result.agentTriggerResult.triggerId,
-            triggerType: result.agentTriggerResult.triggerType,
-            nextRunAt: result.agentTriggerResult.nextRunAt,
-            isEnabled: result.agentTriggerResult.isEnabled,
-          },
-        }
-      : {}),
+    ...(result.agentTriggerResult ? { agentTrigger: result.agentTriggerResult } : {}),
   }, { status: 201 });
 }

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -502,8 +502,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     }
 
     // Create agent trigger workflow if requested
+    let agentTriggerResult: Awaited<ReturnType<typeof createTaskTriggerWorkflow>> | undefined;
     if (agentTrigger && taskListPage.driveId) {
-      await createTaskTriggerWorkflow({
+      agentTriggerResult = await createTaskTriggerWorkflow({
         database: tx,
         driveId: taskListPage.driveId,
         userId,
@@ -515,7 +516,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       });
     }
 
-    return { task: newTask, page: taskPage };
+    return { task: newTask, page: taskPage, agentTriggerResult };
   });
 
   // Fetch task with relations (including assignees)
@@ -607,5 +608,16 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     ...taskWithRelations,
     title: createdTitle,
     pageId: result.page.id,
+    ...(result.agentTriggerResult
+      ? {
+          agentTrigger: {
+            workflowId: result.agentTriggerResult.workflowId,
+            triggerId: result.agentTriggerResult.triggerId,
+            triggerType: result.agentTriggerResult.triggerType,
+            nextRunAt: result.agentTriggerResult.nextRunAt,
+            isEnabled: result.agentTriggerResult.isEnabled,
+          },
+        }
+      : {}),
   }, { status: 201 });
 }

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -806,75 +806,15 @@ describe('agent-communication-tools', () => {
         );
       });
 
-      it('does NOT claim ownership of a supplied conversationId that belongs to a different user (Codex P2)', async () => {
-        // conv-a already has real chat_messages authored by a DIFFERENT user —
-        // the exact pre-fix "legacy conversation, no conversations row yet"
-        // shape. The caller here ('user-123') must not be able to backfill
-        // themselves in as the owner just by supplying that ID.
-        vi.mocked(mockDb.select).mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([
-                { id: 'm1', role: 'user', content: 'someone else asked this', userId: 'victim-user' },
-                { id: 'm2', role: 'assistant', content: 'answer', userId: null },
-              ]),
-            }),
-          }),
-        } as never);
-
-        const context = {
-          toolCallId: '1',
-          messages: [],
-          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
-        };
-
-        await agentCommunicationTools.ask_agent!.execute!(
-          {
-            agentPath: '/test/agent',
-            agentId: 'target-agent-1',
-            question: 'Hijack attempt',
-            conversationId: 'conv-a',
-          },
-          context
-        );
-
-        expect(conversationRepository.createConversation).not.toHaveBeenCalled();
-      });
-
-      it('still claims ownership when the caller authored the existing messages themselves', async () => {
-        vi.mocked(mockDb.select).mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([
-                { id: 'm1', role: 'user', content: 'my earlier question', userId: 'user-123' },
-                { id: 'm2', role: 'assistant', content: 'answer', userId: null },
-              ]),
-            }),
-          }),
-        } as never);
-
-        const context = {
-          toolCallId: '1',
-          messages: [],
-          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
-        };
-
-        await agentCommunicationTools.ask_agent!.execute!(
-          {
-            agentPath: '/test/agent',
-            agentId: 'target-agent-1',
-            question: 'Follow-up',
-            conversationId: 'conv-a',
-          },
-          context
-        );
-
-        expect(conversationRepository.createConversation).toHaveBeenCalledWith(
-          'conv-a',
-          'user-123',
-          'target-agent-1',
-        );
-      });
+      // The ownership-conflict guard (a supplied conversationId must not let
+      // a different caller claim someone else's conversation — Codex P2 on
+      // #1846) now lives inside conversationRepository.createConversation
+      // itself, so every caller (including this tool) gets it "for free"
+      // without a call-site check. That behavior is unit-tested directly
+      // against the repository in
+      // apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts;
+      // this tool always calls createConversation unconditionally (mocked
+      // above), so there's nothing conflict-specific to assert here.
     });
 
     describe('compaction-aware context assembly', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -137,6 +137,11 @@ vi.mock('../../core/message-utils', () => ({
   saveMessageToDatabase: vi.fn(),
   convertDbMessageToUIMessage: vi.fn((msg) => msg),
 }));
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    createConversation: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 vi.mock('../../core/provider-factory', () => ({
   createAIProvider: vi.fn(),
   isProviderError: vi.fn(() => false),
@@ -162,6 +167,7 @@ import { resolvePageAgentIntegrationTools } from '../../core/integration-tool-re
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { prepareHistoryForModel, finishModelRequest } from '../../core/context-assembly';
 import { runCompaction } from '../../core/compaction/compaction-service';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const mockDb = vi.mocked(db);
 const mockCanActorViewPage = vi.mocked(canActorViewPage);
@@ -733,6 +739,71 @@ describe('agent-communication-tools', () => {
           sourceAgentId: null,
           role: 'user',
         });
+      });
+    });
+
+    describe('conversation listing index (#1837 finding #1)', () => {
+      const mockAgent = {
+        id: 'target-agent-1',
+        title: 'Target Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: 'I am a helpful agent',
+        enabledTools: null,
+        aiProvider: null,
+        aiModel: null,
+        isTrashed: false,
+      };
+
+      beforeEach(() => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgent);
+      });
+
+      it('creates a conversations row so a new conversation is listable', async () => {
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'target-agent-1',
+            question: 'New question',
+          },
+          context
+        );
+
+        expect(conversationRepository.createConversation).toHaveBeenCalledWith(
+          'mock-cuid',
+          'user-123',
+          'target-agent-1',
+        );
+      });
+
+      it('creates the row for a continued conversation too (idempotent upsert)', async () => {
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'target-agent-1',
+            question: 'Follow-up',
+            conversationId: 'conv-a',
+          },
+          context
+        );
+
+        expect(conversationRepository.createConversation).toHaveBeenCalledWith(
+          'conv-a',
+          'user-123',
+          'target-agent-1',
+        );
       });
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -805,6 +805,76 @@ describe('agent-communication-tools', () => {
           'target-agent-1',
         );
       });
+
+      it('does NOT claim ownership of a supplied conversationId that belongs to a different user (Codex P2)', async () => {
+        // conv-a already has real chat_messages authored by a DIFFERENT user —
+        // the exact pre-fix "legacy conversation, no conversations row yet"
+        // shape. The caller here ('user-123') must not be able to backfill
+        // themselves in as the owner just by supplying that ID.
+        vi.mocked(mockDb.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([
+                { id: 'm1', role: 'user', content: 'someone else asked this', userId: 'victim-user' },
+                { id: 'm2', role: 'assistant', content: 'answer', userId: null },
+              ]),
+            }),
+          }),
+        } as never);
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'target-agent-1',
+            question: 'Hijack attempt',
+            conversationId: 'conv-a',
+          },
+          context
+        );
+
+        expect(conversationRepository.createConversation).not.toHaveBeenCalled();
+      });
+
+      it('still claims ownership when the caller authored the existing messages themselves', async () => {
+        vi.mocked(mockDb.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([
+                { id: 'm1', role: 'user', content: 'my earlier question', userId: 'user-123' },
+                { id: 'm2', role: 'assistant', content: 'answer', userId: null },
+              ]),
+            }),
+          }),
+        } as never);
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'target-agent-1',
+            question: 'Follow-up',
+            conversationId: 'conv-a',
+          },
+          context
+        );
+
+        expect(conversationRepository.createConversation).toHaveBeenCalledWith(
+          'conv-a',
+          'user-123',
+          'target-agent-1',
+        );
+      });
     });
 
     describe('compaction-aware context assembly', () => {

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -12,6 +12,7 @@ import { canActorViewPage, canActorAccessDrive, filterDriveIdsByAppTokenScope, i
 import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { createAIProvider, isProviderError, type ProviderRequest } from '@/lib/ai/core/provider-factory';
 import { sanitizeMessagesForModel, saveMessageToDatabase, convertDbMessageToUIMessage } from '@/lib/ai/core/message-utils';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { DEFAULT_PROVIDER, DEFAULT_MODEL, AI_PROVIDERS, getModelDisplayName } from '@/lib/ai/core/ai-providers-config';
 import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import type { ToolExecutionContext } from '@/lib/ai/core/types';
@@ -443,6 +444,12 @@ export const agentCommunicationTools = {
 
         // 3. Create or use existing conversation
         const activeConversationId = conversationId || createId();
+
+        // Eagerly ensure a conversations row exists so this conversation is
+        // listable via GET .../conversations (same fix as the consult route,
+        // #1837 finding #1) — without it, chat_messages are persisted but the
+        // listing query's ownership join never matches. Idempotent.
+        await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
 
         // 4. Load conversation history if continuing an existing conversation
         let messages: UIMessage[] = [];

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -445,14 +445,9 @@ export const agentCommunicationTools = {
         // 3. Create or use existing conversation
         const activeConversationId = conversationId || createId();
 
-        // Eagerly ensure a conversations row exists so this conversation is
-        // listable via GET .../conversations (same fix as the consult route,
-        // #1837 finding #1) — without it, chat_messages are persisted but the
-        // listing query's ownership join never matches. Idempotent.
-        await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
-
         // 4. Load conversation history if continuing an existing conversation
         let messages: UIMessage[] = [];
+        let hasConflictingOwner = false;
         if (conversationId) {
           // Load existing conversation history
           const dbMessages = await db
@@ -465,6 +460,15 @@ export const agentCommunicationTools = {
             ))
             .orderBy(chatMessages.createdAt);
 
+          // A legacy conversation (real chat_messages, no conversations row yet
+          // — exactly the backfill case below) must not be "claimable" by a
+          // different caller who supplies its ID: ownership-gated actions
+          // elsewhere trust conversations.userId. Only backfill ownership when
+          // no existing message here belongs to a different user.
+          hasConflictingOwner = dbMessages.some(
+            (m) => m.userId !== null && m.userId !== userId
+          );
+
           messages = dbMessages.map(convertDbMessageToUIMessage);
 
           loggers.ai.debug('Loaded conversation history for ask_agent:', {
@@ -472,6 +476,16 @@ export const agentCommunicationTools = {
             messageCount: messages.length,
             agentId
           });
+        }
+
+        // Eagerly ensure a conversations row exists so this conversation is
+        // listable via GET .../conversations (same fix as the consult route,
+        // #1837 finding #1) — without it, chat_messages are persisted but the
+        // listing query's ownership join never matches. Idempotent via
+        // onConflictDoNothing; skipped entirely when it would misattribute an
+        // existing conversation to the wrong owner (see hasConflictingOwner above).
+        if (!hasConflictingOwner) {
+          await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
         }
 
         // 5. Build and save the user's question message

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -445,9 +445,17 @@ export const agentCommunicationTools = {
         // 3. Create or use existing conversation
         const activeConversationId = conversationId || createId();
 
+        // Eagerly ensure a conversations row exists so this conversation is
+        // listable via GET .../conversations (same fix as the consult route,
+        // #1837 finding #1) — without it, chat_messages are persisted but the
+        // listing query's ownership join never matches. createConversation
+        // itself refuses to claim ownership of a supplied conversationId that
+        // already has messages from a different user (see its doc comment) —
+        // safe to call unconditionally.
+        await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
+
         // 4. Load conversation history if continuing an existing conversation
         let messages: UIMessage[] = [];
-        let hasConflictingOwner = false;
         if (conversationId) {
           // Load existing conversation history
           const dbMessages = await db
@@ -460,15 +468,6 @@ export const agentCommunicationTools = {
             ))
             .orderBy(chatMessages.createdAt);
 
-          // A legacy conversation (real chat_messages, no conversations row yet
-          // — exactly the backfill case below) must not be "claimable" by a
-          // different caller who supplies its ID: ownership-gated actions
-          // elsewhere trust conversations.userId. Only backfill ownership when
-          // no existing message here belongs to a different user.
-          hasConflictingOwner = dbMessages.some(
-            (m) => m.userId !== null && m.userId !== userId
-          );
-
           messages = dbMessages.map(convertDbMessageToUIMessage);
 
           loggers.ai.debug('Loaded conversation history for ask_agent:', {
@@ -476,16 +475,6 @@ export const agentCommunicationTools = {
             messageCount: messages.length,
             agentId
           });
-        }
-
-        // Eagerly ensure a conversations row exists so this conversation is
-        // listable via GET .../conversations (same fix as the consult route,
-        // #1837 finding #1) — without it, chat_messages are persisted but the
-        // listing query's ownership join never matches. Idempotent via
-        // onConflictDoNothing; skipped entirely when it would misattribute an
-        // existing conversation to the wrong owner (see hasConflictingOwner above).
-        if (!hasConflictingOwner) {
-          await conversationRepository.createConversation(activeConversationId, userId, agentId).catch(() => {});
         }
 
         // 5. Build and save the user's question message

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -116,6 +116,81 @@ describe('conversationRepository.getConversation', () => {
   });
 });
 
+describe('conversationRepository.createConversation', () => {
+  // #1846 Codex P2: a caller-supplied conversationId must not be able to
+  // claim ownership of a pre-existing conversation (real chat_messages, no
+  // conversations row yet) authored by a different user. Two DB round trips:
+  // (1) does a conversations row already exist? (2) if not, does any prior
+  // message in this conversation belong to someone else?
+  function mockConversationsLookup(existing: Array<{ id: string }>) {
+    const limitMock = vi.fn().mockResolvedValue(existing);
+    return { where: vi.fn().mockReturnValue({ limit: limitMock }) };
+  }
+  function mockChatMessagesLookup(rows: Array<{ userId: string | null }>) {
+    return { where: vi.fn().mockResolvedValue(rows) };
+  }
+
+  it('does nothing when a conversations row already exists (cheap indexed short-circuit)', async () => {
+    let call = 0;
+    mockSelectChain.from.mockImplementation(() => {
+      call += 1;
+      return mockConversationsLookup([{ id: 'conv-a' }]);
+    });
+
+    await conversationRepository.createConversation('conv-a', 'user-1', 'agent-1');
+
+    expect(call).toBe(1); // only the conversations lookup — never touches chat_messages or inserts
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('creates the row when no conversations row exists and no prior message conflicts', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([]));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    await conversationRepository.createConversation('conv-new', 'user-1', 'agent-1');
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conv-new', userId: 'user-1', contextId: 'agent-1', isShared: false })
+    );
+    expect(onConflictDoNothing).toHaveBeenCalled();
+  });
+
+  it('does NOT create the row when an existing message in this conversation belongs to a different user (Codex P2)', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([
+        { userId: 'victim-user' },
+        { userId: null },
+      ]));
+
+    await conversationRepository.createConversation('conv-legacy', 'attacker-user', 'agent-1');
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('creates the row when prior messages exist but all belong to the caller', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([
+        { userId: 'user-1' },
+        { userId: null },
+      ]));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    await conversationRepository.createConversation('conv-mine', 'user-1', 'agent-1');
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conv-mine', userId: 'user-1' })
+    );
+  });
+});
+
 describe('conversationRepository.setConversationShared', () => {
   it('should update isShared to true for a conversation', async () => {
     const whereMock = vi.fn().mockResolvedValue(undefined);

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -88,17 +88,44 @@ export function generateTitle(preview: string): string {
 
 export const conversationRepository = {
   /**
-   * Eagerly create a conversations row when a new conversation session is started.
-   * This establishes ownership (userId) and sets isShared=false (private by default).
+   * Eagerly create a conversations row when a conversation session is started
+   * or continued. This establishes ownership (userId) and sets isShared=false
+   * (private by default). Idempotent and safe to call on every turn of a
+   * conversation — a cheap indexed lookup short-circuits once the row exists.
+   *
+   * Refuses to claim a caller-supplied conversationId that belongs to someone
+   * else: a legacy conversation (real chat_messages, no conversations row
+   * yet) must not be "claimable" by a different caller who supplies its ID —
+   * ownership-gated actions elsewhere (e.g. conversation deletion) trust
+   * conversations.userId. Centralized here (rather than at each call site)
+   * so every caller — including pre-existing ones — gets this guarantee.
    */
-  async createConversation(conversationId: string, userId: string, agentId: string): Promise<void> {
+  async createConversation(conversationId: string, userId: string, pageId: string): Promise<void> {
+    const [existing] = await db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(eq(conversations.id, conversationId))
+      .limit(1);
+    if (existing) return;
+
+    const priorMessages = await db
+      .select({ userId: chatMessages.userId })
+      .from(chatMessages)
+      .where(and(
+        eq(chatMessages.pageId, pageId),
+        eq(chatMessages.conversationId, conversationId),
+        eq(chatMessages.isActive, true),
+      ));
+    const hasConflictingOwner = priorMessages.some((m) => m.userId !== null && m.userId !== userId);
+    if (hasConflictingOwner) return;
+
     await db
       .insert(conversations)
       .values({
         id: conversationId,
         userId,
         type: 'page',
-        contextId: agentId,
+        contextId: pageId,
         isShared: false,
         updatedAt: new Date(),
       })

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -22,6 +22,14 @@ export interface CreateTaskTriggerWorkflowParams {
   timezone: string;
 }
 
+export interface TaskTriggerWorkflowResult {
+  workflowId: string;
+  triggerId: string;
+  triggerType: 'due_date' | 'completion';
+  nextRunAt: Date | null;
+  isEnabled: boolean;
+}
+
 const logger = loggers.api.child({ module: 'task-trigger-helpers' });
 
 /**
@@ -65,7 +73,7 @@ export async function recomputeTaskTriggerMetadata(
  * and reusing the same workflowId across upserts means the workflow update
  * targets a known id rather than a returned excluded.workflowId.
  */
-export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflowParams): Promise<void> {
+export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflowParams): Promise<TaskTriggerWorkflowResult> {
   const { database, driveId, userId, taskId, taskMetadata, agentTrigger, dueDate, timezone } = params;
   const triggerType = agentTrigger.triggerType;
 
@@ -83,9 +91,9 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
   const triggerPrompt = agentTrigger.prompt || 'Execute instructions from linked page.';
   const nextRunAt = triggerType === 'due_date' && dueDate ? dueDate : null;
 
-  await database.transaction(async (tx) => {
+  const result = await database.transaction(async (tx) => {
     const existing = await tx
-      .select({ workflowId: taskTriggers.workflowId })
+      .select({ workflowId: taskTriggers.workflowId, id: taskTriggers.id })
       .from(taskTriggers)
       .where(and(
         eq(taskTriggers.taskItemId, taskId),
@@ -112,6 +120,8 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
         eq(taskTriggers.taskItemId, taskId),
         eq(taskTriggers.triggerType, triggerType),
       ));
+
+      return { workflowId, triggerId: existing[0].id };
     } else {
       const [createdWorkflow] = await tx.insert(workflows).values({
         driveId,
@@ -126,17 +136,21 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
         isEnabled: true,
       }).returning({ id: workflows.id });
 
-      await tx.insert(taskTriggers).values({
+      const [createdTrigger] = await tx.insert(taskTriggers).values({
         workflowId: createdWorkflow.id,
         taskItemId: taskId,
         triggerType,
         nextRunAt,
         isEnabled: true,
-      });
+      }).returning({ id: taskTriggers.id });
+
+      return { workflowId: createdWorkflow.id, triggerId: createdTrigger.id };
     }
   });
 
   await recomputeTaskTriggerMetadata(database, taskId, taskMetadata);
+
+  return { ...result, triggerType, nextRunAt, isEnabled: true };
 }
 
 /**

--- a/packages/sdk/src/operations/tasks.ts
+++ b/packages/sdk/src/operations/tasks.ts
@@ -61,6 +61,15 @@ const taskItemBaseSchema = z.object({
   updatedAt: z.string(),
 });
 
+/** Echoed back only when this call's inline `agentTrigger` created/updated a trigger — see tasks/[taskId]/route.ts and tasks/route.ts. */
+const taskAgentTriggerResultSchema = z.object({
+  workflowId: z.string(),
+  triggerId: z.string(),
+  triggerType: triggerTypeEnum,
+  nextRunAt: z.string().nullable(),
+  isEnabled: z.boolean(),
+});
+
 /** `{ ...taskWithRelations, title }` shape returned by create_task/update_task/reorder_task. */
 const taskWithRelationsSchema = taskItemBaseSchema.extend({
   assignee: userRefSchema,
@@ -69,6 +78,7 @@ const taskWithRelationsSchema = taskItemBaseSchema.extend({
   page: z.object({ id: z.string(), title: z.string().nullable() }).nullable(),
   assignees: z.array(assigneeEntrySchema),
   title: z.string(),
+  agentTrigger: taskAgentTriggerResultSchema.optional(),
 });
 
 const assigneeEntryInputSchema = z.object({ type: z.enum(['user', 'agent']), id: z.string() });


### PR DESCRIPTION
## Summary

W7 of the SDK/CLI/OAuth epic post-review remediation plan (`unified-churning-metcalfe.md`). Triages all 10 findings from the live 70-tool MCP battery in #1837, fixing the hard failure plus two epic-surface bugs, and deferring the rest with evidence (several trace to the legacy standalone `pagespace-mcp` server surface, not this repo's code).

## Fixes (RED→GREEN test each)

**#1 (hard fail) — `ask_agent` conversations invisible to `list_conversations`.** Neither the consult route (`apps/web/src/app/api/ai/page-agents/consult/route.ts`) nor the internal `ask_agent` tool (`apps/web/src/lib/ai/tools/agent-communication-tools.ts`) ever wrote a `conversations` row — only `chat_messages`. The listing query's ownership join (`conv."userId" = userId OR conv."isShared"`) never matches when no row exists, so the conversation silently drops out of every listing even though `read_conversation` renders it fine by ID. Fixed both call sites to eagerly `createConversation`, mirroring the existing pattern already used in `apps/web/src/app/api/ai/chat/route.ts`.

**#2 — driveless `create_calendar_event` 403s with a scoped-token error.** `checkMCPCreateScope(auth, data.driveId ?? null)` treats a `null` target as "creating a brand-new drive" (its real caller is `POST /api/drives`) and denies it for scoped tokens. The calendar events route reused it for "no drive specified" (a personal event), which isn't a drive-creation operation at all. Now the scope check only runs when a `driveId` is actually supplied.

**#10 (partial) — `update_task`/`create_task` with an inline `agentTrigger` gave no confirmation.** The trigger was created but `createTaskTriggerWorkflow` returned `void`, so the response was indistinguishable from a call that touched no trigger. It now returns the trigger identity (`workflowId`, `triggerId`, `triggerType`, `nextRunAt`, `isEnabled`), surfaced as an `agentTrigger` field in both the create and update routes' responses and in the SDK's `tasks` output schema.

## Deferred (evidence per item)

| # | Finding | Disposition |
|---|---|---|
| 3 | Calendar/due-date timestamps render server-local | Verified `parseNaiveDatetimeInTimezone` round-trips correctly (10am America/New_York → 14:00 UTC → back to 10am). This repo has no calendar/task CLI text formatter yet (raw JSON pass-through) — traces to the legacy `pagespace-mcp` server's own local-time rendering. |
| 4 | All 17 commands show `entryPageAvailable: false` | Traced to `getAppAccessLevel` (packages/lib/src/permissions/app-permissions.ts:136-137) correctly denying a scoped MCP/OAuth token view access to an entry page outside its granted drives — intentional ADR 0002 defense-in-depth, not a bug. Live-reproduced with my own (unscoped) MCP session: all entries resolve correctly. |
| 5 | `regex_search` returns empty `matchingLines` for real regex | Deliberate ReDoS mitigation (`drive-search-service.ts:431-432`, `isLiteralRegexPattern` gate) — running a user-controlled pattern against every line in a JS hot loop (no timeout, unlike the Postgres-side query) is the actual vector being avoided. Documented trade-off, not a defect. |
| 6 | RSVP `responseNote` write-only | SDK schema + REST route already round-trip `responseNote` end-to-end (`attendeeBaseSchema`). No calendar CLI formatter exists yet — legacy-server-only symptom. |
| 7 | `read_conversation` renders tool-only AI turns blank/inconsistent | New SDK's `conversations.read` returns full-fidelity `UIMessage` `parts` arrays, no lossy summarization — legacy-server formatter issue. |
| 8 | `multi_drive_list_agents` returns vestigial `agents: []` | Live-reproduced via the current MCP connector, but the REST route (`multi-drive/route.ts`, verified on master and this branch) returns exactly one of `agentsByDrive`/`agents`, never both, and the SDK schema marks both `.optional()` with no default. Not present in this repo's code — legacy server surface. |
| 9 | `multi_drive_search` TASK_LIST excerpts are empty | `pages.content` is genuinely empty for TASK_LIST pages (task data lives in relational rows); excerpt is built from `page.content.substring(...)`, so it's legitimately empty when a match came from the title. Composing excerpts from task items is a feature-scale change, not a bug fix. |
| 10 (rest) | Channel thread indicator, `get_drive_role` description | `get_drive_role`: SDK schema + REST route already include `description` end-to-end — legacy-server gap. Channel thread indicator: no CLI channel-transcript formatter exists yet in this repo to introduce the "flat" rendering reported. |

## Test plan
- [x] `bun run --filter '@pagespace/lib' test` — 6220 passed
- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bun run --filter 'web' lint` — clean (pre-existing warnings in unrelated files only)
- [x] `bun run --filter '@pagespace/sdk' test` — 719 passed
- [x] Every new/changed behavior has a RED→GREEN test; verified failing before the fix and passing after
- [x] Verified findings #4, #6, #7, #8 against the live `pagespace` MCP surface directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYvh7hg8kwwTeXLJMBjE4x