### PR TITLE
fix(cli): brand the login callback page, bump to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **`pagespace login` no longer hangs after a successful login** — the post-login identity
+  lookup used to retry for up to 2 minutes before the CLI would return control to your terminal;
+  it's now bounded to a few seconds so the command finishes promptly. The browser callback page
+  shown at the end of the flow is also redesigned to match PageSpace's branding instead of
+  showing a bare, unstyled page.
 - **Drive role permission updates are now atomic** — granting or revoking a role's per-page
   permission (via the share dialog, the roles API, or an AI agent tool) could previously race a
   concurrent grant/revoke on the same role and silently drop it, because the update read the

--- a/bun.lock
+++ b/bun.lock
@@ -461,7 +461,7 @@
     },
     "packages/cli": {
       "name": "@pagespace/cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "pagespace": "./dist/bin.js",
         "pagespace-mcp": "./dist/bin-pagespace-mcp.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "pagespace — the official CLI for PageSpace: browser-based login, drive/page/task management, and a `pagespace mcp` stdio server for coding agents.",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/auth/loopback-flow.ts
+++ b/packages/cli/src/auth/loopback-flow.ts
@@ -103,6 +103,16 @@ export type LoopbackLoginResult =
 
 export const CALLBACK_PATH = '/callback';
 
+/**
+ * Light-mode hex values are copied from `packages/lib/src/email-templates/shared-styles.ts`
+ * (`colors.pageBackground`, `colors.heading`, `colors.text`, `colors.mutedText`, `colors.primary`,
+ * `colors.border`, `colors.accent`, `shadows.md`) — the repo's one existing precise conversion of
+ * these OKLCH design tokens to hex, done for the transactional emails. Reusing those values here
+ * keeps this page in sync instead of re-deriving a second, drifting approximation. Success/error
+ * accent colors have no email-template equivalent, so they're approximated directly from
+ * `apps/web/src/app/globals.css`'s `--success`/`--destructive` tokens. Dark-mode values have no
+ * existing source (email templates don't support dark mode) and are approximated the same way.
+ */
 const CALLBACK_PAGE_STYLE = `
     :root { color-scheme: light dark; }
     * { box-sizing: border-box; }
@@ -113,8 +123,8 @@ const CALLBACK_PAGE_STYLE = `
       justify-content: center;
       min-height: 100vh;
       font-family: Geist, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
-      background: #fcfdfe;
-      color: #1f2226;
+      background: #F8F9FB;
+      color: #2C3442;
     }
     .card {
       max-width: 360px;
@@ -122,7 +132,7 @@ const CALLBACK_PAGE_STYLE = `
       padding: 32px;
       border-radius: 16px;
       background: #ffffff;
-      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 8px 24px rgba(0, 0, 0, 0.06);
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.06);
       text-align: center;
     }
     .badge {
@@ -137,56 +147,46 @@ const CALLBACK_PAGE_STYLE = `
     .badge svg { width: 28px; height: 28px; }
     .badge--success { background: rgba(34, 160, 107, 0.12); color: #22a06b; }
     .badge--error { background: rgba(220, 68, 68, 0.12); color: #dc4444; }
-    .wordmark { font-size: 13px; font-weight: 600; letter-spacing: 0.02em; color: #1a6fb8; margin: 0 0 16px; }
-    h1 { font-size: 20px; font-weight: 700; margin: 0 0 8px; }
-    p { font-size: 14px; line-height: 1.5; color: #5a6270; margin: 0; }
+    .wordmark { font-size: 13px; font-weight: 600; letter-spacing: 0.02em; color: #3D64C8; margin: 0 0 16px; }
+    h1 { font-size: 20px; font-weight: 700; margin: 0 0 8px; color: #111723; }
+    p { font-size: 14px; line-height: 1.5; color: #697386; margin: 0; }
     button {
       margin-top: 24px;
       padding: 10px 20px;
       border-radius: 8px;
-      border: 1px solid #d8dde3;
+      border: 1px solid #E4E6EA;
       background: transparent;
-      color: #1f2226;
+      color: #2C3442;
       font: inherit;
       font-weight: 600;
       font-size: 13px;
       cursor: pointer;
     }
-    button:hover { background: #f2f4f7; }
+    button:hover { background: #F0F1F4; }
     @media (prefers-color-scheme: dark) {
       body { background: #1a1a1a; color: #eeeeee; }
       .card { background: #262626; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.35); }
       .badge--success { background: rgba(79, 185, 138, 0.16); color: #4fb98a; }
       .badge--error { background: rgba(226, 87, 74, 0.16); color: #e2574a; }
       .wordmark { color: #4a90c9; }
+      h1 { color: #eeeeee; }
       p { color: #a8adb5; }
       button { border-color: #3a3a3a; color: #eeeeee; }
       button:hover { background: #2f2f2f; }
     }
 `;
 
-const SUCCESS_HTML = `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>PageSpace</title>
-<style>${CALLBACK_PAGE_STYLE}</style>
-</head>
-<body>
-  <div class="card">
-    <div class="badge badge--success">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
-    </div>
-    <p class="wordmark">PageSpace</p>
-    <h1>You're logged in</h1>
-    <p>You can close this tab and return to your terminal.</p>
-    <button onclick="window.close()">Close this tab</button>
-  </div>
-</body>
-</html>`;
+const SUCCESS_ICON_PATH = '<path d="M5 13l4 4L19 7"/>';
+const ERROR_ICON_PATH = '<path d="M6 6l12 12M18 6L6 18"/>';
 
-const ERROR_HTML = `<!doctype html>
+function buildCallbackPage(params: {
+  readonly badgeVariant: 'success' | 'error';
+  readonly iconPath: string;
+  readonly heading: string;
+  readonly subtext: string;
+  readonly closeButton: boolean;
+}): string {
+  return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -196,15 +196,33 @@ const ERROR_HTML = `<!doctype html>
 </head>
 <body>
   <div class="card">
-    <div class="badge badge--error">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M18 6L6 18"/></svg>
+    <div class="badge badge--${params.badgeVariant}">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${params.iconPath}</svg>
     </div>
     <p class="wordmark">PageSpace</p>
-    <h1>Login failed</h1>
-    <p>Return to your terminal and try again.</p>
+    <h1>${params.heading}</h1>
+    <p>${params.subtext}</p>
+    ${params.closeButton ? '<button onclick="window.close()">Close this tab</button>' : ''}
   </div>
 </body>
 </html>`;
+}
+
+const SUCCESS_HTML = buildCallbackPage({
+  badgeVariant: 'success',
+  iconPath: SUCCESS_ICON_PATH,
+  heading: "You're logged in",
+  subtext: 'You can close this tab and return to your terminal.',
+  closeButton: true,
+});
+
+const ERROR_HTML = buildCallbackPage({
+  badgeVariant: 'error',
+  iconPath: ERROR_ICON_PATH,
+  heading: 'Login failed',
+  subtext: 'Return to your terminal and try again.',
+  closeButton: false,
+});
 
 function toBase64Url(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString('base64url');

--- a/packages/cli/src/auth/loopback-flow.ts
+++ b/packages/cli/src/auth/loopback-flow.ts
@@ -103,10 +103,108 @@ export type LoopbackLoginResult =
 
 export const CALLBACK_PATH = '/callback';
 
-const SUCCESS_HTML =
-  "<!doctype html><html><head><title>PageSpace</title></head><body><p>You're logged in — return to your terminal.</p></body></html>";
-const ERROR_HTML =
-  '<!doctype html><html><head><title>PageSpace</title></head><body><p>Login failed — return to your terminal.</p></body></html>';
+const CALLBACK_PAGE_STYLE = `
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      font-family: Geist, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+      background: #fcfdfe;
+      color: #1f2226;
+    }
+    .card {
+      max-width: 360px;
+      width: calc(100% - 48px);
+      padding: 32px;
+      border-radius: 16px;
+      background: #ffffff;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 8px 24px rgba(0, 0, 0, 0.06);
+      text-align: center;
+    }
+    .badge {
+      width: 56px;
+      height: 56px;
+      margin: 0 auto 20px;
+      border-radius: 9999px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .badge svg { width: 28px; height: 28px; }
+    .badge--success { background: rgba(34, 160, 107, 0.12); color: #22a06b; }
+    .badge--error { background: rgba(220, 68, 68, 0.12); color: #dc4444; }
+    .wordmark { font-size: 13px; font-weight: 600; letter-spacing: 0.02em; color: #1a6fb8; margin: 0 0 16px; }
+    h1 { font-size: 20px; font-weight: 700; margin: 0 0 8px; }
+    p { font-size: 14px; line-height: 1.5; color: #5a6270; margin: 0; }
+    button {
+      margin-top: 24px;
+      padding: 10px 20px;
+      border-radius: 8px;
+      border: 1px solid #d8dde3;
+      background: transparent;
+      color: #1f2226;
+      font: inherit;
+      font-weight: 600;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    button:hover { background: #f2f4f7; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #1a1a1a; color: #eeeeee; }
+      .card { background: #262626; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 8px 24px rgba(0, 0, 0, 0.35); }
+      .badge--success { background: rgba(79, 185, 138, 0.16); color: #4fb98a; }
+      .badge--error { background: rgba(226, 87, 74, 0.16); color: #e2574a; }
+      .wordmark { color: #4a90c9; }
+      p { color: #a8adb5; }
+      button { border-color: #3a3a3a; color: #eeeeee; }
+      button:hover { background: #2f2f2f; }
+    }
+`;
+
+const SUCCESS_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PageSpace</title>
+<style>${CALLBACK_PAGE_STYLE}</style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge badge--success">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <p class="wordmark">PageSpace</p>
+    <h1>You're logged in</h1>
+    <p>You can close this tab and return to your terminal.</p>
+    <button onclick="window.close()">Close this tab</button>
+  </div>
+</body>
+</html>`;
+
+const ERROR_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PageSpace</title>
+<style>${CALLBACK_PAGE_STYLE}</style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge badge--error">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M18 6L6 18"/></svg>
+    </div>
+    <p class="wordmark">PageSpace</p>
+    <h1>Login failed</h1>
+    <p>Return to your terminal and try again.</p>
+  </div>
+</body>
+</html>`;
 
 function toBase64Url(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString('base64url');


### PR DESCRIPTION
## Summary

- Redesigns the `pagespace login` browser callback page (`packages/cli/src/auth/loopback-flow.ts`, `SUCCESS_HTML`/`ERROR_HTML`) from a bare unstyled `<p>` into a small, fully self-contained branded page: centered card, circular check/X icon badge, "PageSpace" wordmark, and a "Close this tab" button on success. Fully inline CSS/SVG, zero external network requests (no CDN, no image `src`, no font `@import`), with light/dark variants via `prefers-color-scheme`.
- Light-mode colors are copied from `packages/lib/src/email-templates/shared-styles.ts` — the repo's one existing precise OKLCH-to-hex conversion for transactional-page branding — instead of a second, independently-derived approximation, so this page won't silently drift from the app's actual brand colors. Dark-mode values and the success/error accent colors (no email-template equivalent) are approximated directly from `apps/web/src/app/globals.css`'s tokens.
- The identical `<head>`/`<style>` boilerplate between the success and error pages is factored into a single `buildCallbackPage()` helper so a future shell tweak can't be applied to only one page by mistake.
- Bumps `@pagespace/cli` from `0.1.1` to `0.1.2` so this branding fix ships together with the already-merged login hang/slowness fix (PR #1870 — bounded `confirmIdentity` timeout + `create-loopback-server.ts` socket tracking), which merged *after* `0.1.1` was published and has never actually shipped to npm.
- Adds a `### Fixed` changelog entry covering both the hang fix and the callback page redesign.

Fixes the user-reported bug: `pagespace login` shows a plain unbranded callback page after signing in.

## Test plan

- [x] `bun run --filter '@pagespace/cli' typecheck` — passes, no new errors
- [x] `bun run --filter '@pagespace/cli' test` — 701/701 tests pass, no regressions, no test changes needed (existing `loopback-flow.test.ts` only asserts on `/logged in/i` regex, not exact HTML)
- [x] No `any` types introduced
- [x] Manually verified both HTML strings contain zero external references (`grep` for `https?://|src=|<link|@import|href=` — no matches), re-verified after the color/dedup follow-up commit
- [x] Rendered both pages in headless Chrome (light + dark) — icon badge, wordmark, heading, subtext, and close button all render correctly in both themes, re-verified after the follow-up commit
- [x] Ran an 8-angle self-review pass on the diff (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, CLAUDE.md conventions); the one actionable finding (colors re-derived independently instead of reusing the existing `shared-styles.ts` conversion, plus duplicated HTML boilerplate) was fixed in a follow-up commit
- [x] Did not touch `confirm-identity.ts` or `create-loopback-server.ts` (out of scope, already fixed by #1870)
- [x] Did not run `npm publish` — that remains a manual step for after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZKWtDRfWnKDnwap48prZL