### PR TITLE
fix(web): preserve OAuth loopback redirect URIs

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -21,6 +21,9 @@ export const nextConfig: NextConfig = {
   output: "standalone",
   outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: workspaceDistReady ? [] : ["@pagespace/db", "@pagespace/lib"],
+  // Preserve RFC 8252 loopback redirect_uri query values; NextRequest URL
+  // normalization rewrites percent-encoded 127.0.0.1 to localhost otherwise.
+  skipMiddlewareUrlNormalize: true,
   // pg resolves via bun's cache path (~/.bun/install/cache/pg@.../), which
   // contains no "node_modules" segment, so Next.js's path-based heuristic
   // fails to auto-externalize it. List it explicitly here as a backstop; the

--- a/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
@@ -6,6 +6,7 @@
  * the consent POST, single-use code hashed at rest, state echoed verbatim.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
@@ -41,6 +42,7 @@ import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { createAuthorizationCode } from '@/lib/repositories/oauth-repository';
+import { nextConfig } from '../../../../../../next.config';
 
 const REDIRECT_URI = 'http://127.0.0.1:51234/callback';
 const CODE_CHALLENGE = 'a'.repeat(43);
@@ -193,6 +195,59 @@ describe('GET /api/oauth/authorize — session gate', () => {
     expect(location.pathname).toBe('/oauth/consent');
     expect(location.searchParams.get('client_id')).toBe('pagespace-cli');
     expect(location.searchParams.get('state')).toBe('xyz123');
+  });
+});
+
+describe('GET /api/oauth/authorize — loopback redirect_uri normalization', () => {
+  const cliAuthorizeUrl =
+    'http://web.local/api/oauth/authorize?response_type=code&client_id=pagespace-cli&redirect_uri=http%3A%2F%2F127.0.0.1%3A53397%2Fcallback&code_challenge=uWhtGkQARlvr1Drqj_gD3BMeFu9Q6V96GY7RWuH1Aks&code_challenge_method=S256&scope=account+offline_access&state=x';
+
+  it('keeps middleware URL normalization disabled in Next config', () => {
+    expect(nextConfig.skipMiddlewareUrlNormalize).toBe(true);
+  });
+
+  it('preserves 127.0.0.1 in encoded redirect_uri query params under the NextRequest flag', () => {
+    const previous = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE;
+    process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = '1';
+
+    try {
+      const req = new NextRequest(cliAuthorizeUrl);
+
+      expect(req.url).toContain('redirect_uri=http%3A%2F%2F127.0.0.1%3A53397%2Fcallback');
+      expect(req.url).not.toContain('redirect_uri=http%3A%2F%2Flocalhost%3A53397%2Fcallback');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE;
+      } else {
+        process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = previous;
+      }
+    }
+  });
+
+  it('redirects unauthenticated CLI authorization requests to signin instead of rejecting the redirect_uri', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(null, { status: 401 }),
+    } as never);
+
+    const previous = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE;
+    process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = '1';
+
+    try {
+      const res = await GET(new NextRequest(cliAuthorizeUrl));
+
+      expect(res.status).toBe(302);
+      const location = new URL(res.headers.get('location')!);
+      expect(location.pathname).toBe('/auth/signin');
+      const next = decodeURIComponent(location.searchParams.get('next')!);
+      expect(next).toContain('redirect_uri=http://127.0.0.1:53397/callback');
+      expect(next).not.toContain('redirect_uri=http://localhost:53397/callback');
+    } finally {
+      if (previous === undefined) {
+        delete process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE;
+      } else {
+        process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = previous;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Enable `skipMiddlewareUrlNormalize` in the web Next config so `NextRequest.url` keeps RFC 8252 loopback redirect_uri query values intact.
- Add OAuth authorize regression coverage for the NextRequest normalization flag and unauthenticated CLI signin redirect.

## Root Cause
Next.js URL normalization rewrites the first loopback IP occurrence in the request URL, including percent-encoded query values. That changed `redirect_uri=http://127.0.0.1:53397/callback` into `http://localhost:53397/callback` before OAuth validation, causing the CLI authorization-code flow to fail with an invalid redirect URI.

## Validation
- `bun run --filter 'web' test -- src/app/api/oauth`\n- `bun run --filter '@pagespace/db' build`\n- `bun run --filter '@pagespace/lib' build`\n- `bun run --filter 'web' typecheck`\n- `bun run --filter 'web' build`\n- Standalone server curl returned `302 Found` with `127.0.0.1` preserved in the reflected signin `next` parameter.\n\n## Notes\nThe standalone production curl required a local Postgres instance because production rate limiting fails closed when Postgres is unavailable.