### PR TITLE
feat(web): channel & DM image attachments for mentioned agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 - **`pagespace mcp`** — a stdio MCP server generated from the same operation registry as the CLI
   and SDK, so Claude Desktop, Claude Code, Cursor, and other MCP clients get a tool surface that
   can't drift from what the CLI itself supports.
+- **Channel image attachments for @mentioned agents** — when you @mention an AI agent in a
+  channel or DM, recent image attachments in the conversation are now passed to vision-capable
+  agents as visual context (capped at 5 images per consultation, matching the per-message chat
+  limit). Agents without a vision-capable model get a text note instead, so they know an
+  attachment existed but couldn't be viewed.
 
 ### Changed
 

--- a/apps/web/src/lib/ai/core/validate-image-parts.ts
+++ b/apps/web/src/lib/ai/core/validate-image-parts.ts
@@ -11,8 +11,8 @@ import {
   extractBase64DataUrl,
 } from '@/lib/validation/image-validation';
 
-const MAX_FILE_PARTS_PER_MESSAGE = 5;
-const MAX_DATA_URL_LENGTH = 4 * 1024 * 1024; // 4MB per data URL
+export const MAX_FILE_PARTS_PER_MESSAGE = 5;
+export const MAX_DATA_URL_LENGTH = 4 * 1024 * 1024; // 4MB per data URL
 
 export interface FilePartValidationResult {
   valid: boolean;

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -168,6 +168,7 @@ import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { prepareHistoryForModel, finishModelRequest } from '../../core/context-assembly';
 import { runCompaction } from '../../core/compaction/compaction-service';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import type { z } from 'zod';
 
 const mockDb = vi.mocked(db);
 const mockCanActorViewPage = vi.mocked(canActorViewPage);
@@ -1059,6 +1060,50 @@ describe('agent-communication-tools', () => {
       });
     });
 
+    describe('imageAttachments input schema', () => {
+      // ask_agent is itself an LLM-callable tool, so this schema is the only
+      // gate on untrusted model-supplied input (not just the trusted channel
+      // responder). The AI SDK parses tool-call args against inputSchema
+      // before execute ever runs, so we exercise the schema directly here.
+      const baseInput = { agentPath: '/test/agent', agentId: 'agent-1', question: 'What is this?' };
+
+      it('rejects a non-https, non-data image URL (e.g. an internal/metadata endpoint)', () => {
+        const result = (agentCommunicationTools.ask_agent!.inputSchema as unknown as z.ZodTypeAny).safeParse({
+          ...baseInput,
+          imageAttachments: [{ url: 'http://169.254.169.254/latest/meta-data/', mediaType: 'image/png' }],
+        });
+        expect(result.success).toBe(false);
+      });
+
+      it('accepts an https:// image URL', () => {
+        const result = (agentCommunicationTools.ask_agent!.inputSchema as unknown as z.ZodTypeAny).safeParse({
+          ...baseInput,
+          imageAttachments: [{ url: 'https://example.com/x.png', mediaType: 'image/png' }],
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('accepts a data: image URL', () => {
+        const result = (agentCommunicationTools.ask_agent!.inputSchema as unknown as z.ZodTypeAny).safeParse({
+          ...baseInput,
+          imageAttachments: [{ url: 'data:image/png;base64,iVBORw0KGgo=', mediaType: 'image/png' }],
+        });
+        expect(result.success).toBe(true);
+      });
+
+      it('rejects more than the single-message image cap', () => {
+        const tooMany = Array.from({ length: 6 }, (_, i) => ({
+          url: `https://example.com/${i}.png`,
+          mediaType: 'image/png',
+        }));
+        const result = (agentCommunicationTools.ask_agent!.inputSchema as unknown as z.ZodTypeAny).safeParse({
+          ...baseInput,
+          imageAttachments: tooMany,
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
     describe('imageAttachments', () => {
       const imageAttachments = [
         { url: 'https://example.com/signed/screenshot.png', mediaType: 'image/png', filename: 'screenshot.png' },
@@ -1116,7 +1161,7 @@ describe('agent-communication-tools', () => {
         const savedParts = userMessageCall![0].uiMessage?.parts ?? [];
         expect(savedParts.some((part) => part.type === 'file')).toBe(false);
         const textPart = savedParts.find((part) => part.type === 'text') as { text: string } | undefined;
-        expect(textPart?.text).toMatch(/1 image attachment from recent channel context is attached/i);
+        expect(textPart?.text).toMatch(/1 image attachment from recent channel context was attached/i);
       });
 
       it('given a non-vision target agent and imageAttachments, omits file parts and adds a text note instead', async () => {
@@ -1156,6 +1201,10 @@ describe('agent-communication-tools', () => {
         expect(savedParts.some((part) => part.type === 'file')).toBe(false);
         const textPart = savedParts.find((part) => part.type === 'text') as { text: string } | undefined;
         expect(textPart?.text).toMatch(/does not support vision/i);
+        // Grammar: a single attachment must read "1 image attachment WAS
+        // provided ... IT could not be viewed", not "were"/"they" (the plural
+        // form leaking into the singular case).
+        expect(textPart?.text).toMatch(/1 image attachment was provided.*it could not be viewed/i);
       });
 
       it('given no imageAttachments, behaves exactly as before (no file parts, no vision note)', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -1064,7 +1064,7 @@ describe('agent-communication-tools', () => {
         { url: 'https://example.com/signed/screenshot.png', mediaType: 'image/png', filename: 'screenshot.png' },
       ];
 
-      it('given a vision-capable target agent and imageAttachments, attaches them as file parts and persists them', async () => {
+      it('given a vision-capable target agent and imageAttachments, sends file parts to the model but persists only durable text parts', async () => {
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({
           id: 'agent-1',
           title: 'Vision Agent',
@@ -1093,17 +1093,30 @@ describe('agent-communication-tools', () => {
           context
         );
 
-        const userMessageCall = vi.mocked(saveMessageToDatabase).mock.calls.find(
-          (call) => call[0].role === 'user'
-        );
-        expect(userMessageCall).toBeDefined();
-        const savedParts = userMessageCall![0].uiMessage?.parts ?? [];
-        expect(savedParts).toContainEqual({
+        // The model request (via prepareHistoryForModel) sees the image file parts...
+        const historyArg = vi.mocked(prepareHistoryForModel).mock.calls[0][0].history as Array<{
+          role: string;
+          parts: Array<{ type: string; url?: string; mediaType?: string; filename?: string }>;
+        }>;
+        const modelUserMessage = historyArg[historyArg.length - 1];
+        expect(modelUserMessage.role).toBe('user');
+        expect(modelUserMessage.parts).toContainEqual({
           type: 'file',
           url: imageAttachments[0].url,
           mediaType: imageAttachments[0].mediaType,
           filename: imageAttachments[0].filename,
         });
+
+        // ...but the persisted message must not: the presigned URLs expire,
+        // and replaying them from history would send dead links to the model.
+        const userMessageCall = vi.mocked(saveMessageToDatabase).mock.calls.find(
+          (call) => call[0].role === 'user'
+        );
+        expect(userMessageCall).toBeDefined();
+        const savedParts = userMessageCall![0].uiMessage?.parts ?? [];
+        expect(savedParts.some((part) => part.type === 'file')).toBe(false);
+        const textPart = savedParts.find((part) => part.type === 'text') as { text: string } | undefined;
+        expect(textPart?.text).toMatch(/1 image attachment from recent channel context is attached/i);
       });
 
       it('given a non-vision target agent and imageAttachments, omits file parts and adds a text note instead', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -1058,5 +1058,128 @@ describe('agent-communication-tools', () => {
         expect(toolsArg?.list_drives).toBeDefined();
       });
     });
+
+    describe('imageAttachments', () => {
+      const imageAttachments = [
+        { url: 'https://example.com/signed/screenshot.png', mediaType: 'image/png', filename: 'screenshot.png' },
+      ];
+
+      it('given a vision-capable target agent and imageAttachments, attaches them as file parts and persists them', async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({
+          id: 'agent-1',
+          title: 'Vision Agent',
+          type: 'AI_CHAT',
+          driveId: 'drive-1',
+          systemPrompt: 'I can see images',
+          enabledTools: null,
+          aiProvider: 'anthropic',
+          aiModel: 'claude-sonnet-4.5',
+          isTrashed: false,
+        });
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'agent-1',
+            question: 'What is in this screenshot?',
+            imageAttachments,
+          },
+          context
+        );
+
+        const userMessageCall = vi.mocked(saveMessageToDatabase).mock.calls.find(
+          (call) => call[0].role === 'user'
+        );
+        expect(userMessageCall).toBeDefined();
+        const savedParts = userMessageCall![0].uiMessage?.parts ?? [];
+        expect(savedParts).toContainEqual({
+          type: 'file',
+          url: imageAttachments[0].url,
+          mediaType: imageAttachments[0].mediaType,
+          filename: imageAttachments[0].filename,
+        });
+      });
+
+      it('given a non-vision target agent and imageAttachments, omits file parts and adds a text note instead', async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({
+          id: 'agent-2',
+          title: 'Text Agent',
+          type: 'AI_CHAT',
+          driveId: 'drive-1',
+          systemPrompt: 'I am text-only',
+          enabledTools: null,
+          aiProvider: 'openai',
+          aiModel: 'o1-mini',
+          isTrashed: false,
+        });
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'agent-2',
+            question: 'What is in this screenshot?',
+            imageAttachments,
+          },
+          context
+        );
+
+        const userMessageCall = vi.mocked(saveMessageToDatabase).mock.calls.find(
+          (call) => call[0].role === 'user'
+        );
+        expect(userMessageCall).toBeDefined();
+        const savedParts = userMessageCall![0].uiMessage?.parts ?? [];
+        expect(savedParts.some((part) => part.type === 'file')).toBe(false);
+        const textPart = savedParts.find((part) => part.type === 'text') as { text: string } | undefined;
+        expect(textPart?.text).toMatch(/does not support vision/i);
+      });
+
+      it('given no imageAttachments, behaves exactly as before (no file parts, no vision note)', async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({
+          id: 'agent-1',
+          title: 'Vision Agent',
+          type: 'AI_CHAT',
+          driveId: 'drive-1',
+          systemPrompt: 'I can see images',
+          enabledTools: null,
+          aiProvider: 'anthropic',
+          aiModel: 'claude-sonnet-4.5',
+          isTrashed: false,
+        });
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'agent-1',
+            question: 'Plain question',
+          },
+          context
+        );
+
+        const userMessageCall = vi.mocked(saveMessageToDatabase).mock.calls.find(
+          (call) => call[0].role === 'user'
+        );
+        expect(userMessageCall).toBeDefined();
+        const savedParts = userMessageCall![0].uiMessage?.parts ?? [];
+        expect(savedParts).toEqual([{ type: 'text', text: 'Plain question' }]);
+      });
+    });
   });
 });

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -26,6 +26,7 @@ import { agentTools } from './agent-tools';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { MAX_FILE_PARTS_PER_MESSAGE } from '@/lib/ai/core/validate-image-parts';
 
 // Nesting cap. Intent is 3+ for richer agent-to-agent composition, but held at 2
 // until inner stepCountIs budget is reworked — see PR #713. Raising this without
@@ -390,11 +391,22 @@ export const agentCommunicationTools = {
       question: z.string().describe('Question or request for the target agent. Be specific and provide context.'),
       context: z.string().optional().describe('Additional context about why you\'re asking this question or what you need the response for'),
       conversationId: z.string().optional().describe('Optional conversation ID to continue a previous conversation. If not provided, a new conversation will be created. Use the conversationId returned in previous responses to continue the same conversation.'),
+      // ask_agent is itself an LLM-callable tool, so this input is untrusted
+      // model output, not just internal plumbing from the channel responder.
+      // The URL scheme restriction (https/data only) exists specifically so a
+      // prompt-injected caller can't point the model's file-part fetch at an
+      // arbitrary internal host (e.g. cloud metadata endpoints) — providers
+      // that don't accept URL passthrough have the AI SDK download file-part
+      // URLs server-side. The count cap mirrors the human-upload limit in
+      // validate-image-parts.ts so this path can't be used to bypass it.
       imageAttachments: z.array(z.object({
-        url: z.string().describe('Fetchable URL (data: URL or HTTPS) for the image'),
+        url: z.string().refine(
+          (url) => url.startsWith('https://') || url.startsWith('data:'),
+          { message: 'imageAttachments url must be an https:// or data: URL' }
+        ).describe('Fetchable URL (data: URL or HTTPS) for the image'),
         mediaType: z.string().describe('Image MIME type, e.g. image/png'),
         filename: z.string().optional().describe('Original filename, if known'),
-      })).optional().describe('Recent image attachments (e.g. from channel context) to give the target agent visual context. Ignored if the target agent\'s model does not support vision — a text note is added instead.'),
+      })).max(MAX_FILE_PARTS_PER_MESSAGE).optional().describe('Recent image attachments (e.g. from channel context) to give the target agent visual context. Ignored if the target agent\'s model does not support vision — a text note is added instead.'),
     }),
     execute: async ({ agentPath, agentId, question, context, conversationId, imageAttachments }, { experimental_context }) => {
       const executionContext = experimental_context as ToolExecutionContext;
@@ -486,15 +498,21 @@ export const agentCommunicationTools = {
         // 5. Build and save the user's question message
         const userMessageId = createId();
         const targetHasVision = hasVisionCapability(targetAgent.aiModel || DEFAULT_MODEL);
-        const hasImageAttachments = !!imageAttachments && imageAttachments.length > 0;
-        const visionNote = hasImageAttachments
-          ? targetHasVision
-            ? `\n\n[${imageAttachments!.length} image attachment${imageAttachments!.length === 1 ? '' : 's'} from recent channel context ${imageAttachments!.length === 1 ? 'is' : 'are'} attached to this message.]`
-            : `\n\n[${imageAttachments!.length} image attachment${imageAttachments!.length === 1 ? '' : 's'} were provided but this agent's model does not support vision, so they could not be viewed.]`
-          : '';
+        const attachments = imageAttachments ?? [];
+        const attachmentCount = attachments.length;
+        const hasImageAttachments = attachmentCount > 0;
+        const attachmentNoun = attachmentCount === 1 ? 'image attachment' : 'image attachments';
+        // Past tense throughout: this note is replayed on every later turn of
+        // this conversation, but the file parts themselves are never persisted
+        // (see below) — "is/are attached" would read as still-true on replay.
+        const visionNote = !hasImageAttachments
+          ? ''
+          : targetHasVision
+            ? `\n\n[${attachmentCount} ${attachmentNoun} from recent channel context ${attachmentCount === 1 ? 'was' : 'were'} attached to this message.]`
+            : `\n\n[${attachmentCount} ${attachmentNoun} ${attachmentCount === 1 ? 'was' : 'were'} provided but this agent's model does not support vision, so ${attachmentCount === 1 ? 'it' : 'they'} could not be viewed.]`;
         const userMessageContent = `${context ? `Context: ${context}\n\n` : ''}${question}${visionNote}`;
         const imageFileParts = hasImageAttachments && targetHasVision
-          ? imageAttachments!.map((attachment) => ({
+          ? attachments.map((attachment) => ({
               type: 'file' as const,
               url: attachment.url,
               mediaType: attachment.mediaType,
@@ -516,9 +534,7 @@ export const agentCommunicationTools = {
             },
           ]
         };
-        const modelUserMessage: UIMessage = imageFileParts.length > 0
-          ? { ...userMessage, parts: [...userMessage.parts, ...imageFileParts] }
-          : userMessage;
+        const modelUserMessage: UIMessage = { ...userMessage, parts: [...userMessage.parts, ...imageFileParts] };
 
         // Determine sourceAgentId - only set if the calling context is an AI_CHAT page
         const callingPage = executionContext?.locationContext?.currentPage;

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -25,6 +25,7 @@ import { taskManagementTools } from './task-management-tools';
 import { agentTools } from './agent-tools';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { hasVisionCapability } from '@/lib/ai/core/vision-models';
 
 // Nesting cap. Intent is 3+ for richer agent-to-agent composition, but held at 2
 // until inner stepCountIs budget is reworked — see PR #713. Raising this without
@@ -388,9 +389,14 @@ export const agentCommunicationTools = {
       agentId: z.string().describe('Unique ID of the AI agent page to consult'),
       question: z.string().describe('Question or request for the target agent. Be specific and provide context.'),
       context: z.string().optional().describe('Additional context about why you\'re asking this question or what you need the response for'),
-      conversationId: z.string().optional().describe('Optional conversation ID to continue a previous conversation. If not provided, a new conversation will be created. Use the conversationId returned in previous responses to continue the same conversation.')
+      conversationId: z.string().optional().describe('Optional conversation ID to continue a previous conversation. If not provided, a new conversation will be created. Use the conversationId returned in previous responses to continue the same conversation.'),
+      imageAttachments: z.array(z.object({
+        url: z.string().describe('Fetchable URL (data: URL or HTTPS) for the image'),
+        mediaType: z.string().describe('Image MIME type, e.g. image/png'),
+        filename: z.string().optional().describe('Original filename, if known'),
+      })).optional().describe('Recent image attachments (e.g. from channel context) to give the target agent visual context. Ignored if the target agent\'s model does not support vision — a text note is added instead.'),
     }),
-    execute: async ({ agentPath, agentId, question, context, conversationId }, { experimental_context }) => {
+    execute: async ({ agentPath, agentId, question, context, conversationId, imageAttachments }, { experimental_context }) => {
       const executionContext = experimental_context as ToolExecutionContext;
       const userId = executionContext?.userId;
       
@@ -479,14 +485,30 @@ export const agentCommunicationTools = {
 
         // 5. Build and save the user's question message
         const userMessageId = createId();
-        const userMessageContent = `${context ? `Context: ${context}\n\n` : ''}${question}`;
+        const targetHasVision = hasVisionCapability(targetAgent.aiModel || DEFAULT_MODEL);
+        const hasImageAttachments = !!imageAttachments && imageAttachments.length > 0;
+        const visionNote = hasImageAttachments && !targetHasVision
+          ? `\n\n[${imageAttachments!.length} image attachment${imageAttachments!.length === 1 ? '' : 's'} were provided but this agent's model does not support vision, so they could not be viewed.]`
+          : '';
+        const userMessageContent = `${context ? `Context: ${context}\n\n` : ''}${question}${visionNote}`;
+        const imageFileParts = hasImageAttachments && targetHasVision
+          ? imageAttachments!.map((attachment) => ({
+              type: 'file' as const,
+              url: attachment.url,
+              mediaType: attachment.mediaType,
+              filename: attachment.filename,
+            }))
+          : [];
         const userMessage: UIMessage = {
           id: userMessageId,
           role: 'user' as const,
-          parts: [{
-            type: 'text',
-            text: userMessageContent
-          }]
+          parts: [
+            {
+              type: 'text',
+              text: userMessageContent
+            },
+            ...imageFileParts,
+          ]
         };
 
         // Determine sourceAgentId - only set if the calling context is an AI_CHAT page
@@ -502,6 +524,7 @@ export const agentCommunicationTools = {
           role: 'user',
           content: userMessageContent,
           sourceAgentId, // Track which AI agent sent this message (for agent-to-agent communication)
+          uiMessage: userMessage, // Preserve image file parts (if any) in structured content
         });
 
         // Add user message to conversation

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -487,8 +487,10 @@ export const agentCommunicationTools = {
         const userMessageId = createId();
         const targetHasVision = hasVisionCapability(targetAgent.aiModel || DEFAULT_MODEL);
         const hasImageAttachments = !!imageAttachments && imageAttachments.length > 0;
-        const visionNote = hasImageAttachments && !targetHasVision
-          ? `\n\n[${imageAttachments!.length} image attachment${imageAttachments!.length === 1 ? '' : 's'} were provided but this agent's model does not support vision, so they could not be viewed.]`
+        const visionNote = hasImageAttachments
+          ? targetHasVision
+            ? `\n\n[${imageAttachments!.length} image attachment${imageAttachments!.length === 1 ? '' : 's'} from recent channel context ${imageAttachments!.length === 1 ? 'is' : 'are'} attached to this message.]`
+            : `\n\n[${imageAttachments!.length} image attachment${imageAttachments!.length === 1 ? '' : 's'} were provided but this agent's model does not support vision, so they could not be viewed.]`
           : '';
         const userMessageContent = `${context ? `Context: ${context}\n\n` : ''}${question}${visionNote}`;
         const imageFileParts = hasImageAttachments && targetHasVision
@@ -499,6 +501,11 @@ export const agentCommunicationTools = {
               filename: attachment.filename,
             }))
           : [];
+        // The image file parts carry presigned URLs that expire within the
+        // hour, so they ride only on the in-memory message for THIS model
+        // request. Persisting them would replay dead URLs into every later
+        // request on this conversation once the TTL lapses; the durable
+        // visionNote in the text keeps the history coherent instead.
         const userMessage: UIMessage = {
           id: userMessageId,
           role: 'user' as const,
@@ -507,9 +514,11 @@ export const agentCommunicationTools = {
               type: 'text',
               text: userMessageContent
             },
-            ...imageFileParts,
           ]
         };
+        const modelUserMessage: UIMessage = imageFileParts.length > 0
+          ? { ...userMessage, parts: [...userMessage.parts, ...imageFileParts] }
+          : userMessage;
 
         // Determine sourceAgentId - only set if the calling context is an AI_CHAT page
         const callingPage = executionContext?.locationContext?.currentPage;
@@ -524,11 +533,11 @@ export const agentCommunicationTools = {
           role: 'user',
           content: userMessageContent,
           sourceAgentId, // Track which AI agent sent this message (for agent-to-agent communication)
-          uiMessage: userMessage, // Preserve image file parts (if any) in structured content
+          uiMessage: userMessage, // Durable parts only — transient presigned image parts are deliberately excluded
         });
 
         // Add user message to conversation
-        messages.push(userMessage);
+        messages.push(modelUserMessage);
 
         // 6. Sanitize messages for AI model
         const sanitizedMessages = sanitizeMessagesForModel(messages);

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder-image-attachments.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder-image-attachments.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findMany: vi.fn() },
+      channelMessages: { findMany: vi.fn() },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+  desc: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', isTrashed: 'isTrashed' },
+}));
+vi.mock('@pagespace/db/schema/chat', () => ({
+  channelMessages: { pageId: 'pageId', isActive: 'isActive', createdAt: 'createdAt' },
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    ai: {
+      debug: vi.fn(),
+      child: vi.fn(() => ({ warn: vi.fn(), error: vi.fn() })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+const mockAskAgentExecute = vi.fn();
+vi.mock('@/lib/ai/tools/agent-communication-tools', () => ({
+  agentCommunicationTools: { ask_agent: { execute: (...args: unknown[]) => mockAskAgentExecute(...args) } },
+}));
+const mockSendChannelExecute = vi.fn();
+vi.mock('@/lib/ai/tools/channel-tools', () => ({
+  channelTools: { send_channel_message: { execute: (...args: unknown[]) => mockSendChannelExecute(...args) } },
+}));
+vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
+  channelMessageRepository: {
+    insertChannelThreadReply: vi.fn(),
+    loadChannelMessageWithRelations: vi.fn(),
+    listChannelThreadFollowers: vi.fn().mockResolvedValue([]),
+  },
+}));
+vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
+  createSignedBroadcastHeaders: vi.fn(() => ({ 'x-signed': 'yes' })),
+}));
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: vi.fn(),
+}));
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastInboxEvent: vi.fn(),
+  broadcastThreadReplyCountUpdated: vi.fn(),
+}));
+
+const mockCanUserAccessFile = vi.fn();
+vi.mock('@pagespace/lib/permissions/file-access', () => ({
+  canUserAccessFile: (...args: unknown[]) => mockCanUserAccessFile(...args),
+}));
+
+const mockGeneratePresignedUrl = vi.fn();
+vi.mock('@/lib/presigned-url', () => ({
+  generatePresignedUrl: (...args: unknown[]) => mockGeneratePresignedUrl(...args),
+  getPresignedUrlTtl: () => 3600,
+}));
+
+import { db } from '@pagespace/db/db';
+import { triggerMentionedAgentResponses, type TriggerMentionedAgentResponsesParams } from '../agent-mention-responder';
+
+const mockPagesFindMany = db.query.pages.findMany as unknown as Mock;
+const mockChannelMessagesFindMany = db.query.channelMessages.findMany as unknown as Mock;
+
+const baseParams: TriggerMentionedAgentResponsesParams = {
+  userId: 'user-1',
+  channelId: 'channel-1',
+  channelTitle: 'General',
+  channelType: 'CHANNEL',
+  sourceMessageId: 'msg-1',
+  content: 'Hello',
+  driveId: 'drive-1',
+  driveName: 'Workspace',
+  driveSlug: 'workspace',
+};
+
+const imageMessage = {
+  content: 'Check this out',
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  aiMeta: null,
+  user: { name: 'Alice' },
+  fileId: 'file-1',
+  attachmentMeta: {
+    originalName: 'screenshot.png',
+    size: 2048,
+    mimeType: 'image/png',
+    contentHash: 'hash-abc',
+  },
+};
+
+describe('triggerMentionedAgentResponses — image attachment plumbing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChannelMessagesFindMany.mockResolvedValue([imageMessage]);
+    mockAskAgentExecute.mockResolvedValue({ success: true, response: 'Reply' });
+    mockSendChannelExecute.mockResolvedValue({ success: true });
+    mockCanUserAccessFile.mockResolvedValue(true);
+    mockGeneratePresignedUrl.mockResolvedValue('https://example.com/signed/screenshot.png');
+  });
+
+  it('given an eligible agent with vision and a recent image attachment, passes resolved imageAttachments to ask_agent', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    expect(mockCanUserAccessFile).toHaveBeenCalledWith('user-1', 'file-1', 'drive-1');
+    expect(mockAskAgentExecute).toHaveBeenCalledTimes(1);
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toEqual([
+      { type: 'file', url: 'https://example.com/signed/screenshot.png', mediaType: 'image/png', filename: 'screenshot.png' },
+    ]);
+  });
+
+  it('given only non-vision eligible agents, skips resolving image attachments entirely', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-2', title: 'Text Agent', enabledTools: ['send_channel_message'], aiProvider: 'openai', aiModel: 'o1-mini' },
+    ]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Text Agent](agent-2:page) look at this',
+    });
+
+    expect(mockCanUserAccessFile).not.toHaveBeenCalled();
+    expect(mockGeneratePresignedUrl).not.toHaveBeenCalled();
+    expect(mockAskAgentExecute).toHaveBeenCalledTimes(1);
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
+  });
+
+  it('given a vision-capable agent but no accessible recent attachments, passes no imageAttachments', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    mockCanUserAccessFile.mockResolvedValue(false);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    expect(mockAskAgentExecute).toHaveBeenCalledTimes(1);
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder-image-attachments.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder-image-attachments.test.ts
@@ -5,6 +5,7 @@ vi.mock('@pagespace/db/db', () => ({
     query: {
       pages: { findMany: vi.fn() },
       channelMessages: { findMany: vi.fn() },
+      files: { findMany: vi.fn() },
     },
   },
 }));
@@ -19,6 +20,9 @@ vi.mock('@pagespace/db/schema/core', () => ({
 }));
 vi.mock('@pagespace/db/schema/chat', () => ({
   channelMessages: { pageId: 'pageId', isActive: 'isActive', createdAt: 'createdAt' },
+}));
+vi.mock('@pagespace/db/schema/storage', () => ({
+  files: { id: 'id' },
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
@@ -76,6 +80,17 @@ import { triggerMentionedAgentResponses, type TriggerMentionedAgentResponsesPara
 
 const mockPagesFindMany = db.query.pages.findMany as unknown as Mock;
 const mockChannelMessagesFindMany = db.query.channelMessages.findMany as unknown as Mock;
+const mockFilesFindMany = db.query.files.findMany as unknown as Mock;
+
+const STORED_CONTENT_HASH = 'a'.repeat(64);
+
+const fileRow = {
+  id: 'file-1',
+  driveId: 'file-drive-1',
+  sizeBytes: 2048,
+  mimeType: 'image/png',
+  storagePath: `files/${STORED_CONTENT_HASH}/original`,
+};
 
 const baseParams: TriggerMentionedAgentResponsesParams = {
   userId: 'user-1',
@@ -95,11 +110,14 @@ const imageMessage = {
   aiMeta: null,
   user: { name: 'Alice' },
   fileId: 'file-1',
+  // Client-supplied at message-POST time. contentHash/mimeType/size here are
+  // deliberately WRONG relative to the files row — the resolver must never
+  // trust them for signing (only originalName, as a display label).
   attachmentMeta: {
     originalName: 'screenshot.png',
-    size: 2048,
+    size: 999999999,
     mimeType: 'image/png',
-    contentHash: 'hash-abc',
+    contentHash: 'forged-hash',
   },
 };
 
@@ -107,6 +125,7 @@ describe('triggerMentionedAgentResponses — image attachment plumbing', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockChannelMessagesFindMany.mockResolvedValue([imageMessage]);
+    mockFilesFindMany.mockResolvedValue([fileRow]);
     mockAskAgentExecute.mockResolvedValue({ success: true, response: 'Reply' });
     mockSendChannelExecute.mockResolvedValue({ success: true });
     mockCanUserAccessFile.mockResolvedValue(true);
@@ -123,12 +142,89 @@ describe('triggerMentionedAgentResponses — image attachment plumbing', () => {
       content: '@[Vision Agent](agent-1:page) look at this',
     });
 
-    expect(mockCanUserAccessFile).toHaveBeenCalledWith('user-1', 'file-1', 'drive-1');
+    // Access-checked against the file row's own drive, not the channel's.
+    expect(mockCanUserAccessFile).toHaveBeenCalledWith('user-1', 'file-1', 'file-drive-1');
     expect(mockAskAgentExecute).toHaveBeenCalledTimes(1);
     const askArgs = mockAskAgentExecute.mock.calls[0][0];
     expect(askArgs.imageAttachments).toEqual([
       { type: 'file', url: 'https://example.com/signed/screenshot.png', mediaType: 'image/png', filename: 'screenshot.png' },
     ]);
+  });
+
+  it('signs the stored files row, never the client-supplied attachmentMeta contentHash', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    expect(mockGeneratePresignedUrl).toHaveBeenCalledTimes(1);
+    expect(mockGeneratePresignedUrl).toHaveBeenCalledWith(
+      STORED_CONTENT_HASH,
+      'original',
+      3600,
+      undefined,
+      'image/png'
+    );
+    expect(mockGeneratePresignedUrl).not.toHaveBeenCalledWith(
+      'forged-hash',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('given a fileId with no matching files row, skips it without access checks or signing', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    mockFilesFindMany.mockResolvedValue([]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    expect(mockCanUserAccessFile).not.toHaveBeenCalled();
+    expect(mockGeneratePresignedUrl).not.toHaveBeenCalled();
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
+  });
+
+  it('given a stored file whose real mime type is not an image, skips it even if attachmentMeta claims image/png', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    mockFilesFindMany.mockResolvedValue([{ ...fileRow, mimeType: 'application/pdf' }]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    expect(mockCanUserAccessFile).not.toHaveBeenCalled();
+    expect(mockGeneratePresignedUrl).not.toHaveBeenCalled();
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
+  });
+
+  it('given a stored file over the size cap, resolves but filters it out', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    mockFilesFindMany.mockResolvedValue([{ ...fileRow, sizeBytes: 5 * 1024 * 1024 }]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
   });
 
   it('given only non-vision eligible agents, skips resolving image attachments entirely', async () => {

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder-image-attachments.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder-image-attachments.test.ts
@@ -73,6 +73,10 @@ const mockGeneratePresignedUrl = vi.fn();
 vi.mock('@/lib/presigned-url', () => ({
   generatePresignedUrl: (...args: unknown[]) => mockGeneratePresignedUrl(...args),
   getPresignedUrlTtl: () => 3600,
+  toContentHash: (storagePath: string) => {
+    const m = storagePath.match(/^files\/([a-f0-9]{64})\/original$/i);
+    return m ? m[1].toLowerCase() : storagePath;
+  },
 }));
 
 import { db } from '@pagespace/db/db';
@@ -258,5 +262,75 @@ describe('triggerMentionedAgentResponses — image attachment plumbing', () => {
     expect(mockAskAgentExecute).toHaveBeenCalledTimes(1);
     const askArgs = mockAskAgentExecute.mock.calls[0][0];
     expect(askArgs.imageAttachments).toBeUndefined();
+  });
+
+  it('given the same fileId attached to multiple recent messages, access-checks and signs it only once', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    // Same fileId re-shared across three of the recent messages, plus one distinct image.
+    mockChannelMessagesFindMany.mockResolvedValue([
+      { ...imageMessage, createdAt: new Date('2026-07-01T00:00:00.000Z') },
+      { ...imageMessage, createdAt: new Date('2026-07-01T00:01:00.000Z') },
+      {
+        ...imageMessage,
+        fileId: 'file-2',
+        createdAt: new Date('2026-07-01T00:02:00.000Z'),
+        attachmentMeta: { ...imageMessage.attachmentMeta, originalName: 'other.png' },
+      },
+      { ...imageMessage, createdAt: new Date('2026-07-01T00:03:00.000Z') },
+    ]);
+    mockFilesFindMany.mockResolvedValue([
+      fileRow,
+      { ...fileRow, id: 'file-2', storagePath: `files/${'b'.repeat(64)}/original` },
+    ]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    // Two distinct files, not four — the repeated fileId is deduped before
+    // any access-check or presign work, and doesn't crowd out the distinct one.
+    expect(mockCanUserAccessFile).toHaveBeenCalledTimes(2);
+    expect(mockGeneratePresignedUrl).toHaveBeenCalledTimes(2);
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toHaveLength(2);
+  });
+
+  it('given a files row with no storagePath (reaped/stub blob), skips it rather than signing a dead key', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    mockFilesFindMany.mockResolvedValue([{ ...fileRow, storagePath: null }]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    expect(mockCanUserAccessFile).not.toHaveBeenCalled();
+    expect(mockGeneratePresignedUrl).not.toHaveBeenCalled();
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
+  });
+
+  it('given attachment resolution throws (e.g. S3 signing failure), still sends a text-only reply instead of dropping the mention entirely', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: ['send_channel_message'], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+    mockGeneratePresignedUrl.mockRejectedValue(new Error('S3 signer unavailable'));
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      content: '@[Vision Agent](agent-1:page) look at this',
+    });
+
+    // The mention still gets a reply — image resolution degrades to
+    // text-only rather than aborting triggerMentionedAgentResponses entirely.
+    expect(mockAskAgentExecute).toHaveBeenCalledTimes(1);
+    const askArgs = mockAskAgentExecute.mock.calls[0][0];
+    expect(askArgs.imageAttachments).toBeUndefined();
+    expect(mockSendChannelExecute).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder-vision.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder-vision.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { assert } from '@/lib/ai/core/__tests__/riteway';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findMany: vi.fn() },
+      channelMessages: { findMany: vi.fn() },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  inArray: vi.fn(),
+  desc: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', isTrashed: 'isTrashed' },
+}));
+vi.mock('@pagespace/db/schema/chat', () => ({
+  channelMessages: { pageId: 'pageId', isActive: 'isActive', createdAt: 'createdAt' },
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    ai: {
+      debug: vi.fn(),
+      child: vi.fn(() => ({ warn: vi.fn(), error: vi.fn() })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+vi.mock('@/lib/ai/tools/agent-communication-tools', () => ({
+  agentCommunicationTools: { ask_agent: { execute: vi.fn() } },
+}));
+vi.mock('@/lib/ai/tools/channel-tools', () => ({
+  channelTools: { send_channel_message: { execute: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
+  channelMessageRepository: {
+    insertChannelThreadReply: vi.fn(),
+    loadChannelMessageWithRelations: vi.fn(),
+    listChannelThreadFollowers: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
+  createSignedBroadcastHeaders: vi.fn(() => ({ 'x-signed': 'yes' })),
+}));
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: vi.fn(),
+}));
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastInboxEvent: vi.fn(),
+  broadcastThreadReplyCountUpdated: vi.fn(),
+}));
+
+import { db } from '@pagespace/db/db';
+import { resolveMentionedAgents, fetchRecentChannelMessages } from '../agent-mention-responder';
+
+const mockPagesFindMany = db.query.pages.findMany as unknown as Mock;
+const mockChannelMessagesFindMany = db.query.channelMessages.findMany as unknown as Mock;
+
+describe('resolveMentionedAgents — hasVision', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given a mentioned agent configured with a vision-capable model, should expose hasVision: true', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Vision Agent', enabledTools: [], aiProvider: 'anthropic', aiModel: 'claude-sonnet-4.5' },
+    ]);
+
+    const agents = await resolveMentionedAgents('Hey @[Vision Agent](agent-1:page)');
+
+    assert({
+      given: 'an agent configured with a vision-capable model',
+      should: 'expose hasVision: true on the resolved agent',
+      actual: agents.find((a) => a.id === 'agent-1')?.hasVision,
+      expected: true,
+    });
+  });
+
+  it('given a mentioned agent configured with a non-vision model, should expose hasVision: false', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-2', title: 'Text Agent', enabledTools: [], aiProvider: 'openai', aiModel: 'o1-mini' },
+    ]);
+
+    const agents = await resolveMentionedAgents('Hey @[Text Agent](agent-2:page)');
+
+    assert({
+      given: 'an agent configured with a non-vision model',
+      should: 'expose hasVision: false on the resolved agent',
+      actual: agents.find((a) => a.id === 'agent-2')?.hasVision,
+      expected: false,
+    });
+  });
+
+  it('given a mentioned agent with no aiModel configured, should fall back to the default model to decide hasVision', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-3', title: 'Default Agent', enabledTools: [], aiProvider: null, aiModel: null },
+    ]);
+
+    const agents = await resolveMentionedAgents('Hey @[Default Agent](agent-3:page)');
+
+    assert({
+      given: 'an agent with no aiModel configured',
+      should: 'still return a boolean hasVision (falling back to the default model)',
+      actual: typeof agents.find((a) => a.id === 'agent-3')?.hasVision,
+      expected: 'boolean',
+    });
+  });
+});
+
+describe('fetchRecentChannelMessages — attachment data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given recent channel messages with an image attachment, should expose fileId and attachmentMeta', async () => {
+    mockChannelMessagesFindMany.mockResolvedValue([
+      {
+        content: 'Check this out',
+        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+        aiMeta: null,
+        user: { name: 'Alice' },
+        fileId: 'file-1',
+        attachmentMeta: {
+          originalName: 'screenshot.png',
+          size: 2048,
+          mimeType: 'image/png',
+          contentHash: 'hash-abc',
+        },
+      },
+    ]);
+
+    const messages = await fetchRecentChannelMessages('channel-1');
+
+    assert({
+      given: 'a recent channel message with an image attachment',
+      should: 'expose fileId and attachmentMeta on the returned row',
+      actual: { fileId: messages[0].fileId, attachmentMeta: messages[0].attachmentMeta },
+      expected: {
+        fileId: 'file-1',
+        attachmentMeta: {
+          originalName: 'screenshot.png',
+          size: 2048,
+          mimeType: 'image/png',
+          contentHash: 'hash-abc',
+        },
+      },
+    });
+  });
+
+  it('given a recent channel message with no attachment, should expose null fileId and attachmentMeta', async () => {
+    mockChannelMessagesFindMany.mockResolvedValue([
+      {
+        content: 'Just text',
+        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+        aiMeta: null,
+        user: { name: 'Alice' },
+        fileId: null,
+        attachmentMeta: null,
+      },
+    ]);
+
+    const messages = await fetchRecentChannelMessages('channel-1');
+
+    assert({
+      given: 'a recent channel message with no attachment',
+      should: 'expose null fileId and attachmentMeta',
+      actual: { fileId: messages[0].fileId, attachmentMeta: messages[0].attachmentMeta },
+      expected: { fileId: null, attachmentMeta: null },
+    });
+  });
+});

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder-vision.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder-vision.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { beforeEach, describe, it, vi, type Mock } from 'vitest';
 import { assert } from '@/lib/ai/core/__tests__/riteway';
 
 vi.mock('@pagespace/db/db', () => ({

--- a/apps/web/src/lib/channels/__tests__/build-recent-image-file-parts.test.ts
+++ b/apps/web/src/lib/channels/__tests__/build-recent-image-file-parts.test.ts
@@ -1,0 +1,174 @@
+import { describe, it } from 'vitest';
+import { assert } from '@/lib/ai/core/__tests__/riteway';
+import {
+  buildRecentImageFileParts,
+  MAX_RECENT_IMAGE_ATTACHMENTS,
+  MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES,
+  type RecentImageFileCandidate,
+} from '../build-recent-image-file-parts';
+
+const baseCandidate: RecentImageFileCandidate = {
+  fileId: 'file-1',
+  url: 'https://example.com/signed/file-1',
+  mimeType: 'image/png',
+  filename: 'screenshot.png',
+  sizeBytes: 1024,
+  accessible: true,
+};
+
+describe('buildRecentImageFileParts', () => {
+  it('given a single valid image candidate, should return one file part', () => {
+    const result = buildRecentImageFileParts([baseCandidate]);
+
+    assert({
+      given: 'one accessible, allowed, in-size image candidate',
+      should: 'return a single file part with the resolved url/mediaType/filename',
+      actual: result,
+      expected: [
+        { type: 'file', url: baseCandidate.url, mediaType: 'image/png', filename: 'screenshot.png' },
+      ],
+    });
+  });
+
+  it('given more candidates than the cap, should keep only the most recent maxCount', () => {
+    const candidates = Array.from({ length: MAX_RECENT_IMAGE_ATTACHMENTS + 3 }, (_, i) => ({
+      ...baseCandidate,
+      fileId: `file-${i}`,
+      url: `https://example.com/signed/file-${i}`,
+      filename: `image-${i}.png`,
+    }));
+
+    const result = buildRecentImageFileParts(candidates);
+
+    assert({
+      given: `${candidates.length} valid candidates (more than the cap of ${MAX_RECENT_IMAGE_ATTACHMENTS})`,
+      should: 'cap the output at maxCount, keeping the most recent (last) ones in order',
+      actual: result.map((p) => p.filename),
+      expected: candidates.slice(-MAX_RECENT_IMAGE_ATTACHMENTS).map((c) => c.filename),
+    });
+  });
+
+  it('given a custom maxCount, should cap at that value instead of the default', () => {
+    const candidates = Array.from({ length: 4 }, (_, i) => ({
+      ...baseCandidate,
+      fileId: `file-${i}`,
+      filename: `image-${i}.png`,
+    }));
+
+    const result = buildRecentImageFileParts(candidates, 2);
+
+    assert({
+      given: '4 valid candidates with an explicit maxCount of 2',
+      should: 'cap the output at 2, keeping the last 2',
+      actual: result.map((p) => p.filename),
+      expected: ['image-2.png', 'image-3.png'],
+    });
+  });
+
+  it('given a candidate over the size limit, should skip it', () => {
+    const oversized: RecentImageFileCandidate = {
+      ...baseCandidate,
+      fileId: 'file-oversized',
+      filename: 'huge.png',
+      sizeBytes: MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES + 1,
+    };
+
+    const result = buildRecentImageFileParts([oversized]);
+
+    assert({
+      given: 'a candidate whose sizeBytes exceeds the max',
+      should: 'skip it and return no file parts',
+      actual: result,
+      expected: [],
+    });
+  });
+
+  it('given a candidate with a disallowed mime type, should skip it', () => {
+    const disallowed: RecentImageFileCandidate = {
+      ...baseCandidate,
+      fileId: 'file-disallowed',
+      filename: 'doc.pdf',
+      mimeType: 'application/pdf',
+    };
+
+    const result = buildRecentImageFileParts([disallowed]);
+
+    assert({
+      given: 'a candidate whose mimeType is not an allowed image type',
+      should: 'skip it and return no file parts',
+      actual: result,
+      expected: [],
+    });
+  });
+
+  it('given a candidate with a null mime type, should skip it', () => {
+    const nullMime: RecentImageFileCandidate = {
+      ...baseCandidate,
+      fileId: 'file-null-mime',
+      mimeType: null,
+    };
+
+    const result = buildRecentImageFileParts([nullMime]);
+
+    assert({
+      given: 'a candidate whose mimeType is null',
+      should: 'skip it and return no file parts',
+      actual: result,
+      expected: [],
+    });
+  });
+
+  it('given an inaccessible candidate, should skip it', () => {
+    const inaccessible: RecentImageFileCandidate = {
+      ...baseCandidate,
+      fileId: 'file-inaccessible',
+      accessible: false,
+    };
+
+    const result = buildRecentImageFileParts([inaccessible]);
+
+    assert({
+      given: 'a candidate the user cannot access (accessible: false)',
+      should: 'skip it and return no file parts',
+      actual: result,
+      expected: [],
+    });
+  });
+
+  it('given a mix of valid and invalid candidates, should keep only the valid ones in order', () => {
+    const valid1: RecentImageFileCandidate = { ...baseCandidate, fileId: 'a', filename: 'a.png' };
+    const oversized: RecentImageFileCandidate = {
+      ...baseCandidate,
+      fileId: 'b',
+      filename: 'b.png',
+      sizeBytes: MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES + 1,
+    };
+    const inaccessible: RecentImageFileCandidate = {
+      ...baseCandidate,
+      fileId: 'c',
+      filename: 'c.png',
+      accessible: false,
+    };
+    const valid2: RecentImageFileCandidate = { ...baseCandidate, fileId: 'd', filename: 'd.png' };
+
+    const result = buildRecentImageFileParts([valid1, oversized, inaccessible, valid2]);
+
+    assert({
+      given: 'a mix of valid and invalid candidates',
+      should: 'skip the invalid ones while preserving the relative order of the valid ones',
+      actual: result.map((p) => p.filename),
+      expected: ['a.png', 'd.png'],
+    });
+  });
+
+  it('given no candidates, should return an empty array', () => {
+    const result = buildRecentImageFileParts([]);
+
+    assert({
+      given: 'an empty candidate list',
+      should: 'return an empty array',
+      actual: result,
+      expected: [],
+    });
+  });
+});

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -22,10 +22,11 @@ import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import type { ToolExecutionContext } from '@/lib/ai/core/types';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
 import { DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
-import type { AttachmentMeta } from '@pagespace/db/schema/storage';
+import { files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 import type { ChannelMessageAiMeta } from '@pagespace/db/schema/chat';
 import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
 import { generatePresignedUrl, getPresignedUrlTtl } from '@/lib/presigned-url';
+import { isAllowedImageType } from '@/lib/validation/image-validation';
 import {
   buildRecentImageFileParts,
   type ImageFilePart,
@@ -247,44 +248,78 @@ export async function fetchRecentChannelMessages(channelId: string): Promise<Rec
   });
 }
 
+/** Extract a bare SHA-256 hash from legacy storagePath values like 'files/{hash}/original'. */
+function toContentHash(storagePath: string): string {
+  const m = storagePath.match(/^files\/([a-f0-9]{64})\/original$/i);
+  return m ? m[1].toLowerCase() : storagePath;
+}
+
 /**
  * Resolve recent channel image attachments into presigned, access-checked
  * file parts for ask_agent. Skips the S3/DB round-trips entirely when no
  * eligible agent can view images (nothing would ever consume the result).
+ *
+ * Everything security-relevant — storage key, mime type, size, and the drive
+ * used for the access check — comes from the `files` row, never from the
+ * message's `attachmentMeta` (client-supplied at message-POST time, so a
+ * crafted message could otherwise pair an accessible fileId with a forged
+ * contentHash and mint a presigned URL for an arbitrary object).
+ * `attachmentMeta` is used only for the display filename.
  */
 async function resolveImageAttachmentsForContext(
   userId: string,
-  driveId: string | null | undefined,
   contextMessages: RecentChannelMessage[]
 ): Promise<ImageFilePart[]> {
   const imageCandidateMessages = contextMessages.filter(
-    (message): message is RecentChannelMessage & { fileId: string; attachmentMeta: AttachmentMeta } =>
-      !!message.fileId && !!message.attachmentMeta
+    (message): message is RecentChannelMessage & { fileId: string } => !!message.fileId
   );
 
   if (imageCandidateMessages.length === 0) {
     return [];
   }
 
+  const fileRows = await db.query.files.findMany({
+    where: inArray(files.id, [...new Set(imageCandidateMessages.map((message) => message.fileId))]),
+    columns: { id: true, driveId: true, sizeBytes: true, mimeType: true, storagePath: true },
+  });
+  const filesById = new Map(fileRows.map((file) => [file.id, file]));
+
   const candidates: RecentImageFileCandidate[] = await Promise.all(
     imageCandidateMessages.map(async (message) => {
-      const accessible = await canUserAccessFile(userId, message.fileId, driveId ?? null);
+      const file = filesById.get(message.fileId);
+      const filename = message.attachmentMeta?.originalName || 'attachment';
+
+      // Missing row or a non-image mime type can never become a file part
+      // (buildRecentImageFileParts would drop it), so skip the per-file
+      // access-check/signing work up front.
+      if (!file || !file.mimeType || !isAllowedImageType(file.mimeType)) {
+        return {
+          fileId: message.fileId,
+          url: '',
+          mimeType: file?.mimeType ?? null,
+          filename,
+          sizeBytes: file?.sizeBytes ?? 0,
+          accessible: false,
+        };
+      }
+
+      const accessible = await canUserAccessFile(userId, file.id, file.driveId);
       const url = accessible
         ? await generatePresignedUrl(
-            message.attachmentMeta.contentHash,
+            toContentHash(file.storagePath || file.id),
             'original',
-            getPresignedUrlTtl(message.attachmentMeta.mimeType),
+            getPresignedUrlTtl(file.mimeType),
             undefined,
-            message.attachmentMeta.mimeType
+            file.mimeType
           )
         : '';
 
       return {
-        fileId: message.fileId,
+        fileId: file.id,
         url,
-        mimeType: message.attachmentMeta.mimeType,
-        filename: message.attachmentMeta.originalName,
-        sizeBytes: message.attachmentMeta.size,
+        mimeType: file.mimeType,
+        filename,
+        sizeBytes: file.sizeBytes,
         accessible,
       };
     })
@@ -477,7 +512,7 @@ export async function triggerMentionedAgentResponses(
     // Only worth resolving presigned URLs/access checks when at least one
     // eligible agent can actually view images.
     const imageAttachments = eligibleAgents.some((agent) => agent.hasVision)
-      ? await resolveImageAttachmentsForContext(params.userId, params.driveId, contextMessages)
+      ? await resolveImageAttachmentsForContext(params.userId, contextMessages)
       : [];
 
     for (const agent of eligibleAgents) {

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -25,10 +25,11 @@ import { DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 import type { ChannelMessageAiMeta } from '@pagespace/db/schema/chat';
 import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
-import { generatePresignedUrl, getPresignedUrlTtl } from '@/lib/presigned-url';
+import { generatePresignedUrl, getPresignedUrlTtl, toContentHash } from '@/lib/presigned-url';
 import { isAllowedImageType } from '@/lib/validation/image-validation';
 import {
   buildRecentImageFileParts,
+  MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES,
   type ImageFilePart,
   type RecentImageFileCandidate,
 } from '@/lib/channels/build-recent-image-file-parts';
@@ -248,12 +249,6 @@ export async function fetchRecentChannelMessages(channelId: string): Promise<Rec
   });
 }
 
-/** Extract a bare SHA-256 hash from legacy storagePath values like 'files/{hash}/original'. */
-function toContentHash(storagePath: string): string {
-  const m = storagePath.match(/^files\/([a-f0-9]{64})\/original$/i);
-  return m ? m[1].toLowerCase() : storagePath;
-}
-
 /**
  * Resolve recent channel image attachments into presigned, access-checked
  * file parts for ask_agent. Skips the S3/DB round-trips entirely when no
@@ -270,29 +265,46 @@ async function resolveImageAttachmentsForContext(
   userId: string,
   contextMessages: RecentChannelMessage[]
 ): Promise<ImageFilePart[]> {
-  const imageCandidateMessages = contextMessages.filter(
-    (message): message is RecentChannelMessage & { fileId: string } => !!message.fileId
-  );
+  // Dedup by fileId, keeping each file's MOST RECENT mention: re-sharing the
+  // same screenshot across several of the last 12 messages must not both
+  // (a) redo the access-check/presign per repeat, and (b) crowd out distinct
+  // older images from the eventual 5-slot cap with copies of one image.
+  // Map.delete+set (rather than a plain overwrite) moves the re-seen key to
+  // the end of iteration order, so final ordering reflects last-seen position.
+  const latestByFileId = new Map<string, RecentChannelMessage & { fileId: string }>();
+  for (const message of contextMessages) {
+    if (!message.fileId) continue;
+    const withFileId = message as RecentChannelMessage & { fileId: string };
+    latestByFileId.delete(message.fileId);
+    latestByFileId.set(message.fileId, withFileId);
+  }
 
-  if (imageCandidateMessages.length === 0) {
+  if (latestByFileId.size === 0) {
     return [];
   }
 
   const fileRows = await db.query.files.findMany({
-    where: inArray(files.id, [...new Set(imageCandidateMessages.map((message) => message.fileId))]),
+    where: inArray(files.id, [...latestByFileId.keys()]),
     columns: { id: true, driveId: true, sizeBytes: true, mimeType: true, storagePath: true },
   });
   const filesById = new Map(fileRows.map((file) => [file.id, file]));
 
   const candidates: RecentImageFileCandidate[] = await Promise.all(
-    imageCandidateMessages.map(async (message) => {
+    [...latestByFileId.values()].map(async (message) => {
       const file = filesById.get(message.fileId);
       const filename = message.attachmentMeta?.originalName || 'attachment';
 
-      // Missing row or a non-image mime type can never become a file part
-      // (buildRecentImageFileParts would drop it), so skip the per-file
-      // access-check/signing work up front.
-      if (!file || !file.mimeType || !isAllowedImageType(file.mimeType)) {
+      // Missing row, a non-image mime type, an oversized file, or a stub row
+      // with no blob ever persisted (storagePath null — see reap-orphaned-files)
+      // can never become a valid file part, so skip the per-file
+      // access-check/signing work up front rather than signing a dead URL.
+      if (
+        !file ||
+        !file.storagePath ||
+        !file.mimeType ||
+        !isAllowedImageType(file.mimeType) ||
+        file.sizeBytes > MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES
+      ) {
         return {
           fileId: message.fileId,
           url: '',
@@ -306,7 +318,7 @@ async function resolveImageAttachmentsForContext(
       const accessible = await canUserAccessFile(userId, file.id, file.driveId);
       const url = accessible
         ? await generatePresignedUrl(
-            toContentHash(file.storagePath || file.id),
+            toContentHash(file.storagePath),
             'original',
             getPresignedUrlTtl(file.mimeType),
             undefined,
@@ -510,10 +522,23 @@ export async function triggerMentionedAgentResponses(
     const commandExecution = commandPlan ? commandExecutionDataFromPlan(commandPlan) : undefined;
 
     // Only worth resolving presigned URLs/access checks when at least one
-    // eligible agent can actually view images.
-    const imageAttachments = eligibleAgents.some((agent) => agent.hasVision)
-      ? await resolveImageAttachmentsForContext(params.userId, contextMessages)
-      : [];
+    // eligible agent can actually view images. Resolution failure (S3
+    // misconfigured, transient DB error) must degrade to text-only, not
+    // abort every mentioned agent's reply — this call sits ahead of the
+    // per-agent try/catch below, so an uncaught throw here would propagate
+    // to the function-level catch and silence the whole mention entirely.
+    let imageAttachments: ImageFilePart[] = [];
+    if (eligibleAgents.some((agent) => agent.hasVision)) {
+      try {
+        imageAttachments = await resolveImageAttachmentsForContext(params.userId, contextMessages);
+      } catch (error) {
+        channelMentionLogger.error(
+          'Failed to resolve recent channel image attachments; continuing with text-only replies',
+          error instanceof Error ? error : undefined,
+          { channelId: params.channelId, sourceMessageId: params.sourceMessageId }
+        );
+      }
+    }
 
     for (const agent of eligibleAgents) {
       try {

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -24,6 +24,13 @@ import { hasVisionCapability } from '@/lib/ai/core/vision-models';
 import { DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
 import type { AttachmentMeta } from '@pagespace/db/schema/storage';
 import type { ChannelMessageAiMeta } from '@pagespace/db/schema/chat';
+import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
+import { generatePresignedUrl, getPresignedUrlTtl } from '@/lib/presigned-url';
+import {
+  buildRecentImageFileParts,
+  type ImageFilePart,
+  type RecentImageFileCandidate,
+} from '@/lib/channels/build-recent-image-file-parts';
 
 const channelMentionLogger = loggers.ai.child({ module: 'channel-agent-mentions' });
 
@@ -240,6 +247,52 @@ export async function fetchRecentChannelMessages(channelId: string): Promise<Rec
   });
 }
 
+/**
+ * Resolve recent channel image attachments into presigned, access-checked
+ * file parts for ask_agent. Skips the S3/DB round-trips entirely when no
+ * eligible agent can view images (nothing would ever consume the result).
+ */
+async function resolveImageAttachmentsForContext(
+  userId: string,
+  driveId: string | null | undefined,
+  contextMessages: RecentChannelMessage[]
+): Promise<ImageFilePart[]> {
+  const imageCandidateMessages = contextMessages.filter(
+    (message): message is RecentChannelMessage & { fileId: string; attachmentMeta: AttachmentMeta } =>
+      !!message.fileId && !!message.attachmentMeta
+  );
+
+  if (imageCandidateMessages.length === 0) {
+    return [];
+  }
+
+  const candidates: RecentImageFileCandidate[] = await Promise.all(
+    imageCandidateMessages.map(async (message) => {
+      const accessible = await canUserAccessFile(userId, message.fileId, driveId ?? null);
+      const url = accessible
+        ? await generatePresignedUrl(
+            message.attachmentMeta.contentHash,
+            'original',
+            getPresignedUrlTtl(message.attachmentMeta.mimeType),
+            undefined,
+            message.attachmentMeta.mimeType
+          )
+        : '';
+
+      return {
+        fileId: message.fileId,
+        url,
+        mimeType: message.attachmentMeta.mimeType,
+        filename: message.attachmentMeta.originalName,
+        sizeBytes: message.attachmentMeta.size,
+        accessible,
+      };
+    })
+  );
+
+  return buildRecentImageFileParts(candidates);
+}
+
 function canAgentSendChannelMessages(enabledTools: string[] | null): boolean {
   return Array.isArray(enabledTools) && enabledTools.includes('send_channel_message');
 }
@@ -421,6 +474,12 @@ export async function triggerMentionedAgentResponses(
     const commandContext = buildCommandPromptSection(commandPlan);
     const commandExecution = commandPlan ? commandExecutionDataFromPlan(commandPlan) : undefined;
 
+    // Only worth resolving presigned URLs/access checks when at least one
+    // eligible agent can actually view images.
+    const imageAttachments = eligibleAgents.some((agent) => agent.hasVision)
+      ? await resolveImageAttachmentsForContext(params.userId, params.driveId, contextMessages)
+      : [];
+
     for (const agent of eligibleAgents) {
       try {
         const mentionConversationId = `channel:${params.channelId}:agent:${agent.id}`;
@@ -438,6 +497,7 @@ export async function triggerMentionedAgentResponses(
               ...(commandContext ? ['', commandContext] : []),
             ].join('\n'),
             conversationId: mentionConversationId,
+            ...(imageAttachments.length > 0 ? { imageAttachments } : {}),
           },
           {
             toolCallId: `channel-mention-ask-${params.sourceMessageId}-${agent.id}`,

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -20,6 +20,10 @@ import {
 import { planCommandExecution } from '@/lib/ai/core/command-resolver';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import type { ToolExecutionContext } from '@/lib/ai/core/types';
+import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
+import type { AttachmentMeta } from '@pagespace/db/schema/storage';
+import type { ChannelMessageAiMeta } from '@pagespace/db/schema/chat';
 
 const channelMentionLogger = loggers.ai.child({ module: 'channel-agent-mentions' });
 
@@ -27,10 +31,21 @@ const CONTEXT_MESSAGE_LIMIT = 12;
 const MESSAGE_SNIPPET_LIMIT = 320;
 const TRANSCRIPT_CHAR_LIMIT = 5000;
 
-interface MentionedAgent {
+export interface MentionedAgent {
   id: string;
   title: string;
   enabledTools: string[] | null;
+  /** Whether this agent's configured model (falling back to DEFAULT_MODEL) supports vision. */
+  hasVision: boolean;
+}
+
+export interface RecentChannelMessage {
+  content: string;
+  createdAt: Date;
+  user: { name: string | null } | null;
+  aiMeta: ChannelMessageAiMeta | null;
+  fileId: string | null;
+  attachmentMeta: AttachmentMeta | null;
 }
 
 export interface TriggerMentionedAgentResponsesParams {
@@ -146,7 +161,7 @@ function buildLocationContext(params: TriggerMentionedAgentResponsesParams): Too
   };
 }
 
-async function resolveMentionedAgents(content: string): Promise<MentionedAgent[]> {
+export async function resolveMentionedAgents(content: string): Promise<MentionedAgent[]> {
   const processed = processMentionsInMessage(content);
   if (processed.mentions.length === 0) {
     return [];
@@ -175,6 +190,8 @@ async function resolveMentionedAgents(content: string): Promise<MentionedAgent[]
       id: true,
       title: true,
       enabledTools: true,
+      aiProvider: true,
+      aiModel: true,
     },
   });
 
@@ -194,10 +211,33 @@ async function resolveMentionedAgents(content: string): Promise<MentionedAgent[]
       id: page.id,
       title: page.title || 'Agent',
       enabledTools: Array.isArray(page.enabledTools) ? page.enabledTools : null,
+      hasVision: hasVisionCapability(page.aiModel || DEFAULT_MODEL),
     });
   }
 
   return orderedAgents;
+}
+
+export async function fetchRecentChannelMessages(channelId: string): Promise<RecentChannelMessage[]> {
+  return db.query.channelMessages.findMany({
+    where: and(eq(channelMessages.pageId, channelId), eq(channelMessages.isActive, true)),
+    columns: {
+      content: true,
+      createdAt: true,
+      aiMeta: true,
+      fileId: true,
+      attachmentMeta: true,
+    },
+    with: {
+      user: {
+        columns: {
+          name: true,
+        },
+      },
+    },
+    orderBy: [desc(channelMessages.createdAt)],
+    limit: CONTEXT_MESSAGE_LIMIT,
+  });
 }
 
 function canAgentSendChannelMessages(enabledTools: string[] | null): boolean {
@@ -361,26 +401,7 @@ export async function triggerMentionedAgentResponses(
       return;
     }
 
-    const recentMessages = await db.query.channelMessages.findMany({
-      where: and(
-        eq(channelMessages.pageId, params.channelId),
-        eq(channelMessages.isActive, true)
-      ),
-      columns: {
-        content: true,
-        createdAt: true,
-        aiMeta: true,
-      },
-      with: {
-        user: {
-          columns: {
-            name: true,
-          },
-        },
-      },
-      orderBy: [desc(channelMessages.createdAt)],
-      limit: CONTEXT_MESSAGE_LIMIT,
-    });
+    const recentMessages = await fetchRecentChannelMessages(params.channelId);
 
     const contextMessages = [...recentMessages].reverse();
     const transcript = buildChannelTranscript(contextMessages);

--- a/apps/web/src/lib/channels/build-recent-image-file-parts.ts
+++ b/apps/web/src/lib/channels/build-recent-image-file-parts.ts
@@ -1,12 +1,13 @@
 import { isAllowedImageType } from '@/lib/validation/image-validation';
+import { MAX_FILE_PARTS_PER_MESSAGE, MAX_DATA_URL_LENGTH } from '@/lib/ai/core/validate-image-parts';
 
 /**
- * Mirrors the single-message caps in validate-image-parts.ts (5 images,
+ * Same single-message caps enforced in validate-image-parts.ts (5 images,
  * 4MB each) so a mentioned agent never receives more visual context per
  * consultation than a human would attach to one chat message.
  */
-export const MAX_RECENT_IMAGE_ATTACHMENTS = 5;
-export const MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES = 4 * 1024 * 1024;
+export const MAX_RECENT_IMAGE_ATTACHMENTS = MAX_FILE_PARTS_PER_MESSAGE;
+export const MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES = MAX_DATA_URL_LENGTH;
 
 export interface RecentImageFileCandidate {
   fileId: string;

--- a/apps/web/src/lib/channels/build-recent-image-file-parts.ts
+++ b/apps/web/src/lib/channels/build-recent-image-file-parts.ts
@@ -1,0 +1,53 @@
+import { isAllowedImageType } from '@/lib/validation/image-validation';
+
+/**
+ * Mirrors the single-message caps in validate-image-parts.ts (5 images,
+ * 4MB each) so a mentioned agent never receives more visual context per
+ * consultation than a human would attach to one chat message.
+ */
+export const MAX_RECENT_IMAGE_ATTACHMENTS = 5;
+export const MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES = 4 * 1024 * 1024;
+
+export interface RecentImageFileCandidate {
+  fileId: string;
+  url: string;
+  mimeType: string | null;
+  filename: string;
+  sizeBytes: number;
+  accessible: boolean;
+}
+
+export interface ImageFilePart {
+  type: 'file';
+  url: string;
+  mediaType: string;
+  filename: string;
+}
+
+/**
+ * Pure filter/cap over pre-resolved image attachment candidates. Callers are
+ * responsible for the side effects (S3 presigned URL generation, DB-backed
+ * access checks) before invoking this — it makes no I/O of its own.
+ *
+ * `candidates` is expected oldest-to-newest; the most recent `maxCount`
+ * valid candidates are kept, in their original relative order.
+ */
+export function buildRecentImageFileParts(
+  candidates: RecentImageFileCandidate[],
+  maxCount: number = MAX_RECENT_IMAGE_ATTACHMENTS
+): ImageFilePart[] {
+  const valid = candidates.filter(
+    (candidate) =>
+      candidate.accessible &&
+      candidate.mimeType !== null &&
+      isAllowedImageType(candidate.mimeType) &&
+      candidate.sizeBytes <= MAX_RECENT_IMAGE_ATTACHMENT_SIZE_BYTES
+  );
+
+  return valid.slice(-maxCount).map((candidate) => ({
+    type: 'file' as const,
+    url: candidate.url,
+    mediaType: candidate.mimeType as string,
+    filename: candidate.filename,
+  }));
+}

--- a/apps/web/src/lib/presigned-url.ts
+++ b/apps/web/src/lib/presigned-url.ts
@@ -28,6 +28,12 @@ export function getPresignedUrlTtl(mimeType: string): number {
   return 900;
 }
 
+/** Extract a bare SHA-256 hash from legacy storagePath values like 'files/{hash}/original'. */
+export function toContentHash(storagePath: string): string {
+  const m = storagePath.match(/^files\/([a-f0-9]{64})\/original$/i);
+  return m ? m[1].toLowerCase() : storagePath;
+}
+
 export async function generatePresignedUrl(
   contentHash: string,
   preset?: string,


### PR DESCRIPTION
## Summary
- Add pure `buildRecentImageFileParts` filter/cap builder — caps recent channel-context image attachments at 5, skipping oversized (>4MB), disallowed mime-type, and inaccessible candidates. Takes pre-resolved candidates so it stays a pure function with no DB/S3 I/O of its own.
- Extend `agent-mention-responder`'s queries: `resolveMentionedAgents` now exposes `hasVision` per mentioned agent (via `hasVisionCapability`, falling back to `DEFAULT_MODEL`), and the inline recent-messages query is extracted into an exported `fetchRecentChannelMessages` that also selects `fileId`/`attachmentMeta`.
- Wire `ask_agent` to accept an optional `imageAttachments` param: vision-capable target agents get the images as file parts for the current model request; non-vision agents get a text note instead so they know attachments existed but couldn't be viewed. `agent-mention-responder` resolves recent channel attachments into presigned, access-checked file parts and passes them to every eligible agent's `ask_agent` call — skipping the S3/DB resolution work entirely when no eligible agent has vision.

## Security & durability (review follow-ups)
- **Sign the stored file, not client metadata** — the resolver loads the `files` rows for candidate `fileId`s and derives the storage key (`toContentHash(storagePath)`), mime type, size, and the access-check drive scope from the DB row, matching `/api/files/[id]/view`. Client-supplied `attachmentMeta` (set at message-POST time) is used only for the display filename, so a crafted message can't pair an accessible `fileId` with a forged `contentHash` to mint a presigned URL for an arbitrary object.
- **No expiring URLs in history** — `ask_agent` persists durable text parts only; presigned image file parts are attached to the in-memory message for the current request and never saved, so later mentions on the same conversation don't replay dead URLs. A durable text note keeps the persisted history coherent.
- **Graceful degradation** — a failure resolving recent attachments (S3 misconfig, transient DB error) now falls back to text-only replies instead of silently dropping every mentioned agent's response for that message.
- **`ask_agent` input validation** — `imageAttachments` is untrusted input (the tool is LLM-callable, not just internal plumbing), so the schema now caps the array at the single-message image limit and requires an `https://` or `data:` URL, closing an SSRF-shaped gap.
- **Dedup by fileId** — the same image re-shared across several recent messages is access-checked/signed once, not once per message, and no longer crowds distinct older images out of the 5-slot cap.
- Grammar and replay-safety fixes to the vision/no-vision notes persisted into agent conversation history.
- `toContentHash` and the single-message image caps (5 images / 4MB) are now single exported definitions instead of duplicate copies.

## Epic
Implements PageSpace epic "Channel & DM Image Attachments for Agents" (page `vmfry086oqlasajk8ns1rg7v`), part of the Image & Vision Support effort. All 3 phases (Pure functions → Integration → Quality gate) are complete on the epic board.

## Test plan
- [x] `bun run --filter 'web' typecheck` — clean
- [x] `bunx eslint` on all touched files — clean
- [x] `bunx vitest run` across `src/lib/channels/__tests__/` and `src/lib/ai/tools/__tests__/agent-communication-tools.test.ts` — 109/109 passing (incl. forged-attachmentMeta, missing-files-row, mime-spoof, size-cap, dedup, null-storagePath, resolution-failure-degrades-gracefully, and imageAttachments-schema-validation regressions); 716/716 across the broader `lib/ai` + `lib/channels` area
- [ ] Manual smoke test: mention a vision-capable agent in a channel thread with a recent image attachment and confirm it can describe the image; mention a non-vision agent and confirm it reports the attachment as unviewable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoSJZzR4bEnPwugarKfSbR
