### PR TITLE
fix(ai-chat): stop Page AI history-select from racing a stale fetch

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -361,12 +361,12 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     // active conversation's share state and let the owner toggle it in place.
     enabled: activeTab === 'history' || activeTab === 'chat',
     onConversationLoad: (conversationId, messages) => {
-      // Identity was already set synchronously by the onSelectConversation
-      // wrapper below, before this fetch even started — this callback only
-      // hydrates messages. Use the pre-fetched messages directly (no re-fetch)
-      // and suppress the load-on-select effect so we don't double-request.
-      skipLoadEffectRef.current = conversationId;
-      setActiveTab('chat');
+      // Only reached via the undo-triggered reload path (onUndoApplied below)
+      // — history-select goes straight through setIdentity, letting the
+      // load-on-select effect below do the (one, authoritative) fetch. Doesn't
+      // touch activeTab/skipLoadEffectRef: an undo can land while the user is
+      // on a different tab, and currentConversationId isn't changing here so
+      // the load-on-select effect won't double-fire regardless.
       void loadMessagesForConversation(conversationId, messages);
     },
     onConversationLoadError: (_conversationId, error) => {
@@ -539,8 +539,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // Load-on-select guarantee: whenever currentConversationId changes to a real
   // (non-placeholder) id, reload the latest messages from the DB — unless
   // resolveConversation already prefetched them for this exact id (init path)
-  // or the caller opted out via skipLoadEffectRef (history-select path, which
-  // hydrates through its own onConversationLoad callback instead).
+  // or the caller opted out via skipLoadEffectRef (new-conversation path,
+  // which has no messages to fetch yet). History-select also funnels through
+  // here now — one authoritative fetch path for every conversation switch.
   useEffect(() => {
     if (!currentConversationId) return;
     if (isPlaceholderConversationId(currentConversationId, page.id)) return;
@@ -736,19 +737,16 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // HANDLERS
   // ============================================
 
-  // Adopt the selected id immediately — before the messages fetch even
-  // starts — so a send fired right after clicking a history item can't
-  // race and land under the previous conversation. skipLoadEffectRef must be
-  // set BEFORE setIdentity: setIdentity changes currentConversationId
-  // synchronously, which fires the load-on-select effect on this same render
-  // — if the skip token isn't already in place, that effect fires its own
-  // redundant fetch before loadConversation's onConversationLoad callback
-  // (which runs later, once its fetch resolves) gets a chance to set it.
+  // Adopt the selected id immediately — before any fetch even starts — so a
+  // send fired right after clicking a history item can't race and land under
+  // the previous conversation. The load-on-select effect (keyed on
+  // currentConversationId) does the actual fetch once identity updates —
+  // the same single, stale-guarded path used on init, so there's no separate
+  // loadConversation/onConversationLoad indirection to race against it.
   const handleSelectConversation = useCallback((conversationId: string) => {
-    skipLoadEffectRef.current = conversationId;
     setIdentity(conversationId);
-    void loadConversation(conversationId);
-  }, [setIdentity, loadConversation]);
+    setActiveTab('chat');
+  }, [setIdentity]);
 
   const buildFreshPageContext = useCallback(() => {
     const treeCacheKey = `/api/drives/${encodeURIComponent(driveId)}/pages`;

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.realConversations.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.realConversations.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * AiChatView.test.tsx mocks `useConversations` wholesale, so its "select from
+ * history" tests only prove that AiChatView reacts correctly to a manually
+ * simulated onConversationLoad callback — they never exercise the real
+ * useConversations.loadConversation implementation. This file re-runs the
+ * history-select flow with the REAL useConversations hook (only its network
+ * layer, fetchWithAuth, is mocked) to catch bugs the fully-mocked suite can't see.
+ */
+import { describe, test, vi, beforeEach, type Mock } from 'vitest';
+import { render, act, waitFor, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { assert } from './riteway';
+
+const { mockFetchWithAuth, mockSetMessages } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+  mockSetMessages: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn(), back: vi.fn(), forward: vi.fn(), prefetch: vi.fn() })),
+  usePathname: vi.fn(() => '/'),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  useParams: vi.fn(() => ({ driveId: 'test-drive-id' })),
+}));
+
+vi.mock('@ai-sdk/react', () => {
+  const chatState = {
+    messages: [] as unknown[],
+    sendMessage: vi.fn(),
+    status: 'idle' as const,
+    error: undefined as Error | undefined,
+    regenerate: vi.fn(),
+    setMessages: mockSetMessages,
+    stop: vi.fn(),
+  };
+  return { useChat: vi.fn(() => chatState) };
+});
+
+// useConversations's own SWR list-fetch is irrelevant to loadConversation —
+// stub useSWR itself out but still provide `mutate` since useConversations
+// imports it (unused on this path, but must exist to avoid a crash).
+vi.mock('swr', () => {
+  const swrCache = { get: vi.fn(() => undefined) };
+  return {
+    default: vi.fn(() => ({ data: undefined, isLoading: false })),
+    mutate: vi.fn(),
+    useSWRConfig: vi.fn(() => ({ cache: swrCache })),
+  };
+});
+
+vi.mock('@/hooks/useDrive', () => {
+  const driveState = { drives: [] as unknown[] };
+  return {
+    useDriveStore: vi.fn((selector: (state: typeof driveState) => unknown) =>
+      selector(driveState)
+    ),
+  };
+});
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(() => ({ user: { id: 'user-1', name: 'Test User' } })),
+}));
+
+vi.mock('@/stores/useAssistantSettingsStore', () => ({
+  useAssistantSettingsStore: vi.fn((selector: (state: { webSearchEnabled: boolean }) => unknown) =>
+    selector({ webSearchEnabled: false })
+  ),
+}));
+
+vi.mock('@/stores/useVoiceModeStore', () => {
+  const voiceState = { isEnabled: false, owner: null as null, enable: vi.fn(), disable: vi.fn() };
+  return {
+    useVoiceModeStore: vi.fn(
+      (selector: (state: typeof voiceState) => unknown) => selector(voiceState)
+    ),
+  };
+});
+
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: Object.assign(vi.fn(() => ({ register: vi.fn(), unregister: vi.fn() })), {
+    getState: vi.fn(() => ({ isAnyEditing: () => false })),
+  }),
+  isEditingActive: vi.fn(() => false),
+}));
+
+vi.mock('@/stores/usePendingStreamsStore', () => ({
+  usePendingStreamsStore: Object.assign(vi.fn(() => []), {
+    getState: vi.fn(() => ({
+      streams: new Map(),
+      getOwnStreams: vi.fn(() => []),
+      getRemotePageStreams: vi.fn(() => []),
+    })),
+  }),
+}));
+
+vi.mock('@/hooks/usePageSocketRoom', () => ({ usePageSocketRoom: vi.fn() }));
+vi.mock('@/hooks/useChannelStreamSocket', () => ({
+  useChannelStreamSocket: vi.fn(() => ({ rejoinActiveStreams: vi.fn() })),
+}));
+vi.mock('@/hooks/useAppStateRecovery', () => ({ useAppStateRecovery: vi.fn() }));
+
+vi.mock('@/hooks/useDisplayPreferences', () => ({
+  useDisplayPreferences: vi.fn(() => ({ preferences: { showTokenCounts: false } })),
+}));
+
+vi.mock('@/lib/ai/core/client', () => ({ clearActiveStreamId: vi.fn() }));
+vi.mock('@/lib/ai/core/stream-abort-client', () => ({
+  abortActiveStream: vi.fn(),
+  abortActiveStreamByMessageId: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/vision-models', () => ({ hasVisionCapability: vi.fn(() => false) }));
+
+const { historyTabPropsRef } = vi.hoisted(() => ({
+  historyTabPropsRef: {
+    current: null as null | { onSelectConversation?: (id: string) => void },
+  },
+}));
+
+// Deliberately real: useConversations, useConversationIdentity, useChatTransport,
+// buildChatConfig, conversationIdFrom/isResolving — everything this suite exists
+// to exercise for real. Only the pieces that need real browser/DOM/network APIs
+// AiChatView doesn't itself own are stubbed out below.
+vi.mock('@/lib/ai/shared', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/ai/shared')>()),
+  useMCPTools: vi.fn(() => ({
+    isDesktop: false,
+    runningServers: [],
+    runningServerNames: [],
+    mcpToolSchemas: [],
+    enabledServerCount: 0,
+    isServerEnabled: vi.fn(() => false),
+    setServerEnabled: vi.fn(),
+    allServersEnabled: false,
+    setAllServersEnabled: vi.fn(),
+  })),
+  useMessageActions: vi.fn(() => ({
+    handleEdit: vi.fn(),
+    handleDelete: vi.fn(),
+    handleRetry: vi.fn(),
+    lastAssistantMessageId: null,
+    lastUserMessageId: null,
+  })),
+  useProviderSettings: vi.fn(() => ({
+    isLoading: false,
+    isAnyProviderConfigured: true,
+    needsSetup: false,
+    selectedProvider: 'anthropic',
+    setSelectedProvider: vi.fn(),
+    selectedModel: 'claude-3-5-sonnet',
+    setSelectedModel: vi.fn(),
+    isProviderConfigured: vi.fn(() => true),
+  })),
+  useStreamingRegistration: vi.fn(),
+  useSendHandoff: vi.fn(() => ({ wrapSend: vi.fn((cb: () => void) => cb()) })),
+  useChatTransport: vi.fn(() => ({})),
+  buildChatConfig: vi.fn((params: { id: string; transport: unknown; onError?: (error: Error) => void }) => ({
+    id: params.id,
+    transport: params.transport,
+    experimental_throttle: 100,
+    onError: params.onError ?? vi.fn(),
+  })),
+}));
+
+vi.mock('@/lib/ai/shared/hooks/useImageAttachments', () => {
+  const imageAttachState = {
+    attachments: [] as unknown[],
+    addFiles: vi.fn(),
+    removeFile: vi.fn(),
+    clearFiles: vi.fn(),
+    getFilesForSend: vi.fn(() => [] as unknown[]),
+  };
+  return { useImageAttachments: vi.fn(() => imageAttachState) };
+});
+
+vi.mock('@/lib/tree/tree-utils', () => ({ buildPagePath: vi.fn(() => null) }));
+vi.mock('@/components/ai/page-agents', () => ({
+  PageAgentSettingsTab: vi.fn(() => null),
+  PageAgentHistoryTab: vi.fn((props: { onSelectConversation?: (id: string) => void }) => {
+    historyTabPropsRef.current = props;
+    return null;
+  }),
+}));
+vi.mock('@/components/ai/page-agents/AgentIntegrationsPanel', () => ({
+  AgentIntegrationsPanel: vi.fn(() => null),
+}));
+vi.mock('@/components/ai/voice/VoiceCallPanel', () => ({ VoiceCallPanel: vi.fn(() => null) }));
+vi.mock('@/components/ai/shared/chat', () => ({ ProviderSetupCard: vi.fn(() => null) }));
+vi.mock('@/components/ai/shared', () => ({
+  AiUsageMonitor: vi.fn(() => null),
+  TasksDropdown: vi.fn(() => null),
+}));
+vi.mock('@/components/ai/chat/layouts', () => ({
+  ChatLayout: vi.fn(
+    (props: {
+      renderInput?: (p: Record<string, unknown>) => unknown;
+      onStop?: () => void;
+      isStreaming?: boolean;
+    }) =>
+      props.renderInput?.({
+        value: '',
+        onChange: () => {},
+        onSend: () => {},
+        onStop: props.onStop,
+        isStreaming: props.isStreaming,
+        disabled: false,
+        placeholder: '',
+        driveId: '',
+        crossDrive: undefined,
+        mcpRunningServers: [],
+        mcpServerNames: [],
+        mcpEnabledCount: 0,
+        mcpAllEnabled: false,
+        onMcpToggleAll: () => {},
+        isMcpServerEnabled: () => false,
+        onMcpServerToggle: () => {},
+        showMcp: false,
+        inputPosition: 'centered',
+      }) ?? null
+  ),
+}));
+vi.mock('@/components/ai/chat/input', () => ({ ChatInput: vi.fn(() => null) }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('zustand/react/shallow', () => ({ useShallow: vi.fn((fn: unknown) => fn) }));
+
+vi.mock('@/stores/useFindStore', () => {
+  const findState = {
+    isOpen: false, query: '', currentIndex: 0, totalMatches: 0,
+    open: vi.fn(), close: vi.fn(), setQuery: vi.fn(),
+    next: vi.fn(), prev: vi.fn(), reportMatches: vi.fn(), reset: vi.fn(),
+  };
+  return {
+    useFindStore: vi.fn((selector: (s: typeof findState) => unknown) => selector(findState)),
+  };
+});
+
+import AiChatView from '../AiChatView';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { useMCPTools } from '@/lib/ai/shared';
+
+const latestMcpConversationId = (): string | null => {
+  const calls = vi.mocked(useMCPTools).mock.calls;
+  const last = calls[calls.length - 1] as [{ conversationId: string | null }] | undefined;
+  return last ? last[0].conversationId : null;
+};
+
+const PAGE_ID = 'page-123';
+const CONV_A = 'conv-a-recent';
+const CONV_B = 'conv-b-older';
+const CONVERSATIONS_URL = `/api/ai/page-agents/${PAGE_ID}/conversations`;
+const MESSAGES_URL_A = `/api/ai/page-agents/${PAGE_ID}/conversations/${CONV_A}/messages`;
+const MESSAGES_URL_B = `/api/ai/page-agents/${PAGE_ID}/conversations/${CONV_B}/messages`;
+const AGENT_CONFIG_URL = `/api/pages/${PAGE_ID}/agent-config`;
+const PERMISSIONS_URL = `/api/pages/${PAGE_ID}/permissions/check`;
+
+const makeOkResponse = (data: unknown) => ({
+  ok: true as const,
+  json: vi.fn().mockResolvedValue(data),
+});
+
+const makeErrorResponse = () => ({
+  ok: false as const,
+  json: vi.fn().mockResolvedValue({}),
+});
+
+const makePage = () => ({
+  id: PAGE_ID,
+  title: 'Test Chat',
+  type: PageType.AI_CHAT,
+  content: null,
+  position: 0,
+  isTrashed: false,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  trashedAt: null,
+  driveId: 'test-drive-id',
+  parentId: null,
+  originalParentId: null,
+  children: [],
+  aiChat: null,
+  messages: [],
+});
+
+const conversationA = {
+  id: CONV_A,
+  title: 'Most recent conversation',
+  preview: 'hi',
+  createdAt: '2024-01-02T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+  messageCount: 1,
+  lastMessage: 'hi',
+};
+
+const messagesForB = [
+  { id: 'b-msg-1', role: 'user', parts: [{ type: 'text', text: 'older question' }] },
+  { id: 'b-msg-2', role: 'assistant', parts: [{ type: 'text', text: 'older answer' }] },
+];
+
+describe('AiChatView + real useConversations: history select', () => {
+  const page = makePage();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    historyTabPropsRef.current = null;
+  });
+
+  test('given a conversation is picked from history, real useConversations.loadConversation should resolve and the picked conversation\'s messages should be applied via setMessages', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [conversationA] });
+      }
+      if (url === MESSAGES_URL_A && !opts?.method) {
+        return makeOkResponse({ messages: [] });
+      }
+      if (url === MESSAGES_URL_B && !opts?.method) {
+        return makeOkResponse({ messages: messagesForB });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init resolved to the most recent conversation',
+        should: 'reflect conv-a as current',
+        actual: latestMcpConversationId(),
+        expected: CONV_A,
+      });
+    });
+
+    const historyTrigger = await screen.findByRole('tab', { name: /history/i });
+    await userEvent.click(historyTrigger);
+    await waitFor(() => {
+      assert({
+        given: 'the History tab was clicked',
+        should: 'mount PageAgentHistoryTab and capture its onSelectConversation prop',
+        actual: historyTabPropsRef.current?.onSelectConversation !== undefined,
+        expected: true,
+      });
+    });
+
+    await act(async () => {
+      historyTabPropsRef.current?.onSelectConversation?.(CONV_B);
+      // Allow the real useConversations.loadConversation fetch (and its
+      // onConversationLoad → loadMessagesForConversation → setMessages chain)
+      // to actually run to completion.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      assert({
+        given: 'conv-b was picked from history and its real messages fetch resolved',
+        should: 'call setMessages with conv-b\'s actual messages, not leave the chat empty',
+        actual: mockSetMessages.mock.calls.some((args) =>
+          Array.isArray(args[0]) && args[0].some((m: { id: string }) => m.id === 'b-msg-1')
+        ),
+        expected: true,
+      });
+    });
+
+    assert({
+      given: 'conv-b was picked from history',
+      should: 'have fetched conv-b\'s messages from the real endpoint',
+      actual: (mockFetchWithAuth as unknown as Mock).mock.calls.some((args: unknown[]) => args[0] === MESSAGES_URL_B),
+      expected: true,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -629,7 +629,7 @@ describe('AiChatView initializeChat', () => {
     });
   });
 
-  test('given a conversation is selected from history and onConversationLoad supplies messages, should NOT double-fetch that conversation over the network', async () => {
+  test('given a conversation is selected from history, should fetch its messages directly via the load-on-select effect (not via useConversations.loadConversation)', async () => {
     const HISTORY_CONV_ID = 'history-selected-conv';
     const HISTORY_MESSAGES_URL = `/api/ai/page-agents/${PAGE_ID}/conversations/${HISTORY_CONV_ID}/messages`;
 
@@ -642,9 +642,11 @@ describe('AiChatView initializeChat', () => {
       if (url === MESSAGES_URL && !opts?.method) {
         return makeOkResponse({ messages: [] });
       }
+      if (url === HISTORY_MESSAGES_URL && !opts?.method) {
+        return makeOkResponse({ messages: [{ id: 'history-conv-msg', role: 'assistant', parts: [] }] });
+      }
       return makeErrorResponse();
     });
-    mockLoadConversation.mockResolvedValue(undefined);
 
     render(<AiChatView page={page} />);
     await waitFor(() => expect(latestMcpConversationId()).toBe(CONV_ID));
@@ -657,29 +659,101 @@ describe('AiChatView initializeChat', () => {
       historyTabPropsRef.current!.onSelectConversation!(HISTORY_CONV_ID);
     });
 
-    // Simulates useConversations.loadConversation resolving and invoking its
-    // onConversationLoad callback with pre-fetched messages.
-    act(() => {
-      useConversationsOptionsRef.current?.onConversationLoad?.(HISTORY_CONV_ID, [
-        { id: 'preloaded-msg', role: 'assistant', parts: [] },
-      ]);
+    await waitFor(() => {
+      assert({
+        given: 'a conversation was selected from history',
+        should: 'fetch that conversation\'s messages directly over the network',
+        actual: mockFetchWithAuth.mock.calls.some(([url]) => url === HISTORY_MESSAGES_URL),
+        expected: true,
+      });
     });
 
     await waitFor(() => {
       assert({
-        given: 'history-select fired and onConversationLoad supplied messages directly',
-        should: 'apply the preloaded messages',
+        given: 'a conversation was selected from history',
+        should: 'apply the fetched messages',
         actual: mockSetMessages.mock.calls.some((args) =>
-          Array.isArray(args[0]) && args[0].some((m: { id: string }) => m.id === 'preloaded-msg')
+          Array.isArray(args[0]) && args[0].some((m: { id: string }) => m.id === 'history-conv-msg')
         ),
         expected: true,
       });
     });
 
     assert({
-      given: 'history-select fired and onConversationLoad supplied messages directly',
-      should: 'never independently fetch that conversation\'s messages over the network (no double-fetch)',
-      actual: mockFetchWithAuth.mock.calls.some(([url]) => url === HISTORY_MESSAGES_URL),
+      given: 'a conversation was selected from history',
+      should: 'never call useConversations.loadConversation (history-select no longer routes through it)',
+      actual: mockLoadConversation.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  test('given the user switches to a second history conversation before the first one\'s messages fetch resolves, should apply the second (latest) selection\'s messages even if the first one\'s fetch resolves last', async () => {
+    const CONV_Y = 'history-conv-y';
+    const CONV_Z = 'history-conv-z';
+    const MESSAGES_URL_Y = `/api/ai/page-agents/${PAGE_ID}/conversations/${CONV_Y}/messages`;
+    const MESSAGES_URL_Z = `/api/ai/page-agents/${PAGE_ID}/conversations/${CONV_Z}/messages`;
+
+    let resolveY!: (value: unknown) => void;
+    const pendingY = new Promise((resolve) => { resolveY = resolve; });
+
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [existingConversation] });
+      }
+      if (url === MESSAGES_URL && !opts?.method) {
+        return makeOkResponse({ messages: [] });
+      }
+      // Y's fetch hangs until resolveY() is called explicitly below — simulates
+      // Y's response arriving on the wire AFTER Z's, even though Y was clicked first.
+      if (url === MESSAGES_URL_Y && !opts?.method) return pendingY;
+      if (url === MESSAGES_URL_Z && !opts?.method) {
+        return makeOkResponse({ messages: [{ id: 'z-msg', role: 'assistant', parts: [] }] });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+    await waitFor(() => expect(latestMcpConversationId()).toBe(CONV_ID));
+
+    const historyTrigger = await screen.findByRole('tab', { name: /history/i });
+    await userEvent.click(historyTrigger);
+    await waitFor(() => expect(historyTabPropsRef.current?.onSelectConversation).toBeDefined());
+
+    // Click Y, then immediately click Z (Z is the user's true final selection).
+    act(() => {
+      historyTabPropsRef.current!.onSelectConversation!(CONV_Y);
+    });
+    act(() => {
+      historyTabPropsRef.current!.onSelectConversation!(CONV_Z);
+    });
+
+    // Z resolves quickly (mocked as immediate above); wait for its messages to land.
+    await waitFor(() => {
+      assert({
+        given: 'Y was clicked then Z was clicked before Y\'s fetch resolved',
+        should: 'apply Z\'s messages once its fetch resolves',
+        actual: mockSetMessages.mock.calls.some((args) =>
+          Array.isArray(args[0]) && args[0].some((m: { id: string }) => m.id === 'z-msg')
+        ),
+        expected: true,
+      });
+    });
+
+    // Now let Y's stale, slow fetch finally resolve.
+    await act(async () => {
+      resolveY(makeOkResponse({ messages: [{ id: 'y-msg-stale', role: 'assistant', parts: [] }] }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert({
+      given: 'Y\'s fetch resolves last, after Z\'s messages were already applied',
+      should: 'NOT clobber the display with Y\'s stale messages — the user is on Z',
+      actual: mockSetMessages.mock.calls.some((args) =>
+        Array.isArray(args[0]) && args[0].some((m: { id: string }) => m.id === 'y-msg-stale')
+      ),
       expected: false,
     });
   });


### PR DESCRIPTION
## Summary
- Clicking a conversation in the History tab of a dedicated **AI Chat** page (the `AI_CHAT` page type, `AiChatView.tsx`) could show the empty "start a conversation" screen instead of the selected conversation, even though messages existed. The right-sidebar assistant was unaffected.
- Root cause: `handleSelectConversation` routed through `useConversations.loadConversation` → its `onConversationLoad` callback → `loadMessagesForConversation`, using a `skipLoadEffectRef` token set synchronously per call. Because the token/guard is keyed off *resolution* order rather than *click* order, an earlier, slower-resolving selection could overwrite a later one's messages (including with an empty array) — reproducible in production with real network latency and live-streamed conversations, not in a low-latency single-instance local test.
- Fix: `handleSelectConversation` now just adopts the identity and switches to the Chat tab; the existing load-on-select effect (already used on init, with proper stale-request guarding via `loadRequestedIdRef`) is the single authoritative fetch path for every conversation switch, including history-select. `onConversationLoad` is now only reached by the undo-triggered reload path.

## Test plan
- [x] Added a regression test simulating two overlapping history selections where the earlier click's fetch resolves last — verifies the later selection's messages win.
- [x] Added an integration test exercising the real (unmocked) `useConversations` hook for the history-select path — the existing suite fully mocked it, which is how this race went uncaught.
- [x] `bun run test` — full AI-chat area suite green (158 tests), plus full `apps/web` suite (1 pre-existing unrelated DB-config failure in `activity-tools.test.ts`, confirmed present on `master` before this change).
- [x] `bun run lint` — clean (pre-existing warnings elsewhere untouched).
- [x] `bun run typecheck` — clean across all workspace packages.
- [x] Manually reproduced the History-select flow end-to-end in a real browser (seeded Postgres, built and ran the app in production mode) across simple switch, switch-back, rapid-switch, and re-click-active scenarios to confirm the surrounding flow works correctly before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYwAoga8BSa2tVdxWQ7CNJ