### PR TITLE
feat(web): deliver actual image bytes from read_page's visual branch

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -54,7 +54,7 @@ import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
 import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
-import { getModelCapabilities, hasVisionCapability } from '@/lib/ai/core/model-capabilities';
+import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
 import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
 import { getUserPersonalization } from '@/lib/ai/core/personalization-utils';

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -54,7 +54,8 @@ import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
 import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
-import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
+import { getModelCapabilities, hasVisionCapability } from '@/lib/ai/core/model-capabilities';
+import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
 import { getUserPersonalization } from '@/lib/ai/core/personalization-utils';
 import { applyToolExposureMode } from '@/lib/ai/tools/tool-exposure';
@@ -796,6 +797,17 @@ export async function POST(request: Request) {
 
     // Always inject the finish tool so the model can signal task completion
     filteredTools = { ...filteredTools, ...finishTool } as ToolSet;
+
+    // Guard against a stale read_page tool-result (image bytes delivered on an
+    // earlier turn when the model had vision) being re-embedded as an image when
+    // convertToModelMessages re-converts history for a model that no longer has
+    // vision. Must run before prepareHistoryForModel/finishModelRequest below.
+    if (filteredTools.read_page) {
+      filteredTools = {
+        ...filteredTools,
+        read_page: guardReadPageToolForVision(filteredTools.read_page, hasVisionCapability(resolvedModelName ?? currentModel)),
+      };
+    }
 
     // Build system prompt BEFORE history loading so its token estimate is
     // available for prepareConversationContext's context-window budget math.

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -65,6 +65,7 @@ import {
 import { runAgentWithRetry, AGENT_MAX_STEPS, type RunAgentWithRetryResult } from '@/lib/ai/core/run-agent-with-retry';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
+import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
 import { createToolSearchTool } from '@/lib/ai/tools/tool-search-tool';
 import {
   buildVolatileTurnContext,
@@ -779,6 +780,16 @@ MENTION PROCESSING:
       tool_search: createToolSearchTool(filteredAllTools),
       execute_tool: createExecuteTool(nonCoreTools),
     };
+
+    // Guard against a stale read_page tool-result (image bytes delivered on an
+    // earlier turn when the model had vision) being re-embedded as an image when
+    // history is re-converted for a model that no longer has vision.
+    if (finalTools.read_page) {
+      finalTools = {
+        ...finalTools,
+        read_page: guardReadPageToolForVision(finalTools.read_page, hasVisionCapability(currentModel)),
+      };
+    }
 
     loggers.api.debug('Global Assistant Chat API: Tool modes', {
       isReadOnly: readOnlyMode,

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/mcp-scope-tool-filtering.test.ts
@@ -118,6 +118,7 @@ vi.mock('@/lib/ai/core/tool-filtering', async (importOriginal) => {
 });
 vi.mock('@/lib/ai/core/model-capabilities', () => ({
   getModelCapabilities: vi.fn().mockResolvedValue({}),
+  hasVisionCapability: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('@/lib/ai/tools/tool-exposure', () => ({

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route-backfill.test.ts
@@ -110,6 +110,7 @@ vi.mock('@/lib/ai/core/tool-filtering', () => ({
 
 vi.mock('@/lib/ai/core/model-capabilities', () => ({
   getModelCapabilities: vi.fn().mockResolvedValue({}),
+  hasVisionCapability: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('@/lib/ai/tools/tool-exposure', () => ({

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -102,9 +102,20 @@ vi.mock('@/lib/ai/core/message-utils', () => ({
   extractMessageContent: vi.fn().mockReturnValue('Hello'),
   extractToolResults: vi.fn().mockReturnValue([]),
 }));
-vi.mock('@/lib/ai/core/ai-tools', () => ({
-  pageSpaceTools: {},
-}));
+vi.mock('@/lib/ai/core/ai-tools', async () => {
+  const { toModelOutputForReadPage } = await import('@/lib/ai/tools/read-page-vision-output');
+  return {
+    pageSpaceTools: {
+      // Mirrors the real read_page tool's toModelOutput wiring (page-read-tools.ts)
+      // so the cross-turn vision guard test below exercises the real mapper/guard.
+      read_page: {
+        name: 'read_page',
+        toModelOutput: ({ output }: { output: unknown }) => toModelOutputForReadPage(output),
+        execute: async () => ({}),
+      },
+    },
+  };
+});
 vi.mock('@/lib/ai/core/tool-filtering', () => ({
   filterToolsForReadOnly: vi.fn((tools: unknown) => tools),
   filterToolsForMcpScope: vi.fn((tools: unknown) => tools),
@@ -1042,6 +1053,45 @@ describe('POST /api/v1/chat/completions', () => {
         hasToolResults: Array.isArray(assistantSave?.[0]?.toolResults) && (assistantSave![0].toolResults as unknown[]).length > 0,
       },
       expected: { hasToolCalls: true, hasToolResults: true },
+    });
+  });
+
+  test('cross-turn vision guard: read_page degrades a stale visual_content_delivered result when the requested model lacks vision', async () => {
+    vi.mocked(hasVisionCapability).mockReturnValueOnce(false);
+    vi.mocked(streamText).mockImplementationOnce((() => ({
+      totalUsage: Promise.resolve({ inputTokens: 5, outputTokens: 10 }),
+      steps: Promise.resolve([]),
+      toUIMessageStream: async function* () {
+        yield { type: 'start' };
+        yield { type: 'finish' };
+      },
+    })) as unknown as typeof streamText);
+
+    await POST(makeRequest(validBody));
+
+    const toolsArg = vi.mocked(streamText).mock.calls[0]?.[0]?.tools as
+      | Record<string, { toModelOutput?: (args: { output: unknown }) => unknown }>
+      | undefined;
+    const readPageTool = toolsArg?.read_page;
+    const visualDeliveredOutput = {
+      success: true,
+      type: 'visual_content_delivered',
+      pageId: 'page-1',
+      title: 'diagram.png',
+      mimeType: 'image/jpeg',
+      originalMimeType: 'image/png',
+      message: 'Delivered visual content: "diagram.png" (image/jpeg)',
+      imageBase64: 'ZmFrZS1iYXNlNjQ=',
+      sizeBytes: 1234,
+      metadata: { processingStatus: 'visual', originalFileName: 'diagram.png', presetUsed: 'ai-vision' },
+    };
+
+    const modelOutput = readPageTool!.toModelOutput!({ output: visualDeliveredOutput }) as { type: string; value: Record<string, unknown> };
+    assert({
+      given: 'a request whose resolved model lacks vision and a stale visual_content_delivered read_page result',
+      should: 'degrade to visual_content_metadata rather than re-embedding the image bytes',
+      actual: { type: modelOutput.type, innerType: modelOutput.value.type, containsBase64: JSON.stringify(modelOutput).includes(visualDeliveredOutput.imageBase64) },
+      expected: { type: 'json', innerType: 'visual_content_metadata', containsBase64: false },
     });
   });
 

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -27,6 +27,7 @@ import { getModelCapabilities, hasVisionCapability } from '@/lib/ai/core/model-c
 import { hasFileParts, validateUserMessageFileParts } from '@/lib/ai/core/validate-image-parts';
 import { applyToolExposureMode } from '@/lib/ai/tools/tool-exposure';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
+import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference-request';
 import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
@@ -303,6 +304,16 @@ export async function POST(request: Request): Promise<Response> {
       filteredTools = exposure.tools;
       toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
       finalTools = { ...filteredTools, ...clientToolSet } as ToolSet;
+    }
+
+    // Guard against a stale read_page tool-result (image bytes delivered on an
+    // earlier turn/request when the model had vision) being re-embedded as an
+    // image when history is re-converted for a model that no longer has vision.
+    if (finalTools.read_page) {
+      finalTools = {
+        ...finalTools,
+        read_page: guardReadPageToolForVision(finalTools.read_page, hasVisionCapability(providerResult.modelName)),
+      };
     }
 
     // Load the caller's timezone so time-aware tools (calendar, task triggers)

--- a/apps/web/src/lib/ai/core/__tests__/image-preset-fetch.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/image-preset-fetch.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { fetchCachedImagePreset } from '../image-preset-fetch';
+
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const GARBAGE_BYTES = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+
+describe('fetchCachedImagePreset', () => {
+  it('given a cached ai-vision preset with valid jpeg bytes, should return validated base64 for the ai-vision preset', async () => {
+    const fetchBytes = async (_contentHash: string, preset: string): Promise<Buffer | null> => {
+      if (preset === 'ai-vision') return JPEG_BYTES;
+      if (preset === 'ai-chat') return JPEG_BYTES;
+      return null;
+    };
+
+    const result = await fetchCachedImagePreset('hash-1', 'image/png', { fetchBytes });
+
+    expect(result).toEqual({
+      base64: JPEG_BYTES.toString('base64'),
+      mediaType: 'image/jpeg',
+      preset: 'ai-vision',
+    });
+  });
+
+  it('given no cached ai-vision preset but a valid ai-chat preset, should fall back to the ai-chat preset', async () => {
+    const fetchBytes = async (_contentHash: string, preset: string): Promise<Buffer | null> => {
+      if (preset === 'ai-vision') return null;
+      if (preset === 'ai-chat') return JPEG_BYTES;
+      return null;
+    };
+
+    const result = await fetchCachedImagePreset('hash-2', 'image/png', { fetchBytes });
+
+    expect(result).toEqual({
+      base64: JPEG_BYTES.toString('base64'),
+      mediaType: 'image/jpeg',
+      preset: 'ai-chat',
+    });
+  });
+
+  it('given neither cached preset exists, should fall back to the original file validated against the page mimeType', async () => {
+    const fetchBytes = async (_contentHash: string, preset: string): Promise<Buffer | null> => {
+      if (preset === 'original') return PNG_BYTES;
+      return null;
+    };
+
+    const result = await fetchCachedImagePreset('hash-3', 'image/png', { fetchBytes });
+
+    expect(result).toEqual({
+      base64: PNG_BYTES.toString('base64'),
+      mediaType: 'image/png',
+      preset: 'original',
+    });
+  });
+
+  it('given a cached preset whose bytes fail magic-byte validation, should skip it and fall through to the next preset in the chain', async () => {
+    const fetchBytes = async (_contentHash: string, preset: string): Promise<Buffer | null> => {
+      if (preset === 'ai-vision') return GARBAGE_BYTES;
+      if (preset === 'ai-chat') return JPEG_BYTES;
+      return null;
+    };
+
+    const result = await fetchCachedImagePreset('hash-4', 'image/png', { fetchBytes });
+
+    expect(result).toEqual({
+      base64: JPEG_BYTES.toString('base64'),
+      mediaType: 'image/jpeg',
+      preset: 'ai-chat',
+    });
+  });
+
+  it('given every preset in the chain is missing or invalid, should return null', async () => {
+    const fetchBytes = async (): Promise<Buffer | null> => null;
+
+    const result = await fetchCachedImagePreset('hash-5', 'image/png', { fetchBytes });
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/image-preset-fetch.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/image-preset-fetch.test.ts
@@ -76,4 +76,42 @@ describe('fetchCachedImagePreset', () => {
 
     expect(result).toBeNull();
   });
+
+  it('given an oversized original fallback with no smaller preset available, should skip it and return null rather than deliver an unbounded payload', async () => {
+    const OVERSIZED_PNG = Buffer.concat([PNG_BYTES, Buffer.alloc(5 * 1024 * 1024)]);
+    const fetchBytes = async (_contentHash: string, preset: string): Promise<Buffer | null> => {
+      if (preset === 'original') return OVERSIZED_PNG;
+      return null;
+    };
+
+    const result = await fetchCachedImagePreset('hash-6', 'image/png', { fetchBytes });
+
+    expect(result).toBeNull();
+  });
+
+  it('given a non-404 error on one candidate, should treat it as unusable and fall through to the next preset rather than throwing', async () => {
+    const fetchBytes = async (_contentHash: string, preset: string): Promise<Buffer | null> => {
+      if (preset === 'ai-vision') throw Object.assign(new Error('Access Denied'), { $metadata: { httpStatusCode: 403 } });
+      if (preset === 'ai-chat') return JPEG_BYTES;
+      return null;
+    };
+
+    const result = await fetchCachedImagePreset('hash-7', 'image/png', { fetchBytes });
+
+    expect(result).toEqual({
+      base64: JPEG_BYTES.toString('base64'),
+      mediaType: 'image/jpeg',
+      preset: 'ai-chat',
+    });
+  });
+
+  it('given every candidate throws a non-404 error, should return null rather than throwing', async () => {
+    const fetchBytes = async (): Promise<Buffer | null> => {
+      throw new Error('S3 unavailable');
+    };
+
+    const result = await fetchCachedImagePreset('hash-8', 'image/png', { fetchBytes });
+
+    expect(result).toBeNull();
+  });
 });

--- a/apps/web/src/lib/ai/core/image-preset-fetch.ts
+++ b/apps/web/src/lib/ai/core/image-preset-fetch.ts
@@ -1,0 +1,73 @@
+/**
+ * Fetches a cached image preset (produced by the processor's image pipeline) for a
+ * FILE page's contentHash, preferring higher-quality vision-oriented presets and
+ * falling back down to the original upload when no cache entry is usable.
+ *
+ * The byte fetch is injectable so callers (and tests) can swap the S3/Tigris boundary
+ * without mocking the AWS SDK — the default reuses the same client/bucket/key scheme
+ * already used for presigned thumbnail URLs (`@/lib/presigned-url`).
+ */
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
+import { isAllowedImageType, validateMagicBytes, type AllowedImageType } from '@/lib/validation/image-validation';
+
+export interface FetchedImagePreset {
+  base64: string;
+  mediaType: string;
+  preset: string;
+}
+
+export interface FetchCachedImagePresetDeps {
+  fetchBytes?: (contentHash: string, preset: string) => Promise<Buffer | null>;
+}
+
+async function defaultFetchBytes(contentHash: string, preset: string): Promise<Buffer | null> {
+  const key = preset === 'original' ? `files/${contentHash}/original` : `cache/${contentHash}/${preset}`;
+  try {
+    const response = await getS3Client().send(new GetObjectCommand({ Bucket: getS3Bucket(), Key: key }));
+    if (!response.Body) return null;
+    return Buffer.from(await response.Body.transformToByteArray());
+  } catch (err) {
+    const isNotFound = err && typeof err === 'object' && ('$metadata' in err
+      ? (err as { $metadata: { httpStatusCode?: number } }).$metadata.httpStatusCode === 404
+      : (err as { name?: string }).name === 'NoSuchKey');
+    if (isNotFound) return null;
+    throw err;
+  }
+}
+
+/**
+ * Preset fallback chain: the processor always re-encodes ai-vision/ai-chat presets as
+ * jpeg (see apps/processor/src/types/index.ts IMAGE_PRESETS), regardless of the
+ * original upload's format — only the final "original" fallback is validated against
+ * the page's own declared mimeType.
+ */
+function buildFallbackChain(mimeType: string): Array<{ preset: string; mediaType: string }> {
+  return [
+    { preset: 'ai-vision', mediaType: 'image/jpeg' },
+    { preset: 'ai-chat', mediaType: 'image/jpeg' },
+    { preset: 'original', mediaType: mimeType },
+  ];
+}
+
+export async function fetchCachedImagePreset(
+  contentHash: string,
+  mimeType: string,
+  deps: FetchCachedImagePresetDeps = {},
+): Promise<FetchedImagePreset | null> {
+  const fetchBytes = deps.fetchBytes ?? defaultFetchBytes;
+
+  for (const candidate of buildFallbackChain(mimeType)) {
+    if (!isAllowedImageType(candidate.mediaType)) continue;
+
+    const bytes = await fetchBytes(contentHash, candidate.preset);
+    if (!bytes) continue;
+
+    const base64 = bytes.toString('base64');
+    if (!validateMagicBytes(base64, candidate.mediaType as AllowedImageType)) continue;
+
+    return { base64, mediaType: candidate.mediaType, preset: candidate.preset };
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/ai/core/image-preset-fetch.ts
+++ b/apps/web/src/lib/ai/core/image-preset-fetch.ts
@@ -10,6 +10,8 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
 import { isAllowedImageType, validateMagicBytes, type AllowedImageType } from '@/lib/validation/image-validation';
+import { MAX_IMAGE_SIZE_BYTES } from '@/lib/ai/shared/utils/image-resize';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface FetchedImagePreset {
   base64: string;
@@ -60,8 +62,26 @@ export async function fetchCachedImagePreset(
   for (const candidate of buildFallbackChain(mimeType)) {
     if (!isAllowedImageType(candidate.mediaType)) continue;
 
-    const bytes = await fetchBytes(contentHash, candidate.preset);
+    let bytes: Buffer | null;
+    try {
+      bytes = await fetchBytes(contentHash, candidate.preset);
+    } catch (err) {
+      // A fetch failure (permissions, transient outage, malformed key) degrades to
+      // "this candidate isn't usable" rather than failing the whole read_page call —
+      // the pre-existing metadata-only behavior must remain a guaranteed-success
+      // fallback regardless of which fetchBytes implementation is in use.
+      loggers.ai.warn('fetchCachedImagePreset: candidate fetch failed, skipping', {
+        contentHash,
+        preset: candidate.preset,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
     if (!bytes) continue;
+    // The ai-vision/ai-chat presets are already resized well under this cap; this
+    // matters for the uncapped "original" fallback, which can otherwise be an
+    // arbitrarily large upload (up to the per-tier max file size).
+    if (bytes.length > MAX_IMAGE_SIZE_BYTES) continue;
 
     const base64 = bytes.toString('base64');
     if (!validateMagicBytes(base64, candidate.mediaType as AllowedImageType)) continue;

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -50,6 +50,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
       error: vi.fn(),
       debug: vi.fn(),
+      child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
     },
   },
 
@@ -74,9 +75,21 @@ vi.mock('@paralleldrive/cuid2', () => ({
 vi.mock('../drive-tools', () => ({
   driveTools: { list_drives: { name: 'list_drives' }, create_drive: { name: 'create_drive' } },
 }));
-vi.mock('../page-read-tools', () => ({
-  pageReadTools: { list_pages: { name: 'list_pages' } },
-}));
+vi.mock('../page-read-tools', async () => {
+  const { toModelOutputForReadPage } = await import('../read-page-vision-output');
+  return {
+    pageReadTools: {
+      list_pages: { name: 'list_pages' },
+      // Mirrors the real read_page tool's toModelOutput wiring (page-read-tools.ts)
+      // so the cross-turn vision guard tests exercise the real mapper/guard logic.
+      read_page: {
+        name: 'read_page',
+        toModelOutput: ({ output }: { output: unknown }) => toModelOutputForReadPage(output),
+        execute: async () => ({}),
+      },
+    },
+  };
+});
 vi.mock('../page-write-tools', () => ({
   pageWriteTools: { create_page: { name: 'create_page' } },
 }));
@@ -990,6 +1003,89 @@ describe('agent-communication-tools', () => {
         const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, unknown> | undefined;
         // When built-in tool set is empty, generateText is called with no tools at all
         expect(toolsArg?.github_list_repos).toBeUndefined();
+      });
+    });
+
+    describe('cross-turn vision guard on read_page (PR #1864 follow-up)', () => {
+      const visualDeliveredOutput = {
+        success: true,
+        type: 'visual_content_delivered',
+        pageId: 'page-1',
+        title: 'diagram.png',
+        mimeType: 'image/jpeg',
+        originalMimeType: 'image/png',
+        message: 'Delivered visual content: "diagram.png" (image/jpeg)',
+        imageBase64: 'ZmFrZS1iYXNlNjQ=',
+        sizeBytes: 1234,
+        metadata: { processingStatus: 'visual', originalFileName: 'diagram.png', presetUsed: 'ai-vision' },
+      };
+
+      const mockAgentWithReadPage = (aiModel: string | null) => ({
+        id: 'agent-1',
+        title: 'Test Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: 'I am a helpful agent',
+        enabledTools: ['read_page'],
+        aiProvider: null,
+        aiModel,
+        isTrashed: false,
+      });
+
+      it("given the target agent's configured model lacks vision, should degrade a stale visual_content_delivered read_page result instead of re-embedding the image", async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgentWithReadPage('gpt-3.5-turbo'));
+        vi.mocked(createAIProvider).mockResolvedValue({
+          model: { modelId: 'gpt-3.5-turbo' },
+          provider: 'openai',
+          modelName: 'gpt-3.5-turbo',
+        } as unknown as Awaited<ReturnType<typeof createAIProvider>>);
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'What does this image show?' },
+          context
+        );
+
+        const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, { toModelOutput?: (args: { output: unknown }) => unknown }> | undefined;
+        const readPageTool = toolsArg?.read_page;
+        expect(readPageTool?.toModelOutput).toBeDefined();
+
+        const modelOutput = readPageTool!.toModelOutput!({ output: visualDeliveredOutput }) as { type: string; value: Record<string, unknown> };
+        expect(modelOutput.type).toBe('json');
+        expect(modelOutput.value.type).toBe('visual_content_metadata');
+        expect(JSON.stringify(modelOutput)).not.toContain(visualDeliveredOutput.imageBase64);
+      });
+
+      it("given the target agent's configured model has vision, should leave read_page's image delivery unguarded", async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgentWithReadPage('openai/gpt-5.4'));
+        vi.mocked(createAIProvider).mockResolvedValue({
+          model: { modelId: 'openai/gpt-5.4' },
+          provider: 'openai',
+          modelName: 'openai/gpt-5.4',
+        } as unknown as Awaited<ReturnType<typeof createAIProvider>>);
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'What does this image show?' },
+          context
+        );
+
+        const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, { toModelOutput?: (args: { output: unknown }) => unknown }> | undefined;
+        const readPageTool = toolsArg?.read_page;
+        expect(readPageTool?.toModelOutput).toBeDefined();
+
+        const modelOutput = readPageTool!.toModelOutput!({ output: visualDeliveredOutput }) as { type: string; value: unknown[] };
+        expect(modelOutput.type).toBe('content');
       });
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -909,7 +909,7 @@ describe('page-read-tools', () => {
         const result = await pageReadTools.read_page.execute!(
           { title: 'diagram.png', pageId: 'page-1' },
           createVisionAuthContext()
-        ) as { type: string; imageBase64: string; mimeType: string; success: boolean };
+        ) as { type: string; imageBase64: string; mimeType: string; originalMimeType: string; success: boolean };
 
         assert({
           given: 'a visual FILE page and a vision-capable model',
@@ -930,6 +930,13 @@ describe('page-read-tools', () => {
           should: "deliver the fetched preset's mediaType rather than the page's declared mimeType",
           actual: result.mimeType,
           expected: 'image/jpeg',
+        });
+
+        assert({
+          given: "a visual FILE page whose delivered preset was re-encoded to a different format (png page, jpeg preset)",
+          should: "still carry the page's true mimeType as originalMimeType, for correct reporting if this result later degrades to metadata-only",
+          actual: result.originalMimeType,
+          expected: 'image/png',
         });
       });
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -107,11 +107,15 @@ vi.mock('@/lib/logging/mask', () => ({
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   checkDriveAccess: vi.fn(),
 }));
+vi.mock('../../core/image-preset-fetch', () => ({
+  fetchCachedImagePreset: vi.fn(),
+}));
 
 import { pageReadTools } from '../page-read-tools';
 import { db } from '@pagespace/db/db';
 import { getUserAccessLevel, getUserAccessiblePagesInDriveWithDetails, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { fetchCachedImagePreset } from '../../core/image-preset-fetch';
 import type { ToolExecutionContext } from '../../core/types';
 
 const mockDb = vi.mocked(db);
@@ -119,6 +123,7 @@ const mockGetUserAccessLevel = vi.mocked(getUserAccessLevel);
 const mockGetUserAccessiblePagesInDrive = vi.mocked(getUserAccessiblePagesInDriveWithDetails);
 const mockGetUserDriveAccess = vi.mocked(getUserDriveAccess);
 const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
+const mockFetchCachedImagePreset = vi.mocked(fetchCachedImagePreset);
 
 const createMockPage = (content: string, type = 'DOCUMENT') => ({
   id: 'page-1',
@@ -862,6 +867,87 @@ describe('page-read-tools', () => {
         should: 'include structured channelMessages array',
         actual: Array.isArray((result as { channelMessages: unknown[] }).channelMessages),
         expected: true,
+      });
+    });
+
+    describe('visual FILE pages', () => {
+      const createMockVisualFilePage = () => ({
+        id: 'page-1',
+        title: 'diagram.png',
+        type: 'FILE',
+        isTrashed: false,
+        driveId: 'drive-1',
+        processingStatus: 'visual',
+        mimeType: 'image/png',
+        contentHash: 'hash-abc',
+        fileSize: 5000,
+        originalFileName: 'diagram.png',
+      });
+
+      const createVisionAuthContext = (userId = 'user-123') => ({
+        toolCallId: '1',
+        messages: [],
+        experimental_context: {
+          userId,
+          modelCapabilities: { hasVision: true, hasTools: true, model: 'gpt-5.4', provider: 'openai' },
+        } as ToolExecutionContext,
+      });
+
+      beforeEach(() => {
+        mockDb.query.taskItems = { findFirst: vi.fn().mockResolvedValue(null) } as unknown as typeof mockDb.query.taskItems;
+        mockGetUserAccessLevel.mockResolvedValue(createMockAccessLevel('editor'));
+      });
+
+      it('returns delivered image content for a visual FILE page on a vision-capable model', async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(createMockVisualFilePage());
+        mockFetchCachedImagePreset.mockResolvedValue({
+          base64: 'ZmFrZS1pbWFnZS1ieXRlcw==',
+          mediaType: 'image/jpeg',
+          preset: 'ai-vision',
+        });
+
+        const result = await pageReadTools.read_page.execute!(
+          { title: 'diagram.png', pageId: 'page-1' },
+          createVisionAuthContext()
+        ) as { type: string; imageBase64: string; mimeType: string; success: boolean };
+
+        assert({
+          given: 'a visual FILE page and a vision-capable model',
+          should: 'return a visual_content_delivered result',
+          actual: result.type,
+          expected: 'visual_content_delivered',
+        });
+
+        assert({
+          given: 'a visual FILE page and a vision-capable model',
+          should: 'deliver the base64 bytes from fetchCachedImagePreset',
+          actual: result.imageBase64,
+          expected: 'ZmFrZS1pbWFnZS1ieXRlcw==',
+        });
+
+        assert({
+          given: 'a visual FILE page and a vision-capable model',
+          should: "deliver the fetched preset's mediaType rather than the page's declared mimeType",
+          actual: result.mimeType,
+          expected: 'image/jpeg',
+        });
+      });
+
+      it('falls back to metadata-only when no cached preset is available', async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(createMockVisualFilePage());
+        mockFetchCachedImagePreset.mockResolvedValue(null);
+
+        const result = await pageReadTools.read_page.execute!(
+          { title: 'diagram.png', pageId: 'page-1' },
+          createVisionAuthContext()
+        ) as { type: string };
+
+        assert({
+          given: 'a visual FILE page with no usable cached preset',
+          should: 'fall back to the existing visual_content_metadata result',
+          actual: result.type,
+          expected: 'visual_content_metadata',
+        });
       });
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { toModelOutputForReadPage, degradeVisualContentToMetadata } from '../read-page-vision-output';
+
+describe('toModelOutputForReadPage', () => {
+  it('given a visual_content_delivered output, should map it to a content ToolResultOutput with a text part and an image-data part', () => {
+    const output = {
+      success: true,
+      type: 'visual_content_delivered',
+      pageId: 'page-1',
+      title: 'diagram.png',
+      mimeType: 'image/jpeg',
+      message: 'Delivered visual content: "diagram.png" (image/jpeg)',
+      imageBase64: 'ZmFrZS1iYXNlNjQ=',
+      sizeBytes: 1234,
+      metadata: { processingStatus: 'visual', originalFileName: 'diagram.png', presetUsed: 'ai-vision' },
+    };
+
+    const result = toModelOutputForReadPage(output);
+
+    expect(result).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: output.message },
+        { type: 'image-data', data: output.imageBase64, mediaType: output.mimeType },
+      ],
+    });
+  });
+
+  it('given a visual_content_metadata output (no image bytes), should pass it through as a json ToolResultOutput unchanged', () => {
+    const output = {
+      success: true,
+      type: 'visual_content_metadata',
+      pageId: 'page-2',
+      title: 'diagram.png',
+      message: 'Found visual content: "diagram.png" (image/png)',
+      mimeType: 'image/png',
+      sizeBytes: 5000,
+      summary: 'This is a visual file that requires vision capabilities to process',
+      stats: { documentType: 'VISUAL', mimeType: 'image/png', sizeBytes: 5000, sizeMB: '0.00' },
+      metadata: { requiresVisionModel: true, processingStatus: 'visual', originalFileName: 'diagram.png' },
+    };
+
+    const result = toModelOutputForReadPage(output);
+
+    expect(result).toEqual({ type: 'json', value: output });
+  });
+
+  it('given a visual_requires_vision_model output, should pass it through as a json ToolResultOutput unchanged', () => {
+    const output = {
+      success: true,
+      type: 'visual_requires_vision_model',
+      title: 'diagram.png',
+      mimeType: 'image/png',
+      message: 'This is a visual file (image/png). To view its content, please switch to a vision-capable model.',
+      suggestedModels: ['openai/gpt-5.4'],
+      metadata: { fileType: 'image/png', requiresVision: true },
+    };
+
+    const result = toModelOutputForReadPage(output);
+
+    expect(result).toEqual({ type: 'json', value: output });
+  });
+
+  it('given a plain text-page read result with no visual type field, should pass it through as a json ToolResultOutput unchanged', () => {
+    const output = { success: true, content: '1 | hello world', title: 'notes.md' };
+
+    const result = toModelOutputForReadPage(output);
+
+    expect(result).toEqual({ type: 'json', value: output });
+  });
+
+  it('given an error result, should pass it through as a json ToolResultOutput unchanged', () => {
+    const output = { success: false, error: 'File is still being processed', status: 'processing' };
+
+    const result = toModelOutputForReadPage(output);
+
+    expect(result).toEqual({ type: 'json', value: output });
+  });
+});
+
+describe('degradeVisualContentToMetadata', () => {
+  it('given a visual_content_delivered output, should strip the image bytes and return a visual_content_metadata shape', () => {
+    const output = {
+      success: true,
+      type: 'visual_content_delivered',
+      pageId: 'page-1',
+      title: 'diagram.png',
+      mimeType: 'image/jpeg',
+      message: 'Delivered visual content: "diagram.png" (image/jpeg)',
+      imageBase64: 'ZmFrZS1iYXNlNjQ=',
+      sizeBytes: 1234,
+      metadata: { processingStatus: 'visual', originalFileName: 'diagram.png', presetUsed: 'ai-vision' },
+    };
+
+    const result = degradeVisualContentToMetadata(output) as Record<string, unknown>;
+
+    expect(result.type).toBe('visual_content_metadata');
+    expect(result).not.toHaveProperty('imageBase64');
+    expect(JSON.stringify(result)).not.toContain(output.imageBase64);
+  });
+
+  it('given a non-visual output, should return it unchanged', () => {
+    const output = { success: true, content: '1 | hello world', title: 'notes.md' };
+
+    const result = degradeVisualContentToMetadata(output);
+
+    expect(result).toEqual(output);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { toModelOutputForReadPage, degradeVisualContentToMetadata } from '../read-page-vision-output';
+import { toModelOutputForReadPage, degradeVisualContentToMetadata, guardReadPageToolForVision } from '../read-page-vision-output';
 
 describe('toModelOutputForReadPage', () => {
   it('given a visual_content_delivered output, should map it to a content ToolResultOutput with a text part and an image-data part', () => {
@@ -105,5 +105,52 @@ describe('degradeVisualContentToMetadata', () => {
     const result = degradeVisualContentToMetadata(output);
 
     expect(result).toEqual(output);
+  });
+});
+
+describe('guardReadPageToolForVision', () => {
+  const staleVisualOutput = {
+    success: true,
+    type: 'visual_content_delivered',
+    pageId: 'page-1',
+    title: 'diagram.png',
+    mimeType: 'image/jpeg',
+    message: 'Delivered visual content: "diagram.png" (image/jpeg)',
+    imageBase64: 'ZmFrZS1iYXNlNjQ=',
+    sizeBytes: 1234,
+    metadata: { processingStatus: 'visual', originalFileName: 'diagram.png', presetUsed: 'ai-vision' },
+  };
+
+  const makeReadPageTool = () => ({
+    description: 'Read the content of any page',
+    toModelOutput: ({ output }: { output: unknown }) => toModelOutputForReadPage(output),
+    execute: async () => ({}),
+  });
+
+  it('given hasVision: true, should leave the tool behavior unchanged for a stale image tool result', () => {
+    const guarded = guardReadPageToolForVision(makeReadPageTool(), true);
+
+    const result = guarded.toModelOutput!({ toolCallId: '1', input: {}, output: staleVisualOutput });
+
+    expect(result).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: staleVisualOutput.message },
+        { type: 'image-data', data: staleVisualOutput.imageBase64, mediaType: staleVisualOutput.mimeType },
+      ],
+    });
+  });
+
+  it('given hasVision: false, should degrade a stale image tool result to metadata-only instead of an image content part', () => {
+    const guarded = guardReadPageToolForVision(makeReadPageTool(), false);
+
+    const result = guarded.toModelOutput!({ toolCallId: '1', input: {}, output: staleVisualOutput }) as {
+      type: string;
+      value: Record<string, unknown>;
+    };
+
+    expect(result.type).toBe('json');
+    expect(result.value.type).toBe('visual_content_metadata');
+    expect(JSON.stringify(result)).not.toContain(staleVisualOutput.imageBase64);
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
@@ -9,6 +9,7 @@ describe('toModelOutputForReadPage', () => {
       pageId: 'page-1',
       title: 'diagram.png',
       mimeType: 'image/jpeg',
+      originalMimeType: 'image/png',
       message: 'Delivered visual content: "diagram.png" (image/jpeg)',
       imageBase64: 'ZmFrZS1iYXNlNjQ=',
       sizeBytes: 1234,
@@ -86,6 +87,7 @@ describe('degradeVisualContentToMetadata', () => {
       pageId: 'page-1',
       title: 'diagram.png',
       mimeType: 'image/jpeg',
+      originalMimeType: 'image/png',
       message: 'Delivered visual content: "diagram.png" (image/jpeg)',
       imageBase64: 'ZmFrZS1iYXNlNjQ=',
       sizeBytes: 1234,
@@ -97,6 +99,30 @@ describe('degradeVisualContentToMetadata', () => {
     expect(result.type).toBe('visual_content_metadata');
     expect(result).not.toHaveProperty('imageBase64');
     expect(JSON.stringify(result)).not.toContain(output.imageBase64);
+  });
+
+  it('given a visual_content_delivered output whose delivered bytes were re-encoded to a different format than the original upload, should report the ORIGINAL mimeType, not the delivered preset mimeType', () => {
+    // The processor always re-encodes ai-vision/ai-chat presets as jpeg regardless of
+    // the source format, so a PNG upload's delivered mimeType is 'image/jpeg' — the
+    // degraded result must still tell the model the file is really a PNG.
+    const output = {
+      success: true,
+      type: 'visual_content_delivered',
+      pageId: 'page-1',
+      title: 'diagram.png',
+      mimeType: 'image/jpeg',
+      originalMimeType: 'image/png',
+      message: 'Delivered visual content: "diagram.png" (image/jpeg)',
+      imageBase64: 'ZmFrZS1iYXNlNjQ=',
+      sizeBytes: 1234,
+      metadata: { processingStatus: 'visual', originalFileName: 'diagram.png', presetUsed: 'ai-vision' },
+    };
+
+    const result = degradeVisualContentToMetadata(output) as Record<string, unknown>;
+
+    expect(result.mimeType).toBe('image/png');
+    expect((result.stats as Record<string, unknown>).mimeType).toBe('image/png');
+    expect(result.message).toContain('image/png');
   });
 
   it('given a non-visual output, should return it unchanged', () => {
@@ -115,6 +141,7 @@ describe('guardReadPageToolForVision', () => {
     pageId: 'page-1',
     title: 'diagram.png',
     mimeType: 'image/jpeg',
+    originalMimeType: 'image/png',
     message: 'Delivered visual content: "diagram.png" (image/jpeg)',
     imageBase64: 'ZmFrZS1iYXNlNjQ=',
     sizeBytes: 1234,

--- a/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/read-page-vision-output.test.ts
@@ -123,7 +123,8 @@ describe('guardReadPageToolForVision', () => {
 
   const makeReadPageTool = () => ({
     description: 'Read the content of any page',
-    toModelOutput: ({ output }: { output: unknown }) => toModelOutputForReadPage(output),
+    toModelOutput: ({ output }: { toolCallId: string; input: unknown; output: unknown }) =>
+      toModelOutputForReadPage(output),
     execute: async () => ({}),
   });
 

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -1,7 +1,7 @@
 import { tool, stepCountIs, hasToolCall } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from './finish-tool';
 import { z } from 'zod';
-import { generateText, UIMessage, type ToolSet } from 'ai';
+import { generateText, UIMessage, type ToolSet, type Tool } from 'ai';
 import { db } from '@pagespace/db/db'
 import { eq, and, sql } from '@pagespace/db/operators'
 import { pages, chatMessages, drives } from '@pagespace/db/schema/core';
@@ -19,6 +19,8 @@ import type { ToolExecutionContext } from '@/lib/ai/core/types';
 import { createId } from '@paralleldrive/cuid2';
 import { driveTools } from './drive-tools';
 import { pageReadTools } from './page-read-tools';
+import { guardReadPageToolForVision } from './read-page-vision-output';
+import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
 import { pageWriteTools } from './page-write-tools';
 import { searchTools } from './search-tools';
 import { taskManagementTools } from './task-management-tools';
@@ -571,6 +573,17 @@ export const agentCommunicationTools = {
         // sorted keys — so the serialized tool bytes are prefix-cache-stable without
         // re-sorting here (same guarantee as the chat/global route merges).
         const allAgentTools = { ...agentTools, ...integrationTools };
+
+        // Guard against a stale read_page tool-result (image bytes delivered on an
+        // earlier turn when the target agent had a vision-capable model) being
+        // re-embedded as an image when history is re-converted for a model that no
+        // longer has vision (e.g. the agent's configured model changed since).
+        if (allAgentTools.read_page) {
+          allAgentTools.read_page = guardReadPageToolForVision(
+            allAgentTools.read_page as Tool,
+            hasVisionCapability(resolvedModelName),
+          );
+        }
 
         // 10. Create enhanced execution context for nested calls
         // Preserve locationContext so nested agents know which drive/page they're operating in

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -12,6 +12,8 @@ import { PageType } from '@pagespace/lib/utils/enums';
 import type { ToolExecutionContext } from '../core/types';
 import { getSuggestedVisionModels } from '../core/model-capabilities';
 import { serializePageContentForAI, isTextSerializablePageType } from '../core/page-serializer';
+import { fetchCachedImagePreset } from '../core/image-preset-fetch';
+import { toModelOutputForReadPage } from './read-page-vision-output';
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
@@ -243,6 +245,7 @@ export const pageReadTools = {
       lineStart: z.number().int().optional().describe('Start line number (1-indexed, inclusive). Omit to start from beginning.'),
       lineEnd: z.number().int().optional().describe('End line number (1-indexed, inclusive). Omit to read to end.'),
     }),
+    toModelOutput: ({ output }) => toModelOutputForReadPage(output),
     execute: async ({ title, pageId, lineStart, lineEnd }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
@@ -308,7 +311,33 @@ export const pageReadTools = {
                 };
               }
               
-              // Model supports vision - return metadata about the visual content
+              // Model supports vision - try to deliver actual image bytes from the
+              // processor's cached presets. Falls back to metadata-only (today's
+              // behavior) when no preset in the fallback chain is usable.
+              if (page.contentHash) {
+                const deliveredImage = await fetchCachedImagePreset(
+                  page.contentHash,
+                  page.mimeType || 'application/octet-stream'
+                );
+                if (deliveredImage) {
+                  return {
+                    success: true,
+                    type: 'visual_content_delivered',
+                    pageId: page.id,
+                    title: page.title,
+                    mimeType: deliveredImage.mediaType,
+                    message: `Delivered visual content: "${page.title}" (${deliveredImage.mediaType})`,
+                    imageBase64: deliveredImage.base64,
+                    sizeBytes: page.fileSize || 0,
+                    metadata: {
+                      processingStatus: 'visual',
+                      originalFileName: page.originalFileName,
+                      presetUsed: deliveredImage.preset
+                    }
+                  };
+                }
+              }
+
               // Use page metadata instead of loading the full content
               return {
                 success: true,

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -13,7 +13,7 @@ import type { ToolExecutionContext } from '../core/types';
 import { getSuggestedVisionModels } from '../core/model-capabilities';
 import { serializePageContentForAI, isTextSerializablePageType } from '../core/page-serializer';
 import { fetchCachedImagePreset } from '../core/image-preset-fetch';
-import { toModelOutputForReadPage } from './read-page-vision-output';
+import { toModelOutputForReadPage, buildVisualContentMetadata } from './read-page-vision-output';
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
@@ -326,6 +326,7 @@ export const pageReadTools = {
                     pageId: page.id,
                     title: page.title,
                     mimeType: deliveredImage.mediaType,
+                    originalMimeType: page.mimeType || 'application/octet-stream',
                     message: `Delivered visual content: "${page.title}" (${deliveredImage.mediaType})`,
                     imageBase64: deliveredImage.base64,
                     sizeBytes: page.fileSize || 0,
@@ -339,27 +340,17 @@ export const pageReadTools = {
               }
 
               // Use page metadata instead of loading the full content
-              return {
-                success: true,
-                type: 'visual_content_metadata',
+              return buildVisualContentMetadata({
                 pageId: page.id,
                 title: page.title,
-                message: `Found visual content: "${page.title}" (${page.mimeType || 'unknown type'})`,
                 mimeType: page.mimeType || 'unknown',
                 sizeBytes: page.fileSize || 0,
-                summary: `This is a visual file that requires vision capabilities to process`,
-                stats: {
-                  documentType: 'VISUAL',
-                  mimeType: page.mimeType || 'unknown',
-                  sizeBytes: page.fileSize || 0,
-                  sizeMB: page.fileSize ? (page.fileSize / 1024 / 1024).toFixed(2) : '0'
-                },
                 metadata: {
                   requiresVisionModel: true,
                   processingStatus: 'visual',
                   originalFileName: page.originalFileName
                 }
-              };
+              });
             
             case 'failed':
               return {

--- a/apps/web/src/lib/ai/tools/read-page-vision-output.ts
+++ b/apps/web/src/lib/ai/tools/read-page-vision-output.ts
@@ -16,7 +16,14 @@ export interface VisualContentDeliveredOutput {
   type: 'visual_content_delivered';
   pageId: string;
   title: string;
+  /** Media type of the delivered bytes (imageBase64) — the processor always
+   * re-encodes ai-vision/ai-chat presets as jpeg, so this can differ from the
+   * page's true upload format. */
   mimeType: string;
+  /** The page's true upload format (page.mimeType), independent of which
+   * preset's bytes were actually delivered. Used when degrading to
+   * metadata-only so a stale result reports the real file type. */
+  originalMimeType: string;
   message: string;
   imageBase64: string;
   sizeBytes: number;
@@ -54,15 +61,19 @@ export function toModelOutputForReadPage(output: unknown): ToolResultOutput {
 }
 
 /**
- * Strips image bytes from a visual_content_delivered result, returning the same
- * visual_content_metadata shape read_page already produces when a model lacks vision.
- * Non-visual outputs pass through unchanged. Used to degrade STALE image tool-results
- * from an earlier, vision-capable turn when the active model no longer has vision.
+ * Builds the "visual_content_metadata" envelope read_page returns whenever it can't
+ * (or won't) deliver image bytes — no vision-capable preset available, or a stale
+ * delivered result degraded back down. Shared so the two call sites (page-read-tools.ts's
+ * own no-preset-available fallback, and degradeVisualContentToMetadata below) can't drift.
  */
-export function degradeVisualContentToMetadata(output: unknown): unknown {
-  if (!isVisualContentDelivered(output)) return output;
-
-  const { pageId, title, mimeType, sizeBytes, metadata } = output;
+export function buildVisualContentMetadata(params: {
+  pageId: string;
+  title: string;
+  mimeType: string;
+  sizeBytes: number;
+  metadata: Record<string, unknown>;
+}): Record<string, unknown> {
+  const { pageId, title, mimeType, sizeBytes, metadata } = params;
   return {
     success: true,
     type: 'visual_content_metadata',
@@ -78,8 +89,27 @@ export function degradeVisualContentToMetadata(output: unknown): unknown {
       sizeBytes,
       sizeMB: (sizeBytes / 1024 / 1024).toFixed(2),
     },
-    metadata: { ...metadata, requiresVisionModel: true, imageOmitted: true },
+    metadata,
   };
+}
+
+/**
+ * Strips image bytes from a visual_content_delivered result, returning the same
+ * visual_content_metadata shape read_page already produces when a model lacks vision.
+ * Non-visual outputs pass through unchanged. Used to degrade STALE image tool-results
+ * from an earlier, vision-capable turn when the active model no longer has vision.
+ */
+export function degradeVisualContentToMetadata(output: unknown): unknown {
+  if (!isVisualContentDelivered(output)) return output;
+
+  const { pageId, title, originalMimeType, sizeBytes, metadata } = output;
+  return buildVisualContentMetadata({
+    pageId,
+    title,
+    mimeType: originalMimeType,
+    sizeBytes,
+    metadata: { ...metadata, requiresVisionModel: true, imageOmitted: true },
+  });
 }
 
 interface ToolWithModelOutput {

--- a/apps/web/src/lib/ai/tools/read-page-vision-output.ts
+++ b/apps/web/src/lib/ai/tools/read-page-vision-output.ts
@@ -86,3 +86,21 @@ export function degradeVisualContentToMetadata(output: unknown): unknown {
     metadata: { ...metadata, requiresVisionModel: true, imageOmitted: true },
   };
 }
+
+interface ToolWithModelOutput {
+  toModelOutput?: (options: { toolCallId: string; input: unknown; output: unknown }) => ToolResultOutput | PromiseLike<ToolResultOutput>;
+}
+
+/**
+ * Wraps a tool so its toModelOutput never re-embeds image bytes when the current
+ * request's model lacks vision — guards against a STALE visual_content_delivered
+ * tool-result (persisted from an earlier turn where the model did have vision) being
+ * re-sent as an image when convertToModelMessages re-converts history for this turn.
+ */
+export function guardReadPageToolForVision<T extends ToolWithModelOutput>(tool: T, hasVision: boolean): T {
+  if (hasVision) return tool;
+  return {
+    ...tool,
+    toModelOutput: ({ output }) => toModelOutputForReadPage(degradeVisualContentToMetadata(output)),
+  };
+}

--- a/apps/web/src/lib/ai/tools/read-page-vision-output.ts
+++ b/apps/web/src/lib/ai/tools/read-page-vision-output.ts
@@ -2,11 +2,14 @@
  * Maps read_page's tool output to the AI SDK's tool-result content shape, and
  * degrades an image-bearing result back to metadata-only when needed.
  *
- * The `ToolResultOutput` shape below is written structurally (not imported from
- * `@ai-sdk/provider-utils`, which isn't a direct dependency of this package) so
- * TypeScript checks it against `tool()`'s inferred generic at the `toModelOutput`
- * call site in page-read-tools.ts.
+ * `ToolResultOutput`/`ToolModelOutputFn` are derived from `ai`'s own public `Tool`
+ * type (already a direct dependency) rather than imported by name from
+ * `@ai-sdk/provider-utils`, which only reaches this package transitively.
  */
+import type { Tool } from 'ai';
+
+type ToolModelOutputFn = NonNullable<Tool['toModelOutput']>;
+type ToolResultOutput = Awaited<ReturnType<ToolModelOutputFn>>;
 
 export interface VisualContentDeliveredOutput {
   success: true;
@@ -19,17 +22,6 @@ export interface VisualContentDeliveredOutput {
   sizeBytes: number;
   metadata: Record<string, unknown>;
 }
-
-type ToolResultOutput =
-  | { type: 'text'; value: string }
-  | { type: 'json'; value: unknown }
-  | {
-      type: 'content';
-      value: Array<
-        | { type: 'text'; text: string }
-        | { type: 'image-data'; data: string; mediaType: string }
-      >;
-    };
 
 function isVisualContentDelivered(output: unknown): output is VisualContentDeliveredOutput {
   return (
@@ -53,9 +45,12 @@ export function toModelOutputForReadPage(output: unknown): ToolResultOutput {
         { type: 'text', text: output.message },
         { type: 'image-data', data: output.imageBase64, mediaType: output.mimeType },
       ],
-    };
+    } as unknown as ToolResultOutput;
   }
-  return { type: 'json', value: output };
+  // output is an arbitrary, already-JSON-serializable tool result at runtime;
+  // ToolResultOutput's json variant requires a JSONValue, which can't be proven
+  // statically from `unknown` here.
+  return { type: 'json', value: output } as unknown as ToolResultOutput;
 }
 
 /**
@@ -88,7 +83,7 @@ export function degradeVisualContentToMetadata(output: unknown): unknown {
 }
 
 interface ToolWithModelOutput {
-  toModelOutput?: (options: { toolCallId: string; input: unknown; output: unknown }) => ToolResultOutput | PromiseLike<ToolResultOutput>;
+  toModelOutput?: ToolModelOutputFn;
 }
 
 /**
@@ -99,8 +94,7 @@ interface ToolWithModelOutput {
  */
 export function guardReadPageToolForVision<T extends ToolWithModelOutput>(tool: T, hasVision: boolean): T {
   if (hasVision) return tool;
-  return {
-    ...tool,
-    toModelOutput: ({ output }) => toModelOutputForReadPage(degradeVisualContentToMetadata(output)),
-  };
+  const toModelOutput: ToolModelOutputFn = ({ output }) =>
+    toModelOutputForReadPage(degradeVisualContentToMetadata(output));
+  return { ...tool, toModelOutput } as T;
 }

--- a/apps/web/src/lib/ai/tools/read-page-vision-output.ts
+++ b/apps/web/src/lib/ai/tools/read-page-vision-output.ts
@@ -1,0 +1,88 @@
+/**
+ * Maps read_page's tool output to the AI SDK's tool-result content shape, and
+ * degrades an image-bearing result back to metadata-only when needed.
+ *
+ * The `ToolResultOutput` shape below is written structurally (not imported from
+ * `@ai-sdk/provider-utils`, which isn't a direct dependency of this package) so
+ * TypeScript checks it against `tool()`'s inferred generic at the `toModelOutput`
+ * call site in page-read-tools.ts.
+ */
+
+export interface VisualContentDeliveredOutput {
+  success: true;
+  type: 'visual_content_delivered';
+  pageId: string;
+  title: string;
+  mimeType: string;
+  message: string;
+  imageBase64: string;
+  sizeBytes: number;
+  metadata: Record<string, unknown>;
+}
+
+type ToolResultOutput =
+  | { type: 'text'; value: string }
+  | { type: 'json'; value: unknown }
+  | {
+      type: 'content';
+      value: Array<
+        | { type: 'text'; text: string }
+        | { type: 'image-data'; data: string; mediaType: string }
+      >;
+    };
+
+function isVisualContentDelivered(output: unknown): output is VisualContentDeliveredOutput {
+  return (
+    typeof output === 'object' &&
+    output !== null &&
+    (output as Record<string, unknown>).type === 'visual_content_delivered' &&
+    typeof (output as Record<string, unknown>).imageBase64 === 'string'
+  );
+}
+
+/**
+ * read_page's toModelOutput: delivers image bytes as a real image content part for
+ * visual_content_delivered results; every other output shape passes through as JSON
+ * unchanged (today's behavior for text/TASK_LIST/CHANNEL/error results).
+ */
+export function toModelOutputForReadPage(output: unknown): ToolResultOutput {
+  if (isVisualContentDelivered(output)) {
+    return {
+      type: 'content',
+      value: [
+        { type: 'text', text: output.message },
+        { type: 'image-data', data: output.imageBase64, mediaType: output.mimeType },
+      ],
+    };
+  }
+  return { type: 'json', value: output };
+}
+
+/**
+ * Strips image bytes from a visual_content_delivered result, returning the same
+ * visual_content_metadata shape read_page already produces when a model lacks vision.
+ * Non-visual outputs pass through unchanged. Used to degrade STALE image tool-results
+ * from an earlier, vision-capable turn when the active model no longer has vision.
+ */
+export function degradeVisualContentToMetadata(output: unknown): unknown {
+  if (!isVisualContentDelivered(output)) return output;
+
+  const { pageId, title, mimeType, sizeBytes, metadata } = output;
+  return {
+    success: true,
+    type: 'visual_content_metadata',
+    pageId,
+    title,
+    message: `Found visual content: "${title}" (${mimeType})`,
+    mimeType,
+    sizeBytes,
+    summary: 'This is a visual file that requires vision capabilities to process',
+    stats: {
+      documentType: 'VISUAL',
+      mimeType,
+      sizeBytes,
+      sizeMB: (sizeBytes / 1024 / 1024).toFixed(2),
+    },
+    metadata: { ...metadata, requiresVisionModel: true, imageOmitted: true },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `fetchCachedImagePreset`, a pure-ish helper (injectable byte-fetch) that resolves a FILE page's `contentHash` to validated base64 image bytes from the processor's cached presets, walking a fallback chain: `ai-vision` → `ai-chat` → `original`. Every candidate is gated by `isAllowedImageType` + `validateMagicBytes` + a 4MB size cap (`MAX_IMAGE_SIZE_BYTES`, reused from the vision-attachment feature); unusable candidates fall through, and `null` means "no usable preset" so callers keep today's metadata-only behavior.
- Wires `read_page`'s visual branch to actually deliver image content: when the model has vision and a preset is found, the tool returns a new `visual_content_delivered` result carrying `imageBase64` (plus `originalMimeType`, the page's true upload format, distinct from the delivered preset's re-encoded mediaType), and a `toModelOutput` mapper (`toModelOutputForReadPage`) converts it into a real `image-data` content part for the model. All other output shapes (text pages, TASK_LIST, CHANNEL, errors, metadata-only fallback) pass through as JSON unchanged.
- Guards the cross-turn vision-capability mismatch: a stale `visual_content_delivered` tool result persisted from an earlier vision-capable turn is degraded back to the `visual_content_metadata` shape (bytes stripped, `imageOmitted: true`, and — via `originalMimeType` — the correct file type even though the delivered preset was re-encoded) via `guardReadPageToolForVision`, applied at **every** call site that reconverts persisted history through `read_page`: the in-app chat route, the Global Assistant route, the OpenAI-compatible `v1/chat/completions` API, and `ask_agent`. (`page-agents/consult` was checked and confirmed not vulnerable — its history reconstruction flattens tool results to text and never carries raw image bytes forward.)
- `fetchCachedImagePreset` treats any fetch failure (not just 404/cache-miss) as "this candidate is unusable" and falls through to the next preset — this path previously made zero S3 calls and always succeeded, so a permissions or transient-outage error must not turn a guaranteed-success tool call into a hard failure.
- Derives `ToolResultOutput` from `ai`'s public `Tool` type instead of importing from the transitive `@ai-sdk/provider-utils` dependency.

## Convergence pass (self-review before external review)
Ran an internal 8-angle review (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) against the original diff, adversarially verified each candidate, and fixed everything that survived verification:
- **Guard coverage gap (highest severity):** the stale-image guard was only wired into the in-app chat route; 3 of 4 sibling routes that reconvert history through `read_page` had no protection. Now fixed in all three (see Summary above), with regression tests added per route/tool (`route.test.ts`, `agent-communication-tools.test.ts`).
- **mimeType bug:** a degraded stale result reported the delivered preset's re-encoded format (always jpeg) instead of the page's true upload format — fixed via a new `originalMimeType` field, with a regression test.
- **Error-handling regression:** non-404 S3 errors aborted the whole `read_page` call instead of degrading gracefully — fixed with regression tests for both the fallthrough and all-candidates-fail cases.
- **Unbounded payload risk:** no size cap before falling back to the uncapped `original` preset (up to the per-tier max upload size) — fixed by reusing the existing 4MB `MAX_IMAGE_SIZE_BYTES` convention, with a regression test.
- **Duplication:** the `visual_content_metadata` envelope was hand-built independently in two places — extracted into a shared `buildVisualContentMetadata` helper.
- Not fixed (documented, lower severity, pre-existing pattern): the S3 not-found-error classifier and cache-key scheme in `image-preset-fetch.ts` duplicate similar (not identical) logic already present in 3+ other files across the codebase (avatar route, canvas published-storage, upload s3-effects) — deduplicating those is a larger, separate refactor outside this PR's scope. A missing CHANGELOG entry was also considered and skipped — recent backend/internal AI-tool-behavior PRs consistently follow this same convention.

## Tracking
No GitHub issue — implements PageSpace epic **"read_page Visual Content Delivery"** (page `yrzrmu05pm9at7fghs9h9gby`), part of the Image & Vision Support effort alongside #1854, #1861, #1862. All 3 phases (Pure functions → Integration → Quality gate) are complete on the epic board.

## Test plan
- [x] `tsc --noEmit` in `apps/web` — clean
- [x] `bunx eslint` on all touched files — clean
- [x] Feature suites: `image-preset-fetch`, `read-page-vision-output`, `page-read-tools`, `agent-communication-tools`, `v1/chat/completions` route tests — all passing, including new regression tests for every fix above
- [x] Full `apps/web` vitest suite: 11123/11139 passing; the 16 failures are in 3 files untouched by this branch (message-grouping timezone edge case, DB-dependent activity/auth tests) — same pre-existing set documented on #1861
- [ ] Manual smoke test: `read_page` an image FILE page with a vision-capable model and confirm the model can describe the actual image; switch the conversation to a non-vision model and confirm the stale image result degrades to metadata instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jza5vpdupWUtsFC87PjWcj