### PR TITLE
fix(auth): unify socket tokens into the opaque-token model

### DIFF
--- a/apps/admin/src/app/api/auth/csrf/route.ts
+++ b/apps/admin/src/app/api/auth/csrf/route.ts
@@ -12,7 +12,8 @@ export async function GET(req: Request) {
       return Response.json({ error: 'No session found' }, { status: 401 });
     }
 
-    const sessionClaims = await sessionService.validateSession(sessionToken);
+    // CSRF tokens are only meaningful for browser sessions.
+    const sessionClaims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
     if (!sessionClaims) {
       return Response.json({ error: 'Invalid or expired session' }, { status: 401 });
     }

--- a/apps/admin/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/admin/src/lib/auth/__tests__/auth.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: {
+    validateSession: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+vi.mock('../admin-role', () => ({
+  validateAdminAccess: vi.fn(),
+}));
+vi.mock('../csrf-validation', () => ({
+  validateCSRF: vi.fn(),
+}));
+vi.mock('../cookie-config', () => ({
+  getSessionFromCookies: vi.fn(),
+}));
+
+import { verifyAdminAuth, isAdminAuthError } from '../auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { validateAdminAccess } from '../admin-role';
+import { validateCSRF } from '../csrf-validation';
+import { getSessionFromCookies } from '../cookie-config';
+
+describe('admin verifyAdminAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSessionFromCookies).mockReturnValue('some-cookie-token');
+    vi.mocked(validateCSRF).mockResolvedValue(null);
+    vi.mocked(validateAdminAccess).mockResolvedValue({ isValid: true } as never);
+  });
+
+  function makeRequest(method = 'GET') {
+    return new Request('https://admin.example.com/api/whatever', {
+      method,
+      headers: { cookie: 'session=some-cookie-token' },
+    });
+  }
+
+  it('scopes the admin session cookie to user-type sessions only', async () => {
+    vi.mocked(sessionService.validateSession).mockResolvedValue({
+      sessionId: 'sess-1',
+      userId: 'user-1',
+      userRole: 'admin',
+      tokenVersion: 1,
+      adminRoleVersion: 0,
+      type: 'user',
+      scopes: ['*'],
+      expiresAt: new Date(Date.now() + 60000),
+    });
+
+    await verifyAdminAuth(makeRequest());
+
+    expect(sessionService.validateSession).toHaveBeenCalledWith('some-cookie-token', { expectedType: 'user' });
+  });
+
+  it('rejects a non-user token (e.g. a leaked socket/service/mcp/device token) placed in the admin session cookie', async () => {
+    // Real sessionService.validateSession would return null here because the
+    // stored session's type doesn't match the required 'user' expectedType —
+    // simulate that behavior directly since sessionService is mocked.
+    vi.mocked(sessionService.validateSession).mockResolvedValue(null);
+
+    const result = await verifyAdminAuth(makeRequest());
+
+    expect(isAdminAuthError(result)).toBe(true);
+    if (isAdminAuthError(result)) {
+      expect(result.status).toBe(403);
+    }
+  });
+});

--- a/apps/admin/src/lib/auth/auth.ts
+++ b/apps/admin/src/lib/auth/auth.ts
@@ -24,7 +24,9 @@ async function authenticateSession(request: Request): Promise<VerifiedAdminUser 
   const sessionToken = getSessionFromCookies(cookieHeader);
   if (!sessionToken) return null;
 
-  const claims = await sessionService.validateSession(sessionToken);
+  // Admin session cookie is a browser session only — never accept a socket,
+  // service, mcp, or device token that leaked/replayed into this cookie.
+  const claims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!claims) return null;
 
   return {

--- a/apps/admin/src/lib/auth/csrf-validation.ts
+++ b/apps/admin/src/lib/auth/csrf-validation.ts
@@ -89,8 +89,8 @@ export async function validateCSRF(request: Request): Promise<NextResponse | nul
     );
   }
 
-  // Validate session with server
-  const sessionClaims = await sessionService.validateSession(sessionToken);
+  // Validate session with server — only browser sessions carry CSRF tokens
+  const sessionClaims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!sessionClaims) {
     loggers.auth.warn('CSRF validation failed: invalid session', {
       method,

--- a/apps/processor/src/middleware/auth.ts
+++ b/apps/processor/src/middleware/auth.ts
@@ -56,7 +56,9 @@ export async function authenticateService(req: Request, res: Response, next: Nex
   const tokenPrefix = token.substring(0, 12); // Log prefix only for debugging
 
   try {
-    const claims = await sessionService.validateSession(token);
+    // Processor is service-to-service only — reject non-service session types
+    // via the shared type-scoping mechanism rather than a manual post-check.
+    const claims = await sessionService.validateSession(token, { expectedType: 'service' });
 
     if (!claims) {
       loggers.security.warn('Processor auth: invalid or expired token', {
@@ -64,18 +66,6 @@ export async function authenticateService(req: Request, res: Response, next: Nex
         tokenPrefix,
       });
       respondUnauthorized(res, 'Invalid or expired token');
-      return;
-    }
-
-    // Reject non-service session types - processor is for service-to-service only
-    if (claims.type !== 'service') {
-      loggers.security.warn('Processor auth: non-service token rejected', {
-        ...requestContext,
-        tokenPrefix,
-        tokenType: claims.type,
-        userId: claims.userId,
-      });
-      respondForbidden(res, 'Service token required');
       return;
     }
 

--- a/apps/processor/tests/auth-middleware.test.ts
+++ b/apps/processor/tests/auth-middleware.test.ts
@@ -116,13 +116,12 @@ describe('authenticateService middleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('returns 403 when token is not a service token', async () => {
-    vi.mocked(sessionService.validateSession).mockResolvedValue({
-      userId: 'user-123',
-      userRole: 'user',
-      type: 'session', // Not a service token
-      scopes: ['files:read'],
-    } as any);
+  it('returns 401 when token is not a service token (type-scoping rejects it before middleware sees claims)', async () => {
+    // sessionService.validateSession(token, { expectedType: 'service' }) rejects
+    // a non-service session by returning null — the middleware no longer does
+    // its own post-hoc claims.type check, so this is now indistinguishable
+    // from "invalid or expired token" from the middleware's point of view.
+    vi.mocked(sessionService.validateSession).mockResolvedValue(null);
 
     const req = createMockRequest({
       headers: { authorization: 'Bearer user-token' },
@@ -132,8 +131,9 @@ describe('authenticateService middleware', () => {
 
     await authenticateService(req, res, next);
 
-    expect(res.statusCode).toBe(403);
-    expect(res.jsonData).toEqual({ error: 'Service token required' });
+    expect(sessionService.validateSession).toHaveBeenCalledWith('user-token', { expectedType: 'service' });
+    expect(res.statusCode).toBe(401);
+    expect(res.jsonData).toEqual({ error: 'Invalid or expired token' });
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -153,6 +153,7 @@ describe('authenticateService middleware', () => {
 
     await authenticateService(req, res, next);
 
+    expect(sessionService.validateSession).toHaveBeenCalledWith('valid-service-token', { expectedType: 'service' });
     expect(next).toHaveBeenCalledTimes(1);
     expect(req.auth).toBeDefined();
     expect(req.auth?.userId).toBe('user-123');

--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -670,7 +670,7 @@ describe('Socket.IO middleware - auth', () => {
 
     await capturedIoUseCallback!(socket, next);
 
-    expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sock_validtoken123');
+    expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sock_validtoken123', { expectedType: 'socket' });
     expect(next).toHaveBeenCalledWith(/* no error */);
     expect(next.mock.calls[0]).toHaveLength(0);
   });

--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -65,8 +65,7 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 
-// DB mock – need query.socketTokens.findFirst and chained select().from().where().limit()
-const mockDbFindFirst = vi.fn();
+// DB mock – need chained select().from().where().limit() for the DM/profile lookups
 const mockDbSelect = vi.fn();
 const mockDbFrom = vi.fn();
 const mockDbWhere = vi.fn();
@@ -79,22 +78,15 @@ mockDbLimit.mockResolvedValue([]);
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
-    query: {
-      socketTokens: {
-        findFirst: mockDbFindFirst,
-      },
-    },
     select: mockDbSelect,
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ eq: [a, b] })),
-  gt: vi.fn((a, b) => ({ gt: [a, b] })),
   and: vi.fn((...args) => ({ and: args })),
   or: vi.fn((...args) => ({ or: args })),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
-  socketTokens: { tokenHash: 'tokenHash', expiresAt: 'expiresAt' },
   users: { id: 'id', name: 'name', image: 'image' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
@@ -656,8 +648,14 @@ describe('Socket.IO middleware - auth', () => {
     }));
   });
 
-  it('given valid ps_sock_* token, should authenticate and call next()', async () => {
-    mockDbFindFirst.mockResolvedValue({ userId: 'user-from-sock-token' });
+  it('given valid ps_sock_* token, should authenticate via sessionService and call next()', async () => {
+    vi.mocked(sessionService.validateSession).mockResolvedValue({
+      userId: 'user-from-sock-token',
+      sessionId: 'sock-1',
+      expiresAt: new Date(),
+    } as Parameters<typeof sessionService.validateSession>[0] extends string
+      ? Awaited<ReturnType<typeof sessionService.validateSession>>
+      : never);
     mockDbLimit.mockResolvedValueOnce([{ name: 'Test User', image: null }])
                .mockResolvedValueOnce([]);
 
@@ -672,12 +670,13 @@ describe('Socket.IO middleware - auth', () => {
 
     await capturedIoUseCallback!(socket, next);
 
+    expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sock_validtoken123');
     expect(next).toHaveBeenCalledWith(/* no error */);
     expect(next.mock.calls[0]).toHaveLength(0);
   });
 
-  it('given ps_sock_* token not found in DB, should reject with error', async () => {
-    mockDbFindFirst.mockResolvedValue(null);
+  it('given ps_sock_* token that fails validation, should reject with error', async () => {
+    vi.mocked(sessionService.validateSession).mockResolvedValue(null);
 
     const socket = createMockSocket({
       handshake: {
@@ -695,8 +694,8 @@ describe('Socket.IO middleware - auth', () => {
     }));
   });
 
-  it('given ps_sock_* token DB error, should reject with error', async () => {
-    mockDbFindFirst.mockRejectedValue(new Error('DB connection failed'));
+  it('given ps_sock_* token validation throws, should reject with server error', async () => {
+    vi.mocked(sessionService.validateSession).mockRejectedValue(new Error('Session service error'));
 
     const socket = createMockSocket({
       handshake: {
@@ -710,7 +709,7 @@ describe('Socket.IO middleware - auth', () => {
     await capturedIoUseCallback!(socket, next);
 
     expect(next).toHaveBeenCalledWith(expect.objectContaining({
-      message: expect.stringContaining('Invalid or expired socket token'),
+      message: expect.stringContaining('Server failed'),
     }));
   });
 

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -580,7 +580,7 @@ io.use(async (socket: AuthSocket, next) => {
     try {
       const sessionClaims = await sessionService.validateSession(token, { expectedType: 'socket' });
       if (!sessionClaims) {
-        loggers.realtime.warn('Socket.IO: Socket token validation failed');
+        loggers.realtime.warn('Socket.IO: Socket token validation failed', { tokenPrefix: token.substring(0, 12) });
         return next(new Error('Authentication error: Invalid or expired socket token.'));
       }
 

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -578,7 +578,7 @@ io.use(async (socket: AuthSocket, next) => {
   // same way as the ps_sess_* branch below.
   if (token.startsWith('ps_sock_')) {
     try {
-      const sessionClaims = await sessionService.validateSession(token);
+      const sessionClaims = await sessionService.validateSession(token, { expectedType: 'socket' });
       if (!sessionClaims) {
         loggers.realtime.warn('Socket.IO: Socket token validation failed');
         return next(new Error('Authentication error: Invalid or expired socket token.'));
@@ -597,7 +597,7 @@ io.use(async (socket: AuthSocket, next) => {
   // Check for session token (ps_sess_*) - used by mobile/desktop clients
   if (token.startsWith('ps_sess_')) {
     try {
-      const sessionClaims = await sessionService.validateSession(token);
+      const sessionClaims = await sessionService.validateSession(token, { expectedType: 'user' });
       if (!sessionClaims) {
         loggers.realtime.warn('Socket.IO: Session token validation failed');
         return next(new Error('Authentication error: Invalid or expired session.'));

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -2,13 +2,12 @@ import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { Server, Socket } from 'socket.io';
 import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import { sessionService } from '@pagespace/lib/auth/session-service';
-import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { verifyBroadcastSignature } from '@pagespace/lib/auth/broadcast-auth';
 import * as dotenv from 'dotenv';
 import { db } from '@pagespace/db/db';
-import { eq, gt, and, or } from '@pagespace/db/operators';
+import { eq, and, or } from '@pagespace/db/operators';
 import { dmConversations } from '@pagespace/db/schema/social';
-import { socketTokens, users } from '@pagespace/db/schema/auth';
+import { users } from '@pagespace/db/schema/auth';
 import { userProfiles } from '@pagespace/db/schema/members';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { canRunCode, isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
@@ -163,42 +162,6 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
   }).catch(() => {});
 
   return { ok: true, sandboxId, sessionKey: sandboxResult.sessionKey, sprite, releaseSlot };
-}
-
-/**
- * Validate a short-lived socket token (ps_sock_* format).
- * These tokens are created by /api/auth/socket-token to bypass sameSite: 'strict' cookies.
- *
- * @param token - The socket token to validate
- * @returns Object with userId if valid, null if invalid or expired
- */
-async function validateSocketToken(token: string): Promise<{ userId: string } | null> {
-  /* c8 ignore next 3 */
-  if (!token.startsWith('ps_sock_')) {
-    return null;
-  }
-
-  const tokenHash = hashToken(token);
-
-  try {
-    const record = await db.query.socketTokens.findFirst({
-      where: and(
-        eq(socketTokens.tokenHash, tokenHash),
-        gt(socketTokens.expiresAt, new Date())
-      ),
-    });
-
-    if (!record) {
-      loggers.realtime.debug('Socket token not found or expired', { tokenHashPrefix: tokenHash.substring(0, 8) });
-      return null;
-    }
-
-    loggers.realtime.debug('Socket token validated successfully', { userId: record.userId });
-    return { userId: record.userId };
-  } catch (error) {
-    loggers.realtime.error('Error validating socket token', error as Error);
-    return null;
-  }
 }
 
 /**
@@ -610,17 +573,25 @@ io.use(async (socket: AuthSocket, next) => {
     return next(new Error('Authentication error: No token provided.'));
   }
 
-  // Check for socket token (ps_sock_*) first - these bypass sameSite: 'strict' cookies
+  // Check for socket token (ps_sock_*) first - these bypass sameSite: 'strict' cookies.
+  // Socket tokens are unified opaque sessions (type: 'socket', #1054) validated the
+  // same way as the ps_sess_* branch below.
   if (token.startsWith('ps_sock_')) {
-    const socketAuth = await validateSocketToken(token);
-    if (socketAuth) {
-      socket.data.user = { id: socketAuth.userId, name: 'Unknown', avatarUrl: null };
+    try {
+      const sessionClaims = await sessionService.validateSession(token);
+      if (!sessionClaims) {
+        loggers.realtime.warn('Socket.IO: Socket token validation failed');
+        return next(new Error('Authentication error: Invalid or expired socket token.'));
+      }
+
+      socket.data.user = { id: sessionClaims.userId, name: 'Unknown', avatarUrl: null };
       await populateUserMetadata(socket);
-      loggers.realtime.info('Socket.IO: User authenticated via socket token', { userId: socketAuth.userId });
+      loggers.realtime.info('Socket.IO: User authenticated via socket token', { userId: sessionClaims.userId });
       return next();
+    } catch (error) {
+      loggers.realtime.error('Error validating socket token', error as Error);
+      return next(new Error('Authentication error: Server failed.'));
     }
-    loggers.realtime.warn('Socket.IO: Socket token validation failed');
-    return next(new Error('Authentication error: Invalid or expired socket token.'));
   }
 
   // Check for session token (ps_sess_*) - used by mobile/desktop clients

--- a/apps/web/src/app/activate/page.tsx
+++ b/apps/web/src/app/activate/page.tsx
@@ -32,7 +32,7 @@ export default async function ActivatePage({ searchParams }: ActivatePageProps) 
     redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
   }
 
-  const session = await sessionService.validateSession(sessionToken);
+  const session = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!session) {
     redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
   }

--- a/apps/web/src/app/api/auth/__tests__/csrf.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/csrf.test.ts
@@ -95,7 +95,7 @@ describe('/api/auth/csrf', () => {
       await GET(request);
 
       // Assert: CSRF token is generated using the session ID
-      expect(sessionService.validateSession).toHaveBeenCalledWith('valid-session-token');
+      expect(sessionService.validateSession).toHaveBeenCalledWith('valid-session-token', { expectedType: 'user' });
       expect(generateCSRFToken).toHaveBeenCalledWith('test-session-id');
     });
   });

--- a/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
@@ -304,7 +304,7 @@ describe('Session Fixation Prevention - CSRF Validation', () => {
       await validateCSRF(request);
 
       expect(mockGetSession).toHaveBeenCalledWith('session=ps_sess_test');
-      expect(mockValidateSession).toHaveBeenCalledWith('ps_sess_test');
+      expect(mockValidateSession).toHaveBeenCalledWith('ps_sess_test', { expectedType: 'user' });
     });
   });
 });

--- a/apps/web/src/app/api/auth/csrf/route.ts
+++ b/apps/web/src/app/api/auth/csrf/route.ts
@@ -13,8 +13,9 @@ export async function GET(req: Request) {
       return Response.json({ error: 'No session found' }, { status: 401 });
     }
 
-    // Validate session with server
-    const sessionClaims = await sessionService.validateSession(sessionToken);
+    // Validate session with server. CSRF tokens are only meaningful for
+    // browser sessions — never mint one for other token types in the cookie.
+    const sessionClaims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
     if (!sessionClaims) {
       return Response.json({ error: 'Invalid or expired session' }, { status: 401 });
     }

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -32,7 +32,10 @@ export async function POST(req: Request) {
   let sessionId: string | undefined;
   let sessionRevokeSucceeded = false;
   if (sessionToken) {
-    const sessionClaims = await sessionService.validateSession(sessionToken);
+    // Only a real browser session may trigger logout's userId-scoped device
+    // revocation — a leaked non-user token in the session cookie must not be
+    // able to revoke another user's device tokens.
+    const sessionClaims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
     userId = sessionClaims?.userId;
     sessionId = sessionClaims?.sessionId;
     try {

--- a/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
@@ -13,8 +13,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
  *
  * Dependencies mocked at service seam:
  *   - @/lib/auth/auth-helpers: requireAuth, isAuthError
- *   - @/lib/repositories/session-repository: sessionRepository.createSocketToken
- *   - crypto is NOT mocked (pure utility, real implementation used)
+ *   - @pagespace/lib/auth/session-service: sessionService.createSession (#1054 — unified
+ *     opaque-token model, replaces the old sessionRepository.createSocketToken path)
  */
 
 vi.mock('@/lib/auth/auth-helpers', () => ({
@@ -26,9 +26,9 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
-vi.mock('@/lib/repositories/session-repository', () => ({
-  sessionRepository: {
-    createSocketToken: vi.fn().mockResolvedValue(undefined),
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: {
+    createSession: vi.fn().mockResolvedValue('ps_sock_mocktoken1234567890'),
   },
 }));
 
@@ -51,7 +51,7 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 }));
 
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
-import { sessionRepository } from '@/lib/repositories/session-repository';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { GET } from '../route';
 
 describe('/api/auth/socket-token', () => {
@@ -86,13 +86,13 @@ describe('/api/auth/socket-token', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body.token).toMatch(/^ps_sock_/);
+      expect(body.token).toBe('ps_sock_mocktoken1234567890');
       expect(body.expiresAt).toBe(
         new Date(Date.now() + 5 * 60 * 1000).toISOString()
       );
     });
 
-    it('GET_withValidSession_storesHashedTokenViaRepository', async () => {
+    it('GET_withValidSession_mintsSocketSessionViaSessionService', async () => {
       const request = new Request('http://localhost/api/auth/socket-token', {
         method: 'GET',
         headers: { Cookie: 'session=valid-token' },
@@ -100,26 +100,13 @@ describe('/api/auth/socket-token', () => {
 
       await GET(request);
 
-      expect(sessionRepository.createSocketToken).toHaveBeenCalledTimes(1);
-      const storedArg = vi.mocked(sessionRepository.createSocketToken).mock.calls[0][0];
-      expect(storedArg.userId).toBe('test-user-id');
-      expect(storedArg.expiresAt).toEqual(new Date(Date.now() + 5 * 60 * 1000));
-      expect(storedArg.tokenHash).toMatch(/^[a-f0-9]{64}$/);
-      expect(storedArg.tokenHash.length).toBe(64);
-    });
-
-    it('GET_withValidSession_storesHashNotPlaintext', async () => {
-      const request = new Request('http://localhost/api/auth/socket-token', {
-        method: 'GET',
-        headers: { Cookie: 'session=valid-token' },
+      expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+      expect(sessionService.createSession).toHaveBeenCalledWith({
+        userId: 'test-user-id',
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
       });
-
-      const response = await GET(request);
-      const body = await response.json();
-
-      // The stored hash differs from the returned token
-      const storedCall = vi.mocked(sessionRepository.createSocketToken).mock.calls[0][0];
-      expect(storedCall.tokenHash).not.toBe(body.token);
     });
 
     it('GET_withValidSession_setsCacheControlHeaders', async () => {
@@ -182,7 +169,7 @@ describe('/api/auth/socket-token', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(401);
-      expect(sessionRepository.createSocketToken).not.toHaveBeenCalled();
+      expect(sessionService.createSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/api/auth/socket-token/route.ts
+++ b/apps/web/src/app/api/auth/socket-token/route.ts
@@ -1,8 +1,8 @@
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { sessionRepository } from '@/lib/repositories/session-repository';
-import { hashToken } from '@pagespace/lib/auth/token-utils';
-import { randomBytes } from 'crypto';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+
+const SOCKET_TOKEN_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Socket Token Endpoint (P2-T0 Hotfix)
@@ -14,7 +14,8 @@ import { randomBytes } from 'crypto';
  * Flow:
  * 1. Client calls this endpoint (same-origin, cookies sent)
  * 2. Server validates session via httpOnly cookie
- * 3. Server creates short-lived socket token (5 min)
+ * 3. Server mints a short-lived (5 min) `ps_sock_*` session (type: 'socket')
+ *    through the same unified opaque-token model every other token uses (#1054)
  * 4. Client passes token to Socket.IO auth.token
  */
 export async function GET(request: Request) {
@@ -22,23 +23,19 @@ export async function GET(request: Request) {
   const auth = await requireAuth(request);
   if (isAuthError(auth)) return auth;
 
-  // Generate short-lived socket token (5 minutes)
-  const tokenValue = `ps_sock_${randomBytes(24).toString('base64url')}`;
-  const tokenHash = hashToken(tokenValue);
-  const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
-
-  // Store hash in database (never store plaintext)
-  await sessionRepository.createSocketToken({
-    tokenHash,
+  const token = await sessionService.createSession({
     userId: auth.userId,
-    expiresAt,
+    type: 'socket',
+    scopes: [],
+    expiresInMs: SOCKET_TOKEN_TTL_MS,
   });
+  const expiresAt = new Date(Date.now() + SOCKET_TOKEN_TTL_MS);
 
   auditRequest(request, { eventType: 'auth.token.created', userId: auth.userId, details: { tokenType: 'socket' } });
 
   // Return with no-cache headers to prevent token reuse across sessions
   return Response.json({
-    token: tokenValue,
+    token,
     expiresAt: expiresAt.toISOString(),
   }, {
     headers: {

--- a/apps/web/src/app/oauth/consent/page.tsx
+++ b/apps/web/src/app/oauth/consent/page.tsx
@@ -36,7 +36,8 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
     redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
   }
 
-  const session = await sessionService.validateSession(sessionToken);
+  // Consent screen is gated on a real browser session only.
+  const session = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!session) {
     redirect(`/auth/signin?next=${encodeURIComponent(nextTarget)}`);
   }

--- a/apps/web/src/app/p/[pageId]/page.tsx
+++ b/apps/web/src/app/p/[pageId]/page.tsx
@@ -27,8 +27,8 @@ export default async function PageRedirect({ params }: PageProps) {
     redirect(`/auth/signin?callbackUrl=/p/${pageId}`);
   }
 
-  // Validate the session token
-  const session = await sessionService.validateSession(sessionToken);
+  // Validate the session token — only a browser session may drive this redirect.
+  const session = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!session) {
     redirect(`/auth/signin?callbackUrl=/p/${pageId}`);
   }

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -139,6 +139,18 @@ describe('Auth Middleware', () => {
       expect(result).toEqual(mockSessionClaims);
     });
 
+    it('only accepts user-type sessions — non-user tokens (socket/service/mcp/device) must not authenticate web requests', async () => {
+      // Arrange
+      vi.mocked(sessionService.validateSession).mockResolvedValue(mockSessionClaims);
+
+      // Act
+      await validateSessionToken('ps_sock_leaked');
+
+      // Assert: the type restriction is delegated to sessionService via expectedType,
+      // so a ps_sock_*/ps_svc_*/etc. value in the session cookie can never yield claims.
+      expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sock_leaked', { expectedType: 'user' });
+    });
+
     it('returns null when sessionService throws error', async () => {
       // Arrange
       vi.mocked(sessionService.validateSession).mockRejectedValue(

--- a/apps/web/src/lib/auth/__tests__/csrf-validation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/csrf-validation.test.ts
@@ -265,7 +265,7 @@ describe('csrf-validation', () => {
 
         // Assert: Verify the session-based binding flow
         expect(getSessionFromCookies).toHaveBeenCalled();
-        expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sess_valid');
+        expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sess_valid', { expectedType: 'user' });
         expect(validateCSRFToken).toHaveBeenCalledWith('valid-csrf-token', mockSessionId);
       });
     });
@@ -324,7 +324,7 @@ describe('csrf-validation', () => {
         await validateCSRF(request);
 
         // Assert: Session service validates the correct token
-        expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sess_custom');
+        expect(sessionService.validateSession).toHaveBeenCalledWith('ps_sess_custom', { expectedType: 'user' });
       });
     });
   });

--- a/apps/web/src/lib/auth/csrf-validation.ts
+++ b/apps/web/src/lib/auth/csrf-validation.ts
@@ -89,8 +89,8 @@ export async function validateCSRF(request: Request): Promise<NextResponse | nul
     );
   }
 
-  // Validate session with server
-  const sessionClaims = await sessionService.validateSession(sessionToken);
+  // Validate session with server — only browser sessions carry CSRF tokens
+  const sessionClaims = await sessionService.validateSession(sessionToken, { expectedType: 'user' });
   if (!sessionClaims) {
     loggers.auth.warn('CSRF validation failed: invalid session', {
       method,

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -242,7 +242,11 @@ export async function validateSessionToken(token: string): Promise<SessionClaims
     if (!token) {
       return null;
     }
-    return await sessionService.validateSession(token);
+    // Only browser/user sessions may authenticate generic web requests. Other
+    // session types (service, mcp, device, socket) have their own dedicated
+    // validation surfaces and must not be replayable as a session cookie or
+    // bearer session token.
+    return await sessionService.validateSession(token, { expectedType: 'user' });
   } catch (error) {
     console.error('validateSessionToken error', error);
     return null;

--- a/apps/web/src/lib/repositories/session-repository.ts
+++ b/apps/web/src/lib/repositories/session-repository.ts
@@ -6,7 +6,7 @@
 
 import { db } from '@pagespace/db/db'
 import { eq, and, inArray, type InferSelectModel } from '@pagespace/db/operators'
-import { socketTokens, deviceTokens, mcpTokens } from '@pagespace/db/schema/auth'
+import { deviceTokens, mcpTokens } from '@pagespace/db/schema/auth'
 import { mcpTokenDrives } from '@pagespace/db/schema/members'
 import { drives } from '@pagespace/db/schema/core';
 
@@ -14,17 +14,6 @@ export type DeviceToken = InferSelectModel<typeof deviceTokens>;
 export type McpToken = InferSelectModel<typeof mcpTokens>;
 
 export const sessionRepository = {
-  /**
-   * Store a hashed socket token for Socket.IO authentication.
-   */
-  async createSocketToken(data: {
-    tokenHash: string;
-    userId: string;
-    expiresAt: Date;
-  }): Promise<void> {
-    await db.insert(socketTokens).values(data);
-  },
-
   /**
    * Update a device token's deviceId (one-time OAuth migration fix).
    * Returns the updated record, or null if not found.

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -143,8 +143,12 @@ export const verificationTokens = pgTable('verification_tokens', {
   };
 });
 
-// Socket tokens for cross-origin Socket.IO authentication
-// Short-lived tokens (5 min) that bypass sameSite: 'strict' cookie restrictions
+// DEPRECATED (#1054): superseded by the unified `sessions` table with
+// `type: 'socket'`, minted/validated through opaque-tokens.ts + session-service.ts
+// like every other token type. No longer written to. Left in place (rather than
+// dropped) so the retention-cleanup job keeps purging any legacy rows and so we
+// avoid a table drop in the same PR that changes the write path. Safe to drop in
+// a follow-up once confirmed empty in production.
 export const socketTokens = pgTable('socket_tokens', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
   userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),

--- a/packages/db/src/schema/sessions.ts
+++ b/packages/db/src/schema/sessions.ts
@@ -15,7 +15,9 @@ export const sessions = pgTable('sessions', {
   deviceId: text('device_id'),
 
   // Session metadata
-  type: text('type', { enum: ['user', 'service', 'mcp', 'device'] }).notNull(),
+  // 'socket' = short-lived (5 min) Socket.IO handshake bridge token, minted from
+  // an already-authenticated web session to bypass sameSite: 'strict' cookies.
+  type: text('type', { enum: ['user', 'service', 'mcp', 'device', 'socket'] }).notNull(),
   scopes: text('scopes').array().notNull().default(sql`ARRAY[]::text[]`),
 
   // Resource binding

--- a/packages/lib/src/auth/__tests__/opaque-tokens.test.ts
+++ b/packages/lib/src/auth/__tests__/opaque-tokens.test.ts
@@ -39,6 +39,7 @@ describe('Opaque Token Generation', () => {
     expect(isValidTokenFormat('ps_dev_' + 'd'.repeat(43))).toBe(true);
     expect(isValidTokenFormat('ps_at_' + 'e'.repeat(43))).toBe(true);
     expect(isValidTokenFormat('ps_rt_' + 'f'.repeat(43))).toBe(true);
+    expect(isValidTokenFormat('ps_sock_' + 'g'.repeat(43))).toBe(true);
   });
 
   it('rejects invalid token formats', () => {
@@ -56,7 +57,16 @@ describe('Opaque Token Generation', () => {
     expect(getTokenType('ps_dev_abc123')).toBe('dev');
     expect(getTokenType('ps_at_abc123')).toBe('at');
     expect(getTokenType('ps_rt_abc123')).toBe('rt');
+    expect(getTokenType('ps_sock_abc123')).toBe('sock');
     expect(getTokenType('invalid_token')).toBe(null);
+  });
+
+  it('generates socket token with correct format', () => {
+    const { token, tokenHash, tokenPrefix } = generateOpaqueToken('sock');
+
+    expect(token).toMatch(/^ps_sock_[A-Za-z0-9_-]{43}$/);
+    expect(tokenHash).toHaveLength(64);
+    expect(tokenPrefix).toBe(token.substring(0, 12));
   });
 
   it('token has sufficient entropy (256 bits)', () => {

--- a/packages/lib/src/auth/__tests__/session-service-unit.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-unit.test.ts
@@ -125,6 +125,22 @@ describe('SessionService', () => {
 
       expect(generateOpaqueToken).toHaveBeenCalledWith('dev');
     });
+
+    it('createSession_withSocketType_generatesTokenWithSockPrefix', async () => {
+      vi.mocked(sessionRepository.findUserById).mockResolvedValue({
+        id: 'user-1', tokenVersion: 1, role: 'user', adminRoleVersion: 0,
+      });
+      vi.mocked(sessionRepository.insertSession).mockResolvedValue(undefined);
+
+      await service.createSession({
+        userId: 'user-1', type: 'socket', scopes: [], expiresInMs: 60000,
+      });
+
+      expect(generateOpaqueToken).toHaveBeenCalledWith('sock');
+      expect(sessionRepository.insertSession).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'socket' }),
+      );
+    });
   });
 
   describe('validateSession', () => {

--- a/packages/lib/src/auth/__tests__/session-service-unit.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-unit.test.ts
@@ -245,6 +245,38 @@ describe('SessionService', () => {
       });
       expect(sessionRepository.touchSession).toHaveBeenCalledWith('hashed_ps_sess_valid');
     });
+
+    it('validateSession_withExpectedTypeMismatch_returnsNullWithoutSideEffects', async () => {
+      vi.mocked(isValidTokenFormat).mockReturnValue(true);
+      vi.mocked(sessionRepository.findActiveSession).mockResolvedValue({
+        id: 'sess-1', userId: 'user-1', tokenHash: 'h', tokenVersion: 1,
+        adminRoleVersion: 0, type: 'socket', scopes: [],
+        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null, createdAt: new Date(),
+        resourceType: null, resourceId: null, driveId: null,
+        user: { id: 'user-1', tokenVersion: 1, role: 'user', adminRoleVersion: 0, suspendedAt: null },
+      });
+
+      const result = await service.validateSession('ps_sock_valid', { expectedType: 'user' });
+
+      expect(result).toBeNull();
+      expect(sessionRepository.revokeByHash).not.toHaveBeenCalled();
+      expect(sessionRepository.touchSession).not.toHaveBeenCalled();
+    });
+
+    it('validateSession_withMatchingExpectedType_returnsClaims', async () => {
+      vi.mocked(isValidTokenFormat).mockReturnValue(true);
+      vi.mocked(sessionRepository.findActiveSession).mockResolvedValue({
+        id: 'sess-1', userId: 'user-1', tokenHash: 'h', tokenVersion: 1,
+        adminRoleVersion: 0, type: 'socket', scopes: [],
+        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null, createdAt: new Date(),
+        resourceType: null, resourceId: null, driveId: null,
+        user: { id: 'user-1', tokenVersion: 1, role: 'user', adminRoleVersion: 0, suspendedAt: null },
+      });
+
+      const result = await service.validateSession('ps_sock_valid', { expectedType: 'socket' });
+
+      expect(result?.type).toBe('socket');
+    });
   });
 
   describe('revokeSession', () => {

--- a/packages/lib/src/auth/__tests__/session-service.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service.test.ts
@@ -265,6 +265,62 @@ describe('Session Service', () => {
     });
   });
 
+  describe('socket tokens (#1054)', () => {
+    it('mints a ps_sock_* token', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
+      });
+
+      expect(token).toMatch(/^ps_sock_/);
+    });
+
+    it('validates a socket token and returns claims with type socket', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
+      });
+
+      const claims = await sessionService.validateSession(token);
+
+      expect(claims).toBeTruthy();
+      expect(claims?.userId).toBe(testUserId);
+      expect(claims?.type).toBe('socket');
+    });
+
+    it('returns null for an expired socket token', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 50,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const claims = await sessionService.validateSession(token);
+      expect(claims).toBeNull();
+    });
+
+    it('returns null for a revoked socket token', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
+      });
+
+      await sessionService.revokeSession(token, 'test');
+
+      const claims = await sessionService.validateSession(token);
+      expect(claims).toBeNull();
+    });
+  });
+
   describe('per-app session scoping', () => {
     async function createWebSession() {
       return sessionService.createSession({

--- a/packages/lib/src/auth/__tests__/session-service.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service.test.ts
@@ -319,6 +319,56 @@ describe('Session Service', () => {
       const claims = await sessionService.validateSession(token);
       expect(claims).toBeNull();
     });
+
+    it('rejects a socket token where a user session is expected (cookie/bearer surface)', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
+      });
+
+      const claims = await sessionService.validateSession(token, { expectedType: 'user' });
+      expect(claims).toBeNull();
+    });
+
+    it('accepts a socket token where a socket session is expected (realtime handshake)', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
+      });
+
+      const claims = await sessionService.validateSession(token, { expectedType: 'socket' });
+      expect(claims?.type).toBe('socket');
+    });
+
+    it('rejects a user session where a socket token is expected', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'user',
+        scopes: ['*'],
+        expiresInMs: 3600000,
+      });
+
+      const claims = await sessionService.validateSession(token, { expectedType: 'socket' });
+      expect(claims).toBeNull();
+    });
+
+    it('type-mismatch rejection does not revoke the token for its own surface', async () => {
+      const token = await sessionService.createSession({
+        userId: testUserId,
+        type: 'socket',
+        scopes: [],
+        expiresInMs: 5 * 60 * 1000,
+      });
+
+      await sessionService.validateSession(token, { expectedType: 'user' });
+
+      const claims = await sessionService.validateSession(token, { expectedType: 'socket' });
+      expect(claims?.type).toBe('socket');
+    });
   });
 
   describe('per-app session scoping', () => {

--- a/packages/lib/src/auth/opaque-tokens.ts
+++ b/packages/lib/src/auth/opaque-tokens.ts
@@ -7,7 +7,7 @@ export interface OpaqueToken {
   tokenPrefix: string;
 }
 
-export type TokenType = 'sess' | 'svc' | 'mcp' | 'dev' | 'at' | 'rt';
+export type TokenType = 'sess' | 'svc' | 'mcp' | 'dev' | 'at' | 'rt' | 'sock';
 
 /**
  * Generate cryptographically secure opaque token
@@ -29,10 +29,10 @@ export function isValidTokenFormat(token: string): boolean {
   if (typeof token !== 'string') return false;
   if (token.length < 40 || token.length > 100) return false;
   if (!token.startsWith('ps_')) return false;
-  return /^ps_(sess|svc|mcp|dev|at|rt)_[A-Za-z0-9_-]+$/.test(token);
+  return /^ps_(sess|svc|mcp|dev|at|rt|sock)_[A-Za-z0-9_-]+$/.test(token);
 }
 
 export function getTokenType(token: string): TokenType | null {
-  const match = token.match(/^ps_(sess|svc|mcp|dev|at|rt)_/);
+  const match = token.match(/^ps_(sess|svc|mcp|dev|at|rt|sock)_/);
   return match ? (match[1] as TokenType) : null;
 }

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -22,7 +22,7 @@ export interface SessionRecord {
   tokenHash: string;
   tokenVersion: number;
   adminRoleVersion: number;
-  type: 'user' | 'service' | 'mcp' | 'device';
+  type: 'user' | 'service' | 'mcp' | 'device' | 'socket';
   scopes: string[];
   expiresAt: Date;
   lastUsedAt: Date | null;

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -73,8 +73,16 @@ export class SessionService {
 
   /**
    * Validate token and return claims - this is the ONLY way to get claims
+   *
+   * `expectedType` scopes the token to one authentication surface: pass it at
+   * every boundary that only serves a single session type (e.g. 'user' for
+   * browser cookie/bearer auth, 'socket' for the Socket.IO handshake) so a
+   * token leaked from one surface cannot be replayed on another.
    */
-  async validateSession(token: string): Promise<SessionClaims | null> {
+  async validateSession(
+    token: string,
+    options?: { expectedType?: SessionClaims['type'] }
+  ): Promise<SessionClaims | null> {
     if (!isValidTokenFormat(token)) {
       return null;
     }
@@ -85,6 +93,12 @@ export class SessionService {
 
     if (!session) return null;
     if (!session.user) return null;
+
+    // Wrong-surface token (e.g. a socket token presented as a session cookie):
+    // reject without side effects — the token stays valid at its own surface.
+    if (options?.expectedType && session.type !== options.expectedType) {
+      return null;
+    }
 
     // Check if user is suspended (administrative action)
     if (session.user.suspendedAt) {

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -11,7 +11,7 @@ export interface SessionClaims {
   userRole: 'user' | 'admin';
   tokenVersion: number;
   adminRoleVersion: number;
-  type: 'user' | 'service' | 'mcp' | 'device';
+  type: 'user' | 'service' | 'mcp' | 'device' | 'socket';
   scopes: string[];
   expiresAt: Date; // When this session expires - critical for enforcing TTL on persistent connections
   resourceType?: string;
@@ -21,7 +21,7 @@ export interface SessionClaims {
 
 export interface CreateSessionOptions {
   userId: string;
-  type: 'user' | 'service' | 'mcp' | 'device';
+  type: 'user' | 'service' | 'mcp' | 'device' | 'socket';
   scopes: string[];
   expiresInMs: number;
   deviceId?: string;
@@ -46,7 +46,8 @@ export class SessionService {
     const tokenType: TokenType =
       options.type === 'service' ? 'svc' :
       options.type === 'mcp' ? 'mcp' :
-      options.type === 'device' ? 'dev' : 'sess';
+      options.type === 'device' ? 'dev' :
+      options.type === 'socket' ? 'sock' : 'sess';
 
     const { token, tokenHash, tokenPrefix } = generateOpaqueToken(tokenType);
 

--- a/packages/lib/src/monitoring/__tests__/activity-tracker.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-tracker.test.ts
@@ -320,7 +320,7 @@ describe('activity-tracker', () => {
       });
       const userId = await getUserIdFromRequest(req);
       expect(userId).toBe('user-123');
-      expect(mockValidateSession).toHaveBeenCalledWith('valid-token-here');
+      expect(mockValidateSession).toHaveBeenCalledWith('valid-token-here', { expectedType: 'user' });
     });
 
     it('should return undefined when validateSession returns null', async () => {
@@ -348,7 +348,7 @@ describe('activity-tracker', () => {
       });
       const userId = await getUserIdFromRequest(req);
       expect(userId).toBe('user-456');
-      expect(mockValidateSession).toHaveBeenCalledWith('my-session-token');
+      expect(mockValidateSession).toHaveBeenCalledWith('my-session-token', { expectedType: 'user' });
     });
   });
 });

--- a/packages/lib/src/monitoring/activity-tracker.ts
+++ b/packages/lib/src/monitoring/activity-tracker.ts
@@ -144,7 +144,7 @@ export async function getUserIdFromRequest(request: Request): Promise<string | u
     const token = cookies.session;
     if (!token) return undefined;
 
-    const sessionClaims = await sessionService.validateSession(token);
+    const sessionClaims = await sessionService.validateSession(token, { expectedType: 'user' });
     return sessionClaims?.userId;
   } catch {
     return undefined;


### PR DESCRIPTION
## Summary

Socket tokens minted a bare `ps_sock_*` string by hand (`randomBytes(24)` + manual `hashToken`) and stored it in a standalone `socket_tokens` table, validated by a separate `validateSocketToken` function in `apps/realtime/src/index.ts` — bypassing the unified `ps_{type}_...` opaque-token model (`packages/lib/src/auth/opaque-tokens.ts` + `session-service.ts`) that every other token type (session, service, mcp, device) goes through. Practical consequence: socket tokens had no revocation path and wouldn't pick up future changes to the shared token model (hash algorithm, audit trail, idle timeout, etc.) automatically.

- `packages/lib/src/auth/opaque-tokens.ts` — added `'sock'` to `TokenType` and to the format/parse regexes.
- `packages/db/src/schema/sessions.ts` — added `'socket'` to the `sessions.type` enum. This is a plain `text` column with no DB-level CHECK constraint, so `bun run db:generate` correctly produced **no migration** — confirmed by running it.
- `packages/lib/src/auth/session-service.ts` / `session-repository.ts` — threaded the new `'socket'` type through `SessionClaims`, `CreateSessionOptions`, and `SessionRecord`; `createSession` now maps `type: 'socket'` → `generateOpaqueToken('sock')`.
- `apps/web/src/app/api/auth/socket-token/route.ts` — now mints via `sessionService.createSession({ userId, type: 'socket', scopes: [], expiresInMs: 5 * 60 * 1000 })` instead of hand-rolling the token and calling `sessionRepository.createSocketToken`. Removed the now-dead `createSocketToken` method from `apps/web/src/lib/repositories/session-repository.ts`.
- `apps/realtime/src/index.ts` — the `ps_sock_*` handshake branch now calls `sessionService.validateSession(token)`, same as the `ps_sess_*` branch below it (kept as separate branches so the log lines / error messages stay distinct per token type). Removed the standalone `validateSocketToken` function and its now-unused `hashToken`/`socketTokens`/`gt` imports.

### Migration decision: deprecate, don't drop, `socket_tokens`

The issue offered two paths. I deprecated the old `socket_tokens` table (added a comment in `packages/db/src/schema/auth.ts`) rather than dropping it in this PR:

- It's no longer written to after this change, so it just goes stale/empty going forward.
- `retention-engine.ts`'s existing `cleanupExpiredSocketTokens` keeps purging any legacy rows for free — no code change needed there, and it's outside this PR's scope (GDPR/compliance code, a separate active workstream).
- Two schema tests (`schema-definitions.test.ts`, `schema-coverage.test.ts`) and a prototype architecture diagram still reference the table/relations; leaving the schema in place means zero collateral changes to those.
- New `'socket'`-typed rows in the unified `sessions` table are already covered by the existing `cleanupExpiredSessions` retention job (deletes by `expiresAt`, type-agnostic).

Follow-up: drop the `socket_tokens` table + its retention-engine cleanup function once confirmed empty in production.

### Update: scoped `ps_sock_*` (and every other non-`user` session type) to its own auth surface

Adding `'sock'` to the generic valid-token regex meant `sessionService.validateSession()` returned claims for socket rows anywhere it was called — including web cookie/bearer auth, CSRF, and admin-app auth — without checking `claims.type`. A leaked `ps_sock_*` value could be replayed as a `Cookie: session=...` for up to 5 minutes and treated as a full session (Codex, P1).

Fixed by giving `validateSession()` an optional `{ expectedType }` that rejects (returns `null`, before any revocation/touch side effect) when the stored session's `type` doesn't match:

- `apps/web/src/lib/auth/index.ts` (`validateSessionToken`, the sole entry point for web cookie/bearer auth), both CSRF validators, `apps/web/src/app/oauth/consent/page.tsx`, `apps/web/src/app/p/[pageId]/page.tsx`, `apps/web/src/app/activate/page.tsx`, `apps/web/src/app/api/auth/logout/route.ts`, and the admin app's equivalents (`apps/admin/src/lib/auth/auth.ts`, `csrf-validation.ts`, `app/api/auth/csrf/route.ts`) — all pass `{ expectedType: 'user' }`.
- `apps/realtime/src/index.ts` — the `ps_sock_*` branch passes `{ expectedType: 'socket' }`, the `ps_sess_*` branch passes `{ expectedType: 'user' }`.
- `apps/processor/src/middleware/auth.ts` — migrated its pre-existing manual `claims.type !== 'service'` check to `{ expectedType: 'service' }` (one enforcement mechanism instead of two).
- `packages/lib/src/monitoring/activity-tracker.ts` — scoped to `'user'`.

Verified but deliberately not changed: `mcp-ws/route.ts`/`ws-connections.ts` (intentionally multi-type, scope-gated; socket tokens mint `scopes: []` so they can't pass regardless) and ~9 login routes that validate a token immediately after minting it themselves as `type: 'user'` (not attacker-controlled input).

## Test plan
- [x] `bun run --filter '@pagespace/lib' typecheck`, `--filter '@pagespace/db' typecheck`, `--filter 'realtime' typecheck`, `--filter 'web' typecheck` — all pass
- [x] `bun run db:generate` against latest `master` (branch already based on current master HEAD) — no migration generated, as expected for a plain `text` enum column
- [x] `packages/lib/src/auth/__tests__/opaque-tokens.test.ts` — added `sock` format/parse/generate coverage
- [x] `packages/lib/src/auth/__tests__/session-service-unit.test.ts` — added `createSession_withSocketType_generatesTokenWithSockPrefix`
- [x] `packages/lib/src/auth/__tests__/session-service.test.ts` (real DB) — added mint/validate/expire/revoke lifecycle tests for socket tokens (20/20 pass)
- [x] `apps/realtime/src/__tests__/index.test.ts` — updated the `ps_sock_*` handshake tests to mock `sessionService.validateSession` instead of the old DB query mock (89/89 pass)
- [x] `apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts` — updated to mock `sessionService.createSession` (6/6 pass)
- [x] `eslint` on all changed files — clean
- [x] `bun run --filter 'admin' typecheck`, `--filter '@pagespace/processor' typecheck` — pass
- [x] `apps/admin/src/lib/auth/__tests__/auth.test.ts` (new) — expectedType scoping for admin session cookie
- [x] `apps/processor/tests/auth-middleware.test.ts` — updated for the `expectedType: 'service'` migration
- [x] Full `admin`, `@pagespace/processor`, `realtime` test suites — pass (5 pre-existing `processing-pipeline.test.ts` ELF-detection failures are unrelated to auth and reproduce on `origin/master`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQrHKmW9dd5dRjYxksw1YZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for socket-based sessions and tokens, including a new `ps_sock_*` token format.
  * Socket authentication now uses the unified session flow, with a consistent 5-minute lifetime.

* **Bug Fixes**
  * Improved login and reconnect handling for socket tokens.
  * Expired or revoked socket tokens now correctly fail validation.

* **Documentation**
  * Clarified that legacy socket token storage is deprecated in favor of sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
