### PR TITLE
Resolve GitHub integration/sandbox tool overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **21 new sandbox git/GitHub tools** — agents with code execution can now edit PR titles and
+  descriptions (`gh_pr_edit`), leave top-level PR and issue comments, edit/close/reopen issues,
+  discover repositories (`gh_repo_view`/`gh_repo_list`), search GitHub code/issues/PRs/repos
+  (`gh_search`), list repo labels, inspect commits (`git_show`, `git_blame`), revert a commit,
+  recover from conflicted merges/rebases (`action: abort/continue`), re-run failed CI
+  (`gh_run_rerun`), list and dispatch workflows, list and resolve PR review threads, and fork or
+  create repositories.
+- **12 new GitHub integration tools** — agents without code execution get a full write path to
+  code: create branches, commit and delete files, open/update/merge pull requests, plus CI
+  visibility (check runs, workflow runs), commit listing, branch comparison, issue search, and
+  label listing. A new **Contributor** tool bundle covers the branch → commit → PR → merge flow.
+- The GitHub connection now requests the `workflow` scope so agents can commit changes to GitHub
+  Actions workflow files. Existing connections keep working; reconnect GitHub in Settings >
+  Integrations to pick up the new permission.
+
 - **`pagespace` CLI** — install `@pagespace/cli`, run `pagespace login`, and use verbs like
   `pagespace drives list`, `pagespace pages read`, `pagespace search text`, and `pagespace tasks
   create` without hand-minting a token first.

--- a/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../route';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// Route-level regression test for GitHub-integration/sandbox-tool suppression
+// in 'search' tool-exposure mode.
+//
+// The bug this guards against: `resolvePageAgentIntegrationTools` needs the
+// PRE-exposure tool set to detect whether the sandbox git/gh CLI toolkit is
+// active (search mode moves non-core tools, including all sandbox tools,
+// behind execute_tool — hiding their names from a top-level key scan). A
+// prior implementation captured the tool set AFTER `applyToolExposureMode`
+// ran, so suppression silently never fired in search mode. `resolveThe
+// PageAgentIntegrationTools` is mocked here (its own suppression logic is
+// covered by integration-tool-resolver.test.ts) — this test only asserts on
+// what the ROUTE passes as `currentTools`, which is the part a resolver-level
+// unit test cannot observe.
+// ============================================================================
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
+  isMCPAuthResult: vi.fn(() => false),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  isScopedMCPAuth: vi.fn(() => false),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+  canPrincipalEditPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+  canUserEditPage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com', actorDisplayName: 'Test' }),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      child: vi.fn(() => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => {
+  const pageRow = {
+    id: 'page_123',
+    title: 'Test Page',
+    systemPrompt: null,
+    enabledTools: null,
+    toolExposureMode: 'search',
+    aiProvider: 'openai',
+    aiModel: 'openai/gpt-5.3-chat',
+    driveId: 'drive_A',
+    includeDrivePrompt: false,
+    includePageTree: false,
+    pageTreeScope: null,
+    revision: 0,
+  };
+  return {
+    db: {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => {
+            const result = Promise.resolve([pageRow]);
+            return Object.assign(result, {
+              orderBy: vi.fn().mockResolvedValue([]),
+              limit: vi.fn().mockResolvedValue([]),
+            });
+          }),
+        })),
+      })),
+    },
+  };
+});
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt' },
+  pages: { id: 'id' },
+  drives: { id: 'id', drivePrompt: 'drivePrompt' },
+}));
+
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  requiresProSubscription: vi.fn().mockReturnValue(false),
+  createSubscriptionRequiredResponse: vi.fn(),
+  createAdminRestrictedResponse: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastCreditsEvent: vi.fn(),
+  broadcastAiStreamStart: vi.fn().mockResolvedValue(undefined),
+  broadcastAiStreamComplete: vi.fn().mockResolvedValue(undefined),
+  broadcastChatUserMessage: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {} }),
+  updateUserProviderSettings: vi.fn(),
+  createProviderErrorResponse: vi.fn(),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+// git_clone stands in for the sandbox git/gh CLI toolkit — a real sandbox
+// toolkit registers ~56 tool names, but only one is needed to prove
+// suppression sees it. list_pages is a non-sandbox, non-core tool so it gets
+// deferred behind execute_tool in search mode alongside git_clone.
+vi.mock('@/lib/ai/core/ai-tools', () => ({
+  pageSpaceTools: {
+    git_clone: { description: 'git_clone' },
+    list_pages: { description: 'list_pages' },
+  },
+}));
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  extractMessageContent: vi.fn().mockReturnValue('test content'),
+  extractToolCalls: vi.fn().mockReturnValue([]),
+  extractToolResults: vi.fn().mockReturnValue([]),
+  saveMessageToDatabase: vi.fn(),
+  sanitizeMessagesForModel: vi.fn().mockReturnValue([]),
+  convertDbMessageToUIMessage: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/mention-processor', () => ({
+  processMentionsInMessage: vi.fn().mockReturnValue({ mentions: [], pageIds: [] }),
+}));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/system-prompt', () => ({
+  buildSystemPrompt: vi.fn().mockReturnValue(''),
+  buildPersonalizationPrompt: vi.fn().mockReturnValue(''),
+  TOOL_DISCOVERY_PROMPT: 'discover tools',
+  buildNonCoreToolNamesPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/page-tree-context', () => ({
+  getPageTreeContext: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
+  convertMCPToolsToAISDKSchemas: vi.fn(),
+  parseMCPToolName: vi.fn(),
+  sanitizeToolNamesForProvider: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserPersonalization: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('ai', () => ({
+  streamText: vi.fn(),
+  convertToModelMessages: vi.fn().mockReturnValue([]),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+  tool: vi.fn((config) => config),
+  createUIMessageStream: vi.fn(),
+  createUIMessageStreamResponse: vi.fn(),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn().mockReturnValue('generated_id'),
+  init: vi.fn(() => vi.fn(() => 'test-cuid')),
+}));
+
+vi.mock('@/lib/logging/mask', () => ({
+  maskIdentifier: vi.fn((id: string) => `***${id.slice(-3)}`),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackFeature: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: {
+    trackUsage: vi.fn(),
+    trackToolUsage: vi.fn(),
+  },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
+  extractOpenRouterGenerationIds: vi.fn(() => []),
+}));
+
+vi.mock('@/lib/mcp', () => ({
+  getMCPBridge: vi.fn(),
+}));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn(),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
+  createStreamAbortController: vi.fn().mockReturnValue({ streamId: 'stream_123', signal: new AbortController().signal }),
+  removeStream: vi.fn(),
+  STREAM_ID_HEADER: 'x-stream-id',
+}));
+
+vi.mock('@/lib/ai/core/validate-image-parts', () => ({
+  validateUserMessageFileParts: vi.fn().mockReturnValue({ valid: true }),
+  hasFileParts: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  getModelCapabilities: vi.fn(),
+  hasVisionCapability: vi.fn().mockReturnValue(true),
+}));
+
+// The resolver itself (and its suppression logic) is unit-tested in
+// integration-tool-resolver.test.ts. This test only needs to observe what
+// the route passes as `currentTools`.
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { resolvePageAgentIntegrationTools } from '@/lib/ai/core/integration-tool-resolver';
+
+const mockUserId = 'user_123';
+const chatId = 'page_123'; // in drive_A per db mock above
+
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const createChatRequest = () => {
+  return new Request('https://example.com/api/ai/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'content-length': '200', 'X-Browser-Session-Id': 'session-1' },
+    body: JSON.stringify({
+      messages: [
+        { id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+      ],
+      chatId,
+      selectedProvider: 'openai',
+      selectedModel: 'openai/gpt-5.3-chat',
+    }),
+  });
+};
+
+describe('POST /api/ai/chat - GitHub suppression sees sandbox tools in search mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes the pre-exposure tool set (including sandbox tools) to resolvePageAgentIntegrationTools even in search mode', async () => {
+    const auth = mockWebAuth(mockUserId);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(auth);
+
+    await POST(createChatRequest());
+
+    expect(resolvePageAgentIntegrationTools).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(resolvePageAgentIntegrationTools).mock.calls[0]![0];
+    // In search mode, git_clone/list_pages are moved behind execute_tool and
+    // vanish as top-level keys — this assertion only passes if the route
+    // captured currentTools BEFORE applyToolExposureMode ran.
+    expect(call.currentTools).toHaveProperty('git_clone');
+    expect(call.currentTools).toHaveProperty('list_pages');
+  });
+});

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -53,7 +53,7 @@ import { buildSystemPrompt, buildPersonalizationPrompt } from '@/lib/ai/core/sys
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getAgentContextDrives } from '@pagespace/lib/services/drive-agent-service';
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
-import { filterToolsForReadOnly, filterToolsForMcpScope, suppressGithubIntegrationTools } from '@/lib/ai/core/tool-filtering';
+import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
 import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
 import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
@@ -679,6 +679,11 @@ export async function POST(request: Request) {
     // correctly included in search mode where non-core tools become callable via execute_tool
     // and disappear from filteredTools.
     const allowedToolNames = Object.keys(filteredTools);
+    // Captured before exposure-mode transforms filteredTools below — 'search' mode
+    // moves non-core tools (including all sandbox git/gh tools) behind execute_tool,
+    // hiding their names from a top-level key scan. Integration-tool suppression
+    // needs the pre-exposure set to correctly detect an active sandbox toolkit.
+    const preExposureTools = filteredTools;
     const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
     filteredTools = exposure.tools;
     const toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
@@ -695,15 +700,12 @@ export async function POST(request: Request) {
     // INTEGRATION TOOLS: Resolve and merge integration tools for this agent
     try {
       const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
-      const resolvedIntegrationTools = await resolvePageAgentIntegrationTools({
+      const integrationTools = await resolvePageAgentIntegrationTools({
         agentId: chatId,
         userId,
         driveId: page.driveId,
+        currentTools: preExposureTools,
       });
-      // The sandbox git/gh CLI toolkit and the GitHub OAuth integration tools
-      // overlap in capability — suppress the latter when the former is already
-      // in this agent's tool set to avoid offering two redundant GitHub surfaces.
-      const integrationTools = suppressGithubIntegrationTools(resolvedIntegrationTools, filteredTools);
       if (Object.keys(integrationTools).length > 0) {
         filteredTools = mergeToolSets(filteredTools, integrationTools);
         loggers.ai.info('AI Chat API: Merged integration tools', {

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -53,7 +53,7 @@ import { buildSystemPrompt, buildPersonalizationPrompt } from '@/lib/ai/core/sys
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getAgentContextDrives } from '@pagespace/lib/services/drive-agent-service';
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
-import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
+import { filterToolsForReadOnly, filterToolsForMcpScope, suppressGithubIntegrationTools } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
 import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
 import { guardReadPageToolForVision } from '@/lib/ai/tools/read-page-vision-output';
@@ -695,11 +695,15 @@ export async function POST(request: Request) {
     // INTEGRATION TOOLS: Resolve and merge integration tools for this agent
     try {
       const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
-      const integrationTools = await resolvePageAgentIntegrationTools({
+      const resolvedIntegrationTools = await resolvePageAgentIntegrationTools({
         agentId: chatId,
         userId,
         driveId: page.driveId,
       });
+      // The sandbox git/gh CLI toolkit and the GitHub OAuth integration tools
+      // overlap in capability — suppress the latter when the former is already
+      // in this agent's tool set to avoid offering two redundant GitHub surfaces.
+      const integrationTools = suppressGithubIntegrationTools(resolvedIntegrationTools, filteredTools);
       if (Object.keys(integrationTools).length > 0) {
         filteredTools = mergeToolSets(filteredTools, integrationTools);
         loggers.ai.info('AI Chat API: Merged integration tools', {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -34,7 +34,7 @@ import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import { buildSystemPrompt, buildNonCoreToolNamesPrompt, TOOL_DISCOVERY_PROMPT } from '@/lib/ai/core/system-prompt';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { buildAgentAwarenessPrompt } from '@/lib/ai/core/agent-awareness';
-import { filterToolsForReadOnly, filterToolsForWebSearch, suppressGithubIntegrationTools } from '@/lib/ai/core/tool-filtering';
+import { filterToolsForReadOnly, filterToolsForWebSearch } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree-context';
 import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
@@ -811,15 +811,15 @@ MENTION PROCESSING:
           userDriveRole = access.role;
         }
       }
-      const resolvedIntegrationTools = await resolveGlobalAssistantIntegrationTools({
+      const integrationTools = await resolveGlobalAssistantIntegrationTools({
         userId,
         driveId: currentDriveId,
         userDriveRole,
+        // filteredAllTools (not finalTools) carries raw tool names as top-level
+        // keys — finalTools is always { ...coreTools, tool_search, execute_tool },
+        // which never contains sandbox git/gh tool names directly.
+        currentTools: filteredAllTools,
       });
-      // The sandbox git/gh CLI toolkit and the GitHub OAuth integration tools
-      // overlap in capability — suppress the latter when the former is already
-      // in this agent's tool set to avoid offering two redundant GitHub surfaces.
-      const integrationTools = suppressGithubIntegrationTools(resolvedIntegrationTools, finalTools);
       if (Object.keys(integrationTools).length > 0) {
         finalTools = mergeToolSets(finalTools, integrationTools);
         loggers.api.info('Global Assistant: Merged integration tools', {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -34,7 +34,7 @@ import { buildTimestampSystemPrompt } from '@/lib/ai/core/timestamp-utils';
 import { buildSystemPrompt, buildNonCoreToolNamesPrompt, TOOL_DISCOVERY_PROMPT } from '@/lib/ai/core/system-prompt';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { buildAgentAwarenessPrompt } from '@/lib/ai/core/agent-awareness';
-import { filterToolsForReadOnly, filterToolsForWebSearch } from '@/lib/ai/core/tool-filtering';
+import { filterToolsForReadOnly, filterToolsForWebSearch, suppressGithubIntegrationTools } from '@/lib/ai/core/tool-filtering';
 import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree-context';
 import { getModelCapabilities } from '@/lib/ai/core/model-capabilities';
 import { convertMCPToolsToAISDKSchemas, parseMCPToolName, sanitizeToolNamesForProvider } from '@/lib/ai/core/mcp-tool-converter';
@@ -811,11 +811,15 @@ MENTION PROCESSING:
           userDriveRole = access.role;
         }
       }
-      const integrationTools = await resolveGlobalAssistantIntegrationTools({
+      const resolvedIntegrationTools = await resolveGlobalAssistantIntegrationTools({
         userId,
         driveId: currentDriveId,
         userDriveRole,
       });
+      // The sandbox git/gh CLI toolkit and the GitHub OAuth integration tools
+      // overlap in capability — suppress the latter when the former is already
+      // in this agent's tool set to avoid offering two redundant GitHub surfaces.
+      const integrationTools = suppressGithubIntegrationTools(resolvedIntegrationTools, finalTools);
       if (Object.keys(integrationTools).length > 0) {
         finalTools = mergeToolSets(finalTools, integrationTools);
         loggers.api.info('Global Assistant: Merged integration tools', {

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -411,6 +411,7 @@ export async function POST(request: Request) {
         agentId,
         userId,
         driveId: agent.driveId,
+        currentTools: availableTools,
       });
       integrationToolCount = Object.keys(integrationTools).length;
       if (integrationToolCount > 0) {

--- a/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
@@ -16,9 +16,13 @@ vi.mock('@pagespace/lib/integrations/resolution/resolve-agent-integrations', () 
   resolveAgentIntegrations: vi.fn(),
   resolveGlobalAssistantIntegrations: vi.fn(),
 }));
-vi.mock('@pagespace/lib/integrations/converter/ai-sdk', () => ({
-  convertIntegrationToolsToAISDK: vi.fn(),
-}));
+vi.mock('@pagespace/lib/integrations/converter/ai-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/integrations/converter/ai-sdk')>();
+  return {
+    ...actual,
+    convertIntegrationToolsToAISDK: vi.fn(),
+  };
+});
 vi.mock('@pagespace/lib/integrations/saga/execute-tool', () => ({
   createToolExecutor: vi.fn(),
 }));
@@ -65,6 +69,7 @@ describe('resolvePageAgentIntegrationTools', () => {
       agentId: 'agent-1',
       userId: 'user-1',
       driveId: 'drive-1',
+      currentTools: {},
     });
 
     expect(result).toEqual({});
@@ -109,6 +114,7 @@ describe('resolvePageAgentIntegrationTools', () => {
       agentId: 'agent-1',
       userId: 'user-1',
       driveId: 'drive-1',
+      currentTools: {},
     });
 
     expect(Object.keys(result)).toHaveLength(1);
@@ -118,6 +124,44 @@ describe('resolvePageAgentIntegrationTools', () => {
       { userId: 'user-1', agentId: 'agent-1', driveId: 'drive-1' },
       mockExecutor
     );
+  });
+
+  it('given sandbox git tools active in currentTools, suppresses GitHub integration tools', async () => {
+    const mockGrants = [{ id: 'grant-1' }] as unknown as GrantWithConnectionAndProvider[];
+    mockResolveAgentIntegrations.mockResolvedValue(mockGrants);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+      'int__slack__send_message': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    const result = await resolvePageAgentIntegrationTools({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      driveId: 'drive-1',
+      currentTools: { git_clone: {} },
+    });
+
+    expect(result).not.toHaveProperty('int__github__list_repos');
+    expect(result).toHaveProperty('int__slack__send_message');
+  });
+
+  it('given no sandbox git tools in currentTools, keeps GitHub integration tools', async () => {
+    const mockGrants = [{ id: 'grant-1' }] as unknown as GrantWithConnectionAndProvider[];
+    mockResolveAgentIntegrations.mockResolvedValue(mockGrants);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    const result = await resolvePageAgentIntegrationTools({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      driveId: 'drive-1',
+      currentTools: { read_page: {} },
+    });
+
+    expect(result).toHaveProperty('int__github__list_repos');
   });
 });
 
@@ -133,9 +177,29 @@ describe('resolveGlobalAssistantIntegrationTools', () => {
       userId: 'user-1',
       driveId: null,
       userDriveRole: null,
+      currentTools: {},
     });
 
     expect(result).toEqual({});
+  });
+
+  it('given sandbox git tools active in currentTools, suppresses GitHub integration tools', async () => {
+    mockResolveGlobalIntegrations.mockResolvedValue([{ id: 'grant-1' }] as never);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+      'int__slack__send_message': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    const result = await resolveGlobalAssistantIntegrationTools({
+      userId: 'user-1',
+      driveId: null,
+      userDriveRole: null,
+      currentTools: { gh_pr_view: {} },
+    });
+
+    expect(result).not.toHaveProperty('int__github__list_repos');
+    expect(result).toHaveProperty('int__slack__send_message');
   });
 });
 
@@ -160,9 +224,9 @@ describe('integration tool key order determinism', () => {
     // only from the sort step (not from mockConvert itself).
     mockConvert.mockReturnValue(unorderedTools);
 
-    const build1 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd' });
+    const build1 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd', currentTools: {} });
     mockConvert.mockReturnValue(unorderedTools);
-    const build2 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd' });
+    const build2 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd', currentTools: {} });
 
     expect(JSON.stringify(Object.keys(build1))).toBe(JSON.stringify(Object.keys(build2)));
     // Keys must be alphabetically sorted
@@ -176,9 +240,9 @@ describe('integration tool key order determinism', () => {
     mockResolveAgentIntegrations.mockResolvedValue([{} as never]);
     mockCreateExecutor.mockReturnValue(vi.fn());
     mockConvert.mockReturnValue(tools);
-    const build1 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd' });
+    const build1 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd', currentTools: {} });
     mockConvert.mockReturnValue(tools);
-    const build2 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd' });
+    const build2 = await resolvePageAgentIntegrationTools({ agentId: 'a', userId: 'u', driveId: 'd', currentTools: {} });
 
     // Both serializations must be byte-identical
     expect(JSON.stringify(build1)).toBe(JSON.stringify(build2));

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -233,9 +233,22 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
       'git_commit',
       'git_push',
       'git_checkout',
+      'git_revert',
       'gh_pr_create',
       'gh_pr_merge',
+      'gh_pr_comment',
+      'gh_pr_edit',
+      'gh_pr_update_branch',
+      'gh_pr_thread_resolve',
+      'gh_run_rerun',
+      'gh_workflow_run',
       'gh_issue_create',
+      'gh_issue_comment',
+      'gh_issue_edit',
+      'gh_issue_close',
+      'gh_issue_reopen',
+      'gh_repo_fork',
+      'gh_repo_create',
     ]) {
       expect(isWriteTool(name)).toBe(true);
     }
@@ -247,10 +260,18 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
       'git_status',
       'git_diff',
       'git_log',
+      'git_show',
+      'git_blame',
       'gh_pr_list',
       'gh_pr_view',
+      'gh_pr_thread_list',
+      'gh_workflow_list',
       'gh_issue_list',
       'gh_issue_view',
+      'gh_repo_view',
+      'gh_repo_list',
+      'gh_search',
+      'gh_label_list',
     ]) {
       expect(isWriteTool(name)).toBe(false);
     }

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -7,6 +7,8 @@ import {
   isWebSearchTool,
   isWriteTool,
   isAccountLevelOnlyTool,
+  hasSandboxGitTools,
+  suppressGithubIntegrationTools,
 } from '../tool-filtering';
 
 const baseline = {
@@ -274,5 +276,48 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(filtered).toHaveProperty('readFile');
     expect(filtered).toHaveProperty('git_status');
     expect(filtered).toHaveProperty('gh_pr_view');
+  });
+});
+
+describe('hasSandboxGitTools', () => {
+  it('returns true when a sandbox git tool is present', () => {
+    expect(hasSandboxGitTools({ git_status: 'x', read_page: 'x' })).toBe(true);
+  });
+
+  it('returns true when only a gh_ tool is present', () => {
+    expect(hasSandboxGitTools({ gh_pr_create: 'x' })).toBe(true);
+  });
+
+  it('returns false when no sandbox git tool is present', () => {
+    expect(hasSandboxGitTools({ read_page: 'x', bash: 'x' })).toBe(false);
+  });
+
+  it('returns false for an empty tool set', () => {
+    expect(hasSandboxGitTools({})).toBe(false);
+  });
+});
+
+describe('suppressGithubIntegrationTools', () => {
+  const integrationTools = {
+    int__github__list_repos: 'x',
+    int__github__create_pr_review_comment: 'x',
+    int__slack__send_message: 'x',
+  };
+
+  it('strips int__github__* tools when sandbox git tools are registered', () => {
+    const result = suppressGithubIntegrationTools(integrationTools, { git_clone: 'x' });
+    expect(result).not.toHaveProperty('int__github__list_repos');
+    expect(result).not.toHaveProperty('int__github__create_pr_review_comment');
+    expect(result).toHaveProperty('int__slack__send_message');
+  });
+
+  it('leaves integration tools untouched when no sandbox git tools are registered', () => {
+    const result = suppressGithubIntegrationTools(integrationTools, { read_page: 'x' });
+    expect(result).toEqual(integrationTools);
+  });
+
+  it('leaves integration tools untouched against an empty current tool set', () => {
+    const result = suppressGithubIntegrationTools(integrationTools, {});
+    expect(result).toEqual(integrationTools);
   });
 });

--- a/apps/web/src/lib/ai/core/integration-tool-resolver.ts
+++ b/apps/web/src/lib/ai/core/integration-tool-resolver.ts
@@ -29,6 +29,7 @@ import { logAuditEntry } from '@pagespace/lib/integrations/repositories/audit-re
 import { listGrantsByAgent } from '@pagespace/lib/integrations/repositories/grant-repository';
 import { getConfig } from '@pagespace/lib/integrations/repositories/config-repository';
 import { type DriveRole, type GlobalAssistantConfigData } from '@pagespace/lib/integrations/types';
+import { suppressGithubIntegrationTools } from './tool-filtering';
 
 /** The connection type expected by the tool executor's loadConnection dependency. */
 type LoadConnectionResult = ExecuteToolDependencies['loadConnection'] extends
@@ -83,14 +84,20 @@ function createConfiguredExecutor(userId: string, agentId: string | null, driveI
  * @param params.agentId - The page ID of the AI_CHAT agent
  * @param params.userId - The authenticated user's ID
  * @param params.driveId - The drive containing the agent
+ * @param params.currentTools - The agent's already-resolved tool set (before
+ *   these integration tools are merged in), used to suppress GitHub OAuth
+ *   integration tools when the sandbox git/gh CLI toolkit is already present.
+ *   Callers must pass the pre-tool-exposure-mode set — search mode defers
+ *   non-core tools behind execute_tool, hiding their names from a key scan.
  * @returns AI SDK tool objects ready for merging into the tool set
  */
 export async function resolvePageAgentIntegrationTools(params: {
   agentId: string;
   userId: string;
   driveId: string;
+  currentTools: Record<string, unknown>;
 }): Promise<Record<string, CoreTool>> {
-  const { agentId, userId, driveId } = params;
+  const { agentId, userId, driveId, currentTools } = params;
   const deps = createResolutionDeps();
 
   const grants = await resolveAgentIntegrations(deps, agentId);
@@ -99,10 +106,9 @@ export async function resolvePageAgentIntegrationTools(params: {
 
   const executor = createConfiguredExecutor(userId, agentId, driveId);
 
-  const tools = convertIntegrationToolsToAISDK(
-    grants,
-    { userId, agentId, driveId },
-    executor
+  const tools = suppressGithubIntegrationTools(
+    convertIntegrationToolsToAISDK(grants, { userId, agentId, driveId }, executor),
+    currentTools
   );
   // Sort keys so tool array order is deterministic across requests (only real config
   // changes — webSearch/readOnly/MCP/exposure-mode — may change the tool array).
@@ -119,14 +125,21 @@ export async function resolvePageAgentIntegrationTools(params: {
  * @param params.userId - The authenticated user's ID
  * @param params.driveId - The current drive context (null when in dashboard)
  * @param params.userDriveRole - The user's role in the current drive
+ * @param params.currentTools - The assistant's already-resolved tool set
+ *   (before these integration tools are merged in), used to suppress GitHub
+ *   OAuth integration tools when the sandbox git/gh CLI toolkit is already
+ *   present. Pass the full pre-core/non-core-split filtered tool set — the
+ *   Global Assistant's final tool set never carries raw tool names as
+ *   top-level keys (core tools + tool_search/execute_tool only).
  * @returns AI SDK tool objects ready for merging into the tool set
  */
 export async function resolveGlobalAssistantIntegrationTools(params: {
   userId: string;
   driveId: string | null;
   userDriveRole: DriveRole | null;
+  currentTools: Record<string, unknown>;
 }): Promise<Record<string, CoreTool>> {
-  const { userId, driveId, userDriveRole } = params;
+  const { userId, driveId, userDriveRole, currentTools } = params;
   const deps = createResolutionDeps();
 
   const grants = await resolveGlobalAssistantIntegrations(
@@ -140,10 +153,9 @@ export async function resolveGlobalAssistantIntegrationTools(params: {
 
   const executor = createConfiguredExecutor(userId, null, driveId);
 
-  const tools = convertIntegrationToolsToAISDK(
-    grants,
-    { userId, agentId: null, driveId },
-    executor
+  const tools = suppressGithubIntegrationTools(
+    convertIntegrationToolsToAISDK(grants, { userId, agentId: null, driveId }, executor),
+    currentTools
   );
   // Sort keys so tool array order is deterministic across requests (only real config
   // changes — webSearch/readOnly/MCP/exposure-mode — may change the tool array).

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -95,7 +95,8 @@ const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
 • bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
 • Use editFile for targeted string edits; writeFile rewrites the whole file.
 • Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs (up to 200000ms) if a command needs more than the 120s default.
-• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_run_list, gh_run_view, gh_pr_review, gh_pr_review_comment, gh_pr_close, gh_pr_reopen, gh_pr_ready.`;
+• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_pr_edit, gh_pr_comment, gh_run_list, gh_run_view, gh_pr_review, gh_pr_review_comment, gh_pr_close, gh_pr_reopen, gh_pr_ready. More exist (repo discovery, issues, review threads, CI reruns, search) — tool_search when needed.
+• Keep the PR description current with gh_pr_edit as follow-up commits land. After addressing review feedback, resolve the addressed threads: gh_pr_thread_list → gh_pr_thread_resolve. Use gh_repo_view to learn a repo's default branch instead of guessing main/master.`;
 
 /**
  * Build personalization prompt section from user preferences

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -95,7 +95,7 @@ const SANDBOX_INSTRUCTIONS = `CODE SANDBOX:
 • bash has NO GitHub credentials. For anything touching GitHub (clone/fetch/pull/push, PRs, issues) use the dedicated git_*/gh_* tools — they carry your connected GitHub auth.
 • Use editFile for targeted string edits; writeFile rewrites the whole file.
 • Work on a new branch unless told to work on main/master. Check for AGENTS.md/CLAUDE.md in the repo root and follow it. Install dependencies before running tests or a typecheck — pass bash's timeoutMs (up to 200000ms) if a command needs more than the 120s default.
-• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_run_list, gh_run_view, gh_pr_review, gh_pr_close, gh_pr_reopen, gh_pr_ready.`;
+• Key tools (call via execute_tool; no need to tool_search these): bash, readFile, writeFile, editFile, git_clone, git_checkout, git_add, git_commit, git_push, gh_pr_create, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks, gh_run_list, gh_run_view, gh_pr_review, gh_pr_review_comment, gh_pr_close, gh_pr_reopen, gh_pr_ready.`;
 
 /**
  * Build personalization prompt section from user preferences

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -5,6 +5,9 @@
  * toggles that filter out specific tools based on user settings.
  */
 
+import { SANDBOX_GIT_TOOL_NAMES } from '../tools/sandbox-git-tools';
+import { parseIntegrationToolName } from '@pagespace/lib/integrations/converter/ai-sdk';
+
 // Tools that modify content (excluded in read-only mode; also used by elision to protect side-effectful results)
 export const WRITE_TOOLS = new Set([
   // Page write operations
@@ -99,27 +102,20 @@ export const WRITE_TOOLS = new Set([
 // Web search tools (excluded when web search is disabled)
 const WEB_SEARCH_TOOLS = new Set(['web_search', 'web_fetch']);
 
-// All sandbox git/GitHub tool names (createSandboxGitTools). Their presence in
-// a request's tool set means the agent already has a full git/gh CLI toolkit —
-// used to detect overlap with the GitHub OAuth integration tools below.
-const SANDBOX_GIT_TOOL_NAMES = new Set([
-  'git_clone', 'git_init', 'git_config', 'git_remote_add', 'git_status', 'git_diff',
-  'git_add', 'git_reset', 'git_stash', 'git_commit', 'git_log', 'git_merge', 'git_rebase',
-  'git_checkout', 'git_branch', 'git_fetch', 'git_pull', 'git_push',
-  'gh_pr_create', 'gh_pr_list', 'gh_pr_view', 'gh_pr_diff', 'gh_pr_checks', 'gh_pr_merge',
-  'gh_pr_checkout', 'gh_pr_review', 'gh_pr_review_comment', 'gh_pr_close', 'gh_pr_reopen',
-  'gh_pr_ready', 'gh_run_list', 'gh_run_view', 'gh_issue_create', 'gh_issue_list', 'gh_issue_view',
-]);
-
-// Namespace prefix for integration tools resolved from the GitHub OAuth connection
-// (see buildIntegrationToolName in @pagespace/lib/integrations/converter/ai-sdk).
-const GITHUB_INTEGRATION_TOOL_PREFIX = 'int__github__';
+// Presence of any of these in a request's tool set means the agent already has
+// a full git/gh CLI toolkit — used to detect overlap with the GitHub OAuth
+// integration tools below. Sourced from sandbox-git-tools.ts (single source of
+// truth, sync-checked by that file's own test suite).
+const SANDBOX_GIT_TOOL_NAME_SET = new Set(SANDBOX_GIT_TOOL_NAMES);
 
 /**
- * Whether any sandbox git/GitHub tool is present in a resolved tool set.
+ * Whether the sandbox git/gh CLI toolkit is active — i.e. any of its tool
+ * names appear in a resolved tool set. Must be checked against the tool set
+ * BEFORE per-agent tool-exposure-mode deferral (search mode moves non-core
+ * tools behind execute_tool, hiding these names from a top-level key scan).
  */
 export function hasSandboxGitTools(tools: Record<string, unknown>): boolean {
-  return Object.keys(tools).some((name) => SANDBOX_GIT_TOOL_NAMES.has(name));
+  return Object.keys(tools).some((name) => SANDBOX_GIT_TOOL_NAME_SET.has(name));
 }
 
 /**
@@ -135,7 +131,7 @@ export function suppressGithubIntegrationTools<T>(
 ): Record<string, T> {
   if (!hasSandboxGitTools(currentTools)) return integrationTools;
   return Object.fromEntries(
-    Object.entries(integrationTools).filter(([name]) => !name.startsWith(GITHUB_INTEGRATION_TOOL_PREFIX))
+    Object.entries(integrationTools).filter(([name]) => parseIntegrationToolName(name)?.providerSlug !== 'github')
   );
 }
 

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -89,6 +89,7 @@ export const WRITE_TOOLS = new Set([
   'gh_pr_merge',
   'gh_pr_checkout',
   'gh_pr_review',
+  'gh_pr_review_comment',
   'gh_pr_close',
   'gh_pr_reopen',
   'gh_pr_ready',
@@ -97,6 +98,46 @@ export const WRITE_TOOLS = new Set([
 
 // Web search tools (excluded when web search is disabled)
 const WEB_SEARCH_TOOLS = new Set(['web_search', 'web_fetch']);
+
+// All sandbox git/GitHub tool names (createSandboxGitTools). Their presence in
+// a request's tool set means the agent already has a full git/gh CLI toolkit —
+// used to detect overlap with the GitHub OAuth integration tools below.
+const SANDBOX_GIT_TOOL_NAMES = new Set([
+  'git_clone', 'git_init', 'git_config', 'git_remote_add', 'git_status', 'git_diff',
+  'git_add', 'git_reset', 'git_stash', 'git_commit', 'git_log', 'git_merge', 'git_rebase',
+  'git_checkout', 'git_branch', 'git_fetch', 'git_pull', 'git_push',
+  'gh_pr_create', 'gh_pr_list', 'gh_pr_view', 'gh_pr_diff', 'gh_pr_checks', 'gh_pr_merge',
+  'gh_pr_checkout', 'gh_pr_review', 'gh_pr_review_comment', 'gh_pr_close', 'gh_pr_reopen',
+  'gh_pr_ready', 'gh_run_list', 'gh_run_view', 'gh_issue_create', 'gh_issue_list', 'gh_issue_view',
+]);
+
+// Namespace prefix for integration tools resolved from the GitHub OAuth connection
+// (see buildIntegrationToolName in @pagespace/lib/integrations/converter/ai-sdk).
+const GITHUB_INTEGRATION_TOOL_PREFIX = 'int__github__';
+
+/**
+ * Whether any sandbox git/GitHub tool is present in a resolved tool set.
+ */
+export function hasSandboxGitTools(tools: Record<string, unknown>): boolean {
+  return Object.keys(tools).some((name) => SANDBOX_GIT_TOOL_NAMES.has(name));
+}
+
+/**
+ * Suppress GitHub OAuth integration tools when the sandbox git/gh CLI toolkit is
+ * already registered in the current tool set — the two overlap in capability
+ * (browsing repos, reviewing PRs, filing issues), and offering both surfaces for
+ * the same GitHub account is redundant and confuses tool selection. Other
+ * providers' integration tools (Slack, etc.) are untouched.
+ */
+export function suppressGithubIntegrationTools<T>(
+  integrationTools: Record<string, T>,
+  currentTools: Record<string, unknown>
+): Record<string, T> {
+  if (!hasSandboxGitTools(currentTools)) return integrationTools;
+  return Object.fromEntries(
+    Object.entries(integrationTools).filter(([name]) => !name.startsWith(GITHUB_INTEGRATION_TOOL_PREFIX))
+  );
+}
 
 // Tools that require account-level (unscoped) access — excluded entirely from
 // a drive-scoped MCP token's tool list, mirroring the isMcpScoped() call-time

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -67,9 +67,10 @@ export const WRITE_TOOLS = new Set([
   // Sandbox / code-execution operations — all mutate the persistent sandbox
   // filesystem or a remote. bash can run arbitrary mutations, so it is excluded
   // in read-only mode too. Read-only sandbox tools (readFile, git_status,
-  // git_diff, git_log, gh_pr_list, gh_pr_view, gh_pr_diff, gh_pr_checks,
-  // gh_run_list, gh_run_view, gh_issue_list, gh_issue_view) are
-  // intentionally NOT listed and remain available.
+  // git_diff, git_log, git_show, git_blame, gh_pr_list, gh_pr_view, gh_pr_diff,
+  // gh_pr_checks, gh_pr_thread_list, gh_run_list, gh_run_view, gh_workflow_list,
+  // gh_issue_list, gh_issue_view, gh_repo_view, gh_repo_list, gh_search,
+  // gh_label_list) are intentionally NOT listed and remain available.
   'bash',
   'writeFile',
   'editFile',
@@ -83,6 +84,7 @@ export const WRITE_TOOLS = new Set([
   'git_commit',
   'git_merge',
   'git_rebase',
+  'git_revert',
   'git_checkout',
   'git_branch',
   'git_fetch',
@@ -93,10 +95,22 @@ export const WRITE_TOOLS = new Set([
   'gh_pr_checkout',
   'gh_pr_review',
   'gh_pr_review_comment',
+  'gh_pr_comment',
+  'gh_pr_edit',
+  'gh_pr_update_branch',
+  'gh_pr_thread_resolve',
   'gh_pr_close',
   'gh_pr_reopen',
   'gh_pr_ready',
+  'gh_run_rerun',
+  'gh_workflow_run',
   'gh_issue_create',
+  'gh_issue_comment',
+  'gh_issue_edit',
+  'gh_issue_close',
+  'gh_issue_reopen',
+  'gh_repo_fork',
+  'gh_repo_create',
 ]);
 
 // Web search tools (excluded when web search is disabled)

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -857,6 +857,457 @@ describe('gh_pr_ready', () => {
   });
 });
 
+// ── git_show ───────────────────────────────────────────────────────────────
+
+describe('git_show', () => {
+  it('defaults to HEAD', async () => {
+    const deps = makeDeps();
+    const { git_show } = createSandboxGitTools(deps);
+    await git_show.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('git');
+    expect(calls[0].args).toEqual(['show', 'HEAD']);
+  });
+
+  it('builds --stat with a ref and path filter', async () => {
+    const deps = makeDeps();
+    const { git_show } = createSandboxGitTools(deps);
+    await git_show.execute!({ ref: 'abc123', stat: true, path: 'src/foo.ts' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['show', '--stat', 'abc123', '--', 'src/foo.ts']);
+  });
+});
+
+// ── git_blame ──────────────────────────────────────────────────────────────
+
+describe('git_blame', () => {
+  it('builds a line-range blame', async () => {
+    const deps = makeDeps();
+    const { git_blame } = createSandboxGitTools(deps);
+    await git_blame.execute!({ path: 'src/foo.ts', start_line: 5, end_line: 20 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['blame', '-L', '5,20', '--', 'src/foo.ts']);
+  });
+
+  it('rejects start_line without end_line', async () => {
+    const deps = makeDeps();
+    const { git_blame } = createSandboxGitTools(deps);
+    const result = await git_blame.execute!({ path: 'src/foo.ts', start_line: 5 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── git_merge / git_rebase conflict recovery ────────────────────────────────
+
+describe('git_merge action', () => {
+  it('runs a plain merge by default', async () => {
+    const deps = makeDeps();
+    const { git_merge } = createSandboxGitTools(deps);
+    await git_merge.execute!({ branch: 'feature-x' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['merge', 'feature-x']);
+  });
+
+  it('builds --abort without requiring a branch', async () => {
+    const deps = makeDeps();
+    const { git_merge } = createSandboxGitTools(deps);
+    await git_merge.execute!({ action: 'abort' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['merge', '--abort']);
+  });
+
+  it('rejects a run without a branch', async () => {
+    const deps = makeDeps();
+    const { git_merge } = createSandboxGitTools(deps);
+    const result = await git_merge.execute!({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+});
+
+describe('git_rebase action', () => {
+  it('runs a plain rebase by default', async () => {
+    const deps = makeDeps();
+    const { git_rebase } = createSandboxGitTools(deps);
+    await git_rebase.execute!({ branch_or_ref: 'origin/main' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['rebase', 'origin/main']);
+  });
+
+  it('builds --continue without requiring a ref', async () => {
+    const deps = makeDeps();
+    const { git_rebase } = createSandboxGitTools(deps);
+    await git_rebase.execute!({ action: 'continue' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['rebase', '--continue']);
+  });
+
+  it('rejects a run without a ref', async () => {
+    const deps = makeDeps();
+    const { git_rebase } = createSandboxGitTools(deps);
+    const result = await git_rebase.execute!({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+});
+
+// ── git_revert ─────────────────────────────────────────────────────────────
+
+describe('git_revert', () => {
+  it('builds --no-edit with a single sha', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    await git_revert.execute!({ sha: 'abc1234' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['revert', '--no-edit', 'abc1234']);
+  });
+
+  it('rejects a range', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    const result = await git_revert.execute!({ sha: 'HEAD~3..HEAD' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('rejects a ref name', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    const result = await git_revert.execute!({ sha: 'main' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+});
+
+// ── gh_pr_comment ──────────────────────────────────────────────────────────
+
+describe('gh_pr_comment', () => {
+  it('builds ["pr", "comment", "<number>", "--body", ...]', async () => {
+    const deps = makeDeps();
+    const { gh_pr_comment } = createSandboxGitTools(deps);
+    await gh_pr_comment.execute!({ number: 42, body: 'Thanks, addressed!' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args).toEqual(['pr', 'comment', '42', '--body', 'Thanks, addressed!']);
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_comment } = createSandboxGitTools(deps);
+    const result = await gh_pr_comment.execute!({ number: 42, body: 'hi' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_edit ─────────────────────────────────────────────────────────────
+
+describe('gh_pr_edit', () => {
+  it('builds title/body/label/reviewer flags', async () => {
+    const deps = makeDeps();
+    const { gh_pr_edit } = createSandboxGitTools(deps);
+    await gh_pr_edit.execute!(
+      {
+        number: 42,
+        title: 'New title',
+        body: 'New body',
+        add_labels: ['bug', 'urgent'],
+        remove_labels: ['wip'],
+        add_reviewers: ['octocat'],
+      },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual([
+      'pr', 'edit', '42',
+      '--title', 'New title',
+      '--body', 'New body',
+      '--add-label', 'bug,urgent',
+      '--remove-label', 'wip',
+      '--add-reviewer', 'octocat',
+    ]);
+  });
+
+  it('rejects an edit with no fields', async () => {
+    const deps = makeDeps();
+    const { gh_pr_edit } = createSandboxGitTools(deps);
+    const result = await gh_pr_edit.execute!({ number: 42 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_pr_update_branch ────────────────────────────────────────────────────
+
+describe('gh_pr_update_branch', () => {
+  it('builds ["pr", "update-branch", "<number>"]', async () => {
+    const deps = makeDeps();
+    const { gh_pr_update_branch } = createSandboxGitTools(deps);
+    await gh_pr_update_branch.execute!({ number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['pr', 'update-branch', '42']);
+  });
+});
+
+// ── gh_pr_thread_list / gh_pr_thread_resolve ───────────────────────────────
+
+describe('gh_pr_thread_list', () => {
+  it('passes variables as flags, never interpolated into the query document', async () => {
+    const deps = makeDeps();
+    const { gh_pr_thread_list } = createSandboxGitTools(deps);
+    await gh_pr_thread_list.execute!({ owner: 'acme', repo: 'webapp', number: 42 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args[0]).toBe('api');
+    expect(calls[0].args[1]).toBe('graphql');
+    const queryArg = calls[0].args[calls[0].args.indexOf('-f') + 1];
+    expect(queryArg).toContain('reviewThreads');
+    expect(queryArg).not.toContain('acme');
+    expect(calls[0].args).toContain('owner=acme');
+    expect(calls[0].args).toContain('repo=webapp');
+    expect(calls[0].args).toContain('number=42');
+  });
+});
+
+describe('gh_pr_thread_resolve', () => {
+  it('uses the fixed mutation document with threadId as a flag', async () => {
+    const deps = makeDeps();
+    const { gh_pr_thread_resolve } = createSandboxGitTools(deps);
+    await gh_pr_thread_resolve.execute!({ thread_id: 'PRRT_abc123' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args[0]).toBe('api');
+    expect(calls[0].args[1]).toBe('graphql');
+    const queryArg = calls[0].args[calls[0].args.indexOf('-f') + 1];
+    expect(queryArg).toContain('resolveReviewThread');
+    expect(queryArg).not.toContain('PRRT_abc123');
+    expect(calls[0].args).toContain('threadId=PRRT_abc123');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_thread_resolve } = createSandboxGitTools(deps);
+    const result = await gh_pr_thread_resolve.execute!({ thread_id: 'PRRT_abc123' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+// ── gh_run_rerun / gh_workflow_* ───────────────────────────────────────────
+
+describe('gh_run_rerun', () => {
+  it('builds ["run", "rerun", "<id>"] and adds --failed for failed_only', async () => {
+    const deps = makeDeps();
+    const { gh_run_rerun } = createSandboxGitTools(deps);
+    await gh_run_rerun.execute!({ runId: 123, failed_only: true }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['run', 'rerun', '123', '--failed']);
+  });
+});
+
+describe('gh_workflow_list', () => {
+  it('builds ["workflow", "list", ...] with json fields', async () => {
+    const deps = makeDeps();
+    const { gh_workflow_list } = createSandboxGitTools(deps);
+    await gh_workflow_list.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['workflow', 'list', '--limit', '50', '--json', 'id,name,path,state']);
+  });
+});
+
+describe('gh_workflow_run', () => {
+  it('builds workflow dispatch with ref and -f inputs', async () => {
+    const deps = makeDeps();
+    const { gh_workflow_run } = createSandboxGitTools(deps);
+    await gh_workflow_run.execute!(
+      { workflow: 'ci.yml', ref: 'main', inputs: { environment: 'staging' } },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual([
+      'workflow', 'run', 'ci.yml', '--ref', 'main', '-f', 'environment=staging',
+    ]);
+  });
+
+  it('rejects an invalid input name', async () => {
+    const deps = makeDeps();
+    const { gh_workflow_run } = createSandboxGitTools(deps);
+    const result = await gh_workflow_run.execute!(
+      { workflow: 'ci.yml', ref: 'main', inputs: { 'bad name!': 'x' } },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('requires ref in the schema', () => {
+    const { gh_workflow_run } = createSandboxGitTools(makeDeps());
+    const parse = (gh_workflow_run.inputSchema as { safeParse: (v: unknown) => { success: boolean } }).safeParse;
+    expect(parse({ workflow: 'ci.yml' }).success).toBe(false);
+    expect(parse({ workflow: 'ci.yml', ref: 'main' }).success).toBe(true);
+  });
+});
+
+// ── gh_issue lifecycle ─────────────────────────────────────────────────────
+
+describe('gh_issue_comment', () => {
+  it('builds ["issue", "comment", "<number>", "--body", ...]', async () => {
+    const deps = makeDeps();
+    const { gh_issue_comment } = createSandboxGitTools(deps);
+    await gh_issue_comment.execute!({ number: 7, body: 'On it.' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['issue', 'comment', '7', '--body', 'On it.']);
+  });
+});
+
+describe('gh_issue_edit', () => {
+  it('builds label and assignee flags', async () => {
+    const deps = makeDeps();
+    const { gh_issue_edit } = createSandboxGitTools(deps);
+    await gh_issue_edit.execute!(
+      { number: 7, add_labels: ['bug'], add_assignees: ['octocat'] },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual([
+      'issue', 'edit', '7', '--add-label', 'bug', '--add-assignee', 'octocat',
+    ]);
+  });
+
+  it('rejects an edit with no fields', async () => {
+    const deps = makeDeps();
+    const { gh_issue_edit } = createSandboxGitTools(deps);
+    const result = await gh_issue_edit.execute!({ number: 7 }, {} as never);
+    expect(result).toMatchObject({ success: false });
+  });
+});
+
+describe('gh_issue_close', () => {
+  it('maps not_planned to the gh "not planned" reason', async () => {
+    const deps = makeDeps();
+    const { gh_issue_close } = createSandboxGitTools(deps);
+    await gh_issue_close.execute!(
+      { number: 7, comment: 'Duplicate of #5', reason: 'not_planned' },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual([
+      'issue', 'close', '7', '--comment', 'Duplicate of #5', '--reason', 'not planned',
+    ]);
+  });
+});
+
+describe('gh_issue_reopen', () => {
+  it('builds ["issue", "reopen", "<number>"]', async () => {
+    const deps = makeDeps();
+    const { gh_issue_reopen } = createSandboxGitTools(deps);
+    await gh_issue_reopen.execute!({ number: 7 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['issue', 'reopen', '7']);
+  });
+});
+
+// ── gh repo / search / labels ──────────────────────────────────────────────
+
+describe('gh_repo_view', () => {
+  it('includes defaultBranchRef in json fields', async () => {
+    const deps = makeDeps();
+    const { gh_repo_view } = createSandboxGitTools(deps);
+    await gh_repo_view.execute!({ repo: 'acme/webapp' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args.slice(0, 3)).toEqual(['repo', 'view', 'acme/webapp']);
+    expect(calls[0].args[calls[0].args.indexOf('--json') + 1]).toContain('defaultBranchRef');
+  });
+});
+
+describe('gh_repo_list', () => {
+  it('lists the connected account by default', async () => {
+    const deps = makeDeps();
+    const { gh_repo_list } = createSandboxGitTools(deps);
+    await gh_repo_list.execute!({}, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args.slice(0, 2)).toEqual(['repo', 'list']);
+    expect(calls[0].args).toContain('--limit');
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_repo_list } = createSandboxGitTools(deps);
+    const result = await gh_repo_list.execute!({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
+describe('gh_repo_fork', () => {
+  it('forks without cloning or adding a remote', async () => {
+    const deps = makeDeps();
+    const { gh_repo_fork } = createSandboxGitTools(deps);
+    await gh_repo_fork.execute!({ repo: 'acme/webapp' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['repo', 'fork', 'acme/webapp', '--clone=false', '--remote=false']);
+  });
+});
+
+describe('gh_repo_create', () => {
+  it('builds an explicit-visibility create', async () => {
+    const deps = makeDeps();
+    const { gh_repo_create } = createSandboxGitTools(deps);
+    await gh_repo_create.execute!(
+      { name: 'my-tool', visibility: 'private', description: 'A tool' },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['repo', 'create', 'my-tool', '--private', '--description', 'A tool']);
+  });
+
+  it('rejects a name with flag-like characters', async () => {
+    const deps = makeDeps();
+    const { gh_repo_create } = createSandboxGitTools(deps);
+    const result = await gh_repo_create.execute!(
+      { name: '--source=.', visibility: 'private' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('requires visibility in the schema', () => {
+    const { gh_repo_create } = createSandboxGitTools(makeDeps());
+    const parse = (gh_repo_create.inputSchema as { safeParse: (v: unknown) => { success: boolean } }).safeParse;
+    expect(parse({ name: 'my-tool' }).success).toBe(false);
+    expect(parse({ name: 'my-tool', visibility: 'public' }).success).toBe(true);
+  });
+});
+
+describe('gh_search', () => {
+  it('uses issue-shaped json fields for prs', async () => {
+    const deps = makeDeps();
+    const { gh_search } = createSandboxGitTools(deps);
+    await gh_search.execute!({ type: 'prs', query: 'fix login repo:acme/webapp' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args.slice(0, 3)).toEqual(['search', 'prs', 'fix login repo:acme/webapp']);
+    expect(calls[0].args[calls[0].args.indexOf('--json') + 1]).toBe('number,title,state,url,repository');
+  });
+
+  it('uses code-shaped json fields for code', async () => {
+    const deps = makeDeps();
+    const { gh_search } = createSandboxGitTools(deps);
+    await gh_search.execute!({ type: 'code', query: 'useState repo:acme/webapp' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args[calls[0].args.indexOf('--json') + 1]).toBe('repository,path,url');
+  });
+});
+
+describe('gh_label_list', () => {
+  it('scopes to an explicit repo when given', async () => {
+    const deps = makeDeps();
+    const { gh_label_list } = createSandboxGitTools(deps);
+    await gh_label_list.execute!({ repo: 'acme/webapp' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual([
+      'label', 'list', '--repo', 'acme/webapp', '--limit', '50', '--json', 'name,description,color',
+    ]);
+  });
+});
+
 // ── cwd threading ────────────────────────────────────────────────────────────
 
 describe('cwd threading', () => {
@@ -930,10 +1381,10 @@ describe('schema strictness', () => {
 // ── tool count ─────────────────────────────────────────────────────────────
 
 describe('createSandboxGitTools', () => {
-  it('exports exactly 35 tools', () => {
+  it('exports exactly 56 tools', () => {
     const deps = makeDeps();
     const tools = createSandboxGitTools(deps);
-    expect(Object.keys(tools)).toHaveLength(35);
+    expect(Object.keys(tools)).toHaveLength(56);
   });
 
   it('SANDBOX_GIT_TOOL_NAMES stays in sync with the factory output', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -876,6 +876,14 @@ describe('git_show', () => {
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['show', '--stat', 'abc123', '--', 'src/foo.ts']);
   });
+
+  it('rejects a ref that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { git_show } = createSandboxGitTools(deps);
+    const result = await git_show.execute!({ ref: '--exec=whoami' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
 });
 
 // ── git_blame ──────────────────────────────────────────────────────────────
@@ -974,6 +982,38 @@ describe('git_revert', () => {
     const { git_revert } = createSandboxGitTools(deps);
     const result = await git_revert.execute!({ sha: 'main' }, {} as never);
     expect(result).toMatchObject({ success: false });
+  });
+
+  it('builds --abort without requiring a sha', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    await git_revert.execute!({ action: 'abort' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['revert', '--abort']);
+  });
+
+  it('builds --continue without requiring a sha', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    await git_revert.execute!({ action: 'continue' }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['revert', '--continue']);
+  });
+
+  it('rejects a run without a sha', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    const result = await git_revert.execute!({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('supports mainline for reverting a merge commit', async () => {
+    const deps = makeDeps();
+    const { git_revert } = createSandboxGitTools(deps);
+    await git_revert.execute!({ sha: 'abc1234', mainline: 1 }, {} as never);
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toEqual(['revert', '--no-edit', '-m', '1', 'abc1234']);
   });
 });
 
@@ -1143,6 +1183,17 @@ describe('gh_workflow_run', () => {
     expect(parse({ workflow: 'ci.yml' }).success).toBe(false);
     expect(parse({ workflow: 'ci.yml', ref: 'main' }).success).toBe(true);
   });
+
+  it('rejects a workflow name that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { gh_workflow_run } = createSandboxGitTools(deps);
+    const result = await gh_workflow_run.execute!(
+      { workflow: '--repo=other/repo', ref: 'main' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
 });
 
 // ── gh_issue lifecycle ─────────────────────────────────────────────────────
@@ -1215,6 +1266,14 @@ describe('gh_repo_view', () => {
     expect(calls[0].args.slice(0, 3)).toEqual(['repo', 'view', 'acme/webapp']);
     expect(calls[0].args[calls[0].args.indexOf('--json') + 1]).toContain('defaultBranchRef');
   });
+
+  it('rejects a repo that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { gh_repo_view } = createSandboxGitTools(deps);
+    const result = await gh_repo_view.execute!({ repo: '--help' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
 });
 
 describe('gh_repo_list', () => {
@@ -1234,6 +1293,14 @@ describe('gh_repo_list', () => {
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
+
+  it('rejects an owner that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { gh_repo_list } = createSandboxGitTools(deps);
+    const result = await gh_repo_list.execute!({ owner: '--limit=999' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
 });
 
 describe('gh_repo_fork', () => {
@@ -1243,6 +1310,14 @@ describe('gh_repo_fork', () => {
     await gh_repo_fork.execute!({ repo: 'acme/webapp' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args).toEqual(['repo', 'fork', 'acme/webapp', '--clone=false', '--remote=false']);
+  });
+
+  it('rejects a repo that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { gh_repo_fork } = createSandboxGitTools(deps);
+    const result = await gh_repo_fork.execute!({ repo: '--clone=true' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
 });
 
@@ -1269,6 +1344,17 @@ describe('gh_repo_create', () => {
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
 
+  it('rejects a name with a leading hyphen (flag injection)', async () => {
+    const deps = makeDeps();
+    const { gh_repo_create } = createSandboxGitTools(deps);
+    const result = await gh_repo_create.execute!(
+      { name: '--private', visibility: 'private' },
+      {} as never,
+    );
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
   it('requires visibility in the schema', () => {
     const { gh_repo_create } = createSandboxGitTools(makeDeps());
     const parse = (gh_repo_create.inputSchema as { safeParse: (v: unknown) => { success: boolean } }).safeParse;
@@ -1278,13 +1364,15 @@ describe('gh_repo_create', () => {
 });
 
 describe('gh_search', () => {
-  it('uses issue-shaped json fields for prs', async () => {
+  it('uses issue-shaped json fields for prs, with query last after a "--" separator', async () => {
     const deps = makeDeps();
     const { gh_search } = createSandboxGitTools(deps);
     await gh_search.execute!({ type: 'prs', query: 'fix login repo:acme/webapp' }, {} as never);
     const calls = getRunCalls(deps);
-    expect(calls[0].args.slice(0, 3)).toEqual(['search', 'prs', 'fix login repo:acme/webapp']);
-    expect(calls[0].args[calls[0].args.indexOf('--json') + 1]).toBe('number,title,state,url,repository');
+    expect(calls[0].args).toEqual([
+      'search', 'prs', '--limit', '20', '--json', 'number,title,state,url,repository',
+      '--', 'fix login repo:acme/webapp',
+    ]);
   });
 
   it('uses code-shaped json fields for code', async () => {
@@ -1293,6 +1381,18 @@ describe('gh_search', () => {
     await gh_search.execute!({ type: 'code', query: 'useState repo:acme/webapp' }, {} as never);
     const calls = getRunCalls(deps);
     expect(calls[0].args[calls[0].args.indexOf('--json') + 1]).toBe('repository,path,url');
+  });
+
+  it('places a leading-hyphen query after the "--" separator rather than letting it be parsed as a flag', async () => {
+    const deps = makeDeps();
+    const { gh_search } = createSandboxGitTools(deps);
+    await gh_search.execute!({ type: 'code', query: '-1 test' }, {} as never);
+    const calls = getRunCalls(deps);
+    const dashDashIndex = calls[0].args.indexOf('--');
+    const queryIndex = calls[0].args.indexOf('-1 test');
+    expect(dashDashIndex).toBeGreaterThan(-1);
+    expect(queryIndex).toBe(dashDashIndex + 1);
+    expect(queryIndex).toBe(calls[0].args.length - 1);
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -931,6 +931,14 @@ describe('git_merge action', () => {
     const result = await git_merge.execute!({}, {} as never);
     expect(result).toMatchObject({ success: false });
   });
+
+  it('rejects a branch that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { git_merge } = createSandboxGitTools(deps);
+    const result = await git_merge.execute!({ branch: '--strategy=octopus' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
 });
 
 describe('git_rebase action', () => {
@@ -955,6 +963,14 @@ describe('git_rebase action', () => {
     const { git_rebase } = createSandboxGitTools(deps);
     const result = await git_rebase.execute!({}, {} as never);
     expect(result).toMatchObject({ success: false });
+  });
+
+  it('rejects a branch_or_ref that looks like a flag', async () => {
+    const deps = makeDeps();
+    const { git_rebase } = createSandboxGitTools(deps);
+    const result = await git_rebase.execute!({ branch_or_ref: '--exec=whoami' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createSandboxGitTools } from '../sandbox-git-tools';
+import { createSandboxGitTools, SANDBOX_GIT_TOOL_NAMES } from '../sandbox-git-tools';
 import type { GitSandboxToolsDeps } from '../sandbox-git-tools';
 
 const mockRun = vi.fn();
@@ -934,6 +934,12 @@ describe('createSandboxGitTools', () => {
     const deps = makeDeps();
     const tools = createSandboxGitTools(deps);
     expect(Object.keys(tools)).toHaveLength(35);
+  });
+
+  it('SANDBOX_GIT_TOOL_NAMES stays in sync with the factory output', () => {
+    const deps = makeDeps();
+    const tools = createSandboxGitTools(deps);
+    expect([...SANDBOX_GIT_TOOL_NAMES].sort()).toEqual(Object.keys(tools).sort());
   });
 
   it('no tool passes sh or -c as the cmd or first arg', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -700,6 +700,89 @@ describe('gh_pr_review', () => {
   });
 });
 
+// ── gh_pr_review_comment ────────────────────────────────────────────────────
+
+describe('gh_pr_review_comment', () => {
+  it('builds the correct gh api call for an inline comment', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review_comment } = createSandboxGitTools(deps);
+    await gh_pr_review_comment.execute!(
+      { number: 42, body: 'Off-by-one here', path: 'src/index.ts', line: 10, side: 'RIGHT', commit_id: 'abc123' },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].cmd).toBe('gh');
+    expect(calls[0].args[0]).toBe('api');
+    expect(calls[0].args[1]).toBe('repos/{owner}/{repo}/pulls/42/comments');
+    expect(calls[0].args).toContain('-f');
+    expect(calls[0].args).toContain('body=Off-by-one here');
+    expect(calls[0].args).toContain('path=src/index.ts');
+    expect(calls[0].args).toContain('side=RIGHT');
+    expect(calls[0].args).toContain('commit_id=abc123');
+    expect(calls[0].args).toContain('-F');
+    expect(calls[0].args).toContain('line=10');
+  });
+
+  it('includes start_line/start_side for a multi-line comment', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review_comment } = createSandboxGitTools(deps);
+    await gh_pr_review_comment.execute!(
+      {
+        number: 42,
+        body: 'Refactor this block',
+        path: 'src/index.ts',
+        line: 20,
+        start_line: 10,
+        start_side: 'RIGHT',
+        commit_id: 'abc123',
+      },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('start_line=10');
+    expect(calls[0].args).toContain('start_side=RIGHT');
+  });
+
+  it('includes subject_type for a file-level comment', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review_comment } = createSandboxGitTools(deps);
+    await gh_pr_review_comment.execute!(
+      { number: 42, body: 'Consider splitting this file', path: 'src/index.ts', commit_id: 'abc123', subject_type: 'file' },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('subject_type=file');
+  });
+
+  it('builds a reply with only in_reply_to and body', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review_comment } = createSandboxGitTools(deps);
+    await gh_pr_review_comment.execute!(
+      { number: 42, body: 'Fixed in latest push', in_reply_to: 999 },
+      {} as never,
+    );
+    const calls = getRunCalls(deps);
+    expect(calls[0].args).toContain('in_reply_to=999');
+    expect(calls[0].args).not.toContain('path=undefined');
+  });
+
+  it('rejects empty body', async () => {
+    const deps = makeDeps();
+    const { gh_pr_review_comment } = createSandboxGitTools(deps);
+    const result = await gh_pr_review_comment.execute!({ number: 42, body: '' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+
+  it('returns no-connection error when token is null', async () => {
+    const deps = makeDeps(null);
+    const { gh_pr_review_comment } = createSandboxGitTools(deps);
+    const result = await gh_pr_review_comment.execute!({ number: 42, body: 'LGTM' }, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
+});
+
 // ── gh_pr_close ────────────────────────────────────────────────────────────
 
 describe('gh_pr_close', () => {
@@ -847,10 +930,10 @@ describe('schema strictness', () => {
 // ── tool count ─────────────────────────────────────────────────────────────
 
 describe('createSandboxGitTools', () => {
-  it('exports exactly 34 tools', () => {
+  it('exports exactly 35 tools', () => {
     const deps = makeDeps();
     const tools = createSandboxGitTools(deps);
-    expect(Object.keys(tools)).toHaveLength(34);
+    expect(Object.keys(tools)).toHaveLength(35);
   });
 
   it('no tool passes sh or -c as the cmd or first arg', async () => {

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -644,6 +644,7 @@ export const agentCommunicationTools = {
             agentId,
             userId,
             driveId: targetAgent.driveId,
+            currentTools: agentTools,
           });
         } catch (error) {
           loggers.ai.error('ask_agent: failed to resolve integration tools, falling back to built-in tools only', error as Error);

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -1,5 +1,5 @@
 /**
- * Agent git/GitHub tools: all 34 tools running inside a sandbox.
+ * Agent git/GitHub tools: all 35 tools running inside a sandbox.
  *
  * Pure factory — no DB imports, no Sprites SDK. Production wiring lives in
  * `sandbox-git-tools-runtime.ts`. Each tool's execute handler:
@@ -695,6 +695,45 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       ),
   });
 
+  const ghPrReviewComment = tool({
+    description:
+      'Add a review comment on a pull request. For inline comments: provide path, commit_id, and line. For file-level comments: provide path, commit_id, and subject_type "file". For replies: provide in_reply_to (comment ID) and body only. Use head sha from gh_pr_view for commit_id. Requires a connected GitHub account.',
+    inputSchema: z.object({
+      number: z.number().int().positive(),
+      body: z.string().min(1),
+      path: z.string().optional(),
+      line: z.number().int().positive().optional(),
+      side: z.enum(['LEFT', 'RIGHT']).optional(),
+      commit_id: z.string().optional(),
+      start_line: z.number().int().positive().optional(),
+      start_side: z.enum(['LEFT', 'RIGHT']).optional(),
+      in_reply_to: z.number().int().positive().optional(),
+      subject_type: z.enum(['line', 'file']).optional(),
+      cwd: cwdField,
+    })
+      .strict(),
+    execute: async (
+      { number, body, path, line, side, commit_id, start_line, start_side, in_reply_to, subject_type, cwd },
+      options,
+    ) => {
+      if (!body) {
+        return { success: false as const, error: 'body is required' };
+      }
+      const fields: string[] = ['-f', `body=${body}`];
+      if (path !== undefined) fields.push('-f', `path=${path}`);
+      if (line !== undefined) fields.push('-F', `line=${line}`);
+      if (side) fields.push('-f', `side=${side}`);
+      if (commit_id !== undefined) fields.push('-f', `commit_id=${commit_id}`);
+      if (start_line !== undefined) fields.push('-F', `start_line=${start_line}`);
+      if (start_side) fields.push('-f', `start_side=${start_side}`);
+      if (in_reply_to !== undefined) fields.push('-F', `in_reply_to=${in_reply_to}`);
+      if (subject_type) fields.push('-f', `subject_type=${subject_type}`);
+      return withToken(options, (ctx, token) =>
+        gitR('gh', ['api', `repos/{owner}/{repo}/pulls/${number}/comments`, ...fields], ctx, token, cwd),
+      );
+    },
+  });
+
   const ghPrClose = tool({
     description: 'Close a pull request with an optional comment. Requires a connected GitHub account.',
     inputSchema: z
@@ -900,6 +939,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     gh_pr_merge: ghPrMerge,
     gh_pr_checkout: ghPrCheckout,
     gh_pr_review: ghPrReview,
+    gh_pr_review_comment: ghPrReviewComment,
     gh_pr_close: ghPrClose,
     gh_pr_reopen: ghPrReopen,
     gh_pr_ready: ghPrReady,

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -50,6 +50,19 @@ function isDeleteRefspec(refspec: string): boolean {
   return spec.includes(':') && spec.slice(0, spec.lastIndexOf(':')).trim() === '';
 }
 
+// Tool names returned by createSandboxGitTools, kept next to the factory so a
+// new tool is one glance away from being added here too. Consumed by
+// tool-filtering.ts to detect whether the sandbox git/gh toolkit is active —
+// checked against the factory's return keys in this file's own test suite.
+export const SANDBOX_GIT_TOOL_NAMES: readonly string[] = [
+  'git_clone', 'git_init', 'git_config', 'git_remote_add', 'git_status', 'git_diff',
+  'git_add', 'git_reset', 'git_stash', 'git_commit', 'git_log', 'git_merge', 'git_rebase',
+  'git_checkout', 'git_branch', 'git_fetch', 'git_pull', 'git_push',
+  'gh_pr_create', 'gh_pr_list', 'gh_pr_view', 'gh_pr_diff', 'gh_pr_checks', 'gh_pr_merge',
+  'gh_pr_checkout', 'gh_pr_review', 'gh_pr_review_comment', 'gh_pr_close', 'gh_pr_reopen',
+  'gh_pr_ready', 'gh_run_list', 'gh_run_view', 'gh_issue_create', 'gh_issue_list', 'gh_issue_view',
+];
+
 export interface GitSandboxToolsDeps {
   gitRunDeps: GitSandboxRunDeps;
   resolveContext: ResolveSandboxContext;
@@ -719,17 +732,25 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       if (!body) {
         return { success: false as const, error: 'body is required' };
       }
-      const fields: string[] = ['-f', `body=${body}`];
-      if (path !== undefined) fields.push('-f', `path=${path}`);
-      if (line !== undefined) fields.push('-F', `line=${line}`);
-      if (side) fields.push('-f', `side=${side}`);
-      if (commit_id !== undefined) fields.push('-f', `commit_id=${commit_id}`);
-      if (start_line !== undefined) fields.push('-F', `start_line=${start_line}`);
-      if (start_side) fields.push('-f', `start_side=${start_side}`);
-      if (in_reply_to !== undefined) fields.push('-F', `in_reply_to=${in_reply_to}`);
-      if (subject_type) fields.push('-f', `subject_type=${subject_type}`);
       return withToken(options, (ctx, token) =>
-        gitR('gh', ['api', `repos/{owner}/{repo}/pulls/${number}/comments`, ...fields], ctx, token, cwd),
+        gitR(
+          'gh',
+          [
+            'api', `repos/{owner}/{repo}/pulls/${number}/comments`,
+            '-f', `body=${body}`,
+            ...(path !== undefined ? ['-f', `path=${path}`] : []),
+            ...(line !== undefined ? ['-F', `line=${line}`] : []),
+            ...(side ? ['-f', `side=${side}`] : []),
+            ...(commit_id !== undefined ? ['-f', `commit_id=${commit_id}`] : []),
+            ...(start_line !== undefined ? ['-F', `start_line=${start_line}`] : []),
+            ...(start_side ? ['-f', `start_side=${start_side}`] : []),
+            ...(in_reply_to !== undefined ? ['-F', `in_reply_to=${in_reply_to}`] : []),
+            ...(subject_type ? ['-f', `subject_type=${subject_type}`] : []),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
       );
     },
   });

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -508,6 +508,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       .strict()
       .refine((d) => (d.action ?? 'run') !== 'run' || !!d.branch, {
         message: 'branch is required when running a merge',
+      })
+      .refine((d) => d.branch === undefined || !startsLikeFlag(d.branch), {
+        message: 'branch must not start with "-"',
       }),
     execute: async ({ branch, strategy, action, cwd }, options) => {
       const opened = await open(options);
@@ -518,6 +521,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       }
       if (!branch) {
         return { success: false as const, error: 'branch is required when running a merge' };
+      }
+      if (startsLikeFlag(branch)) {
+        return { success: false as const, error: 'branch must not start with "-"' };
       }
       const strategyFlag =
         strategy === 'squash' ? ['--squash'] : strategy === 'ff-only' ? ['--ff-only'] : [];
@@ -544,6 +550,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       .strict()
       .refine((d) => (d.action ?? 'run') !== 'run' || !!d.branch_or_ref, {
         message: 'branch_or_ref is required when running a rebase',
+      })
+      .refine((d) => d.branch_or_ref === undefined || !startsLikeFlag(d.branch_or_ref), {
+        message: 'branch_or_ref must not start with "-"',
       }),
     execute: async ({ branch_or_ref, action, cwd }, options) => {
       const opened = await open(options);
@@ -554,6 +563,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       }
       if (!branch_or_ref) {
         return { success: false as const, error: 'branch_or_ref is required when running a rebase' };
+      }
+      if (startsLikeFlag(branch_or_ref)) {
+        return { success: false as const, error: 'branch_or_ref must not start with "-"' };
       }
       return git('git', ['rebase', branch_or_ref], opened.ctx, cwd);
     },

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -50,6 +50,12 @@ function isDeleteRefspec(refspec: string): boolean {
   return spec.includes(':') && spec.slice(0, spec.lastIndexOf(':')).trim() === '';
 }
 
+// A value starting with "-" passed as a bare positional CLI arg can be
+// reinterpreted as a flag by git/gh's argument parser (e.g. a ref of
+// "--exec=whoami"). Identifier-like params (refs, repo slugs, workflow names)
+// never legitimately start with "-", so reject rather than pass through.
+const startsLikeFlag = (value: string): boolean => value.startsWith('-');
+
 // Tool names returned by createSandboxGitTools, kept next to the factory so a
 // new tool is one glance away from being added here too. Consumed by
 // tool-filtering.ts to detect whether the sandbox git/gh toolkit is active —
@@ -427,14 +433,21 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   const gitShow = tool({
     description:
       'Show a commit: message, author, and full diff (or --stat summary). Use with SHAs from git_log.',
-    inputSchema: z.object({
-      ref: z.string().min(1).optional().describe('Commit SHA or ref (defaults to HEAD)'),
-      stat: z.boolean().optional().describe('Show a diffstat summary instead of the full patch'),
-      path: z.string().optional().describe('Limit output to a single file path'),
-      cwd: cwdField,
-    })
-      .strict(),
+    inputSchema: z
+      .object({
+        ref: z.string().min(1).optional().describe('Commit SHA or ref (defaults to HEAD)'),
+        stat: z.boolean().optional().describe('Show a diffstat summary instead of the full patch'),
+        path: z.string().optional().describe('Limit output to a single file path'),
+        cwd: cwdField,
+      })
+      .strict()
+      .refine((d) => d.ref === undefined || !startsLikeFlag(d.ref), {
+        message: 'ref must not start with "-"',
+      }),
     execute: async ({ ref, stat, path, cwd }, options) => {
+      if (ref !== undefined && startsLikeFlag(ref)) {
+        return { success: false as const, error: 'ref must not start with "-"' };
+      }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
       return git(
@@ -548,17 +561,38 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitRevert = tool({
     description:
-      'Revert a single commit by creating a new commit that undoes it. Safe forward-fix — history is not rewritten. Takes one commit SHA (no ranges).',
+      'Revert a single commit by creating a new commit that undoes it. Safe forward-fix — history is not rewritten. Takes one commit SHA (no ranges). If a previous revert stopped on conflicts, use action "abort" to back out or "continue" after resolving. Reverting a merge commit requires "mainline" (the parent number to revert to).',
     inputSchema: z
       .object({
         sha: z
           .string()
-          .regex(/^[0-9a-f]{4,40}$/, 'sha must be a single lowercase commit SHA (no ranges or refs)'),
+          .regex(/^[0-9a-f]{4,40}$/, 'sha must be a single lowercase commit SHA (no ranges or refs)')
+          .optional()
+          .describe('Commit to revert (required unless aborting/continuing)'),
+        action: z
+          .enum(['run', 'abort', 'continue'])
+          .optional()
+          .describe('run (default) reverts a commit; abort/continue recover a conflicted revert'),
+        mainline: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe('Parent number to revert to; required when sha is a merge commit'),
         cwd: cwdField,
       })
-      .strict(),
-    execute: async ({ sha, cwd }, options) => {
-      if (!/^[0-9a-f]{4,40}$/.test(sha)) {
+      .strict()
+      .refine((d) => (d.action ?? 'run') !== 'run' || !!d.sha, {
+        message: 'sha is required when running a revert',
+      }),
+    execute: async ({ sha, action, mainline, cwd }, options) => {
+      const mode = action ?? 'run';
+      if (mode !== 'run') {
+        const opened = await open(options);
+        if (!opened.ok) return opened.error;
+        return git('git', ['revert', `--${mode}`], opened.ctx, cwd);
+      }
+      if (!sha || !/^[0-9a-f]{4,40}$/.test(sha)) {
         return {
           success: false as const,
           error: 'sha must be a single lowercase commit SHA (no ranges or refs)',
@@ -566,7 +600,12 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       }
       const opened = await open(options);
       if (!opened.ok) return opened.error;
-      return git('git', ['revert', '--no-edit', sha], opened.ctx, cwd);
+      return git(
+        'git',
+        ['revert', '--no-edit', ...(mainline ? ['-m', String(mainline)] : []), sha],
+        opened.ctx,
+        cwd,
+      );
     },
   });
 
@@ -1207,6 +1246,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       if (!workflow || !ref) {
         return { success: false as const, error: 'workflow and ref are required' };
       }
+      if (startsLikeFlag(workflow)) {
+        return { success: false as const, error: 'workflow must not start with "-"' };
+      }
       const badInput = Object.keys(inputs ?? {}).find((k) => !/^[A-Za-z0-9_-]+$/.test(k));
       if (badInput !== undefined) {
         return {
@@ -1431,8 +1473,11 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         cwd: cwdField,
       })
       .strict(),
-    execute: async ({ repo, cwd }, options) =>
-      withToken(options, (ctx, token) =>
+    execute: async ({ repo, cwd }, options) => {
+      if (repo !== undefined && startsLikeFlag(repo)) {
+        return { success: false as const, error: 'repo must not start with "-"' };
+      }
+      return withToken(options, (ctx, token) =>
         gitR(
           'gh',
           [
@@ -1444,7 +1489,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           token,
           cwd,
         ),
-      ),
+      );
+    },
   });
 
   const ghRepoList = tool({
@@ -1457,8 +1503,11 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         cwd: cwdField,
       })
       .strict(),
-    execute: async ({ owner, limit, cwd }, options) =>
-      withToken(options, (ctx, token) =>
+    execute: async ({ owner, limit, cwd }, options) => {
+      if (owner !== undefined && startsLikeFlag(owner)) {
+        return { success: false as const, error: 'owner must not start with "-"' };
+      }
+      return withToken(options, (ctx, token) =>
         gitR(
           'gh',
           [
@@ -1471,7 +1520,8 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
           token,
           cwd,
         ),
-      ),
+      );
+    },
   });
 
   const ghRepoFork = tool({
@@ -1487,6 +1537,9 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       if (!repo) {
         return { success: false as const, error: 'repo is required' };
       }
+      if (startsLikeFlag(repo)) {
+        return { success: false as const, error: 'repo must not start with "-"' };
+      }
       return withToken(options, (ctx, token) =>
         gitR('gh', ['repo', 'fork', repo, '--clone=false', '--remote=false'], ctx, token, cwd),
       );
@@ -1500,17 +1553,21 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       .object({
         name: z
           .string()
-          .regex(/^[A-Za-z0-9._-]+$/, 'name may contain only letters, digits, ".", "_", and "-"'),
+          .regex(
+            /^[A-Za-z0-9][A-Za-z0-9._-]*$/,
+            'name must start with a letter or digit and may otherwise contain only letters, digits, ".", "_", and "-"',
+          ),
         visibility: z.enum(['private', 'public']),
         description: z.string().optional(),
         cwd: cwdField,
       })
       .strict(),
     execute: async ({ name, visibility, description, cwd }, options) => {
-      if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+      if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) {
         return {
           success: false as const,
-          error: 'name may contain only letters, digits, ".", "_", and "-"',
+          error:
+            'name must start with a letter or digit and may otherwise contain only letters, digits, ".", "_", and "-"',
         };
       }
       if (!visibility) {
@@ -1557,9 +1614,13 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
         gitR(
           'gh',
           [
-            'search', type, query,
+            'search', type,
             '--limit', String(limit ?? 20),
             '--json', jsonFields,
+            // query is genuine free text (may legitimately start with "-", e.g. "-1"
+            // or a search qualifier) — the "--" separator, not a regex reject, is
+            // what keeps gh from reinterpreting it as a flag.
+            '--', query,
           ],
           ctx,
           token,

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -1,5 +1,5 @@
 /**
- * Agent git/GitHub tools: all 35 tools running inside a sandbox.
+ * Agent git/GitHub tools: all 56 tools running inside a sandbox.
  *
  * Pure factory — no DB imports, no Sprites SDK. Production wiring lives in
  * `sandbox-git-tools-runtime.ts`. Each tool's execute handler:
@@ -56,11 +56,18 @@ function isDeleteRefspec(refspec: string): boolean {
 // checked against the factory's return keys in this file's own test suite.
 export const SANDBOX_GIT_TOOL_NAMES: readonly string[] = [
   'git_clone', 'git_init', 'git_config', 'git_remote_add', 'git_status', 'git_diff',
-  'git_add', 'git_reset', 'git_stash', 'git_commit', 'git_log', 'git_merge', 'git_rebase',
-  'git_checkout', 'git_branch', 'git_fetch', 'git_pull', 'git_push',
+  'git_add', 'git_reset', 'git_stash', 'git_commit', 'git_log', 'git_show', 'git_blame',
+  'git_merge', 'git_rebase', 'git_revert', 'git_checkout', 'git_branch',
+  'git_fetch', 'git_pull', 'git_push',
   'gh_pr_create', 'gh_pr_list', 'gh_pr_view', 'gh_pr_diff', 'gh_pr_checks', 'gh_pr_merge',
-  'gh_pr_checkout', 'gh_pr_review', 'gh_pr_review_comment', 'gh_pr_close', 'gh_pr_reopen',
-  'gh_pr_ready', 'gh_run_list', 'gh_run_view', 'gh_issue_create', 'gh_issue_list', 'gh_issue_view',
+  'gh_pr_checkout', 'gh_pr_review', 'gh_pr_review_comment', 'gh_pr_comment', 'gh_pr_edit',
+  'gh_pr_update_branch', 'gh_pr_thread_list', 'gh_pr_thread_resolve', 'gh_pr_close',
+  'gh_pr_reopen', 'gh_pr_ready',
+  'gh_run_list', 'gh_run_view', 'gh_run_rerun', 'gh_workflow_list', 'gh_workflow_run',
+  'gh_issue_create', 'gh_issue_list', 'gh_issue_view', 'gh_issue_comment', 'gh_issue_edit',
+  'gh_issue_close', 'gh_issue_reopen',
+  'gh_repo_view', 'gh_repo_list', 'gh_repo_fork', 'gh_repo_create',
+  'gh_search', 'gh_label_list',
 ];
 
 export interface GitSandboxToolsDeps {
@@ -79,6 +86,34 @@ const NO_CONNECTION_ERROR = {
     'No GitHub connection found. Connect your GitHub account in Settings → Integrations to use remote git operations.',
   reason: 'error' as const,
 };
+
+// GraphQL documents for review-thread tools. These MUST stay module-level
+// constants — variables are passed via separate -f/-F flags, never interpolated
+// into the document, so tool input can't alter the query shape.
+const LIST_THREADS_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 10) {
+            nodes { databaseId author { login } body }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const RESOLVE_THREAD_MUTATION = `mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}`;
 
 export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitSandboxToolsDeps): Record<string, Tool> {
   /** Resolve context + gate check shared by every tool. */
@@ -389,17 +424,88 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
-  const gitMerge = tool({
-    description: 'Merge a branch.',
+  const gitShow = tool({
+    description:
+      'Show a commit: message, author, and full diff (or --stat summary). Use with SHAs from git_log.',
     inputSchema: z.object({
-      branch: z.string().min(1),
-      strategy: z.enum(['merge', 'squash', 'ff-only']).optional(),
+      ref: z.string().min(1).optional().describe('Commit SHA or ref (defaults to HEAD)'),
+      stat: z.boolean().optional().describe('Show a diffstat summary instead of the full patch'),
+      path: z.string().optional().describe('Limit output to a single file path'),
       cwd: cwdField,
     })
       .strict(),
-    execute: async ({ branch, strategy, cwd }, options) => {
+    execute: async ({ ref, stat, path, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
+      return git(
+        'git',
+        ['show', ...(stat ? ['--stat'] : []), ref ?? 'HEAD', ...(path ? ['--', path] : [])],
+        opened.ctx,
+        cwd,
+      );
+    },
+  });
+
+  const gitBlame = tool({
+    description: 'Show which commit and author last modified each line of a file.',
+    inputSchema: z
+      .object({
+        path: z.string().min(1),
+        start_line: z.number().int().positive().optional(),
+        end_line: z.number().int().positive().optional(),
+        cwd: cwdField,
+      })
+      .strict()
+      .refine((d) => (d.start_line === undefined) === (d.end_line === undefined), {
+        message: 'start_line and end_line must be provided together',
+      }),
+    execute: async ({ path, start_line, end_line, cwd }, options) => {
+      if ((start_line === undefined) !== (end_line === undefined)) {
+        return { success: false as const, error: 'start_line and end_line must be provided together' };
+      }
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git(
+        'git',
+        [
+          'blame',
+          ...(start_line !== undefined ? ['-L', `${start_line},${end_line}`] : []),
+          '--',
+          path,
+        ],
+        opened.ctx,
+        cwd,
+      );
+    },
+  });
+
+  const gitMerge = tool({
+    description:
+      'Merge a branch. If a previous merge stopped on conflicts, use action "abort" to back out or "continue" after resolving.',
+    inputSchema: z
+      .object({
+        branch: z.string().min(1).optional().describe('Branch to merge (required unless aborting/continuing)'),
+        strategy: z.enum(['merge', 'squash', 'ff-only']).optional(),
+        action: z
+          .enum(['run', 'abort', 'continue'])
+          .optional()
+          .describe('run (default) merges a branch; abort/continue recover a conflicted merge'),
+        cwd: cwdField,
+      })
+      .strict()
+      .refine((d) => (d.action ?? 'run') !== 'run' || !!d.branch, {
+        message: 'branch is required when running a merge',
+      }),
+    execute: async ({ branch, strategy, action, cwd }, options) => {
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      const mode = action ?? 'run';
+      if (mode !== 'run') {
+        return git('git', ['merge', `--${mode}`], opened.ctx, cwd);
+      }
+      if (!branch) {
+        return { success: false as const, error: 'branch is required when running a merge' };
+      }
       const strategyFlag =
         strategy === 'squash' ? ['--squash'] : strategy === 'ff-only' ? ['--ff-only'] : [];
       return git('git', ['merge', ...strategyFlag, branch], opened.ctx, cwd);
@@ -407,12 +513,60 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
   });
 
   const gitRebase = tool({
-    description: 'Rebase onto a branch or ref. Non-interactive only.',
-    inputSchema: z.object({ branch_or_ref: z.string().min(1), cwd: cwdField }).strict(),
-    execute: async ({ branch_or_ref, cwd }, options) => {
+    description:
+      'Rebase onto a branch or ref. Non-interactive only. If a previous rebase stopped on conflicts, use action "abort" to back out or "continue" after resolving.',
+    inputSchema: z
+      .object({
+        branch_or_ref: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Branch or ref to rebase onto (required unless aborting/continuing)'),
+        action: z
+          .enum(['run', 'abort', 'continue'])
+          .optional()
+          .describe('run (default) starts a rebase; abort/continue recover a conflicted rebase'),
+        cwd: cwdField,
+      })
+      .strict()
+      .refine((d) => (d.action ?? 'run') !== 'run' || !!d.branch_or_ref, {
+        message: 'branch_or_ref is required when running a rebase',
+      }),
+    execute: async ({ branch_or_ref, action, cwd }, options) => {
       const opened = await open(options);
       if (!opened.ok) return opened.error;
+      const mode = action ?? 'run';
+      if (mode !== 'run') {
+        return git('git', ['rebase', `--${mode}`], opened.ctx, cwd);
+      }
+      if (!branch_or_ref) {
+        return { success: false as const, error: 'branch_or_ref is required when running a rebase' };
+      }
       return git('git', ['rebase', branch_or_ref], opened.ctx, cwd);
+    },
+  });
+
+  const gitRevert = tool({
+    description:
+      'Revert a single commit by creating a new commit that undoes it. Safe forward-fix — history is not rewritten. Takes one commit SHA (no ranges).',
+    inputSchema: z
+      .object({
+        sha: z
+          .string()
+          .regex(/^[0-9a-f]{4,40}$/, 'sha must be a single lowercase commit SHA (no ranges or refs)'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ sha, cwd }, options) => {
+      if (!/^[0-9a-f]{4,40}$/.test(sha)) {
+        return {
+          success: false as const,
+          error: 'sha must be a single lowercase commit SHA (no ranges or refs)',
+        };
+      }
+      const opened = await open(options);
+      if (!opened.ok) return opened.error;
+      return git('git', ['revert', '--no-edit', sha], opened.ctx, cwd);
     },
   });
 
@@ -482,7 +636,7 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
 
   const gitPush = tool({
     description:
-      'Push to a remote. Requires a connected GitHub account. cwd defaults to /workspace — pass it to push from a cloned subdir. Force-push (--force-with-lease) is allowed on feature/PR branches but refused for the default branch (main/master); to update an open PR, push to its branch rather than opening a new one.',
+      'Push to a remote. Requires a connected GitHub account. cwd defaults to /workspace — pass it to push from a cloned subdir. Force-push (--force-with-lease) is allowed on feature/PR branches but refused for the default branch (main/master); to update an open PR, push to its branch rather than opening a new one. Note: pushes touching .github/workflows files require a GitHub connection made after workflow permissions were added — ask the user to reconnect GitHub in Settings → Integrations if GitHub refuses the push.',
     inputSchema: z.object({
       remote: z.string().optional(),
       branch: z.string().optional(),
@@ -755,6 +909,148 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     },
   });
 
+  const ghPrComment = tool({
+    description:
+      'Add a top-level conversation comment on a pull request (not a review). For inline code comments use gh_pr_review_comment; to approve/request changes use gh_pr_review. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        body: z.string().min(1),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ number, body, cwd }, options) => {
+      if (!body) {
+        return { success: false as const, error: 'body is required' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR('gh', ['pr', 'comment', String(number), '--body', body], ctx, token, cwd),
+      );
+    },
+  });
+
+  const ghPrEdit = tool({
+    description:
+      'Edit a pull request: title, body, base branch, labels, or reviewers. Use to keep the PR description current as follow-up commits land. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        title: z.string().optional(),
+        body: z.string().optional(),
+        base: z.string().optional().describe('New base branch'),
+        add_labels: z.array(z.string()).optional(),
+        remove_labels: z.array(z.string()).optional(),
+        add_reviewers: z.array(z.string()).optional().describe('GitHub usernames to request review from'),
+        cwd: cwdField,
+      })
+      .strict()
+      .refine(
+        (d) =>
+          d.title !== undefined ||
+          d.body !== undefined ||
+          d.base !== undefined ||
+          !!d.add_labels?.length ||
+          !!d.remove_labels?.length ||
+          !!d.add_reviewers?.length,
+        { message: 'Provide at least one field to edit' },
+      ),
+    execute: async ({ number, title, body, base, add_labels, remove_labels, add_reviewers, cwd }, options) => {
+      if (
+        title === undefined &&
+        body === undefined &&
+        base === undefined &&
+        !add_labels?.length &&
+        !remove_labels?.length &&
+        !add_reviewers?.length
+      ) {
+        return { success: false as const, error: 'Provide at least one field to edit' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'pr', 'edit', String(number),
+            ...(title !== undefined ? ['--title', title] : []),
+            ...(body !== undefined ? ['--body', body] : []),
+            ...(base !== undefined ? ['--base', base] : []),
+            ...(add_labels?.length ? ['--add-label', add_labels.join(',')] : []),
+            ...(remove_labels?.length ? ['--remove-label', remove_labels.join(',')] : []),
+            ...(add_reviewers?.length ? ['--add-reviewer', add_reviewers.join(',')] : []),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      );
+    },
+  });
+
+  const ghPrUpdateBranch = tool({
+    description:
+      'Update a pull request branch with the latest changes from its base branch (like the "Update branch" button). Requires a connected GitHub account.',
+    inputSchema: z
+      .object({ number: z.number().int().positive(), cwd: cwdField })
+      .strict(),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR('gh', ['pr', 'update-branch', String(number)], ctx, token, cwd),
+      ),
+  });
+
+  const ghPrThreadList = tool({
+    description:
+      'List review threads on a pull request with their resolved state and thread IDs. Use the thread id with gh_pr_thread_resolve after addressing feedback. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        owner: z.string().min(1).describe('Repository owner'),
+        repo: z.string().min(1).describe('Repository name'),
+        number: z.number().int().positive(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ owner, repo, number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'api', 'graphql',
+            '-f', `query=${LIST_THREADS_QUERY}`,
+            '-f', `owner=${owner}`,
+            '-f', `repo=${repo}`,
+            '-F', `number=${number}`,
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghPrThreadResolve = tool({
+    description:
+      'Resolve a pull request review thread after its feedback has been addressed. Get thread IDs from gh_pr_thread_list. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        thread_id: z.string().min(1).describe('Review thread node ID from gh_pr_thread_list'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ thread_id, cwd }, options) => {
+      if (!thread_id) {
+        return { success: false as const, error: 'thread_id is required' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          ['api', 'graphql', '-f', `query=${RESOLVE_THREAD_MUTATION}`, '-f', `threadId=${thread_id}`],
+          ctx,
+          token,
+          cwd,
+        ),
+      );
+    },
+  });
+
   const ghPrClose = tool({
     description: 'Close a pull request with an optional comment. Requires a connected GitHub account.',
     inputSchema: z
@@ -857,6 +1153,83 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       ),
   });
 
+  const ghRunRerun = tool({
+    description:
+      'Re-run a GitHub Actions workflow run. Pass failed_only: true to re-run only the failed jobs (the usual choice for flaky CI). Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        runId: z.number().int().positive().describe('Run databaseId from gh_run_list'),
+        failed_only: z.boolean().optional().describe('Re-run only the failed jobs'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ runId, failed_only, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR('gh', ['run', 'rerun', String(runId), ...(failed_only ? ['--failed'] : [])], ctx, token, cwd),
+      ),
+  });
+
+  const ghWorkflowList = tool({
+    description: 'List GitHub Actions workflows in the repository. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        limit: z.number().int().positive().max(100).optional(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ limit, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          ['workflow', 'list', '--limit', String(limit ?? 50), '--json', 'id,name,path,state'],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghWorkflowRun = tool({
+    description:
+      'Dispatch a GitHub Actions workflow run on a ref. WARNING: this triggers real automation (deploys, releases, jobs) — only dispatch workflows you understand. The workflow must have a workflow_dispatch trigger. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        workflow: z.string().min(1).describe('Workflow file name (e.g. "ci.yml") or ID'),
+        ref: z.string().min(1).describe('Branch or tag to run the workflow on'),
+        inputs: z
+          .record(z.string().regex(/^[A-Za-z0-9_-]+$/, 'input names must be alphanumeric/_/-'), z.string())
+          .optional()
+          .describe('workflow_dispatch inputs as key/value pairs'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ workflow, ref, inputs, cwd }, options) => {
+      if (!workflow || !ref) {
+        return { success: false as const, error: 'workflow and ref are required' };
+      }
+      const badInput = Object.keys(inputs ?? {}).find((k) => !/^[A-Za-z0-9_-]+$/.test(k));
+      if (badInput !== undefined) {
+        return {
+          success: false as const,
+          error: `Invalid workflow input name "${badInput}" — input names must be alphanumeric/_/-`,
+        };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'workflow', 'run', workflow,
+            '--ref', ref,
+            ...Object.entries(inputs ?? {}).flatMap(([key, value]) => ['-f', `${key}=${value}`]),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      );
+    },
+  });
+
   // ── GitHub Issues (token required) ──────────────────────────────────────
 
   const ghIssueCreate = tool({
@@ -933,6 +1306,296 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
       ),
   });
 
+  const ghIssueComment = tool({
+    description: 'Add a comment to an issue. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        body: z.string().min(1),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ number, body, cwd }, options) => {
+      if (!body) {
+        return { success: false as const, error: 'body is required' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR('gh', ['issue', 'comment', String(number), '--body', body], ctx, token, cwd),
+      );
+    },
+  });
+
+  const ghIssueEdit = tool({
+    description:
+      'Edit an issue: title, body, labels, or assignees. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        title: z.string().optional(),
+        body: z.string().optional(),
+        add_labels: z.array(z.string()).optional(),
+        remove_labels: z.array(z.string()).optional(),
+        add_assignees: z.array(z.string()).optional().describe('GitHub usernames to assign'),
+        remove_assignees: z.array(z.string()).optional().describe('GitHub usernames to unassign'),
+        cwd: cwdField,
+      })
+      .strict()
+      .refine(
+        (d) =>
+          d.title !== undefined ||
+          d.body !== undefined ||
+          !!d.add_labels?.length ||
+          !!d.remove_labels?.length ||
+          !!d.add_assignees?.length ||
+          !!d.remove_assignees?.length,
+        { message: 'Provide at least one field to edit' },
+      ),
+    execute: async (
+      { number, title, body, add_labels, remove_labels, add_assignees, remove_assignees, cwd },
+      options,
+    ) => {
+      if (
+        title === undefined &&
+        body === undefined &&
+        !add_labels?.length &&
+        !remove_labels?.length &&
+        !add_assignees?.length &&
+        !remove_assignees?.length
+      ) {
+        return { success: false as const, error: 'Provide at least one field to edit' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'issue', 'edit', String(number),
+            ...(title !== undefined ? ['--title', title] : []),
+            ...(body !== undefined ? ['--body', body] : []),
+            ...(add_labels?.length ? ['--add-label', add_labels.join(',')] : []),
+            ...(remove_labels?.length ? ['--remove-label', remove_labels.join(',')] : []),
+            ...(add_assignees?.length ? ['--add-assignee', add_assignees.join(',')] : []),
+            ...(remove_assignees?.length ? ['--remove-assignee', remove_assignees.join(',')] : []),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      );
+    },
+  });
+
+  const ghIssueClose = tool({
+    description:
+      'Close an issue with an optional comment and reason. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        number: z.number().int().positive(),
+        comment: z.string().optional().describe('Comment to post when closing'),
+        reason: z.enum(['completed', 'not_planned']).optional(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ number, comment, reason, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'issue', 'close', String(number),
+            ...(comment ? ['--comment', comment] : []),
+            ...(reason ? ['--reason', reason === 'not_planned' ? 'not planned' : 'completed'] : []),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghIssueReopen = tool({
+    description: 'Reopen a closed issue. Requires a connected GitHub account.',
+    inputSchema: z.object({ number: z.number().int().positive(), cwd: cwdField }).strict(),
+    execute: async ({ number, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR('gh', ['issue', 'reopen', String(number)], ctx, token, cwd),
+      ),
+  });
+
+  // ── GitHub repos, search, labels (token required) ───────────────────────
+
+  const ghRepoView = tool({
+    description:
+      'View a repository: default branch, visibility, and description. Use before cloning to discover the default branch instead of guessing main/master. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        repo: z.string().optional().describe('Repository as "owner/repo" (defaults to the repo in cwd)'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ repo, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'repo', 'view',
+            ...(repo ? [repo] : []),
+            '--json', 'nameWithOwner,description,defaultBranchRef,visibility,url,isFork',
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghRepoList = tool({
+    description:
+      'List repositories for the connected account or a given owner/org. Use to discover repos to clone. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        owner: z.string().optional().describe('User or org to list repos for (defaults to the connected account)'),
+        limit: z.number().int().positive().max(100).optional(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ owner, limit, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'repo', 'list',
+            ...(owner ? [owner] : []),
+            '--limit', String(limit ?? 30),
+            '--json', 'nameWithOwner,description,visibility,updatedAt,url',
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
+  const ghRepoFork = tool({
+    description:
+      'Fork a repository to the connected account (fork only — clone it explicitly with git_clone afterwards). Use to contribute to repos without push access. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        repo: z.string().min(1).describe('Repository to fork as "owner/repo"'),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ repo, cwd }, options) => {
+      if (!repo) {
+        return { success: false as const, error: 'repo is required' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR('gh', ['repo', 'fork', repo, '--clone=false', '--remote=false'], ctx, token, cwd),
+      );
+    },
+  });
+
+  const ghRepoCreate = tool({
+    description:
+      'Create a new repository on the connected account. Visibility must be chosen explicitly. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        name: z
+          .string()
+          .regex(/^[A-Za-z0-9._-]+$/, 'name may contain only letters, digits, ".", "_", and "-"'),
+        visibility: z.enum(['private', 'public']),
+        description: z.string().optional(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ name, visibility, description, cwd }, options) => {
+      if (!/^[A-Za-z0-9._-]+$/.test(name)) {
+        return {
+          success: false as const,
+          error: 'name may contain only letters, digits, ".", "_", and "-"',
+        };
+      }
+      if (!visibility) {
+        return { success: false as const, error: 'visibility is required (private or public)' };
+      }
+      return withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'repo', 'create', name,
+            visibility === 'private' ? '--private' : '--public',
+            ...(description ? ['--description', description] : []),
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      );
+    },
+  });
+
+  const ghSearch = tool({
+    description:
+      'Search GitHub for code, issues, pull requests, or repositories. Uses GitHub search syntax — include "repo:owner/repo" to scope to a repository. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        type: z.enum(['code', 'issues', 'prs', 'repos']),
+        query: z.string().min(1),
+        limit: z.number().int().positive().max(100).optional(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ type, query, limit, cwd }, options) => {
+      if (!query) {
+        return { success: false as const, error: 'query is required' };
+      }
+      const jsonFields =
+        type === 'code'
+          ? 'repository,path,url'
+          : type === 'repos'
+            ? 'fullName,description,url'
+            : 'number,title,state,url,repository';
+      return withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'search', type, query,
+            '--limit', String(limit ?? 20),
+            '--json', jsonFields,
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      );
+    },
+  });
+
+  const ghLabelList = tool({
+    description:
+      'List the labels available in a repository. Check here before applying labels to issues or PRs. Requires a connected GitHub account.',
+    inputSchema: z
+      .object({
+        repo: z.string().optional().describe('Repository as "owner/repo" (defaults to the repo in cwd)'),
+        limit: z.number().int().positive().max(100).optional(),
+        cwd: cwdField,
+      })
+      .strict(),
+    execute: async ({ repo, limit, cwd }, options) =>
+      withToken(options, (ctx, token) =>
+        gitR(
+          'gh',
+          [
+            'label', 'list',
+            ...(repo ? ['--repo', repo] : []),
+            '--limit', String(limit ?? 50),
+            '--json', 'name,description,color',
+          ],
+          ctx,
+          token,
+          cwd,
+        ),
+      ),
+  });
+
   return {
     git_clone: gitClone,
     git_init: gitInit,
@@ -945,8 +1608,11 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     git_stash: gitStash,
     git_commit: gitCommit,
     git_log: gitLog,
+    git_show: gitShow,
+    git_blame: gitBlame,
     git_merge: gitMerge,
     git_rebase: gitRebase,
+    git_revert: gitRevert,
     git_checkout: gitCheckout,
     git_branch: gitBranch,
     git_fetch: gitFetch,
@@ -961,13 +1627,31 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate }: GitS
     gh_pr_checkout: ghPrCheckout,
     gh_pr_review: ghPrReview,
     gh_pr_review_comment: ghPrReviewComment,
+    gh_pr_comment: ghPrComment,
+    gh_pr_edit: ghPrEdit,
+    gh_pr_update_branch: ghPrUpdateBranch,
+    gh_pr_thread_list: ghPrThreadList,
+    gh_pr_thread_resolve: ghPrThreadResolve,
     gh_pr_close: ghPrClose,
     gh_pr_reopen: ghPrReopen,
     gh_pr_ready: ghPrReady,
     gh_run_list: ghRunList,
     gh_run_view: ghRunView,
+    gh_run_rerun: ghRunRerun,
+    gh_workflow_list: ghWorkflowList,
+    gh_workflow_run: ghWorkflowRun,
     gh_issue_create: ghIssueCreate,
     gh_issue_list: ghIssueList,
     gh_issue_view: ghIssueView,
+    gh_issue_comment: ghIssueComment,
+    gh_issue_edit: ghIssueEdit,
+    gh_issue_close: ghIssueClose,
+    gh_issue_reopen: ghIssueReopen,
+    gh_repo_view: ghRepoView,
+    gh_repo_list: ghRepoList,
+    gh_repo_fork: ghRepoFork,
+    gh_repo_create: ghRepoCreate,
+    gh_search: ghSearch,
+    gh_label_list: ghLabelList,
   };
 }

--- a/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
@@ -279,6 +279,7 @@ describe('executeWorkflow', () => {
       agentId: 'agent_1',
       userId: 'user_123',
       driveId: 'drive_abc',
+      currentTools: {},
     });
 
     const genCall = vi.mocked(generateText).mock.calls[0][0] as Record<string, unknown>;

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -269,6 +269,7 @@ async function runExecution(input: WorkflowExecutionInput, startTime: number): P
         agentId: agent.id,
         userId: input.createdBy,
         driveId: input.driveId,
+        currentTools: availableTools,
       });
 
       if (Object.keys(integrationTools).length > 0) {

--- a/packages/lib/src/integrations/execution/build-request.test.ts
+++ b/packages/lib/src/integrations/execution/build-request.test.ts
@@ -90,6 +90,69 @@ describe('interpolatePath', () => {
       interpolatePath({ template, input, rawPathParams: ['path'] })
     ).toThrow(/path/);
   });
+
+  it('given a rawPathParams value with percent-encoded ".." segments, should throw', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = {
+      owner: 'acme',
+      repo: 'webapp',
+      path: '%2e%2e/%2e%2e/other-org/other-repo/contents/secret.txt',
+    };
+
+    expect(() =>
+      interpolatePath({ template, input, rawPathParams: ['path'] })
+    ).toThrow(/path/);
+  });
+
+  it('given a rawPathParams value with mixed-case percent-encoded ".." segments, should throw', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = { owner: 'acme', repo: 'webapp', path: '%2E%2e/other-org/other-repo/contents/x' };
+
+    expect(() =>
+      interpolatePath({ template, input, rawPathParams: ['path'] })
+    ).toThrow(/path/);
+  });
+
+  it('given a rawPathParams value mixing a literal dot with a percent-encoded dot (".%2e"), should throw', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = { owner: 'acme', repo: 'webapp', path: '.%2e/other-org/other-repo/contents/x' };
+
+    expect(() =>
+      interpolatePath({ template, input, rawPathParams: ['path'] })
+    ).toThrow(/path/);
+  });
+
+  it('given a rawPathParams value containing a backslash, should throw rather than let it act as a path separator', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = { owner: 'acme', repo: 'webapp', path: '..\\..\\other-org\\other-repo\\contents\\x' };
+
+    expect(() =>
+      interpolatePath({ template, input, rawPathParams: ['path'] })
+    ).toThrow(/path/);
+  });
+
+  it('given a plain identifier param with a percent-encoded ".." value, should throw', () => {
+    const template = '/repos/{owner}/{repo}';
+    const input = { owner: '%2e%2e', repo: 'webapp' };
+
+    expect(() => interpolatePath({ template, input })).toThrow(/owner/);
+  });
+
+  it('given a plain identifier param containing a backslash, should throw', () => {
+    const template = '/repos/{owner}/{repo}';
+    const input = { owner: 'acme\\evil', repo: 'webapp' };
+
+    expect(() => interpolatePath({ template, input })).toThrow(/owner/);
+  });
+
+  it('given a rawPathParams value with a legitimate dotted segment (".github"), should preserve it', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = { owner: 'acme', repo: 'webapp', path: '.github/workflows/ci.yml' };
+
+    const result = interpolatePath({ template, input, rawPathParams: ['path'] });
+
+    expect(result).toBe('/repos/acme/webapp/contents/.github/workflows/ci.yml');
+  });
 });
 
 describe('resolveValue', () => {

--- a/packages/lib/src/integrations/execution/build-request.test.ts
+++ b/packages/lib/src/integrations/execution/build-request.test.ts
@@ -14,7 +14,7 @@ describe('interpolatePath', () => {
     const template = '/repos/{owner}/{repo}/issues';
     const input = { owner: 'acme', repo: 'webapp' };
 
-    const result = interpolatePath(template, input);
+    const result = interpolatePath({ template, input });
 
     expect(result).toBe('/repos/acme/webapp/issues');
   });
@@ -23,7 +23,7 @@ describe('interpolatePath', () => {
     const template = '/user/repos';
     const input = {};
 
-    const result = interpolatePath(template, input);
+    const result = interpolatePath({ template, input });
 
     expect(result).toBe('/user/repos');
   });
@@ -32,7 +32,7 @@ describe('interpolatePath', () => {
     const template = '/repos/{owner}/{repo}';
     const input = { owner: 'acme' };
 
-    const result = interpolatePath(template, input);
+    const result = interpolatePath({ template, input });
 
     expect(result).toBe('/repos/acme/');
   });
@@ -41,9 +41,54 @@ describe('interpolatePath', () => {
     const template = '/issues/{issueNumber}';
     const input = { issueNumber: 123 };
 
-    const result = interpolatePath(template, input);
+    const result = interpolatePath({ template, input });
 
     expect(result).toBe('/issues/123');
+  });
+
+  it('given a plain identifier param containing "..", should throw rather than build a traversing path', () => {
+    const template = '/repos/{owner}/{repo}/issues';
+    const input = { owner: '..', repo: 'webapp' };
+
+    expect(() => interpolatePath({ template, input })).toThrow(/owner/);
+  });
+
+  it('given a plain identifier param containing a literal slash, should throw', () => {
+    const template = '/repos/{owner}/{repo}/issues';
+    const input = { owner: 'acme/evil', repo: 'webapp' };
+
+    expect(() => interpolatePath({ template, input })).toThrow(/owner/);
+  });
+
+  it('given a rawPathParams value containing ".." segments, should throw rather than escape the base path', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = {
+      owner: 'acme',
+      repo: 'webapp',
+      path: '../../other-org/other-repo/contents/secret.txt',
+    };
+
+    expect(() =>
+      interpolatePath({ template, input, rawPathParams: ['path'] })
+    ).toThrow(/path/);
+  });
+
+  it('given a rawPathParams value with legitimate nested slashes, should preserve them literally', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = { owner: 'acme', repo: 'webapp', path: 'src/components/Foo.tsx' };
+
+    const result = interpolatePath({ template, input, rawPathParams: ['path'] });
+
+    expect(result).toBe('/repos/acme/webapp/contents/src/components/Foo.tsx');
+  });
+
+  it('given a rawPathParams value that is exactly "..", should throw', () => {
+    const template = '/repos/{owner}/{repo}/contents/{path}';
+    const input = { owner: 'acme', repo: 'webapp', path: '..' };
+
+    expect(() =>
+      interpolatePath({ template, input, rawPathParams: ['path'] })
+    ).toThrow(/path/);
   });
 });
 
@@ -360,5 +405,57 @@ describe('buildHttpRequest', () => {
     const result = buildHttpRequest(config, {}, 'https://api.example.com');
 
     expect(result.url).toBe('https://api.example.com/items');
+  });
+
+  it('given a "path" value containing "../" and no rawPathParams declared, should throw rather than build an escaping URL', () => {
+    const config: HttpExecutionConfig = {
+      method: 'PUT',
+      pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+      bodyTemplate: { message: { $param: 'message' } },
+    };
+    const input = {
+      owner: 'acme',
+      repo: 'webapp',
+      path: '../../other-org/other-repo/contents/secret.txt',
+      message: 'evil commit',
+    };
+
+    expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+  });
+
+  it('given a "path" value containing "../" with rawPathParams declared, should still throw', () => {
+    const config: HttpExecutionConfig = {
+      method: 'PUT',
+      pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+      rawPathParams: ['path'],
+      bodyTemplate: { message: { $param: 'message' } },
+    };
+    const input = {
+      owner: 'acme',
+      repo: 'webapp',
+      path: '../../other-org/other-repo/contents/secret.txt',
+      message: 'evil commit',
+    };
+
+    expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+  });
+
+  it('given a legitimate nested "path" value with rawPathParams declared, should build the correct URL', () => {
+    const config: HttpExecutionConfig = {
+      method: 'PUT',
+      pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+      rawPathParams: ['path'],
+      bodyTemplate: { message: { $param: 'message' } },
+    };
+    const input = {
+      owner: 'acme',
+      repo: 'webapp',
+      path: 'src/components/Foo.tsx',
+      message: 'update Foo',
+    };
+
+    const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+    expect(result.url).toBe('https://api.github.com/repos/acme/webapp/contents/src/components/Foo.tsx');
   });
 });

--- a/packages/lib/src/integrations/execution/build-request.ts
+++ b/packages/lib/src/integrations/execution/build-request.ts
@@ -7,16 +7,30 @@
 
 import type { HttpExecutionConfig, HttpRequest, ParameterRef } from '../types';
 
-const isDotSegment = (segment: string): boolean => segment === '.' || segment === '..';
+// The WHATWG URL Standard's path state treats these literal (ASCII
+// case-insensitive) strings as single-/double-dot segments — and normalizes
+// them — even though they aren't the literal "." / "..". A segment check
+// that only compares against "." / ".." disagrees with what `URL.pathname =`
+// actually normalizes, so it can be bypassed with e.g. "%2e%2e". Backslash is
+// also treated as a path separator by the URL parser for special schemes
+// (http/https among them), so it must be rejected outright rather than
+// split on — it isn't a legitimate character in a GitHub API path segment.
+const SINGLE_DOT_SEGMENT = /^(\.|%2e)$/i;
+const DOUBLE_DOT_SEGMENT = /^(\.\.|\.%2e|%2e\.|%2e%2e)$/i;
+const isDotSegment = (segment: string): boolean =>
+  SINGLE_DOT_SEGMENT.test(segment) || DOUBLE_DOT_SEGMENT.test(segment);
 
 /**
  * A raw path param may contain literal "/" (e.g. a nested file path), but
- * every segment must still be non-empty and not "." or "..", otherwise a
- * value like "../../other-repo/contents/x" walks the built URL out of the
- * intended path prefix once assigned to `URL.pathname` (which normalizes
- * dot-segments).
+ * every segment must still be non-empty and not a dot-segment, otherwise a
+ * value like "../../other-repo/contents/x" (or its percent-encoded
+ * equivalent) walks the built URL out of the intended path prefix once
+ * assigned to `URL.pathname` (which normalizes dot-segments).
  */
 const assertNoTraversal = ({ key, value }: { key: string; value: string }): string => {
+  if (value.includes('\\')) {
+    throw new Error(`Path parameter "${key}" must not contain "\\"`);
+  }
   if (value.split('/').some((segment) => segment === '' || isDotSegment(segment))) {
     throw new Error(`Path parameter "${key}" must not contain empty or "."/".." segments`);
   }
@@ -29,7 +43,7 @@ const assertNoTraversal = ({ key, value }: { key: string; value: string }): stri
  * structure rather than fill a single path segment.
  */
 const assertPlainIdentifier = ({ key, value }: { key: string; value: string }): string => {
-  if (value.includes('/') || isDotSegment(value)) {
+  if (value.includes('/') || value.includes('\\') || isDotSegment(value)) {
     throw new Error(`Path parameter "${key}" must not contain "/" or be "." or ".."`);
   }
   return value;

--- a/packages/lib/src/integrations/execution/build-request.ts
+++ b/packages/lib/src/integrations/execution/build-request.ts
@@ -7,17 +7,57 @@
 
 import type { HttpExecutionConfig, HttpRequest, ParameterRef } from '../types';
 
+const isDotSegment = (segment: string): boolean => segment === '.' || segment === '..';
+
+/**
+ * A raw path param may contain literal "/" (e.g. a nested file path), but
+ * every segment must still be non-empty and not "." or "..", otherwise a
+ * value like "../../other-repo/contents/x" walks the built URL out of the
+ * intended path prefix once assigned to `URL.pathname` (which normalizes
+ * dot-segments).
+ */
+const assertNoTraversal = ({ key, value }: { key: string; value: string }): string => {
+  if (value.split('/').some((segment) => segment === '' || isDotSegment(segment))) {
+    throw new Error(`Path parameter "${key}" must not contain empty or "."/".." segments`);
+  }
+  return value;
+};
+
+/**
+ * A plain identifier param (owner, repo, ref, sha, ...) should never carry a
+ * path separator or a dot-segment; allowing either lets it reshape the URL
+ * structure rather than fill a single path segment.
+ */
+const assertPlainIdentifier = ({ key, value }: { key: string; value: string }): string => {
+  if (value.includes('/') || isDotSegment(value)) {
+    throw new Error(`Path parameter "${key}" must not contain "/" or be "." or ".."`);
+  }
+  return value;
+};
+
 /**
  * Interpolate path template with input values.
  * Replaces {param} placeholders with corresponding input values.
+ * Params listed in `rawPathParams` may contain literal "/" (still traversal-checked);
+ * every other param must be a plain identifier with no "/" or "."/".." segments.
  */
-export const interpolatePath = (
-  template: string,
-  input: Record<string, unknown>
-): string => {
+export const interpolatePath = ({
+  template,
+  input,
+  rawPathParams = [],
+}: {
+  template: string;
+  input: Record<string, unknown>;
+  rawPathParams?: string[];
+}): string => {
+  const rawKeys = new Set(rawPathParams);
   return template.replace(/\{(\w+)\}/g, (_, key) => {
     const value = input[key];
-    return value !== undefined ? String(value) : '';
+    if (value === undefined) return '';
+    const str = String(value);
+    return rawKeys.has(key)
+      ? assertNoTraversal({ key, value: str })
+      : assertPlainIdentifier({ key, value: str });
   });
 };
 
@@ -135,7 +175,11 @@ export const buildHttpRequest = (
   baseUrl: string
 ): HttpRequest => {
   // Build path
-  const path = interpolatePath(config.pathTemplate, input);
+  const path = interpolatePath({
+    template: config.pathTemplate,
+    input,
+    rawPathParams: config.rawPathParams,
+  });
 
   // Build URL - properly merge base path with request path
   const baseUrlObj = new URL(baseUrl);

--- a/packages/lib/src/integrations/providers/generic-webhook.test.ts
+++ b/packages/lib/src/integrations/providers/generic-webhook.test.ts
@@ -198,6 +198,14 @@ describe('genericWebhookProvider', () => {
         buildHttpRequest(config, { path: '../../admin/reset' }, 'https://hooks.example.com')
       ).toThrow();
     });
+
+    it('given a path containing percent-encoded "../" segments, should throw rather than escape the webhook host path', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+
+      expect(() =>
+        buildHttpRequest(config, { path: '%2e%2e/%2e%2e/admin/reset' }, 'https://hooks.example.com')
+      ).toThrow();
+    });
   });
 
   describe('send_form_webhook tool', () => {

--- a/packages/lib/src/integrations/providers/generic-webhook.test.ts
+++ b/packages/lib/src/integrations/providers/generic-webhook.test.ts
@@ -190,6 +190,14 @@ describe('genericWebhookProvider', () => {
 
       expect(result.url).toBe('https://hooks.example.com/api/v2/events');
     });
+
+    it('given a path containing "../" segments, should throw rather than escape the webhook host path', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+
+      expect(() =>
+        buildHttpRequest(config, { path: '../../admin/reset' }, 'https://hooks.example.com')
+      ).toThrow();
+    });
   });
 
   describe('send_form_webhook tool', () => {
@@ -216,6 +224,17 @@ describe('genericWebhookProvider', () => {
       expect(result.method).toBe('POST');
       expect(result.url).toBe('https://hooks.example.com/notify');
       expect(result.body).toBe('channel=%23general&text=hello');
+    });
+  });
+
+  describe('path parameter traversal wiring', () => {
+    it('given send_webhook, send_get_webhook, and send_form_webhook, should each declare rawPathParams: ["path"]', () => {
+      const pathTools = ['send_webhook', 'send_get_webhook', 'send_form_webhook'];
+      for (const id of pathTools) {
+        const tool = genericWebhookProvider.tools.find((t) => t.id === id)!;
+        const config = (tool.execution as { config: HttpExecutionConfig }).config;
+        expect(config.rawPathParams).toEqual(['path']);
+      }
     });
   });
 

--- a/packages/lib/src/integrations/providers/generic-webhook.ts
+++ b/packages/lib/src/integrations/providers/generic-webhook.ts
@@ -76,6 +76,7 @@ export const genericWebhookProvider: IntegrationProviderConfig = {
         config: {
           method: 'POST',
           pathTemplate: '/{path}',
+          rawPathParams: ['path'],
           bodyTemplate: { $param: 'body' },
           bodyEncoding: 'json',
         },
@@ -102,6 +103,7 @@ export const genericWebhookProvider: IntegrationProviderConfig = {
         config: {
           method: 'GET',
           pathTemplate: '/{path}',
+          rawPathParams: ['path'],
         },
       },
     },
@@ -129,6 +131,7 @@ export const genericWebhookProvider: IntegrationProviderConfig = {
         config: {
           method: 'POST',
           pathTemplate: '/{path}',
+          rawPathParams: ['path'],
           bodyTemplate: { $param: 'body' },
           bodyEncoding: 'form',
         },

--- a/packages/lib/src/integrations/providers/github.test.ts
+++ b/packages/lib/src/integrations/providers/github.test.ts
@@ -410,6 +410,22 @@ describe('githubProvider', () => {
       expect(tool.outputTransform!.mapping).toHaveProperty('encoding');
       expect(tool.outputTransform!.mapping).toHaveProperty('sha');
     });
+
+    it('given a path containing "../" segments, should throw rather than escape the declared repo', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: '../../other-org/other-repo/contents/secret.txt',
+      };
+
+      expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+    });
+
+    it('given the tool config, should declare rawPathParams: ["path"]', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      expect(config.rawPathParams).toEqual(['path']);
+    });
   });
 
   describe('get_repo_tree tool', () => {
@@ -954,6 +970,24 @@ describe('githubProvider', () => {
 
       expect(JSON.parse(result.body!).sha).toBe('blob123');
     });
+
+    it('given a path containing "../" segments, should throw rather than write to a different repo', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: '../../other-org/other-repo/contents/secret.txt',
+        message: 'evil commit',
+        content: 'aGVsbG8=',
+      };
+
+      expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+    });
+
+    it('given the tool config, should declare rawPathParams: ["path"]', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      expect(config.rawPathParams).toEqual(['path']);
+    });
   });
 
   describe('delete_file tool', () => {
@@ -984,6 +1018,24 @@ describe('githubProvider', () => {
       expect(body.message).toBe('chore: remove legacy module');
       expect(body.sha).toBe('blob123');
       expect(body.branch).toBe('cleanup');
+    });
+
+    it('given a path containing "../" segments, should throw rather than delete from a different repo', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: '../../other-org/other-repo/contents/secret.txt',
+        message: 'evil delete',
+        sha: 'blob123',
+      };
+
+      expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+    });
+
+    it('given the tool config, should declare rawPathParams: ["path"]', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      expect(config.rawPathParams).toEqual(['path']);
     });
   });
 

--- a/packages/lib/src/integrations/providers/github.test.ts
+++ b/packages/lib/src/integrations/providers/github.test.ts
@@ -20,11 +20,12 @@ describe('githubProvider', () => {
       expect(githubProvider.name).toBe('GitHub');
     });
 
-    it('given the provider config, should use OAuth2 auth with repo and read:user scopes', () => {
+    it('given the provider config, should use OAuth2 auth with repo, workflow, and read:user scopes', () => {
       const { authMethod } = githubProvider;
       expect(authMethod.type).toBe('oauth2');
       if (authMethod.type !== 'oauth2') throw new Error('unexpected auth type');
       expect(authMethod.config.scopes).toContain('repo');
+      expect(authMethod.config.scopes).toContain('workflow');
       expect(authMethod.config.scopes).toContain('read:user');
       expect(authMethod.config.pkceRequired).toBe(false);
     });
@@ -64,8 +65,8 @@ describe('githubProvider', () => {
       });
     });
 
-    it('given the provider config, should have 19 tools', () => {
-      expect(githubProvider.tools).toHaveLength(19);
+    it('given the provider config, should have 31 tools', () => {
+      expect(githubProvider.tools).toHaveLength(31);
     });
   });
 
@@ -78,6 +79,12 @@ describe('githubProvider', () => {
       'list_branches',
       'search_code',
       'get_commit',
+      'list_commits',
+      'compare_refs',
+      'list_check_runs',
+      'list_workflow_runs',
+      'search_issues',
+      'list_labels',
       'list_issues',
       'list_issue_comments',
       'get_pull_request',
@@ -93,6 +100,12 @@ describe('githubProvider', () => {
       'create_issue_comment',
       'create_pr_review',
       'create_pr_review_comment',
+      'create_branch',
+      'create_or_update_file',
+      'delete_file',
+      'create_pull_request',
+      'update_pull_request',
+      'merge_pull_request',
     ];
 
     it('given read tools, should all be category read', () => {
@@ -119,16 +132,19 @@ describe('githubProvider', () => {
     });
 
     it('given standard read tools, should not have tool-level rate limits', () => {
-      const standardReadIds = readToolIds.filter((id) => id !== 'search_code');
+      const searchToolIds = ['search_code', 'search_issues'];
+      const standardReadIds = readToolIds.filter((id) => !searchToolIds.includes(id));
       for (const id of standardReadIds) {
         const tool = findTool(id);
         expect(tool.rateLimit).toBeUndefined();
       }
     });
 
-    it('given search_code tool, should have stricter rate limit due to GitHub search limits', () => {
-      const tool = findTool('search_code');
-      expect(tool.rateLimit).toEqual({ requests: 10, windowMs: 60_000 });
+    it('given search tools, should have stricter rate limits due to GitHub search limits', () => {
+      for (const id of ['search_code', 'search_issues']) {
+        const tool = findTool(id);
+        expect(tool.rateLimit).toEqual({ requests: 10, windowMs: 60_000 });
+      }
     });
 
     it('given all tool IDs, should account for every tool in the provider', () => {
@@ -735,16 +751,335 @@ describe('githubProvider', () => {
     });
   });
 
+  // ─── New Tool Tests: Commits & CI Reads ────────────────────────────────
+
+  describe('list_commits tool', () => {
+    const tool = findTool('list_commits');
+
+    it('given the tool, should require owner and repo', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo']);
+    });
+
+    it('given branch and path filters, should build correct GET request', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp', sha: 'develop', path: 'src/index.ts', per_page: 5 };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.url).toContain('/repos/acme/webapp/commits');
+      expect(result.url).toContain('sha=develop');
+      expect(result.url).toContain('per_page=5');
+    });
+  });
+
+  describe('compare_refs tool', () => {
+    const tool = findTool('compare_refs');
+
+    it('given the tool, should require owner, repo, base, and head', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'base', 'head']);
+    });
+
+    it('given base and head, should build a three-dot compare path', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp', base: 'main', head: 'feature-x' };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/compare/main...feature-x');
+    });
+
+    it('given the tool, should map ahead/behind counts', () => {
+      expect(tool.outputTransform!.mapping).toHaveProperty('ahead_by');
+      expect(tool.outputTransform!.mapping).toHaveProperty('behind_by');
+      expect(tool.outputTransform!.mapping).toHaveProperty('total_commits');
+    });
+  });
+
+  describe('list_check_runs tool', () => {
+    const tool = findTool('list_check_runs');
+
+    it('given the tool, should require owner, repo, and ref', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'ref']);
+    });
+
+    it('given a commit ref, should build correct GET request', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp', ref: 'abc123' };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/commits/abc123/check-runs');
+    });
+
+    it('given the tool, should extract check_runs array from response', () => {
+      expect(tool.outputTransform!.extract).toBe('$.check_runs');
+      expect(tool.outputTransform!.mapping).toHaveProperty('conclusion');
+    });
+  });
+
+  describe('list_workflow_runs tool', () => {
+    const tool = findTool('list_workflow_runs');
+
+    it('given the tool, should require owner and repo', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo']);
+    });
+
+    it('given branch and status filters, should build correct GET request', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp', branch: 'main', status: 'failure' };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.url).toContain('/repos/acme/webapp/actions/runs');
+      expect(result.url).toContain('branch=main');
+      expect(result.url).toContain('status=failure');
+    });
+
+    it('given the tool, should extract workflow_runs array from response', () => {
+      expect(tool.outputTransform!.extract).toBe('$.workflow_runs');
+    });
+  });
+
+  describe('search_issues tool', () => {
+    const tool = findTool('search_issues');
+
+    it('given the tool, should require q parameter', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['q']);
+    });
+
+    it('given a search query, should build correct GET request', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { q: 'login bug repo:acme/webapp is:issue', per_page: 10 };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.url).toContain('/search/issues');
+      expect(result.url).toContain('q=login');
+      expect(result.url).toContain('per_page=10');
+    });
+
+    it('given the tool, should extract items array from response', () => {
+      expect(tool.outputTransform!.extract).toBe('$.items');
+    });
+  });
+
+  describe('list_labels tool', () => {
+    const tool = findTool('list_labels');
+
+    it('given the tool, should require owner and repo', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo']);
+    });
+
+    it('given owner and repo, should build correct GET request', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp' };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/labels');
+    });
+  });
+
+  // ─── New Tool Tests: Code Contribution Writes ──────────────────────────
+
+  describe('create_branch tool', () => {
+    const tool = findTool('create_branch');
+
+    it('given the tool, should require owner, repo, ref, and sha', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'ref', 'sha']);
+    });
+
+    it('given a fully qualified ref and sha, should build correct POST', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp', ref: 'refs/heads/my-feature', sha: 'abc123' };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.method).toBe('POST');
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/git/refs');
+      expect(JSON.parse(result.body!)).toEqual({ ref: 'refs/heads/my-feature', sha: 'abc123' });
+    });
+  });
+
+  describe('create_or_update_file tool', () => {
+    const tool = findTool('create_or_update_file');
+
+    it('given the tool, should require owner, repo, path, message, and content', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'path', 'message', 'content']);
+    });
+
+    it('given a new file on a branch, should build correct PUT without sha', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: 'docs/notes.md',
+        message: 'docs: add notes',
+        content: 'aGVsbG8=',
+        branch: 'my-feature',
+      };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.method).toBe('PUT');
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/contents/docs/notes.md');
+
+      const body = JSON.parse(result.body!);
+      expect(body.message).toBe('docs: add notes');
+      expect(body.content).toBe('aGVsbG8=');
+      expect(body.branch).toBe('my-feature');
+      expect(body).not.toHaveProperty('sha');
+    });
+
+    it('given an existing file update, should include the blob sha', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: 'README.md',
+        message: 'docs: update readme',
+        content: 'aGVsbG8=',
+        sha: 'blob123',
+      };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(JSON.parse(result.body!).sha).toBe('blob123');
+    });
+  });
+
+  describe('delete_file tool', () => {
+    const tool = findTool('delete_file');
+
+    it('given the tool, should require owner, repo, path, message, and sha', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'path', 'message', 'sha']);
+    });
+
+    it('given a file and its blob sha, should build correct DELETE with body', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: 'old/legacy.ts',
+        message: 'chore: remove legacy module',
+        sha: 'blob123',
+        branch: 'cleanup',
+      };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.method).toBe('DELETE');
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/contents/old/legacy.ts');
+
+      const body = JSON.parse(result.body!);
+      expect(body.message).toBe('chore: remove legacy module');
+      expect(body.sha).toBe('blob123');
+      expect(body.branch).toBe('cleanup');
+    });
+  });
+
+  describe('create_pull_request tool', () => {
+    const tool = findTool('create_pull_request');
+
+    it('given the tool, should require owner, repo, title, head, and base', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'title', 'head', 'base']);
+    });
+
+    it('given head and base branches, should build correct POST', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        title: 'Add login flow',
+        head: 'my-feature',
+        base: 'main',
+        body: 'Implements the login flow.',
+        draft: true,
+      };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.method).toBe('POST');
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/pulls');
+
+      const body = JSON.parse(result.body!);
+      expect(body.title).toBe('Add login flow');
+      expect(body.head).toBe('my-feature');
+      expect(body.base).toBe('main');
+      expect(body.draft).toBe(true);
+    });
+  });
+
+  describe('update_pull_request tool', () => {
+    const tool = findTool('update_pull_request');
+
+    it('given the tool, should require owner, repo, and pull_number', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'pull_number']);
+    });
+
+    it('given a new title and body, should build correct PATCH', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        pull_number: 7,
+        title: 'Add login flow (with tests)',
+        body: 'Updated description.',
+      };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.method).toBe('PATCH');
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/pulls/7');
+
+      const body = JSON.parse(result.body!);
+      expect(body.title).toBe('Add login flow (with tests)');
+      expect(body.body).toBe('Updated description.');
+      expect(body).not.toHaveProperty('state');
+    });
+  });
+
+  describe('merge_pull_request tool', () => {
+    const tool = findTool('merge_pull_request');
+
+    it('given the tool, should require owner, repo, pull_number, and merge_method', () => {
+      const required = (tool.inputSchema as { required: string[] }).required;
+      expect(required).toEqual(['owner', 'repo', 'pull_number', 'merge_method']);
+    });
+
+    it('given a squash merge, should build correct PUT', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = { owner: 'acme', repo: 'webapp', pull_number: 7, merge_method: 'squash' };
+
+      const result = buildHttpRequest(config, input, 'https://api.github.com');
+
+      expect(result.method).toBe('PUT');
+      expect(result.url).toBe('https://api.github.com/repos/acme/webapp/pulls/7/merge');
+      expect(JSON.parse(result.body!)).toEqual({ merge_method: 'squash' });
+    });
+  });
+
   // ─── Tool Bundles ──────────────────────────────────────────────────────
 
   describe('tool bundles', () => {
     const bundles = githubProvider.toolBundles!;
     const toolIds = new Set(githubProvider.tools.map((t) => t.id));
 
-    it('given the provider, should define read_only, code_review, issue_triage, and full bundles', () => {
+    it('given the provider, should define read_only, code_review, issue_triage, contributor, and full bundles', () => {
       expect(bundles).toBeDefined();
       const ids = bundles.map((b) => b.id);
-      expect(ids).toEqual(['read_only', 'code_review', 'issue_triage', 'full']);
+      expect(ids).toEqual(['read_only', 'code_review', 'issue_triage', 'contributor', 'full']);
     });
 
     it('given every bundle, should reference only tool ids that exist on the provider', () => {

--- a/packages/lib/src/integrations/providers/github.test.ts
+++ b/packages/lib/src/integrations/providers/github.test.ts
@@ -422,6 +422,17 @@ describe('githubProvider', () => {
       expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
     });
 
+    it('given a path containing percent-encoded "../" segments, should throw rather than escape the declared repo', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: '%2e%2e/%2e%2e/other-org/other-repo/contents/secret.txt',
+      };
+
+      expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+    });
+
     it('given the tool config, should declare rawPathParams: ["path"]', () => {
       const config = (tool.execution as { config: HttpExecutionConfig }).config;
       expect(config.rawPathParams).toEqual(['path']);
@@ -984,6 +995,19 @@ describe('githubProvider', () => {
       expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
     });
 
+    it('given a path containing percent-encoded "../" segments, should throw rather than write to a different repo', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: '%2e%2e/%2e%2e/other-org/other-repo/contents/secret.txt',
+        message: 'evil commit',
+        content: 'aGVsbG8=',
+      };
+
+      expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+    });
+
     it('given the tool config, should declare rawPathParams: ["path"]', () => {
       const config = (tool.execution as { config: HttpExecutionConfig }).config;
       expect(config.rawPathParams).toEqual(['path']);
@@ -1026,6 +1050,19 @@ describe('githubProvider', () => {
         owner: 'acme',
         repo: 'webapp',
         path: '../../other-org/other-repo/contents/secret.txt',
+        message: 'evil delete',
+        sha: 'blob123',
+      };
+
+      expect(() => buildHttpRequest(config, input, 'https://api.github.com')).toThrow();
+    });
+
+    it('given a path containing percent-encoded "../" segments, should throw rather than delete from a different repo', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const input = {
+        owner: 'acme',
+        repo: 'webapp',
+        path: '%2e%2e/%2e%2e/other-org/other-repo/contents/secret.txt',
         message: 'evil delete',
         sha: 'blob123',
       };

--- a/packages/lib/src/integrations/providers/github.ts
+++ b/packages/lib/src/integrations/providers/github.ts
@@ -19,12 +19,13 @@ export const githubProvider: IntegrationProviderConfig = {
       authorizationUrl: 'https://github.com/login/oauth/authorize',
       tokenUrl: 'https://github.com/login/oauth/access_token',
       revokeUrl: 'https://github.com/settings/connections/applications',
-      scopes: ['repo', 'read:user'],
+      scopes: ['repo', 'workflow', 'read:user'],
       pkceRequired: false,
     },
   },
   oauthScopeDescriptions: {
     repo: 'Read and write code, issues, and pull requests on any repository your GitHub account can access',
+    workflow: 'Update GitHub Actions workflow files when committing code',
     'read:user': 'Read your GitHub profile (username and avatar)',
   },
   connectNotes:
@@ -417,6 +418,350 @@ export const githubProvider: IntegrationProviderConfig = {
           files: 'files',
         },
         maxLength: 5000,
+      },
+    },
+
+    {
+      id: 'list_commits',
+      name: 'List Commits',
+      description:
+        'List commits on a repository branch, optionally filtered to a file path',
+      category: 'read',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          sha: {
+            type: 'string',
+            description: 'Branch name or commit SHA to start listing from (defaults to default branch)',
+          },
+          path: {
+            type: 'string',
+            description: 'Only commits containing this file path',
+          },
+          per_page: {
+            type: 'integer',
+            description: 'Results per page (max 100)',
+          },
+          page: {
+            type: 'integer',
+            description: 'Page number',
+          },
+        },
+        required: ['owner', 'repo'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'GET',
+          pathTemplate: '/repos/{owner}/{repo}/commits',
+          queryParams: {
+            sha: { $param: 'sha' },
+            path: { $param: 'path' },
+            per_page: { $param: 'per_page', transform: 'string' },
+            page: { $param: 'page', transform: 'string' },
+          },
+        },
+      },
+      outputTransform: {
+        mapping: {
+          sha: 'sha',
+          message: 'commit.message',
+          author_name: 'commit.author.name',
+          author_date: 'commit.author.date',
+          html_url: 'html_url',
+        },
+        maxLength: 500,
+      },
+    },
+    {
+      id: 'compare_refs',
+      name: 'Compare Refs',
+      description:
+        'Compare two branches, tags, or commits (like a PR diff preview). Returns ahead/behind counts and total commits between base and head.',
+      category: 'read',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          base: {
+            type: 'string',
+            description: 'Base ref (branch, tag, or commit SHA)',
+          },
+          head: {
+            type: 'string',
+            description: 'Head ref (branch, tag, or commit SHA)',
+          },
+        },
+        required: ['owner', 'repo', 'base', 'head'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'GET',
+          pathTemplate: '/repos/{owner}/{repo}/compare/{base}...{head}',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          status: 'status',
+          ahead_by: 'ahead_by',
+          behind_by: 'behind_by',
+          total_commits: 'total_commits',
+          merge_base_sha: 'merge_base_commit.sha',
+          html_url: 'html_url',
+        },
+        maxLength: 500,
+      },
+    },
+    {
+      id: 'list_check_runs',
+      name: 'List Check Runs',
+      description:
+        'List CI check runs (build, lint, tests) for a commit SHA, branch, or tag. Use the PR head SHA to see whether a pull request is green.',
+      category: 'read',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          ref: {
+            type: 'string',
+            description: 'Commit SHA, branch name, or tag name',
+          },
+          per_page: {
+            type: 'integer',
+            description: 'Results per page (max 100)',
+          },
+          page: {
+            type: 'integer',
+            description: 'Page number',
+          },
+        },
+        required: ['owner', 'repo', 'ref'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'GET',
+          pathTemplate: '/repos/{owner}/{repo}/commits/{ref}/check-runs',
+          queryParams: {
+            per_page: { $param: 'per_page', transform: 'string' },
+            page: { $param: 'page', transform: 'string' },
+          },
+        },
+      },
+      outputTransform: {
+        extract: '$.check_runs',
+        mapping: {
+          name: 'name',
+          status: 'status',
+          conclusion: 'conclusion',
+          html_url: 'html_url',
+          started_at: 'started_at',
+          completed_at: 'completed_at',
+        },
+        maxLength: 500,
+      },
+    },
+    {
+      id: 'list_workflow_runs',
+      name: 'List Workflow Runs',
+      description:
+        'List GitHub Actions workflow runs for a repository, filterable by branch and status. Use to check CI outcomes after a push.',
+      category: 'read',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          branch: {
+            type: 'string',
+            description: 'Filter runs to a branch',
+          },
+          status: {
+            type: 'string',
+            enum: ['queued', 'in_progress', 'completed', 'success', 'failure'],
+            description: 'Filter by run status or conclusion',
+          },
+          event: {
+            type: 'string',
+            description: 'Filter by trigger event (e.g. "push", "pull_request")',
+          },
+          per_page: {
+            type: 'integer',
+            description: 'Results per page (max 100)',
+          },
+          page: {
+            type: 'integer',
+            description: 'Page number',
+          },
+        },
+        required: ['owner', 'repo'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'GET',
+          pathTemplate: '/repos/{owner}/{repo}/actions/runs',
+          queryParams: {
+            branch: { $param: 'branch' },
+            status: { $param: 'status' },
+            event: { $param: 'event' },
+            per_page: { $param: 'per_page', transform: 'string' },
+            page: { $param: 'page', transform: 'string' },
+          },
+        },
+      },
+      outputTransform: {
+        extract: '$.workflow_runs',
+        mapping: {
+          id: 'id',
+          name: 'name',
+          status: 'status',
+          conclusion: 'conclusion',
+          head_branch: 'head_branch',
+          event: 'event',
+          html_url: 'html_url',
+          created_at: 'created_at',
+        },
+        maxLength: 500,
+      },
+    },
+    {
+      id: 'search_issues',
+      name: 'Search Issues and PRs',
+      description:
+        'Search issues and pull requests across GitHub. Uses GitHub search syntax — include "repo:owner/repo" to scope to a repository. Example: "login bug repo:acme/webapp is:issue is:open"',
+      category: 'read',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          q: {
+            type: 'string',
+            description:
+              'Search query using GitHub issue search syntax. Include "repo:owner/repo" to scope to a repository and "is:issue" or "is:pr" to filter type.',
+          },
+          sort: {
+            type: 'string',
+            enum: ['created', 'updated', 'comments'],
+            description: 'Sort field',
+          },
+          order: {
+            type: 'string',
+            enum: ['asc', 'desc'],
+            description: 'Sort order',
+          },
+          per_page: {
+            type: 'integer',
+            description: 'Results per page (max 100)',
+          },
+          page: {
+            type: 'integer',
+            description: 'Page number',
+          },
+        },
+        required: ['q'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'GET',
+          pathTemplate: '/search/issues',
+          queryParams: {
+            q: { $param: 'q' },
+            sort: { $param: 'sort' },
+            order: { $param: 'order' },
+            per_page: { $param: 'per_page', transform: 'string' },
+            page: { $param: 'page', transform: 'string' },
+          },
+        },
+      },
+      outputTransform: {
+        extract: '$.items',
+        mapping: {
+          number: 'number',
+          title: 'title',
+          state: 'state',
+          html_url: 'html_url',
+          created_at: 'created_at',
+          pull_request_url: 'pull_request.html_url',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
+    {
+      id: 'list_labels',
+      name: 'List Labels',
+      description: 'List the labels available in a repository. Check here before applying labels to issues or PRs.',
+      category: 'read',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          per_page: {
+            type: 'integer',
+            description: 'Results per page (max 100)',
+          },
+          page: {
+            type: 'integer',
+            description: 'Page number',
+          },
+        },
+        required: ['owner', 'repo'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'GET',
+          pathTemplate: '/repos/{owner}/{repo}/labels',
+          queryParams: {
+            per_page: { $param: 'per_page', transform: 'string' },
+            page: { $param: 'page', transform: 'string' },
+          },
+        },
+      },
+      outputTransform: {
+        mapping: {
+          name: 'name',
+          description: 'description',
+          color: 'color',
+        },
+        maxLength: 500,
       },
     },
 
@@ -1247,6 +1592,374 @@ export const githubProvider: IntegrationProviderConfig = {
       },
       rateLimit: { requests: 10, windowMs: 60_000 },
     },
+    {
+      id: 'create_branch',
+      name: 'Create Branch',
+      description:
+        'Create a new branch in a repository from a commit SHA. Get the SHA of the branch to fork from via list_branches (commit_sha field).',
+      category: 'write',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          ref: {
+            type: 'string',
+            description: 'Fully qualified ref for the new branch, e.g. "refs/heads/my-feature"',
+          },
+          sha: {
+            type: 'string',
+            description: 'Commit SHA the new branch points at (e.g. the default branch head from list_branches)',
+          },
+        },
+        required: ['owner', 'repo', 'ref', 'sha'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'POST',
+          pathTemplate: '/repos/{owner}/{repo}/git/refs',
+          bodyTemplate: {
+            ref: { $param: 'ref' },
+            sha: { $param: 'sha' },
+          },
+          bodyEncoding: 'json',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          ref: 'ref',
+          sha: 'object.sha',
+          url: 'url',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
+    {
+      id: 'create_or_update_file',
+      name: 'Create or Update File',
+      description:
+        'Create or update a single file in a repository with a commit message. Content must be base64-encoded. To update an existing file, pass its current blob sha (from get_repo_content). Note: writing files under .github/workflows requires a GitHub connection made after workflow permissions were added — reconnect in Settings → Integrations if GitHub rejects the write.',
+      category: 'write',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          path: {
+            type: 'string',
+            description: 'Path of the file to create or update (e.g. "src/index.ts")',
+          },
+          message: {
+            type: 'string',
+            description: 'Commit message',
+          },
+          content: {
+            type: 'string',
+            description: 'New file content, base64-encoded',
+          },
+          branch: {
+            type: 'string',
+            description: 'Branch to commit to (defaults to the default branch)',
+          },
+          sha: {
+            type: 'string',
+            description: 'Current blob SHA of the file being replaced (required when updating an existing file)',
+          },
+        },
+        required: ['owner', 'repo', 'path', 'message', 'content'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'PUT',
+          pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+          bodyTemplate: {
+            message: { $param: 'message' },
+            content: { $param: 'content' },
+            branch: { $param: 'branch' },
+            sha: { $param: 'sha' },
+          },
+          bodyEncoding: 'json',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          path: 'content.path',
+          sha: 'content.sha',
+          html_url: 'content.html_url',
+          commit_sha: 'commit.sha',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
+    {
+      id: 'delete_file',
+      name: 'Delete File',
+      description:
+        'Delete a file from a repository with a commit message. Requires the current blob sha of the file (from get_repo_content).',
+      category: 'write',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          path: {
+            type: 'string',
+            description: 'Path of the file to delete',
+          },
+          message: {
+            type: 'string',
+            description: 'Commit message',
+          },
+          sha: {
+            type: 'string',
+            description: 'Current blob SHA of the file being deleted',
+          },
+          branch: {
+            type: 'string',
+            description: 'Branch to commit to (defaults to the default branch)',
+          },
+        },
+        required: ['owner', 'repo', 'path', 'message', 'sha'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'DELETE',
+          pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+          bodyTemplate: {
+            message: { $param: 'message' },
+            sha: { $param: 'sha' },
+            branch: { $param: 'branch' },
+          },
+          bodyEncoding: 'json',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          commit_sha: 'commit.sha',
+          message: 'commit.message',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
+    {
+      id: 'create_pull_request',
+      name: 'Create Pull Request',
+      description:
+        'Open a pull request from a head branch into a base branch',
+      category: 'write',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          title: {
+            type: 'string',
+            description: 'Pull request title',
+          },
+          head: {
+            type: 'string',
+            description: 'Branch with the changes (use "user:branch" for cross-fork PRs)',
+          },
+          base: {
+            type: 'string',
+            description: 'Branch to merge into (e.g. the default branch)',
+          },
+          body: {
+            type: 'string',
+            description: 'Pull request description (markdown)',
+          },
+          draft: {
+            type: 'boolean',
+            description: 'Open as a draft pull request',
+          },
+        },
+        required: ['owner', 'repo', 'title', 'head', 'base'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'POST',
+          pathTemplate: '/repos/{owner}/{repo}/pulls',
+          bodyTemplate: {
+            title: { $param: 'title' },
+            head: { $param: 'head' },
+            base: { $param: 'base' },
+            body: { $param: 'body' },
+            draft: { $param: 'draft' },
+          },
+          bodyEncoding: 'json',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          number: 'number',
+          title: 'title',
+          state: 'state',
+          html_url: 'html_url',
+          head_ref: 'head.ref',
+          base_ref: 'base.ref',
+          draft: 'draft',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
+    {
+      id: 'update_pull_request',
+      name: 'Update Pull Request',
+      description:
+        'Update a pull request: change title, body, state (open/closed), or base branch. Keep PR descriptions current as follow-up commits land.',
+      category: 'write',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          pull_number: {
+            type: 'integer',
+            description: 'Pull request number',
+          },
+          title: {
+            type: 'string',
+            description: 'New pull request title',
+          },
+          body: {
+            type: 'string',
+            description: 'New pull request description (markdown)',
+          },
+          state: {
+            type: 'string',
+            enum: ['open', 'closed'],
+            description: 'Pull request state',
+          },
+          base: {
+            type: 'string',
+            description: 'New base branch',
+          },
+        },
+        required: ['owner', 'repo', 'pull_number'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'PATCH',
+          pathTemplate: '/repos/{owner}/{repo}/pulls/{pull_number}',
+          bodyTemplate: {
+            title: { $param: 'title' },
+            body: { $param: 'body' },
+            state: { $param: 'state' },
+            base: { $param: 'base' },
+          },
+          bodyEncoding: 'json',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          number: 'number',
+          title: 'title',
+          state: 'state',
+          html_url: 'html_url',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
+    {
+      id: 'merge_pull_request',
+      name: 'Merge Pull Request',
+      description:
+        'Merge a pull request using merge, squash, or rebase. Check list_check_runs on the PR head SHA first to confirm CI is green.',
+      category: 'write',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: {
+            type: 'string',
+            description: 'Repository owner',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name',
+          },
+          pull_number: {
+            type: 'integer',
+            description: 'Pull request number',
+          },
+          merge_method: {
+            type: 'string',
+            enum: ['merge', 'squash', 'rebase'],
+            description: 'How to merge the pull request',
+          },
+          commit_title: {
+            type: 'string',
+            description: 'Title of the merge commit (defaults to GitHub’s standard title)',
+          },
+          commit_message: {
+            type: 'string',
+            description: 'Body of the merge commit',
+          },
+        },
+        required: ['owner', 'repo', 'pull_number', 'merge_method'],
+      },
+      execution: {
+        type: 'http',
+        config: {
+          method: 'PUT',
+          pathTemplate: '/repos/{owner}/{repo}/pulls/{pull_number}/merge',
+          bodyTemplate: {
+            merge_method: { $param: 'merge_method' },
+            commit_title: { $param: 'commit_title' },
+            commit_message: { $param: 'commit_message' },
+          },
+          bodyEncoding: 'json',
+        },
+      },
+      outputTransform: {
+        mapping: {
+          merged: 'merged',
+          sha: 'sha',
+          message: 'message',
+        },
+        maxLength: 500,
+      },
+      rateLimit: { requests: 10, windowMs: 60_000 },
+    },
   ],
   toolBundles: [
     {
@@ -1262,6 +1975,12 @@ export const githubProvider: IntegrationProviderConfig = {
         'list_branches',
         'search_code',
         'get_commit',
+        'list_commits',
+        'compare_refs',
+        'list_check_runs',
+        'list_workflow_runs',
+        'search_issues',
+        'list_labels',
         'list_issues',
         'list_issue_comments',
         'get_pull_request',
@@ -1274,7 +1993,7 @@ export const githubProvider: IntegrationProviderConfig = {
     {
       id: 'code_review',
       name: 'Code review',
-      description: 'Read pull requests and code, then post reviews, inline comments, and replies.',
+      description: 'Read pull requests, code, and CI results, then post reviews, inline comments, and replies.',
       toolIds: [
         'get_pull_request',
         'list_pull_requests',
@@ -1283,6 +2002,9 @@ export const githubProvider: IntegrationProviderConfig = {
         'list_pr_review_comments',
         'get_repo_content',
         'get_commit',
+        'list_commits',
+        'compare_refs',
+        'list_check_runs',
         'create_pr_review',
         'create_pr_review_comment',
         'create_issue_comment',
@@ -1291,19 +2013,47 @@ export const githubProvider: IntegrationProviderConfig = {
     {
       id: 'issue_triage',
       name: 'Issue triage',
-      description: 'Read, open, update, and comment on issues.',
+      description: 'Read, search, open, update, and comment on issues.',
       toolIds: [
         'list_issues',
         'list_issue_comments',
+        'search_issues',
+        'list_labels',
         'create_issue',
         'update_issue',
         'create_issue_comment',
       ],
     },
     {
+      id: 'contributor',
+      name: 'Contributor',
+      description: 'Create branches, commit files, and open, update, and merge pull requests.',
+      toolIds: [
+        'list_repos',
+        'get_repo',
+        'get_repo_content',
+        'get_repo_tree',
+        'list_branches',
+        'get_commit',
+        'list_commits',
+        'compare_refs',
+        'list_check_runs',
+        'get_pull_request',
+        'list_pull_requests',
+        'list_pr_files',
+        'create_branch',
+        'create_or_update_file',
+        'delete_file',
+        'create_pull_request',
+        'update_pull_request',
+        'merge_pull_request',
+        'create_issue_comment',
+      ],
+    },
+    {
       id: 'full',
       name: 'Full access',
-      description: 'Every GitHub tool — read and write across repos, issues, and pull requests.',
+      description: 'Every GitHub tool — read and write across repos, code, issues, pull requests, and CI.',
       toolIds: [
         'list_repos',
         'get_repo',
@@ -1312,6 +2062,12 @@ export const githubProvider: IntegrationProviderConfig = {
         'list_branches',
         'search_code',
         'get_commit',
+        'list_commits',
+        'compare_refs',
+        'list_check_runs',
+        'list_workflow_runs',
+        'search_issues',
+        'list_labels',
         'list_issues',
         'list_issue_comments',
         'get_pull_request',
@@ -1324,6 +2080,12 @@ export const githubProvider: IntegrationProviderConfig = {
         'create_issue_comment',
         'create_pr_review',
         'create_pr_review_comment',
+        'create_branch',
+        'create_or_update_file',
+        'delete_file',
+        'create_pull_request',
+        'update_pull_request',
+        'merge_pull_request',
       ],
     },
   ],

--- a/packages/lib/src/integrations/providers/github.ts
+++ b/packages/lib/src/integrations/providers/github.ts
@@ -196,6 +196,7 @@ export const githubProvider: IntegrationProviderConfig = {
         config: {
           method: 'GET',
           pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+          rawPathParams: ['path'],
           queryParams: {
             ref: { $param: 'ref' },
           },
@@ -1687,6 +1688,7 @@ export const githubProvider: IntegrationProviderConfig = {
         config: {
           method: 'PUT',
           pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+          rawPathParams: ['path'],
           bodyTemplate: {
             message: { $param: 'message' },
             content: { $param: 'content' },
@@ -1748,6 +1750,7 @@ export const githubProvider: IntegrationProviderConfig = {
         config: {
           method: 'DELETE',
           pathTemplate: '/repos/{owner}/{repo}/contents/{path}',
+          rawPathParams: ['path'],
           bodyTemplate: {
             message: { $param: 'message' },
             sha: { $param: 'sha' },

--- a/packages/lib/src/integrations/types.ts
+++ b/packages/lib/src/integrations/types.ts
@@ -68,6 +68,8 @@ export interface ParameterRef {
 export interface HttpExecutionConfig {
   method: HttpMethod;
   pathTemplate: string;
+  /** Param names allowed to contain literal "/" segments (e.g. a nested file path); still rejects "." and ".." segments. */
+  rawPathParams?: string[];
   queryParams?: Record<string, string | ParameterRef>;
   headers?: Record<string, string | ParameterRef>;
   bodyTemplate?: Record<string, unknown> | string;

--- a/tasks/reviews/pu-github-tooling-updates.md
+++ b/tasks/reviews/pu-github-tooling-updates.md
@@ -1,0 +1,48 @@
+# Review: pu/github-tooling-updates (PR #1879)
+
+Reviewed: 2026-07-05
+Branch: `pu/github-tooling-updates` vs `master` (21 files, +3399/-413), plus two already-landed
+follow-up fix commits (`85d150dd6`, `0d27629d6`) from a prior review round.
+No PageSpace board tracks this PR (confirmed via `multi_drive_search` across all 3 connected
+drives) — recording here per the review skill's repo-log fallback.
+
+Scope: GitHub OAuth integration REST tools (`packages/lib/src/integrations/`) + sandbox git/gh
+CLI toolkit (`apps/web/src/lib/ai/tools/sandbox-git-tools.ts`) + centralized GitHub-tool
+suppression (`apps/web/src/lib/ai/core/integration-tool-resolver.ts`, `tool-filtering.ts`).
+
+Method: 3 independent agents (GitHub-integration security, sandbox-CLI security, suppression
+architecture) + self-run churn/hygiene pass. Both blockers below were independently reproduced
+(not just agent-asserted) — see verification notes.
+
+## Findings
+
+- [x] BLOCKER · `packages/lib/src/integrations/execution/build-request.ts:10-36` (`isDotSegment`/`assertNoTraversal`/`assertPlainIdentifier`) · Path-traversal guard checks the raw literal string, but `buildHttpRequest` (line 192) assigns the result to `URL.pathname`, which normalizes percent-encoded (`%2e%2e`) and backslash dot-segments the same as literal `..` — the validator and the consumer disagree, so encoded payloads bypass validation and still traverse. · Verified independently with `node`: `new URL('https://api.github.com'); u.pathname='/repos/acme/webapp/contents/%2e%2e/%2e%2e/other-org/other-repo/contents/secret.txt'` → normalizes to `/repos/acme/other-org/other-repo/contents/secret.txt`, identical to the literal-`..` case the existing tests already block. Also reproduces on a *plain-identifier* param (not just `rawPathParams`): `owner: '%2e%2e'` on `/repos/{owner}/{repo}` collapses to `/webapp`, escaping the `/repos/` prefix entirely. Affects every path-interpolating tool: `get_repo_content`/`create_or_update_file`/`delete_file` in `github.ts` and the three `{path}` tools in `generic-webhook.ts`. — **fixed**: `isDotSegment` now matches the WHATWG URL Standard's literal single-/double-dot-segment definitions (`.`, `%2e`, `..`, `.%2e`, `%2e.`, `%2e%2e`, ASCII case-insensitive) instead of only `.`/`..`; both `assertNoTraversal` and `assertPlainIdentifier` also reject any literal backslash outright (the URL parser treats `\` as a path separator for special schemes like https, and no legitimate GitHub API path segment needs one). Confirmed empirically against real `URL` normalization behavior (including that `%2f`/`%252e`/`%5c` do *not* get decoded by `URL`, so no double-decode step is needed, and that legitimate dotted paths like `.github/workflows/ci.yml` are unaffected).
+
+- [x] BLOCKER · `apps/web/src/lib/ai/tools/sandbox-git-tools.ts:558` (`git_rebase`, param `branch_or_ref`) · No `startsLikeFlag` guard (unlike `git_show`'s `ref`, which got one in `85d150dd6`), so `branch_or_ref: '--exec=<cmd>'` becomes argv `['rebase', '--exec=<cmd>']` — a real git flag that shell-execs `<cmd>` after each replayed commit. · Verified independently by reading the code path end-to-end: `git()` (line 140-141) calls `runGitInSandbox` with no `preResolvedToken`, so `git-tool-runners.ts:67-70` unconditionally resolves and injects `GH_TOKEN`/`GITHUB_TOKEN` into the child env whenever the user has a GitHub connection (`git-tool-runners.ts:111-120`) — including this "local" git command. An attacker who can influence `branch_or_ref` (e.g. content echoed back from an untrusted PR/issue body) gets both arbitrary command execution in the sandbox and exfiltration of the user's GitHub OAuth token via `$GH_TOKEN`/`$GITHUB_TOKEN` in the exec'd command — the exact credential the system prompt says the plain `bash` tool deliberately lacks. — **fixed**: added the same `startsLikeFlag` `.refine()` + execute-time check used by `git_show`'s `ref`.
+
+- [x] MAJOR · `apps/web/src/lib/ai/tools/sandbox-git-tools.ts:524` (`git_merge`, param `branch`) · Also a bare positional with no `startsLikeFlag` guard. `git merge` has no `--exec`, but `--strategy=<name>`/`-s<name>` makes git exec `git-merge-<name>` off PATH — a flag-injection primitive (and a way to silently force `-X theirs`/`--no-verify` semantics) even without direct RCE. — **fixed**: same guard pattern added.
+
+- [x] MAJOR · `packages/lib/src/integrations/execution/build-request.test.ts`, `packages/lib/src/integrations/providers/github.test.ts`, `packages/lib/src/integrations/providers/generic-webhook.test.ts` · All new traversal tests use only literal `../` payloads; none cover `%2e%2e`, mixed-case percent-encoding, `.%2e`/`%2e.`, or backslash variants — so the entire new suite is green despite the BLOCKER above. — **fixed**: added RED tests for percent-encoded, mixed-case, `.%2e`, and backslash variants in `build-request.test.ts` (plus a legitimate-`.github/`-path preservation test), and one confirmatory encoded-traversal test in each of `github.test.ts` (get/create/delete file content tools) and `generic-webhook.test.ts`.
+
+- [x] MAJOR (test gap mirroring the vuln) · `apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts` · Has "rejects a value that looks like a flag" tests for `git_show`, `gh_workflow_run`, `gh_repo_view`, `gh_repo_list`, `gh_repo_fork`, `gh_repo_create`, and `gh_search`'s `--` placement, but none for `git_merge`'s `branch` or `git_rebase`'s `branch_or_ref` — the two gaps above. — **fixed**: added the missing pair (`git_merge action` / `git_rebase action` describe blocks), each asserting `success: false` and that `acquireSandbox` was never called.
+
+- [x] MINOR · `apps/web/src/app/api/ai/chat/route.ts` (and the global-messages route) suppression fix · No end-to-end route-handler test exercises `toolExposureMode: 'search'` with sandbox tools present — the exact scenario the original suppression bug manifested in. — **fixed** (chat/route.ts only; global-messages route left as a follow-up, see below): added `apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts`, asserting `resolvePageAgentIntegrationTools` receives a `currentTools` set that still contains the sandbox tool name even in `'search'` mode. Regression-tested: temporarily reverted the route to pass the post-exposure set and confirmed this new test fails (`expected {...} to have property "git_clone"`), then restored the correct code and confirmed it passes again — the test is a genuine tripwire, not a vacuous pass.
+
+## Verdict
+
+2 blockers / 3 majors / 1 minor / 0 nits. **6/6 fixed.**
+
+Both blockers were genuine, independently-reproduced security holes that defeated protections this
+same PR claimed to have just landed (`0d27629d6` path-traversal fix, `85d150dd6` CLI arg-injection
+fix) — the original fixes covered the reported PoCs but not adjacent variants (encoding, and one
+sibling tool). All fixes verified: `bun test` green on every touched unit-test file (192 packages/lib
++ 187 apps/web tests, all passing via vitest — apps/web tests require vitest, not bare `bun test`),
+`tsc --noEmit` clean on both `apps/web` and `packages/lib` when invoked directly (the one observed
+typecheck failure was a stale `.next/types` cache artifact from running via `turbo` at the repo root,
+reproduced identically on a fully-stashed clean baseline — pre-existing worktree noise, not a
+regression from this changeset).
+
+**Follow-up (not blocking, not done here):** the MINOR fix only added a route-level suppression test
+for `chat/route.ts` (page-agent route). The global assistant route
+(`apps/web/src/app/api/ai/global/[id]/messages/route.ts`) has the identical gap and would benefit
+from the same test pattern — left out here to keep the fix pass scoped to what was explicitly found.


### PR DESCRIPTION
## Summary
- Add `gh_pr_review_comment` to the sandbox git/gh CLI toolkit (34→35 tools), giving it parity with the GitHub OAuth integration's inline PR comment tool — supports inline comments, multi-line ranges, file-level comments, and replies via `gh api repos/{owner}/{repo}/pulls/{number}/comments`.
- Suppress the GitHub OAuth integration tools (`int__github__*`) when the sandbox git/gh CLI toolkit is already present in an agent's tool set, since the two overlap in capability (browsing repos, reviewing PRs, filing issues) and offering both is redundant. Other providers' integration tools (Slack, etc.) are untouched.

## Suppression is centralized in the resolver, not each route
A self-review pass (8 independent finder angles) caught that the first cut of this suppression logic was checked against the wrong tool-set snapshot and was effectively a no-op in production:
- The Global Assistant's tool set is always `{ ...coreTools, tool_search, execute_tool }` — sandbox git/gh tool names never appear as top-level keys there, so the check always failed.
- The page-agent chat route checked the tool set *after* `applyToolExposureMode`, which in `'search'` exposure mode moves all non-core tools behind `execute_tool` — so it only worked in the default `'upfront'` mode.
- Two more call sites (`workflow-executor.ts`, the `ask_agent` tool) had the identical overlap but were never wired to any suppression at all.

Fixed by moving `suppressGithubIntegrationTools` out of the individual call sites and into `resolvePageAgentIntegrationTools`/`resolveGlobalAssistantIntegrationTools` in `integration-tool-resolver.ts` — the actual shared choke point all 5 call sites already go through. Each caller now passes its own pre-exposure/pre-merge tool set as a required `currentTools` param, so a future caller can't forget to wire in suppression.

Also, while in there:
- `SANDBOX_GIT_TOOL_NAMES` is now exported from `sandbox-git-tools.ts` (single source of truth) instead of a second hand-maintained list, with a test asserting the two stay in sync.
- Suppression uses the existing `parseIntegrationToolName` parser instead of a hardcoded `'int__github__'` string prefix.
- `system-prompt.ts`'s sandbox "Key tools" hint list now includes `gh_pr_review_comment`.

## Expand GitHub tooling for end-to-end repo workflows
Both GitHub surfaces still stopped short of a full clone→branch→commit→push→PR→review→CI→merge loop. Sandbox agents couldn't edit PR descriptions, comment, triage issues, discover repos, search GitHub, or resolve review threads. Integration (non-sandbox) agents had zero write path to code and zero CI visibility.

**Sandbox git/gh CLI toolkit (35 → 56 tools):**
- PR lifecycle: `gh_pr_edit`, `gh_pr_comment`, `gh_pr_update_branch`, `gh_pr_thread_list`/`gh_pr_thread_resolve` (GraphQL via fixed module-level query documents — variables are passed only as `-f`/`-F` flags, never interpolated into the document)
- Issues: `gh_issue_comment`/`edit`/`close`/`reopen`
- Discovery: `gh_repo_view`/`gh_repo_list` (fixes `list_repos` being suppressed for sandbox agents with no replacement), `gh_search`, `gh_label_list`
- CI: `gh_run_rerun`, `gh_workflow_list`, `gh_workflow_run` (guarded: required `workflow`+`ref`, input-name validation, description warns it triggers real automation)
- git: `git_show`, `git_blame`, `git_revert` (single-SHA only, always `--no-edit`); `git_merge`/`git_rebase` gained `action: abort/continue` so a conflicted merge/rebase no longer strands the agent
- Repo creation: `gh_repo_fork` (fork-only, no `--clone`), `gh_repo_create` (explicit visibility required, name regex blocks flag injection)

**GitHub OAuth integration REST tools (19 → 31):**
- Code writes: `create_branch`, `create_or_update_file`, `delete_file`, `create_pull_request`, `update_pull_request`, `merge_pull_request`
- CI/history reads: `list_check_runs`, `list_workflow_runs`, `list_commits`, `compare_refs`, `search_issues`, `list_labels`
- New **Contributor** tool bundle covering the branch→commit→PR→merge flow

**OAuth scope:** added `workflow` so agents can commit changes to `.github/workflows` files. Existing connections keep working; reconnect GitHub in Settings → Integrations to pick up the new permission.

Force-push behavior was reviewed and left as-is: it already works on feature/PR branches (requires an explicit `branch` name so the tool can verify the target, since it can't see the sandbox's current branch); only force-push/delete of `main`/`master` stays refused, to protect the shared branch from an agent rewriting or wiping its history.

## Test plan
- [x] `gh_pr_review_comment` RED→GREEN tests in `sandbox-git-tools.test.ts` (inline, multi-line, file-level, reply, empty-body rejection, no-connection error) + tool-count assertion bumped to 35, plus a sync-guard test for `SANDBOX_GIT_TOOL_NAMES`
- [x] `hasSandboxGitTools`/`suppressGithubIntegrationTools` tests in `tool-filtering.test.ts`
- [x] `resolvePageAgentIntegrationTools`/`resolveGlobalAssistantIntegrationTools` suppression tests in `integration-tool-resolver.test.ts` (both the "suppresses when sandbox active" and "keeps when not" cases)
- [x] All 21 new sandbox tools covered in `sandbox-git-tools.test.ts` (args assembly, guard rejections, GraphQL non-interpolation, no-connection errors) — tool count bumped to 56, name-registry sync test updated
- [x] All 12 new integration tools covered in `github.test.ts` (required fields, request building, rate limits, bundle membership) — tool count bumped to 31, bundle list includes `contributor`
- [x] `tool-filtering.test.ts` extended for new write/read classifications
- [x] `bun run typecheck` clean across all 16 turbo tasks
- [x] Full `packages/lib` integrations suite green (575/575), sandbox + tool-filtering suites green (163/163), agent-integrations route/panel suites green (43/43)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSCa3MXEsetfgMZDyQ4tci
https://claude.ai/code/session_01GbhcSnVWZAyMjqak5Xr17f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded GitHub tooling with support for PR comments/reviews, issue actions, repo browsing/search, workflow runs, commit inspection, branch/file operations, and merge/revert recovery.
  * Added new tool bundles for common workflows, including contributor and issue triage flows.
  * GitHub connections now request the **workflow** permission so workflow files can be updated.

* **Bug Fixes**
  * Improved tool selection so overlapping GitHub tools are handled more reliably when sandbox Git tools are already available.
  * Updated guidance for keeping PR descriptions and review threads in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->