### PR TITLE
feat(web): OpenAI-compatible API image handling

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -317,6 +317,85 @@ describe('POST /api/v1/chat/completions', () => {
     });
   });
 
+  test('validates file parts in earlier user messages, not just the final one', async () => {
+    vi.mocked(hasFileParts).mockImplementation((message: UIMessage) => message.id === 'msg-1');
+    vi.mocked(validateUserMessageFileParts).mockReturnValue({ valid: false, error: 'Image "cat.png" exceeds the 4MB size limit', filePartCount: 1 });
+    const bodyWithEarlierImage = {
+      model: 'ps-agent://page-123',
+      messages: [
+        {
+          role: 'user',
+          id: 'msg-1',
+          content: 'What is in this image?',
+          parts: [{ type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
+        },
+        { role: 'assistant', id: 'msg-2', content: 'A cat.', parts: [{ type: 'text', text: 'A cat.' }] },
+        { role: 'user', id: 'msg-3', content: 'Thanks!', parts: [{ type: 'text', text: 'Thanks!' }] },
+      ],
+    };
+    const response = await POST(makeRequest(bodyWithEarlierImage));
+    const body = await response.json();
+    assert({
+      given: 'a resent full history where only an EARLIER user message carries an invalid file part and the final message is text-only',
+      should: 'still return 400 from file-part validation and never call the prepaid credit gate',
+      actual: { status: response.status, error: body.error, creditGateCalled: vi.mocked(canConsumeAI).mock.calls.length > 0 },
+      expected: { status: 400, error: 'Image "cat.png" exceeds the 4MB size limit', creditGateCalled: false },
+    });
+  });
+
+  test('applies the vision-capability gate to images in earlier user messages', async () => {
+    vi.mocked(hasFileParts).mockImplementation((message: UIMessage) => message.id === 'msg-1');
+    vi.mocked(hasVisionCapability).mockReturnValue(false);
+    const bodyWithEarlierImage = {
+      model: 'ps-agent://page-123',
+      messages: [
+        {
+          role: 'user',
+          id: 'msg-1',
+          content: 'What is in this image?',
+          parts: [{ type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
+        },
+        { role: 'assistant', id: 'msg-2', content: 'A cat.', parts: [{ type: 'text', text: 'A cat.' }] },
+        { role: 'user', id: 'msg-3', content: 'Thanks!', parts: [{ type: 'text', text: 'Thanks!' }] },
+      ],
+    };
+    const response = await POST(makeRequest(bodyWithEarlierImage));
+    const body = await response.json();
+    assert({
+      given: 'a resent full history with a valid image in an EARLIER user message and a non-vision model',
+      should: 'return 400 from the vision gate and never call the prepaid credit gate',
+      actual: { status: response.status, error: body.error, creditGateCalled: vi.mocked(canConsumeAI).mock.calls.length > 0 },
+      expected: {
+        status: 400,
+        error: `The selected model "${agentPage.aiModel}" does not support image attachments. Please choose a vision-capable model.`,
+        creditGateCalled: false,
+      },
+    });
+  });
+
+  test('returns 403 to a caller without page access before any vision error can reveal the agent model', async () => {
+    vi.mocked(canPrincipalViewPage).mockResolvedValue(false);
+    vi.mocked(hasFileParts).mockReturnValue(true);
+    vi.mocked(hasVisionCapability).mockReturnValue(false);
+    const bodyWithImage = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        id: 'msg-1',
+        content: 'What is in this image?',
+        parts: [{ type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
+      }],
+    };
+    const response = await POST(makeRequest(bodyWithImage));
+    const body = await response.json();
+    assert({
+      given: 'an authenticated caller with a valid image who lacks view permission on a non-vision agent page',
+      should: 'return the permission 403 rather than the vision 400 that would leak the configured model',
+      actual: { status: response.status, error: body.error, leaksModel: String(body.error).includes(String(agentPage.aiModel)) },
+      expected: { status: 403, error: 'Access denied', leaksModel: false },
+    });
+  });
+
   test('returns 401 when auth fails', async () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
       error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -111,6 +111,12 @@ vi.mock('@/lib/ai/core/tool-filtering', () => ({
 }));
 vi.mock('@/lib/ai/core/model-capabilities', () => ({
   getModelCapabilities: vi.fn().mockResolvedValue({}),
+  hasVisionCapability: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/ai/core/validate-image-parts', () => ({
+  hasFileParts: vi.fn().mockReturnValue(false),
+  validateUserMessageFileParts: vi.fn().mockReturnValue({ valid: true, filePartCount: 0 }),
 }));
 
 vi.mock('@/lib/ai/tools/tool-exposure', () => ({
@@ -182,6 +188,8 @@ import type { UIMessage } from 'ai';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
+import { hasFileParts, validateUserMessageFileParts } from '@/lib/ai/core/validate-image-parts';
 
 const mcpAuth = {
   userId: 'user-1',
@@ -230,6 +238,9 @@ describe('POST /api/v1/chat/completions', () => {
     } as unknown as ReturnType<typeof db.select>);
     vi.mocked(chatMessageRepository.getMessagesForPage).mockResolvedValue([]);
     vi.mocked(canConsumeAI).mockResolvedValue({ allowed: true, reason: 'unlimited' });
+    vi.mocked(hasFileParts).mockReturnValue(false);
+    vi.mocked(hasVisionCapability).mockReturnValue(true);
+    vi.mocked(validateUserMessageFileParts).mockReturnValue({ valid: true, filePartCount: 0 });
   });
 
   test('returns 402 when the prepaid credit gate denies the request', async () => {
@@ -252,6 +263,57 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'return a 200 SSE stream',
       actual: { status: response.status, contentType: response.headers.get('content-type') },
       expected: { status: 200, contentType: 'text/event-stream' },
+    });
+  });
+
+  test('returns 400 and never touches the credit gate when an image is sent to a non-vision model', async () => {
+    vi.mocked(hasFileParts).mockReturnValue(true);
+    vi.mocked(hasVisionCapability).mockReturnValue(false);
+    const bodyWithImage = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        id: 'msg-1',
+        content: 'What is in this image?',
+        parts: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' },
+        ],
+      }],
+    };
+    const response = await POST(makeRequest(bodyWithImage));
+    const body = await response.json();
+    assert({
+      given: 'a user message with a file part sent to an agent configured with a non-vision model',
+      should: 'return 400 with a descriptive error and never call the prepaid credit gate',
+      actual: { status: response.status, error: body.error, creditGateCalled: vi.mocked(canConsumeAI).mock.calls.length > 0 },
+      expected: {
+        status: 400,
+        error: `The selected model "${agentPage.aiModel}" does not support image attachments. Please choose a vision-capable model.`,
+        creditGateCalled: false,
+      },
+    });
+  });
+
+  test('returns 400 when file-part validation fails, before the credit gate', async () => {
+    vi.mocked(hasFileParts).mockReturnValue(true);
+    vi.mocked(validateUserMessageFileParts).mockReturnValue({ valid: false, error: 'Image "cat.png" exceeds the 4MB size limit', filePartCount: 1 });
+    const bodyWithImage = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        id: 'msg-1',
+        content: 'What is in this image?',
+        parts: [{ type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' }],
+      }],
+    };
+    const response = await POST(makeRequest(bodyWithImage));
+    const body = await response.json();
+    assert({
+      given: 'a user message with a file part that fails size/format validation',
+      should: 'return 400 with the validation error and never call the prepaid credit gate',
+      actual: { status: response.status, error: body.error, creditGateCalled: vi.mocked(canConsumeAI).mock.calls.length > 0 },
+      expected: { status: 400, error: 'Image "cat.png" exceeds the 4MB size limit', creditGateCalled: false },
     });
   });
 

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -373,6 +373,59 @@ describe('POST /api/v1/chat/completions', () => {
     });
   });
 
+  test('rejects invalid file parts on assistant-role messages too', async () => {
+    vi.mocked(hasFileParts).mockImplementation((message: UIMessage) => message.role === 'assistant');
+    vi.mocked(validateUserMessageFileParts).mockReturnValue({ valid: false, error: 'Image "x.png" is not a valid data URL', filePartCount: 1 });
+    const bodyWithAssistantImage = {
+      model: 'ps-agent://page-123',
+      messages: [
+        { role: 'user', id: 'msg-1', content: 'Draw a cat.', parts: [{ type: 'text', text: 'Draw a cat.' }] },
+        {
+          role: 'assistant',
+          id: 'msg-2',
+          content: '',
+          parts: [{ type: 'file', url: 'https://attacker.example/x.png', mediaType: 'image/png' }],
+        },
+        { role: 'user', id: 'msg-3', content: 'Another one.', parts: [{ type: 'text', text: 'Another one.' }] },
+      ],
+    };
+    const response = await POST(makeRequest(bodyWithAssistantImage));
+    const body = await response.json();
+    assert({
+      given: 'a resent history where an ASSISTANT-role message carries an invalid file part (e.g. a remote URL)',
+      should: 'return 400 from file-part validation instead of letting non-user roles bypass the gate',
+      actual: { status: response.status, error: body.error, creditGateCalled: vi.mocked(canConsumeAI).mock.calls.length > 0 },
+      expected: { status: 400, error: 'Image "x.png" is not a valid data URL', creditGateCalled: false },
+    });
+  });
+
+  test('a valid image on a vision-capable model passes the gate and reaches the credit gate', async () => {
+    vi.mocked(hasFileParts).mockReturnValue(true);
+    const bodyWithImage = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        id: 'msg-1',
+        content: 'What is in this image?',
+        parts: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' },
+        ],
+      }],
+    };
+    const response = await POST(makeRequest(bodyWithImage));
+    assert({
+      given: 'a valid image sent to a vision-capable model by an authorized caller with credits',
+      should: 'proceed through the image gate to the credit gate and return a 200 SSE stream',
+      actual: {
+        status: response.status,
+        contentType: response.headers.get('content-type'),
+        creditGateCalled: vi.mocked(canConsumeAI).mock.calls.length > 0,
+      },
+      expected: { status: 200, contentType: 'text/event-stream', creditGateCalled: true },
+    });
+  });
+
   test('returns 403 to a caller without page access before any vision error can reveal the agent model', async () => {
     vi.mocked(canPrincipalViewPage).mockResolvedValue(false);
     vi.mocked(hasFileParts).mockReturnValue(true);

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -105,24 +105,6 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
   }
 
-  // 4b. Image security + vision-capability gate — mirrors the in-app chat route
-  // (apps/web/src/app/api/ai/chat/route.ts) and runs before the credit hold (6b) so a
-  // rejected image never reserves a hold or an in-flight slot.
-  const userMessageForValidation = messages[messages.length - 1];
-  const messageHasImages = userMessageForValidation?.role === 'user' && hasFileParts(userMessageForValidation);
-  if (messageHasImages) {
-    const imageValidation = validateUserMessageFileParts(userMessageForValidation);
-    if (!imageValidation.valid) {
-      return NextResponse.json({ error: imageValidation.error }, { status: 400 });
-    }
-    if (page.aiModel && !hasVisionCapability(page.aiModel)) {
-      return NextResponse.json(
-        { error: `The selected model "${page.aiModel}" does not support image attachments. Please choose a vision-capable model.` },
-        { status: 400 },
-      );
-    }
-  }
-
   // 5. Permission check. View is necessary but not sufficient: this endpoint runs
   // the agent's server-side tools (including write tools) with the agent page as the
   // actor, so it requires the same edit gate the in-app page chat enforces before
@@ -138,7 +120,31 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }
 
-  // 5b. Conversation ownership check — if a conversation_id is provided the caller
+  // 5b. Image security + vision-capability gate — mirrors the in-app chat route
+  // (apps/web/src/app/api/ai/chat/route.ts). Runs after the permission checks so an
+  // unauthorized caller gets the 403 and never learns the agent's configured model from
+  // the vision error, and before the credit hold (6b) so a rejected image never reserves
+  // a hold or an in-flight slot. Every user message in the request body is validated —
+  // not just the newest one — because non-threaded and client_manages_history callers
+  // resend full history, and validateInferenceRequest maps image_url parts to file
+  // parts on all of them.
+  const userMessagesWithImages = messages.filter(m => m.role === 'user' && hasFileParts(m));
+  if (userMessagesWithImages.length > 0) {
+    for (const messageWithImages of userMessagesWithImages) {
+      const imageValidation = validateUserMessageFileParts(messageWithImages);
+      if (!imageValidation.valid) {
+        return NextResponse.json({ error: imageValidation.error }, { status: 400 });
+      }
+    }
+    if (page.aiModel && !hasVisionCapability(page.aiModel)) {
+      return NextResponse.json(
+        { error: `The selected model "${page.aiModel}" does not support image attachments. Please choose a vision-capable model.` },
+        { status: 400 },
+      );
+    }
+  }
+
+  // 5c. Conversation ownership check — if a conversation_id is provided the caller
   // must own the conversations row. This prevents one user from appending messages
   // into another user's thread.
   //

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -120,29 +120,23 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }
 
-  // 5b. Image security + vision-capability gate — mirrors the in-app chat route
+  // 5b. Image security gate — mirrors the in-app chat route
   // (apps/web/src/app/api/ai/chat/route.ts). Runs after the permission checks so an
-  // unauthorized caller gets the 403 and never learns the agent's configured model from
-  // the vision error, and before the credit hold (6b) so a rejected image never reserves
-  // a hold or an in-flight slot. Every user message in the request body is validated —
-  // not just the newest one — because non-threaded and client_manages_history callers
-  // resend full history, and validateInferenceRequest maps image_url parts to file
-  // parts on all of them.
-  const userMessagesWithImages = messages.filter(m => m.role === 'user' && hasFileParts(m));
-  if (userMessagesWithImages.length > 0) {
-    for (const messageWithImages of userMessagesWithImages) {
-      const imageValidation = validateUserMessageFileParts(messageWithImages);
-      if (!imageValidation.valid) {
-        return NextResponse.json({ error: imageValidation.error }, { status: 400 });
-      }
-    }
-    if (page.aiModel && !hasVisionCapability(page.aiModel)) {
-      return NextResponse.json(
-        { error: `The selected model "${page.aiModel}" does not support image attachments. Please choose a vision-capable model.` },
-        { status: 400 },
-      );
+  // unauthorized caller gets the 403 and never learns anything page-specific from image
+  // errors, and before the credit hold (6b) so a rejected image never reserves a hold or
+  // an in-flight slot. EVERY message in the request body is validated — not just the
+  // newest one (non-threaded and client_manages_history callers resend full history) and
+  // not just user-role ones: normalizeMessage passes pre-built `parts` arrays through
+  // as-is and the AI SDK forwards assistant file parts to the provider exactly like user
+  // ones, so an assistant-role message must not bypass the data:-URL/size/magic-byte rules.
+  const messagesWithFileParts = messages.filter(m => hasFileParts(m));
+  for (const messageWithFileParts of messagesWithFileParts) {
+    const imageValidation = validateUserMessageFileParts(messageWithFileParts);
+    if (!imageValidation.valid) {
+      return NextResponse.json({ error: imageValidation.error }, { status: 400 });
     }
   }
+  const requestHasImageParts = messagesWithFileParts.length > 0;
 
   // 5c. Conversation ownership check — if a conversation_id is provided the caller
   // must own the conversations row. This prevents one user from appending messages
@@ -201,6 +195,18 @@ export async function POST(request: Request): Promise<Response> {
   // agent configured with `glm` + an invalid model resolves to the metered default,
   // so both the admin gate and the credit gate below key off this, not the raw config.
   const effectiveProvider = providerResult.provider;
+
+  // 6a. Vision-capability gate — judged against the RESOLVED model (post
+  // catalog-substitution), not the raw page config: a null or invalid configured model
+  // resolves to a real default, and that resolved model is what the images will actually
+  // reach. Still before the credit hold (6b) so a rejected image never reserves a hold
+  // or an in-flight slot.
+  if (requestHasImageParts && !hasVisionCapability(providerResult.modelName)) {
+    return NextResponse.json(
+      { error: `The selected model "${providerResult.modelName}" does not support image attachments. Please choose a vision-capable model.` },
+      { status: 400 },
+    );
+  }
 
   // 6b. Prepaid credit gate: block out-of-credits users before any model invocation.
   // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -23,7 +23,8 @@ import { buildSystemPrompt } from '@/lib/ai/core/system-prompt';
 import { sanitizeMessagesForModel, saveMessageToDatabase, extractMessageContent, convertDbMessageToUIMessage, extractToolResults } from '@/lib/ai/core/message-utils';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
-import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
+import { getModelCapabilities, hasVisionCapability } from '@/lib/ai/core/model-capabilities';
+import { hasFileParts, validateUserMessageFileParts } from '@/lib/ai/core/validate-image-parts';
 import { applyToolExposureMode } from '@/lib/ai/tools/tool-exposure';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
@@ -102,6 +103,24 @@ export async function POST(request: Request): Promise<Response> {
   const [page] = await db.select().from(pages).where(eq(pages.id, pageId));
   if (!page || page.type !== PageType.AI_CHAT) {
     return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+  }
+
+  // 4b. Image security + vision-capability gate — mirrors the in-app chat route
+  // (apps/web/src/app/api/ai/chat/route.ts) and runs before the credit hold (6b) so a
+  // rejected image never reserves a hold or an in-flight slot.
+  const userMessageForValidation = messages[messages.length - 1];
+  const messageHasImages = userMessageForValidation?.role === 'user' && hasFileParts(userMessageForValidation);
+  if (messageHasImages) {
+    const imageValidation = validateUserMessageFileParts(userMessageForValidation);
+    if (!imageValidation.valid) {
+      return NextResponse.json({ error: imageValidation.error }, { status: 400 });
+    }
+    if (page.aiModel && !hasVisionCapability(page.aiModel)) {
+      return NextResponse.json(
+        { error: `The selected model "${page.aiModel}" does not support image attachments. Please choose a vision-capable model.` },
+        { status: 400 },
+      );
+    }
   }
 
   // 5. Permission check. View is necessary but not sufficient: this endpoint runs

--- a/apps/web/src/lib/ai/core/__tests__/validate-image-parts.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/validate-image-parts.test.ts
@@ -73,6 +73,20 @@ describe('validate-image-parts', () => {
       expect(result.filePartCount).toBe(1);
     });
 
+    it('given a file part with a missing url, should return invalid instead of throwing', () => {
+      const msg = makeUserMessage([{ type: 'file', filename: 'broken.png' }]);
+      const result = validateUserMessageFileParts(msg);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Image "broken.png" is missing a valid url');
+    });
+
+    it('given a file part with a non-string url, should return invalid instead of throwing', () => {
+      const msg = makeUserMessage([{ type: 'file', url: 42, filename: 'weird.png' }]);
+      const result = validateUserMessageFileParts(msg);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('Image "weird.png" is missing a valid url');
+    });
+
     it('given more than 5 file parts, should return invalid with count error', () => {
       const parts = Array.from({ length: 6 }, (_, i) =>
         makeFilePart({ filename: `img-${i}.png` })

--- a/apps/web/src/lib/ai/core/validate-image-parts.ts
+++ b/apps/web/src/lib/ai/core/validate-image-parts.ts
@@ -82,6 +82,17 @@ export function validateUserMessageFileParts(
     const url = part.url;
     const filename = part.filename || `image-${i + 1}`;
 
+    // A file part without a string url is malformed input, not a crash: callers (the
+    // OpenAI-compat route especially) accept arbitrary client-built parts arrays, so
+    // this must reject cleanly instead of throwing on url.length below.
+    if (typeof url !== 'string') {
+      return {
+        valid: false,
+        error: `Image "${filename}" is missing a valid url`,
+        filePartCount: fileParts.length,
+      };
+    }
+
     // Size check
     if (url.length > MAX_DATA_URL_LENGTH) {
       return {

--- a/apps/web/src/lib/ai/core/validate-image-parts.ts
+++ b/apps/web/src/lib/ai/core/validate-image-parts.ts
@@ -52,7 +52,10 @@ export function hasFileParts(message: UIMessage): boolean {
 }
 
 /**
- * Validate all file parts in a user message.
+ * Validate all file parts in a message. Named for its original call site (validating the
+ * caller's own user message before inference); the checks below are structural and apply
+ * to a message's file parts regardless of role, so callers may also use it on assistant
+ * messages that carry file parts (e.g. resent history) to close the same bypass.
  * Checks:
  * 1. File part count limit
  * 2. Per-image data URL size limit

--- a/apps/web/src/lib/ai/openai-api/__tests__/map-image-url-part.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/map-image-url-part.test.ts
@@ -36,6 +36,17 @@ describe('mapImageUrlPartToFilePart', () => {
     });
   });
 
+  test('bare-string image_url (non-object) is rejected', () => {
+    const part = { type: 'image_url', image_url: 'data:image/png;base64,aGVsbG8=' };
+    const result = mapImageUrlPartToFilePart(part);
+    assert({
+      given: 'an image_url value that is a bare string instead of the OpenAI {url} object',
+      should: 'return ok:false with the missing-url error (spec requires an object)',
+      actual: result,
+      expected: { ok: false, error: 'image_url part must have image_url.url (string)' },
+    });
+  });
+
   test('data: URL with no explicit mediaType', () => {
     const part = { type: 'image_url', image_url: { url: 'data:,plaintext' } };
     const result = mapImageUrlPartToFilePart(part);

--- a/apps/web/src/lib/ai/openai-api/__tests__/map-image-url-part.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/map-image-url-part.test.ts
@@ -47,14 +47,14 @@ describe('mapImageUrlPartToFilePart', () => {
     });
   });
 
-  test('data: URL with no explicit mediaType', () => {
+  test('data: URL with no MIME type segment is rejected', () => {
     const part = { type: 'image_url', image_url: { url: 'data:,plaintext' } };
     const result = mapImageUrlPartToFilePart(part);
     assert({
       given: 'a data: URL with no MIME type segment',
-      should: 'return ok:true with mediaType undefined',
+      should: 'return ok:false — FileUIPart requires a mediaType and the image validator would reject it downstream anyway',
       actual: result,
-      expected: { ok: true, part: { type: 'file', url: 'data:,plaintext', mediaType: undefined } },
+      expected: { ok: false, error: 'image_url data: URL must include a MIME type (e.g. data:image/png;base64,...)' },
     });
   });
 });

--- a/apps/web/src/lib/ai/openai-api/__tests__/map-image-url-part.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/map-image-url-part.test.ts
@@ -1,0 +1,49 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import { mapImageUrlPartToFilePart } from '../map-image-url-part';
+
+describe('mapImageUrlPartToFilePart', () => {
+  test('data: URL image_url part is mapped to a file part', () => {
+    const part = { type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } };
+    const result = mapImageUrlPartToFilePart(part);
+    assert({
+      given: 'an image_url part whose url is a data: URL',
+      should: 'return ok:true with a file part carrying the url and mediaType',
+      actual: result,
+      expected: { ok: true, part: { type: 'file', url: 'data:image/png;base64,aGVsbG8=', mediaType: 'image/png' } },
+    });
+  });
+
+  test('remote http(s) URL image_url part is rejected', () => {
+    const part = { type: 'image_url', image_url: { url: 'https://example.com/cat.png' } };
+    const result = mapImageUrlPartToFilePart(part);
+    assert({
+      given: 'an image_url part whose url is a remote http(s) URL',
+      should: 'return ok:false with a descriptive error instead of throwing or silently dropping',
+      actual: result,
+      expected: { ok: false, error: 'image_url must be a data: URL — remote image URLs are not supported' },
+    });
+  });
+
+  test('image_url part missing image_url.url is rejected', () => {
+    const part = { type: 'image_url', image_url: {} };
+    const result = mapImageUrlPartToFilePart(part);
+    assert({
+      given: 'an image_url part with no image_url.url string',
+      should: 'return ok:false with a descriptive error',
+      actual: result,
+      expected: { ok: false, error: 'image_url part must have image_url.url (string)' },
+    });
+  });
+
+  test('data: URL with no explicit mediaType', () => {
+    const part = { type: 'image_url', image_url: { url: 'data:,plaintext' } };
+    const result = mapImageUrlPartToFilePart(part);
+    assert({
+      given: 'a data: URL with no MIME type segment',
+      should: 'return ok:true with mediaType undefined',
+      actual: result,
+      expected: { ok: true, part: { type: 'file', url: 'data:,plaintext', mediaType: undefined } },
+    });
+  });
+});

--- a/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
@@ -192,6 +192,66 @@ describe('validateInferenceRequest', () => {
     });
   });
 
+  test('content-array message with text and a data: image_url part normalizes both into parts', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } },
+        ],
+      }],
+    };
+    const result = validateInferenceRequest(body);
+    const parts = result.ok ? result.data.messages[0].parts as Array<Record<string, unknown>> : [];
+    assert({
+      given: 'a content-array message with a text part and a data: image_url part',
+      should: 'return ok:true with both a text part and a file part (image no longer dropped)',
+      actual: result.ok
+        ? { ok: true, partCount: parts.length, firstType: parts[0]?.type, secondType: parts[1]?.type, secondUrl: parts[1]?.url }
+        : { ok: false },
+      expected: { ok: true, partCount: 2, firstType: 'text', secondType: 'file', secondUrl: 'data:image/png;base64,aGVsbG8=' },
+    });
+  });
+
+  test('content-array message with only a data: image_url part is not treated as empty content', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,aGVsbG8=' } }],
+      }],
+    };
+    const result = validateInferenceRequest(body);
+    const parts = result.ok ? result.data.messages[0].parts as Array<Record<string, unknown>> : [];
+    assert({
+      given: 'a content-array message with only a data: image_url part (no text)',
+      should: 'return ok:true with a single file part, not a 400 for empty content',
+      actual: result.ok
+        ? { ok: true, partCount: parts.length, partType: parts[0]?.type }
+        : { ok: false },
+      expected: { ok: true, partCount: 1, partType: 'file' },
+    });
+  });
+
+  test('content-array message with a remote-URL image_url part returns 400 with a descriptive error', () => {
+    const body = {
+      model: 'ps-agent://page-123',
+      messages: [{
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'https://example.com/cat.png' } }],
+      }],
+    };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a content-array message with an image_url part pointing at a remote http(s) URL',
+      should: 'return ok:false with status 400 and a descriptive error, not silently drop the image',
+      actual: result,
+      expected: { ok: false, status: 400, error: 'image_url must be a data: URL — remote image URLs are not supported' },
+    });
+  });
+
   test('conversation_id is extracted and returned as conversationId', () => {
     const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
     const body = { model: 'ps-agent://page-123', messages, conversation_id: 'conv-xyz' };

--- a/apps/web/src/lib/ai/openai-api/map-image-url-part.ts
+++ b/apps/web/src/lib/ai/openai-api/map-image-url-part.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure mapper from an OpenAI-format `image_url` content part to PageSpace's internal
+ * file-part shape (mirrors the AI SDK's FileUIPart). Extracted so the OpenAI-compat
+ * message normalizer (validate-inference-request.ts) stays a thin caller and the
+ * mapping/rejection rules are unit-testable in isolation.
+ *
+ * PageSpace only accepts inline data: URLs for images — there is no server-side fetch
+ * of remote URLs, so a remote http(s) image_url is rejected here rather than silently
+ * dropped or fetched.
+ */
+export interface FilePart {
+  type: 'file';
+  url: string;
+  mediaType?: string;
+  filename?: string;
+}
+
+export type ImageUrlMapResult =
+  | { ok: true; part: FilePart }
+  | { ok: false; error: string };
+
+const DATA_URL_MEDIA_TYPE = /^data:([^;,]+)/;
+
+export const mapImageUrlPartToFilePart = (part: Record<string, unknown>): ImageUrlMapResult => {
+  const imageUrl = part.image_url as Record<string, unknown> | undefined;
+  const url = typeof imageUrl?.url === 'string' ? imageUrl.url : undefined;
+
+  if (!url) {
+    return { ok: false, error: 'image_url part must have image_url.url (string)' };
+  }
+  if (!url.startsWith('data:')) {
+    return { ok: false, error: 'image_url must be a data: URL — remote image URLs are not supported' };
+  }
+
+  const match = DATA_URL_MEDIA_TYPE.exec(url);
+  return { ok: true, part: { type: 'file', url, mediaType: match?.[1] } };
+};

--- a/apps/web/src/lib/ai/openai-api/map-image-url-part.ts
+++ b/apps/web/src/lib/ai/openai-api/map-image-url-part.ts
@@ -1,22 +1,18 @@
 /**
- * Pure mapper from an OpenAI-format `image_url` content part to PageSpace's internal
- * file-part shape (mirrors the AI SDK's FileUIPart). Extracted so the OpenAI-compat
- * message normalizer (validate-inference-request.ts) stays a thin caller and the
- * mapping/rejection rules are unit-testable in isolation.
+ * Pure mapper from an OpenAI-format `image_url` content part to the AI SDK's FileUIPart
+ * shape. Extracted so the OpenAI-compat message normalizer (validate-inference-request.ts)
+ * stays a thin caller and the mapping/rejection rules are unit-testable in isolation.
  *
  * PageSpace only accepts inline data: URLs for images — there is no server-side fetch
  * of remote URLs, so a remote http(s) image_url is rejected here rather than silently
- * dropped or fetched.
+ * dropped or fetched. The data: URL must carry a MIME segment because FileUIPart
+ * requires a mediaType (and the downstream image validator rejects MIME-less data URLs
+ * anyway).
  */
-export interface FilePart {
-  type: 'file';
-  url: string;
-  mediaType?: string;
-  filename?: string;
-}
+import type { FileUIPart } from 'ai';
 
 export type ImageUrlMapResult =
-  | { ok: true; part: FilePart }
+  | { ok: true; part: FileUIPart }
   | { ok: false; error: string };
 
 const DATA_URL_MEDIA_TYPE = /^data:([^;,]+)/;
@@ -33,5 +29,8 @@ export const mapImageUrlPartToFilePart = (part: Record<string, unknown>): ImageU
   }
 
   const match = DATA_URL_MEDIA_TYPE.exec(url);
-  return { ok: true, part: { type: 'file', url, mediaType: match?.[1] } };
+  if (!match) {
+    return { ok: false, error: 'image_url data: URL must include a MIME type (e.g. data:image/png;base64,...)' };
+  }
+  return { ok: true, part: { type: 'file', url, mediaType: match[1] } };
 };

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from 'ai';
 import { createId } from '@paralleldrive/cuid2';
+import { mapImageUrlPartToFilePart } from './map-image-url-part';
 
 export interface OpenAIToolDefinition {
   type: 'function';
@@ -36,22 +37,35 @@ export const parseAgentModelUri = (model: string): string | null => {
 
 const VALID_ROLES = new Set(['user', 'assistant', 'system', 'tool']);
 
-const normalizeMessage = (msg: Record<string, unknown>): UIMessage => {
+type NormalizeMessageResult =
+  | { ok: true; message: UIMessage }
+  | { ok: false; error: string };
+
+const normalizeMessage = (msg: Record<string, unknown>): NormalizeMessageResult => {
   const id = typeof msg.id === 'string' ? msg.id : createId();
   if (Array.isArray(msg.parts)) {
-    return { ...msg, id } as unknown as UIMessage;
+    return { ok: true, message: { ...msg, id } as unknown as UIMessage };
   }
   const role = msg.role as UIMessage['role'];
   if (typeof msg.content === 'string') {
-    return { id, role, parts: [{ type: 'text' as const, text: msg.content }] } as unknown as UIMessage;
+    return { ok: true, message: { id, role, parts: [{ type: 'text' as const, text: msg.content }] } as unknown as UIMessage };
   }
   if (Array.isArray(msg.content)) {
-    const parts = (msg.content as Array<Record<string, unknown>>)
-      .filter(c => c.type === 'text' && typeof c.text === 'string')
-      .map(c => ({ type: 'text' as const, text: c.text as string }));
-    return { id, role, parts } as unknown as UIMessage;
+    const parts: Array<Record<string, unknown>> = [];
+    for (const c of msg.content as Array<Record<string, unknown>>) {
+      if (c.type === 'text' && typeof c.text === 'string') {
+        parts.push({ type: 'text', text: c.text });
+      } else if (c.type === 'image_url') {
+        const mapped = mapImageUrlPartToFilePart(c);
+        if (!mapped.ok) {
+          return { ok: false, error: mapped.error };
+        }
+        parts.push(mapped.part);
+      }
+    }
+    return { ok: true, message: { id, role, parts } as unknown as UIMessage };
   }
-  return { id, role, parts: [] } as unknown as UIMessage;
+  return { ok: true, message: { id, role, parts: [] } as unknown as UIMessage };
 };
 
 type NormalizeResult =
@@ -147,7 +161,11 @@ const normalizeMessages = (rawMessages: Record<string, unknown>[]): NormalizeRes
       continue;
     }
 
-    result.push(normalizeMessage(msg));
+    const normalized = normalizeMessage(msg);
+    if (!normalized.ok) {
+      return { ok: false, error: normalized.error };
+    }
+    result.push(normalized.message);
     i++;
   }
 

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -44,14 +44,16 @@ type NormalizeMessageResult =
 const normalizeMessage = (msg: Record<string, unknown>): NormalizeMessageResult => {
   const id = typeof msg.id === 'string' ? msg.id : createId();
   if (Array.isArray(msg.parts)) {
+    // Pre-built parts arrays are client-controlled and pass through unverified here;
+    // the route validates any file parts they carry before inference.
     return { ok: true, message: { ...msg, id } as unknown as UIMessage };
   }
   const role = msg.role as UIMessage['role'];
   if (typeof msg.content === 'string') {
-    return { ok: true, message: { id, role, parts: [{ type: 'text' as const, text: msg.content }] } as unknown as UIMessage };
+    return { ok: true, message: { id, role, parts: [{ type: 'text', text: msg.content }] } };
   }
   if (Array.isArray(msg.content)) {
-    const parts: Array<Record<string, unknown>> = [];
+    const parts: UIMessage['parts'] = [];
     for (const c of msg.content as Array<Record<string, unknown>>) {
       if (c.type === 'text' && typeof c.text === 'string') {
         parts.push({ type: 'text', text: c.text });
@@ -60,12 +62,12 @@ const normalizeMessage = (msg: Record<string, unknown>): NormalizeMessageResult 
         if (!mapped.ok) {
           return { ok: false, error: mapped.error };
         }
-        parts.push({ ...mapped.part });
+        parts.push(mapped.part);
       }
     }
-    return { ok: true, message: { id, role, parts } as unknown as UIMessage };
+    return { ok: true, message: { id, role, parts } };
   }
-  return { ok: true, message: { id, role, parts: [] } as unknown as UIMessage };
+  return { ok: true, message: { id, role, parts: [] } };
 };
 
 type NormalizeResult =

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -60,7 +60,7 @@ const normalizeMessage = (msg: Record<string, unknown>): NormalizeMessageResult 
         if (!mapped.ok) {
           return { ok: false, error: mapped.error };
         }
-        parts.push(mapped.part);
+        parts.push({ ...mapped.part });
       }
     }
     return { ok: true, message: { id, role, parts } as unknown as UIMessage };


### PR DESCRIPTION
## Summary
- Adds `mapImageUrlPartToFilePart`, a pure mapper from an OpenAI-format `image_url` content part to the AI SDK's `FileUIPart` — accepts `data:` URLs with a MIME segment, rejects remote http(s) URLs (no server-side fetch of remote images is supported) and MIME-less data URLs.
- Wires it into `normalizeMessage` (used by `validateInferenceRequest`) so `image_url` content parts are no longer silently dropped: valid `data:` URLs become file parts, everything else returns a descriptive 400.
- Adds the same image-security + vision-capability gate the in-app chat route already enforces to `/api/v1/chat/completions`:
  - **Every message in the request body** with file parts is size/format/magic-byte-validated — regardless of position (client-managed-history callers resend full history) and regardless of role (pre-built assistant-role `parts` arrays are forwarded to providers by the AI SDK just like user ones, so they must not bypass the gate).
  - Images to a non-vision model are rejected with 400. The vision gate judges the **resolved** model from `createAIProvider` (post catalog-substitution), not raw `page.aiModel`, so a null/invalid configured model neither skips nor mis-judges the gate.
  - The gate runs **after** the page permission checks (an unauthorized caller gets a 403 and never learns the agent's configured model from the vision error) and **before** the prepaid credit hold (a rejected image never reserves a hold or an in-flight slot).
- Hardens the shared `validateUserMessageFileParts` helper: a file part with a missing/non-string `url` now rejects cleanly instead of throwing a TypeError (which surfaced as a raw 500 on this public OpenAI-compat surface).

## Review follow-ups
- Codex P1 (validate all request images, not just the final message) — fixed in ffea681c3.
- Codex P2 (authorize before returning vision errors that name the agent model) — fixed in ffea681c3.
- Adversarial self-review — a741c140b closes the assistant-role bypass, the malformed-file-part 500, and the raw-vs-resolved model gating.
- CodeRabbit nitpick (unsafe `as unknown as UIMessage` casts / `FilePart` vs `FileUIPart` mismatch) — fixed in df1a64a01.

## Test plan
- [x] `bun run typecheck` — passes
- [x] Touched-area unit tests (`route`, `map-image-url-part`, `validate-inference-request`, `validate-image-parts`, full `openai-api` dir): 194/194 pass, including 8 new regression tests for the review findings
- [x] TDD RED→GREEN for each of the three named tasks (pure mapper, normalizeMessage wiring, route vision-gate), tracked against PageSpace epic page `hdjtt72pamsm4z0ea8ozw7q1` (100% complete)

PageSpace epic: hdjtt72pamsm4z0ea8ozw7q1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013S5LybZ4QZS23x922z2yCY