### PR TITLE
feat(web): persist chat attachments to S3 instead of inline base64

### DIFF
--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -123,7 +123,7 @@ export async function PATCH(
         const updated = await chatMessageRepository.getMessageById(messageId);
         if (!updated) return;
         const triggeredBy = await resolveTriggeredBy(userId, request);
-        const uiMessage = convertDbMessageToUIMessage(updated);
+        const uiMessage = await convertDbMessageToUIMessage(updated);
         await broadcastAiMessageEdited({
           messageId,
           pageId: message.pageId,

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
     );
 
     // Convert to UIMessage format with tool calls and results
-    const messages = dbMessages.map(convertDbMessageToUIMessage);
+    const messages = await Promise.all(dbMessages.map(convertDbMessageToUIMessage));
 
     auditRequest(request, { eventType: 'data.read', userId: auth.userId, resourceType: 'message', resourceId: pageId, details: {
       source: 'ai-chat',

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -906,7 +906,7 @@ export async function POST(request: Request) {
       ))
       .orderBy(chatMessages.createdAt);
 
-    const conversationHistory: UIMessage[] = dbMessages.map(msg =>
+    const conversationHistory: UIMessage[] = await Promise.all(dbMessages.map(msg =>
       convertDbMessageToUIMessage({
         id: msg.id,
         pageId: msg.pageId,
@@ -920,7 +920,7 @@ export async function POST(request: Request) {
         editedAt: msg.editedAt,
         messageType: msg.messageType === 'todo_list' ? 'todo_list' : 'standard',
       })
-    );
+    ));
 
     loggers.ai.debug('AI Chat API: Loaded conversation from database', {
       messageCount: conversationHistory.length,

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -170,7 +170,7 @@ export async function GET(
     const orderedMessages = messagesToReturn.reverse();
 
     // Convert to UIMessage format with proper tool call reconstruction
-    const uiMessages = orderedMessages.map(msg =>
+    const uiMessages = await Promise.all(orderedMessages.map(msg =>
       convertGlobalAssistantMessageToUIMessage({
         id: msg.id,
         conversationId: msg.conversationId,
@@ -183,7 +183,7 @@ export async function GET(
         isActive: msg.isActive,
         editedAt: msg.editedAt,
       })
-    );
+    ));
 
     // Determine cursors for pagination
     const nextCursor = hasMore && orderedMessages.length > 0
@@ -517,7 +517,7 @@ export async function POST(
       .orderBy(messages.createdAt);
 
     // Convert database messages to UI format
-    const conversationHistory = dbMessages.map(msg =>
+    const conversationHistory = await Promise.all(dbMessages.map(msg =>
       convertGlobalAssistantMessageToUIMessage({
         id: msg.id,
         conversationId: msg.conversationId,
@@ -530,7 +530,7 @@ export async function POST(
         isActive: msg.isActive,
         editedAt: msg.editedAt,
       })
-    );
+    ));
 
     loggers.api.debug('Global Assistant Chat API: Loaded conversation history from database', {
       messageCount: conversationHistory.length,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -105,7 +105,7 @@ export async function PATCH(
         const updated = await chatMessageRepository.getMessageById(messageId);
         if (!updated) return;
         const triggeredBy = await resolveTriggeredBy(userId, request);
-        const uiMessage = convertDbMessageToUIMessage(updated);
+        const uiMessage = await convertDbMessageToUIMessage(updated);
         await broadcastAiMessageEdited({
           messageId,
           pageId: agentId,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -171,7 +171,7 @@ export async function GET(
     const orderedMessages = messagesToReturn.reverse();
 
     // Convert to UIMessage format
-    const messages = orderedMessages.map(convertDbMessageToUIMessage);
+    const messages = await Promise.all(orderedMessages.map(convertDbMessageToUIMessage));
 
     // Determine cursors for pagination
     const nextCursor = hasMore && orderedMessages.length > 0

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -291,7 +291,7 @@ export async function POST(request: Request): Promise<Response> {
     let inferenceMessages = messages;
     if (isThreadMode && !clientManagesHistory) {
       const dbMessages = await chatMessageRepository.getMessagesForPage(pageId, conversationId);
-      inferenceMessages = [...dbMessages.map(convertDbMessageToUIMessage), userMessage];
+      inferenceMessages = [...await Promise.all(dbMessages.map(convertDbMessageToUIMessage)), userMessage];
     }
 
     // Back-fill: when the client manages full history, persist tool results that arrived

--- a/apps/web/src/lib/ai/core/__tests__/message-utils-data-parts.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils-data-parts.test.ts
@@ -19,9 +19,9 @@ const commandPart = {
 const textPart = { type: 'text' as const, text: 'On it.' };
 
 describe('extractStructuredContentFromParts — data parts', () => {
-  it('captures data-* part payloads and records them in partsOrder', () => {
+  it('captures data-* part payloads and records them in partsOrder', async () => {
     const structured = JSON.parse(
-      extractStructuredContentFromParts([commandPart, textPart], 'On it.')
+      await extractStructuredContentFromParts([commandPart, textPart], 'On it.')
     );
 
     expect(structured.partsOrder).toEqual([
@@ -37,16 +37,16 @@ describe('extractStructuredContentFromParts — data parts', () => {
     ]);
   });
 
-  it('omits the dataParts field when there are none', () => {
-    const structured = JSON.parse(extractStructuredContentFromParts([textPart], 'On it.'));
+  it('omits the dataParts field when there are none', async () => {
+    const structured = JSON.parse(await extractStructuredContentFromParts([textPart], 'On it.'));
     expect(structured.dataParts).toBeUndefined();
   });
 });
 
 describe('convertDbMessageToUIMessage — data parts', () => {
-  it('reconstructs persisted data-* parts in their original position', () => {
-    const content = extractStructuredContentFromParts([commandPart, textPart], 'On it.');
-    const reconstructed = convertDbMessageToUIMessage({
+  it('reconstructs persisted data-* parts in their original position', async () => {
+    const content = await extractStructuredContentFromParts([commandPart, textPart], 'On it.');
+    const reconstructed = await convertDbMessageToUIMessage({
       id: 'm1',
       pageId: 'p1',
       userId: null,
@@ -68,8 +68,8 @@ describe('convertDbMessageToUIMessage — data parts', () => {
     ]);
   });
 
-  it('still reconstructs legacy structured content without dataParts', () => {
-    const reconstructed = convertDbMessageToUIMessage({
+  it('still reconstructs legacy structured content without dataParts', async () => {
+    const reconstructed = await convertDbMessageToUIMessage({
       id: 'm1',
       pageId: 'p1',
       userId: null,

--- a/apps/web/src/lib/ai/core/__tests__/message-utils-file-parts.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils-file-parts.test.ts
@@ -19,7 +19,7 @@ describe('convertDbMessageToUIMessage with file parts', () => {
     toolResults: null,
   };
 
-  it('given structured content with file parts, should reconstruct file parts in order', () => {
+  it('given structured content with file parts, should reconstruct file parts in order', async () => {
     const structuredContent = JSON.stringify({
       textParts: ['Look at this image:'],
       fileParts: [
@@ -32,7 +32,7 @@ describe('convertDbMessageToUIMessage with file parts', () => {
       originalContent: 'Look at this image:',
     });
 
-    const result = convertDbMessageToUIMessage({
+    const result = await convertDbMessageToUIMessage({
       ...baseMeta,
       content: structuredContent,
     });
@@ -47,7 +47,7 @@ describe('convertDbMessageToUIMessage with file parts', () => {
     });
   });
 
-  it('given multiple interleaved text and file parts, should preserve ordering', () => {
+  it('given multiple interleaved text and file parts, should preserve ordering', async () => {
     const structuredContent = JSON.stringify({
       textParts: ['First text', 'Second text'],
       fileParts: [
@@ -63,7 +63,7 @@ describe('convertDbMessageToUIMessage with file parts', () => {
       originalContent: 'First text Second text',
     });
 
-    const result = convertDbMessageToUIMessage({
+    const result = await convertDbMessageToUIMessage({
       ...baseMeta,
       content: structuredContent,
     });
@@ -84,8 +84,8 @@ describe('convertDbMessageToUIMessage with file parts', () => {
     expect(filePart2.filename).toBe('chart.png');
   });
 
-  it('given plain text content (no structured data), should return single text part', () => {
-    const result = convertDbMessageToUIMessage({
+  it('given plain text content (no structured data), should return single text part', async () => {
+    const result = await convertDbMessageToUIMessage({
       ...baseMeta,
       content: 'Just plain text',
     });
@@ -94,14 +94,14 @@ describe('convertDbMessageToUIMessage with file parts', () => {
     expect(result.parts[0]).toEqual({ type: 'text', text: 'Just plain text' });
   });
 
-  it('given structured content without fileParts, should handle backward compatibility', () => {
+  it('given structured content without fileParts, should handle backward compatibility', async () => {
     const structuredContent = JSON.stringify({
       textParts: ['Hello world'],
       partsOrder: [{ index: 0, type: 'text' }],
       originalContent: 'Hello world',
     });
 
-    const result = convertDbMessageToUIMessage({
+    const result = await convertDbMessageToUIMessage({
       ...baseMeta,
       content: structuredContent,
     });
@@ -110,7 +110,7 @@ describe('convertDbMessageToUIMessage with file parts', () => {
     expect(result.parts[0]).toEqual({ type: 'text', text: 'Hello world' });
   });
 
-  it('given structured content with file parts but missing optional fields, should handle gracefully', () => {
+  it('given structured content with file parts but missing optional fields, should handle gracefully', async () => {
     const structuredContent = JSON.stringify({
       textParts: [],
       fileParts: [
@@ -122,7 +122,7 @@ describe('convertDbMessageToUIMessage with file parts', () => {
       originalContent: '',
     });
 
-    const result = convertDbMessageToUIMessage({
+    const result = await convertDbMessageToUIMessage({
       ...baseMeta,
       content: structuredContent,
     });
@@ -135,8 +135,8 @@ describe('convertDbMessageToUIMessage with file parts', () => {
     expect(filePart.filename).toBeUndefined();
   });
 
-  it('given null content, should return empty text part', () => {
-    const result = convertDbMessageToUIMessage({
+  it('given null content, should return empty text part', async () => {
+    const result = await convertDbMessageToUIMessage({
       ...baseMeta,
       content: null as unknown as string,
     });

--- a/apps/web/src/lib/ai/core/__tests__/message-utils-storage-attachments.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils-storage-attachments.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UIMessage } from 'ai';
+
+const mockUploadChatAttachment = vi.fn();
+const mockGetChatAttachmentUrl = vi.fn();
+
+vi.mock('@/lib/upload/chat-attachment-storage', () => ({
+  uploadChatAttachment: (...args: unknown[]) => mockUploadChatAttachment(...args),
+  getChatAttachmentUrl: (...args: unknown[]) => mockGetChatAttachmentUrl(...args),
+}));
+
+import { extractStructuredContentFromParts, convertDbMessageToUIMessage } from '../message-utils';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUploadChatAttachment.mockResolvedValue({
+    storageKey: 'chat-attachments/deadbeef/original',
+    contentHash: 'deadbeef',
+  });
+  mockGetChatAttachmentUrl.mockResolvedValue('https://signed.example.com/get/deadbeef');
+});
+
+describe('extractStructuredContentFromParts — S3-backed file parts', () => {
+  it('given a new data: URL file part, should upload it and persist a storageKey instead of raw base64', async () => {
+    const filePart = {
+      type: 'file' as const,
+      url: 'data:image/png;base64,aGVsbG8gd29ybGQ=', // "hello world"
+      mediaType: 'image/png',
+      filename: 'screenshot.png',
+    } as unknown as UIMessage['parts'][number];
+
+    const content = await extractStructuredContentFromParts([filePart], '');
+    const structured = JSON.parse(content);
+
+    expect(structured.fileParts).toHaveLength(1);
+    expect(structured.fileParts[0].storageKey).toBe('chat-attachments/deadbeef/original');
+    expect(structured.fileParts[0].url).toBeUndefined();
+    expect(content).not.toContain('aGVsbG8gd29ybGQ=');
+
+    expect(mockUploadChatAttachment).toHaveBeenCalledTimes(1);
+    const [buffer, mediaType] = mockUploadChatAttachment.mock.calls[0];
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect((buffer as Buffer).toString('utf-8')).toBe('hello world');
+    expect(mediaType).toBe('image/png');
+  });
+
+  it('given a file part with an already-hosted (non-data) URL, should pass it through unchanged', async () => {
+    const filePart = {
+      type: 'file' as const,
+      url: 'https://example.com/already-hosted.png',
+      mediaType: 'image/png',
+      filename: 'hosted.png',
+    } as unknown as UIMessage['parts'][number];
+
+    const content = await extractStructuredContentFromParts([filePart], '');
+    const structured = JSON.parse(content);
+
+    expect(structured.fileParts).toEqual([
+      { url: 'https://example.com/already-hosted.png', mediaType: 'image/png', filename: 'hosted.png' },
+    ]);
+    expect(mockUploadChatAttachment).not.toHaveBeenCalled();
+  });
+});
+
+describe('convertDbMessageToUIMessage — S3-backed file parts', () => {
+  const baseMeta = {
+    id: 'msg-1',
+    pageId: 'page-1',
+    userId: 'user-1',
+    role: 'user' as const,
+    createdAt: new Date('2025-01-01'),
+    isActive: true,
+    editedAt: null,
+    toolCalls: null,
+    toolResults: null,
+  };
+
+  it('given a persisted storageKey file part, should regenerate a fresh presigned URL', async () => {
+    const structuredContent = JSON.stringify({
+      textParts: [],
+      fileParts: [{ storageKey: 'chat-attachments/deadbeef/original', mediaType: 'image/png', filename: 'a.png' }],
+      partsOrder: [{ index: 0, type: 'file' }],
+      originalContent: '',
+    });
+
+    const result = await convertDbMessageToUIMessage({ ...baseMeta, content: structuredContent });
+
+    expect(mockGetChatAttachmentUrl).toHaveBeenCalledWith('chat-attachments/deadbeef/original');
+    expect(result.parts[0]).toEqual({
+      type: 'file',
+      url: 'https://signed.example.com/get/deadbeef',
+      mediaType: 'image/png',
+      filename: 'a.png',
+    });
+  });
+
+  it('given a legacy persisted url file part (no storageKey), should pass the url through unchanged', async () => {
+    const structuredContent = JSON.stringify({
+      textParts: [],
+      fileParts: [{ url: 'data:image/png;base64,legacydata', mediaType: 'image/png', filename: 'b.png' }],
+      partsOrder: [{ index: 0, type: 'file' }],
+      originalContent: '',
+    });
+
+    const result = await convertDbMessageToUIMessage({ ...baseMeta, content: structuredContent });
+
+    expect(mockGetChatAttachmentUrl).not.toHaveBeenCalled();
+    expect(result.parts[0]).toEqual({
+      type: 'file',
+      url: 'data:image/png;base64,legacydata',
+      mediaType: 'image/png',
+      filename: 'b.png',
+    });
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/message-utils-storage-attachments.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils-storage-attachments.test.ts
@@ -7,6 +7,10 @@ const mockGetChatAttachmentUrl = vi.fn();
 vi.mock('@/lib/upload/chat-attachment-storage', () => ({
   uploadChatAttachment: (...args: unknown[]) => mockUploadChatAttachment(...args),
   getChatAttachmentUrl: (...args: unknown[]) => mockGetChatAttachmentUrl(...args),
+  parseChatAttachmentStorageKey: (url: string) => {
+    const match = /(chat-attachments\/[0-9a-f]{64}\/original)/.exec(url);
+    return match ? match[1] : null;
+  },
 }));
 
 import { extractStructuredContentFromParts, convertDbMessageToUIMessage } from '../message-utils';
@@ -57,6 +61,39 @@ describe('extractStructuredContentFromParts — S3-backed file parts', () => {
 
     expect(structured.fileParts).toEqual([
       { url: 'https://example.com/already-hosted.png', mediaType: 'image/png', filename: 'hosted.png' },
+    ]);
+    expect(mockUploadChatAttachment).not.toHaveBeenCalled();
+  });
+
+  it('given a data: URL file part with no explicit mediaType, should persist the mediaType parsed from the data URL', async () => {
+    const filePart = {
+      type: 'file' as const,
+      url: 'data:image/png;base64,aGVsbG8gd29ybGQ=',
+      filename: 'screenshot.png',
+    } as unknown as UIMessage['parts'][number];
+
+    const content = await extractStructuredContentFromParts([filePart], '');
+    const structured = JSON.parse(content);
+
+    expect(structured.fileParts[0].mediaType).toBe('image/png');
+    const [, uploadedMediaType] = mockUploadChatAttachment.mock.calls[0];
+    expect(uploadedMediaType).toBe('image/png');
+  });
+
+  it('given a re-sent presigned chat-attachment URL (regenerate/resend), should recover and persist the storageKey instead of the expiring URL', async () => {
+    const hash = 'd'.repeat(64);
+    const filePart = {
+      type: 'file' as const,
+      url: `https://bucket.example.com/chat-attachments/${hash}/original?X-Amz-Signature=abc`,
+      mediaType: 'image/png',
+      filename: 'resent.png',
+    } as unknown as UIMessage['parts'][number];
+
+    const content = await extractStructuredContentFromParts([filePart], '');
+    const structured = JSON.parse(content);
+
+    expect(structured.fileParts).toEqual([
+      { storageKey: `chat-attachments/${hash}/original`, mediaType: 'image/png', filename: 'resent.png' },
     ]);
     expect(mockUploadChatAttachment).not.toHaveBeenCalled();
   });
@@ -111,5 +148,20 @@ describe('convertDbMessageToUIMessage — S3-backed file parts', () => {
       mediaType: 'image/png',
       filename: 'b.png',
     });
+  });
+
+  it('given the presigned URL regeneration fails, should fall back to originalContent text instead of leaking the raw structured JSON', async () => {
+    mockGetChatAttachmentUrl.mockRejectedValue(new Error('S3 unavailable'));
+    const structuredContent = JSON.stringify({
+      textParts: [],
+      fileParts: [{ storageKey: 'chat-attachments/deadbeef/original', mediaType: 'image/png', filename: 'a.png' }],
+      partsOrder: [{ index: 0, type: 'file' }],
+      originalContent: 'my message',
+    });
+
+    const result = await convertDbMessageToUIMessage({ ...baseMeta, content: structuredContent });
+
+    expect(result.parts).toEqual([{ type: 'text', text: 'my message' }]);
+    expect(JSON.stringify(result)).not.toContain('storageKey');
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
@@ -105,7 +105,7 @@ describe('extractToolResults', () => {
 });
 
 describe('convertDbMessageToUIMessage — output-error round-trip', () => {
-  it('given a persisted message whose toolResults state is output-error, should reconstruct a tool part with state=output-error and the original errorText', () => {
+  it('given a persisted message whose toolResults state is output-error, should reconstruct a tool part with state=output-error and the original errorText', async () => {
     const partsOrder = [{ index: 0, type: 'tool-list_pages', toolCallId: 'tc1' }];
     const dbMessage = {
       id: 'msg-err',
@@ -138,7 +138,7 @@ describe('convertDbMessageToUIMessage — output-error round-trip', () => {
       isActive: true,
     };
 
-    const reconstructed = convertDbMessageToUIMessage(dbMessage);
+    const reconstructed = await convertDbMessageToUIMessage(dbMessage);
 
     expect(reconstructed.parts).toEqual([
       {
@@ -152,7 +152,7 @@ describe('convertDbMessageToUIMessage — output-error round-trip', () => {
     ]);
   });
 
-  it('given a persisted message whose toolResults state is output-available, should reconstruct a tool part with state=output-available (no regression)', () => {
+  it('given a persisted message whose toolResults state is output-available, should reconstruct a tool part with state=output-available (no regression)', async () => {
     const partsOrder = [{ index: 0, type: 'tool-list_pages', toolCallId: 'tc1' }];
     const dbMessage = {
       id: 'msg-ok',
@@ -170,7 +170,7 @@ describe('convertDbMessageToUIMessage — output-error round-trip', () => {
       isActive: true,
     };
 
-    const reconstructed = convertDbMessageToUIMessage(dbMessage);
+    const reconstructed = await convertDbMessageToUIMessage(dbMessage);
 
     expect(reconstructed.parts).toEqual([
       {

--- a/apps/web/src/lib/ai/core/__tests__/validate-image-parts.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/validate-image-parts.test.ts
@@ -116,6 +116,17 @@ describe('validate-image-parts', () => {
       expect(result.error).toContain('not a valid data URL');
     });
 
+    it('given a re-sent presigned chat-attachment URL (e.g. from regenerate), should return valid', () => {
+      const hash = 'c'.repeat(64);
+      const msg = makeUserMessage([
+        makeFilePart({
+          url: `https://bucket.example.com/chat-attachments/${hash}/original?X-Amz-Signature=abc`,
+        }),
+      ]);
+      const result = validateUserMessageFileParts(msg);
+      expect(result.valid).toBe(true);
+    });
+
     it('given an invalid data URL format, should return invalid', () => {
       const msg = makeUserMessage([
         makeFilePart({ url: 'data:broken' }),

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -10,7 +10,7 @@ import { chatMessages } from '@pagespace/db/schema/core'
 import { messages } from '@pagespace/db/schema/conversations';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
-import { uploadChatAttachment, getChatAttachmentUrl } from '@/lib/upload/chat-attachment-storage';
+import { uploadChatAttachment, getChatAttachmentUrl, parseChatAttachmentStorageKey } from '@/lib/upload/chat-attachment-storage';
 
 /** Parse a `data:<mediaType>;base64,<data>` URL into its raw bytes and media type. */
 function decodeDataUrl(dataUrl: string): { buffer: Buffer; mediaType: string } | null {
@@ -281,22 +281,30 @@ function parseToolResults(raw: unknown): ToolResult[] {
  * Convert database message to UIMessage format with tool parts
  */
 export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): Promise<UIMessage> {
-  // Parse structured content
-  if (dbMessage.content) {
-    try {
-      const parsed = JSON.parse(dbMessage.content);
-      if (parsed.textParts && parsed.partsOrder) {
-        debugLogAI('Reconstructing message with structured content', {
-          textPartsCount: parsed.textParts.length,
-          totalPartsCount: parsed.partsOrder.length
-        });
+  const parsed = parseStructuredContent(dbMessage.content);
+  if (parsed) {
+    debugLogAI('Reconstructing message with structured content', {
+      textPartsCount: parsed.textParts.length,
+      totalPartsCount: parsed.partsOrder.length
+    });
 
-        const structured = await reconstructMessageFromStructuredContent(dbMessage, parsed);
-        return { ...structured, userName: dbMessage.userName } as ExtendedUIMessage;
-      }
-    } catch {
-      // Content is plain text, not structured
-      debugLogAI('Using plain text content for message', { messageId: dbMessage.id });
+    try {
+      const structured = await reconstructFromStructuredContent(dbMessage, parsed);
+      return { ...structured, userName: dbMessage.userName } as ExtendedUIMessage;
+    } catch (error) {
+      // Reconstruction failed (e.g. S3 presign error) — fall back to the
+      // original plain-text content rather than leaking the raw structured
+      // JSON to the user and the model.
+      loggers.ai.error('Failed to reconstruct structured message content', error as Error, { messageId: dbMessage.id });
+      return {
+        id: dbMessage.id,
+        role: dbMessage.role as 'user' | 'assistant' | 'system',
+        parts: [{ type: 'text' as const, text: parsed.originalContent || '' }],
+        createdAt: dbMessage.createdAt,
+        editedAt: dbMessage.editedAt,
+        messageType: dbMessage.messageType || 'standard',
+        userName: dbMessage.userName,
+      } as ExtendedUIMessage;
     }
   }
 
@@ -310,6 +318,17 @@ export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): P
     messageType: dbMessage.messageType || 'standard',
     userName: dbMessage.userName,
   } as ExtendedUIMessage;
+}
+
+/** Parse persisted structured content, returning null for plain-text (legacy) content. */
+function parseStructuredContent(content: string | null | undefined): StructuredContentData | null {
+  if (!content) return null;
+  try {
+    const parsed = JSON.parse(content);
+    return parsed && parsed.textParts && parsed.partsOrder ? parsed as StructuredContentData : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -408,16 +427,6 @@ async function reconstructFromStructuredContent(
 }
 
 /**
- * Reconstruct message from structured content (new format with chronological ordering)
- */
-async function reconstructMessageFromStructuredContent(
-  dbMessage: DatabaseMessage,
-  structuredData: StructuredContentData
-): Promise<UIMessage> {
-  return reconstructFromStructuredContent(dbMessage, structuredData);
-}
-
-/**
  * Extract structured content data from UIMessage parts for database storage
  */
 export async function extractStructuredContentFromParts(uiParts: UIMessage['parts'], originalContent: string): Promise<string> {
@@ -429,12 +438,20 @@ export async function extractStructuredContentFromParts(uiParts: UIMessage['part
     uiParts
       .filter(isFilePart)
       .map(async (fp): Promise<PersistedFilePart> => {
+        // Echoed back from a previous reconstruction (resend/regenerate resubmits
+        // history containing our own presigned GET URL) — recover the stable
+        // storageKey instead of persisting the URL, which expires in an hour.
+        const echoedStorageKey = parseChatAttachmentStorageKey(fp.url);
+        if (echoedStorageKey) {
+          return { storageKey: echoedStorageKey, mediaType: fp.mediaType, filename: fp.filename };
+        }
         const decoded = decodeDataUrl(fp.url);
         if (!decoded) {
           return { url: fp.url, mediaType: fp.mediaType, filename: fp.filename };
         }
-        const { storageKey } = await uploadChatAttachment(decoded.buffer, fp.mediaType || decoded.mediaType);
-        return { storageKey, mediaType: fp.mediaType, filename: fp.filename };
+        const mediaType = fp.mediaType || decoded.mediaType;
+        const { storageKey } = await uploadChatAttachment(decoded.buffer, mediaType);
+        return { storageKey, mediaType, filename: fp.filename };
       })
   );
 
@@ -553,21 +570,25 @@ export async function saveMessageToDatabase({
  * Convert Global Assistant database message to UIMessage format
  */
 export async function convertGlobalAssistantMessageToUIMessage(dbMessage: GlobalAssistantMessage): Promise<UIMessage> {
-  // Parse structured content
-  if (dbMessage.content) {
-    try {
-      const parsed = JSON.parse(dbMessage.content);
-      if (parsed.textParts && parsed.partsOrder) {
-        debugLogAI('Global Assistant: Reconstructing message with structured content', {
-          textPartsCount: parsed.textParts.length,
-          totalPartsCount: parsed.partsOrder.length
-        });
+  const parsed = parseStructuredContent(dbMessage.content);
+  if (parsed) {
+    debugLogAI('Global Assistant: Reconstructing message with structured content', {
+      textPartsCount: parsed.textParts.length,
+      totalPartsCount: parsed.partsOrder.length
+    });
 
-        return await reconstructGlobalAssistantMessageFromStructuredContent(dbMessage, parsed);
-      }
-    } catch {
-      // Content is plain text, not structured
-      debugLogAI('Global Assistant: Using plain text content for message', { messageId: dbMessage.id });
+    try {
+      return await reconstructFromStructuredContent(dbMessage, parsed);
+    } catch (error) {
+      loggers.ai.error('Failed to reconstruct structured global assistant message content', error as Error, { messageId: dbMessage.id });
+      return {
+        id: dbMessage.id,
+        role: dbMessage.role as 'user' | 'assistant' | 'system',
+        parts: [{ type: 'text' as const, text: parsed.originalContent || '' }],
+        createdAt: dbMessage.createdAt,
+        editedAt: dbMessage.editedAt,
+        messageType: dbMessage.messageType || 'standard',
+      } as ExtendedUIMessage;
     }
   }
 
@@ -581,17 +602,6 @@ export async function convertGlobalAssistantMessageToUIMessage(dbMessage: Global
     messageType: dbMessage.messageType || 'standard',
   } as ExtendedUIMessage;
 }
-
-/**
- * Reconstruct Global Assistant message from structured content (new format with chronological ordering)
- */
-async function reconstructGlobalAssistantMessageFromStructuredContent(
-  dbMessage: GlobalAssistantMessage,
-  structuredData: StructuredContentData
-): Promise<UIMessage> {
-  return reconstructFromStructuredContent(dbMessage, structuredData);
-}
-
 
 /**
  * Save a Global Assistant message with tool calls and results to the database

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -10,6 +10,15 @@ import { chatMessages } from '@pagespace/db/schema/core'
 import { messages } from '@pagespace/db/schema/conversations';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
+import { uploadChatAttachment, getChatAttachmentUrl } from '@/lib/upload/chat-attachment-storage';
+
+/** Parse a `data:<mediaType>;base64,<data>` URL into its raw bytes and media type. */
+function decodeDataUrl(dataUrl: string): { buffer: Buffer; mediaType: string } | null {
+  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl);
+  if (!match) return null;
+  const [, mediaType, base64Data] = match;
+  return { buffer: Buffer.from(base64Data, 'base64'), mediaType };
+}
 
 /** Narrow a UIMessage part to TextUIPart */
 function isTextPart(part: { type: string }): part is TextUIPart {
@@ -136,9 +145,17 @@ interface PersistedDataPart {
   data: unknown;
 }
 
+/** A persisted file part is either a fresh S3-backed `storageKey` or a legacy `url` (never both). */
+interface PersistedFilePart {
+  url?: string;
+  storageKey?: string;
+  mediaType?: string;
+  filename?: string;
+}
+
 interface StructuredContentData {
   textParts: string[];
-  fileParts?: Array<{ url: string; mediaType?: string; filename?: string }>;
+  fileParts?: PersistedFilePart[];
   dataParts?: PersistedDataPart[];
   partsOrder: Array<{ index: number; type: string; toolCallId?: string }>;
   originalContent?: string;
@@ -263,7 +280,7 @@ function parseToolResults(raw: unknown): ToolResult[] {
 /**
  * Convert database message to UIMessage format with tool parts
  */
-export function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): UIMessage {
+export async function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): Promise<UIMessage> {
   // Parse structured content
   if (dbMessage.content) {
     try {
@@ -274,7 +291,7 @@ export function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): UIMessa
           totalPartsCount: parsed.partsOrder.length
         });
 
-        const structured = reconstructMessageFromStructuredContent(dbMessage, parsed);
+        const structured = await reconstructMessageFromStructuredContent(dbMessage, parsed);
         return { ...structured, userName: dbMessage.userName } as ExtendedUIMessage;
       }
     } catch {
@@ -299,10 +316,10 @@ export function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): UIMessa
  * Shared helper: reconstruct a UIMessage from structured content data and
  * the common fields present on both DatabaseMessage and GlobalAssistantMessage.
  */
-function reconstructFromStructuredContent(
+async function reconstructFromStructuredContent(
   msg: ReconstructableMessage,
   structuredData: StructuredContentData
-): UIMessage {
+): Promise<UIMessage> {
   const parts: Array<TextUIPart | ToolPart | FileUIPart | PersistedDataPart> = [];
   let textPartIndex = 0;
   let filePartIndex = 0;
@@ -323,7 +340,7 @@ function reconstructFromStructuredContent(
   const dataParts = structuredData.dataParts || [];
 
   // Reconstruct parts in original order
-  structuredData.partsOrder.forEach(partOrder => {
+  for (const partOrder of structuredData.partsOrder) {
     if (partOrder.type === 'text') {
       if (textPartIndex < structuredData.textParts.length) {
         const textContent = structuredData.textParts[textPartIndex];
@@ -338,9 +355,10 @@ function reconstructFromStructuredContent(
     } else if (partOrder.type === 'file') {
       if (filePartIndex < fileParts.length) {
         const fp = fileParts[filePartIndex];
+        const url = fp.storageKey ? await getChatAttachmentUrl(fp.storageKey) : fp.url;
         parts.push({
           type: 'file',
-          url: fp.url,
+          url: url || '',
           mediaType: fp.mediaType || 'application/octet-stream',
           filename: fp.filename,
         });
@@ -373,7 +391,7 @@ function reconstructFromStructuredContent(
     } else if (partOrder.type === 'step-start') {
       // Skip step-start parts for now - they're AI SDK internal
     }
-  });
+  }
 
   const resolvedParts: UIMessage['parts'] = parts.length > 0
     ? parts as UIMessage['parts']
@@ -392,28 +410,33 @@ function reconstructFromStructuredContent(
 /**
  * Reconstruct message from structured content (new format with chronological ordering)
  */
-function reconstructMessageFromStructuredContent(
+async function reconstructMessageFromStructuredContent(
   dbMessage: DatabaseMessage,
   structuredData: StructuredContentData
-): UIMessage {
+): Promise<UIMessage> {
   return reconstructFromStructuredContent(dbMessage, structuredData);
 }
 
 /**
  * Extract structured content data from UIMessage parts for database storage
  */
-export function extractStructuredContentFromParts(uiParts: UIMessage['parts'], originalContent: string): string {
+export async function extractStructuredContentFromParts(uiParts: UIMessage['parts'], originalContent: string): Promise<string> {
   const textParts = uiParts
     .filter(isTextPart)
     .map(p => p.text || '');
 
-  const filePartsData = uiParts
-    .filter(isFilePart)
-    .map(fp => ({
-      url: fp.url,
-      mediaType: fp.mediaType,
-      filename: fp.filename,
-    }));
+  const filePartsData: PersistedFilePart[] = await Promise.all(
+    uiParts
+      .filter(isFilePart)
+      .map(async (fp): Promise<PersistedFilePart> => {
+        const decoded = decodeDataUrl(fp.url);
+        if (!decoded) {
+          return { url: fp.url, mediaType: fp.mediaType, filename: fp.filename };
+        }
+        const { storageKey } = await uploadChatAttachment(decoded.buffer, fp.mediaType || decoded.mediaType);
+        return { storageKey, mediaType: fp.mediaType, filename: fp.filename };
+      })
+  );
 
   const dataPartsData: PersistedDataPart[] = uiParts
     .filter(isDataPart)
@@ -475,7 +498,7 @@ export async function saveMessageToDatabase({
 
     // If we have the complete UIMessage, store structured content to preserve chronological order
     if (uiMessage?.parts && uiMessage.parts.length > 0) {
-      structuredContent = extractStructuredContentFromParts(uiMessage.parts, content);
+      structuredContent = await extractStructuredContentFromParts(uiMessage.parts, content);
 
       debugLogAI('Saving structured content', {
         textPartsCount: uiMessage.parts.filter(isTextPart).length,
@@ -529,7 +552,7 @@ export async function saveMessageToDatabase({
 /**
  * Convert Global Assistant database message to UIMessage format
  */
-export function convertGlobalAssistantMessageToUIMessage(dbMessage: GlobalAssistantMessage): UIMessage {
+export async function convertGlobalAssistantMessageToUIMessage(dbMessage: GlobalAssistantMessage): Promise<UIMessage> {
   // Parse structured content
   if (dbMessage.content) {
     try {
@@ -540,7 +563,7 @@ export function convertGlobalAssistantMessageToUIMessage(dbMessage: GlobalAssist
           totalPartsCount: parsed.partsOrder.length
         });
 
-        return reconstructGlobalAssistantMessageFromStructuredContent(dbMessage, parsed);
+        return await reconstructGlobalAssistantMessageFromStructuredContent(dbMessage, parsed);
       }
     } catch {
       // Content is plain text, not structured
@@ -562,10 +585,10 @@ export function convertGlobalAssistantMessageToUIMessage(dbMessage: GlobalAssist
 /**
  * Reconstruct Global Assistant message from structured content (new format with chronological ordering)
  */
-function reconstructGlobalAssistantMessageFromStructuredContent(
+async function reconstructGlobalAssistantMessageFromStructuredContent(
   dbMessage: GlobalAssistantMessage,
   structuredData: StructuredContentData
-): UIMessage {
+): Promise<UIMessage> {
   return reconstructFromStructuredContent(dbMessage, structuredData);
 }
 
@@ -598,7 +621,7 @@ export async function saveGlobalAssistantMessageToDatabase({
 
     // If we have the complete UIMessage, store structured content to preserve chronological order
     if (uiMessage?.parts && uiMessage.parts.length > 0) {
-      structuredContent = extractStructuredContentFromParts(uiMessage.parts, content);
+      structuredContent = await extractStructuredContentFromParts(uiMessage.parts, content);
 
       debugLogAI('Global Assistant: Saving structured content', {
         textPartsCount: uiMessage.parts.filter(isTextPart).length,

--- a/apps/web/src/lib/ai/core/validate-image-parts.ts
+++ b/apps/web/src/lib/ai/core/validate-image-parts.ts
@@ -10,6 +10,7 @@ import {
   isAllowedImageType,
   extractBase64DataUrl,
 } from '@/lib/validation/image-validation';
+import { parseChatAttachmentStorageKey } from '@/lib/upload/chat-attachment-storage';
 
 const MAX_FILE_PARTS_PER_MESSAGE = 5;
 const MAX_DATA_URL_LENGTH = 4 * 1024 * 1024; // 4MB per data URL
@@ -81,6 +82,14 @@ export function validateUserMessageFileParts(
     const part = fileParts[i];
     const url = part.url;
     const filename = part.filename || `image-${i + 1}`;
+
+    // Already-persisted attachment echoed back by the client (e.g. resend/regenerate
+    // resubmitting history that now carries a presigned chat-attachment GET URL instead
+    // of the original data: URL) — it was validated when first uploaded, so skip the
+    // new-upload checks below rather than rejecting it as an invalid data URL.
+    if (parseChatAttachmentStorageKey(url)) {
+      continue;
+    }
 
     // Size check
     if (url.length > MAX_DATA_URL_LENGTH) {

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -468,7 +468,7 @@ export const agentCommunicationTools = {
             ))
             .orderBy(chatMessages.createdAt);
 
-          messages = dbMessages.map(convertDbMessageToUIMessage);
+          messages = await Promise.all(dbMessages.map(convertDbMessageToUIMessage));
 
           loggers.ai.debug('Loaded conversation history for ask_agent:', {
             conversationId,

--- a/apps/web/src/lib/upload/__tests__/chat-attachment-storage.test.ts
+++ b/apps/web/src/lib/upload/__tests__/chat-attachment-storage.test.ts
@@ -1,22 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockCheckObjectExists = vi.fn();
-const mockIssuePresignedPutUrl = vi.fn();
+const mockPutObject = vi.fn();
 
 vi.mock('@/lib/upload/s3-effects', () => ({
   checkObjectExists: (...args: unknown[]) => mockCheckObjectExists(...args),
-  issuePresignedPutUrl: (...args: unknown[]) => mockIssuePresignedPutUrl(...args),
+  putObject: (...args: unknown[]) => mockPutObject(...args),
 }));
 
-const mockFetch = vi.fn();
-vi.stubGlobal('fetch', mockFetch);
-
-import { buildChatAttachmentKey, uploadChatAttachment } from '../chat-attachment-storage';
+import { buildChatAttachmentKey, uploadChatAttachment, parseChatAttachmentStorageKey } from '../chat-attachment-storage';
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockIssuePresignedPutUrl.mockResolvedValue('https://signed.example.com/put');
-  mockFetch.mockResolvedValue({ ok: true, status: 200 });
+  mockPutObject.mockResolvedValue(undefined);
 });
 
 describe('buildChatAttachmentKey', () => {
@@ -31,36 +27,22 @@ describe('uploadChatAttachment', () => {
   const buffer = Buffer.from('hello world');
   const mediaType = 'image/png';
 
-  it('given the object already exists, should skip the presigned PUT entirely (dedup)', async () => {
+  it('given the object already exists, should skip the PUT entirely (dedup)', async () => {
     mockCheckObjectExists.mockResolvedValue(true);
 
     const result = await uploadChatAttachment(buffer, mediaType);
 
-    expect(mockIssuePresignedPutUrl).not.toHaveBeenCalled();
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPutObject).not.toHaveBeenCalled();
     expect(result.storageKey.startsWith('files/')).toBe(false);
     expect(result.storageKey).toBe(buildChatAttachmentKey(result.contentHash));
   });
 
-  it('given the object does not exist, should issue a presigned PUT and upload the bytes', async () => {
+  it('given the object does not exist, should PUT the bytes directly to S3', async () => {
     mockCheckObjectExists.mockResolvedValue(false);
 
     const result = await uploadChatAttachment(buffer, mediaType);
 
-    expect(mockIssuePresignedPutUrl).toHaveBeenCalledWith(
-      result.storageKey,
-      mediaType,
-      buffer.byteLength,
-      expect.any(Number),
-    );
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://signed.example.com/put',
-      expect.objectContaining({
-        method: 'PUT',
-        body: buffer,
-        headers: expect.objectContaining({ 'Content-Type': mediaType }),
-      }),
-    );
+    expect(mockPutObject).toHaveBeenCalledWith(result.storageKey, buffer, mediaType);
   });
 
   it('given the same bytes twice, should produce the same content-addressed storage key', async () => {
@@ -73,11 +55,11 @@ describe('uploadChatAttachment', () => {
     expect(second.contentHash).toBe(first.contentHash);
   });
 
-  it('given the PUT response is not ok, should throw', async () => {
+  it('given the PUT rejects, should propagate the error', async () => {
     mockCheckObjectExists.mockResolvedValue(false);
-    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+    mockPutObject.mockRejectedValue(new Error('S3 unavailable'));
 
-    await expect(uploadChatAttachment(buffer, mediaType)).rejects.toThrow();
+    await expect(uploadChatAttachment(buffer, mediaType)).rejects.toThrow('S3 unavailable');
   });
 
   it('given a buffer over the 4MB cap, should throw without touching S3', async () => {
@@ -86,8 +68,7 @@ describe('uploadChatAttachment', () => {
     await expect(uploadChatAttachment(oversized, mediaType)).rejects.toThrow(/exceeds/i);
 
     expect(mockCheckObjectExists).not.toHaveBeenCalled();
-    expect(mockIssuePresignedPutUrl).not.toHaveBeenCalled();
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPutObject).not.toHaveBeenCalled();
   });
 
   it('given a buffer exactly at the 4MB cap, should upload normally', async () => {
@@ -97,6 +78,37 @@ describe('uploadChatAttachment', () => {
     const result = await uploadChatAttachment(atLimit, mediaType);
 
     expect(result.storageKey).toBe(buildChatAttachmentKey(result.contentHash));
-    expect(mockFetch).toHaveBeenCalled();
+    expect(mockPutObject).toHaveBeenCalled();
+  });
+});
+
+describe('parseChatAttachmentStorageKey', () => {
+  it('given a presigned GET URL for a chat attachment, should recover the storage key', () => {
+    const url = 'https://bucket.example.com/chat-attachments/' +
+      'a'.repeat(64) +
+      '/original?X-Amz-Signature=abc&X-Amz-Expires=3600';
+
+    expect(parseChatAttachmentStorageKey(url)).toBe(`chat-attachments/${'a'.repeat(64)}/original`);
+  });
+
+  it('given a path-style S3 URL with a bucket prefix, should still recover the storage key', () => {
+    const url = 'https://s3.example.com/my-bucket/chat-attachments/' +
+      'b'.repeat(64) +
+      '/original?X-Amz-Signature=abc';
+
+    expect(parseChatAttachmentStorageKey(url)).toBe(`chat-attachments/${'b'.repeat(64)}/original`);
+  });
+
+  it('given an arbitrary external URL, should return null', () => {
+    expect(parseChatAttachmentStorageKey('https://example.com/img.png')).toBeNull();
+  });
+
+  it('given a data: URL, should return null', () => {
+    expect(parseChatAttachmentStorageKey('data:image/png;base64,aGVsbG8=')).toBeNull();
+  });
+
+  it('given a hash of the wrong length, should return null', () => {
+    const url = 'https://bucket.example.com/chat-attachments/deadbeef/original';
+    expect(parseChatAttachmentStorageKey(url)).toBeNull();
   });
 });

--- a/apps/web/src/lib/upload/__tests__/chat-attachment-storage.test.ts
+++ b/apps/web/src/lib/upload/__tests__/chat-attachment-storage.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCheckObjectExists = vi.fn();
+const mockIssuePresignedPutUrl = vi.fn();
+
+vi.mock('@/lib/upload/s3-effects', () => ({
+  checkObjectExists: (...args: unknown[]) => mockCheckObjectExists(...args),
+  issuePresignedPutUrl: (...args: unknown[]) => mockIssuePresignedPutUrl(...args),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { buildChatAttachmentKey, uploadChatAttachment } from '../chat-attachment-storage';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIssuePresignedPutUrl.mockResolvedValue('https://signed.example.com/put');
+  mockFetch.mockResolvedValue({ ok: true, status: 200 });
+});
+
+describe('buildChatAttachmentKey', () => {
+  it('given a content hash, should build a key outside the global files/ prefix', () => {
+    const key = buildChatAttachmentKey('abc123');
+    expect(key.startsWith('files/')).toBe(false);
+    expect(key).toBe('chat-attachments/abc123/original');
+  });
+});
+
+describe('uploadChatAttachment', () => {
+  const buffer = Buffer.from('hello world');
+  const mediaType = 'image/png';
+
+  it('given the object already exists, should skip the presigned PUT entirely (dedup)', async () => {
+    mockCheckObjectExists.mockResolvedValue(true);
+
+    const result = await uploadChatAttachment(buffer, mediaType);
+
+    expect(mockIssuePresignedPutUrl).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.storageKey.startsWith('files/')).toBe(false);
+    expect(result.storageKey).toBe(buildChatAttachmentKey(result.contentHash));
+  });
+
+  it('given the object does not exist, should issue a presigned PUT and upload the bytes', async () => {
+    mockCheckObjectExists.mockResolvedValue(false);
+
+    const result = await uploadChatAttachment(buffer, mediaType);
+
+    expect(mockIssuePresignedPutUrl).toHaveBeenCalledWith(
+      result.storageKey,
+      mediaType,
+      buffer.byteLength,
+      expect.any(Number),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://signed.example.com/put',
+      expect.objectContaining({
+        method: 'PUT',
+        body: buffer,
+        headers: expect.objectContaining({ 'Content-Type': mediaType }),
+      }),
+    );
+  });
+
+  it('given the same bytes twice, should produce the same content-addressed storage key', async () => {
+    mockCheckObjectExists.mockResolvedValue(false);
+
+    const first = await uploadChatAttachment(buffer, mediaType);
+    const second = await uploadChatAttachment(Buffer.from('hello world'), mediaType);
+
+    expect(second.storageKey).toBe(first.storageKey);
+    expect(second.contentHash).toBe(first.contentHash);
+  });
+
+  it('given the PUT response is not ok, should throw', async () => {
+    mockCheckObjectExists.mockResolvedValue(false);
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(uploadChatAttachment(buffer, mediaType)).rejects.toThrow();
+  });
+});

--- a/apps/web/src/lib/upload/__tests__/chat-attachment-storage.test.ts
+++ b/apps/web/src/lib/upload/__tests__/chat-attachment-storage.test.ts
@@ -79,4 +79,24 @@ describe('uploadChatAttachment', () => {
 
     await expect(uploadChatAttachment(buffer, mediaType)).rejects.toThrow();
   });
+
+  it('given a buffer over the 4MB cap, should throw without touching S3', async () => {
+    const oversized = Buffer.alloc(4 * 1024 * 1024 + 1);
+
+    await expect(uploadChatAttachment(oversized, mediaType)).rejects.toThrow(/exceeds/i);
+
+    expect(mockCheckObjectExists).not.toHaveBeenCalled();
+    expect(mockIssuePresignedPutUrl).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('given a buffer exactly at the 4MB cap, should upload normally', async () => {
+    mockCheckObjectExists.mockResolvedValue(false);
+    const atLimit = Buffer.alloc(4 * 1024 * 1024);
+
+    const result = await uploadChatAttachment(atLimit, mediaType);
+
+    expect(result.storageKey).toBe(buildChatAttachmentKey(result.contentHash));
+    expect(mockFetch).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/lib/upload/__tests__/s3-effects.test.ts
+++ b/apps/web/src/lib/upload/__tests__/s3-effects.test.ts
@@ -31,7 +31,7 @@ vi.mock('@/lib/presigned-url', () => ({
   getS3Bucket: () => 'test-bucket',
 }));
 
-import { issuePresignedPutUrl, checkObjectExists } from '../s3-effects';
+import { issuePresignedPutUrl, checkObjectExists, putObject } from '../s3-effects';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -59,6 +59,28 @@ describe('issuePresignedPutUrl', () => {
       expect.anything(),
       { expiresIn: 600 },
     );
+  });
+});
+
+describe('putObject', () => {
+  it('sends a PutObjectCommand with the bucket, key, body, and content type', async () => {
+    mockSend.mockResolvedValue({});
+    const body = Buffer.from('hello');
+
+    await putObject('chat-attachments/abc/original', body, 'image/png');
+
+    expect(putObjectCtor).toHaveBeenCalledWith({
+      Bucket: 'test-bucket',
+      Key: 'chat-attachments/abc/original',
+      Body: body,
+      ContentType: 'image/png',
+    });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a failed send', async () => {
+    mockSend.mockRejectedValue(new Error('S3 unavailable'));
+    await expect(putObject('key', Buffer.from('x'), 'image/png')).rejects.toThrow('S3 unavailable');
   });
 });
 

--- a/apps/web/src/lib/upload/chat-attachment-storage.ts
+++ b/apps/web/src/lib/upload/chat-attachment-storage.ts
@@ -2,17 +2,20 @@ import { createHash } from 'crypto';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
-import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
+import { checkObjectExists, putObject } from '@/lib/upload/s3-effects';
 
 const CHAT_ATTACHMENT_PREFIX = 'chat-attachments';
-const PUT_URL_TTL_SECONDS = 300;
 const GET_URL_TTL_SECONDS = 3600;
+// Matches the storage key this module mints in buildChatAttachmentKey, wherever
+// it appears in a URL path — virtual-hosted (bucket.host/key) and path-style
+// (host/bucket/key) presigned URLs both put the key verbatim in the pathname.
+const CHAT_ATTACHMENT_KEY_PATTERN = /(chat-attachments\/[0-9a-f]{64}\/original)/;
 // Defense-in-depth mirror of MAX_DATA_URL_LENGTH in validate-image-parts.ts: the
 // chat route validates inbound data URLs, but this helper must stay safe for any
 // future caller that skips route-level validation.
 const MAX_CHAT_ATTACHMENT_BYTES = 4 * 1024 * 1024;
 
-export function hashAttachmentBuffer(buffer: Buffer): string {
+function hashAttachmentBuffer(buffer: Buffer): string {
   return createHash('sha256').update(buffer).digest('hex');
 }
 
@@ -34,15 +37,7 @@ export async function uploadChatAttachment(
 
   const exists = await checkObjectExists(storageKey);
   if (!exists) {
-    const putUrl = await issuePresignedPutUrl(storageKey, mediaType, buffer.byteLength, PUT_URL_TTL_SECONDS);
-    const response = await fetch(putUrl, {
-      method: 'PUT',
-      headers: { 'Content-Type': mediaType },
-      body: buffer,
-    });
-    if (!response.ok) {
-      throw new Error(`Failed to upload chat attachment to S3: ${response.status}`);
-    }
+    await putObject(storageKey, buffer, mediaType);
   }
 
   return { storageKey, contentHash };
@@ -51,4 +46,15 @@ export async function uploadChatAttachment(
 export async function getChatAttachmentUrl(storageKey: string): Promise<string> {
   const command = new GetObjectCommand({ Bucket: getS3Bucket(), Key: storageKey });
   return getSignedUrl(getS3Client(), command, { expiresIn: GET_URL_TTL_SECONDS });
+}
+
+/**
+ * Recover a chat-attachment storage key from a URL, if it is one of our own
+ * presigned GET URLs for this prefix. Used to recognize an attachment echoed
+ * back by a client (e.g. on resend/regenerate) so it can be re-persisted by
+ * its stable storageKey instead of its expiring presigned URL.
+ */
+export function parseChatAttachmentStorageKey(url: string): string | null {
+  const match = CHAT_ATTACHMENT_KEY_PATTERN.exec(url);
+  return match ? match[1] : null;
 }

--- a/apps/web/src/lib/upload/chat-attachment-storage.ts
+++ b/apps/web/src/lib/upload/chat-attachment-storage.ts
@@ -1,0 +1,45 @@
+import { createHash } from 'crypto';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
+import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
+
+const CHAT_ATTACHMENT_PREFIX = 'chat-attachments';
+const PUT_URL_TTL_SECONDS = 300;
+const GET_URL_TTL_SECONDS = 3600;
+
+export function hashAttachmentBuffer(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+export function buildChatAttachmentKey(contentHash: string): string {
+  return `${CHAT_ATTACHMENT_PREFIX}/${contentHash}/original`;
+}
+
+export async function uploadChatAttachment(
+  buffer: Buffer,
+  mediaType: string,
+): Promise<{ storageKey: string; contentHash: string }> {
+  const contentHash = hashAttachmentBuffer(buffer);
+  const storageKey = buildChatAttachmentKey(contentHash);
+
+  const exists = await checkObjectExists(storageKey);
+  if (!exists) {
+    const putUrl = await issuePresignedPutUrl(storageKey, mediaType, buffer.byteLength, PUT_URL_TTL_SECONDS);
+    const response = await fetch(putUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': mediaType },
+      body: buffer,
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to upload chat attachment to S3: ${response.status}`);
+    }
+  }
+
+  return { storageKey, contentHash };
+}
+
+export async function getChatAttachmentUrl(storageKey: string): Promise<string> {
+  const command = new GetObjectCommand({ Bucket: getS3Bucket(), Key: storageKey });
+  return getSignedUrl(getS3Client(), command, { expiresIn: GET_URL_TTL_SECONDS });
+}

--- a/apps/web/src/lib/upload/chat-attachment-storage.ts
+++ b/apps/web/src/lib/upload/chat-attachment-storage.ts
@@ -7,6 +7,10 @@ import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects
 const CHAT_ATTACHMENT_PREFIX = 'chat-attachments';
 const PUT_URL_TTL_SECONDS = 300;
 const GET_URL_TTL_SECONDS = 3600;
+// Defense-in-depth mirror of MAX_DATA_URL_LENGTH in validate-image-parts.ts: the
+// chat route validates inbound data URLs, but this helper must stay safe for any
+// future caller that skips route-level validation.
+const MAX_CHAT_ATTACHMENT_BYTES = 4 * 1024 * 1024;
 
 export function hashAttachmentBuffer(buffer: Buffer): string {
   return createHash('sha256').update(buffer).digest('hex');
@@ -20,6 +24,11 @@ export async function uploadChatAttachment(
   buffer: Buffer,
   mediaType: string,
 ): Promise<{ storageKey: string; contentHash: string }> {
+  if (buffer.byteLength > MAX_CHAT_ATTACHMENT_BYTES) {
+    throw new Error(
+      `Chat attachment of ${buffer.byteLength} bytes exceeds the ${MAX_CHAT_ATTACHMENT_BYTES}-byte limit`,
+    );
+  }
   const contentHash = hashAttachmentBuffer(buffer);
   const storageKey = buildChatAttachmentKey(contentHash);
 

--- a/apps/web/src/lib/upload/s3-effects.ts
+++ b/apps/web/src/lib/upload/s3-effects.ts
@@ -17,6 +17,10 @@ export async function checkObjectExists(key: string): Promise<boolean> {
   }
 }
 
+export async function putObject(key: string, body: Buffer, contentType: string): Promise<void> {
+  await getS3Client().send(new PutObjectCommand({ Bucket: getS3Bucket(), Key: key, Body: body, ContentType: contentType }));
+}
+
 export async function issuePresignedPutUrl(
   key: string,
   contentType: string,


### PR DESCRIPTION
## Summary
- Adds a content-hash-deduped S3 upload helper for chat attachments (`chat-attachments/` prefix, distinct from the existing global `files/` prefix), reusing the existing S3 client utilities from the page-attachment pipeline. Uploads go directly to S3 via `PutObjectCommand` (the server already holds credentials) rather than a presign-then-self-fetch round trip. The helper enforces its own 4MB cap as defense-in-depth (the chat route already enforces a 4MB data-URL limit at ingress).
- `extractStructuredContentFromParts` now uploads new `data:` URL file parts to S3 and persists a `storageKey` instead of the raw base64 payload; already-hosted/legacy `url` file parts pass through unchanged.
- `reconstructFromStructuredContent` (and `convertDbMessageToUIMessage` / `convertGlobalAssistantMessageToUIMessage`) now regenerate a fresh presigned GET URL for `storageKey` file parts on read, and pass legacy `url` parts through unchanged — no backfill needed, old rows keep working.
- Updates every caller of the now-async `convertDbMessageToUIMessage` / `convertGlobalAssistantMessageToUIMessage` (7 route/tool call sites) to `await`/`Promise.all` the result.
- A client can echo a previously-issued presigned GET URL back (regenerate, edit-resend, or the v1 completions API's client-managed history). `parseChatAttachmentStorageKey` recognizes our own `chat-attachments/<hash>/original` URLs so these round-trip correctly instead of being rejected by upload validation or silently persisted as a soon-to-expire URL.
- Message reconstruction failures (e.g. a transient S3 presign error) now fall back to the message's original plain-text content instead of leaking the raw structured-content JSON to the user and the model.

PageSpace epic: `odj8s6igydf20nuyoosjmo9i` (Chat Attachment S3 Persistence, part of Image & Vision Support) — all 3 phases marked complete on the board.

## Review follow-ups
- **Codex P2** (storage quota/reaper accounting for the `chat-attachments/` prefix): not a metering regression — these bytes previously persisted unmetered as inline base64 in `chat_messages` rows; ingress is bounded (≤5 image parts/message, ≤4MB each, MIME allowlist + magic bytes) and the helper now rejects >4MB buffers itself. Full quota/files-row/reaper integration is tracked as a follow-up task in the epic (`ecvc9vky5h12hsp40acj1kys`).
- **Self-review** (8-angle pass over this branch's own diff) surfaced and fixed: a regression where regenerate/resend on an attachment message would 400 (presigned URLs weren't recognized as already-validated); a data-loss path where a re-persisted presigned URL would go permanently dead after its 1-hour TTL; a silent catch that could swallow S3 presign errors and render raw JSON as message text; a dropped media-type fallback; two no-op wrapper functions removed; and the presign+self-fetch upload replaced with a direct `PutObjectCommand`.

## Merge with master
- Merged master (24 commits landed while this PR was open, including a concurrent PR touching the same file) — one real conflict in `validate-image-parts.ts`: master added a `typeof url !== 'string'` malformed-input guard at the same insertion point as this PR's `parseChatAttachmentStorageKey` exemption check. Resolved by combining both — the malformed-input check runs first, then the storage-key exemption, then the existing data-URL checks. Full test suite + typecheck re-verified green after the merge.

## Test plan
- [x] TDD: RED test written and confirmed failing before each GREEN implementation, for every Named Task in the epic and every self-review fix (S3 upload helper, extract-async, reconstruct-async, caller updates, 4MB helper cap, storage-key round-trip recognition, media-type fallback, reconstruction-error fallback, direct S3 PUT)
- [x] `bun run --filter web typecheck` — clean
- [x] Full `apps/web` ai/upload/api-ai test surface (2556 tests) — only one pre-existing/unrelated failure (an activity-tools test requiring a DB role not present in this environment, confirmed pre-existing via `git stash` against the unmodified tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2gi6pdYTJBA6V3PwfKFfC
