### PR TITLE
fix(security): correctness/robustness hardening for #1178 stream revocation

### DIFF
--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -426,6 +426,47 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       testRegistry.finish(mockMessageId);
       await readSSEBody(response);
     });
+
+    it('given the permission recheck throws (e.g. a transient DB error), should fail closed: close the stream and emit a denial audit event', async () => {
+      vi.useFakeTimers();
+      vi.mocked(canUserViewPage)
+        .mockResolvedValueOnce(true) // initial join-time gate check
+        .mockRejectedValueOnce(new Error('DB connection lost')); // first recheck tick
+      testRegistry.register(mockMessageId, mockMeta);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      await vi.advanceTimersByTimeAsync(RECHECK_INTERVAL_MS);
+
+      const body = await readSSEBody(response);
+
+      expect(body).toContain('data: {"done":true,"aborted":true}\n\n');
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'authz.access.denied',
+          resourceType: 'ai_stream',
+          resourceId: mockMessageId,
+          details: expect.objectContaining({ reason: 'permission_recheck_failed', pageId: mockPageId }),
+        }),
+      );
+    });
+
+    it('given the permission recheck throws, should not schedule a further recheck (no leaked timer)', async () => {
+      vi.useFakeTimers();
+      vi.mocked(canUserViewPage)
+        .mockResolvedValueOnce(true)
+        .mockRejectedValueOnce(new Error('DB connection lost'));
+      testRegistry.register(mockMessageId, mockMeta);
+
+      await GET(makeRequest(), makeContext(mockMessageId));
+      await vi.advanceTimersByTimeAsync(RECHECK_INTERVAL_MS);
+
+      vi.mocked(canUserViewPage).mockClear();
+      await vi.advanceTimersByTimeAsync(RECHECK_INTERVAL_MS * 3);
+
+      expect(canUserViewPage).not.toHaveBeenCalled();
+    });
   });
 
   describe('client disconnect', () => {

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -394,6 +394,38 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       // No leaked interval still polling after the stream naturally finished.
       expect(canUserViewPage).not.toHaveBeenCalled();
     });
+
+    it('given a slow permission check, should not start a second overlapping check before the first resolves', async () => {
+      vi.useFakeTimers();
+      let resolveRecheck!: (allowed: boolean) => void;
+      let callCount = 0;
+      vi.mocked(canUserViewPage).mockImplementation(() => {
+        callCount += 1;
+        // Call #1 is the initial join-time gate check — resolve it immediately
+        // so the stream actually starts; only the recheck ticks are made slow.
+        if (callCount === 1) return Promise.resolve(true);
+        return new Promise((res) => { resolveRecheck = res; });
+      });
+      testRegistry.register(mockMessageId, mockMeta);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      // First recheck tick fires; canUserViewPage is now pending (not yet resolved).
+      await vi.advanceTimersByTimeAsync(RECHECK_INTERVAL_MS);
+      expect(canUserViewPage).toHaveBeenCalledTimes(2);
+
+      // Advancing well past another interval must not start a second recheck —
+      // the next one is only scheduled once the pending check resolves.
+      await vi.advanceTimersByTimeAsync(RECHECK_INTERVAL_MS * 3);
+      expect(canUserViewPage).toHaveBeenCalledTimes(2);
+
+      resolveRecheck(true);
+      await vi.advanceTimersByTimeAsync(RECHECK_INTERVAL_MS);
+      expect(canUserViewPage).toHaveBeenCalledTimes(3);
+
+      testRegistry.finish(mockMessageId);
+      await readSSEBody(response);
+    });
   });
 
   describe('client disconnect', () => {

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -56,19 +56,17 @@ export async function GET(
   }
 
   const encoder = new TextEncoder();
+  const encodeDoneFrame = (aborted: boolean): Uint8Array =>
+    encoder.encode(`data: ${JSON.stringify({ done: true, aborted })}\n\n`);
   // Chunks that arrive during subscribe's synchronous buffer replay, before the
   // ReadableStream controller exists, are collected here and flushed in start().
   const preBuffer: Uint8Array[] = [];
   let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
   let streamClosed = false;
-  let recheckIntervalId: ReturnType<typeof setInterval> | null = null;
-
-  const clearRecheckInterval = () => {
-    if (recheckIntervalId !== null) {
-      clearInterval(recheckIntervalId);
-      recheckIntervalId = null;
-    }
-  };
+  // Self-rescheduled after each check resolves (see recheckAccess) rather than a
+  // fixed-cadence interval, so a slow permission check can't stack overlapping ones.
+  let recheckTimeoutId: ReturnType<typeof setTimeout> | undefined;
+  const clearRecheckTimeout = () => clearTimeout(recheckTimeoutId);
 
   const unsubscribe = streamMulticastRegistry.subscribe(
     messageId,
@@ -81,8 +79,8 @@ export async function GET(
       }
     },
     (aborted) => {
-      clearRecheckInterval();
-      const done = encoder.encode(`data: ${JSON.stringify({ done: true, aborted })}\n\n`);
+      clearRecheckTimeout();
+      const done = encodeDoneFrame(aborted);
       if (streamController) {
         streamController.enqueue(done);
         streamController.close();
@@ -126,35 +124,41 @@ export async function GET(
       request.signal.addEventListener('abort', () => {
         if (streamClosed) return;
         streamClosed = true;
-        clearRecheckInterval();
+        clearRecheckTimeout();
         unsubscribe();
         controller.close();
       }, { once: true });
 
-      recheckIntervalId = setInterval(() => {
-        void (async () => {
-          if (streamClosed) {
-            clearRecheckInterval();
-            return;
-          }
-          const stillAllowed = await hasViewAccess();
-          if (streamClosed || stillAllowed) return;
+      const recheckAccess = async () => {
+        if (streamClosed) return;
+        const stillAllowed = await hasViewAccess();
+        if (streamClosed) return;
 
-          streamClosed = true;
-          clearRecheckInterval();
-          unsubscribe();
-          auditRequest(request, {
-            eventType: 'authz.access.denied',
-            resourceType: 'ai_stream',
-            resourceId: messageId,
-            details: { reason: 'permission_revoked_mid_stream', pageId: meta.pageId },
-            riskScore: 0.5,
-          });
-          const revoked = encoder.encode(`data: ${JSON.stringify({ done: true, aborted: true })}\n\n`);
-          controller.enqueue(revoked);
+        if (stillAllowed) {
+          recheckTimeoutId = setTimeout(() => void recheckAccess(), PERMISSION_RECHECK_INTERVAL_MS);
+          return;
+        }
+
+        streamClosed = true;
+        unsubscribe();
+        auditRequest(request, {
+          eventType: 'authz.access.denied',
+          resourceType: 'ai_stream',
+          resourceId: messageId,
+          details: { reason: 'permission_revoked_mid_stream', pageId: meta.pageId },
+          riskScore: 0.5,
+        });
+        try {
+          controller.enqueue(encodeDoneFrame(true));
           controller.close();
-        })();
-      }, PERMISSION_RECHECK_INTERVAL_MS);
+        } catch {
+          // Controller may already be closed via a racing path (e.g. client abort
+          // firing between the streamClosed check above and this enqueue) — the
+          // stream is already torn down either way, nothing more to do.
+        }
+      };
+
+      recheckTimeoutId = setTimeout(() => void recheckAccess(), PERMISSION_RECHECK_INTERVAL_MS);
     },
   });
 

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -129,23 +129,14 @@ export async function GET(
         controller.close();
       }, { once: true });
 
-      const recheckAccess = async () => {
-        if (streamClosed) return;
-        const stillAllowed = await hasViewAccess();
-        if (streamClosed) return;
-
-        if (stillAllowed) {
-          recheckTimeoutId = setTimeout(() => void recheckAccess(), PERMISSION_RECHECK_INTERVAL_MS);
-          return;
-        }
-
+      const closeStreamAsDenied = (reason: string) => {
         streamClosed = true;
         unsubscribe();
         auditRequest(request, {
           eventType: 'authz.access.denied',
           resourceType: 'ai_stream',
           resourceId: messageId,
-          details: { reason: 'permission_revoked_mid_stream', pageId: meta.pageId },
+          details: { reason, pageId: meta.pageId },
           riskScore: 0.5,
         });
         try {
@@ -156,6 +147,28 @@ export async function GET(
           // firing between the streamClosed check above and this enqueue) — the
           // stream is already torn down either way, nothing more to do.
         }
+      };
+
+      const recheckAccess = async () => {
+        if (streamClosed) return;
+        let stillAllowed: boolean;
+        try {
+          stillAllowed = await hasViewAccess();
+        } catch {
+          // Fail closed: a broken permission check must not silently disable the
+          // revocation backstop for the rest of the stream's lifetime. Without this,
+          // a transient DB error would leave the stream open with no future rechecks.
+          if (!streamClosed) closeStreamAsDenied('permission_recheck_failed');
+          return;
+        }
+        if (streamClosed) return;
+
+        if (stillAllowed) {
+          recheckTimeoutId = setTimeout(() => void recheckAccess(), PERMISSION_RECHECK_INTERVAL_MS);
+          return;
+        }
+
+        closeStreamAsDenied('permission_revoked_mid_stream');
       };
 
       recheckTimeoutId = setTimeout(() => void recheckAccess(), PERMISSION_RECHECK_INTERVAL_MS);

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -94,6 +94,7 @@ vi.mock('@/lib/ai/streams/bootstrapConsumerGuard', () => ({
 }));
 
 import { useChannelStreamSocket } from '../useChannelStreamSocket';
+import { releaseBootstrapConsumer } from '@/lib/ai/streams/bootstrapConsumerGuard';
 import type {
   AiStreamStartPayload,
   AiStreamCompletePayload,
@@ -763,6 +764,38 @@ describe('useChannelStreamSocket', () => {
 
       expect(capturedSignal.aborted).toBe(false);
       expect(mockClearPageStreams).not.toHaveBeenCalledWith('page-a');
+    });
+
+    it('given access_revoked fires and the aborted consumeStreamJoin promise later resolves, should NOT call onStreamComplete or onOwnStreamFinalize (revocation is not a clean finish)', async () => {
+      let resolveJoin!: (v: { aborted: boolean }) => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = res; }),
+      );
+      const onStreamComplete = vi.fn();
+      const onOwnStreamFinalize = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete, onOwnStreamFinalize }));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      act(() => { mockSocket._trigger('access_revoked', { room: 'page-a', reason: 'permission_revoked' }); });
+
+      // The abort propagates through consumeStreamJoin as a resolved (not rejected) promise.
+      await act(async () => { resolveJoin({ aborted: true }); });
+
+      expect(onStreamComplete).not.toHaveBeenCalled();
+      expect(onOwnStreamFinalize).not.toHaveBeenCalled();
+    });
+
+    it('given access_revoked for the current channel, should release the bootstrap consumer guard for each aborted controller', () => {
+      mockConsumeStreamJoin.mockReturnValue(new Promise(() => {})); // never resolves
+
+      renderHook(() => useChannelStreamSocket('page-a'));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+      vi.mocked(releaseBootstrapConsumer).mockClear();
+
+      act(() => { mockSocket._trigger('access_revoked', { room: 'page-a', reason: 'permission_revoked' }); });
+
+      expect(releaseBootstrapConsumer).toHaveBeenCalledWith('msg-1');
     });
 
     it('given the hook unmounts, should remove the access_revoked listener', () => {

--- a/apps/web/src/hooks/useAccessRevocation.ts
+++ b/apps/web/src/hooks/useAccessRevocation.ts
@@ -12,16 +12,7 @@ import { useEffect, useCallback, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { toast } from 'sonner';
 import { useSocketStore } from '@/stores/useSocketStore';
-
-interface AccessRevokedPayload {
-  room: string;
-  reason: 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked' | 'page_private';
-  metadata?: {
-    driveId?: string;
-    pageId?: string;
-    driveName?: string;
-  };
-}
+import type { AccessRevokedPayload } from '@/lib/websocket/socket-utils';
 
 /**
  * Determines if the user is currently viewing the revoked resource

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -20,6 +20,7 @@ import type {
   ChatConversationRenamedPayload,
   ChatConversationDeletedPayload,
   ChatGlobalConversationAddedPayload,
+  AccessRevokedPayload,
 } from '@/lib/websocket/socket-utils';
 import type { UIMessage } from 'ai';
 import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
@@ -30,10 +31,6 @@ interface ActiveStreamRow {
   /** Last debounced snapshot persisted server-side — a prefix of the live multicast buffer, if still alive. */
   parts?: UIMessagePart[];
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
-}
-
-interface AccessRevokedPayload {
-  room: string;
 }
 
 export interface UseChannelStreamSocketOptions {
@@ -370,8 +367,14 @@ export function useChannelStreamSocket(
     // the page/channel room id directly (socket.join(pageId)), so `room` is the channelId.
     const handleAccessRevoked = (payload: AccessRevokedPayload) => {
       if (payload.room !== channelId) return;
-      for (const controller of controllers.values()) {
+      // Set cancelled first, exactly like unmount: consumeStreamJoin resolves (not
+      // rejects) on abort, so without this the pending .then()/.catch() would run
+      // the "clean finalize" path (onStreamComplete, onOwnStreamFinalize) for a
+      // stream that was actually killed by a permission revocation, not completion.
+      cancelled = true;
+      for (const [msgId, controller] of controllers.entries()) {
         controller.abort();
+        releaseBootstrapConsumer(msgId);
       }
       clearPageStreams(channelId);
     };

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -120,6 +120,17 @@ export interface KickResult {
   error?: string;
 }
 
+/** Client-received shape of the `access_revoked` socket event (see apps/realtime/src/kick-handler.ts's executeKick). */
+export interface AccessRevokedPayload {
+  room: string;
+  reason: KickReason;
+  metadata?: {
+    driveId?: string;
+    pageId?: string;
+    driveName?: string;
+  };
+}
+
 export interface InboxEventPayload {
   operation: InboxOperation;
   type: 'dm' | 'channel';


### PR DESCRIPTION
## Summary

Follow-up to #1871 (merged) — that PR's branch had one more commit pushed after the merge landed (an 8-angle self-review pass), so it never made it to master. This PR carries just that commit.

The self-review (line-by-line, removed-behavior, cross-file trace, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) surfaced one real correctness bug and several robustness improvements:

- **Correctness:** `handleAccessRevoked` (in `useChannelStreamSocket.ts`) didn't set the effect's `cancelled` flag before aborting open controllers. Because `consumeStreamJoin` *resolves* (not rejects) on abort, the pending `.then()` ran the "clean finalize" path — firing `onStreamComplete`/`onOwnStreamFinalize` as if the stream completed normally rather than being forcibly severed by a permission revocation. This was masked today only because `clearPageStreams` happens to run synchronously first (so downstream `onStreamComplete` consumers see an already-cleared store entry and no-op) — but relied on unstated ordering rather than being explicit. Fixed by setting `cancelled = true` first, mirroring the existing unmount-cleanup path exactly.
- Mirrored `releaseBootstrapConsumer(msgId)` per aborted controller in `handleAccessRevoked`, matching what unmount cleanup already does.
- Promoted the duplicated `AccessRevokedPayload` interface (previously independently declared, with **different shapes**, in both `useChannelStreamSocket.ts` and `useAccessRevocation.ts`) to a single exported type in `socket-utils.ts`.
- `stream-join/[messageId]/route.ts`: replaced the fixed-cadence `setInterval` permission recheck with a self-rescheduling `setTimeout`, so a slow DB permission check can no longer stack overlapping queries under DB latency/contention.
- Extracted a shared `encodeDoneFrame` helper to dedupe SSE done-frame construction between the registry's `onComplete` callback and the recheck-failure close path, and wrapped the latter's `enqueue`/`close` in try/catch for parity with the registry's own defensive dispatch pattern.
- Simplified `clearRecheckInterval` → `clearRecheckTimeout` (dropped an unneeded null-guard — `clearTimeout` is a safe no-op on an undefined/stale handle).

## Out of scope (documented, not fixed here)

- Generalizing the revocation-recheck mechanism into `stream-multicast-registry.ts` itself — only one consumer of the registry exists today; premature for a hypothetical second one.
- DB-load mitigations for the recheck (caching, exponential backoff) — no evidence of real load at current scale; premature optimization.
- A separate, pre-existing bug in `apps/realtime/src/kick-handler.ts` (its `VALID_REASONS` omits `'page_private'`, so making a page private never actually kicks active viewers) — filed separately as #1872, unrelated root cause in an untouched file.

## Test plan

- [x] `hooks/__tests__/useChannelStreamSocket.test.ts` (67 tests, +3 new): new test asserts `onStreamComplete`/`onOwnStreamFinalize` do NOT fire when the aborted-due-to-revocation promise later resolves; new test asserts `releaseBootstrapConsumer` is called per aborted controller.
- [x] `stream-join/[messageId]/__tests__/route.test.ts` (25 tests, +1 new): new test asserts a slow permission check cannot trigger a second overlapping check before the first resolves (proves the `setInterval` → `setTimeout` fix).
- [x] `useAccessRevocation.test.ts` (5 tests) — unaffected by the shared-type promotion.
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing warnings in unrelated files)
- [x] `bun run test:unit` (full monorepo suite) — no new regressions; same 16 pre-existing failures (Postgres test-role config issue, `@pagespace/sdk` package resolution, a midnight-boundary grouping test), all unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFkMBFVHNPy5JU1KcEV67b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live stream handling when access is revoked, so interrupted sessions now stop cleanly and avoid duplicate completion actions.
  - Reduced race conditions during permission checks, helping prevent overlapping rechecks and making revocation handling more reliable.
  - Added safer cleanup for aborted streams so connection state is released consistently.

- **Tests**
  - Added coverage for delayed permission rechecks and revoked-access stream behavior to protect against regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->