### PR TITLE
fix(integrations): make builtin provider config authoritative at the shared read path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   `@pagespace/cli`). It keeps working exactly as before — same tools, same env vars — and now
   prints a one-line migration notice to stderr. See the
   [migration guide](packages/cli/docs/migrating-from-pagespace-mcp.md).
+
+### Fixed
+
+- Builtin integrations (GitHub, Slack, Notion, generic webhook) now always use the current tool
+  definitions after a deploy. Previously a stale cached copy of the provider config could keep
+  agents on renamed tools or missing bundles until something happened to refresh it.
+- Custom integration providers can no longer register a slug reserved by a builtin provider
+  (the API now returns 409), and a custom provider whose slug already collides with a builtin
+  keeps its own configuration instead of being silently handed the builtin's tools and OAuth
+  settings.

--- a/apps/web/src/app/api/agents/[agentId]/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/__tests__/route.test.ts
@@ -54,6 +54,7 @@ vi.mock('@/lib/websocket/socket-utils', () => ({
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { builtinProviders } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 const mockUserId = 'user_123';
 const mockAgentId = 'agent-1';
@@ -162,7 +163,9 @@ describe('GET /api/agents/[agentId]/integrations response shape', () => {
     ]);
   });
 
-  it('returns canonical builtin tools and bundles for github even when the stored config is stale', async () => {
+  it('surfaces the repository-resolved canonical config for a builtin provider', async () => {
+    // The repository layer resolves builtin config to the canonical in-memory
+    // definition before it reaches the route; the route must pass it through.
     mockListGrantsByAgent.mockResolvedValue([
       {
         id: 'grant-1',
@@ -177,7 +180,7 @@ describe('GET /api/agents/[agentId]/integrations response shape', () => {
           id: 'conn-1',
           name: 'GitHub',
           status: 'active',
-          provider: { slug: 'github', name: 'GitHub', config: { tools: [] } },
+          provider: { slug: 'github', name: 'GitHub', config: builtinProviders.github, providerType: 'builtin' },
         },
       },
     ]);
@@ -188,10 +191,48 @@ describe('GET /api/agents/[agentId]/integrations response shape', () => {
     );
     const body = await response.json();
     const provider = body.grants[0].connection.provider;
-    // Canonical github config surfaces despite the empty stored config.
     expect(provider.toolBundles.map((b: { id: string }) => b.id)).toContain('read_only');
     expect(provider.tools.map((t: { id: string }) => t.id)).toContain('list_issues');
     expect(provider.tools.length).toBeGreaterThan(0);
+  });
+
+  it('does not overlay builtin config onto a custom provider whose slug collides with a builtin', async () => {
+    mockListGrantsByAgent.mockResolvedValue([
+      {
+        id: 'grant-1',
+        agentId: mockAgentId,
+        connectionId: 'conn-1',
+        allowedTools: null,
+        deniedTools: null,
+        readOnly: false,
+        rateLimitOverride: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        connection: {
+          id: 'conn-1',
+          name: 'GitHub Proxy',
+          status: 'active',
+          provider: {
+            slug: 'github', // collides with the builtin slug
+            name: 'GitHub Proxy',
+            providerType: 'custom',
+            config: {
+              tools: [{ id: 'proxy_tool', name: 'proxy_tool', description: 'proxied', category: 'read' }],
+            },
+          },
+        },
+      },
+    ]);
+
+    const response = await GET(
+      new Request('http://localhost/api/agents/agent-1/integrations'),
+      { params: Promise.resolve({ agentId: mockAgentId }) }
+    );
+    const body = await response.json();
+    const provider = body.grants[0].connection.provider;
+    // The custom provider's own tools surface — not the builtin GitHub tools.
+    expect(provider.tools).toEqual([
+      { id: 'proxy_tool', name: 'proxy_tool', description: 'proxied', category: 'read' },
+    ]);
   });
 
   it('drops malformed tool entries while keeping well-formed ones', async () => {
@@ -378,15 +419,15 @@ describe('POST /api/agents/[agentId]/integrations default bundle', () => {
     );
   });
 
-  it('uses the canonical builtin bundle for github even when the stored config lacks bundles', async () => {
-    // Simulates an upgraded install whose persisted provider config has not yet
-    // been refreshed with toolBundles.
+  it('derives the default bundle from the repository-resolved builtin config', async () => {
+    // The repository resolves a builtin provider's config to the canonical
+    // in-memory definition (with toolBundles) before the route sees it.
     mockGetConnectionWithProvider.mockResolvedValue({
       id: 'conn-1',
       userId: mockUserId,
       driveId: null,
       status: 'active',
-      provider: { slug: 'github', name: 'GitHub', config: { tools: [] } },
+      provider: { slug: 'github', name: 'GitHub', config: builtinProviders.github, providerType: 'builtin' },
     });
 
     await POST(postRequest({ connectionId: 'conn-1' }), {
@@ -399,5 +440,34 @@ describe('POST /api/agents/[agentId]/integrations default bundle', () => {
     expect(allowed).toContain('list_issues');
     expect(allowed).not.toContain('create_issue');
     expect(allowed).not.toBeNull();
+  });
+
+  it('derives the default bundle from a slug-colliding custom provider\'s own config', async () => {
+    mockGetConnectionWithProvider.mockResolvedValue({
+      id: 'conn-1',
+      userId: mockUserId,
+      driveId: null,
+      status: 'active',
+      provider: {
+        slug: 'github', // collides with the builtin slug
+        name: 'GitHub Proxy',
+        providerType: 'custom',
+        config: {
+          toolBundles: [
+            { id: 'proxy_reads', name: 'Proxy reads', description: 'reads', toolIds: ['proxy_read'], recommended: true },
+          ],
+        },
+      },
+    });
+
+    await POST(postRequest({ connectionId: 'conn-1' }), {
+      params: Promise.resolve({ agentId: mockAgentId }),
+    });
+
+    // The custom provider's own bundle wins — never the builtin GitHub bundle.
+    expect(mockCreateGrant).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ allowedTools: ['proxy_read'] })
+    );
   });
 });

--- a/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -9,7 +9,6 @@ import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { listGrantsByAgent, createGrant, findGrant } from '@pagespace/lib/integrations/repositories/grant-repository';
 import { getConnectionWithProvider } from '@pagespace/lib/integrations/repositories/connection-repository';
-import { getBuiltinProvider } from '@pagespace/lib/integrations/providers/builtin-providers';
 import type { ToolDefinition, ToolBundle } from '@pagespace/lib/integrations/types';
 import { broadcastAgentGrantChanged } from '@/lib/websocket/socket-utils';
 
@@ -87,17 +86,6 @@ const defaultAllowedToolsForProvider = (config: unknown): string[] | null => {
   return preferred.toolIds.filter((id) => !dangerous.has(id));
 };
 
-/**
- * Resolve the config to read tools/bundles from. Prefer the canonical builtin
- * definition (always current, carries toolBundles) over the persisted DB config,
- * which on upgraded installs may lack bundles or carry stale tool names until
- * GET /api/integrations/providers refreshes it. Falls back to the DB config for
- * custom (non-builtin) providers.
- */
-const resolveProviderConfig = (
-  provider: { slug: string; config: unknown } | null | undefined
-): unknown => (provider ? getBuiltinProvider(provider.slug) ?? provider.config : null);
-
 const createGrantSchema = z.object({
   connectionId: z.string().min(1),
   // Omitted (undefined) → default to the provider's recommended bundle.
@@ -137,9 +125,9 @@ export async function GET(
     return NextResponse.json({
       grants: grants.map((g) => {
         const provider = g.connection?.provider ?? null;
-        // The per-agent panel reads this, so presets must show immediately after
-        // deploy — use the canonical builtin config rather than possibly-stale DB.
-        const providerConfig = resolveProviderConfig(provider);
+        // The repository already resolves builtin provider config to the
+        // canonical in-memory definition, so this is current after any deploy.
+        const providerConfig = provider?.config ?? null;
         return {
           id: g.id,
           agentId: g.agentId,
@@ -227,11 +215,12 @@ export async function POST(
       return NextResponse.json({ error: 'Grant already exists for this connection' }, { status: 409 });
     }
 
-    // Without the canonical config, the default would fall back to null (all
-    // non-dangerous tools) on upgraded installs instead of the Read-only bundle.
+    // connection.provider.config is repository-resolved to the canonical
+    // builtin definition, so the default derives from the current bundles
+    // (e.g. GitHub's Read-only bundle) rather than a possibly-stale DB row.
     const resolvedAllowedTools =
       allowedTools === undefined
-        ? defaultAllowedToolsForProvider(resolveProviderConfig(connection.provider))
+        ? defaultAllowedToolsForProvider(connection.provider?.config ?? null)
         : allowedTools;
 
     const grant = await createGrant(db, {

--- a/apps/web/src/app/api/drives/[driveId]/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/__tests__/route.test.ts
@@ -58,6 +58,7 @@ import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encr
 import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler'
 import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { builtinProviders } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 // ============================================================================
 // Test Helpers
@@ -544,6 +545,45 @@ describe('POST /api/drives/[driveId]/integrations', () => {
           redirectUri: 'https://app.example.com/api/user/integrations/callback',
           state: 'signed-state-token',
         })
+      );
+    });
+
+    it('should build the authorize URL from the canonical builtin config, not a stale persisted copy', async () => {
+      process.env.OAUTH_STATE_SECRET = 'test-secret';
+      process.env.INTEGRATION_GITHUB_CLIENT_ID = 'client-id-123';
+
+      // Persisted row is a builtin (providerType: 'builtin') but its authMethod
+      // config has drifted from what's shipped in code.
+      vi.mocked(getProviderById).mockResolvedValue({
+        id: 'prov-oauth',
+        slug: 'github',
+        providerType: 'builtin',
+        enabled: true,
+        driveId: null,
+        config: {
+          authMethod: {
+            type: 'oauth2',
+            config: { authorizationUrl: 'https://stale.example.com/authorize', scopes: [] },
+          },
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never);
+
+      vi.mocked(createSignedState).mockReturnValue('signed-state-token');
+      vi.mocked(buildOAuthAuthorizationUrl).mockReturnValue('https://github.com/login/oauth/authorize?state=signed-state-token');
+
+      const request = new Request('https://example.com/api/drives/d/integrations', {
+        method: 'POST',
+        body: JSON.stringify({ providerId: 'prov-oauth', name: 'GitHub' }),
+      });
+      const response = await POST(request, createContext(MOCK_DRIVE_ID));
+
+      expect(response.status).toBe(200);
+      // The canonical in-memory GitHub auth config is used, not the stale DB copy.
+      expect(buildOAuthAuthorizationUrl).toHaveBeenCalledWith(
+        builtinProviders.github.authMethod.type === 'oauth2' ? builtinProviders.github.authMethod.config : undefined,
+        expect.anything()
       );
     });
 

--- a/apps/web/src/app/api/drives/[driveId]/integrations/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/route.ts
@@ -8,10 +8,10 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { listDriveConnections, createConnection, findDriveConnection } from '@pagespace/lib/integrations/repositories/connection-repository'
 import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository'
+import { resolveProviderConfig } from '@pagespace/lib/integrations/providers/builtin-providers';
 import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials'
 import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler'
 import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
-import type { IntegrationProviderConfig } from '@pagespace/lib/integrations/types';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -118,7 +118,13 @@ export async function POST(
       return NextResponse.json({ error: 'Connection already exists for this provider' }, { status: 409 });
     }
 
-    const config = provider.config as IntegrationProviderConfig;
+    // Builtin providers may have changed shape (new scopes, renamed auth
+    // params) since this row was persisted — resolve to the canonical
+    // in-memory definition rather than trusting the possibly-stale DB copy.
+    const config = resolveProviderConfig(provider);
+    if (!config) {
+      return NextResponse.json({ error: 'Provider configuration is missing' }, { status: 500 });
+    }
 
     // OAuth providers: redirect
     if (config.authMethod.type === 'oauth2') {

--- a/apps/web/src/app/api/integrations/providers/route.ts
+++ b/apps/web/src/app/api/integrations/providers/route.ts
@@ -5,7 +5,7 @@ import { db } from '@pagespace/db/db';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { listEnabledProviders, createProvider, seedBuiltinProviders, refreshBuiltinProviders } from '@pagespace/lib/integrations/repositories/provider-repository';
-import { builtinProviderList } from '@pagespace/lib/integrations/providers/builtin-providers';
+import { builtinProviderList, isBuiltinProvider } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 import { sanitizeConnectMetadata } from '@/lib/integrations/connect-metadata';
 
@@ -119,6 +119,15 @@ export async function POST(request: Request) {
     }
 
     const { slug, name, description, iconUrl, documentationUrl, providerType, config, driveId } = validation.data;
+
+    // Builtin slugs are reserved: a custom provider that claimed one would
+    // shadow the builtin at seed time and confuse slug-based resolution.
+    if (isBuiltinProvider(slug)) {
+      return NextResponse.json(
+        { error: `Slug "${slug}" is reserved for a builtin provider` },
+        { status: 409 }
+      );
+    }
 
     const provider = await createProvider(db, {
       slug,

--- a/apps/web/src/app/api/user/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/__tests__/route.test.ts
@@ -2,7 +2,7 @@
  * Security audit tests for /api/user/integrations
  * Verifies auditRequest is called for GET.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const mockListUserConnections = vi.hoisted(() => vi.fn());
 
@@ -46,9 +46,14 @@ vi.mock('@pagespace/lib/integrations/oauth/oauth-state', () => ({
   createSignedState: vi.fn(),
 }));
 
-import { GET } from '../route';
+import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository';
+import { findUserConnection } from '@pagespace/lib/integrations/repositories/connection-repository';
+import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler';
+import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
+import { builtinProviders } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 const mockUserId = 'user_123';
 
@@ -77,6 +82,59 @@ describe('GET /api/user/integrations audit', () => {
     expect(auditRequest).toHaveBeenCalledWith(
       req,
       { eventType: 'data.read', userId: mockUserId, resourceType: 'user_integrations', resourceId: 'self' }
+    );
+  });
+});
+
+describe('POST /api/user/integrations OAuth flow', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = ['OAUTH_STATE_SECRET', 'WEB_APP_URL', 'INTEGRATION_GITHUB_CLIENT_ID'] as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+    for (const key of envKeys) savedEnv[key] = process.env[key];
+    process.env.OAUTH_STATE_SECRET = 'test-secret';
+    process.env.WEB_APP_URL = 'https://app.example.com';
+    process.env.INTEGRATION_GITHUB_CLIENT_ID = 'client-id-123';
+    vi.mocked(findUserConnection).mockResolvedValue(null);
+    vi.mocked(createSignedState).mockReturnValue('signed-state-token');
+    vi.mocked(buildOAuthAuthorizationUrl).mockReturnValue('https://github.com/login/oauth/authorize?state=signed-state-token');
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it('builds the authorize URL from the canonical builtin config, not a stale persisted copy', async () => {
+    vi.mocked(getProviderById).mockResolvedValue({
+      id: 'prov-oauth',
+      slug: 'github',
+      providerType: 'builtin',
+      enabled: true,
+      config: {
+        authMethod: {
+          type: 'oauth2',
+          // Persisted config has drifted from what's shipped in code.
+          config: { authorizationUrl: 'https://stale.example.com/authorize', scopes: [] },
+        },
+      },
+    } as never);
+
+    const request = new Request('http://localhost/api/user/integrations', {
+      method: 'POST',
+      body: JSON.stringify({ providerId: 'prov-oauth', name: 'GitHub' }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const canonicalAuthMethod = builtinProviders.github.authMethod;
+    expect(buildOAuthAuthorizationUrl).toHaveBeenCalledWith(
+      canonicalAuthMethod.type === 'oauth2' ? canonicalAuthMethod.config : undefined,
+      expect.anything()
     );
   });
 });

--- a/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
@@ -100,6 +100,7 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 }));
 
 import { GET } from '../route';
+import { builtinProviders } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 // Test fixtures
 const BASE_URL = 'http://localhost:3000';
@@ -319,6 +320,30 @@ describe('GET /api/user/integrations/callback', () => {
       await GET(request);
 
       expect(mockExchangeOAuthCode).toHaveBeenCalled();
+    });
+
+    it('exchanges the code using the canonical builtin token endpoint, not a stale persisted copy', async () => {
+      mockGetProviderById.mockResolvedValueOnce({
+        id: 'provider-1',
+        slug: 'github',
+        providerType: 'builtin',
+        config: {
+          authMethod: {
+            type: 'oauth2',
+            // Persisted tokenUrl has drifted from what's shipped in code.
+            config: { authUrl: 'https://stale.example.com/authorize', tokenUrl: 'https://stale.example.com/token', scopes: [] },
+          },
+        },
+      });
+
+      const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
+      await GET(request);
+
+      const canonicalAuthMethod = builtinProviders.github.authMethod;
+      expect(mockExchangeOAuthCode).toHaveBeenCalledWith(
+        canonicalAuthMethod.type === 'oauth2' ? canonicalAuthMethod.config : undefined,
+        expect.anything()
+      );
     });
   });
 

--- a/apps/web/src/app/api/user/integrations/callback/route.ts
+++ b/apps/web/src/app/api/user/integrations/callback/route.ts
@@ -8,8 +8,9 @@ import { verifySignedState } from '@pagespace/lib/integrations/oauth/oauth-state
 import { exchangeOAuthCode } from '@pagespace/lib/integrations/oauth/oauth-handler';
 import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials';
 import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository';
+import { resolveProviderConfig } from '@pagespace/lib/integrations/providers/builtin-providers';
 import { createConnection, findUserConnection, findDriveConnection, updateConnectionCredentials, updateConnectionStatus } from '@pagespace/lib/integrations/repositories/connection-repository';
-import type { IntegrationProviderConfig, OAuth2Config } from '@pagespace/lib/integrations/types';
+import type { OAuth2Config } from '@pagespace/lib/integrations/types';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { isSafeReturnUrl } from '@/lib/auth';
 
@@ -83,8 +84,11 @@ export async function GET(request: Request) {
       return NextResponse.redirect(new URL(`${defaultReturn}?error=provider_not_found`, baseUrl));
     }
 
-    const config = provider.config as IntegrationProviderConfig;
-    if (config.authMethod.type !== 'oauth2') {
+    // Builtin providers may have changed shape (new token endpoint, renamed
+    // auth params) since this row was persisted — resolve to the canonical
+    // in-memory definition rather than trusting the possibly-stale DB copy.
+    const config = resolveProviderConfig(provider);
+    if (!config || config.authMethod.type !== 'oauth2') {
       return NextResponse.redirect(new URL(`${defaultReturn}?error=not_oauth`, baseUrl));
     }
 

--- a/apps/web/src/app/api/user/integrations/route.ts
+++ b/apps/web/src/app/api/user/integrations/route.ts
@@ -7,10 +7,10 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { listUserConnections, createConnection, findUserConnection } from '@pagespace/lib/integrations/repositories/connection-repository';
 import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository';
+import { resolveProviderConfig } from '@pagespace/lib/integrations/providers/builtin-providers';
 import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials';
 import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler';
 import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
-import type { IntegrationProviderConfig } from '@pagespace/lib/integrations/types';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -101,7 +101,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Connection already exists for this provider' }, { status: 409 });
     }
 
-    const config = provider.config as IntegrationProviderConfig;
+    // Builtin providers may have changed shape (new scopes, renamed auth
+    // params) since this row was persisted — resolve to the canonical
+    // in-memory definition rather than trusting the possibly-stale DB copy.
+    const config = resolveProviderConfig(provider);
+    if (!config) {
+      return NextResponse.json({ error: 'Provider configuration is missing' }, { status: 500 });
+    }
 
     // OAuth providers: redirect to auth URL
     if (config.authMethod.type === 'oauth2') {

--- a/packages/lib/src/compliance/erasure/__tests__/revoke-integration-tokens.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/revoke-integration-tokens.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { integrationConnections: { findMany: vi.fn() } },
+    update: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(() => 'eq') }));
+vi.mock('@pagespace/db/schema/integrations', () => ({
+  integrationConnections: { userId: 'userId', id: 'id' },
+}));
+vi.mock('../../../integrations/credentials/encrypt-credentials', () => ({
+  decryptCredentials: vi.fn(),
+}));
+
+import { revokeUserIntegrationTokens } from '../revoke-integration-tokens';
+import { db } from '@pagespace/db/db';
+import { decryptCredentials } from '../../../integrations/credentials/encrypt-credentials';
+
+function mockConnections(connections: unknown[]) {
+  vi.mocked(db.query.integrationConnections.findMany).mockResolvedValue(connections as never);
+}
+
+function mockUpdate() {
+  const whereFn = vi.fn().mockResolvedValue(undefined);
+  const setFn = vi.fn().mockReturnValue({ where: whereFn });
+  vi.mocked(db.update).mockReturnValue({ set: setFn } as never);
+  return { setFn, whereFn };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+});
+
+describe('revokeUserIntegrationTokens', () => {
+  it('uses the canonical builtin revoke URL even when the persisted provider config is stale', async () => {
+    mockConnections([
+      {
+        id: 'conn-1',
+        credentials: { accessToken: 'enc-token' },
+        provider: {
+          slug: 'github',
+          config: {
+            authMethod: {
+              type: 'oauth2',
+              config: { revokeUrl: 'https://stale.example.com/revoke' },
+            },
+          },
+        },
+      },
+    ]);
+    mockUpdate();
+    vi.mocked(decryptCredentials).mockResolvedValue({ accessToken: 'plain-token' });
+
+    const result = await revokeUserIntegrationTokens('user-1');
+
+    // The builtin GitHub definition's revoke URL wins, never the stale DB copy.
+    expect(fetch).toHaveBeenCalledWith(
+      'https://github.com/settings/connections/applications',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(fetch).not.toHaveBeenCalledWith('https://stale.example.com/revoke', expect.anything());
+    expect(result).toEqual({ revoked: 1, failed: 0 });
+  });
+
+  it('falls back to the persisted config for a non-builtin (custom) provider', async () => {
+    mockConnections([
+      {
+        id: 'conn-2',
+        credentials: { accessToken: 'enc-token' },
+        provider: {
+          slug: 'my-custom-provider',
+          config: {
+            authMethod: {
+              type: 'oauth2',
+              config: { revokeUrl: 'https://custom.example.com/revoke' },
+            },
+          },
+        },
+      },
+    ]);
+    mockUpdate();
+    vi.mocked(decryptCredentials).mockResolvedValue({ accessToken: 'plain-token' });
+
+    await revokeUserIntegrationTokens('user-1');
+
+    expect(fetch).toHaveBeenCalledWith('https://custom.example.com/revoke', expect.anything());
+  });
+
+  it('marks the connection revoked even with no credentials or provider', async () => {
+    mockConnections([{ id: 'conn-3', credentials: null, provider: null }]);
+    const { setFn } = mockUpdate();
+
+    const result = await revokeUserIntegrationTokens('user-1');
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledWith({ status: 'revoked' });
+    expect(result).toEqual({ revoked: 1, failed: 0 });
+  });
+});

--- a/packages/lib/src/compliance/erasure/__tests__/revoke-integration-tokens.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/revoke-integration-tokens.test.ts
@@ -127,4 +127,46 @@ describe('revokeUserIntegrationTokens', () => {
     expect(setFn).toHaveBeenCalledWith({ status: 'revoked' });
     expect(result).toEqual({ revoked: 1, failed: 0 });
   });
+
+  it('still marks the connection revoked when the persisted config is malformed (missing authMethod)', async () => {
+    mockConnections([
+      {
+        id: 'conn-5',
+        credentials: { accessToken: 'enc-token' },
+        // Custom provider row with no authMethod at all — a plausible
+        // hand-created/partially-populated custom provider config.
+        provider: { slug: 'partial-provider', providerType: 'custom', config: {} },
+      },
+    ]);
+    const { setFn } = mockUpdate();
+    vi.mocked(decryptCredentials).mockResolvedValue({ accessToken: 'plain-token' });
+
+    const result = await revokeUserIntegrationTokens('user-1');
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledWith({ status: 'revoked' });
+    expect(result).toEqual({ revoked: 1, failed: 0 });
+  });
+
+  it('still marks the connection revoked when authMethod is oauth2 but its config is missing', async () => {
+    mockConnections([
+      {
+        id: 'conn-6',
+        credentials: { accessToken: 'enc-token' },
+        provider: {
+          slug: 'partial-oauth-provider',
+          providerType: 'custom',
+          config: { authMethod: { type: 'oauth2' } },
+        },
+      },
+    ]);
+    const { setFn } = mockUpdate();
+    vi.mocked(decryptCredentials).mockResolvedValue({ accessToken: 'plain-token' });
+
+    const result = await revokeUserIntegrationTokens('user-1');
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(setFn).toHaveBeenCalledWith({ status: 'revoked' });
+    expect(result).toEqual({ revoked: 1, failed: 0 });
+  });
 });

--- a/packages/lib/src/compliance/erasure/__tests__/revoke-integration-tokens.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/revoke-integration-tokens.test.ts
@@ -42,6 +42,7 @@ describe('revokeUserIntegrationTokens', () => {
         credentials: { accessToken: 'enc-token' },
         provider: {
           slug: 'github',
+          providerType: 'builtin',
           config: {
             authMethod: {
               type: 'oauth2',
@@ -72,6 +73,7 @@ describe('revokeUserIntegrationTokens', () => {
         credentials: { accessToken: 'enc-token' },
         provider: {
           slug: 'my-custom-provider',
+          providerType: 'custom',
           config: {
             authMethod: {
               type: 'oauth2',
@@ -87,6 +89,32 @@ describe('revokeUserIntegrationTokens', () => {
     await revokeUserIntegrationTokens('user-1');
 
     expect(fetch).toHaveBeenCalledWith('https://custom.example.com/revoke', expect.anything());
+  });
+
+  it('uses the custom provider revoke URL when its slug collides with a builtin', async () => {
+    mockConnections([
+      {
+        id: 'conn-4',
+        credentials: { accessToken: 'enc-token' },
+        provider: {
+          slug: 'github', // collides with the builtin slug
+          providerType: 'custom',
+          config: {
+            authMethod: {
+              type: 'oauth2',
+              config: { revokeUrl: 'https://proxy.example.com/revoke' },
+            },
+          },
+        },
+      },
+    ]);
+    mockUpdate();
+    vi.mocked(decryptCredentials).mockResolvedValue({ accessToken: 'plain-token' });
+
+    await revokeUserIntegrationTokens('user-1');
+
+    // The custom provider's own revoke URL wins — not the builtin GitHub one.
+    expect(fetch).toHaveBeenCalledWith('https://proxy.example.com/revoke', expect.anything());
   });
 
   it('marks the connection revoked even with no credentials or provider', async () => {

--- a/packages/lib/src/compliance/erasure/revoke-integration-tokens.ts
+++ b/packages/lib/src/compliance/erasure/revoke-integration-tokens.ts
@@ -9,6 +9,43 @@ export interface OAuthRevokeResult {
   failed: number;
 }
 
+interface ConnectionWithProvider {
+  id: string;
+  credentials: unknown;
+  provider: { slug: string; providerType: string; config: unknown } | null;
+}
+
+/**
+ * Best-effort upstream OAuth revoke. Never throws — a malformed or
+ * unexpectedly-shaped provider config must not block marking the connection
+ * revoked in the DB below, since that DB write is what erasure depends on.
+ */
+async function attemptUpstreamRevoke(connection: ConnectionWithProvider): Promise<void> {
+  if (!connection.credentials) return;
+
+  try {
+    const providerConfig = resolveProviderConfig(connection.provider);
+    if (providerConfig?.authMethod.type !== 'oauth2') return;
+
+    const revokeUrl = providerConfig.authMethod.config?.revokeUrl;
+    if (!revokeUrl) return;
+
+    const credentials = await decryptCredentials(connection.credentials as Record<string, string>);
+    const accessToken = credentials.accessToken || credentials.access_token;
+    if (!accessToken) return;
+
+    await fetch(revokeUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: `token=${encodeURIComponent(accessToken)}`,
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    // Upstream revoke failure is non-fatal — token may be expired, provider
+    // unreachable, or the persisted config may be malformed/unexpected shape.
+  }
+}
+
 /**
  * Revoke all OAuth tokens for a user before account erasure (Art. 17 GDPR).
  *
@@ -28,35 +65,9 @@ export async function revokeUserIntegrationTokens(userId: string): Promise<OAuth
   let failed = 0;
 
   for (const connection of connections) {
+    await attemptUpstreamRevoke(connection);
+
     try {
-      const providerConfig = resolveProviderConfig(connection.provider);
-
-      if (providerConfig && connection.credentials) {
-        if (providerConfig.authMethod.type === 'oauth2') {
-          const revokeUrl = providerConfig.authMethod.config.revokeUrl;
-
-          if (revokeUrl) {
-            try {
-              const credentials = await decryptCredentials(
-                connection.credentials as Record<string, string>
-              );
-              const accessToken = credentials.accessToken || credentials.access_token;
-
-              if (accessToken) {
-                await fetch(revokeUrl, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                  body: `token=${encodeURIComponent(accessToken)}`,
-                  signal: AbortSignal.timeout(10_000),
-                });
-              }
-            } catch {
-              // HTTP revoke failure is non-fatal — token may be expired or provider unreachable
-            }
-          }
-        }
-      }
-
       await db
         .update(integrationConnections)
         .set({ status: 'revoked' })

--- a/packages/lib/src/compliance/erasure/revoke-integration-tokens.ts
+++ b/packages/lib/src/compliance/erasure/revoke-integration-tokens.ts
@@ -2,7 +2,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { integrationConnections } from '@pagespace/db/schema/integrations';
 import { decryptCredentials } from '../../integrations/credentials/encrypt-credentials';
-import type { IntegrationProviderConfig } from '../../integrations/types';
+import { resolveProviderConfig } from '../../integrations/providers/builtin-providers';
 
 export interface OAuthRevokeResult {
   revoked: number;
@@ -29,9 +29,9 @@ export async function revokeUserIntegrationTokens(userId: string): Promise<OAuth
 
   for (const connection of connections) {
     try {
-      if (connection.provider && connection.credentials) {
-        const providerConfig = connection.provider.config as IntegrationProviderConfig;
+      const providerConfig = resolveProviderConfig(connection.provider);
 
+      if (providerConfig && connection.credentials) {
         if (providerConfig.authMethod.type === 'oauth2') {
           const revokeUrl = providerConfig.authMethod.config.revokeUrl;
 

--- a/packages/lib/src/integrations/providers/builtin-providers.test.ts
+++ b/packages/lib/src/integrations/providers/builtin-providers.test.ts
@@ -24,26 +24,59 @@ describe('getBuiltinProvider / isBuiltinProvider', () => {
 });
 
 describe('resolveProviderConfig', () => {
-  it('given a builtin provider slug, should ignore stale persisted config and return the in-memory definition', () => {
+  it('given a builtin provider row, should ignore stale persisted config and return the in-memory definition', () => {
     const stalePersistedConfig = {
       id: 'github',
       name: 'GitHub (stale)',
       tools: [], // e.g. missing tools/bundles added since this row was last seeded
     };
 
-    const resolved = resolveProviderConfig({ slug: 'github', config: stalePersistedConfig });
+    const resolved = resolveProviderConfig({
+      slug: 'github',
+      providerType: 'builtin',
+      config: stalePersistedConfig,
+    });
 
     expect(resolved).toBe(builtinProviders.github);
     expect(resolved).not.toBe(stalePersistedConfig);
     expect(resolved?.tools.length).toBeGreaterThan(0);
   });
 
-  it('given a non-builtin (custom) provider slug, should fall back to the persisted config', () => {
+  it('given a custom provider, should fall back to the persisted config', () => {
     const customConfig = { id: 'my-custom-provider', name: 'Custom', tools: [] };
 
-    const resolved = resolveProviderConfig({ slug: 'my-custom-provider', config: customConfig });
+    const resolved = resolveProviderConfig({
+      slug: 'my-custom-provider',
+      providerType: 'custom',
+      config: customConfig,
+    });
 
     expect(resolved).toBe(customConfig);
+  });
+
+  it('given a non-builtin provider whose slug collides with a builtin, should keep its own persisted config', () => {
+    const customConfig = { id: 'github', name: 'My GitHub Proxy', tools: [] };
+
+    const resolved = resolveProviderConfig({
+      slug: 'github',
+      providerType: 'custom',
+      config: customConfig,
+    });
+
+    expect(resolved).toBe(customConfig);
+    expect(resolved).not.toBe(builtinProviders.github);
+  });
+
+  it('given a builtin-typed row whose slug no longer has an in-memory definition, should fall back to the persisted config', () => {
+    const persistedConfig = { id: 'retired-builtin', name: 'Retired', tools: [] };
+
+    const resolved = resolveProviderConfig({
+      slug: 'retired-builtin',
+      providerType: 'builtin',
+      config: persistedConfig,
+    });
+
+    expect(resolved).toBe(persistedConfig);
   });
 
   it('given no provider, should return null', () => {

--- a/packages/lib/src/integrations/providers/builtin-providers.test.ts
+++ b/packages/lib/src/integrations/providers/builtin-providers.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  builtinProviders,
+  builtinProviderList,
+  getBuiltinProvider,
+  isBuiltinProvider,
+  resolveProviderConfig,
+} from './builtin-providers';
+
+describe('getBuiltinProvider / isBuiltinProvider', () => {
+  it('given a known builtin slug, should return its definition', () => {
+    expect(getBuiltinProvider('github')).toBe(builtinProviders.github);
+    expect(isBuiltinProvider('github')).toBe(true);
+  });
+
+  it('given an unknown slug, should return null / false', () => {
+    expect(getBuiltinProvider('not-a-provider')).toBeNull();
+    expect(isBuiltinProvider('not-a-provider')).toBe(false);
+  });
+
+  it('should list every registered builtin provider', () => {
+    expect(builtinProviderList).toHaveLength(Object.keys(builtinProviders).length);
+  });
+});
+
+describe('resolveProviderConfig', () => {
+  it('given a builtin provider slug, should ignore stale persisted config and return the in-memory definition', () => {
+    const stalePersistedConfig = {
+      id: 'github',
+      name: 'GitHub (stale)',
+      tools: [], // e.g. missing tools/bundles added since this row was last seeded
+    };
+
+    const resolved = resolveProviderConfig({ slug: 'github', config: stalePersistedConfig });
+
+    expect(resolved).toBe(builtinProviders.github);
+    expect(resolved).not.toBe(stalePersistedConfig);
+    expect(resolved?.tools.length).toBeGreaterThan(0);
+  });
+
+  it('given a non-builtin (custom) provider slug, should fall back to the persisted config', () => {
+    const customConfig = { id: 'my-custom-provider', name: 'Custom', tools: [] };
+
+    const resolved = resolveProviderConfig({ slug: 'my-custom-provider', config: customConfig });
+
+    expect(resolved).toBe(customConfig);
+  });
+
+  it('given no provider, should return null', () => {
+    expect(resolveProviderConfig(null)).toBeNull();
+    expect(resolveProviderConfig(undefined)).toBeNull();
+  });
+});

--- a/packages/lib/src/integrations/providers/builtin-providers.ts
+++ b/packages/lib/src/integrations/providers/builtin-providers.ts
@@ -21,17 +21,14 @@ export const getBuiltinProvider = (
 export const isBuiltinProvider = (id: string): boolean => id in builtinProviders;
 
 /**
- * The authoritative config for a provider, at any read site.
- *
- * Builtin providers are defined in code and can change shape (new tool ids,
- * renamed bundles) on any deploy. The persisted `integration_providers.config`
- * row is only a cache seeded at install time and refreshed lazily — it can lag
- * behind the in-memory definition until something happens to trigger a refresh.
- * Rather than trust that cache, always prefer the current in-memory definition
- * for a `providerType: 'builtin'` row; custom/openapi/webhook providers keep
- * their persisted config, even if their slug happens to collide with a builtin
- * (rows created before slug reservation existed), so a custom provider is never
- * silently handed a builtin's tools or OAuth metadata.
+ * The authoritative config for a provider, at any read site: for a
+ * `providerType: 'builtin'` row, prefer the current in-memory definition over
+ * the persisted `integration_providers.config` cache, which only refreshes
+ * lazily and can lag behind after a deploy. Every other providerType keeps its
+ * own persisted config unconditionally — including a row whose slug happens
+ * to collide with a builtin — so a custom provider is never silently handed a
+ * builtin's tools or OAuth metadata. The returned object may be the shared
+ * in-memory builtin definition itself; treat it as read-only.
  */
 export const resolveProviderConfig = (
   provider: { slug: string; providerType: string; config: unknown } | null | undefined
@@ -40,4 +37,19 @@ export const resolveProviderConfig = (
   const persisted = provider.config as IntegrationProviderConfig | null;
   if (provider.providerType !== 'builtin') return persisted;
   return getBuiltinProvider(provider.slug) ?? persisted;
+};
+
+/**
+ * Immutably overlay the resolved config onto a provider row. Returns the row
+ * unchanged (same reference) when resolution is a no-op — e.g. custom
+ * providers — so list paths don't clone rows for nothing. Shared by the
+ * repository read paths so connection reads and grant reads can never drift.
+ */
+export const withResolvedConfig = <
+  P extends { slug: string; providerType: string; config: unknown },
+>(
+  provider: P
+): P => {
+  const resolved = resolveProviderConfig(provider);
+  return resolved === provider.config ? provider : { ...provider, config: resolved };
 };

--- a/packages/lib/src/integrations/providers/builtin-providers.ts
+++ b/packages/lib/src/integrations/providers/builtin-providers.ts
@@ -19,3 +19,21 @@ export const getBuiltinProvider = (
 ): IntegrationProviderConfig | null => builtinProviders[id] ?? null;
 
 export const isBuiltinProvider = (id: string): boolean => id in builtinProviders;
+
+/**
+ * The authoritative config for a provider, at any read site.
+ *
+ * Builtin providers are defined in code and can change shape (new tool ids,
+ * renamed bundles) on any deploy. The persisted `integration_providers.config`
+ * row is only a cache seeded at install time and refreshed lazily — it can lag
+ * behind the in-memory definition until something happens to trigger a refresh.
+ * Rather than trust that cache, always prefer the current in-memory definition
+ * for a slug that matches a builtin; only custom/openapi/mcp/webhook providers,
+ * which have no in-memory definition, fall back to their persisted config.
+ */
+export const resolveProviderConfig = (
+  provider: { slug: string; config: unknown } | null | undefined
+): IntegrationProviderConfig | null =>
+  provider
+    ? getBuiltinProvider(provider.slug) ?? (provider.config as IntegrationProviderConfig | null)
+    : null;

--- a/packages/lib/src/integrations/providers/builtin-providers.ts
+++ b/packages/lib/src/integrations/providers/builtin-providers.ts
@@ -28,12 +28,16 @@ export const isBuiltinProvider = (id: string): boolean => id in builtinProviders
  * row is only a cache seeded at install time and refreshed lazily — it can lag
  * behind the in-memory definition until something happens to trigger a refresh.
  * Rather than trust that cache, always prefer the current in-memory definition
- * for a slug that matches a builtin; only custom/openapi/mcp/webhook providers,
- * which have no in-memory definition, fall back to their persisted config.
+ * for a `providerType: 'builtin'` row; custom/openapi/webhook providers keep
+ * their persisted config, even if their slug happens to collide with a builtin
+ * (rows created before slug reservation existed), so a custom provider is never
+ * silently handed a builtin's tools or OAuth metadata.
  */
 export const resolveProviderConfig = (
-  provider: { slug: string; config: unknown } | null | undefined
-): IntegrationProviderConfig | null =>
-  provider
-    ? getBuiltinProvider(provider.slug) ?? (provider.config as IntegrationProviderConfig | null)
-    : null;
+  provider: { slug: string; providerType: string; config: unknown } | null | undefined
+): IntegrationProviderConfig | null => {
+  if (!provider) return null;
+  const persisted = provider.config as IntegrationProviderConfig | null;
+  if (provider.providerType !== 'builtin') return persisted;
+  return getBuiltinProvider(provider.slug) ?? persisted;
+};

--- a/packages/lib/src/integrations/repositories/connection-repository.test.ts
+++ b/packages/lib/src/integrations/repositories/connection-repository.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveProviderConfig } from '../providers/builtin-providers';
 
 // Define types locally for testing
 type ConnectionStatus = 'active' | 'expired' | 'error' | 'pending' | 'revoked';
@@ -60,6 +61,17 @@ const createMockDb = (): MockDb => ({
 // Inline repository implementations for testing
 // (Real implementation in connection-repository.ts uses drizzle)
 
+function withResolvedProviderConfig(connection: MockConnection): MockConnection {
+  if (!connection.provider) return connection;
+  return {
+    ...connection,
+    provider: {
+      ...connection.provider,
+      config: resolveProviderConfig(connection.provider),
+    },
+  };
+}
+
 const createConnection = async (
   db: MockDb,
   data: Partial<MockConnection>
@@ -79,10 +91,11 @@ const getConnectionWithProvider = async (
   db: MockDb,
   connectionId: string
 ): Promise<MockConnection | null> => {
-  return db.query.integrationConnections.findFirst({
+  const connection = await db.query.integrationConnections.findFirst({
     where: { id: connectionId },
     with: { provider: true },
-  }) ?? null;
+  });
+  return connection ? withResolvedProviderConfig(connection) : null;
 };
 
 const findUserConnection = async (
@@ -127,20 +140,22 @@ const listUserConnections = async (
   db: MockDb,
   userId: string
 ): Promise<MockConnection[]> => {
-  return db.query.integrationConnections.findMany({
+  const connections = await db.query.integrationConnections.findMany({
     where: { userId },
     with: { provider: true },
-  }) ?? [];
+  });
+  return (connections ?? []).map(withResolvedProviderConfig);
 };
 
 const listDriveConnections = async (
   db: MockDb,
   driveId: string
 ): Promise<MockConnection[]> => {
-  return db.query.integrationConnections.findMany({
+  const connections = await db.query.integrationConnections.findMany({
     where: { driveId },
     with: { provider: true },
-  }) ?? [];
+  });
+  return (connections ?? []).map(withResolvedProviderConfig);
 };
 
 describe('createConnection', () => {
@@ -251,13 +266,13 @@ describe('getConnectionWithProvider', () => {
     const connectionWithProvider: MockConnection = {
       id: 'conn-123',
       providerId: 'provider-1',
-      name: 'My GitHub',
+      name: 'My Custom Integration',
       status: 'active',
       provider: {
         id: 'provider-1',
-        slug: 'github',
-        name: 'GitHub',
-        config: { baseUrl: 'https://api.github.com' },
+        slug: 'my-custom-provider',
+        name: 'Custom',
+        config: { baseUrl: 'https://api.example.com' },
       },
     };
 
@@ -267,7 +282,30 @@ describe('getConnectionWithProvider', () => {
 
     expect(result).toEqual(connectionWithProvider);
     expect(result?.provider).toBeDefined();
-    expect(result?.provider?.slug).toBe('github');
+    expect(result?.provider?.slug).toBe('my-custom-provider');
+  });
+
+  it('given a builtin provider slug, should overlay the canonical config over a stale persisted copy', async () => {
+    const connectionWithStaleProvider: MockConnection = {
+      id: 'conn-123',
+      providerId: 'provider-1',
+      name: 'My GitHub',
+      status: 'active',
+      provider: {
+        id: 'provider-1',
+        slug: 'github',
+        name: 'GitHub',
+        // Stale persisted config — e.g. seeded before a tool rename/bundle addition.
+        config: { baseUrl: 'https://api.github.com', tools: [] },
+      },
+    };
+
+    mockDb.query.integrationConnections.findFirst.mockResolvedValue(connectionWithStaleProvider);
+
+    const result = await getConnectionWithProvider(mockDb, 'conn-123');
+
+    expect(result?.provider?.config).not.toEqual({ baseUrl: 'https://api.github.com', tools: [] });
+    expect((result?.provider?.config as { tools: unknown[] }).tools.length).toBeGreaterThan(0);
   });
 
   it('given non-existent connection ID, should return null', async () => {
@@ -444,8 +482,11 @@ describe('listUserConnections', () => {
 
     const result = await listUserConnections(mockDb, 'user-1');
 
-    expect(result).toEqual(userConnections);
     expect(result).toHaveLength(2);
+    // Stale/empty persisted config (`{}`) is overlaid with the canonical builtin
+    // definition for both connections, not returned as-is.
+    expect(result[0].provider?.config).not.toEqual({});
+    expect(result[1].provider?.config).not.toEqual({});
   });
 
   it('given user with no connections, should return empty array', async () => {
@@ -473,6 +514,7 @@ describe('listDriveConnections', () => {
 
     const result = await listDriveConnections(mockDb, 'drive-1');
 
-    expect(result).toEqual(driveConnections);
+    expect(result).toHaveLength(1);
+    expect(result[0].provider?.config).not.toEqual({});
   });
 });

--- a/packages/lib/src/integrations/repositories/connection-repository.test.ts
+++ b/packages/lib/src/integrations/repositories/connection-repository.test.ts
@@ -30,6 +30,7 @@ interface MockConnection {
     slug: string;
     name: string;
     config: unknown;
+    providerType: string;
   };
 }
 
@@ -273,6 +274,7 @@ describe('getConnectionWithProvider', () => {
         slug: 'my-custom-provider',
         name: 'Custom',
         config: { baseUrl: 'https://api.example.com' },
+        providerType: 'custom',
       },
     };
 
@@ -297,6 +299,7 @@ describe('getConnectionWithProvider', () => {
         name: 'GitHub',
         // Stale persisted config — e.g. seeded before a tool rename/bundle addition.
         config: { baseUrl: 'https://api.github.com', tools: [] },
+        providerType: 'builtin',
       },
     };
 
@@ -306,6 +309,29 @@ describe('getConnectionWithProvider', () => {
 
     expect(result?.provider?.config).not.toEqual({ baseUrl: 'https://api.github.com', tools: [] });
     expect((result?.provider?.config as { tools: unknown[] }).tools.length).toBeGreaterThan(0);
+  });
+
+  it('given a custom provider whose slug collides with a builtin, should keep its own persisted config', async () => {
+    const customConfig = { baseUrl: 'https://proxy.example.com', tools: [] };
+    const connectionWithShadowingProvider: MockConnection = {
+      id: 'conn-123',
+      providerId: 'provider-1',
+      name: 'My GitHub Proxy',
+      status: 'active',
+      provider: {
+        id: 'provider-1',
+        slug: 'github', // collides with the builtin slug, but is a custom provider
+        name: 'GitHub Proxy',
+        config: customConfig,
+        providerType: 'custom',
+      },
+    };
+
+    mockDb.query.integrationConnections.findFirst.mockResolvedValue(connectionWithShadowingProvider);
+
+    const result = await getConnectionWithProvider(mockDb, 'conn-123');
+
+    expect(result?.provider?.config).toBe(customConfig);
   });
 
   it('given non-existent connection ID, should return null', async () => {
@@ -474,8 +500,8 @@ describe('listUserConnections', () => {
 
   it('given user ID, should return all user connections with provider info', async () => {
     const userConnections: MockConnection[] = [
-      { id: 'conn-1', providerId: 'p1', name: 'GitHub', status: 'active', provider: { id: 'p1', slug: 'github', name: 'GitHub', config: {} } },
-      { id: 'conn-2', providerId: 'p2', name: 'Slack', status: 'active', provider: { id: 'p2', slug: 'slack', name: 'Slack', config: {} } },
+      { id: 'conn-1', providerId: 'p1', name: 'GitHub', status: 'active', provider: { id: 'p1', slug: 'github', name: 'GitHub', config: {}, providerType: 'builtin' } },
+      { id: 'conn-2', providerId: 'p2', name: 'Slack', status: 'active', provider: { id: 'p2', slug: 'slack', name: 'Slack', config: {}, providerType: 'builtin' } },
     ];
 
     mockDb.query.integrationConnections.findMany.mockResolvedValue(userConnections);
@@ -507,7 +533,7 @@ describe('listDriveConnections', () => {
 
   it('given drive ID, should return all drive connections with provider info', async () => {
     const driveConnections: MockConnection[] = [
-      { id: 'conn-1', providerId: 'p1', name: 'Team Notion', status: 'active', provider: { id: 'p1', slug: 'notion', name: 'Notion', config: {} } },
+      { id: 'conn-1', providerId: 'p1', name: 'Team Notion', status: 'active', provider: { id: 'p1', slug: 'notion', name: 'Notion', config: {}, providerType: 'builtin' } },
     ];
 
     mockDb.query.integrationConnections.findMany.mockResolvedValue(driveConnections);

--- a/packages/lib/src/integrations/repositories/connection-repository.ts
+++ b/packages/lib/src/integrations/repositories/connection-repository.ts
@@ -8,7 +8,7 @@
 import { db as defaultDb } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { integrationConnections, type IntegrationConnection, type NewIntegrationConnection } from '@pagespace/db/schema/integrations';
-import { resolveProviderConfig } from '../providers/builtin-providers';
+import { withResolvedConfig } from '../providers/builtin-providers';
 
 // Type for the database instance (allows dependency injection for testing)
 export type ConnectionRepository = {
@@ -34,13 +34,8 @@ type ConnectionWithProvider = IntegrationConnection & {
  */
 function withResolvedProviderConfig<T extends ConnectionWithProvider>(connection: T): T {
   if (!connection.provider) return connection;
-  return {
-    ...connection,
-    provider: {
-      ...connection.provider,
-      config: resolveProviderConfig(connection.provider),
-    },
-  };
+  const provider = withResolvedConfig(connection.provider);
+  return provider === connection.provider ? connection : { ...connection, provider };
 }
 
 /**

--- a/packages/lib/src/integrations/repositories/connection-repository.ts
+++ b/packages/lib/src/integrations/repositories/connection-repository.ts
@@ -8,6 +8,7 @@
 import { db as defaultDb } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { integrationConnections, type IntegrationConnection, type NewIntegrationConnection } from '@pagespace/db/schema/integrations';
+import { resolveProviderConfig } from '../providers/builtin-providers';
 
 // Type for the database instance (allows dependency injection for testing)
 export type ConnectionRepository = {
@@ -26,6 +27,21 @@ type ConnectionWithProvider = IntegrationConnection & {
     providerType: string;
   } | null;
 };
+
+/**
+ * Overlay the authoritative builtin config onto a connection's provider before
+ * it leaves the repository, so every caller reads canonical config uniformly.
+ */
+function withResolvedProviderConfig<T extends ConnectionWithProvider>(connection: T): T {
+  if (!connection.provider) return connection;
+  return {
+    ...connection,
+    provider: {
+      ...connection.provider,
+      config: resolveProviderConfig(connection.provider),
+    },
+  };
+}
 
 /**
  * Create a new integration connection.
@@ -70,7 +86,7 @@ export const getConnectionWithProvider = async (
     },
   });
 
-  return connection ?? null;
+  return connection ? withResolvedProviderConfig(connection) : null;
 };
 
 /**
@@ -160,7 +176,7 @@ export const listUserConnections = async (
     },
   });
 
-  return connections;
+  return connections.map(withResolvedProviderConfig);
 };
 
 /**
@@ -177,7 +193,7 @@ export const listDriveConnections = async (
     },
   });
 
-  return connections;
+  return connections.map(withResolvedProviderConfig);
 };
 
 /**

--- a/packages/lib/src/integrations/repositories/grant-repository.test.ts
+++ b/packages/lib/src/integrations/repositories/grant-repository.test.ts
@@ -26,7 +26,7 @@ interface MockConnection {
   id: string;
   name: string;
   status: string;
-  provider?: { slug: string; name: string; config: unknown };
+  provider?: { slug: string; name: string; config: unknown; providerType: string };
 }
 
 interface MockAgent {
@@ -285,7 +285,7 @@ describe('listGrantsByAgent', () => {
           id: 'conn-1',
           name: 'GitHub',
           status: 'active',
-          provider: { slug: 'github', name: 'GitHub', config: {} },
+          provider: { slug: 'github', name: 'GitHub', config: {}, providerType: 'builtin' },
         },
       },
       {
@@ -299,7 +299,7 @@ describe('listGrantsByAgent', () => {
           id: 'conn-2',
           name: 'Slack',
           status: 'active',
-          provider: { slug: 'slack', name: 'Slack', config: {} },
+          provider: { slug: 'slack', name: 'Slack', config: {}, providerType: 'builtin' },
         },
       },
     ];
@@ -327,7 +327,7 @@ describe('listGrantsByAgent', () => {
           name: 'GitHub',
           status: 'active',
           // Stale persisted config — no tools/bundles, as if seeded before a rename.
-          provider: { slug: 'github', name: 'GitHub', config: { tools: [] } },
+          provider: { slug: 'github', name: 'GitHub', config: { tools: [] }, providerType: 'builtin' },
         },
       },
     ];
@@ -339,6 +339,33 @@ describe('listGrantsByAgent', () => {
     const config = result[0].connection?.provider?.config as { tools: unknown[] };
     expect(config).not.toEqual({ tools: [] });
     expect(config.tools.length).toBeGreaterThan(0);
+  });
+
+  it('given a custom provider whose slug collides with a builtin, should keep its own persisted config', async () => {
+    const customConfig = { tools: [{ id: 'proxy_tool' }] };
+    const grants: MockGrant[] = [
+      {
+        id: 'grant-1',
+        agentId: 'agent-1',
+        connectionId: 'conn-1',
+        allowedTools: null,
+        deniedTools: null,
+        readOnly: false,
+        connection: {
+          id: 'conn-1',
+          name: 'GitHub Proxy',
+          status: 'active',
+          // Slug collides with the builtin, but this is a custom provider.
+          provider: { slug: 'github', name: 'GitHub Proxy', config: customConfig, providerType: 'custom' },
+        },
+      },
+    ];
+
+    mockDb.query.integrationToolGrants.findMany.mockResolvedValue(grants);
+
+    const result = await listGrantsByAgent(mockDb, 'agent-1');
+
+    expect(result[0].connection?.provider?.config).toBe(customConfig);
   });
 
   it('given agent with no grants, should return empty array', async () => {

--- a/packages/lib/src/integrations/repositories/grant-repository.test.ts
+++ b/packages/lib/src/integrations/repositories/grant-repository.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveProviderConfig } from '../providers/builtin-providers';
 
 // Define types locally for testing
 interface MockGrant {
@@ -25,7 +26,7 @@ interface MockConnection {
   id: string;
   name: string;
   status: string;
-  provider?: { slug: string; name: string };
+  provider?: { slug: string; name: string; config: unknown };
 }
 
 interface MockAgent {
@@ -58,6 +59,20 @@ const createMockDb = (): MockDb => ({
 });
 
 // Inline repository implementations for testing
+function withResolvedProviderConfig(grant: MockGrant): MockGrant {
+  if (!grant.connection?.provider) return grant;
+  return {
+    ...grant,
+    connection: {
+      ...grant.connection,
+      provider: {
+        ...grant.connection.provider,
+        config: resolveProviderConfig(grant.connection.provider),
+      },
+    },
+  };
+}
+
 const createGrant = async (
   db: MockDb,
   data: Partial<MockGrant>
@@ -87,10 +102,11 @@ const listGrantsByAgent = async (
   db: MockDb,
   agentId: string
 ): Promise<MockGrant[]> => {
-  return db.query.integrationToolGrants.findMany({
+  const grants = await db.query.integrationToolGrants.findMany({
     where: { agentId },
     with: { connection: { with: { provider: true } } },
-  }) ?? [];
+  });
+  return (grants ?? []).map(withResolvedProviderConfig);
 };
 
 const listGrantsByConnection = async (
@@ -269,7 +285,7 @@ describe('listGrantsByAgent', () => {
           id: 'conn-1',
           name: 'GitHub',
           status: 'active',
-          provider: { slug: 'github', name: 'GitHub' },
+          provider: { slug: 'github', name: 'GitHub', config: {} },
         },
       },
       {
@@ -283,7 +299,7 @@ describe('listGrantsByAgent', () => {
           id: 'conn-2',
           name: 'Slack',
           status: 'active',
-          provider: { slug: 'slack', name: 'Slack' },
+          provider: { slug: 'slack', name: 'Slack', config: {} },
         },
       },
     ];
@@ -295,6 +311,34 @@ describe('listGrantsByAgent', () => {
     expect(result).toHaveLength(2);
     expect(result[0].connection?.provider?.slug).toBe('github');
     expect(result[1].connection?.provider?.slug).toBe('slack');
+  });
+
+  it('given a builtin provider with stale persisted config, should overlay the canonical definition', async () => {
+    const grants: MockGrant[] = [
+      {
+        id: 'grant-1',
+        agentId: 'agent-1',
+        connectionId: 'conn-1',
+        allowedTools: null,
+        deniedTools: null,
+        readOnly: false,
+        connection: {
+          id: 'conn-1',
+          name: 'GitHub',
+          status: 'active',
+          // Stale persisted config — no tools/bundles, as if seeded before a rename.
+          provider: { slug: 'github', name: 'GitHub', config: { tools: [] } },
+        },
+      },
+    ];
+
+    mockDb.query.integrationToolGrants.findMany.mockResolvedValue(grants);
+
+    const result = await listGrantsByAgent(mockDb, 'agent-1');
+
+    const config = result[0].connection?.provider?.config as { tools: unknown[] };
+    expect(config).not.toEqual({ tools: [] });
+    expect(config.tools.length).toBeGreaterThan(0);
   });
 
   it('given agent with no grants, should return empty array', async () => {

--- a/packages/lib/src/integrations/repositories/grant-repository.ts
+++ b/packages/lib/src/integrations/repositories/grant-repository.ts
@@ -8,6 +8,7 @@
 import { db as defaultDb } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { integrationToolGrants, type IntegrationToolGrant, type NewIntegrationToolGrant } from '@pagespace/db/schema/integrations';
+import { resolveProviderConfig } from '../providers/builtin-providers';
 
 type GrantWithConnection = IntegrationToolGrant & {
   connection: {
@@ -21,6 +22,25 @@ type GrantWithConnection = IntegrationToolGrant & {
     } | null;
   } | null;
 };
+
+/**
+ * Overlay the authoritative builtin config onto a grant's connection provider
+ * before it leaves the repository, mirroring connection-repository.ts so every
+ * reader of `connection.provider.config` sees canonical config uniformly.
+ */
+function withResolvedProviderConfig(grant: GrantWithConnection): GrantWithConnection {
+  if (!grant.connection?.provider) return grant;
+  return {
+    ...grant,
+    connection: {
+      ...grant.connection,
+      provider: {
+        ...grant.connection.provider,
+        config: resolveProviderConfig(grant.connection.provider),
+      },
+    },
+  };
+}
 
 type GrantWithAgent = IntegrationToolGrant & {
   agent: {
@@ -94,7 +114,7 @@ export const listGrantsByAgent = async (
     },
   });
 
-  return grants;
+  return grants.map(withResolvedProviderConfig);
 };
 
 /**

--- a/packages/lib/src/integrations/repositories/grant-repository.ts
+++ b/packages/lib/src/integrations/repositories/grant-repository.ts
@@ -19,6 +19,7 @@ type GrantWithConnection = IntegrationToolGrant & {
       slug: string;
       name: string;
       config: unknown;
+      providerType: string;
     } | null;
   } | null;
 };

--- a/packages/lib/src/integrations/repositories/grant-repository.ts
+++ b/packages/lib/src/integrations/repositories/grant-repository.ts
@@ -8,7 +8,7 @@
 import { db as defaultDb } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { integrationToolGrants, type IntegrationToolGrant, type NewIntegrationToolGrant } from '@pagespace/db/schema/integrations';
-import { resolveProviderConfig } from '../providers/builtin-providers';
+import { withResolvedConfig } from '../providers/builtin-providers';
 
 type GrantWithConnection = IntegrationToolGrant & {
   connection: {
@@ -31,16 +31,9 @@ type GrantWithConnection = IntegrationToolGrant & {
  */
 function withResolvedProviderConfig(grant: GrantWithConnection): GrantWithConnection {
   if (!grant.connection?.provider) return grant;
-  return {
-    ...grant,
-    connection: {
-      ...grant.connection,
-      provider: {
-        ...grant.connection.provider,
-        config: resolveProviderConfig(grant.connection.provider),
-      },
-    },
-  };
+  const provider = withResolvedConfig(grant.connection.provider);
+  if (provider === grant.connection.provider) return grant;
+  return { ...grant, connection: { ...grant.connection, provider } };
 }
 
 type GrantWithAgent = IntegrationToolGrant & {

--- a/packages/lib/src/integrations/repositories/provider-repository.ts
+++ b/packages/lib/src/integrations/repositories/provider-repository.ts
@@ -188,6 +188,13 @@ function stableStringify(value: unknown): string {
  * Refresh builtin provider configs from the in-memory definitions.
  * Compares the full config (tools, schemas, rate limits, etc.) via stable
  * JSON serialization. Only touches providers with providerType 'builtin'.
+ *
+ * No longer load-bearing for staleness: every read path that resolves a
+ * builtin provider's config now goes through `resolveProviderConfig`
+ * (`../providers/builtin-providers`), which always prefers the in-memory
+ * definition over this persisted row. This write-back is kept only so the
+ * persisted row (visible to direct DB queries, admin tooling, etc.) doesn't
+ * drift indefinitely — it is a sync convenience, not a correctness dependency.
  */
 export const refreshBuiltinProviders = async (
   database: typeof defaultDb,


### PR DESCRIPTION
## Summary

- Adds `resolveProviderConfig(provider)` to `packages/lib/src/integrations/providers/builtin-providers.ts`: for a `providerType: 'builtin'` row, it always returns the in-memory definition instead of the persisted `integration_providers.config` row, which is only a lazily-refreshed cache that can lag behind after a deploy (renamed tools, new bundles, etc.) — the staleness described in #1452.
- The overlay is gated on `providerType === 'builtin'`: a custom/openapi/webhook provider whose slug collides with a builtin (e.g. an admin-created provider with slug `github`, created before the builtin was seeded) keeps its own persisted config — it is never silently handed the builtin's tools or OAuth revoke metadata. `POST /api/integrations/providers` additionally rejects builtin-reserved slugs (409) so new shadowing rows can't be created.
- Applies the helper (via a shared `withResolvedConfig` overlay, extracted to avoid duplicating the same logic in two repositories) at every shared read path that eagerly loads `connection.provider`:
  - `connection-repository.ts`: `getConnectionWithProvider`, `listUserConnections`, `listDriveConnections`
  - `grant-repository.ts`: `listGrantsByAgent`
  - `packages/lib/src/compliance/erasure/revoke-integration-tokens.ts` queries connections directly (outside the repository layer), so it calls the helper itself — this fixes GDPR token revocation hitting a stale OAuth revoke URL.
  - **OAuth connect/callback routes** (`POST /api/user/integrations`, `POST /api/drives/[driveId]/integrations`, `GET /api/user/integrations/callback`) also read the provider directly via `getProviderById` for the authorize/token-exchange flow — these now resolve through the same helper, so a builtin's OAuth endpoints/scopes changing in code no longer risk building the authorize redirect or exchanging the code against a stale persisted URL.
- The previously localized `resolveProviderConfig` in `apps/web/.../agents/[agentId]/integrations/route.ts` is removed: its inputs (`listGrantsByAgent`, `getConnectionWithProvider`) are already repository-resolved, and a slug-only overlay there would have re-clobbered a colliding custom provider.
- Hardened `revokeUserIntegrationTokens` (GDPR Art. 17 erasure): a malformed/unexpectedly-shaped provider config (missing `authMethod`, or `oauth2` with no nested `config`) previously threw inside the same `try`/`catch` guarding the DB status update, silently skipping the `revoked` write. Pre-existing (verified against the pre-PR revision), but directly in a function this PR already touches for the same class of issue — the upstream-revoke attempt is now isolated in its own never-throws helper, and the DB write always runs regardless.
- `refreshBuiltinProviders` (`provider-repository.ts`) is kept, but its doc comment now records that it's a best-effort write-back for direct DB readers, not load-bearing for correctness anymore.
- Confirmed (no bug found, checked as part of review): a builtin provider's persisted config can never be customized via `PUT /api/integrations/providers/[providerId]`, since that route rejects any request where `provider.isSystem` is true, and every builtin-created row is seeded with `isSystem: true`. The new overlay can't discard an admin customization the write path itself already disallows.
- CHANGELOG updated per repo convention for user-visible changes (new 409 on builtin-slug collision, corrected builtin config resolution).

## Test plan

- [x] `builtin-providers.test.ts`: builtin row ignores stale persisted config; custom provider falls back to persisted config; custom provider with a builtin-colliding slug keeps its own config; builtin-typed row whose slug no longer exists in code falls back to persisted config; null/undefined provider returns null.
- [x] `connection-repository.test.ts` / `grant-repository.test.ts`: stale-config overlay plus slug-collision cases proving a custom provider's config is never replaced.
- [x] `revoke-integration-tokens.test.ts`: builtin revoke URL wins over stale persisted config; custom provider fallback; slug-collision case; two new malformed-config regression cases (missing `authMethod`, `oauth2` with no nested `config`) proving the connection is still marked `revoked`.
- [x] `agents/[agentId]/integrations` route tests: GET tool listing and POST default-bundle both pass through repository-resolved config; slug-collision case added for both.
- [x] New regression tests in `user/integrations`, `drives/[driveId]/integrations`, and `user/integrations/callback` route test suites: each proves the OAuth authorize/token-exchange call now uses the canonical builtin config, not a stale persisted copy.
- [x] `bun run --filter '@pagespace/lib' typecheck` and `bun run --filter 'web' typecheck` — clean.
- [x] `bun run test` in `packages/lib` — 280 files / 6238 tests passed.
- [x] All integration route test suites in `apps/web` (10 files / 172 tests) — passed.
- [x] `eslint` on all changed files — clean.

Fixes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAq1YQdBQkwHmN8BQRWtiZ