### PR TITLE
fix(realtime): kick active viewers when a page is made private

### DIFF
--- a/apps/realtime/src/__tests__/kick-handler.test.ts
+++ b/apps/realtime/src/__tests__/kick-handler.test.ts
@@ -391,7 +391,7 @@ describe('handleKickRequest', () => {
     mockedRegistry.getSocketsForUser.mockReturnValue([]);
     const io = createMockIo(new Map());
 
-    const validReasons = ['member_removed', 'role_changed', 'permission_revoked', 'session_revoked'] as const;
+    const validReasons = ['member_removed', 'role_changed', 'permission_revoked', 'session_revoked', 'page_private'] as const;
 
     for (const reason of validReasons) {
       const body = JSON.stringify({

--- a/apps/realtime/src/kick-handler.ts
+++ b/apps/realtime/src/kick-handler.ts
@@ -15,7 +15,7 @@ import { socketRegistry } from './socket-registry';
 export interface KickPayload {
   userId: string;
   roomPattern: string; // e.g., 'drive:abc123' or 'drive:*' for all drives
-  reason: 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked';
+  reason: 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked' | 'page_private';
   metadata?: {
     driveId?: string;
     pageId?: string;
@@ -30,7 +30,7 @@ export interface KickResult {
   error?: string;
 }
 
-const VALID_REASONS = ['member_removed', 'role_changed', 'permission_revoked', 'session_revoked'] as const;
+const VALID_REASONS = ['member_removed', 'role_changed', 'permission_revoked', 'session_revoked', 'page_private'] as const;
 
 interface ParseResult {
   success: boolean;

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -62,6 +62,7 @@ import {
   createPageEventPayload,
   createDriveEventPayload,
   createDriveMemberEventPayload,
+  kickUserFromRooms,
   type PageEventPayload,
   type DriveEventPayload,
   type DriveMemberEventPayload,
@@ -69,6 +70,7 @@ import {
   type CreditsEventPayload,
   type AiStreamStartPayload,
   type AiStreamCompletePayload,
+  type KickPayload,
 } from '../socket-utils';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 
@@ -160,6 +162,77 @@ describe('socket-utils', () => {
       };
 
       await expect(broadcastPageEvent(payload)).resolves.not.toThrow();
+    });
+  });
+
+  describe('kickUserFromRooms', () => {
+    const payload: KickPayload = {
+      userId: 'user-123',
+      roomPattern: 'page-456',
+      reason: 'page_private',
+      metadata: { pageId: 'page-456' },
+    };
+
+    it('given a successful kick, should return the result and log info', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, kickedCount: 2, rooms: ['page-456'] }),
+      });
+
+      const result = await kickUserFromRooms(payload);
+
+      expect(result).toEqual({ success: true, kickedCount: 2, rooms: ['page-456'] });
+      expect(loggerSpies.realtimeLogger.info).toHaveBeenCalledWith(
+        'User kicked from rooms',
+        expect.objectContaining({ reason: 'page_private', kickedCount: 2 })
+      );
+    });
+
+    it('given the realtime server rejects the request (e.g. unrecognized reason), should log the status/body and return a failure result without throwing', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve(JSON.stringify({ error: 'Missing or invalid reason' })),
+      });
+
+      const result = await kickUserFromRooms(payload);
+
+      expect(result).toEqual({
+        success: false,
+        kickedCount: 0,
+        rooms: [],
+        error: 'Kick request failed with status 400',
+      });
+      expect(loggerSpies.realtimeLogger.error).toHaveBeenCalledWith(
+        'Kick request rejected by realtime server',
+        undefined,
+        expect.objectContaining({
+          reason: 'page_private',
+          status: 400,
+          errorBody: JSON.stringify({ error: 'Missing or invalid reason' }),
+        })
+      );
+      expect(loggerSpies.realtimeLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      const result = await kickUserFromRooms(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+    });
+
+    it('given fetch throws, should not throw and should return a failure result', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(kickUserFromRooms(payload)).resolves.toEqual({
+        success: false,
+        kickedCount: 0,
+        rooms: [],
+        error: 'Network error',
+      });
     });
   });
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -1279,6 +1279,22 @@ export async function kickUserFromRooms(payload: KickPayload): Promise<KickResul
       signal: AbortSignal.timeout(30000),
     });
 
+    if (!response.ok) {
+      const errorBody = await response.text();
+      realtimeLogger.error(
+        'Kick request rejected by realtime server',
+        undefined,
+        {
+          userId: maskIdentifier(payload.userId),
+          roomPattern: payload.roomPattern,
+          reason: payload.reason,
+          status: response.status,
+          errorBody,
+        }
+      );
+      return { success: false, kickedCount: 0, rooms: [], error: `Kick request failed with status ${response.status}` };
+    }
+
     const result = await response.json() as KickResult;
 
     if (result.success) {


### PR DESCRIPTION
## Summary
- `apps/realtime/src/kick-handler.ts` rejected any kick request with `reason: 'page_private'` because `VALID_REASONS`/`KickPayload.reason` never included it, even though `apps/web` already sends that reason when a page transitions to private and the client (`useAccessRevocation.ts`) already has copy for it ("This page has been made private").
- Net effect: making a page private silently failed to disconnect active viewers from the page's Socket.IO room.
- Added `'page_private'` to `KickPayload.reason` and `VALID_REASONS`; updated the existing "all valid reasons" test to cover it.
- **Compounding issue (also called out in #1872):** `kickUserFromRooms` in `apps/web` parsed the kick endpoint's response body without checking `response.ok` first, so a 400 (like the one this bug produced) was silently swallowed with no error log — which is why the mismatch went unnoticed. Added an explicit `response.ok` check that logs the status/body and returns a failure `KickResult` instead of masking it as a normal response.

Fixes #1872

## Test plan
- [x] `bun run --filter 'realtime' test` — all 465 tests pass, including the updated exhaustive-reasons test
- [x] `apps/web` `socket-utils.test.ts` — added coverage for `kickUserFromRooms`: success path, non-ok response (status/body logged, failure result returned, no throw), missing realtime URL, and network error
- [x] `bun run --filter 'web' typecheck` / `lint` — clean
- [ ] Manual: open a page as User B, mark it private as User A via ShareDialog, confirm User B gets kicked with the "This page has been made private" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsGwxhX4VpkcJ3r5E6GBiW