### PR TITLE
fix(storage): lock-then-recheck before deleting orphaned file records

### DIFF
--- a/apps/web/src/lib/storage/reap-orphaned-files.ts
+++ b/apps/web/src/lib/storage/reap-orphaned-files.ts
@@ -112,6 +112,20 @@ export async function reapOrphanedFiles(database: Database, options?: ReapOption
     : [];
   const deletedIdSet = new Set(deletedIds);
 
+  // A reaped orphan (physical blob already deleted above) whose row survived
+  // deleteFileRecords's recheck means either (a) another concurrent reap
+  // deleted the row first — benign, race-safe by design — or (b) the row
+  // became newly referenced between the scan and the recheck, so its blob
+  // is now gone out from under a live reference. deleteFileRecords doesn't
+  // report which case occurred, but either way this is worth surfacing:
+  // case (b) is the residual gap the #1867 lock-then-recheck fix narrows
+  // but can't fully close (the physical delete already happened by this point).
+  for (const orphan of reapedOrphans) {
+    if (!deletedIdSet.has(orphan.id)) {
+      console.warn(`[ReapOrphans] Physical blob for ${orphan.id} was deleted but its files row survived the recheck (raced with another reap or a new reference) — the row may now point at a missing blob.`);
+    }
+  }
+
   // Credit storage quota back for every reaped orphan whose row this call
   // actually deleted. computeStorageCreditOnUnlink (M8) centralizes the rules:
   // attribute to the original uploader (createdBy), skip rows nulled by a user

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
@@ -253,12 +253,24 @@ describe('isFileOrphaned', () => {
 });
 
 describe('deleteFileRecords', () => {
-  function fakeTransactionalDb(executeImpl: (call: number, node: unknown) => { rows: unknown[] }) {
+  // Dispatches each tx.execute call by inspecting the SQL text itself (does
+  // this statement contain DELETE?) rather than by call position/count, so
+  // the fake stays correct even if deleteFileRecords's statement order or
+  // count changes — a position-keyed fake would silently start matching the
+  // wrong statement instead of failing loudly.
+  function fakeTransactionalDb(opts: {
+    deleteResult?: { rows: unknown[] };
+    rejectLock?: Error;
+    rejectDelete?: Error;
+  } = {}) {
     const executed: unknown[] = [];
     const tx = {
       execute: vi.fn((node: unknown) => {
         executed.push(node);
-        return Promise.resolve(executeImpl(executed.length, node));
+        const isDelete = /DELETE/i.test(sqlText(node));
+        if (isDelete && opts.rejectDelete) return Promise.reject(opts.rejectDelete);
+        if (!isDelete && opts.rejectLock) return Promise.reject(opts.rejectLock);
+        return Promise.resolve(isDelete ? (opts.deleteResult ?? { rows: [] }) : { rows: [] });
       }),
     };
     const db = {
@@ -268,9 +280,9 @@ describe('deleteFileRecords', () => {
   }
 
   it('given_fileIds_locksCandidateRowsThenRechecksAndDeletesInASeparateStatement', async () => {
-    const { db, executed } = fakeTransactionalDb((call) =>
-      call === 2 ? { rows: [{ id: 'f1' }, { id: 'f2' }] } : { rows: [] },
-    );
+    const { db, executed } = fakeTransactionalDb({
+      deleteResult: { rows: [{ id: 'f1' }, { id: 'f2' }] },
+    });
 
     const result = await deleteFileRecords(db as never, ['f1', 'f2']);
 
@@ -308,9 +320,7 @@ describe('deleteFileRecords', () => {
     // referencing it committed before the recheck statement ran, so the
     // guarded DELETE's WHERE clause (re-evaluated fresh after the lock)
     // excludes it — only f1 comes back as actually deleted.
-    const { db } = fakeTransactionalDb((call) =>
-      call === 2 ? { rows: [{ id: 'f1' }] } : { rows: [] },
-    );
+    const { db } = fakeTransactionalDb({ deleteResult: { rows: [{ id: 'f1' }] } });
 
     const result = await deleteFileRecords(db as never, ['f1', 'f2']);
 
@@ -318,14 +328,19 @@ describe('deleteFileRecords', () => {
   });
 
   it('given_databaseErrorDuringLock_propagatesAndNeverAttemptsDelete', async () => {
-    const tx = {
-      execute: vi.fn().mockRejectedValueOnce(new Error('disk full')),
-    };
-    const db = {
-      transaction: vi.fn((cb: (t: typeof tx) => unknown) => cb(tx)),
-    };
+    const { db, tx } = fakeTransactionalDb({ rejectLock: new Error('disk full') });
 
     await expect(deleteFileRecords(db as never, ['f1'])).rejects.toThrow('disk full');
     expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('given_databaseErrorDuringRecheckDelete_propagatesAfterLockSucceeds', async () => {
+    // The old single-statement delete's error path was covered directly;
+    // the two-statement split needs its own case for the SECOND statement
+    // (the guarded DELETE) failing after the lock already succeeded.
+    const { db, tx } = fakeTransactionalDb({ rejectDelete: new Error('constraint violation') });
+
+    await expect(deleteFileRecords(db as never, ['f1'])).rejects.toThrow('constraint violation');
+    expect(tx.execute).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
@@ -1,22 +1,11 @@
 /**
- * @scaffold — orphan-detector accepts `db` as a parameter but the mock
- * reproduces the ORM delete().where().returning() chain shape.
- * findOrphanedFileRecords and isFileOrphaned use raw SQL (db.execute),
- * which is a clean boundary mock.
- *
- * REVIEW: wrap deleteFileRecords in a repository seam to eliminate
- * the ORM chain mock for that function.
+ * @scaffold — findOrphanedFileRecords, isFileOrphaned, and deleteFileRecords
+ * all use raw SQL (db.execute / tx.execute), which is a clean boundary mock.
  */
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('drizzle-orm', () => ({
-  eq: (col: unknown, val: unknown) => ({ _op: 'eq', col, val }),
   sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
-  inArray: (col: unknown, vals: unknown[]) => ({ _op: 'inArray', col, vals }),
-}));
-
-vi.mock('@pagespace/db/schema/storage', () => ({
-  files: { id: 'files.id' },
 }));
 
 import {
@@ -24,7 +13,24 @@ import {
   isFileOrphaned,
   deleteFileRecords,
 } from './orphan-detector';
-import { files } from '@pagespace/db/schema/storage';
+
+type SqlNode = { strings: TemplateStringsArray; values: unknown[] };
+
+// Recursively flattens the mocked sql`` tag's nested fragments (e.g. the
+// shared REFERENCE_JOINS/IS_UNREFERENCED/NO_LIVE_SIBLING_SHARES_BLOB
+// fragments interpolated into a parent query) into one full SQL string, so
+// substring/regex assertions below can see the composed query, not just the
+// outermost template's literal segments.
+function sqlText(node: unknown): string {
+  if (node && typeof node === 'object' && 'strings' in node) {
+    const { strings, values } = node as SqlNode;
+    return strings.reduce<string>(
+      (acc, str, i) => acc + str + (i < values.length ? sqlText(values[i]) : ''),
+      '',
+    );
+  }
+  return '';
+}
 
 describe('findOrphanedFileRecords', () => {
   it('given_orphanedFilesExist_returnsAllWithParsedSizeBytes', async () => {
@@ -99,10 +105,7 @@ describe('findOrphanedFileRecords', () => {
       { id: 'f1', storagePath: '/p', driveId: 'd1', sizeBytes: 1024, createdBy: 'u1' },
     ]);
     // The restriction fragment must be interpolated into the executed SQL.
-    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray; values: unknown[] };
-    const fullSql = sqlArg.values
-      .map(v => (v && typeof v === 'object' && 'strings' in v ? (v as { strings: TemplateStringsArray }).strings.join('') : ''))
-      .join('');
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
     expect(fullSql).toContain('= ANY(');
   });
 
@@ -115,9 +118,9 @@ describe('findOrphanedFileRecords', () => {
 
     await findOrphanedFileRecords(db as never);
 
-    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
-    const fullSql = sqlArg.strings.join('');
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
     expect(fullSql).toContain('storagePath');
+    expect(fullSql).toContain('other_f');
   });
 
   it('given_dmLinkageTablesExist_queryReferencesFileConversationsAndDirectMessages', async () => {
@@ -130,8 +133,7 @@ describe('findOrphanedFileRecords', () => {
 
     await findOrphanedFileRecords(db as never);
 
-    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
-    const fullSql = sqlArg.strings.join('');
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
     expect(fullSql).toContain('file_conversations');
     expect(fullSql).toContain('direct_messages');
   });
@@ -146,8 +148,7 @@ describe('findOrphanedFileRecords', () => {
 
     await findOrphanedFileRecords(db as never);
 
-    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
-    const fullSql = sqlArg.strings.join('');
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
     // Both the LEFT JOIN predicate (top-level) and the sibling-blob EXISTS subquery
     // need the isActive filter, otherwise sibling files referenced by soft-deleted
     // DMs would protect a shared blob that nothing live points at.
@@ -220,8 +221,7 @@ describe('isFileOrphaned', () => {
 
     await isFileOrphaned(db as never, 'file-1');
 
-    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
-    const fullSql = sqlArg.strings.join('');
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
     expect(fullSql).toContain('file_conversations');
     expect(fullSql).toContain('direct_messages');
   });
@@ -233,52 +233,99 @@ describe('isFileOrphaned', () => {
 
     await isFileOrphaned(db as never, 'file-1');
 
-    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
-    const fullSql = sqlArg.strings.join('');
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
     expect(fullSql).toMatch(/dm\."?isActive"?\s*=\s*true/i);
+  });
+
+  it('given_sharedStoragePathDedupRequired_queryIncludesStoragePathGuard', async () => {
+    // isFileOrphaned previously lacked the sibling-blob guard
+    // findOrphanedFileRecords already had — both must now share it via the
+    // same predicate fragment so a live sibling record protects its blob here too.
+    const db = {
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    };
+
+    await isFileOrphaned(db as never, 'file-1');
+
+    const fullSql = sqlText(db.execute.mock.calls[0][0]);
+    expect(fullSql).toContain('other_f');
   });
 });
 
 describe('deleteFileRecords', () => {
-  it('given_fileIds_deletesFromFilesTableAndReturnsDeletedIds', async () => {
-    const mockDeleteFn = vi.fn();
-    const db = {
-      delete: (table: unknown) => {
-        mockDeleteFn(table);
-        return {
-          where: vi.fn(() => ({
-            returning: vi.fn().mockResolvedValue([{ id: 'f1' }, { id: 'f2' }]),
-          })),
-        };
-      },
+  function fakeTransactionalDb(executeImpl: (call: number, node: unknown) => { rows: unknown[] }) {
+    const executed: unknown[] = [];
+    const tx = {
+      execute: vi.fn((node: unknown) => {
+        executed.push(node);
+        return Promise.resolve(executeImpl(executed.length, node));
+      }),
     };
+    const db = {
+      transaction: vi.fn((cb: (t: typeof tx) => unknown) => cb(tx)),
+    };
+    return { db, tx, executed };
+  }
+
+  it('given_fileIds_locksCandidateRowsThenRechecksAndDeletesInASeparateStatement', async () => {
+    const { db, executed } = fakeTransactionalDb((call) =>
+      call === 2 ? { rows: [{ id: 'f1' }, { id: 'f2' }] } : { rows: [] },
+    );
 
     const result = await deleteFileRecords(db as never, ['f1', 'f2']);
 
     expect(result).toEqual(['f1', 'f2']);
-    expect(mockDeleteFn).toHaveBeenCalledWith(files);
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+    expect(executed).toHaveLength(2);
+
+    // Statement 1: lock only, no delete — mirrors purgeInactiveMessages's
+    // reasoning that folding the lock into the DELETE would keep a stale
+    // pre-block snapshot and could miss a reference that committed while
+    // this statement waited on the row lock.
+    const lockSql = sqlText(executed[0]);
+    expect(lockSql).toMatch(/FOR UPDATE/i);
+    expect(lockSql).not.toMatch(/DELETE/i);
+
+    // Statement 2: separate statement, fresh snapshot, re-verifies
+    // referencedness as part of the DELETE's WHERE clause.
+    const deleteSql = sqlText(executed[1]);
+    expect(deleteSql).toMatch(/DELETE\s+FROM\s+files/i);
+    expect(deleteSql).toMatch(/file_conversations/);
+    expect(deleteSql).toMatch(/direct_messages/);
   });
 
-  it('given_emptyArray_returnsEmptyWithoutCallingDB', async () => {
-    const db = {
-      delete: vi.fn(),
-    };
+  it('given_emptyArray_returnsEmptyWithoutStartingATransaction', async () => {
+    const db = { transaction: vi.fn() };
 
     const result = await deleteFileRecords(db as never, []);
 
     expect(result).toEqual([]);
-    expect(db.delete).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
   });
 
-  it('given_databaseError_propagates', async () => {
+  it('given_rowBecameReferencedBeforeRecheck_deleteSkipsItAndReturnsOnlyStillOrphanedIds', async () => {
+    // Simulates the #1867 race: f2 was orphaned at scan time but a message
+    // referencing it committed before the recheck statement ran, so the
+    // guarded DELETE's WHERE clause (re-evaluated fresh after the lock)
+    // excludes it — only f1 comes back as actually deleted.
+    const { db } = fakeTransactionalDb((call) =>
+      call === 2 ? { rows: [{ id: 'f1' }] } : { rows: [] },
+    );
+
+    const result = await deleteFileRecords(db as never, ['f1', 'f2']);
+
+    expect(result).toEqual(['f1']);
+  });
+
+  it('given_databaseErrorDuringLock_propagatesAndNeverAttemptsDelete', async () => {
+    const tx = {
+      execute: vi.fn().mockRejectedValueOnce(new Error('disk full')),
+    };
     const db = {
-      delete: () => ({
-        where: () => ({
-          returning: vi.fn().mockRejectedValue(new Error('disk full')),
-        }),
-      }),
+      transaction: vi.fn((cb: (t: typeof tx) => unknown) => cb(tx)),
     };
 
     await expect(deleteFileRecords(db as never, ['f1'])).rejects.toThrow('disk full');
+    expect(tx.execute).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
@@ -142,19 +142,35 @@ export async function isFileOrphaned(database: DB, fileId: string): Promise<bool
  * protocol (dm-message-repository.ts). A single locking DELETE would keep
  * its pre-block snapshot and could still drop a row a just-committed insert
  * now depends on.
+ *
+ * This closes the race for the two insert paths above, which are the only
+ * writers that take FOR UPDATE on `files` before referencing it. The
+ * content-addressed-storage dedup path (a `pages` row pointing at an
+ * existing upload's storagePath, apps/web's upload-complete route) does not
+ * take that lock, so it isn't covered by this protocol — a pre-existing,
+ * separate gap, not introduced or fixed here.
  */
 export async function deleteFileRecords(database: DB, fileIds: string[]): Promise<string[]> {
   if (fileIds.length === 0) return [];
 
   return database.transaction(async (tx) => {
+    // ORDER BY id gives every concurrent deleteFileRecords call (e.g. the
+    // weekly cron sweep racing a user-facing trash purge) the same lock
+    // acquisition order for overlapping id sets, avoiding a deadlock that
+    // an unordered multi-row FOR UPDATE could otherwise hit.
     await tx.execute(sql`
-      SELECT 1 FROM files WHERE id = ANY(${fileIds}::text[]) FOR UPDATE
+      SELECT 1 FROM files WHERE id = ANY(${fileIds}::text[]) ORDER BY id FOR UPDATE
     `);
 
+    // The subquery re-aliases `files` as `f` (matching REFERENCE_JOINS/
+    // IS_UNREFERENCED/NO_LIVE_SIBLING_SHARES_BLOB, which are all written
+    // against that alias) in its own independent scope — it is a semi-join,
+    // not correlated to the outer DELETE target, so the outer row is
+    // aliased `target` to avoid reading as a self-reference.
     const result = await tx.execute(sql`
-      DELETE FROM files f
-      WHERE f.id = ANY(${fileIds}::text[])
-        AND f.id IN (
+      DELETE FROM files target
+      WHERE target.id = ANY(${fileIds}::text[])
+        AND target.id IN (
           SELECT f.id
           FROM files f
           ${REFERENCE_JOINS}
@@ -162,7 +178,7 @@ export async function deleteFileRecords(database: DB, fileIds: string[]): Promis
             AND ${IS_UNREFERENCED}
             AND ${NO_LIVE_SIBLING_SHARES_BLOB}
         )
-      RETURNING f.id
+      RETURNING target.id
     `);
 
     return (result.rows as Array<{ id: string }>).map(row => row.id);

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
@@ -1,6 +1,5 @@
-import { sql, inArray } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
-import { files } from '@pagespace/db/schema/storage';
 
 export interface OrphanedFile {
   id: string;
@@ -11,6 +10,47 @@ export interface OrphanedFile {
 }
 
 type DB = NodePgDatabase<Record<string, unknown>>;
+
+// Shared predicate for "is file `f` referenced anywhere". Every fragment below
+// assumes the base `files` row is aliased `f`. Kept as one definition so
+// findOrphanedFileRecords, isFileOrphaned, and deleteFileRecords's recheck
+// can't silently drift from each other the way isFileOrphaned previously did
+// (it was missing the sibling-blob guard findOrphanedFileRecords already had).
+const REFERENCE_JOINS = sql`
+  LEFT JOIN file_pages fp ON fp."fileId" = f.id
+  LEFT JOIN channel_messages cm ON cm."fileId" = f.id
+  LEFT JOIN pages p ON p."filePath" = f."storagePath" AND p."filePath" IS NOT NULL
+  LEFT JOIN file_conversations fc ON fc."fileId" = f.id
+  LEFT JOIN direct_messages dm ON dm."fileId" = f.id AND dm."isActive" = true
+`;
+
+const IS_UNREFERENCED = sql`
+  fp."fileId" IS NULL
+  AND cm."fileId" IS NULL
+  AND p.id IS NULL
+  AND fc."fileId" IS NULL
+  AND dm."fileId" IS NULL
+`;
+
+// Content-addressed storage means one physical blob may back multiple file
+// records (same storagePath). A row is only truly reclaimable when every
+// sibling sharing that storagePath also has no live references.
+const NO_LIVE_SIBLING_SHARES_BLOB = sql`
+  (
+    f."storagePath" IS NULL
+    OR NOT EXISTS (
+      SELECT 1 FROM files other_f
+      WHERE other_f."storagePath" = f."storagePath"
+        AND other_f.id != f.id
+        AND (
+          EXISTS (SELECT 1 FROM file_pages WHERE "fileId" = other_f.id)
+          OR EXISTS (SELECT 1 FROM channel_messages WHERE "fileId" = other_f.id)
+          OR EXISTS (SELECT 1 FROM file_conversations WHERE "fileId" = other_f.id)
+          OR EXISTS (SELECT 1 FROM direct_messages WHERE "fileId" = other_f.id AND "isActive" = true)
+        )
+    )
+  )
+`;
 
 /**
  * Find file records with zero references across all linkage tables.
@@ -48,30 +88,9 @@ export async function findOrphanedFileRecords(
   const result = await database.execute(sql`
     SELECT f.id, f."storagePath", f."driveId", f."sizeBytes", f."createdBy"
     FROM files f
-    LEFT JOIN file_pages fp ON fp."fileId" = f.id
-    LEFT JOIN channel_messages cm ON cm."fileId" = f.id
-    LEFT JOIN pages p ON p."filePath" = f."storagePath" AND p."filePath" IS NOT NULL
-    LEFT JOIN file_conversations fc ON fc."fileId" = f.id
-    LEFT JOIN direct_messages dm ON dm."fileId" = f.id AND dm."isActive" = true
-    WHERE fp."fileId" IS NULL
-      AND cm."fileId" IS NULL
-      AND p.id IS NULL
-      AND fc."fileId" IS NULL
-      AND dm."fileId" IS NULL${idFilter}
-      AND (
-        f."storagePath" IS NULL
-        OR NOT EXISTS (
-          SELECT 1 FROM files other_f
-          WHERE other_f."storagePath" = f."storagePath"
-            AND other_f.id != f.id
-            AND (
-              EXISTS (SELECT 1 FROM file_pages WHERE "fileId" = other_f.id)
-              OR EXISTS (SELECT 1 FROM channel_messages WHERE "fileId" = other_f.id)
-              OR EXISTS (SELECT 1 FROM file_conversations WHERE "fileId" = other_f.id)
-              OR EXISTS (SELECT 1 FROM direct_messages WHERE "fileId" = other_f.id AND "isActive" = true)
-            )
-        )
-      )
+    ${REFERENCE_JOINS}
+    WHERE ${IS_UNREFERENCED}${idFilter}
+      AND ${NO_LIVE_SIBLING_SHARES_BLOB}
   `);
 
   return (result.rows as Array<{
@@ -96,17 +115,10 @@ export async function isFileOrphaned(database: DB, fileId: string): Promise<bool
   const result = await database.execute(sql`
     SELECT 1
     FROM files f
-    LEFT JOIN file_pages fp ON fp."fileId" = f.id
-    LEFT JOIN channel_messages cm ON cm."fileId" = f.id
-    LEFT JOIN pages p ON p."filePath" = f."storagePath" AND p."filePath" IS NOT NULL
-    LEFT JOIN file_conversations fc ON fc."fileId" = f.id
-    LEFT JOIN direct_messages dm ON dm."fileId" = f.id AND dm."isActive" = true
+    ${REFERENCE_JOINS}
     WHERE f.id = ${fileId}
-      AND fp."fileId" IS NULL
-      AND cm."fileId" IS NULL
-      AND p.id IS NULL
-      AND fc."fileId" IS NULL
-      AND dm."fileId" IS NULL
+      AND ${IS_UNREFERENCED}
+      AND ${NO_LIVE_SIBLING_SHARES_BLOB}
     LIMIT 1
   `);
 
@@ -119,13 +131,40 @@ export async function isFileOrphaned(database: DB, fileId: string): Promise<bool
  * atomic, only the single invocation that removes a given row gets its ID
  * back — callers can credit storage off this set without double-counting
  * when two reaps race on the same orphan.
+ *
+ * The scan that decided `fileIds` (findOrphanedFileRecords) may be long past
+ * by the time this runs — reapOrphanedFiles loops per-orphan doing an HTTP
+ * call to the processor before batching this call. A message send racing
+ * that window (insertDmMessageWithAttachment/insertChannelMessageWithAttachment)
+ * takes FOR UPDATE on the same `files` row before referencing it, so we lock
+ * the candidate rows first and re-verify referencedness in a *separate*
+ * statement afterward — mirroring purgeInactiveMessages's two-statement
+ * protocol (dm-message-repository.ts). A single locking DELETE would keep
+ * its pre-block snapshot and could still drop a row a just-committed insert
+ * now depends on.
  */
 export async function deleteFileRecords(database: DB, fileIds: string[]): Promise<string[]> {
   if (fileIds.length === 0) return [];
 
-  const result = await database
-    .delete(files)
-    .where(inArray(files.id, fileIds))
-    .returning({ id: files.id });
-  return result.map(row => row.id);
+  return database.transaction(async (tx) => {
+    await tx.execute(sql`
+      SELECT 1 FROM files WHERE id = ANY(${fileIds}::text[]) FOR UPDATE
+    `);
+
+    const result = await tx.execute(sql`
+      DELETE FROM files f
+      WHERE f.id = ANY(${fileIds}::text[])
+        AND f.id IN (
+          SELECT f.id
+          FROM files f
+          ${REFERENCE_JOINS}
+          WHERE f.id = ANY(${fileIds}::text[])
+            AND ${IS_UNREFERENCED}
+            AND ${NO_LIVE_SIBLING_SHARES_BLOB}
+        )
+      RETURNING f.id
+    `);
+
+    return (result.rows as Array<{ id: string }>).map(row => row.id);
+  });
 }


### PR DESCRIPTION
## Summary
- `deleteFileRecords` hard-deleted `files` rows via a plain `DELETE ... WHERE id = ANY(...)` with no re-verification of referencedness at delete time, trusting the ids `findOrphanedFileRecords` decided at scan time. `reapOrphanedFiles` widens the gap further — it scans once, then loops per-orphan doing an HTTP call to the processor (up to 10s each) before batching the DB delete, so a message referencing one of those file ids can commit during that window and have its `fileId` silently nulled by `onDelete: 'set null'` once the batched delete finally runs.
- Fixed by mirroring `purgeInactiveMessages`'s two-statement lock-then-recheck protocol (`dm-message-repository.ts`): lock candidate `files` rows `FOR UPDATE`, then re-verify referencedness in a separate statement (fresh snapshot) before deleting. Kept localized to `orphan-detector.ts` — no shared primitive with `dm-message-repository.ts`, since the two sites lock different tables/predicates.
- Extracted the shared "is file referenced" predicate into reusable `sql` fragments (`REFERENCE_JOINS`, `IS_UNREFERENCED`, `NO_LIVE_SIBLING_SHARES_BLOB`) so `findOrphanedFileRecords`, `isFileOrphaned`, and the new recheck can't drift.

Fixes #1867

## ⚠️ Security-relevant side effect worth explicit reviewer attention
Unifying the predicate also fixes `isFileOrphaned`, which was **missing** the content-addressed-storage sibling-blob guard (`NO_LIVE_SIBLING_SHARES_BLOB`) that `findOrphanedFileRecords` already had. `isFileOrphaned` isn't just an internal helper — it's the authorization gate `apps/processor/src/services/rbac.ts`'s `assertDeleteFileAccess` calls immediately before physically deleting a blob from disk for system file-bound orphan reaps (`DELETE /api/files/:contentHash`). Before this PR, that check could wrongly authorize physically deleting a blob still needed by a sibling `files` row sharing the same `storagePath` (content-addressed dedup) — a more severe, irreversible-data-loss bug than the metadata race this PR's title describes. This PR closes that gap as a side effect of sharing the predicate. Flagging explicitly so it gets its own look rather than riding in unnoticed under a "race condition" framing.

## Known residual limitations (by design, not fixed here)
- **Blob-already-gone race**: `reapOrphanedFiles` deletes each orphan's physical blob via an HTTP call *before* the batched `deleteFileRecords` call at the end of its loop. If the new recheck correctly keeps a row alive (because it became referenced), that row may now point at an already-deleted blob. This PR can't close that gap (the physical delete already happened by the time the recheck runs) but now logs a warning (`[ReapOrphans] Physical blob for ... was deleted but its files row survived the recheck ...`) so it's no longer silent. Fully closing it would mean restructuring `reap-orphaned-files.ts` to delete each orphan's blob and row together, immediately — out of scope for this targeted fix.
- **`pages` content-dedup path isn't covered by the lock**: the lock-then-recheck protocol only closes the race against the two message-attachment insert paths (`insertDmMessageWithAttachment`/`insertChannelMessageWithAttachment`), which already take `FOR UPDATE` on `files` before referencing it. The content-addressed-storage dedup path (a `pages` row pointing at an existing upload's `storagePath`) does not take that lock, so a concurrent dedup-upload racing a reap isn't covered — a separate, pre-existing gap, called out explicitly in `deleteFileRecords`'s docstring now.
- **No batch-size cap on the weekly global sweep**: pre-existing (the old single-DELETE version had no cap either), but this PR's two-statement transaction holds row locks slightly longer per invocation. Not addressed here; a chunking mechanism for very large sweeps would be a separate follow-up.
- **No shared lock-then-recheck primitive**: this is now the second hand-rolled implementation of the same protocol (after `purgeInactiveMessages`). Deliberately not extracted into a shared primitive in this PR — the two sites lock different tables/predicates and generalizing now isn't worth the added diff/risk, per explicit scope discussion.

## Hardening added during self-review
- `ORDER BY id` on the lock statement, so concurrent `deleteFileRecords` calls with overlapping-but-differently-ordered `fileIds` can't deadlock on inconsistent lock acquisition order.
- Renamed the DELETE's outer alias from `f` to `target` — the inner subquery independently re-aliases `files` as `f` (required, since the shared predicate fragments are written against that alias), and reusing `f` for both read as a correlated self-reference when it isn't one.

## Test plan
- [x] `bunx vitest run src/compliance/file-cleanup/orphan-detector.test.ts` — 22/22 pass, including tests asserting the exact lock-then-recheck statement shape, a simulated race where a row becomes referenced before the recheck runs, and both the lock-statement and delete-statement failure paths
- [x] `bunx vitest run src/lib/storage/__tests__/reap-orphaned-files.test.ts` — 6/6 pass unchanged, confirming `deleteFileRecords`'s external contract (array of ids in → array of deleted ids out) is preserved
- [x] `bun run --filter '@pagespace/lib' typecheck` / `bun run --filter 'web' typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nMWEao7YKHXaUiabBww9U