### PR TITLE
fix(web): OAuth discovery 404s — .well-known is unroutable in App Router

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -118,6 +118,12 @@ export async function middleware(req: NextRequest) {
     // Note: Cron routes handle their own auth via validateSignedCronRequest (HMAC-SHA256 + nonce)
     // Device/mobile auth endpoints authenticate via body tokens (device token, magic link),
     // not session cookies, so they must bypass the cookie check to allow cookie-expired recovery.
+    // OAuth grant endpoints are public by protocol design (RFC 6749/7009/8628): the CLI calls
+    // them with no browser session at all, authenticating via client_id/code/refresh_token/
+    // device_code in the request body instead — each route enforces its own auth internally
+    // (authorize's POST still requires a session; token/revoke/device_authorization never do).
+    // Exact matches only — device_authorization's /verify and /decision sub-routes are the
+    // browser-side /activate screen and DO require a session, so must not be swept in here.
     if (
       pathname.startsWith('/api/auth/csrf') ||
       pathname.startsWith('/api/auth/login-csrf') ||
@@ -130,6 +136,10 @@ export async function middleware(req: NextRequest) {
       pathname.startsWith('/api/mcp/') ||
       pathname.startsWith('/api/drives') ||
       pathname.startsWith('/api/cron/') ||
+      pathname === '/api/oauth/authorize' ||
+      pathname === '/api/oauth/token' ||
+      pathname === '/api/oauth/revoke' ||
+      pathname === '/api/oauth/device_authorization' ||
       pathname === '/api/memory/cron' ||
       pathname === '/api/pulse/cron' ||
       pathname === '/api/integrations/zoom/webhook' ||

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -103,6 +103,16 @@ export async function middleware(req: NextRequest) {
       return response;
     }
 
+    // RFC 8414 OAuth discovery metadata — must be reachable with no session,
+    // since it's the first request the CLI login flow makes. Middleware sees
+    // the pre-rewrite pathname (next.config's rewrites() runs after
+    // middleware), so this must match the original well-known URL, not its
+    // /api/oauth/authorization-server-metadata destination.
+    if (pathname === '/.well-known/oauth-authorization-server') {
+      const { response } = createSecureResponse(isProduction, req, { isAPIRoute: true });
+      return response;
+    }
+
     // Public routes that don't require authentication
     // Note: Cron routes handle their own auth via validateSignedCronRequest (HMAC-SHA256 + nonce)
     // Device/mobile auth endpoints authenticate via body tokens (device token, magic link),

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -14,6 +14,7 @@ import {
   isOriginValidationBlocking,
 } from '@/lib/auth';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
+import { WELL_KNOWN_REWRITES } from '@/lib/well-known/rewrites';
 
 // Edge-safe middleware: only checks presence of auth tokens, not validity.
 // Full validation happens in route handlers via verifyAuth()/validateMCPToken().
@@ -103,12 +104,12 @@ export async function middleware(req: NextRequest) {
       return response;
     }
 
-    // RFC 8414 OAuth discovery metadata — must be reachable with no session,
-    // since it's the first request the CLI login flow makes. Middleware sees
-    // the pre-rewrite pathname (next.config's rewrites() runs after
-    // middleware), so this must match the original well-known URL, not its
-    // /api/oauth/authorization-server-metadata destination.
-    if (pathname === '/.well-known/oauth-authorization-server') {
+    // Well-known discovery routes (e.g. RFC 8414 OAuth metadata) must be
+    // reachable with no session — for OAuth discovery it's the first request
+    // the CLI login flow makes. Middleware sees the pre-rewrite pathname
+    // (next.config's rewrites() runs after middleware), so this must match
+    // against WELL_KNOWN_REWRITES' `source` values, not their destinations.
+    if (WELL_KNOWN_REWRITES.some((rewrite) => rewrite.source === pathname)) {
       const { response } = createSecureResponse(isProduction, req, { isAPIRoute: true });
       return response;
     }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,7 +14,9 @@ const libDistExists = fs.existsSync(path.resolve(__dirname, "../../packages/lib/
 const workspaceDistReady =
   process.env.NODE_ENV === "production" && dbDistExists && libDistExists;
 
-const nextConfig: NextConfig = {
+// Named export so tests can assert on rewrites()/redirects() without going
+// through withSentryConfig's wrapping.
+export const nextConfig: NextConfig = {
   output: "standalone",
   outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: workspaceDistReady ? [] : ["@pagespace/db", "@pagespace/lib"],
@@ -96,6 +98,17 @@ const nextConfig: NextConfig = {
       { source: '/dashboard/inbox/new', destination: '/dashboard/dms/new', permanent: false },
       { source: '/dashboard/inbox', destination: '/dashboard/dms', permanent: false },
       { source: '/dashboard/:driveId/inbox', destination: '/dashboard/:driveId/channels', permanent: false },
+    ];
+  },
+  async rewrites() {
+    return [
+      // Next.js App Router does not route dot-prefixed folders (app/.well-known/*
+      // never lands in the build manifest), so the RFC 8414 discovery URL is
+      // rewritten to a normal, routable API path.
+      {
+        source: '/.well-known/oauth-authorization-server',
+        destination: '/api/well-known/oauth-authorization-server',
+      },
     ];
   },
 };

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import CopyPlugin from "copy-webpack-plugin";
 import { withSentryConfig } from "@sentry/nextjs";
+import { WELL_KNOWN_REWRITES } from "./src/lib/well-known/rewrites";
 
 // Guard: only externalize workspace packages when running in production AND
 // their dist directories exist. The production check prevents stale dist/
@@ -101,15 +102,7 @@ export const nextConfig: NextConfig = {
     ];
   },
   async rewrites() {
-    return [
-      // Next.js App Router does not route dot-prefixed folders (app/.well-known/*
-      // never lands in the build manifest), so the RFC 8414 discovery URL is
-      // rewritten to a normal, routable API path.
-      {
-        source: '/.well-known/oauth-authorization-server',
-        destination: '/api/well-known/oauth-authorization-server',
-      },
-    ];
+    return [...WELL_KNOWN_REWRITES];
   },
 };
 

--- a/apps/web/src/__tests__/next-config-well-known-rewrite.test.ts
+++ b/apps/web/src/__tests__/next-config-well-known-rewrite.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+
+describe('next.config rewrites — RFC 8414 discovery URL', () => {
+  it('rewrites the unroutable /.well-known/oauth-authorization-server URL to the routable API destination', async () => {
+    const { nextConfig } = await import('../../next.config');
+
+    const rewrites = await nextConfig.rewrites?.();
+
+    expect(rewrites).toContainEqual({
+      source: '/.well-known/oauth-authorization-server',
+      destination: '/api/well-known/oauth-authorization-server',
+    });
+  });
+});

--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -92,6 +92,9 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['ai/ollama/models', 'Local Ollama model discovery, no user data'],
   ['ai/lmstudio/models', 'Local LMStudio model discovery, no user data'],
 
+  // --- OAuth discovery (RFC 8414, public by spec) ---
+  ['well-known/oauth-authorization-server', 'RFC 8414 authorization server metadata — public by spec, unauthenticated, no user data or resource access; destination of the /.well-known/oauth-authorization-server rewrite'],
+
   // --- Share link management routes ---
   // TODO: Add audit coverage in follow-up PR
   ['drives/[driveId]/share-links', 'Share link CRUD — invite link management, follow-up'],

--- a/apps/web/src/app/api/well-known/oauth-authorization-server/__tests__/route.test.ts
+++ b/apps/web/src/app/api/well-known/oauth-authorization-server/__tests__/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 const ORIGINAL_ENV = { ...process.env };
 
-describe('GET /.well-known/oauth-authorization-server', () => {
+describe('GET /api/well-known/oauth-authorization-server (destination of the /.well-known/oauth-authorization-server rewrite)', () => {
   beforeEach(() => {
     process.env.WEB_APP_URL = 'https://pagespace.ai';
     delete process.env.NEXT_PUBLIC_APP_URL;

--- a/apps/web/src/app/api/well-known/oauth-authorization-server/route.ts
+++ b/apps/web/src/app/api/well-known/oauth-authorization-server/route.ts
@@ -3,6 +3,12 @@ import { buildServerMetadata } from '@pagespace/lib/auth/oauth/metadata';
 // Metadata depends on runtime env config, not build-time state.
 export const dynamic = 'force-dynamic';
 
+// Rewritten to from the RFC 8414 well-known URL by next.config.ts, because
+// Next.js App Router does not route dot-prefixed folders (app/.well-known/*
+// never lands in the build manifest). Deliberately not under api/oauth/: this
+// is unauthenticated-by-spec public metadata with nothing to rate-limit or
+// audit, and api/oauth/__tests__/hardening.test.ts enforces zero exceptions
+// for routes that live there.
 export async function GET(): Promise<Response> {
   const issuer = process.env.WEB_APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? '';
 

--- a/apps/web/src/lib/well-known/rewrites.ts
+++ b/apps/web/src/lib/well-known/rewrites.ts
@@ -1,0 +1,17 @@
+/**
+ * Single source of truth for `/.well-known/*` routes rewritten to routable
+ * API paths. Next.js App Router does not route dot-prefixed folders under
+ * app/, so any `/.well-known/*` handler must live at a normal path and be
+ * reached via a next.config.ts rewrite of its public URL.
+ *
+ * Both next.config.ts (which registers the rewrite) and middleware.ts (which
+ * must let the request through unauthenticated, since it runs on the
+ * pre-rewrite pathname) import this list, so a new well-known route can't be
+ * wired into one and forgotten in the other.
+ */
+export const WELL_KNOWN_REWRITES = [
+  {
+    source: '/.well-known/oauth-authorization-server',
+    destination: '/api/well-known/oauth-authorization-server',
+  },
+] as const;

--- a/apps/web/src/lib/well-known/rewrites.ts
+++ b/apps/web/src/lib/well-known/rewrites.ts
@@ -8,6 +8,11 @@
  * must let the request through unauthenticated, since it runs on the
  * pre-rewrite pathname) import this list, so a new well-known route can't be
  * wired into one and forgotten in the other.
+ *
+ * `source` must stay a literal path, not a Next.js rewrite pattern
+ * (`:param`, `*`, etc.) — middleware.ts matches it with `===`, not
+ * path-to-regexp, since every `/.well-known/*` URL is a fixed, spec-defined
+ * path with no dynamic segments.
  */
 export const WELL_KNOWN_REWRITES = [
   {

--- a/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock all runtime dependencies so middleware() can run without a real DB/session.
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/middleware/monitoring', () => ({
+  monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
+}));
+const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: new Headers() } }));
+vi.mock('@/middleware/security-headers', () => ({
+  createSecureResponse,
+  createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isPublicPageRoute: vi.fn(() => false),
+  isPublishedSiteHost: vi.fn(() => false),
+  isSecureRequest: vi.fn(() => true),
+  shouldDisableCOEP: vi.fn(() => false),
+}));
+vi.mock('@/lib/auth', () => ({
+  validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
+  isOriginValidationBlocking: vi.fn(() => false),
+}));
+// No session cookie: exactly the CLI's position — it is a background process
+// with no browser session, calling these endpoints directly over HTTP.
+vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
+
+const { middleware } = await import('../../../middleware');
+
+describe('middleware — OAuth grant endpoints are public by protocol design', () => {
+  it.each([
+    '/api/oauth/authorize',
+    '/api/oauth/token',
+    '/api/oauth/revoke',
+    '/api/oauth/device_authorization',
+  ])('lets POST %s through with no session cookie instead of 401ing before the route runs', async (path) => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest(`https://pagespace.ai${path}`, { method: 'POST' });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).toHaveBeenCalled();
+    expect(response.status).not.toBe(401);
+  });
+
+  it.each([
+    '/api/oauth/device_authorization/verify',
+    '/api/oauth/device_authorization/decision',
+  ])('control: %s is the browser /activate screen and still requires a session (401 with none)', async (path) => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest(`https://pagespace.ai${path}`, { method: 'POST' });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
+++ b/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock all runtime dependencies so middleware() can run without a real DB/session.
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/middleware/monitoring', () => ({
+  monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
+}));
+const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: new Headers() } }));
+vi.mock('@/middleware/security-headers', () => ({
+  createSecureResponse,
+  createSecureErrorResponse: vi.fn(),
+  isPublicPageRoute: vi.fn(() => false),
+  isPublishedSiteHost: vi.fn(() => false),
+  shouldDisableCOEP: vi.fn(() => false),
+}));
+vi.mock('@/lib/auth', () => ({
+  validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
+  isOriginValidationBlocking: vi.fn(() => false),
+}));
+// No session cookie: this is the exact scenario the CLI login flow hits —
+// discovery is always the first, unauthenticated request.
+vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
+
+const { middleware } = await import('../../../middleware');
+
+describe('middleware — RFC 8414 discovery URL', () => {
+  it('lets /.well-known/oauth-authorization-server through with no session cookie, as an API route', async () => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest('https://pagespace.ai/.well-known/oauth-authorization-server');
+
+    await middleware(req);
+
+    // The redirect-to-signin path (the bug) is never reached: createSecureResponse
+    // is called directly, and with isAPIRoute so JSON CSP applies, not page CSP.
+    expect(createSecureResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ isAPIRoute: true }),
+    );
+  });
+
+  it('still redirects other unauthenticated non-API routes to sign-in (control case)', async () => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest('https://pagespace.ai/dashboard');
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).not.toHaveBeenCalled();
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/signin');
+  });
+});

--- a/apps/web/src/test/next-server-stub.ts
+++ b/apps/web/src/test/next-server-stub.ts
@@ -16,7 +16,10 @@ class NextResponseStub extends Response {
 export const NextResponse = NextResponseStub;
 
 export class NextRequest extends Request {
+  readonly nextUrl: URL;
+
   constructor(input: string | URL | Request, init?: RequestInit) {
     super(input, init);
+    this.nextUrl = new URL(this.url);
   }
 }

--- a/packages/cli/src/auth/discover.ts
+++ b/packages/cli/src/auth/discover.ts
@@ -1,6 +1,9 @@
 /**
  * RFC 8414 authorization server metadata discovery (Phase 4 task 3) — the
- * client-side counterpart to `apps/web/src/app/.well-known/oauth-authorization-server`.
+ * client-side counterpart to `apps/web/src/app/api/well-known/oauth-authorization-server`,
+ * reached via the `/.well-known/oauth-authorization-server` rewrite in
+ * apps/web/next.config.ts (Next.js App Router does not route dot-prefixed
+ * folders under app/).
  * Zero trust: the fetched JSON is untrusted network input, validated with zod
  * before any field is trusted; a missing/malformed endpoint URL fails closed
  * rather than falling back to a guessed path.


### PR DESCRIPTION
## Summary
- Production bug: `pagespace login` failed because `GET https://pagespace.ai/.well-known/oauth-authorization-server` returned 404, blocking all CLI OAuth logins.
- Root cause: Next.js App Router does not route dot-prefixed folders, so `apps/web/src/app/.well-known/oauth-authorization-server/route.ts` never landed in the build manifest. Its `__tests__` only imported `GET()` directly, so they passed while the real URL was dead — this repo already works around the same limitation for `apple-app-site-association` by serving it as a static file from `public/.well-known/`.
- Fix: moved the handler to the routable `apps/web/src/app/api/well-known/oauth-authorization-server/route.ts`, added a `next.config.ts` rewrite mapping the untouched RFC 8414 URL to that destination, and fixed `middleware.ts` (which runs on the pre-rewrite pathname) to let the well-known path through unauthenticated.
- Deliberately kept the new route out of `app/api/oauth/` — that tree's `hardening.test.ts` sweep requires rate-limiting + audit logging on every route with zero exceptions, and this is unauthenticated-by-spec public metadata. Added it to the app-wide `security-audit-coverage.test.ts` allowlist instead.
- `packages/cli/src/auth/discover.ts` is unchanged in behavior — only its doc comment was updated to point at the new file location.
- Confirmed no other `app/.well-known/*` routes exist in the repo with the same bug.
- **Follow-up self-review fix**: extracted `WELL_KNOWN_REWRITES` to `apps/web/src/lib/well-known/rewrites.ts` as a single source of truth, imported by both `next.config.ts` and `middleware.ts`, instead of duplicating the path string in both files.
- **Second, more serious middleware gap found during PR convergence** (flagged by an automated reviewer, then verified and fixed): even with discovery working, the CLI's actual login would still fail — `/api/oauth/token`, `/api/oauth/device_authorization`, and `/api/oauth/revoke` are public-by-protocol-design (RFC 6749/7009/8628: the CLI has no browser session when calling them) but were **not** in `middleware.ts`'s public-route allowlist, so a session-less request got `401 Authentication required` before the route ever ran. `/api/oauth/authorize` had the same issue — its GET handler is documented to redirect to sign-in when there's no session, but middleware's blanket 401 preempted that. Fixed with exact-path allowlist entries (not a `startsWith` prefix, since `device_authorization`'s `/verify` and `/decision` sub-routes are the browser `/activate` screen and must keep requiring a session — proven by a control-case test). Verified directly against the real `middleware()` function, since none of the 130 existing OAuth route tests exercise middleware at all (they import `GET`/`POST` directly) — the same root-cause class as the original bug.

## Regression coverage
- `next-config-well-known-rewrite.test.ts` — asserts the rewrite mapping exists in `next.config.ts`.
- `well-known-oauth-discovery.test.ts` — proves middleware lets the well-known path through unauthenticated, with a control case proving other unauthenticated routes still redirect to sign-in.
- `oauth-public-endpoints.test.ts` — proves `authorize`/`token`/`revoke`/`device_authorization` are reachable with no session cookie, with a control case proving `device_authorization/verify` and `/decision` still require one.
- Relocated route test — 200 + valid RFC 8414 metadata, unauthenticated.
- Verified end-to-end against the actual built **standalone** server: `GET /.well-known/oauth-authorization-server` returns `200` with valid JSON metadata, no session/cookie required.

## Note for maintainers (separate, pre-existing, NOT fixed in this PR)
While verifying the above with a local Docker-equivalent standalone build, `.next/server/middleware-manifest.json` came back **empty** (`"middleware": {}`) even after a fully clean rebuild — `middleware.ts` isn't landing in the build at all in that path. This predates this PR (reproduces on unmodified `origin/master` too) and is unrelated to anything changed here; I verified this PR's middleware logic instead via direct unit tests against the real `middleware()` function (bypassing webpack/Next's build pipeline entirely, same pattern as this repo's existing `matcher.test.ts`/`security-headers.test.ts`), which is conclusive for correctness of the logic itself. But *whether middleware is actually bundled into the real production artifact* is a distinct, more alarming question this PR doesn't answer, and is worth a dedicated investigation.

Checked this against the official Next.js docs (this app runs 15.5.18) to firm up the theory rather than leave it as a guess:
- [`next.config.js: webpack`](https://nextjs.org/docs/app/api-reference/config/next-config-js/webpack) confirms `isServer` is `true` for **both** the Node.js server build and the Edge runtime build — `nextRuntime` (`'nodejs' | 'edge' | undefined`) is what actually distinguishes them. `apps/web/next.config.ts`'s `webpack()` only checks `isServer` before pushing `bunWorkspaceExternals` (which externalizes `@pagespace/lib`/`@pagespace/db` as `commonjs` requires) — it never checks `nextRuntime === 'nodejs'`, so the same CommonJS externalization is applied to the Edge middleware compilation too.
- [Middleware execution order](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) confirms Middleware runs in the **Edge runtime by default** — a V8 isolate with no CommonJS/`require()` support at runtime — which is consistent with a broken/empty middleware bundle if externals meant for Node.js leak into that compilation.
- Same page's version history: **Next.js 15.5+ (stable) supports opting Middleware into the Node.js runtime** via `export const config = { runtime: 'nodejs', matcher: [...] }`. Since this app is already on 15.5.18, that flag would sidestep the whole Edge-runtime/CommonJS-externals class of problem and seems like the most direct fix, but I haven't verified it closes this specific gap — flagging as the most promising lead for whoever picks this up, not a verified fix.

Also confirmed independently: the `.well-known` dot-folder exclusion this PR's root cause depends on is **not** a documented Next.js App Router convention (only `_private` folders and `(route-groups)` are documented) — it's an empirically-observed, undocumented side effect of file-discovery tooling conventionally skipping dotfiles, not something Next.js promises to keep excluding. The fix in this PR (an explicit `next.config.ts` rewrite) doesn't depend on that behavior persisting, so it's robust either way.

## Test plan
- [x] `bun run --filter web typecheck`
- [x] `bun run --filter web lint` (no new warnings)
- [x] All new/relocated/existing middleware + OAuth tests green (219 tests across 17 files)
- [x] `bun run --filter web build` succeeds; `/api/well-known/oauth-authorization-server` present in `.next/server/app/api/well-known/`, no `.well-known` dot-folder anywhere in the manifest
- [x] Live smoke test against the built standalone server: real URL returns 200 with valid metadata, unauthenticated
- [x] `packages/cli` typecheck + tests green after building `@pagespace/sdk`
- [x] Rebased on latest `master` (which independently fixed the same stale `scaffold.test.ts` assertion — my duplicate fix for that was dropped during rebase, no conflict remains)
- [ ] Full `vitest run` (web) has 2 pre-existing, unrelated failures requiring a live Postgres `test` role (`admin-role-version.test.ts`, `activity-tools.test.ts`) and one pre-existing timezone-flake (`grouping.test.ts`) — confirmed present on `origin/master` before this change, not touched by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmNKa7L6qQcw38EYmgNXzs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for public OAuth discovery and grant endpoints without requiring a signed-in session.
  * Added automatic routing for `/.well-known/oauth-authorization-server` to the API endpoint used for discovery.

* **Bug Fixes**
  * Improved middleware handling so discovery requests are treated as public API traffic.
  * Kept browser-only OAuth verification and approval pages protected.

* **Tests**
  * Added coverage for well-known routing and unauthenticated OAuth endpoint behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
