### PR TITLE
feat(sandbox): PR diff, CI visibility, PR review, and lifecycle tools

### DIFF
--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -95,7 +95,7 @@ const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
 • bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
 • Use editFile for targeted string edits; writeFile rewrites the whole file.
 • Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs (up to 200000ms) if a command needs more than the 120s default.
-• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_run_list, gh_run_view, gh_pr_review, gh_pr_close.`;
+• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_run_list, gh_run_view, gh_pr_review, gh_pr_close, gh_pr_reopen, gh_pr_ready.`;
 
 /**
  * Build personalization prompt section from user preferences

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -95,7 +95,7 @@ const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
 • bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
 • Use editFile for targeted string edits; writeFile rewrites the whole file.
 • Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs (up to 200000ms) if a command needs more than the 120s default.
-• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view.`;
+• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_run_list, gh_run_view, gh_pr_review, gh_pr_close.`;
 
 /**
  * Build personalization prompt section from user preferences

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -64,7 +64,8 @@ export const WRITE_TOOLS = new Set([
   // Sandbox / code-execution operations — all mutate the persistent sandbox
   // filesystem or a remote. bash can run arbitrary mutations, so it is excluded
   // in read-only mode too. Read-only sandbox tools (readFile, git_status,
-  // git_diff, git_log, gh_pr_list, gh_pr_view, gh_issue_list, gh_issue_view) are
+  // git_diff, git_log, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks,
+  // gh_run_list, gh_run_view, gh_issue_list, gh_issue_view) are
   // intentionally NOT listed and remain available.
   'bash',
   'writeFile',
@@ -87,6 +88,10 @@ export const WRITE_TOOLS = new Set([
   'gh_pr_create',
   'gh_pr_merge',
   'gh_pr_checkout',
+  'gh_pr_review',
+  'gh_pr_close',
+  'gh_pr_reopen',
+  'gh_pr_ready',
   'gh_issue_create',
 ]);
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -177,6 +177,40 @@ describe('git_diff', () => {
     const calls = getRunCalls(deps);
     expect(calls[0].args).toContain('--cached');
   });
+
+  it('uses three-dot merge-base diff when base is given', async () => {
+    const deps = makeDeps();
+    const { git_diff } = createSandboxGitTools(deps);
+    await git_diff.execute!({ base: 'origin/master' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('origin/master...HEAD');
+  });
+
+  it('uses explicit head ref when both base and head are given', async () => {
+    const deps = makeDeps();
+    const { git_diff } = createSandboxGitTools(deps);
+    await git_diff.execute!({ base: 'origin/master', head: 'feature-x' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('origin/master...feature-x');
+  });
+
+  it('includes --path filter when path is given with base', async () => {
+    const deps = makeDeps();
+    const { git_diff } = createSandboxGitTools(deps);
+    await git_diff.execute!({ base: 'origin/master', path: 'src/foo.ts' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--');
+    expect(calls[0].args).toContain('src/foo.ts');
+  });
+
+  it('falls back to working-tree diff when base is not given', async () => {
+    const deps = makeDeps();
+    const { git_diff } = createSandboxGitTools(deps);
+    await git_diff.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['diff']);
+    expect(calls[0].args).not.toContain('...');
+  });
 });
 
 // ── git_reset ──────────────────────────────────────────────────────────────
@@ -479,6 +513,27 @@ describe('gh_pr_create', () => {
   });
 });
 
+// ── gh_pr_diff ─────────────────────────────────────────────────────────────
+
+describe('gh_pr_diff', () => {
+  it('builds ["pr", "diff", "<number>"]', async () => {
+    const deps = makeDeps();
+    const { gh_pr_diff } = createSandboxGitTools(deps);
+    await gh_pr_diff.execute!({ number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toEqual(['pr', 'diff', '42', '--color', 'never']);
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_diff } = createSandboxGitTools(deps);
+    const result = await gh_pr_diff.execute!({ number: 42 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
 // ── gh_issue_create ────────────────────────────────────────────────────────
 
 describe('gh_issue_create', () => {
@@ -493,6 +548,212 @@ describe('gh_issue_create', () => {
     const deps = makeDeps(null);
     const { gh_issue_create } = createSandboxGitTools(deps);
     const result = await gh_issue_create.execute!({ title: 'Issue', body: 'b' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_run_list ─────────────────────────────────────────────────────────────
+
+describe('gh_run_list', () => {
+  it('defaults to limit 10', async () => {
+    const deps = makeDeps();
+    const { gh_run_list } = createSandboxGitTools(deps);
+    await gh_run_list.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('--limit');
+    const limitIdx = calls[0].args.indexOf('--limit');
+    expect(calls[0].args[limitIdx + 1]).toBe('10');
+  });
+
+  it('passes branch and status filters', async () => {
+    const deps = makeDeps();
+    const { gh_run_list } = createSandboxGitTools(deps);
+    await gh_run_list.execute!({ branch: 'feat/x', status: 'completed' }, {} as never);
+    const calls = getRunCalls(deps);
+    const branchIdx = calls[0].args.indexOf('--branch');
+    expect(calls[0].args[branchIdx + 1]).toBe('feat/x');
+    const statusIdx = calls[0].args.indexOf('--status');
+    expect(calls[0].args[statusIdx + 1]).toBe('completed');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_run_list } = createSandboxGitTools(deps);
+    const result = await gh_run_list.execute!({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_run_view ──────────────────────────────────────────────────────────────
+
+describe('gh_run_view', () => {
+  it('uses --json when log is not set', async () => {
+    const deps = makeDeps();
+    const { gh_run_view } = createSandboxGitTools(deps);
+    await gh_run_view.execute!({ runId: 12345 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('--json');
+    expect(calls[0].args).toContain('12345');
+    expect(calls[0].args).not.toContain('--log-failed');
+  });
+
+  it('uses --log-failed when log: true', async () => {
+    const deps = makeDeps();
+    const { gh_run_view } = createSandboxGitTools(deps);
+    await gh_run_view.execute!({ runId: 12345, log: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--log-failed');
+    expect(calls[0].args).not.toContain('--json');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_run_view } = createSandboxGitTools(deps);
+    const result = await gh_run_view.execute!({ runId: 12345 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_checks ───────────────────────────────────────────────────────────
+
+describe('gh_pr_checks', () => {
+  it('calls gh pr checks with JSON output', async () => {
+    const deps = makeDeps();
+    const { gh_pr_checks } = createSandboxGitTools(deps);
+    await gh_pr_checks.execute!({ number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('checks');
+    expect(calls[0].args).toContain('42');
+    const jsonIdx = calls[0].args.indexOf('--json');
+    expect(jsonIdx).toBeGreaterThan(-1);
+    expect(calls[0].args[jsonIdx + 1]).toContain('name');
+    expect(calls[0].args[jsonIdx + 1]).toContain('state');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_checks } = createSandboxGitTools(deps);
+    const result = await gh_pr_checks.execute!({ number: 42 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_review ───────────────────────────────────────────────────────────
+
+describe('gh_pr_review', () => {
+  it('uses --approve for approve action', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review } = createSandboxGitTools(deps);
+    await gh_pr_review.execute!({ number: 42, action: 'approve', body: 'LGTM' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('--approve');
+    expect(calls[0].args).toContain('LGTM');
+  });
+
+  it('uses --request-changes for request_changes action', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review } = createSandboxGitTools(deps);
+    await gh_pr_review.execute!({ number: 42, action: 'request_changes', body: 'Fix X' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--request-changes');
+    expect(calls[0].args).toContain('Fix X');
+  });
+
+  it('uses --comment for comment action', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review } = createSandboxGitTools(deps);
+    await gh_pr_review.execute!({ number: 42, action: 'comment', body: 'Note: ...' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('--comment');
+    expect(calls[0].args).toContain('Note: ...');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_review } = createSandboxGitTools(deps);
+    const result = await gh_pr_review.execute!({ number: 42, action: 'approve' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_close ────────────────────────────────────────────────────────────
+
+describe('gh_pr_close', () => {
+  it('includes --comment when comment is given', async () => {
+    const deps = makeDeps();
+    const { gh_pr_close } = createSandboxGitTools(deps);
+    await gh_pr_close.execute!({ number: 42, comment: 'Duplicate' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toContain('close');
+    expect(calls[0].args).toContain('42');
+    expect(calls[0].args).toContain('--comment');
+    expect(calls[0].args).toContain('Duplicate');
+  });
+
+  it('omits --comment when not given', async () => {
+    const deps = makeDeps();
+    const { gh_pr_close } = createSandboxGitTools(deps);
+    await gh_pr_close.execute!({ number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).not.toContain('--comment');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_close } = createSandboxGitTools(deps);
+    const result = await gh_pr_close.execute!({ number: 42 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_reopen ───────────────────────────────────────────────────────────
+
+describe('gh_pr_reopen', () => {
+  it('builds ["pr", "reopen", "<number>"]', async () => {
+    const deps = makeDeps();
+    const { gh_pr_reopen } = createSandboxGitTools(deps);
+    await gh_pr_reopen.execute!({ number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toEqual(['pr', 'reopen', '42']);
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_reopen } = createSandboxGitTools(deps);
+    const result = await gh_pr_reopen.execute!({ number: 42 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_ready ────────────────────────────────────────────────────────────
+
+describe('gh_pr_ready', () => {
+  it('builds ["pr", "ready", "<number>"]', async () => {
+    const deps = makeDeps();
+    const { gh_pr_ready } = createSandboxGitTools(deps);
+    await gh_pr_ready.execute!({ number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toEqual(['pr', 'ready', '42']);
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_ready } = createSandboxGitTools(deps);
+    const result = await gh_pr_ready.execute!({ number: 42 }, {} as never);
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
@@ -571,10 +832,10 @@ describe('schema strictness', () => {
 // ── tool count ─────────────────────────────────────────────────────────────
 
 describe('createSandboxGitTools', () => {
-  it('exports exactly 26 tools', () => {
+  it('exports exactly 34 tools', () => {
     const deps = makeDeps();
     const tools = createSandboxGitTools(deps);
-    expect(Object.keys(tools)).toHaveLength(26);
+    expect(Object.keys(tools)).toHaveLength(34);
   });
 
   it('no tool passes sh or -c as the cmd or first arg', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -211,6 +211,21 @@ describe('git_diff', () => {
     expect(calls[0].args).toEqual(['diff']);
     expect(calls[0].args).not.toContain('...');
   });
+
+  it('rejects head without base', () => {
+    const { git_diff } = createSandboxGitTools(makeDeps());
+    const ok = (v: unknown) => (git_diff.inputSchema as unknown as { safeParse: (v: unknown) => { success: boolean } }).safeParse(v).success;
+    expect(ok({ head: 'feature-x' })).toBe(false);
+    expect(ok({ base: 'origin/master', head: 'feature-x' })).toBe(true);
+  });
+
+  it('rejects staged combined with base', () => {
+    const { git_diff } = createSandboxGitTools(makeDeps());
+    const ok = (v: unknown) => (git_diff.inputSchema as unknown as { safeParse: (v: unknown) => { success: boolean } }).safeParse(v).success;
+    expect(ok({ staged: true, base: 'origin/master' })).toBe(false);
+    expect(ok({ staged: true })).toBe(true);
+    expect(ok({ base: 'origin/master' })).toBe(true);
+  });
 });
 
 // ── git_reset ──────────────────────────────────────────────────────────────

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -1,5 +1,5 @@
 /**
- * Agent git/GitHub tools: all 26 tools running inside a sandbox.
+ * Agent git/GitHub tools: all 34 tools running inside a sandbox.
  *
  * Pure factory — no DB imports, no Sprites SDK. Production wiring lives in
  * `sandbox-git-tools-runtime.ts`. Each tool's execute handler:
@@ -229,13 +229,34 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   });
 
   const gitDiff = tool({
-    description: 'Show changes in the working tree or staged changes.',
+    description:
+      'Show changes in the working tree, staged changes, or between two refs. Pass base + head to diff between branches/commits (e.g. base: "origin/master", head: "HEAD"). Uses three-dot diff (merge-base to head) so only changes unique to head are shown. Falls back to working-tree diff when neither is given.',
     inputSchema: z
-      .object({ staged: z.boolean().optional(), path: z.string().optional(), cwd: cwdField })
+      .object({
+        staged: z.boolean().optional(),
+        path: z.string().optional(),
+        base: z
+          .string()
+          .optional()
+          .describe('Base ref to diff from (e.g. "origin/master", "HEAD~1")'),
+        head: z
+          .string()
+          .optional()
+          .describe('Head ref to diff to (defaults to HEAD when base is given)'),
+        cwd: cwdField,
+      })
       .strict(),
-    execute: async ({ staged, path, cwd }, options) => {
+    execute: async ({ staged, path, base, head, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
+      if (base) {
+        return git(
+          'git',
+          ['diff', `${base}...${head ?? 'HEAD'}`, ...(path ? ['--', path] : [])],
+          opened.ctx,
+          cwd,
+        );
+      }
       return git(
         'git',
         ['diff', ...(staged ? ['--cached'] : []), ...(path ? ['--', path] : [])],
@@ -559,7 +580,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   });
 
   const ghPrView = tool({
-    description: 'View a pull request. Requires a connected GitHub account.',
+    description: 'View a pull request with CI status, review state, and file change counts. Requires a connected GitHub account.',
     inputSchema: z
       .object({ number: z.number().int().positive().optional(), cwd: cwdField })
       .strict(),
@@ -570,8 +591,38 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           [
             'pr', 'view',
             ...(number ? [String(number)] : []),
-            '--json', 'number,title,body,state,url,headRefName,baseRefName,mergeable',
+            '--json', 'number,title,body,state,url,headRefName,baseRefName,mergeable,additions,deletions,changedFiles,statusCheckRollup,reviewDecision,isDraft',
           ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghPrDiff = tool({
+    description:
+      'Get the server-side diff for a pull request. Always merge-base correct, unaffected by local clone depth. Prefer this over git_diff for PR review. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({ number: z.number().int().positive().optional(), cwd: cwdField })
+      .strict(),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR('gh', ['pr', 'diff', ...(number ? [String(number)] : []), '--color', 'never'], ctx, token, cwd),
+      ),
+  });
+
+  const ghPrChecks = tool({
+    description:
+      'List CI check statuses for a pull request (name, state, link). Each check is PASS/FAIL/PENDING/SKIP. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({ number: z.number().int().positive().optional(), cwd: cwdField })
+      .strict(),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          ['pr', 'checks', ...(number ? [String(number)] : []), '--json', 'name,state,startedAt,completedAt,link'],
           ctx,
           token,
           cwd,
@@ -609,6 +660,135 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }).strict(),
     execute: async ({ number, cwd }, options) =>
       withToken(options, (ctx, token) => gitR('gh', ['pr', 'checkout', String(number)], ctx, token, cwd)),
+  });
+
+  const ghPrReview = tool({
+    description:
+      'Submit a review on a pull request: approve, request changes, or leave a comment. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        action: z.enum(['approve', 'request_changes', 'comment']),
+        body: z.string().optional().describe('Review body / comment text'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ number, action, body, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'pr', 'review', String(number),
+            ...(action === 'approve' ? ['--approve'] : action === 'request_changes' ? ['--request-changes'] : ['--comment']),
+            ...(body ? ['--body', body] : []),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghPrClose = tool({
+    description: 'Close a pull request with an optional comment. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        comment: z.string().optional().describe('Comment to post when closing'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ number, comment, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          ['pr', 'close', String(number), ...(comment ? ['--comment', comment] : [])],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghPrReopen = tool({
+    description: 'Reopen a closed pull request. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({ number: z.number().int().positive(), cwd: cwdField })
+      .strict(),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR('gh', ['pr', 'reopen', String(number)], ctx, token, cwd),
+      ),
+  });
+
+  const ghPrReady = tool({
+    description: 'Mark a draft pull request as ready for review. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({ number: z.number().int().positive(), cwd: cwdField })
+      .strict(),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR('gh', ['pr', 'ready', String(number)], ctx, token, cwd),
+      ),
+  });
+
+  // ── GitHub Actions / CI ───────────────────────────────────────────────
+
+  const ghRunList = tool({
+    description:
+      'List GitHub Actions workflow runs. Use to check CI status after pushing or to find failing runs. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        branch: z.string().optional(),
+        limit: z.number().int().positive().max(50).optional(),
+        status: z.enum(['queued', 'in_progress', 'completed']).optional(),
+        event: z.string().optional().describe('Filter by trigger event (e.g. "pull_request", "push")'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ branch, limit, status, event, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'run', 'list',
+            '--limit', String(limit ?? 10),
+            ...(branch ? ['--branch', branch] : []),
+            ...(status ? ['--status', status] : []),
+            ...(event ? ['--event', event] : []),
+            '--json', 'databaseId,status,conclusion,name,headBranch,event,createdAt,displayTitle',
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghRunView = tool({
+    description:
+      'View details of a specific GitHub Actions run including job-level pass/fail status. Pass log: true to include logs for failed jobs (can be large). Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        runId: z.number().int().positive().describe('Run databaseId from gh_run_list'),
+        log: z.boolean().optional().describe('Include logs for failed jobs'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ runId, log, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'run', 'view', String(runId),
+            ...(log ? ['--log-failed'] : []),
+            ...(log ? [] : ['--json', 'databaseId,status,conclusion,name,headBranch,displayTitle,jobs']),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
   });
 
   // ── GitHub Issues (token required) ──────────────────────────────────────
@@ -709,8 +889,16 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     gh_pr_create: ghPrCreate,
     gh_pr_list: ghPrList,
     gh_pr_view: ghPrView,
+    gh_pr_diff: ghPrDiff,
+    gh_pr_checks: ghPrChecks,
     gh_pr_merge: ghPrMerge,
     gh_pr_checkout: ghPrCheckout,
+    gh_pr_review: ghPrReview,
+    gh_pr_close: ghPrClose,
+    gh_pr_reopen: ghPrReopen,
+    gh_pr_ready: ghPrReady,
+    gh_run_list: ghRunList,
+    gh_run_view: ghRunView,
     gh_issue_create: ghIssueCreate,
     gh_issue_list: ghIssueList,
     gh_issue_view: ghIssueView,

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -245,7 +245,13 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           .describe('Head ref to diff to (defaults to HEAD when base is given)'),
         cwd: cwdField,
       })
-      .strict(),
+      .strict()
+      .refine((d) => !d.head || d.base, {
+        message: 'head requires base — diffing to a head ref without a base has no meaning',
+      })
+      .refine((d) => !d.staged || !d.base, {
+        message: 'staged and base are mutually exclusive — use staged for --cached or base for ref diff',
+      }),
     execute: async ({ staged, path, base, head, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;


### PR DESCRIPTION
## What

Expands the sandbox git/gh tool set from 26 to 34 tools, fixing the two workflow gaps that broke agent code reviews and CI visibility.

## Root Cause

Two problems surfaced during a PR review last week:
1. An agent reviewing PR #1868 used `git diff origin/master..HEAD` on a shallow clone, producing a diff that showed changes from other merged PRs as "removed." No tool existed to fetch the server-side PR diff (merge-base correct, independent of local clone state).
2. No way to check CI status, post a review, or manage PR lifecycle from agent context.

## New Tools (8)

| Tool | Purpose |
|------|---------|
| `gh_pr_diff` | Server-side PR diff via `gh pr diff`. Always merge-base correct. |
| `gh_pr_checks` | Per-check CI status (name, state, link) via `gh pr checks` |
| `gh_run_list` | List GitHub Actions runs, filter by branch/status/event |
| `gh_run_view` | View run details with job-level pass/fail. `log: true` for failed logs |
| `gh_pr_review` | Submit approve / request-changes / comment review |
| `gh_pr_close` | Close a PR with optional comment |
| `gh_pr_reopen` | Reopen a closed PR |
| `gh_pr_ready` | Mark a draft PR as ready for review |

## Enhanced Tools (2)

| Tool | Change |
|------|--------|
| `git_diff` | Added `base`/`head` params for three-dot merge-base diff (`base...head`) |
| `gh_pr_view` | Enriched JSON: `additions`, `deletions`, `changedFiles`, `statusCheckRollup`, `reviewDecision`, `isDraft` |

## Supporting Changes

- **System prompt**: New tools added to key-tools list
- **Tool filtering**: Write tools (`gh_pr_review`, `gh_pr_close`, `gh_pr_reopen`, `gh_pr_ready`) registered in `WRITE_TOOLS`; read tools (`gh_pr_diff`, `gh_pr_checks`, `gh_run_list`, `gh_run_view`) remain available in read-only mode
- **Tests**: 81 tests covering all new tools (arg construction, action mapping, token-gate, no-connection error path)

## Validation

- `bun run --filter 'web' test` — 81 passed
- `bun run --filter 'web' typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded GitHub PR support with more review, close/reopen, ready, and check-status actions.
  * Added workflow run listing and run-detail viewing, including failed-job logs when available.
  * Improved diff viewing for pull requests and branch comparisons, with better path and branch selection.
* **Bug Fixes**
  * Diff output now handles more comparison scenarios consistently, including working tree, staged, and two-branch diffs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->