### PR TITLE
fix(roles): make updateDriveRole JSONB mutations atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   `@pagespace/cli`). It keeps working exactly as before — same tools, same env vars — and now
   prints a one-line migration notice to stderr. See the
   [migration guide](packages/cli/docs/migrating-from-pagespace-mcp.md).
+
+### Fixed
+
+- **Drive role permission updates are now atomic** — granting or revoking a role's per-page
+  permission (via the share dialog, the roles API, or an AI agent tool) could previously race a
+  concurrent grant/revoke on the same role and silently drop it, because the update read the
+  role's permissions, merged in JS, and wrote the whole map back with no lock in between. Updates
+  now merge under a row lock inside a transaction, and setting a role as default no longer risks a
+  database deadlock or two roles ending up marked default at once.

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
@@ -469,7 +469,12 @@ describe('PATCH /api/drives/[driveId]/roles/[roleId]', () => {
       });
     });
 
-    it('merges a single-page patch into the existing map instead of replacing it — page_1 survives a page_2-only PATCH', async () => {
+    it('forwards permissionsPatch to updateDriveRole untouched so the merge happens under the service\'s row lock, not against this unlocked read', async () => {
+      // updateDriveRole now merges permissionsPatch against the role row it
+      // locks inside its own transaction; the route must not pre-merge
+      // against `existingRole` (an unlocked read) and pass a full `permissions`
+      // replace, which would reintroduce the read-modify-write race permissionsPatch
+      // exists to prevent (#1425).
       vi.mocked(getRoleById).mockResolvedValue(
         createRoleFixture({
           id: mockRoleId,
@@ -493,14 +498,15 @@ describe('PATCH /api/drives/[driveId]/roles/[roleId]', () => {
 
       expect(response.status).toBe(200);
       expect(updateDriveRole).toHaveBeenCalledWith(mockDriveId, mockRoleId, expect.objectContaining({
-        permissions: {
-          page_1: { canView: true, canEdit: true, canShare: false },
+        permissionsPatch: {
           page_2: { canView: true, canEdit: false, canShare: false },
         },
       }));
+      const call = vi.mocked(updateDriveRole).mock.calls[0][2];
+      expect(call.permissions).toBeUndefined();
     });
 
-    it('a null patch entry prunes the page key (falls back to drive-wide) instead of writing an all-false entry', async () => {
+    it('forwards a null patch entry (prune) to updateDriveRole untouched', async () => {
       vi.mocked(getRoleById).mockResolvedValue(
         createRoleFixture({
           id: mockRoleId,
@@ -523,9 +529,7 @@ describe('PATCH /api/drives/[driveId]/roles/[roleId]', () => {
 
       expect(response.status).toBe(200);
       expect(updateDriveRole).toHaveBeenCalledWith(mockDriveId, mockRoleId, expect.objectContaining({
-        permissions: {
-          page_2: { canView: true, canEdit: false, canShare: false },
-        },
+        permissionsPatch: { page_1: null },
       }));
     });
 

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch, mergeRolePermissionsPatch } from '@pagespace/lib/services/drive-role-service';
+import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions, validateRolePermissionsPatch } from '@pagespace/lib/services/drive-role-service';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
@@ -125,16 +125,17 @@ export async function PATCH(
       return NextResponse.json({ error: 'Invalid permissionsPatch structure' }, { status: 400 });
     }
 
-    const resolvedPermissions = permissionsPatch !== undefined
-      ? mergeRolePermissionsPatch(existingRole.permissions, permissionsPatch)
-      : permissions;
-
+    // Forward permissionsPatch to the service untouched: updateDriveRole
+    // merges it against the role row it locks inside its transaction. Merging
+    // here against the unlocked `existingRole` read above would reintroduce
+    // the read-modify-write race the patch input exists to prevent.
     const { role: updatedRole } = await updateDriveRole(driveId, roleId, {
       name,
       description,
       color,
       isDefault,
-      permissions: resolvedPermissions,
+      permissions,
+      ...(permissionsPatch !== undefined && { permissionsPatch }),
       ...(driveWidePermissions !== undefined && { driveWidePermissions }),
     });
 
@@ -152,7 +153,9 @@ export async function PATCH(
       roleId,
       roleName: updatedRole.name,
       driveId,
-      permissions: resolvedPermissions ? summarizePermissions(resolvedPermissions) : undefined,
+      permissions: (permissions !== undefined || permissionsPatch !== undefined)
+        ? summarizePermissions(updatedRole.permissions)
+        : undefined,
       previousPermissions: summarizePermissions(existingRole.permissions),
       driveWidePermissions: driveWidePermissions !== undefined ? (driveWidePermissions ?? null) : undefined,
       previousDriveWidePermissions: existingRole.driveWidePermissions ?? null,

--- a/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/role-management-tools.test.ts
@@ -397,16 +397,21 @@ describe('role-management-tools', () => {
       expect(result.success).toBe(false);
     });
 
-    it('merges the page grant into role.permissions for an admin', async () => {
+    it('sends a single-page permissionsPatch for an admin', async () => {
       mockCheckAccess.mockResolvedValueOnce(adminAccess);
       mockGetRole.mockResolvedValueOnce(
         makeRole({ permissions: { existing: { canView: true, canEdit: false, canShare: false } } })
       );
       mockFindPage.mockResolvedValueOnce({ id: 'page1', driveId: 'drive1' } as never);
-      mockUpdateRole.mockImplementationOnce(async (_d, _r, patch) => ({
-        role: makeRole({ permissions: patch.permissions }),
+      mockUpdateRole.mockResolvedValueOnce({
+        role: makeRole({
+          permissions: {
+            existing: { canView: true, canEdit: false, canShare: false },
+            page1: { canView: true, canEdit: true, canShare: false },
+          },
+        }),
         wasDefault: false,
-      }));
+      });
 
       const result = await roleManagementTools.set_role_page_permissions.execute!(
         input,
@@ -414,11 +419,10 @@ describe('role-management-tools', () => {
       ) as { success: boolean };
 
       expect(result.success).toBe(true);
+      // permissionsPatch merges just this page atomically inside updateDriveRole
+      // — not a full `permissions` replace computed from the getRoleById read.
       expect(mockUpdateRole).toHaveBeenCalledWith('drive1', 'role1', {
-        permissions: {
-          existing: { canView: true, canEdit: false, canShare: false },
-          page1: { canView: true, canEdit: true, canShare: false },
-        },
+        permissionsPatch: { page1: { canView: true, canEdit: true, canShare: false } },
       });
     });
 
@@ -510,10 +514,10 @@ describe('role-management-tools', () => {
           },
         })
       );
-      mockUpdateRole.mockImplementationOnce(async (_d, _r, patch) => ({
-        role: makeRole({ permissions: patch.permissions }),
+      mockUpdateRole.mockResolvedValueOnce({
+        role: makeRole({ permissions: { page2: { canView: true, canEdit: false, canShare: false } } }),
         wasDefault: false,
-      }));
+      });
 
       const result = await roleManagementTools.remove_role_page_permissions.execute!(
         { driveId: 'drive1', roleId: 'role1', pageId: 'page1' },
@@ -521,8 +525,10 @@ describe('role-management-tools', () => {
       ) as { success: boolean };
 
       expect(result.success).toBe(true);
+      // permissionsPatch with a null entry prunes just this page atomically —
+      // not a full `permissions` replace computed from the getRoleById read.
       expect(mockUpdateRole).toHaveBeenCalledWith('drive1', 'role1', {
-        permissions: { page2: { canView: true, canEdit: false, canShare: false } },
+        permissionsPatch: { page1: null },
       });
     });
 

--- a/apps/web/src/lib/ai/tools/role-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/role-management-tools.ts
@@ -11,7 +11,6 @@ import {
   updateDriveRole,
   deleteDriveRole,
   type DriveRoleAccessInfo,
-  type RolePermissions,
 } from '@pagespace/lib/services/drive-role-service';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
@@ -48,15 +47,6 @@ async function requireDriveAdmin(
 
   return { ok: true, access: { ...access, drive: access.drive } };
 }
-
-const mergePagePermission = (
-  permissions: RolePermissions,
-  pageId: string,
-  perm: { canView: boolean; canEdit: boolean; canShare: boolean }
-): RolePermissions => ({ ...permissions, [pageId]: perm });
-
-const prunePagePermission = (permissions: RolePermissions, pageId: string): RolePermissions =>
-  Object.fromEntries(Object.entries(permissions).filter(([key]) => key !== pageId));
 
 async function logAndBroadcastRoleChange(
   context: ToolExecutionContext,
@@ -322,15 +312,20 @@ export const roleManagementTools = {
         });
         if (!page) return { success: false, error: `Page "${pageId}" not found in this drive` };
 
-        const merged = mergePagePermission(role.permissions, pageId, { canView, canEdit, canShare });
-        await updateDriveRole(driveId, roleId, { permissions: merged });
+        // permissionsPatch merges this single page atomically against whatever
+        // permissions map is current at write time — a full `permissions`
+        // replace computed from the `role` read above would race a concurrent
+        // grant/revoke on a different page and silently drop it.
+        const { role: updatedRole } = await updateDriveRole(driveId, roleId, {
+          permissionsPatch: { [pageId]: { canView, canEdit, canShare } },
+        });
 
         await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'update', role.name);
 
         return {
           success: true,
           summary: `Set ${role.name}'s permissions on page ${pageId}: view=${canView}, edit=${canEdit}, share=${canShare}`,
-          stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(merged).length },
+          stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(updatedRole.permissions).length },
           nextSteps: ['Use get_drive_role to see the full permission map'],
         };
       } catch (error) {
@@ -405,15 +400,19 @@ export const roleManagementTools = {
           };
         }
 
-        const pruned = prunePagePermission(role.permissions, pageId);
-        await updateDriveRole(driveId, roleId, { permissions: pruned });
+        // permissionsPatch with a `null` entry prunes just this page atomically
+        // — see set_role_page_permissions above for why a full `permissions`
+        // replace computed from the `role` read would race a concurrent mutation.
+        const { role: updatedRole } = await updateDriveRole(driveId, roleId, {
+          permissionsPatch: { [pageId]: null },
+        });
 
         await logAndBroadcastRoleChange(context as ToolExecutionContext, driveId, gate.access.drive.name, 'update', role.name);
 
         return {
           success: true,
           summary: `Removed ${role.name}'s permission entry for page ${pageId}`,
-          stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(pruned).length },
+          stats: { driveName: gate.access.drive.name, pagePermissionCount: Object.keys(updatedRole.permissions).length },
           nextSteps: ['Use get_drive_role to see the remaining permission map'],
         };
       } catch (error) {

--- a/apps/web/src/services/api/__tests__/permission-management-service.test.ts
+++ b/apps/web/src/services/api/__tests__/permission-management-service.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: vi.fn() },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a, b) => ['eq', a, b]),
+  and: vi.fn((...c) => ['and', ...c]),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'users.id' } }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'pages.id' } }));
+vi.mock('@pagespace/db/schema/members', () => ({
+  pagePermissions: { pageId: 'pagePermissions.pageId', userId: 'pagePermissions.userId' },
+  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', role: 'driveMembers.role' },
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessLevel: vi.fn(async () => ({ canShare: true })),
+}));
+vi.mock('@pagespace/lib/services/drive-role-service', () => ({
+  listDriveRoles: vi.fn(),
+  getRoleById: vi.fn(),
+  updateDriveRole: vi.fn(),
+}));
+
+import { db } from '@pagespace/db/db';
+import { getRoleById, updateDriveRole } from '@pagespace/lib/services/drive-role-service';
+import { rolePermissionService } from '../permission-management-service';
+
+type MockFn = ReturnType<typeof vi.fn>;
+const mockPagesFindFirst = (db as unknown as { query: { pages: { findFirst: MockFn } } }).query.pages.findFirst;
+const mockGetRoleById = getRoleById as unknown as MockFn;
+const mockUpdateDriveRole = updateDriveRole as unknown as MockFn;
+
+describe('rolePermissionService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPagesFindFirst.mockResolvedValue({ driveId: 'drive-1' });
+    mockGetRoleById.mockResolvedValue({
+      id: 'role-1',
+      permissions: { 'page-existing': { canView: true, canEdit: false, canShare: false } },
+    });
+  });
+
+  describe('setRolePagePermission', () => {
+    it('should send a permissionsPatch for just the target page, not a full permissions replace', async () => {
+      const result = await rolePermissionService.setRolePagePermission(
+        'user-1',
+        'page-1',
+        'role-1',
+        { canView: true, canEdit: true, canShare: false },
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(mockUpdateDriveRole).toHaveBeenCalledWith('drive-1', 'role-1', {
+        permissionsPatch: {
+          'page-1': { canView: true, canEdit: true, canShare: false },
+        },
+      });
+      // Must NOT compute a full-map replace from the earlier `getRoleById` read —
+      // that's the read-modify-write race this call site used to have (#1425).
+      const call = mockUpdateDriveRole.mock.calls[0][2];
+      expect(call.permissions).toBeUndefined();
+    });
+
+    it('should reject canEdit/canShare without canView', async () => {
+      const result = await rolePermissionService.setRolePagePermission(
+        'user-1',
+        'page-1',
+        'role-1',
+        { canView: false, canEdit: true, canShare: false },
+      );
+      expect(result).toEqual({ success: false, error: 'canView must be true when canEdit or canShare is set', status: 400 });
+      expect(mockUpdateDriveRole).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when role not found', async () => {
+      mockGetRoleById.mockResolvedValueOnce(null);
+      const result = await rolePermissionService.setRolePagePermission(
+        'user-1',
+        'page-1',
+        'role-1',
+        { canView: true, canEdit: false, canShare: false },
+      );
+      expect(result).toEqual({ success: false, error: 'Role not found', status: 404 });
+      expect(mockUpdateDriveRole).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when page not found', async () => {
+      mockPagesFindFirst.mockResolvedValueOnce(null);
+      const result = await rolePermissionService.setRolePagePermission(
+        'user-1',
+        'page-1',
+        'role-1',
+        { canView: true, canEdit: false, canShare: false },
+      );
+      expect(result).toEqual({ success: false, error: 'Page not found', status: 404 });
+      expect(mockUpdateDriveRole).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeRolePagePermission', () => {
+    it('should send a null permissionsPatch entry for just the target page, not a full permissions replace', async () => {
+      const result = await rolePermissionService.removeRolePagePermission('user-1', 'page-existing', 'role-1');
+
+      expect(result).toEqual({ success: true });
+      expect(mockUpdateDriveRole).toHaveBeenCalledWith('drive-1', 'role-1', {
+        permissionsPatch: { 'page-existing': null },
+      });
+      const call = mockUpdateDriveRole.mock.calls[0][2];
+      expect(call.permissions).toBeUndefined();
+    });
+
+    it('should return 404 when role not found', async () => {
+      mockGetRoleById.mockResolvedValueOnce(null);
+      const result = await rolePermissionService.removeRolePagePermission('user-1', 'page-1', 'role-1');
+      expect(result).toEqual({ success: false, error: 'Role not found', status: 404 });
+      expect(mockUpdateDriveRole).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/services/api/permission-management-service.ts
+++ b/apps/web/src/services/api/permission-management-service.ts
@@ -341,9 +341,12 @@ export const rolePermissionService = {
     const role = await getRoleById(page.driveId, roleId);
     if (!role) return { success: false, error: 'Role not found', status: 404 };
 
+    // permissionsPatch merges this single page atomically against whatever
+    // permissions map is current at write time — a full `permissions` replace
+    // computed from the `role` read above would race a concurrent grant/revoke
+    // on a different page and silently drop it.
     await updateDriveRole(page.driveId, roleId, {
-      permissions: {
-        ...role.permissions,
+      permissionsPatch: {
         [pageId]: {
           canView: permissions.canView,
           canEdit: permissions.canEdit,
@@ -371,10 +374,10 @@ export const rolePermissionService = {
     const role = await getRoleById(page.driveId, roleId);
     if (!role) return { success: false, error: 'Role not found', status: 404 };
 
-    const remainingPermissions = Object.fromEntries(
-      Object.entries(role.permissions).filter(([key]) => key !== pageId)
-    );
-    await updateDriveRole(page.driveId, roleId, { permissions: remainingPermissions });
+    // permissionsPatch with a `null` entry prunes just this page atomically —
+    // see setRolePagePermission above for why a full `permissions` replace
+    // computed from the `role` read would race a concurrent mutation.
+    await updateDriveRole(page.driveId, roleId, { permissionsPatch: { [pageId]: null } });
     return { success: true };
   },
 };

--- a/packages/lib/src/services/__tests__/drive-role-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-role-service.test.ts
@@ -58,6 +58,7 @@ import {
   reorderDriveRoles,
   validateRolePermissions,
   validateDriveWidePermissions,
+  mergeRolePermissionsPatch,
 } from '../drive-role-service';
 
 type MockFn = ReturnType<typeof vi.fn>;
@@ -247,21 +248,53 @@ describe('drive-role-service', () => {
   });
 
   describe('updateDriveRole', () => {
+    // Builds a mock `tx` whose `select().from().where().for('update')` resolves
+    // to `existingRoleRows`, and whose `update().set().where()` chain resolves
+    // each successive call to the next entry in `updateResults` (`returning()`
+    // resolves; a plain no-`returning()` update — e.g. unsetting other
+    // defaults — resolves `where()` itself to `undefined`).
+    function makeTx(existingRoleRows: unknown[], updateResults: Array<unknown[] | undefined>) {
+      const forMock = vi.fn().mockResolvedValue(existingRoleRows);
+      let updateCall = 0;
+      const updateMock = vi.fn(() => ({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            const result = updateResults[updateCall++];
+            if (result === undefined) return Promise.resolve(undefined);
+            return { returning: vi.fn().mockResolvedValue(result) };
+          }),
+        }),
+      }));
+      return {
+        select: vi.fn(() => ({
+          from: vi.fn(() => ({
+            where: vi.fn(() => ({ for: forMock })),
+          })),
+        })),
+        update: updateMock,
+        forMock,
+      };
+    }
+
     it('should throw when role not found', async () => {
-      mockDb.query.driveRoles.findFirst.mockResolvedValueOnce(null);
+      const tx = makeTx([], []);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
       await expect(updateDriveRole('drive-1', 'r-x', { name: 'X' }))
         .rejects.toThrow('Role not found');
     });
 
+    it('should lock the role row with FOR UPDATE', async () => {
+      const tx = makeTx([{ id: 'r1', isDefault: false, permissions: {} }], [[{ id: 'r1', name: 'Updated' }]]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      await updateDriveRole('drive-1', 'r1', { name: 'Updated' });
+      expect(tx.forMock).toHaveBeenCalledWith('update');
+    });
+
     it('should update and return result', async () => {
-      mockDb.query.driveRoles.findFirst.mockResolvedValueOnce({ id: 'r1', isDefault: false });
-      mockDb.update.mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([{ id: 'r1', name: 'Updated' }]),
-          }),
-        }),
-      });
+      const tx = makeTx([{ id: 'r1', isDefault: false, permissions: {} }], [[{ id: 'r1', name: 'Updated' }]]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
 
       const result = await updateDriveRole('drive-1', 'r1', { name: 'Updated' });
       expect(result.role.name).toBe('Updated');
@@ -269,20 +302,11 @@ describe('drive-role-service', () => {
     });
 
     it('should unset other defaults when setting isDefault', async () => {
-      mockDb.query.driveRoles.findFirst.mockResolvedValueOnce({ id: 'r1', isDefault: false });
-      mockDb.update
-        .mockReturnValueOnce({
-          set: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue(undefined),
-          }),
-        })
-        .mockReturnValueOnce({
-          set: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([{ id: 'r1', isDefault: true }]),
-            }),
-          }),
-        });
+      const tx = makeTx(
+        [{ id: 'r1', isDefault: false, permissions: {} }],
+        [undefined, [{ id: 'r1', isDefault: true }]]
+      );
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
 
       const result = await updateDriveRole('drive-1', 'r1', { isDefault: true });
       expect(result.role.isDefault).toBe(true);
@@ -292,6 +316,61 @@ describe('drive-role-service', () => {
       await expect(
         updateDriveRole('drive-1', 'r1', { driveWidePermissions: { bad: 'field' } as never })
       ).rejects.toThrow('Invalid driveWidePermissions structure');
+      // Validation short-circuits before any transaction is opened.
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it('should throw when both permissions and permissionsPatch are given', async () => {
+      await expect(
+        updateDriveRole('drive-1', 'r1', { permissions: {}, permissionsPatch: {} })
+      ).rejects.toThrow('Cannot specify both permissions and permissionsPatch');
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it('should merge permissionsPatch against the row read inside the transaction, not a stale pre-transaction read', async () => {
+      // Regression test for the read-modify-write race (#1425): the existing
+      // permissions used for the merge must come from the locked, in-transaction
+      // read, so a concurrent writer that changed the row between an earlier
+      // unlocked read and this call is still reflected.
+      const lockedRow = {
+        id: 'r1',
+        isDefault: false,
+        permissions: { 'page-a': { canView: true, canEdit: false, canShare: false } },
+      };
+      const tx = makeTx([lockedRow], [[{ id: 'r1', permissions: {
+        'page-a': { canView: true, canEdit: false, canShare: false },
+        'page-b': { canView: true, canEdit: true, canShare: false },
+      } }]]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      await updateDriveRole('drive-1', 'r1', {
+        permissionsPatch: { 'page-b': { canView: true, canEdit: true, canShare: false } },
+      });
+
+      const setCall = (tx.update.mock.results[0]?.value as { set: MockFn }).set;
+      expect(setCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          permissions: {
+            'page-a': { canView: true, canEdit: false, canShare: false },
+            'page-b': { canView: true, canEdit: true, canShare: false },
+          },
+        })
+      );
+    });
+
+    it('should prune a page via a null permissionsPatch entry', async () => {
+      const lockedRow = {
+        id: 'r1',
+        isDefault: false,
+        permissions: { 'page-a': { canView: true, canEdit: false, canShare: false } },
+      };
+      const tx = makeTx([lockedRow], [[{ id: 'r1', permissions: {} }]]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      await updateDriveRole('drive-1', 'r1', { permissionsPatch: { 'page-a': null } });
+
+      const setCall = (tx.update.mock.results[0]?.value as { set: MockFn }).set;
+      expect(setCall).toHaveBeenCalledWith(expect.objectContaining({ permissions: {} }));
     });
   });
 
@@ -361,5 +440,53 @@ describe('drive-role-service', () => {
       expect(validateDriveWidePermissions({ canView: 1, canEdit: false, canShare: false })).toBe(false));
     it('should return false for object with extra keys', () =>
       expect(validateDriveWidePermissions({ canView: true, canEdit: false, canShare: false, canDelete: true })).toBe(false));
+  });
+
+  describe('mergeRolePermissionsPatch', () => {
+    it('should add a new page entry', () => {
+      const existing = { 'page-a': { canView: true, canEdit: false, canShare: false } };
+      const merged = mergeRolePermissionsPatch(existing, {
+        'page-b': { canView: true, canEdit: true, canShare: false },
+      });
+      expect(merged).toEqual({
+        'page-a': { canView: true, canEdit: false, canShare: false },
+        'page-b': { canView: true, canEdit: true, canShare: false },
+      });
+    });
+
+    it('should overwrite an existing page entry', () => {
+      const existing = { 'page-a': { canView: true, canEdit: false, canShare: false } };
+      const merged = mergeRolePermissionsPatch(existing, {
+        'page-a': { canView: true, canEdit: true, canShare: true },
+      });
+      expect(merged['page-a']).toEqual({ canView: true, canEdit: true, canShare: true });
+    });
+
+    it('should prune a page entry when patched with null', () => {
+      const existing = {
+        'page-a': { canView: true, canEdit: false, canShare: false },
+        'page-b': { canView: true, canEdit: true, canShare: false },
+      };
+      const merged = mergeRolePermissionsPatch(existing, { 'page-a': null });
+      expect(merged).toEqual({ 'page-b': { canView: true, canEdit: true, canShare: false } });
+    });
+
+    it('should leave pages not named in the patch untouched', () => {
+      const existing = {
+        'page-a': { canView: true, canEdit: false, canShare: false },
+        'page-b': { canView: true, canEdit: true, canShare: false },
+      };
+      const merged = mergeRolePermissionsPatch(existing, {
+        'page-c': { canView: true, canEdit: false, canShare: false },
+      });
+      expect(merged['page-a']).toEqual(existing['page-a']);
+      expect(merged['page-b']).toEqual(existing['page-b']);
+    });
+
+    it('should not mutate the existing map', () => {
+      const existing = { 'page-a': { canView: true, canEdit: false, canShare: false } };
+      mergeRolePermissionsPatch(existing, { 'page-b': { canView: true, canEdit: true, canShare: false } });
+      expect(existing).toEqual({ 'page-a': { canView: true, canEdit: false, canShare: false } });
+    });
   });
 });

--- a/packages/lib/src/services/__tests__/drive-role-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-role-service.test.ts
@@ -248,13 +248,16 @@ describe('drive-role-service', () => {
   });
 
   describe('updateDriveRole', () => {
-    // Builds a mock `tx` whose `select().from().where().for('update')` resolves
-    // to `existingRoleRows`, and whose `update().set().where()` chain resolves
+    // Builds a mock `tx` whose `select().from().where().for('update')` (single
+    // target-row lock) and `select().from().where().orderBy().for('update')`
+    // (drive-wide ordered lock, used when setting isDefault) both resolve to
+    // `existingRoleRows`, and whose `update().set().where()` chain resolves
     // each successive call to the next entry in `updateResults` (`returning()`
     // resolves; a plain no-`returning()` update — e.g. unsetting other
     // defaults — resolves `where()` itself to `undefined`).
     function makeTx(existingRoleRows: unknown[], updateResults: Array<unknown[] | undefined>) {
       const forMock = vi.fn().mockResolvedValue(existingRoleRows);
+      const orderByMock = vi.fn(() => ({ for: forMock }));
       let updateCall = 0;
       const updateMock = vi.fn(() => ({
         set: vi.fn().mockReturnValue({
@@ -268,11 +271,12 @@ describe('drive-role-service', () => {
       return {
         select: vi.fn(() => ({
           from: vi.fn(() => ({
-            where: vi.fn(() => ({ for: forMock })),
+            where: vi.fn(() => ({ for: forMock, orderBy: orderByMock })),
           })),
         })),
         update: updateMock,
         forMock,
+        orderByMock,
       };
     }
 
@@ -310,6 +314,44 @@ describe('drive-role-service', () => {
 
       const result = await updateDriveRole('drive-1', 'r1', { isDefault: true });
       expect(result.role.isDefault).toBe(true);
+    });
+
+    it('should lock all drive role rows in a consistent order when setting isDefault', async () => {
+      // The drive-wide "unset other defaults" write touches every role row in
+      // the drive; locking only the target row first would let two concurrent
+      // default-switches deadlock on each other's targets. The isDefault path
+      // must take an ordered drive-wide lock instead of a single-row lock.
+      const tx = makeTx(
+        [
+          { id: 'r1', isDefault: true, permissions: {} },
+          { id: 'r2', isDefault: false, permissions: {} },
+        ],
+        [undefined, [{ id: 'r2', isDefault: true }]]
+      );
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      const result = await updateDriveRole('drive-1', 'r2', { isDefault: true });
+      expect(result.role.isDefault).toBe(true);
+      expect(result.wasDefault).toBe(false);
+      expect(tx.orderByMock).toHaveBeenCalledTimes(1);
+      expect(tx.forMock).toHaveBeenCalledWith('update');
+    });
+
+    it('should not take the drive-wide ordered lock when isDefault is not being set', async () => {
+      const tx = makeTx([{ id: 'r1', isDefault: false, permissions: {} }], [[{ id: 'r1', name: 'Updated' }]]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      await updateDriveRole('drive-1', 'r1', { name: 'Updated' });
+      expect(tx.orderByMock).not.toHaveBeenCalled();
+      expect(tx.forMock).toHaveBeenCalledWith('update');
+    });
+
+    it('should throw when target role is missing from the drive-wide locked set on the isDefault path', async () => {
+      const tx = makeTx([{ id: 'r-other', isDefault: true, permissions: {} }], []);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      await expect(updateDriveRole('drive-1', 'r-x', { isDefault: true }))
+        .rejects.toThrow('Role not found');
     });
 
     it('should throw when driveWidePermissions is malformed', async () => {

--- a/packages/lib/src/services/__tests__/drive-role-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-role-service.test.ts
@@ -75,6 +75,58 @@ type MockDb = {
 };
 const mockDb = db as unknown as MockDb;
 
+// Builds a mock transaction client (`tx`) shared by createDriveRole,
+// updateDriveRole, and reorderDriveRoles tests. `tx.select().from().where()`
+// resolves directly to `selectRows` (the plain, unordered read used by
+// createDriveRole's non-default path) and also chains `.for('update')`
+// (single-row lock) or `.orderBy(asc(id)).for('update')` (ordered drive-wide
+// lock, taken whenever isDefault is involved) — both resolving to the same
+// `selectRows`. `tx.update().set().where()` resolves each successive call to
+// the next entry in `updateResults` (`returning()` resolves; a plain
+// no-`returning()` update — e.g. unsetting other defaults — resolves
+// `where()` itself to `undefined`). `tx.insert().values().returning()`
+// resolves to `insertResult`.
+function makeTx(
+  selectRows: unknown[],
+  updateResults: Array<unknown[] | undefined> = [],
+  insertResult?: unknown[]
+) {
+  const forMock = vi.fn().mockResolvedValue(selectRows);
+  const orderByMock = vi.fn(() => ({ for: forMock }));
+  const selectWhereChain = {
+    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+      Promise.resolve(selectRows).then(resolve, reject),
+    for: forMock,
+    orderBy: orderByMock,
+  };
+  let updateCall = 0;
+  const updateMock = vi.fn(() => ({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockImplementation(() => {
+        const result = updateResults[updateCall++];
+        if (result === undefined) return Promise.resolve(undefined);
+        return { returning: vi.fn().mockResolvedValue(result) };
+      }),
+    }),
+  }));
+  const insertMock = vi.fn(() => ({
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(insertResult ?? []),
+    }),
+  }));
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => selectWhereChain),
+      })),
+    })),
+    update: updateMock,
+    insert: insertMock,
+    forMock,
+    orderByMock,
+  };
+}
+
 describe('drive-role-service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -184,102 +236,59 @@ describe('drive-role-service', () => {
 
   describe('createDriveRole', () => {
     it('should create role at next position', async () => {
-      mockDb.query.driveRoles.findMany.mockResolvedValueOnce([
-        { id: 'r1', position: 0 }, { id: 'r2', position: 1 },
-      ]);
-
       const newRole = { id: 'r3', name: 'New Role', position: 2 };
-      mockDb.insert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([newRole]),
-        }),
-      });
+      const tx = makeTx([{ id: 'r1', position: 0 }, { id: 'r2', position: 1 }], [], [newRole]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
 
       const result = await createDriveRole('drive-1', { name: 'New Role', permissions: {} });
       expect(result).toEqual(newRole);
     });
 
     it('should start at 0 when no existing roles', async () => {
-      mockDb.query.driveRoles.findMany.mockResolvedValueOnce([]);
-
-      mockDb.insert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: 'r1', position: 0 }]),
-        }),
-      });
+      const tx = makeTx([], [], [{ id: 'r1', position: 0 }]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
 
       const result = await createDriveRole('drive-1', { name: 'First', permissions: {} });
       expect(result.position).toBe(0);
     });
 
     it('should unset other defaults when isDefault', async () => {
-      mockDb.query.driveRoles.findMany.mockResolvedValueOnce([]);
-      mockDb.update.mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(undefined),
-        }),
-      });
-      mockDb.insert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: 'r1', isDefault: true }]),
-        }),
-      });
+      // isDefault takes the ordered drive-wide lock (see makeTx / updateDriveRole
+      // tests below) before the unset-defaults write and the insert.
+      const tx = makeTx([], [undefined], [{ id: 'r1', isDefault: true }]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
 
       const result = await createDriveRole('drive-1', { name: 'Default', isDefault: true, permissions: {} });
       expect(result.isDefault).toBe(true);
+      expect(tx.orderByMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not take the drive-wide ordered lock when isDefault is not set', async () => {
+      const tx = makeTx([{ id: 'r1', position: 0 }], [], [{ id: 'r2', position: 1 }]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
+      await createDriveRole('drive-1', { name: 'Non-default', permissions: {} });
+      expect(tx.orderByMock).not.toHaveBeenCalled();
     });
 
     it('should throw when driveWidePermissions is malformed', async () => {
       await expect(
         createDriveRole('drive-1', { name: 'X', permissions: {}, driveWidePermissions: { invalid: true } as never })
       ).rejects.toThrow('Invalid driveWidePermissions structure');
+      // Validation short-circuits before any transaction is opened.
+      expect(mockDb.transaction).not.toHaveBeenCalled();
     });
 
     it('should accept null driveWidePermissions', async () => {
-      mockDb.query.driveRoles.findMany.mockResolvedValueOnce([]);
-      mockDb.insert.mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: 'r1', driveWidePermissions: null }]),
-        }),
-      });
+      const tx = makeTx([], [], [{ id: 'r1', driveWidePermissions: null }]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
       const result = await createDriveRole('drive-1', { name: 'X', permissions: {}, driveWidePermissions: null });
       expect(result.driveWidePermissions).toBeNull();
     });
   });
 
   describe('updateDriveRole', () => {
-    // Builds a mock `tx` whose `select().from().where().for('update')` (single
-    // target-row lock) and `select().from().where().orderBy().for('update')`
-    // (drive-wide ordered lock, used when setting isDefault) both resolve to
-    // `existingRoleRows`, and whose `update().set().where()` chain resolves
-    // each successive call to the next entry in `updateResults` (`returning()`
-    // resolves; a plain no-`returning()` update — e.g. unsetting other
-    // defaults — resolves `where()` itself to `undefined`).
-    function makeTx(existingRoleRows: unknown[], updateResults: Array<unknown[] | undefined>) {
-      const forMock = vi.fn().mockResolvedValue(existingRoleRows);
-      const orderByMock = vi.fn(() => ({ for: forMock }));
-      let updateCall = 0;
-      const updateMock = vi.fn(() => ({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() => {
-            const result = updateResults[updateCall++];
-            if (result === undefined) return Promise.resolve(undefined);
-            return { returning: vi.fn().mockResolvedValue(result) };
-          }),
-        }),
-      }));
-      return {
-        select: vi.fn(() => ({
-          from: vi.fn(() => ({
-            where: vi.fn(() => ({ for: forMock, orderBy: orderByMock })),
-          })),
-        })),
-        update: updateMock,
-        forMock,
-        orderByMock,
-      };
-    }
-
     it('should throw when role not found', async () => {
       const tx = makeTx([], []);
       mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
@@ -433,25 +442,24 @@ describe('drive-role-service', () => {
 
   describe('reorderDriveRoles', () => {
     it('should throw for invalid role IDs', async () => {
-      mockDb.query.driveRoles.findMany.mockResolvedValueOnce([{ id: 'r1' }, { id: 'r2' }]);
+      const tx = makeTx([{ id: 'r1' }, { id: 'r2' }]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
+
       await expect(reorderDriveRoles('drive-1', ['r1', 'r3'])).rejects.toThrow('Invalid role IDs');
     });
 
-    it('should update positions in transaction', async () => {
-      mockDb.query.driveRoles.findMany.mockResolvedValueOnce([{ id: 'r1' }, { id: 'r2' }]);
-      mockDb.transaction.mockImplementation(async (fn: Function) => {
-        const tx = {
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockResolvedValue(undefined),
-            }),
-          }),
-        };
-        await fn(tx);
-      });
+    it('should update positions in transaction, taking the ordered drive-wide lock', async () => {
+      // Locking the drive's role rows in id order before writing positions
+      // avoids a deadlock against a concurrent updateDriveRole isDefault
+      // switch, which locks in the same order (see lockDriveRolesInOrder).
+      const tx = makeTx([{ id: 'r1' }, { id: 'r2' }], [undefined, undefined]);
+      mockDb.transaction.mockImplementation(async (fn: Function) => fn(tx));
 
       // void function — verifying it resolves without error is the contract
       await expect(reorderDriveRoles('drive-1', ['r2', 'r1'])).resolves.toBeUndefined();
+      expect(tx.orderByMock).toHaveBeenCalledTimes(1);
+      expect(tx.forMock).toHaveBeenCalledWith('update');
+      expect(tx.update).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/lib/src/services/drive-role-service.ts
+++ b/packages/lib/src/services/drive-role-service.ts
@@ -233,6 +233,12 @@ export async function createDriveRole(
  * is the classic JSONB read-modify-write race. Locking the row and re-reading
  * it inside the transaction serializes concurrent updates so both merges
  * survive.
+ *
+ * When `isDefault` is being set, the drive-wide "unset other defaults" write
+ * needs locks on every role row in the drive. Locking only the target row
+ * first would let two concurrent default-switches each hold their own target
+ * while waiting for the other's — a deadlock — so that path instead locks all
+ * of the drive's role rows up front in a consistent (id) order.
  */
 export async function updateDriveRole(
   driveId: string,
@@ -248,14 +254,27 @@ export async function updateDriveRole(
   }
 
   return db.transaction(async (tx) => {
-    const [existingRole] = await tx
-      .select()
-      .from(driveRoles)
-      .where(and(
-        eq(driveRoles.id, roleId),
-        eq(driveRoles.driveId, driveId)
-      ))
-      .for('update');
+    let existingRole: typeof driveRoles.$inferSelect | undefined;
+    if (input.isDefault) {
+      // Setting a default updates every role row in the drive, so acquire all
+      // of the drive's role locks in id order (see doc comment above).
+      const lockedRoles = await tx
+        .select()
+        .from(driveRoles)
+        .where(eq(driveRoles.driveId, driveId))
+        .orderBy(asc(driveRoles.id))
+        .for('update');
+      existingRole = lockedRoles.find((role) => role.id === roleId);
+    } else {
+      [existingRole] = await tx
+        .select()
+        .from(driveRoles)
+        .where(and(
+          eq(driveRoles.id, roleId),
+          eq(driveRoles.driveId, driveId)
+        ))
+        .for('update');
+    }
 
     if (!existingRole) {
       throw new Error('Role not found');

--- a/packages/lib/src/services/drive-role-service.ts
+++ b/packages/lib/src/services/drive-role-service.ts
@@ -179,8 +179,49 @@ export async function getRoleById(
   return role as DriveRole | null;
 }
 
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 /**
- * Create a new role for a drive
+ * Lock every role row in the drive with `FOR UPDATE`, acquiring the locks in a
+ * consistent (id) order.
+ *
+ * Any mutation that writes drive-wide (unsetting other roles' `isDefault`,
+ * reordering positions) needs locks on all of the drive's role rows. If each
+ * writer locked rows in its own order, two concurrent writers could each hold
+ * a row the other needs — a Postgres deadlock. Funneling every drive-wide
+ * writer through this single id-ordered acquisition serializes them instead.
+ */
+async function lockDriveRolesInOrder(tx: Tx, driveId: string) {
+  return tx
+    .select()
+    .from(driveRoles)
+    .where(eq(driveRoles.driveId, driveId))
+    .orderBy(asc(driveRoles.id))
+    .for('update');
+}
+
+/**
+ * Unset `isDefault` on whichever role currently holds it in the drive.
+ * Filtering to `isDefault = true` keeps the write to at most one row instead
+ * of rewriting every role in the drive. Callers must already hold the ordered
+ * drive-wide lock (`lockDriveRolesInOrder`) before calling this.
+ */
+async function unsetOtherDefaultRoles(tx: Tx, driveId: string) {
+  await tx.update(driveRoles)
+    .set({ isDefault: false })
+    .where(and(
+      eq(driveRoles.driveId, driveId),
+      eq(driveRoles.isDefault, true)
+    ));
+}
+
+/**
+ * Create a new role for a drive.
+ *
+ * Runs inside a transaction: when `isDefault` is set, the drive-wide "unset
+ * other defaults" write takes the ordered drive-wide lock (see
+ * `lockDriveRolesInOrder`) so a create racing an `updateDriveRole` default
+ * switch can neither deadlock nor leave two default roles behind.
  */
 export async function createDriveRole(
   driveId: string,
@@ -190,36 +231,39 @@ export async function createDriveRole(
     throw new Error('Invalid driveWidePermissions structure');
   }
 
-  // Get the highest position to add new role at the end
-  const existingRoles = await db.query.driveRoles.findMany({
-    where: eq(driveRoles.driveId, driveId),
-    orderBy: [asc(driveRoles.position)],
+  return db.transaction(async (tx) => {
+    // Read existing roles for the position computation; when creating as
+    // default this doubles as the ordered drive-wide lock acquisition.
+    const existingRoles = input.isDefault
+      ? await lockDriveRolesInOrder(tx, driveId)
+      : await tx
+          .select()
+          .from(driveRoles)
+          .where(eq(driveRoles.driveId, driveId));
+
+    const maxPosition = existingRoles.length > 0
+      ? Math.max(...existingRoles.map(r => r.position)) + 1
+      : 0;
+
+    // If setting as default, unset other defaults
+    if (input.isDefault) {
+      await unsetOtherDefaultRoles(tx, driveId);
+    }
+
+    const [newRole] = await tx.insert(driveRoles).values({
+      driveId,
+      name: input.name.trim(),
+      description: input.description,
+      color: input.color,
+      isDefault: input.isDefault || false,
+      permissions: input.permissions,
+      driveWidePermissions: input.driveWidePermissions ?? null,
+      position: maxPosition,
+      updatedAt: new Date(),
+    }).returning();
+
+    return newRole as DriveRole;
   });
-
-  const maxPosition = existingRoles.length > 0
-    ? Math.max(...existingRoles.map(r => r.position)) + 1
-    : 0;
-
-  // If setting as default, unset other defaults
-  if (input.isDefault) {
-    await db.update(driveRoles)
-      .set({ isDefault: false })
-      .where(eq(driveRoles.driveId, driveId));
-  }
-
-  const [newRole] = await db.insert(driveRoles).values({
-    driveId,
-    name: input.name.trim(),
-    description: input.description,
-    color: input.color,
-    isDefault: input.isDefault || false,
-    permissions: input.permissions,
-    driveWidePermissions: input.driveWidePermissions ?? null,
-    position: maxPosition,
-    updatedAt: new Date(),
-  }).returning();
-
-  return newRole as DriveRole;
 }
 
 /**
@@ -256,14 +300,9 @@ export async function updateDriveRole(
   return db.transaction(async (tx) => {
     let existingRole: typeof driveRoles.$inferSelect | undefined;
     if (input.isDefault) {
-      // Setting a default updates every role row in the drive, so acquire all
-      // of the drive's role locks in id order (see doc comment above).
-      const lockedRoles = await tx
-        .select()
-        .from(driveRoles)
-        .where(eq(driveRoles.driveId, driveId))
-        .orderBy(asc(driveRoles.id))
-        .for('update');
+      // Setting a default updates every role row in the drive, so acquire the
+      // ordered drive-wide lock (see lockDriveRolesInOrder).
+      const lockedRoles = await lockDriveRolesInOrder(tx, driveId);
       existingRole = lockedRoles.find((role) => role.id === roleId);
     } else {
       [existingRole] = await tx
@@ -282,9 +321,7 @@ export async function updateDriveRole(
 
     // If setting as default and wasn't already, unset other defaults
     if (input.isDefault && !existingRole.isDefault) {
-      await tx.update(driveRoles)
-        .set({ isDefault: false })
-        .where(eq(driveRoles.driveId, driveId));
+      await unsetOtherDefaultRoles(tx, driveId);
     }
 
     const resolvedPermissions = input.permissionsPatch !== undefined
@@ -341,26 +378,28 @@ export async function deleteDriveRole(
 }
 
 /**
- * Reorder roles for a drive
+ * Reorder roles for a drive.
+ *
+ * Takes the ordered drive-wide lock before writing: the per-role position
+ * updates run in caller-supplied order, which would otherwise acquire row
+ * locks in an arbitrary order and could deadlock against a concurrent default
+ * switch holding the id-ordered lock. Holding all the rows up front also makes
+ * the membership validation authoritative rather than a pre-transaction
+ * snapshot.
  */
 export async function reorderDriveRoles(
   driveId: string,
   roleIds: string[]
 ): Promise<void> {
-  // Validate that all roleIds belong to this drive
-  const existingRoles = await db.query.driveRoles.findMany({
-    where: eq(driveRoles.driveId, driveId),
-    columns: { id: true },
-  });
-  const existingIds = new Set(existingRoles.map(r => r.id));
-  const invalidIds = roleIds.filter(id => !existingIds.has(id));
-
-  if (invalidIds.length > 0) {
-    throw new Error('Invalid role IDs');
-  }
-
-  // Update positions in a transaction
   await db.transaction(async (tx) => {
+    const existingRoles = await lockDriveRolesInOrder(tx, driveId);
+    const existingIds = new Set(existingRoles.map(r => r.id));
+    const invalidIds = roleIds.filter(id => !existingIds.has(id));
+
+    if (invalidIds.length > 0) {
+      throw new Error('Invalid role IDs');
+    }
+
     for (let index = 0; index < roleIds.length; index++) {
       const roleId = roleIds[index];
       await tx.update(driveRoles)

--- a/packages/lib/src/services/drive-role-service.ts
+++ b/packages/lib/src/services/drive-role-service.ts
@@ -52,7 +52,11 @@ export interface UpdateRoleInput {
   description?: string | null;
   color?: string | null;
   isDefault?: boolean;
+  // Mutually exclusive with `permissionsPatch`: `permissions` replaces the whole
+  // map, `permissionsPatch` merges specific pages atomically against whatever is
+  // currently stored (see `updateDriveRole`).
   permissions?: RolePermissions;
+  permissionsPatch?: RolePermissionsPatch;
   driveWidePermissions?: PagePerm | null;
 }
 
@@ -219,7 +223,16 @@ export async function createDriveRole(
 }
 
 /**
- * Update an existing role
+ * Update an existing role.
+ *
+ * The read (existing permissions) + merge + write all happen inside a single
+ * transaction with the role row locked via `FOR UPDATE`. Without this, two
+ * concurrent callers merging different pages into `permissions` (or unsetting
+ * other roles' `isDefault`) could each read the same pre-update snapshot and
+ * the second writer would silently clobber the first writer's change — this
+ * is the classic JSONB read-modify-write race. Locking the row and re-reading
+ * it inside the transaction serializes concurrent updates so both merges
+ * survive.
  */
 export async function updateDriveRole(
   driveId: string,
@@ -230,45 +243,56 @@ export async function updateDriveRole(
     throw new Error('Invalid driveWidePermissions structure');
   }
 
-  // Get existing role
-  const existingRole = await db.query.driveRoles.findFirst({
-    where: and(
-      eq(driveRoles.id, roleId),
-      eq(driveRoles.driveId, driveId)
-    ),
+  if (input.permissions !== undefined && input.permissionsPatch !== undefined) {
+    throw new Error('Cannot specify both permissions and permissionsPatch');
+  }
+
+  return db.transaction(async (tx) => {
+    const [existingRole] = await tx
+      .select()
+      .from(driveRoles)
+      .where(and(
+        eq(driveRoles.id, roleId),
+        eq(driveRoles.driveId, driveId)
+      ))
+      .for('update');
+
+    if (!existingRole) {
+      throw new Error('Role not found');
+    }
+
+    // If setting as default and wasn't already, unset other defaults
+    if (input.isDefault && !existingRole.isDefault) {
+      await tx.update(driveRoles)
+        .set({ isDefault: false })
+        .where(eq(driveRoles.driveId, driveId));
+    }
+
+    const resolvedPermissions = input.permissionsPatch !== undefined
+      ? mergeRolePermissionsPatch(existingRole.permissions as RolePermissions, input.permissionsPatch)
+      : input.permissions;
+
+    const [updatedRole] = await tx.update(driveRoles)
+      .set({
+        ...(input.name !== undefined && { name: input.name.trim() }),
+        ...(input.description !== undefined && { description: input.description }),
+        ...(input.color !== undefined && { color: input.color }),
+        ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
+        ...(resolvedPermissions !== undefined && { permissions: resolvedPermissions }),
+        ...(input.driveWidePermissions !== undefined && { driveWidePermissions: input.driveWidePermissions }),
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(driveRoles.id, roleId),
+        eq(driveRoles.driveId, driveId)
+      ))
+      .returning();
+
+    return {
+      role: updatedRole as DriveRole,
+      wasDefault: existingRole.isDefault,
+    };
   });
-
-  if (!existingRole) {
-    throw new Error('Role not found');
-  }
-
-  // If setting as default and wasn't already, unset other defaults
-  if (input.isDefault && !existingRole.isDefault) {
-    await db.update(driveRoles)
-      .set({ isDefault: false })
-      .where(eq(driveRoles.driveId, driveId));
-  }
-
-  const [updatedRole] = await db.update(driveRoles)
-    .set({
-      ...(input.name !== undefined && { name: input.name.trim() }),
-      ...(input.description !== undefined && { description: input.description }),
-      ...(input.color !== undefined && { color: input.color }),
-      ...(input.isDefault !== undefined && { isDefault: input.isDefault }),
-      ...(input.permissions !== undefined && { permissions: input.permissions }),
-      ...(input.driveWidePermissions !== undefined && { driveWidePermissions: input.driveWidePermissions }),
-      updatedAt: new Date(),
-    })
-    .where(and(
-      eq(driveRoles.id, roleId),
-      eq(driveRoles.driveId, driveId)
-    ))
-    .returning();
-
-  return {
-    role: updatedRole as DriveRole,
-    wasDefault: existingRole.isDefault,
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary

`updateDriveRole` in `packages/lib/src/services/drive-role-service.ts` did a
read-modify-write on the `drive_roles.permissions` JSONB column: a plain
`db.query.driveRoles.findFirst` read, followed by a separate
`db.update(driveRoles).set({ permissions: ... })` write, with no transaction
or lock in between. Two concurrent callers merging different pages into the
same role's permissions (e.g. `setRolePagePermission` granting page A while
`removeRolePagePermission` revokes page B) could each read the same snapshot
and the second writer would silently clobber the first writer's change.

- `setRolePagePermission` / `removeRolePagePermission` in
  `apps/web/src/services/api/permission-management-service.ts` were exactly
  this pattern: read the role via `getRoleById` (unlocked), spread/filter the
  full `permissions` map in JS, then call `updateDriveRole` with the computed
  full-map replace.

### Fix

- `updateDriveRole` now runs the read + merge + write inside a single
  `db.transaction`, locking the role row with `.for('update')` and re-reading
  it inside the transaction before computing the final `permissions` value —
  the same pattern already used in `credit-gate.ts` and
  `channel-message-repository.ts` for this class of race.
- Added a `permissionsPatch` input (using the existing
  `mergeRolePermissionsPatch` helper) so per-page callers merge/prune a
  single page atomically against whatever is current at write time, rather
  than computing a full replace from an unlocked read. `setRolePagePermission`
  and `removeRolePagePermission` now use this patch path.
- `permissions` (full-map replace) is unchanged for callers that intend a
  wholesale replace.
- **Deadlock avoidance for default-role switches** (review follow-up):
  setting a role as default unsets `isDefault` on every other role in the
  drive, which needs locks on all of the drive's role rows. Locking only the
  target row first would let two concurrent default-switches each hold their
  own target while waiting for the other's — a Postgres deadlock. The
  `isDefault` path now locks all of the drive's role rows up front in a
  consistent (id) order (`ORDER BY id FOR UPDATE`) so concurrent switches
  serialize instead of deadlocking. Non-default updates keep the cheaper
  single-row lock — they only write the row they already hold, so they can't
  participate in a lock cycle.

### Known follow-up (out of scope here)

`apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts`'s
`permissionsPatch` PATCH body still computes its merge in the route handler
(`getRoleById` → `mergeRolePermissionsPatch` → `updateDriveRole({ permissions:
resolved })`) before calling the now-atomic `updateDriveRole`, so it has the
identical unlocked read-merge-write race for its own two-page-in-one-request
case. Migrating it to pass `permissionsPatch` straight through to
`updateDriveRole` (dropping its local merge) would close that too, but it's
outside this PR's file scope (`drive-role-service.ts` +
`permission-management-service.ts`) — flagging so it can be picked up
separately.

## Test plan
- [x] `packages/lib/src/services/__tests__/drive-role-service.test.ts` — new
      tests cover: role-row locked via `FOR UPDATE`, `permissionsPatch` merge
      is computed from the in-transaction (locked) read rather than a stale
      snapshot, null-patch pruning, rejecting `permissions` +
      `permissionsPatch` together, direct unit tests for
      `mergeRolePermissionsPatch`, plus the isDefault path taking the ordered
      drive-wide lock (and the non-default path not taking it). 49/49 passing.
- [x] New `apps/web/src/services/api/__tests__/permission-management-service.test.ts`
      — verifies `setRolePagePermission`/`removeRolePagePermission` send a
      single-page `permissionsPatch` (not a full `permissions` replace) and
      preserve existing 400/404 behavior. 6/6 passing.
- [x] `bun run typecheck` clean for `@pagespace/lib` and `web`.
- [x] Full `packages/lib/src/services/__tests__/` suite (655 tests) and the
      broader web `services/api` + `app/api/pages` + `app/api/drives` suite
      (1758 tests, including the existing `roles/[roleId]` route tests) pass
      with no regressions.

Fixes #1425

https://claude.ai/code/session_0128ezjVzp578X2gojKA1EEU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of role permission updates by applying per-page changes atomically, preventing concurrent updates from being dropped.
  * Page permission set/remove operations now consistently update only the targeted page grants.
  * Default role switching is safer, reducing the risk of deadlocks and conflicting default-role states under concurrent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->