### PR TITLE
fix(theme): close mobile dark-mode init race, harden navbar repaint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   `@pagespace/cli`). It keeps working exactly as before — same tools, same env vars — and now
   prints a one-line migration notice to stderr. See the
   [migration guide](packages/cli/docs/migrating-from-pagespace-mcp.md).
+
+### Fixed
+
+- On mobile, the app no longer loads in the wrong theme and switches after first paint — a race
+  that could leave the navbar "half stuck" in the previous theme's colors on iOS/Android WebKit.
+  The saved theme is now resolved server-side before the first render, and theme toggles force the
+  translucent "liquid glass" surfaces to repaint.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,6 +55,10 @@ svg.lucide {
 }
 
 :root {
+  /* Keep native UI (scrollbars, form controls, overscroll canvas) in step
+     with the theme from the very first server-rendered paint — next-themes
+     only sets an inline color-scheme once its script runs. */
+  color-scheme: light;
   --radius: 0.625rem;
 
   /* iOS Safe Area Support */
@@ -126,6 +130,7 @@ svg.lucide {
 }
 
 .dark {
+  color-scheme: dark;
   --radius: 0.625rem;
   --background: oklch(0.15 0 0);
   --foreground: oklch(0.94 0 0);
@@ -292,13 +297,18 @@ svg.lucide {
 
 @layer components {
   /* Liquid Glass Utilities */
-  /* `transform: translateZ(0)` promotes each surface to its own compositing
+  /* `transform: translateZ(0)` promotes the surface to its own compositing
      layer. Mobile WebKit has a long-standing bug where a `backdrop-filter`
-     element (especially combined with `position: sticky`, e.g. the navbar)
-     doesn't repaint its blurred background after an ancestor's `.dark` class
-     toggles — it keeps showing the previous theme's colors until something
-     else forces a repaint. Layer promotion up front makes that repaint
-     reliable; see also GlassRepaintFix in ThemeProvider.tsx for a runtime nudge. */
+     element combined with `position: sticky` (the navbar and document header
+     — the surfaces users reported stuck in the old theme) doesn't repaint
+     its blurred background after an ancestor's `.dark` class toggles.
+     Layer promotion up front makes that repaint reliable; see also
+     GlassRepaintFix in ThemeProvider.tsx for a runtime nudge.
+     Deliberately scoped to `-thin` (the only sticky surfaces): promoting the
+     large non-sticky sidebars would cost permanent layer memory on mobile,
+     and `transform` turns each surface into a containing block for
+     `position: fixed` descendants — a layout hazard the sticky navbar
+     doesn't share. */
   .liquid-glass-thin {
     background: var(--material-thin);
     backdrop-filter: blur(20px) saturate(180%);
@@ -318,7 +328,6 @@ svg.lucide {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.6),
       var(--shadow-elevated);
-    transform: translateZ(0);
   }
 
   /* Dark Mode Glossy Gradient */
@@ -333,14 +342,12 @@ svg.lucide {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.03),
       var(--shadow-elevated);
-    transform: translateZ(0);
   }
 
   .liquid-glass-thick {
     background: var(--material-thick);
     backdrop-filter: blur(32px) saturate(190%);
     -webkit-backdrop-filter: blur(32px) saturate(190%);
-    transform: translateZ(0);
   }
 
   /* Reduced transparency support */
@@ -352,6 +359,9 @@ svg.lucide {
       backdrop-filter: none;
       -webkit-backdrop-filter: none;
       box-shadow: none;
+      /* No blur here, so no WebKit repaint bug — don't pay for a permanent
+         compositing layer on the devices most likely to use this setting. */
+      transform: none;
     }
   }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -292,10 +292,18 @@ svg.lucide {
 
 @layer components {
   /* Liquid Glass Utilities */
+  /* `transform: translateZ(0)` promotes each surface to its own compositing
+     layer. Mobile WebKit has a long-standing bug where a `backdrop-filter`
+     element (especially combined with `position: sticky`, e.g. the navbar)
+     doesn't repaint its blurred background after an ancestor's `.dark` class
+     toggles — it keeps showing the previous theme's colors until something
+     else forces a repaint. Layer promotion up front makes that repaint
+     reliable; see also GlassRepaintFix in ThemeProvider.tsx for a runtime nudge. */
   .liquid-glass-thin {
     background: var(--material-thin);
     backdrop-filter: blur(20px) saturate(180%);
     -webkit-backdrop-filter: blur(20px) saturate(180%);
+    transform: translateZ(0);
   }
 
   /* Light Mode Glossy Gradient */
@@ -310,6 +318,7 @@ svg.lucide {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.6),
       var(--shadow-elevated);
+    transform: translateZ(0);
   }
 
   /* Dark Mode Glossy Gradient */
@@ -324,12 +333,14 @@ svg.lucide {
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.03),
       var(--shadow-elevated);
+    transform: translateZ(0);
   }
 
   .liquid-glass-thick {
     background: var(--material-thick);
     backdrop-filter: blur(32px) saturate(190%);
     -webkit-backdrop-filter: blur(32px) saturate(190%);
+    transform: translateZ(0);
   }
 
   /* Reduced transparency support */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -172,6 +172,11 @@ export default async function RootLayout({
           defaultTheme={initialTheme ?? "system"}
           enableSystem
           disableTransitionOnChange
+          // Without the nonce, the enforced CSP (nonce + strict-dynamic, see
+          // security-headers.ts) blocks next-themes' inline pre-hydration
+          // script in production — theme would only apply after hydration,
+          // recreating the late post-paint switch this PR removes.
+          nonce={nonce}
         >
           <ClientTrackingProvider />
           {children}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { connection } from "next/server";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "@/styles/editor-readonly.css";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
+import { THEME_COOKIE_NAME } from "@/lib/theme-cookie";
 import ClientTrackingProvider from "@/components/providers/ClientTrackingProvider";
 import ConsentProvider from "@/components/providers/ConsentProvider";
 import { Toaster } from "@/components/ui/sonner";
@@ -81,8 +82,22 @@ export default async function RootLayout({
   const requestHeaders = await headers();
   const nonce = requestHeaders.get(NONCE_HEADER) ?? undefined;
 
+  // Resolve the initial theme from the cookie server-side so the very first
+  // render (and next-themes' pre-hydration script, via defaultTheme) already
+  // agrees with it. Previously this only happened client-side, after mount —
+  // a real post-paint theme switch that mobile WebKit doesn't always repaint
+  // cleanly on `backdrop-filter` surfaces like the navbar (issues #1155, #1202).
+  const cookieStore = await cookies();
+  const themeCookie = cookieStore.get(THEME_COOKIE_NAME)?.value;
+  const initialTheme =
+    themeCookie === "dark" || themeCookie === "light" ? themeCookie : undefined;
+
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={initialTheme === "dark" ? "dark" : undefined}
+    >
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
@@ -154,7 +169,7 @@ export default async function RootLayout({
         />
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme={initialTheme ?? "system"}
           enableSystem
           disableTransitionOnChange
         >

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -13,20 +13,43 @@ import { syncThemeToCookie } from "@/lib/theme-cookie";
 // theme switch (not just a settle) and mobile WebKit can fail to repaint
 // `backdrop-filter` surfaces (e.g. the navbar) when it happens — see
 // GlassRepaintFix below.
+//
+// The cookie is a strict mirror of next-themes' state, "system" included.
+// Skipping "system" would leave a stale "dark"/"light" cookie behind when a
+// user switches back to system: the server would then paint the stale theme
+// and the client would flip it after hydration — the exact post-paint switch
+// this PR removes. (layout.tsx treats any value other than "dark"/"light"
+// as "no explicit theme".)
+//
+// localStorage is mirrored too: when the theme came from the cookie alone
+// (fresh device via defaultTheme, see layout.tsx), next-themes never writes
+// its storage key — only setTheme does — and Safari's ITP expires
+// script-written cookies after ~7 days, so without this the preference
+// would silently reset. Writing storage directly is invisible, unlike the
+// setTheme call this PR removed.
+const THEME_STORAGE_KEY = "theme"; // next-themes' default storageKey
+
 function ThemeCookieSync() {
   const { theme } = useTheme();
 
   React.useEffect(() => {
-    if (theme && theme !== "system") {
-      syncThemeToCookie(theme);
+    if (!theme) return;
+    syncThemeToCookie(theme);
+    try {
+      if (localStorage.getItem(THEME_STORAGE_KEY) !== theme) {
+        localStorage.setItem(THEME_STORAGE_KEY, theme);
+      }
+    } catch {
+      // Storage unavailable (private mode / blocked) — cookie still covers us.
     }
   }, [theme]);
 
   return null;
 }
 
-const GLASS_SELECTOR =
-  ".liquid-glass-thin, .liquid-glass-regular, .liquid-glass-thick";
+// Attribute match rather than an explicit class list so future glass
+// variants added in globals.css are covered without touching this file.
+const GLASS_SELECTOR = '[class*="liquid-glass-"]';
 
 // Mobile WebKit has a known bug: elements combining `position: sticky` with
 // `backdrop-filter` (our "liquid glass" surfaces — the navbar is the one
@@ -46,19 +69,47 @@ function GlassRepaintFix() {
   React.useEffect(() => {
     const html = document.documentElement;
     let wasDark = html.classList.contains("dark");
+    let restore: (() => void) | null = null;
+    let frame = 0;
+
     const observer = new MutationObserver(() => {
       const isDark = html.classList.contains("dark");
       if (isDark === wasDark) return;
       wasDark = isDark;
-      document.querySelectorAll<HTMLElement>(GLASS_SELECTOR).forEach((el) => {
-        const prevTransform = el.style.transform;
+      // Finish any in-flight nudge first so we never capture our own
+      // perturbed transform as the value to restore.
+      if (restore) {
+        cancelAnimationFrame(frame);
+        restore();
+      }
+      const els = Array.from(
+        document.querySelectorAll<HTMLElement>(GLASS_SELECTOR)
+      );
+      const prevTransforms = els.map((el) => el.style.transform);
+      els.forEach((el) => {
         el.style.transform = "translateZ(0.01px)";
-        void el.offsetHeight;
-        el.style.transform = prevTransform;
       });
+      restore = () => {
+        els.forEach((el, i) => {
+          el.style.transform = prevTransforms[i];
+        });
+        restore = null;
+      };
+      // Restore on the next frame, not synchronously: transform is
+      // layout-inert, so a same-task set-and-restore is a net style no-op by
+      // paint time and the compositor may skip the recomposite entirely. The
+      // perturbed value must survive to one real paint. (translateZ has no
+      // visual effect without perspective, so the held frame is invisible.)
+      frame = requestAnimationFrame(restore);
     });
     observer.observe(html, { attributes: true, attributeFilter: ["class"] });
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (restore) {
+        cancelAnimationFrame(frame);
+        restore();
+      }
+    };
   }, []);
 
   return null;

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -3,20 +3,18 @@
 import * as React from "react";
 import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
 import { type ThemeProviderProps } from "next-themes";
-import { syncThemeToCookie, getThemeFromCookie } from "@/lib/theme-cookie";
+import { syncThemeToCookie } from "@/lib/theme-cookie";
 
+// Theme resolution now happens once, before paint: the server reads the
+// `theme` cookie and passes it as `defaultTheme` (see layout.tsx), so
+// next-themes' own pre-hydration script resolves the right theme on the
+// first pass. Writing the cookie back on change is all this needs to do —
+// it must NOT call `setTheme` after mount, since that's a real, visible
+// theme switch (not just a settle) and mobile WebKit can fail to repaint
+// `backdrop-filter` surfaces (e.g. the navbar) when it happens — see
+// GlassRepaintFix below.
 function ThemeCookieSync() {
-  const { theme, setTheme } = useTheme();
-
-  React.useEffect(() => {
-    const stored = localStorage.getItem("theme");
-    if (!stored) {
-      const cookieTheme = getThemeFromCookie();
-      if (cookieTheme) {
-        setTheme(cookieTheme);
-      }
-    }
-  }, [setTheme]);
+  const { theme } = useTheme();
 
   React.useEffect(() => {
     if (theme && theme !== "system") {
@@ -27,10 +25,64 @@ function ThemeCookieSync() {
   return null;
 }
 
+const GLASS_SELECTOR =
+  ".liquid-glass-thin, .liquid-glass-regular, .liquid-glass-thick";
+
+// Mobile WebKit has a known bug: elements combining `position: sticky` with
+// `backdrop-filter` (our "liquid glass" surfaces — the navbar is the one
+// users have reported this on) can keep painting the previous theme's
+// background after `.dark` toggles on <html>, since the compositor doesn't
+// always know to recomposite a blurred layer when only the color underneath
+// changed. Nudge a reflow on those elements whenever the resolved theme
+// actually changes, so Safari is forced to repaint them.
+function GlassRepaintFix() {
+  const { resolvedTheme } = useTheme();
+  const hasMounted = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
+    document.querySelectorAll<HTMLElement>(GLASS_SELECTOR).forEach((el) => {
+      const prevTransform = el.style.transform;
+      el.style.transform = "translateZ(0.01px)";
+      void el.offsetHeight;
+      el.style.transform = prevTransform;
+    });
+  }, [resolvedTheme]);
+
+  return null;
+}
+
+// Instrumentation for the reported "navbar stuck in the wrong theme" bug: if
+// <html>'s class ever drifts from what next-themes thinks the resolved theme
+// is, log it so a future report comes with the data needed to pin down the
+// cause instead of "couldn't reproduce".
+function ThemeMismatchGuard() {
+  const { resolvedTheme } = useTheme();
+
+  React.useEffect(() => {
+    if (!resolvedTheme) return;
+    const hasDarkClass = document.documentElement.classList.contains("dark");
+    const expectedDark = resolvedTheme === "dark";
+    if (hasDarkClass !== expectedDark) {
+      console.warn(
+        "[theme] <html> class is out of sync with resolvedTheme — UI may look stuck in the wrong theme until the next toggle.",
+        { resolvedTheme, hasDarkClass }
+      );
+    }
+  }, [resolvedTheme]);
+
+  return null;
+}
+
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return (
     <NextThemesProvider {...props}>
       <ThemeCookieSync />
+      <GlassRepaintFix />
+      <ThemeMismatchGuard />
       {children}
     </NextThemesProvider>
   );

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -33,24 +33,33 @@ const GLASS_SELECTOR =
 // users have reported this on) can keep painting the previous theme's
 // background after `.dark` toggles on <html>, since the compositor doesn't
 // always know to recomposite a blurred layer when only the color underneath
-// changed. Nudge a reflow on those elements whenever the resolved theme
+// changed. Nudge a reflow on those elements whenever <html>'s theme class
 // actually changes, so Safari is forced to repaint them.
+//
+// A MutationObserver (rather than a React effect on `resolvedTheme`) is
+// deliberate: React flushes this child's effects *before* next-themes'
+// provider effect mutates <html class>, so an effect here would force the
+// reflow while the old class was still applied and fix nothing. Observing
+// the DOM fires strictly after the class change, and also covers switches
+// React never initiates (OS theme change, `storage` events from other tabs).
 function GlassRepaintFix() {
-  const { resolvedTheme } = useTheme();
-  const hasMounted = React.useRef(false);
-
   React.useEffect(() => {
-    if (!hasMounted.current) {
-      hasMounted.current = true;
-      return;
-    }
-    document.querySelectorAll<HTMLElement>(GLASS_SELECTOR).forEach((el) => {
-      const prevTransform = el.style.transform;
-      el.style.transform = "translateZ(0.01px)";
-      void el.offsetHeight;
-      el.style.transform = prevTransform;
+    const html = document.documentElement;
+    let wasDark = html.classList.contains("dark");
+    const observer = new MutationObserver(() => {
+      const isDark = html.classList.contains("dark");
+      if (isDark === wasDark) return;
+      wasDark = isDark;
+      document.querySelectorAll<HTMLElement>(GLASS_SELECTOR).forEach((el) => {
+        const prevTransform = el.style.transform;
+        el.style.transform = "translateZ(0.01px)";
+        void el.offsetHeight;
+        el.style.transform = prevTransform;
+      });
     });
-  }, [resolvedTheme]);
+    observer.observe(html, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
 
   return null;
 }
@@ -64,14 +73,20 @@ function ThemeMismatchGuard() {
 
   React.useEffect(() => {
     if (!resolvedTheme) return;
-    const hasDarkClass = document.documentElement.classList.contains("dark");
-    const expectedDark = resolvedTheme === "dark";
-    if (hasDarkClass !== expectedDark) {
-      console.warn(
-        "[theme] <html> class is out of sync with resolvedTheme — UI may look stuck in the wrong theme until the next toggle.",
-        { resolvedTheme, hasDarkClass }
-      );
-    }
+    // Defer the check one frame: this child effect runs before next-themes'
+    // provider effect has applied the new class to <html>, so a synchronous
+    // read would report a "mismatch" on every legitimate toggle.
+    const frame = requestAnimationFrame(() => {
+      const hasDarkClass = document.documentElement.classList.contains("dark");
+      const expectedDark = resolvedTheme === "dark";
+      if (hasDarkClass !== expectedDark) {
+        console.warn(
+          "[theme] <html> class is out of sync with resolvedTheme — UI may look stuck in the wrong theme until the next toggle.",
+          { resolvedTheme, hasDarkClass }
+        );
+      }
+    });
+    return () => cancelAnimationFrame(frame);
   }, [resolvedTheme]);
 
   return null;

--- a/apps/web/src/lib/theme-cookie.ts
+++ b/apps/web/src/lib/theme-cookie.ts
@@ -1,13 +1,9 @@
-const COOKIE_NAME = "theme";
+export const THEME_COOKIE_NAME = "theme";
+const COOKIE_NAME = THEME_COOKIE_NAME;
 const MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
 export function syncThemeToCookie(theme: string) {
   const cookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
   const domain = cookieDomain ? `; domain=${cookieDomain}` : "";
   document.cookie = `${COOKIE_NAME}=${theme}; path=/; max-age=${MAX_AGE}; SameSite=Lax${domain}`;
-}
-
-export function getThemeFromCookie(): string | null {
-  const match = document.cookie.match(new RegExp(`(?:^|; )${COOKIE_NAME}=([^;]*)`));
-  return match ? match[1] : null;
 }

--- a/apps/web/src/lib/theme-cookie.ts
+++ b/apps/web/src/lib/theme-cookie.ts
@@ -1,9 +1,8 @@
 export const THEME_COOKIE_NAME = "theme";
-const COOKIE_NAME = THEME_COOKIE_NAME;
 const MAX_AGE = 60 * 60 * 24 * 365; // 1 year
 
 export function syncThemeToCookie(theme: string) {
   const cookieDomain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
   const domain = cookieDomain ? `; domain=${cookieDomain}` : "";
-  document.cookie = `${COOKIE_NAME}=${theme}; path=/; max-age=${MAX_AGE}; SameSite=Lax${domain}`;
+  document.cookie = `${THEME_COOKIE_NAME}=${theme}; path=/; max-age=${MAX_AGE}; SameSite=Lax${domain}`;
 }


### PR DESCRIPTION
## Investigation

Both #1155 and #1202 report the same symptom on mobile: the navbar appears
"half stuck in light mode" while the rest of the app is dark, and the
background "is not even black" — described as if colors got swapped. Both
reporters (and Jono) could not reproduce it consistently.

**Ruled out:** `globals.css`'s `:root` / `.dark` variable sets — checked
every value, nothing is swapped or duplicated. `ThemeProvider.tsx`'s
`next-themes` config (`attribute="class"`, `defaultTheme="system"`,
`enableSystem`, `disableTransitionOnChange`) is standard and correct.

**Root causes found (two independent ones):**

1. **CSP was blocking next-themes' pre-hydration script in production.**
   The app enforces `script-src 'nonce-…' 'strict-dynamic'`
   (`security-headers.ts`), which makes browsers ignore the
   `'unsafe-inline'` fallback — and `next-themes`' inline theme script was
   rendered without a nonce. So the theme was only ever applied in
   next-themes' React effect, **after hydration**: on a slow mobile device
   that's seconds of wrong-theme UI followed by a late `<html>` class flip.
2. **`ThemeCookieSync` ran a post-mount `setTheme()`** whenever
   `localStorage` had no `"theme"` key but a `theme` cookie existed (e.g. a
   returning user on a fresh device/browser profile). Another real,
   *visible* theme switch firing after first paint.

Mobile WebKit has a documented compositing quirk: elements combining
`position: sticky` with `backdrop-filter` (our `liquid-glass-*` utility
classes — the navbar uses `liquid-glass-thin`) don't always repaint their
blurred background when an ancestor's class changes out from under them
post-paint. The stale composited layer keeps showing the old theme's
colors, blended with the new content behind it — which matches "half stuck
in light mode" and "background not even black" (a blend of stale-light +
new-dark, not a clean either/or). Both root causes above produce exactly
that kind of post-paint class flip.

## Fixes

- **Un-block the pre-hydration script** (`layout.tsx`): pass the request's
  CSP `nonce` through to `next-themes`, so its inline script actually runs
  and resolves the theme before first paint.
- **Close the init race at the source** (`layout.tsx`): read the `theme`
  cookie server-side, pass it as next-themes' `defaultTheme`, and set the
  class directly on `<html>` — the server's first paint already agrees
  with the stored preference; there's no longer a legitimate reason for a
  post-mount `setTheme()` call.
- **Cookie and localStorage are now strict mirrors of next-themes state**
  (`ThemeProvider.tsx`): the cookie is written for every theme change
  including `"system"` (a skipped `"system"` write would leave a stale
  `dark`/`light` cookie that the server now trusts on every load), and the
  storage key is mirrored too (with the `setTheme()` call gone, a
  cookie-only visitor would otherwise never get localStorage seeded, and
  Safari ITP expires script-written cookies after ~7 days).
- **Defense for real theme toggles** (`GlassRepaintFix`): a
  `MutationObserver` on `<html>`'s `class` attribute nudges the
  `.liquid-glass-*` surfaces to recomposite whenever the theme class
  actually changes. Per Codex review, a React effect on `resolvedTheme`
  would flush *before* next-themes' provider effect mutates the class; the
  observer fires strictly after, and also covers OS theme changes and
  cross-tab switches. The perturbed transform is held for one animation
  frame (a same-task set-and-restore is a net style no-op the compositor
  may skip; `translateZ` is invisible without perspective).
- `globals.css`: `transform: translateZ(0)` promotes `.liquid-glass-thin`
  (the sticky navbar/doc-header surfaces from the reports) to its own
  compositing layer up front. Deliberately *not* applied to the large
  non-sticky sidebar surfaces — permanent layer memory on mobile plus the
  containing-block-for-`fixed`-descendants hazard aren't worth it where
  the bug doesn't occur — and reset under
  `prefers-reduced-transparency`, where there's no blur to repaint.
- `globals.css`: declare `color-scheme` (`:root` light / `.dark` dark) so
  native UI — scrollbars, form controls, the overscroll canvas — matches
  the theme from the first server-rendered paint instead of waiting for
  next-themes to set it inline.
- **Instrumentation** (`ThemeMismatchGuard`): logs a console warning if
  `<html>`'s class ever drifts from what next-themes thinks the resolved
  theme is (checked one frame deferred, after the provider has applied the
  class), so a future report comes with data instead of "couldn't
  reproduce" — retrievable on-device via Safari Web Inspector.

## Limitations / follow-ups

- I could not get a live mobile-Safari repro in this sandbox: booting the
  full app needs Postgres/Docker services not available here, and the
  underlying WebKit compositing behavior doesn't reproduce in desktop
  Chrome's mobile emulation. The CSP finding, however, is verifiable by
  inspection (un-nonced inline script + `strict-dynamic` policy) and
  reproduces the reported symptom class by construction.
- `apps/marketing` has a byte-for-byte fork of the old theme-cookie
  machinery (including the post-mount `setTheme()` pattern removed here)
  sharing the same cross-subdomain cookie. Fixing it the same way — and
  extracting a shared module — is a follow-up; this PR keeps its blast
  radius to the web app the issues were reported against.

Addresses #1155, #1202

## Test plan

- [x] `bun run --filter web typecheck` — clean
- [x] `bun run --filter web lint` — clean (pre-existing warnings elsewhere, unrelated)
- [ ] Manual verification on a real iOS/Android device or Safari, toggling
      theme and reloading mid-transition, especially around the navbar
- [ ] Verify in prod devtools that the next-themes inline script now
      executes (no CSP violation report for it) and `<html>` has the right
      class before first paint
