### PR TITLE
fix(cli): close loopback socket deterministically and bound identity confirmation timeout

### DIFF
--- a/packages/cli/src/auth/__tests__/confirm-identity.test.ts
+++ b/packages/cli/src/auth/__tests__/confirm-identity.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PageSpaceClient, StaticTokenProvider } from '@pagespace/sdk';
-import { whoamiOperation } from '@pagespace/cli';
+import { CONFIRM_IDENTITY_TIMEOUT_MS, confirmIdentity, whoamiOperation } from '@pagespace/cli';
 
 describe('whoamiOperation', () => {
   it('is a GET against /api/auth/me carrying the access token as a Bearer header', async () => {
@@ -28,4 +28,32 @@ describe('whoamiOperation', () => {
     expect(capturedAuth).toBe('Bearer ps_at_test-token');
     expect(result).toEqual({ name: 'Ada Lovelace', email: 'ada@example.com' });
   });
+});
+
+describe('confirmIdentity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('bounds its wait to ~3s with zero retries against a server that never responds', async () => {
+    let callCount = 0;
+    const neverRespondingFetch = (async (_url: string, init?: RequestInit) => {
+      callCount += 1;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('This operation was aborted', 'AbortError'));
+        });
+      });
+    }) as unknown as typeof fetch;
+    vi.stubGlobal('fetch', neverRespondingFetch);
+
+    const start = Date.now();
+    await expect(confirmIdentity({ host: 'https://pagespace.ai', accessToken: 'ps_at_test-token' })).rejects.toThrow();
+    const elapsedMs = Date.now() - start;
+
+    // Zero retries: exactly one attempt, not up to 3 (the SDK default).
+    expect(callCount).toBe(1);
+    expect(elapsedMs).toBeGreaterThanOrEqual(CONFIRM_IDENTITY_TIMEOUT_MS - 100);
+    expect(elapsedMs).toBeLessThan(CONFIRM_IDENTITY_TIMEOUT_MS + 2_000);
+  }, 8_000);
 });

--- a/packages/cli/src/auth/__tests__/create-loopback-server.test.ts
+++ b/packages/cli/src/auth/__tests__/create-loopback-server.test.ts
@@ -1,3 +1,4 @@
+import { connect } from 'node:net';
 import { describe, expect, it } from 'vitest';
 import { createLoopbackServer, LOOPBACK_HOST } from '@pagespace/cli';
 
@@ -96,6 +97,48 @@ describe('createLoopbackServer', () => {
       await b.close();
     }
   });
+
+  it('sends Connection: close on both the 200 callback response and the 404 fallback response', async () => {
+    const server = await createLoopbackServer();
+    try {
+      const pending = server.nextCallback();
+      const callbackResponsePromise = fetch(`http://127.0.0.1:${server.port}/callback?code=abc&state=xyz`);
+      await pending;
+      await server.finish('ok');
+      const callbackResponse = await callbackResponsePromise;
+      expect(callbackResponse.headers.get('connection')).toBe('close');
+
+      const notFoundResponse = await fetch(`http://127.0.0.1:${server.port}/other`);
+      expect(notFoundResponse.headers.get('connection')).toBe('close');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it(
+    'close() resolves quickly even with an idle socket open that never sent a request',
+    async () => {
+      const server = await createLoopbackServer();
+      const socket = connect(server.port, LOOPBACK_HOST);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          socket.once('connect', () => resolve());
+          socket.once('error', reject);
+        });
+
+        const timeout = new Promise<'timeout'>((resolve) => {
+          setTimeout(() => resolve('timeout'), 1500);
+        });
+        const closed = server.close().then(() => 'closed' as const);
+
+        const winner = await Promise.race([closed, timeout]);
+        expect(winner).toBe('closed');
+      } finally {
+        socket.destroy();
+      }
+    },
+    3000,
+  );
 
   it(
     'a request to a non-/callback path (e.g. a favicon prefetch) does not consume the single-use callback',

--- a/packages/cli/src/auth/confirm-identity.ts
+++ b/packages/cli/src/auth/confirm-identity.ts
@@ -24,8 +24,22 @@ export const whoamiOperation = defineOperation({
   description: "Confirm the authenticated user's identity (name/email).",
 });
 
+/**
+ * This call is purely cosmetic (a nicer "Logged in as NAME <email>" message) —
+ * by the time it runs, the token exchange and credential persistence have
+ * already succeeded. Bound it to a short, deterministic budget with no
+ * retries so a slow/unresponsive server can never stall CLI exit waiting on
+ * this call; a failure here is silently absorbed by the caller (loopback-flow.ts).
+ */
+export const CONFIRM_IDENTITY_TIMEOUT_MS = 3_000;
+
 export const confirmIdentity: ConfirmIdentity = async ({ host, accessToken }): Promise<Identity> => {
-  const client = new PageSpaceClient({ baseUrl: host, auth: new StaticTokenProvider(accessToken) });
+  const client = new PageSpaceClient({
+    baseUrl: host,
+    auth: new StaticTokenProvider(accessToken),
+    timeoutMs: CONFIRM_IDENTITY_TIMEOUT_MS,
+    retryPolicy: { maxRetries: 0 },
+  });
   const result = await client.invoke(whoamiOperation, {});
   return { name: result.name, email: result.email };
 };

--- a/packages/cli/src/auth/create-loopback-server.ts
+++ b/packages/cli/src/auth/create-loopback-server.ts
@@ -6,6 +6,7 @@
  * caller closes it — this is a single-use, single-attempt server per login.
  */
 import { createServer } from 'node:http';
+import type { Socket } from 'node:net';
 import { CALLBACK_PATH } from './loopback-flow.js';
 import type { LoopbackCallback, LoopbackServer } from './loopback-flow.js';
 
@@ -25,7 +26,25 @@ export function createLoopbackServer(): Promise<LoopbackServer> {
     let pendingResolve: ((callback: LoopbackCallback) => void) | null = null;
     let respond: ((html: string) => void) | null = null;
 
+    // Every socket the server accepts is tracked so close() can deterministically
+    // clear connections that never reached a response — a TCP connection can be
+    // opened (favicon prefetch, a stray probe) and simply never send request
+    // bytes, in which case the 'request' event (and therefore the Connection:
+    // close header below) never fires for it, and Node's default server.close()
+    // would then wait on that socket forever. Sockets that DID reach a request
+    // are left alone: their response always carries Connection: close, so Node
+    // ends them itself once the write flushes — never truncating an in-flight
+    // response.
+    const sockets = new Set<Socket>();
+    const respondedSockets = new WeakSet<Socket>();
+
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+    });
+
     server.on('request', (req, res) => {
+      respondedSockets.add(req.socket);
       const url = new URL(req.url ?? '/', `http://${LOOPBACK_HOST}`);
 
       // Browsers routinely fire off incidental requests (favicon, prefetch)
@@ -34,7 +53,7 @@ export function createLoopbackServer(): Promise<LoopbackServer> {
       // path must never touch pendingResolve/respond — otherwise it can
       // consume the single-use callback slot the real redirect needs.
       if (url.pathname !== CALLBACK_PATH) {
-        res.writeHead(404).end();
+        res.writeHead(404, { Connection: 'close' }).end();
         return;
       }
 
@@ -49,7 +68,7 @@ export function createLoopbackServer(): Promise<LoopbackServer> {
       );
 
       respond = (html: string) => {
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', Connection: 'close' });
         res.end(html);
       };
 
@@ -84,6 +103,11 @@ export function createLoopbackServer(): Promise<LoopbackServer> {
           respond?.(html);
         },
         close(): Promise<void> {
+          for (const socket of sockets) {
+            if (!respondedSockets.has(socket)) {
+              socket.destroy();
+            }
+          }
           return new Promise((res) => server.close(() => res()));
         },
       });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -185,7 +185,7 @@ export type {
 export { createLoopbackServer, LOOPBACK_HOST, PortBindError } from './auth/create-loopback-server.js';
 export { createDiscoverMetadata, DiscoveryError } from './auth/discover.js';
 export { createExchangeCode, TokenExchangeError } from './auth/exchange-code.js';
-export { confirmIdentity, whoamiOperation } from './auth/confirm-identity.js';
+export { CONFIRM_IDENTITY_TIMEOUT_MS, confirmIdentity, whoamiOperation } from './auth/confirm-identity.js';
 export { openBrowser } from './auth/open-browser.js';
 
 // Token revocation (RFC 7009) — Phase 4 task 5, reused by `pagespace logout`.


### PR DESCRIPTION
## Summary

Fixes a reported bug where a user logs in via `pagespace login`, the browser correctly renders "You're logged in — return to your terminal", but the CLI process itself never prints its final "Logged in as ..." line and hangs indefinitely.

Two independent root causes, both fixed:

**1. Unbounded cosmetic identity-confirmation call (`packages/cli/src/auth/confirm-identity.ts`)**

`confirmIdentity` is a purely cosmetic `GET /api/auth/me` call made *after* the real login (token exchange + credential persistence) has already succeeded — it only prettifies the final message with the user's name/email. It was using the SDK client's default config: 30s timeout × up to 3 retries (worst case ~2 minutes), with the result silently caught to `null` by the caller. Fixed by constructing the client with an explicit `timeoutMs: 3000` and `retryPolicy: { maxRetries: 0 }`. The existing null-identity fallback path in `loopback-flow.ts` / `login.ts` is untouched — it was already correct and already tested.

**2. Non-deterministic socket close (`packages/cli/src/auth/create-loopback-server.ts`)**

`close()` was a plain `server.close(callback)`, which only resolves once every open socket ends. None of the server's responses set `Connection: close`, so Node defaulted to keep-alive, and any lingering socket (browser keep-alive pool, a stray favicon/prefetch connection that opens a TCP connection but never sends bytes) could block `close()` — and therefore the whole CLI process exit — indefinitely.

Fix, two parts:
- Added `Connection: close` to every response the server sends (both the 200 callback success path and the 404 fallback path).
- Added deterministic tracking of every accepted socket. In `close()`, any socket that never reached the `request` handler (and therefore never got a response, and never got the `Connection: close` header) is force-destroyed. Sockets that *did* get a request are left alone — their response always carries `Connection: close`, so Node ends them itself once the write flushes, without any risk of truncating an in-flight response.

Note: the originally proposed fix for part 2 used `server.closeIdleConnections()`. I verified empirically (isolated repro script) that this does **not** cover the exact case that mattered — a TCP connection that is accepted but never sends any HTTP request bytes is not tracked in Node's idle/keep-alive connection pool, so `closeIdleConnections()` left such a socket open indefinitely. The implemented fix uses explicit socket tracking instead, which I verified resolves `close()` in low single-digit milliseconds even with such a socket open.

## Test plan
- [x] `bun run --filter '@pagespace/cli' test` passes (701/701), including two new test cases, no regressions.
- [x] `bun run --filter '@pagespace/cli' typecheck` passes.
- [x] `create-loopback-server.test.ts` has a new test that opens a raw `net.connect` socket, never sends any request bytes, and asserts `close()` resolves within ~1.5s (raced against a timer) rather than hanging.
- [x] `create-loopback-server.test.ts` has a new test asserting the `Connection: close` header is present on both the 200 and 404 response paths.
- [x] `confirm-identity.test.ts` has a new test asserting `confirmIdentity` makes exactly one attempt (zero retries) and bounds its wait to ~3s against a server that never responds, instead of the previous ~2 minute worst case.
- [x] `loopback-flow.test.ts` re-run with no changes needed — existing null-identity-on-failure test still passes.
- [x] No new `any` types, no disabled lint/typecheck, no `--no-verify`, no skipped tests, no TODO stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZQRtyLBSk5s43bcXtY7ub