### PR TITLE
fix(global-chat): stop sends from silently landing in a frozen, stale conversation

### DIFF
--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
@@ -1,0 +1,324 @@
+/**
+ * POST /api/ai/global/[id]/messages must resolve conversation identity from
+ * the request BODY when present, not solely from the URL path segment.
+ *
+ * Root cause this guards against: `useChat`'s internal Chat instance is
+ * constructed once (per PR #1739's stable-id fix, needed to avoid clobbering
+ * messages) and never re-applies a later `transport` — so the URL baked into
+ * the transport at first construction is permanently reused, even after the
+ * client's conversation-identity state (correctly) moves on. Trusting
+ * `body.conversationId` over the frozen URL segment is what makes "New Chat"
+ * and history-select actually take effect on the next send.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const {
+  mockCreateStreamLifecycle,
+  mockLifecyclePushPart,
+  mockLifecycleFinish,
+  mockBroadcastChatUserMessage,
+  mockSaveGlobalAssistantMessageToDatabase,
+} = vi.hoisted(() => ({
+  mockCreateStreamLifecycle: vi.fn(),
+  mockLifecyclePushPart: vi.fn(),
+  mockLifecycleFinish: vi.fn(),
+  mockBroadcastChatUserMessage: vi.fn().mockResolvedValue(undefined),
+  mockSaveGlobalAssistantMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+interface MockUIStreamOptions {
+  execute?: (ctx: Record<string, unknown>) => Promise<void> | void;
+  onFinish?: (result: { responseMessage: unknown }) => Promise<void> | void;
+}
+interface MockStreamTextOptions {
+  onChunk?: (ctx: { chunk: Record<string, unknown> }) => void;
+  onAbort?: () => void;
+}
+const captured = vi.hoisted(() => ({
+  createUIMessageStreamOptions: {} as MockUIStreamOptions,
+  streamTextOptions: {} as MockStreamTextOptions,
+  totalUsage: undefined as unknown,
+  steps: [] as unknown,
+}));
+
+vi.mock('@/lib/ai/core/stream-lifecycle', () => ({
+  createStreamLifecycle: mockCreateStreamLifecycle,
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastCreditsEvent: vi.fn().mockResolvedValue(undefined),
+  broadcastChatUserMessage: mockBroadcastChatUserMessage,
+}));
+
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastGlobalConversationAdded: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn(),
+      child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+const mockConversation = {
+  id: 'conv-1',
+  userId: 'user-1',
+  title: 'Test Conversation',
+  type: 'global',
+  contextId: null,
+  isActive: true,
+};
+const mockUserProfile = { displayName: 'Display User' };
+const mockAuthUser = { name: 'Auth User', subscriptionTier: 'free' };
+
+vi.mock('@pagespace/db/db', () => {
+  const select = vi.fn(() => ({
+    from: vi.fn((table: unknown) => {
+      const tableLabel = table as { __label?: string } | undefined;
+      const isUsers = tableLabel?.__label === 'users';
+      return {
+        where: vi.fn(() => ({
+          then: <T>(
+            resolve?: ((value: unknown[]) => T | PromiseLike<T>) | null,
+            reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
+          ) => Promise.resolve(isUsers ? [mockAuthUser] : [mockConversation]).then(resolve, reject),
+          orderBy: vi.fn().mockResolvedValue([]),
+          limit: vi.fn().mockResolvedValue(isUsers ? [mockAuthUser] : [mockUserProfile]),
+        })),
+      };
+    }),
+  }));
+  const insert = vi.fn(() => ({ values: vi.fn(() => ({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) })) }));
+  const update = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }));
+  return { db: { select, insert, update } };
+});
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(), and: vi.fn(), desc: vi.fn(), gt: vi.fn(), lt: vi.fn(),
+  exists: vi.fn((sub) => ({ type: 'exists', sub })),
+}));
+
+vi.mock('../resolve-or-create-conversation', () => ({
+  resolveOrCreateConversation: vi.fn().mockResolvedValue({
+    conversation: { id: 'conv-1', userId: 'user-1', title: 'Test Conversation', type: 'global', contextId: null, isActive: true, createdAt: new Date('2024-01-01') },
+    isNew: false,
+  }),
+  ConversationOwnershipError: class ConversationOwnershipError extends Error {},
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ drives: { id: 'id', drivePrompt: 'drivePrompt' } }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { __label: 'users', id: 'id', name: 'name', subscriptionTier: 'subscriptionTier' } }));
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  conversations: { id: 'id', userId: 'userId', isActive: 'isActive', lastMessageAt: 'lastMessageAt', updatedAt: 'updatedAt', title: 'title' },
+  messages: { conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt', id: 'id' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  userProfiles: { __label: 'userProfiles', userId: 'userId', displayName: 'displayName' },
+}));
+
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  createAdminRestrictedResponse: vi.fn(),
+  requiresProSubscription: vi.fn().mockReturnValue(false),
+  createSubscriptionRequiredResponse: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {}, provider: 'openai', modelName: 'openai/gpt-5.3-chat' }),
+  updateUserProviderSettings: vi.fn(),
+  createProviderErrorResponse: vi.fn(),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/core/ai-tools', () => ({
+  pageSpaceTools: {},
+  corePageSpaceTools: {},
+}));
+vi.mock('@/lib/ai/core/system-prompt', () => ({
+  TOOL_DISCOVERY_PROMPT: 'TOOLS: mock',
+  buildSystemPrompt: vi.fn().mockReturnValue(''),
+  buildNonCoreToolNamesPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  extractMessageContent: vi.fn().mockReturnValue('test content'),
+  extractToolCalls: vi.fn().mockReturnValue([]),
+  extractToolResults: vi.fn().mockReturnValue([]),
+  sanitizeMessagesForModel: vi.fn().mockReturnValue([]),
+  convertGlobalAssistantMessageToUIMessage: vi.fn(),
+  saveGlobalAssistantMessageToDatabase: mockSaveGlobalAssistantMessageToDatabase,
+}));
+vi.mock('@/lib/ai/core/mention-processor', () => ({
+  processMentionsInMessage: vi.fn().mockReturnValue({ mentions: [], pageIds: [] }),
+  buildMentionSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/agent-awareness', () => ({
+  buildAgentAwarenessPrompt: vi.fn().mockResolvedValue(''),
+}));
+vi.mock('@/lib/ai/core/tool-filtering', () => ({
+  filterToolsForReadOnly: vi.fn().mockReturnValue({}),
+  filterToolsForWebSearch: vi.fn().mockReturnValue({}),
+}));
+vi.mock('@/lib/ai/core/page-tree-context', () => ({
+  getPageTreeContext: vi.fn().mockResolvedValue(''),
+  getDriveListSummary: vi.fn().mockResolvedValue(''),
+}));
+vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
+  convertMCPToolsToAISDKSchemas: vi.fn(),
+  parseMCPToolName: vi.fn(),
+  sanitizeToolNamesForProvider: vi.fn((t: unknown) => t),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserPersonalization: vi.fn().mockResolvedValue(null),
+  getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+}));
+
+vi.mock('@/lib/ai/core/stub-tools', () => ({
+  CORE_TOOL_NAMES: new Set(['list_drives', 'list_pages', 'read_page', 'get_page_details', 'create_page', 'replace_lines', 'regex_search', 'multi_drive_search']),
+}));
+vi.mock('@/lib/ai/tools/execute-tool', () => ({ createExecuteTool: vi.fn().mockReturnValue({}) }));
+
+vi.mock('ai', () => ({
+  streamText: vi.fn().mockImplementation((options: MockStreamTextOptions) => {
+    captured.streamTextOptions = options;
+    return {
+      toUIMessageStream: () => (async function* () {})(),
+      get totalUsage() { return Promise.resolve(captured.totalUsage); },
+      get steps() { return Promise.resolve(captured.steps); },
+      finishReason: Promise.resolve('stop'),
+      response: Promise.resolve({ messages: [] }),
+    };
+  }),
+  convertToModelMessages: vi.fn().mockReturnValue([]),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+  tool: vi.fn((config: unknown) => config),
+  createUIMessageStream: vi.fn().mockImplementation((options: MockUIStreamOptions) => {
+    captured.createUIMessageStreamOptions = options;
+    return {};
+  }),
+  createUIMessageStreamResponse: vi.fn().mockReturnValue(new Response('', { status: 200 })),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({ createId: vi.fn().mockReturnValue('test-message-id') }));
+vi.mock('@/lib/logging/mask', () => ({ maskIdentifier: vi.fn((id: string) => `***${id.slice(-3)}`) }));
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
+  extractOpenRouterGenerationIds: vi.fn(() => []),
+}));
+vi.mock('@pagespace/lib/monitoring/ai-context-calculator', () => ({
+  calculateTotalContextSize: vi.fn().mockReturnValue({
+    totalTokens: 0, messageCount: 0, systemPromptTokens: 0, toolDefinitionTokens: 0,
+    conversationTokens: 0, wasTruncated: false, truncationStrategy: undefined, messageIds: [],
+  }),
+}));
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  getDriveAccess: vi.fn().mockResolvedValue({ isMember: false, role: null }),
+}));
+vi.mock('@/lib/utils/query-params', () => ({ parseBoundedIntParam: vi.fn().mockReturnValue(50) }));
+vi.mock('@/lib/mcp', () => ({ getMCPBridge: vi.fn() }));
+vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
+  createStreamAbortController: vi.fn().mockReturnValue({ streamId: 'stream_123', signal: new AbortController().signal }),
+  removeStream: vi.fn(),
+  STREAM_ID_HEADER: 'x-stream-id',
+}));
+vi.mock('@/lib/ai/core/stream-pipe-utils', () => ({
+  pipeUIMessageStreamStrippingStart: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/lib/ai/core/validate-image-parts', () => ({
+  validateUserMessageFileParts: vi.fn().mockReturnValue({ valid: true }),
+  hasFileParts: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  getModelCapabilities: vi.fn().mockResolvedValue({}),
+  hasVisionCapability: vi.fn().mockReturnValue(true),
+}));
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  isModelAllowedForTier: vi.fn().mockReturnValue(true),
+  ADMIN_ONLY_PROVIDERS: new Set<string>([]),
+  resolveProviderModel: vi.fn((sp: string, sm: string) => ({
+    provider: sp && sm ? sp : 'openai',
+    model: sm || 'openai/gpt-5.3-chat',
+  })),
+}));
+vi.mock('@/lib/ai/core/tool-utils', () => ({
+  mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })),
+}));
+vi.mock('@/lib/ai/tools/finish-tool', () => ({ finishTool: {}, FINISH_TOOL_NAME: 'finish' }));
+vi.mock('@/lib/ai/tools/tool-search-tool', () => ({ createToolSearchTool: vi.fn().mockReturnValue({}) }));
+vi.mock('@/lib/ai/core/compaction/prepare-context', () => ({
+  prepareConversationContext: vi.fn().mockImplementation(
+    ({ messages }: { messages: unknown[] }) =>
+      Promise.resolve({ messages, scheduleCompaction: () => {}, pendingCompaction: null }),
+  ),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import type { SessionAuthResult } from '@/lib/auth';
+import { resolveOrCreateConversation } from '../resolve-or-create-conversation';
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: 'user-1',
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const makeRequest = (body: Record<string, unknown>) =>
+  new Request('https://example.com/api/ai/global/url-conv-id/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'content-length': '400', 'X-Browser-Session-Id': 'session-1' },
+    body: JSON.stringify({
+      messages: [{ id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      selectedProvider: 'openai',
+      selectedModel: 'openai/gpt-5.3-chat',
+      ...body,
+    }),
+  });
+
+// The URL segment is what a frozen (stale) useChat transport would still be
+// pointed at — a real request from an affected browser session sends this
+// value in the URL, but the FRESH conversationId in the body.
+const makeContext = () => ({ params: Promise.resolve({ id: 'url-conv-id' }) });
+
+describe('POST /api/ai/global/[id]/messages — conversation identity resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.createUIMessageStreamOptions = {};
+    captured.streamTextOptions = {};
+    captured.totalUsage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+    mockCreateStreamLifecycle.mockResolvedValue({ pushPart: mockLifecyclePushPart, finish: mockLifecycleFinish });
+  });
+
+  it('given the body includes a conversationId different from the URL segment, should resolve using the BODY id, not the URL id', async () => {
+    await POST(makeRequest({ conversationId: 'body-conv-id' }), makeContext());
+
+    expect(resolveOrCreateConversation).toHaveBeenCalledWith('user-1', 'body-conv-id');
+  });
+
+  it('given the body omits conversationId, should fall back to the URL segment', async () => {
+    await POST(makeRequest({}), makeContext());
+
+    expect(resolveOrCreateConversation).toHaveBeenCalledWith('user-1', 'url-conv-id');
+  });
+});

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -247,8 +247,38 @@ export async function POST(
     }
     const userId = auth.userId;
 
-    const { id: conversationId } = await context.params;
+    const { id: urlConversationId } = await context.params;
     loggers.api.debug('Global Assistant Chat API: Authentication successful', { userId });
+
+    // Body size guard — reject payloads over 25MB before parsing
+    const contentLength = parseInt(request.headers.get('content-length') || '0', 10);
+    if (contentLength > 25 * 1024 * 1024) {
+      loggers.api.warn('Global Assistant Chat API: Request body too large', { contentLength });
+      return NextResponse.json({ error: 'Request body too large (max 25MB)' }, { status: 413 });
+    }
+
+    // Parse request body
+    const requestBody = await request.json();
+
+    // The URL segment is baked into useChat's transport at construction and
+    // never updates thereafter (its Chat instance is deliberately kept alive
+    // across conversation switches to avoid clobbering messages — see
+    // chat-config.ts). The body's conversationId reflects the client's
+    // current identity state and is what determines where this message
+    // actually lands; the URL segment is only a fallback for callers that
+    // don't send one.
+    const conversationId: string =
+      typeof requestBody.conversationId === 'string' && requestBody.conversationId.length > 0
+        ? requestBody.conversationId
+        : urlConversationId;
+
+    loggers.api.debug('Global Assistant Chat API: Request body received', {
+      messageCount: requestBody.messages?.length || 0,
+      conversationId,
+      selectedProvider: requestBody.selectedProvider,
+      selectedModel: requestBody.selectedModel,
+      hasLocationContext: !!requestBody.locationContext
+    });
 
     // Resolve existing conversation or auto-create on first message (lazy creation).
     // Clients generate the ID locally; this is the point where the DB row is guaranteed.
@@ -263,23 +293,6 @@ export async function POST(
       throw e;
     }
 
-    // Body size guard — reject payloads over 25MB before parsing
-    const contentLength = parseInt(request.headers.get('content-length') || '0', 10);
-    if (contentLength > 25 * 1024 * 1024) {
-      loggers.api.warn('Global Assistant Chat API: Request body too large', { contentLength });
-      return NextResponse.json({ error: 'Request body too large (max 25MB)' }, { status: 413 });
-    }
-
-    // Parse request body
-    const requestBody = await request.json();
-    loggers.api.debug('Global Assistant Chat API: Request body received', {
-      messageCount: requestBody.messages?.length || 0,
-      conversationId,
-      selectedProvider: requestBody.selectedProvider,
-      selectedModel: requestBody.selectedModel,
-      hasLocationContext: !!requestBody.locationContext
-    });
-    
     const {
       messages: requestMessages, // Used ONLY to extract new user message, NOT for conversation history
       selectedProvider,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -68,6 +68,7 @@ import {
   buildChatConfig,
   AGENT_CHAT_ID,
   LocationContext,
+  buildGlobalChatRequestBody,
 } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
@@ -810,15 +811,16 @@ const GlobalAssistantView: React.FC = () => {
           webSearchEnabled,
           mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
         }
-      : {
+      : buildGlobalChatRequestBody({
+          conversationId: currentConversationId,
           isReadOnly,
           webSearchEnabled,
           showPageTree,
-          locationContext: locationContext || undefined,
+          locationContext,
           selectedProvider: currentProvider,
           selectedModel: currentModel,
-          mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
-        };
+          mcpTools: mcpToolSchemas,
+        });
 
     // wrapSend handles pendingSend registration and cleanup when streaming starts
     wrapSend(() => sendMessage({ text: input, files: files.length > 0 ? files : undefined }, { body: requestBody }));
@@ -841,15 +843,16 @@ const GlobalAssistantView: React.FC = () => {
           webSearchEnabled,
           mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
         }
-      : {
+      : buildGlobalChatRequestBody({
+          conversationId: currentConversationId,
           isReadOnly,
           webSearchEnabled,
           showPageTree,
-          locationContext: locationContext || undefined,
+          locationContext,
           selectedProvider: currentProvider,
           selectedModel: currentModel,
-          mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
-        };
+          mcpTools: mcpToolSchemas,
+        });
 
     // wrapSend handles pendingSend registration and cleanup when streaming starts
     wrapSend(() => sendMessage({ text }, { body: requestBody }));

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -35,7 +35,7 @@ import { LocationContext } from '@/lib/ai/shared';
 import { parseTabPath, getStaticTabMeta } from '@/lib/tabs/tab-title';
 import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId } from '@/lib/ai/core/client';
 import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
-import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery, buildChatConfig, SIDEBAR_AGENT_CHAT_ID } from '@/lib/ai/shared';
+import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery, buildChatConfig, SIDEBAR_AGENT_CHAT_ID, buildGlobalChatRequestBody } from '@/lib/ai/shared';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
@@ -772,14 +772,15 @@ const SidebarChatTab: React.FC = () => {
           locationContext: locationContext || undefined,
           enabledTools: selectedAgent.enabledTools,
         }
-      : {
+      : buildGlobalChatRequestBody({
+          conversationId: currentConversationId,
           isReadOnly,
           webSearchEnabled,
           showPageTree,
-          locationContext: locationContext || undefined,
+          locationContext,
           selectedProvider: currentProvider,
           selectedModel: currentModel,
-        };
+        });
 
     // wrapSend handles pendingSend registration and cleanup when streaming starts
     wrapSend(() => sendMessage({ text: input, files: files.length > 0 ? files : undefined }, { body }));
@@ -821,14 +822,15 @@ const SidebarChatTab: React.FC = () => {
           locationContext: locationContext || undefined,
           enabledTools: selectedAgent.enabledTools,
         }
-      : {
+      : buildGlobalChatRequestBody({
+          conversationId: currentConversationId,
           isReadOnly,
           webSearchEnabled,
           showPageTree,
-          locationContext: locationContext || undefined,
+          locationContext,
           selectedProvider: currentProvider,
           selectedModel: currentModel,
-        };
+        });
 
     // wrapSend handles pendingSend registration and cleanup when streaming starts
     wrapSend(() => sendMessage({ text }, { body }));

--- a/apps/web/src/lib/ai/shared/__tests__/global-chat-request-body.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/global-chat-request-body.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { buildGlobalChatRequestBody } from '../global-chat-request-body';
+
+const baseParams = {
+  conversationId: 'conv-123',
+  isReadOnly: false,
+  webSearchEnabled: true,
+  showPageTree: false,
+  selectedProvider: 'openai',
+  selectedModel: 'openai/gpt-5.3-chat',
+};
+
+describe('buildGlobalChatRequestBody', () => {
+  it('given a conversationId, should include it in the returned body', () => {
+    const body = buildGlobalChatRequestBody(baseParams);
+    expect(body.conversationId).toBe('conv-123');
+  });
+
+  it('given null conversationId, should pass null through rather than omitting the field', () => {
+    const body = buildGlobalChatRequestBody({ ...baseParams, conversationId: null });
+    expect(body.conversationId).toBeNull();
+  });
+
+  it('given a different conversationId across two calls, should reflect the new value each time (not frozen)', () => {
+    const first = buildGlobalChatRequestBody({ ...baseParams, conversationId: 'conv-a' });
+    const second = buildGlobalChatRequestBody({ ...baseParams, conversationId: 'conv-b' });
+    expect(first.conversationId).toBe('conv-a');
+    expect(second.conversationId).toBe('conv-b');
+  });
+
+  it('given no locationContext, should default to undefined', () => {
+    const body = buildGlobalChatRequestBody(baseParams);
+    expect(body.locationContext).toBeUndefined();
+  });
+
+  it('given a null locationContext, should default to undefined', () => {
+    const body = buildGlobalChatRequestBody({ ...baseParams, locationContext: null });
+    expect(body.locationContext).toBeUndefined();
+  });
+
+  it('given a locationContext object, should pass it through', () => {
+    const locationContext = { currentPage: { id: 'p1', title: 'Page', type: 'Document', path: '/p1' } };
+    const body = buildGlobalChatRequestBody({ ...baseParams, locationContext });
+    expect(body.locationContext).toBe(locationContext);
+  });
+
+  it('given no mcpTools, should default to undefined', () => {
+    const body = buildGlobalChatRequestBody(baseParams);
+    expect(body.mcpTools).toBeUndefined();
+  });
+
+  it('given an empty mcpTools array, should default to undefined', () => {
+    const body = buildGlobalChatRequestBody({ ...baseParams, mcpTools: [] });
+    expect(body.mcpTools).toBeUndefined();
+  });
+
+  it('given a non-empty mcpTools array, should pass it through', () => {
+    const tools = [{ name: 'tool-1' }];
+    const body = buildGlobalChatRequestBody({ ...baseParams, mcpTools: tools });
+    expect(body.mcpTools).toBe(tools);
+  });
+
+  it('given the same inputs, should produce equal output on every call (purity)', () => {
+    const a = buildGlobalChatRequestBody(baseParams);
+    const b = buildGlobalChatRequestBody(baseParams);
+    expect(a).toEqual(b);
+  });
+
+  it('should pass through isReadOnly, webSearchEnabled, showPageTree, selectedProvider, selectedModel unchanged', () => {
+    const body = buildGlobalChatRequestBody(baseParams);
+    expect(body.isReadOnly).toBe(false);
+    expect(body.webSearchEnabled).toBe(true);
+    expect(body.showPageTree).toBe(false);
+    expect(body.selectedProvider).toBe('openai');
+    expect(body.selectedModel).toBe('openai/gpt-5.3-chat');
+  });
+});

--- a/apps/web/src/lib/ai/shared/global-chat-request-body.ts
+++ b/apps/web/src/lib/ai/shared/global-chat-request-body.ts
@@ -1,0 +1,54 @@
+import type { LocationContext } from './chat-types';
+
+/**
+ * Pure builder for the Global Assistant (non-agent) chat request body.
+ *
+ * useChat's Chat instance is kept alive across conversation switches (a
+ * stable id, per chat-config.ts, to avoid clobbering messages) — its
+ * transport is captured once at construction and never updated. The URL
+ * baked into that transport at construction time can go stale the moment the
+ * user switches conversations. `conversationId` in this body is what the
+ * server actually trusts (see apps/web/src/app/api/ai/global/[id]/messages/
+ * route.ts), so it must reflect the CURRENT conversation on every call, not
+ * just whatever the transport's URL still points at.
+ */
+export interface GlobalChatRequestBodyParams {
+  conversationId: string | null;
+  isReadOnly: boolean;
+  webSearchEnabled: boolean;
+  showPageTree: boolean;
+  locationContext?: LocationContext | null;
+  selectedProvider: string | null;
+  selectedModel: string | null;
+  mcpTools?: unknown[];
+}
+
+export interface GlobalChatRequestBody {
+  // Index signature so this satisfies sendMessage's Record<string, unknown>
+  // body option — plain named interfaces aren't structurally assignable to
+  // index-signature types without one, even with fully compatible fields.
+  [key: string]: unknown;
+  conversationId: string | null;
+  isReadOnly: boolean;
+  webSearchEnabled: boolean;
+  showPageTree: boolean;
+  locationContext: LocationContext | undefined;
+  selectedProvider: string | null;
+  selectedModel: string | null;
+  mcpTools: unknown[] | undefined;
+}
+
+export function buildGlobalChatRequestBody(
+  params: GlobalChatRequestBodyParams
+): GlobalChatRequestBody {
+  return {
+    conversationId: params.conversationId,
+    isReadOnly: params.isReadOnly,
+    webSearchEnabled: params.webSearchEnabled,
+    showPageTree: params.showPageTree,
+    locationContext: params.locationContext || undefined,
+    selectedProvider: params.selectedProvider,
+    selectedModel: params.selectedModel,
+    mcpTools: params.mcpTools && params.mcpTools.length > 0 ? params.mcpTools : undefined,
+  };
+}

--- a/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
+++ b/apps/web/src/lib/ai/shared/hooks/__tests__/useMessageActions.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMessageActions } from '../useMessageActions';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  patch: vi.fn(),
+  del: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/ai/core/browser-session-id', () => ({
+  getBrowserSessionId: vi.fn().mockReturnValue('session-1'),
+}));
+
+describe('useMessageActions — handleRetry regenerate body', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given global mode (agentId null), should include conversationId in the regenerate body — not send undefined', async () => {
+    const regenerate = vi.fn();
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: null,
+        conversationId: 'global-conv-1',
+        messages: [],
+        setMessages: vi.fn(),
+        regenerate,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRetry();
+    });
+
+    expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'global-conv-1' } });
+  });
+
+  it('given global mode and the conversation changes between renders, should regenerate with the NEW conversationId', async () => {
+    const regenerate = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ conversationId }) =>
+        useMessageActions({
+          agentId: null,
+          conversationId,
+          messages: [],
+          setMessages: vi.fn(),
+          regenerate,
+        }),
+      { initialProps: { conversationId: 'conv-first' } }
+    );
+
+    rerender({ conversationId: 'conv-second' });
+
+    await act(async () => {
+      await result.current.handleRetry();
+    });
+
+    expect(regenerate).toHaveBeenCalledWith({ body: { conversationId: 'conv-second' } });
+  });
+
+  it('given agent mode, should include chatId and conversationId in the regenerate body (existing behavior)', async () => {
+    const regenerate = vi.fn();
+    const { result } = renderHook(() =>
+      useMessageActions({
+        agentId: 'agent-1',
+        conversationId: 'agent-conv-1',
+        messages: [],
+        setMessages: vi.fn(),
+        regenerate,
+      })
+    );
+
+    await act(async () => {
+      await result.current.handleRetry();
+    });
+
+    expect(regenerate).toHaveBeenCalledWith({
+      body: { chatId: 'agent-1', conversationId: 'agent-conv-1' },
+    });
+  });
+});

--- a/apps/web/src/lib/ai/shared/hooks/index.ts
+++ b/apps/web/src/lib/ai/shared/hooks/index.ts
@@ -20,3 +20,4 @@ export {
   SIDEBAR_AGENT_CHAT_ID,
   buildChatConfig,
 } from '../chat-config';
+export { buildGlobalChatRequestBody } from '../global-chat-request-body';

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -240,14 +240,20 @@ export function useMessageActions({
       );
     }
 
-    // Now regenerate with a clean slate
+    // Now regenerate with a clean slate. conversationId is included for both
+    // modes — global mode's useChat transport is frozen at first construction
+    // (see global-chat-request-body.ts), so the body is what actually
+    // determines which conversation this lands in after a switch, same as a
+    // regular send.
     regenerate({
       body: isAgentMode
         ? {
             chatId: agentId,
             conversationId,
           }
-        : undefined,
+        : {
+            conversationId,
+          },
     });
   }, [isAgentMode, agentId, conversationId, setMessages, regenerate]);
 


### PR DESCRIPTION
## Summary

After merging #1849 (conversation-identity refactor), Global Assistant chat still exhibited the reported symptoms: right-sidebar history "not working," new messages landing in old conversations, and sending to an existing conversation landing in the wrong one. This is a **different, deeper bug** than #1849 fixed — that PR correctly fixed client-side identity *state*; this fixes how that state actually reaches the network.

## Root cause

PR #1739 gave every `useChat` a **stable per-surface `id`** (e.g. `GLOBAL_CHAT_ID`, a constant) so the AI SDK wouldn't recreate its internal `Chat` instance — and clobber messages — on every conversation switch. The side effect nobody caught: **`transport` is captured once at `Chat` construction and never re-applied.** Verified directly in `@ai-sdk/react`'s source — `shouldRecreateChat` only checks `id`/`chat` identity, never `transport`.

`GlobalChatContext.tsx` builds a conversation-specific transport URL (`/api/ai/global/${currentConversationId}/messages`). That URL gets frozen at whatever conversation was active the *first* time in a mount. Every later "New Chat" or history-select correctly updates the UI/identity state (thanks to #1849) — but the actual POST keeps hitting the original, stale URL. The server trusted **only** that URL segment (`context.params`), and the client's global-mode request body never even included `conversationId` (unlike the agent-mode branch right next to it, which does).

Net effect: once Global Assistant sends its first message in a page load, every subsequent send goes to that same first conversation — forever, regardless of what the UI shows.

**Confirmed unaffected:** agent mode and `AiChatView.tsx` (page-scoped chat) — both already use a static endpoint + a per-call request body carrying `conversationId`, which the server reads fresh. This fix brings global mode in line with that existing, safe pattern.

## Changes

- **New** `apps/web/src/lib/ai/shared/global-chat-request-body.ts` — `buildGlobalChatRequestBody()`, a pure function replacing 4 duplicated (2 files × 2 handlers) inline object literals, always including `conversationId`.
- `apps/web/src/app/api/ai/global/[id]/messages/route.ts` — POST now parses the body before resolving the conversation and prefers a validated `body.conversationId` over the URL param, falling back to the URL only when absent. `resolveOrCreateConversation` is unchanged (already validates CUID2 format + ownership regardless of source — no new security surface).
- `GlobalAssistantView.tsx` / `SidebarChatTab.tsx` — both `handleSendMessage` and `handleVoiceSend` build their non-agent request body via the shared helper.
- `useMessageActions.ts` — `handleRetry`'s `regenerate()` call also now includes `conversationId` for global mode (was `body: undefined`, unlike the agent branch right next to it). Same root cause, different call path — retrying a response after a conversation switch had the identical misrouting risk. Found by an automated review pass on this PR; verified against source and fixed.

## Why the existing test suite didn't catch this

Every test touching `useChat` mocks it completely, so none exercise the SDK's real instance-reuse/transport-freezing behavior. The fix only needed testing the things actually observable through those mocks — the request body sent per call (both send and retry), and the server's id-resolution priority — all covered below.

## Test plan

- [x] `bun run typecheck` — clean
- [x] 16 new tests (11 pure-function, 2 route-level, 3 retry-path) + existing suites, 107 tests across 8 touched files, all green
- [x] `bun run --filter web test` — 744/748 files green project-wide (4 pre-existing, environment/DB-flakiness failures unrelated to this change, confirmed via 3 separate full-suite runs today with different exact failures each time — Postgres role setup, a midnight-boundary date test, two DB-dependent auth/activity tests)
- [ ] Manual smoke test in a running instance: open Global Assistant, send a message, click "New Chat", send a second message — reload and confirm the second message persisted under the new conversation, not the first. Select an older conversation from sidebar history and send — confirm it lands there. Also test "Retry" on a response after switching conversations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JT8umuwBmmtKiwmBhyq5uH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Global assistant messages now use the conversation ID from the message when provided, and otherwise fall back to the conversation ID in the page URL.
  * Request payloads for global chat are now built more consistently, including optional location context and tool data handling.

* **Tests**
  * Added coverage for conversation ID resolution and global chat request payload construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
