### PR TITLE
fix(gdpr): include system_logs/api_metrics/error_logs in DSAR export (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **GDPR data exports now include system logs, API metrics, and error logs** — the account data
+  export (`Settings > Privacy > Download my data`) previously omitted these three monitoring
+  tables even though they can carry your user ID until account deletion. They're now included in
+  both the native ZIP (`system-logs.json`, `api-metrics.json`, `error-logs.json`) and the portable
+  schema.org export, with raw stack traces, IP addresses, user agents, and internal admin fields
+  redacted.
 - **`pagespace login` no longer hangs after a successful login** — the post-login identity
   lookup used to retry for up to 2 minutes before the CLI would return control to your terminal;
   it's now bounded to a few seconds so the command finishes promptly. The browser callback page

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -85,6 +85,9 @@ const mockUserData = {
   messages: [],
   files: [],
   activity: [],
+  systemLogs: [],
+  apiMetrics: [],
+  errorLogs: [],
   aiUsage: [],
   tasks: [],
   sessions: [],
@@ -190,8 +193,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      // 11 data files (personalization omitted when null) + manifest.json
-      expect(mockArchive.append).toHaveBeenCalledTimes(12);
+      // 14 data files (personalization omitted when null) + manifest.json
+      expect(mockArchive.append).toHaveBeenCalledTimes(15);
       // Verify each data category name pattern
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
@@ -202,6 +205,9 @@ describe('GET /api/account/export', () => {
       expect(appendCalls.some((n: string) => n.includes('messages.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('files-metadata.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('activity.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('system-logs.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('api-metrics.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('error-logs.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('ai-usage.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('tasks.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('sessions.json'))).toBe(true);
@@ -255,8 +261,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      // 12 data files + manifest.json
-      expect(mockArchive.append).toHaveBeenCalledTimes(13);
+      // 15 data files + manifest.json
+      expect(mockArchive.append).toHaveBeenCalledTimes(16);
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
       );

--- a/docs/security/gdpr-export-format.md
+++ b/docs/security/gdpr-export-format.md
@@ -37,11 +37,19 @@ out-of-band knowledge.
 ## Native format
 
 Per-category JSON files: `profile.json`, `drives.json`, `pages.json`,
-`messages.json`, `files-metadata.json`, `activity.json`, `ai-usage.json`,
-`tasks.json`, `sessions.json`, `notifications.json`, `display-preferences.json`,
-and `personalization.json` (only when the user has personalization). Shapes are
+`messages.json`, `files-metadata.json`, `activity.json`, `system-logs.json`,
+`api-metrics.json`, `error-logs.json`, `ai-usage.json`, `tasks.json`,
+`sessions.json`, `notifications.json`, `display-preferences.json`, and
+`personalization.json` (only when the user has personalization). Shapes are
 the `*Export` interfaces in
-`packages/lib/src/compliance/export/gdpr-export.ts`.
+`packages/lib/src/compliance/export/gdpr-export.ts`. `system-logs.json`,
+`api-metrics.json`, and `error-logs.json` cover rows in the monitoring tables
+keyed to the user's (nullable, non-FK) `userId` — a deliberately
+redaction-conscious subset that excludes raw stack traces, IP addresses, user
+agents, session/request correlation IDs, and internal admin references
+(e.g. `resolvedBy`), keeping only what/when/where fields (timestamp,
+level/name, message, category, endpoint, method, duration/status,
+file/line/column, resolved).
 
 ## Portable format (schema.org)
 
@@ -60,8 +68,9 @@ it can be ingested by other tools without bespoke parsers:
   (`encodingFormat`, `contentSize`, `contentUrl`, `isPartOf`, `dateCreated`).
 
 The portable format is **lossless**: categories without a natural schema.org
-type (activity, AI usage, tasks, sessions, notifications, display preferences,
-personalization) are carried verbatim as
+type (activity, system logs, API metrics, error logs, AI usage, tasks,
+sessions, notifications, display preferences, personalization) are carried
+verbatim as
 [`PropertyValue`](https://schema.org/PropertyValue) entries under
 `additionalProperty`, so the portable bundle contains exactly the same data as
 the native export.

--- a/packages/lib/src/compliance/export/export-format.test.ts
+++ b/packages/lib/src/compliance/export/export-format.test.ts
@@ -31,6 +31,9 @@ function makeData(overrides: Partial<AllUserData> = {}): AllUserData {
     messages: [{ id: 'm1', source: 'channel', content: 'hi', createdAt: D1 }],
     files: [],
     activity: [],
+    systemLogs: [],
+    apiMetrics: [],
+    errorLogs: [],
     aiUsage: [],
     tasks: [],
     sessions: [],
@@ -64,6 +67,9 @@ describe('buildNativeExportFiles', () => {
     expect(byName['drives.json']).toBe(1);
     expect(byName['messages.json']).toBe(1);
     expect(byName['files-metadata.json']).toBe(0);
+    expect(byName['system-logs.json']).toBe(0);
+    expect(byName['api-metrics.json']).toBe(0);
+    expect(byName['error-logs.json']).toBe(0);
   });
 
   it('given_nullPersonalization_omitsItFromInventory', () => {
@@ -190,6 +196,9 @@ describe('toPortableExport', () => {
     const full = makeData({
       files: [{ id: 'f1', driveId: 'd1', sizeBytes: 1, mimeType: null, storagePath: null, createdAt: D1 }],
       activity: [{ id: 'a1', operation: 'create', resourceType: 'page', resourceId: 'p1', timestamp: D1, metadata: null }],
+      systemLogs: [{ id: 'sl1', timestamp: D1, level: 'error', message: 'boom', category: 'api', endpoint: '/api/foo', method: 'POST', duration: 12 }],
+      apiMetrics: [{ id: 'am1', timestamp: D1, endpoint: '/api/foo', method: 'GET', statusCode: 200, duration: 42, requestSize: 100, responseSize: 200 }],
+      errorLogs: [{ id: 'el1', timestamp: D1, name: 'TypeError', message: 'oops', endpoint: '/api/foo', method: 'POST', file: 'foo.ts', line: 10, column: 5, resolved: false }],
       aiUsage: [{ id: 'ai1', provider: 'openrouter', model: 'm', inputTokens: 1, outputTokens: 2, cost: 0.1, timestamp: D1 }],
       tasks: [{ listId: 'l1', listTitle: 'L', items: [] }],
       sessions: [{ id: 's1', type: 'session', deviceId: null, scopes: [], createdByIp: null, lastUsedAt: null, lastUsedIp: null, expiresAt: D2, revokedAt: null, revokedReason: null, createdAt: D1 }],
@@ -208,10 +217,13 @@ describe('toPortableExport', () => {
     // everything else carried verbatim under additionalProperty
     const props = portable.additionalProperty as Array<{ name: string; value: unknown }>;
     const byName = Object.fromEntries(props.map((p) => [p.name, p.value]));
-    for (const key of ['activity', 'aiUsage', 'tasks', 'sessions', 'notifications', 'displayPreferences', 'personalization']) {
+    for (const key of ['activity', 'systemLogs', 'apiMetrics', 'errorLogs', 'aiUsage', 'tasks', 'sessions', 'notifications', 'displayPreferences', 'personalization']) {
       expect(byName).toHaveProperty(key);
     }
     expect((byName.activity as unknown[]).length).toBe(1);
+    expect((byName.systemLogs as unknown[]).length).toBe(1);
+    expect((byName.apiMetrics as unknown[]).length).toBe(1);
+    expect((byName.errorLogs as unknown[]).length).toBe(1);
     expect((byName.sessions as unknown[]).length).toBe(1);
     expect(byName.personalization).not.toBeNull();
   });

--- a/packages/lib/src/compliance/export/export-format.test.ts
+++ b/packages/lib/src/compliance/export/export-format.test.ts
@@ -196,9 +196,9 @@ describe('toPortableExport', () => {
     const full = makeData({
       files: [{ id: 'f1', driveId: 'd1', sizeBytes: 1, mimeType: null, storagePath: null, createdAt: D1 }],
       activity: [{ id: 'a1', operation: 'create', resourceType: 'page', resourceId: 'p1', timestamp: D1, metadata: null }],
-      systemLogs: [{ id: 'sl1', timestamp: D1, level: 'error', message: 'boom', category: 'api', endpoint: '/api/foo', method: 'POST', duration: 12 }],
-      apiMetrics: [{ id: 'am1', timestamp: D1, endpoint: '/api/foo', method: 'GET', statusCode: 200, duration: 42, requestSize: 100, responseSize: 200 }],
-      errorLogs: [{ id: 'el1', timestamp: D1, name: 'TypeError', message: 'oops', endpoint: '/api/foo', method: 'POST', file: 'foo.ts', line: 10, column: 5, resolved: false }],
+      systemLogs: [{ id: 'sl1', timestamp: D1, level: 'error', message: 'boom', category: null, endpoint: '/api/foo', method: null, duration: null }],
+      apiMetrics: [{ id: 'am1', timestamp: D1, endpoint: '/api/foo', method: 'GET', statusCode: 200, duration: 42, requestSize: null, responseSize: null }],
+      errorLogs: [{ id: 'el1', timestamp: D1, name: 'TypeError', message: 'oops', endpoint: null, method: null, file: null, line: null, column: null, resolved: null }],
       aiUsage: [{ id: 'ai1', provider: 'openrouter', model: 'm', inputTokens: 1, outputTokens: 2, cost: 0.1, timestamp: D1 }],
       tasks: [{ listId: 'l1', listTitle: 'L', items: [] }],
       sessions: [{ id: 's1', type: 'session', deviceId: null, scopes: [], createdByIp: null, lastUsedAt: null, lastUsedIp: null, expiresAt: D2, revokedAt: null, revokedReason: null, createdAt: D1 }],

--- a/packages/lib/src/compliance/export/export-format.ts
+++ b/packages/lib/src/compliance/export/export-format.ts
@@ -61,6 +61,9 @@ export function buildNativeExportFiles(data: AllUserData): ExportFile[] {
     { name: 'messages.json', description: 'Chat, channel, conversation and direct messages', recordCount: data.messages.length, data: data.messages },
     { name: 'files-metadata.json', description: 'Uploaded file metadata', recordCount: data.files.length, data: data.files },
     { name: 'activity.json', description: 'Activity / audit trail entries', recordCount: data.activity.length, data: data.activity },
+    { name: 'system-logs.json', description: 'System log entries associated with your account', recordCount: data.systemLogs.length, data: data.systemLogs },
+    { name: 'api-metrics.json', description: 'API request metrics associated with your account', recordCount: data.apiMetrics.length, data: data.apiMetrics },
+    { name: 'error-logs.json', description: 'Error log entries associated with your account', recordCount: data.errorLogs.length, data: data.errorLogs },
     { name: 'ai-usage.json', description: 'AI usage records', recordCount: data.aiUsage.length, data: data.aiUsage },
     { name: 'tasks.json', description: 'Task lists and items', recordCount: data.tasks.length, data: data.tasks },
     { name: 'sessions.json', description: 'Authentication sessions', recordCount: data.sessions.length, data: data.sessions },
@@ -99,8 +102,9 @@ function toIso(value: Date | null | undefined): string | null {
  * Map the collected data onto a documented, interoperable schema.org structure
  * (https://schema.org): the data subject as a `Person`, with drives/pages as
  * `CreativeWork`, messages as `Message`, and files as `MediaObject`. The
- * remaining operational categories (activity, AI usage, tasks, sessions,
- * notifications, display preferences, personalization) are carried verbatim as
+ * remaining operational categories (activity, system logs, API metrics, error
+ * logs, AI usage, tasks, sessions, notifications, display preferences,
+ * personalization) are carried verbatim as
  * `PropertyValue` entries so the portable bundle is **complete** — no data
  * category is dropped (GDPR Art 20). Dates are ISO-8601 strings (mapped fields
  * explicitly; values inside `additionalProperty` serialize to ISO-8601 via
@@ -164,6 +168,9 @@ export function toPortableExport(data: AllUserData): Record<string, unknown> {
     // bundle loses nothing relative to the native export.
     additionalProperty: [
       { '@type': 'PropertyValue', name: 'activity', value: data.activity },
+      { '@type': 'PropertyValue', name: 'systemLogs', value: data.systemLogs },
+      { '@type': 'PropertyValue', name: 'apiMetrics', value: data.apiMetrics },
+      { '@type': 'PropertyValue', name: 'errorLogs', value: data.errorLogs },
       { '@type': 'PropertyValue', name: 'aiUsage', value: data.aiUsage },
       { '@type': 'PropertyValue', name: 'tasks', value: data.tasks },
       { '@type': 'PropertyValue', name: 'sessions', value: data.sessions },

--- a/packages/lib/src/compliance/export/gdpr-export.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.test.ts
@@ -69,6 +69,19 @@ const { mockTable } = vi.hoisted(() => {
     expiresAt: `${name}.expiresAt`,
     revokedAt: `${name}.revokedAt`,
     revokedReason: `${name}.revokedReason`,
+    level: `${name}.level`,
+    category: `${name}.category`,
+    duration: `${name}.duration`,
+    statusCode: `${name}.statusCode`,
+    requestSize: `${name}.requestSize`,
+    responseSize: `${name}.responseSize`,
+    stack: `${name}.stack`,
+    file: `${name}.file`,
+    line: `${name}.line`,
+    column: `${name}.column`,
+    resolved: `${name}.resolved`,
+    method: `${name}.method`,
+    endpoint: `${name}.endpoint`,
   });
   return { mockTable: fn };
 });
@@ -82,6 +95,9 @@ vi.mock('@pagespace/db/schema/core', () => ({
 vi.mock('@pagespace/db/schema/monitoring', () => ({
   activityLogs: mockTable('activityLogs'),
   aiUsageLogs: mockTable('aiUsageLogs'),
+  systemLogs: mockTable('systemLogs'),
+  apiMetrics: mockTable('apiMetrics'),
+  errorLogs: mockTable('errorLogs'),
 }));
 vi.mock('@pagespace/db/schema/storage', () => ({
   files: mockTable('files'),
@@ -121,6 +137,9 @@ import {
   collectUserMessages,
   collectUserFiles,
   collectUserActivity,
+  collectUserSystemLogs,
+  collectUserApiMetrics,
+  collectUserErrorLogs,
   collectUserAiUsage,
   collectUserTasks,
   collectUserSessions,
@@ -366,6 +385,52 @@ describe('collectUserActivity', () => {
   });
 });
 
+describe('collectUserSystemLogs', () => {
+  it('given_systemLogsExist_returnsLogs', async () => {
+    const log = {
+      id: 'sl1', timestamp: new Date(), level: 'error', message: 'boom',
+      category: 'api', endpoint: '/api/foo', method: 'POST', duration: 12,
+    };
+    const db = createChainDb([[log]]);
+
+    const result = await collectUserSystemLogs(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('boom');
+  });
+});
+
+describe('collectUserApiMetrics', () => {
+  it('given_apiMetricsExist_returnsMetrics', async () => {
+    const metric = {
+      id: 'am1', timestamp: new Date(), endpoint: '/api/foo', method: 'GET',
+      statusCode: 200, duration: 42, requestSize: 100, responseSize: 200,
+    };
+    const db = createChainDb([[metric]]);
+
+    const result = await collectUserApiMetrics(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].statusCode).toBe(200);
+  });
+});
+
+describe('collectUserErrorLogs', () => {
+  it('given_errorLogsExist_returnsLogs', async () => {
+    const errorLog = {
+      id: 'el1', timestamp: new Date(), name: 'TypeError', message: 'oops',
+      endpoint: '/api/foo', method: 'POST', file: 'foo.ts', line: 10, column: 5,
+      resolved: false,
+    };
+    const db = createChainDb([[errorLog]]);
+
+    const result = await collectUserErrorLogs(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('TypeError');
+  });
+});
+
 describe('collectUserAiUsage', () => {
   it('given_usageExists_returnsLogs', async () => {
     const usage = {
@@ -575,6 +640,9 @@ describe('collectAllUserData', () => {
     expect(Array.isArray(result!.messages)).toBe(true);
     expect(Array.isArray(result!.files)).toBe(true);
     expect(Array.isArray(result!.activity)).toBe(true);
+    expect(Array.isArray(result!.systemLogs)).toBe(true);
+    expect(Array.isArray(result!.apiMetrics)).toBe(true);
+    expect(Array.isArray(result!.errorLogs)).toBe(true);
     expect(Array.isArray(result!.aiUsage)).toBe(true);
     expect(Array.isArray(result!.tasks)).toBe(true);
     expect(Array.isArray(result!.sessions)).toBe(true);

--- a/packages/lib/src/compliance/export/gdpr-export.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.test.ts
@@ -398,6 +398,21 @@ describe('collectUserSystemLogs', () => {
     expect(result).toHaveLength(1);
     expect(result[0].message).toBe('boom');
   });
+
+  it('given_nullableFieldsAreNull_passesThroughNull', async () => {
+    const log = {
+      id: 'sl2', timestamp: new Date(), level: 'info', message: 'no context',
+      category: null, endpoint: null, method: null, duration: null,
+    };
+    const db = createChainDb([[log]]);
+
+    const result = await collectUserSystemLogs(db as never, 'user-1');
+
+    expect(result[0].category).toBeNull();
+    expect(result[0].endpoint).toBeNull();
+    expect(result[0].method).toBeNull();
+    expect(result[0].duration).toBeNull();
+  });
 });
 
 describe('collectUserApiMetrics', () => {
@@ -412,6 +427,19 @@ describe('collectUserApiMetrics', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].statusCode).toBe(200);
+  });
+
+  it('given_requestAndResponseSizeAreNull_passesThroughNull', async () => {
+    const metric = {
+      id: 'am2', timestamp: new Date(), endpoint: '/api/bar', method: 'DELETE',
+      statusCode: 204, duration: 5, requestSize: null, responseSize: null,
+    };
+    const db = createChainDb([[metric]]);
+
+    const result = await collectUserApiMetrics(db as never, 'user-1');
+
+    expect(result[0].requestSize).toBeNull();
+    expect(result[0].responseSize).toBeNull();
   });
 });
 
@@ -428,6 +456,21 @@ describe('collectUserErrorLogs', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('TypeError');
+  });
+
+  it('given_resolvedTrueAndNullableFieldsNull_passesThroughCorrectly', async () => {
+    const errorLog = {
+      id: 'el2', timestamp: new Date(), name: 'RangeError', message: 'fixed now',
+      endpoint: null, method: null, file: null, line: null, column: null,
+      resolved: true,
+    };
+    const db = createChainDb([[errorLog]]);
+
+    const result = await collectUserErrorLogs(db as never, 'user-1');
+
+    expect(result[0].resolved).toBe(true);
+    expect(result[0].endpoint).toBeNull();
+    expect(result[0].file).toBeNull();
   });
 });
 

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -2,7 +2,7 @@ import { eq, inArray, or, and, ne } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { users } from '@pagespace/db/schema/auth';
 import { drives, pages, chatMessages } from '@pagespace/db/schema/core';
-import { aiUsageLogs, activityLogs } from '@pagespace/db/schema/monitoring';
+import { aiUsageLogs, activityLogs, systemLogs, apiMetrics, errorLogs } from '@pagespace/db/schema/monitoring';
 import { files, filePages } from '@pagespace/db/schema/storage';
 import { driveMembers } from '@pagespace/db/schema/members';
 import { channelMessages } from '@pagespace/db/schema/chat';
@@ -75,6 +75,48 @@ export interface UserActivityExport {
   metadata: Record<string, unknown> | null;
 }
 
+// Excludes errorStack/ip/userAgent/sessionId/requestId/metadata — internal
+// diagnostic and network telemetry, not data about the subject's own activity.
+export interface UserSystemLogExport {
+  id: string;
+  timestamp: Date;
+  level: string;
+  message: string;
+  category: string | null;
+  endpoint: string | null;
+  method: string | null;
+  duration: number | null;
+}
+
+// Excludes ip/userAgent/sessionId/requestId/error/cache fields — internal
+// diagnostic and network telemetry, not data about the subject's own activity.
+export interface UserApiMetricExport {
+  id: string;
+  timestamp: Date;
+  endpoint: string;
+  method: string;
+  statusCode: number;
+  duration: number;
+  requestSize: number | null;
+  responseSize: number | null;
+}
+
+// Excludes stack/ip/userAgent/sessionId/requestId/metadata/resolvedBy —
+// internal diagnostic telemetry and internal admin references, not data
+// about the subject's own activity.
+export interface UserErrorLogExport {
+  id: string;
+  timestamp: Date;
+  name: string;
+  message: string;
+  endpoint: string | null;
+  method: string | null;
+  file: string | null;
+  line: number | null;
+  column: number | null;
+  resolved: boolean | null;
+}
+
 export interface UserAiUsageExport {
   id: string;
   provider: string;
@@ -144,6 +186,9 @@ export interface AllUserData {
   messages: UserMessageExport[];
   files: UserFileExport[];
   activity: UserActivityExport[];
+  systemLogs: UserSystemLogExport[];
+  apiMetrics: UserApiMetricExport[];
+  errorLogs: UserErrorLogExport[];
   aiUsage: UserAiUsageExport[];
   tasks: UserTaskExport[];
   sessions: UserSessionExport[];
@@ -420,6 +465,62 @@ export async function collectUserActivity(database: DB, userId: string): Promise
   return result;
 }
 
+export async function collectUserSystemLogs(database: DB, userId: string): Promise<UserSystemLogExport[]> {
+  const result = await database
+    .select({
+      id: systemLogs.id,
+      timestamp: systemLogs.timestamp,
+      level: systemLogs.level,
+      message: systemLogs.message,
+      category: systemLogs.category,
+      endpoint: systemLogs.endpoint,
+      method: systemLogs.method,
+      duration: systemLogs.duration,
+    })
+    .from(systemLogs)
+    .where(eq(systemLogs.userId, userId));
+
+  return result;
+}
+
+export async function collectUserApiMetrics(database: DB, userId: string): Promise<UserApiMetricExport[]> {
+  const result = await database
+    .select({
+      id: apiMetrics.id,
+      timestamp: apiMetrics.timestamp,
+      endpoint: apiMetrics.endpoint,
+      method: apiMetrics.method,
+      statusCode: apiMetrics.statusCode,
+      duration: apiMetrics.duration,
+      requestSize: apiMetrics.requestSize,
+      responseSize: apiMetrics.responseSize,
+    })
+    .from(apiMetrics)
+    .where(eq(apiMetrics.userId, userId));
+
+  return result;
+}
+
+export async function collectUserErrorLogs(database: DB, userId: string): Promise<UserErrorLogExport[]> {
+  const result = await database
+    .select({
+      id: errorLogs.id,
+      timestamp: errorLogs.timestamp,
+      name: errorLogs.name,
+      message: errorLogs.message,
+      endpoint: errorLogs.endpoint,
+      method: errorLogs.method,
+      file: errorLogs.file,
+      line: errorLogs.line,
+      column: errorLogs.column,
+      resolved: errorLogs.resolved,
+    })
+    .from(errorLogs)
+    .where(eq(errorLogs.userId, userId));
+
+  return result;
+}
+
 export async function collectUserAiUsage(database: DB, userId: string): Promise<UserAiUsageExport[]> {
   const result = await database
     .select({
@@ -567,11 +668,14 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
   const userDrives = await collectUserDrives(database, userId);
   const driveIds = userDrives.map(d => d.id);
 
-  const [userPages, userMessages, userFiles, activity, aiUsage, tasks, userSessions, userNotifications, userDisplayPreferences, userPersonalizationData] = await Promise.all([
+  const [userPages, userMessages, userFiles, activity, userSystemLogs, userApiMetrics, userErrorLogs, aiUsage, tasks, userSessions, userNotifications, userDisplayPreferences, userPersonalizationData] = await Promise.all([
     collectUserPages(database, userId, driveIds),
     collectUserMessages(database, userId),
     collectUserFiles(database, userId),
     collectUserActivity(database, userId),
+    collectUserSystemLogs(database, userId),
+    collectUserApiMetrics(database, userId),
+    collectUserErrorLogs(database, userId),
     collectUserAiUsage(database, userId),
     collectUserTasks(database, userId),
     collectUserSessions(database, userId),
@@ -587,6 +691,9 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
     messages: userMessages,
     files: userFiles,
     activity,
+    systemLogs: userSystemLogs,
+    apiMetrics: userApiMetrics,
+    errorLogs: userErrorLogs,
     aiUsage,
     tasks,
     sessions: userSessions,

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -668,6 +668,9 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
   const userDrives = await collectUserDrives(database, userId);
   const driveIds = userDrives.map(d => d.id);
 
+  // Positional: this destructuring order must exactly match the Promise.all array
+  // order below (each collector returns a differently-shaped array, so TypeScript
+  // cannot catch a reorder/insert mismatch here).
   const [userPages, userMessages, userFiles, activity, userSystemLogs, userApiMetrics, userErrorLogs, aiUsage, tasks, userSessions, userNotifications, userDisplayPreferences, userPersonalizationData] = await Promise.all([
     collectUserPages(database, userId, driveIds),
     collectUserMessages(database, userId),


### PR DESCRIPTION
## Summary

- Issue #545 flagged that a data subject's Art 15 access/export request omits `system_logs`, `api_metrics`, and `error_logs`, even though those tables retain a nullable, no-FK `user_id` column right up until account deletion.
- Note on scope: issue #545's full ask is broader (a log-governance matrix across `activity`/`security_audit`/`system_logs`/`api_metrics`/`error_logs`/`ai_usage`, plus data-residency/egress policy). This PR is a scoped slice covering only the confirmed DSAR **export** gap for the three named monitoring tables; the issue is intentionally left open pending the rest of that broader work, which is out of scope here. See the [issue comment](https://github.com/2witstudios/PageSpace/issues/545#issuecomment-4888704898) for two follow-ups I found but deliberately did not fold into this PR: `security_audit_log` is also still missing from the export, and the unbounded (no-LIMIT) query pattern this PR extends to `system_logs`/`api_metrics` could use pagination at scale (precedent: PR #1084).
- Deletion was already fully wired (`packages/lib/src/logging/monitoring-purge.ts` already purges all three tables on erasure) — the gap was entirely on the export side.
- Added `collectUserSystemLogs`, `collectUserApiMetrics`, `collectUserErrorLogs` to `packages/lib/src/compliance/export/gdpr-export.ts`, mirroring `collectUserActivity`'s existing pattern, and wired them into `AllUserData`/`collectAllUserData`.
- Also updated `packages/lib/src/compliance/export/export-format.ts` — its `buildNativeExportFiles` and `toPortableExport` functions manually enumerate every `AllUserData` field (not derived from `Object.keys`), so without this change the new data would be collected from the DB but silently dropped from the actual ZIP/portable export a user downloads.
- Updated `docs/security/gdpr-export-format.md` and `CHANGELOG.md` (per repo CLAUDE.md's changelog rule for user-visible changes) to document the three new native files and portable `additionalProperty` entries.

## Redaction judgment call

Each new table carries internal diagnostic/security telemetry alongside the fields relevant to a data subject: `ip`, `userAgent`, `errorStack`/`stack`, `sessionId`, `requestId`, opaque `metadata` jsonb, and (for `error_logs`) `resolvedBy` (an internal admin's user id, not the subject's).

I chose to export only the fields describing *what happened, when, and where*:
- `UserSystemLogExport`: `id, timestamp, level, message, category, endpoint, method, duration`
- `UserApiMetricExport`: `id, timestamp, endpoint, method, statusCode, duration, requestSize, responseSize`
- `UserErrorLogExport`: `id, timestamp, name, message, endpoint, method, file, line, column, resolved`

Excluded: raw stack traces, IP addresses, user agents, session/request correlation IDs, opaque metadata blobs, and internal admin references. This is a deliberate exclusion, not an oversight. Happy to revisit if legal/compliance wants stack traces or IPs included for completeness.

## Test plan
- [x] `bun test` (vitest) for `packages/lib/src/compliance/export/` — 48/48 new+existing tests pass (35 in `gdpr-export.test.ts`, 13 in `export-format.test.ts`, including null-path coverage for every nullable field on the 3 new collectors), 217+/217+ across `packages/lib/src/compliance` pass
- [x] `bunx tsc --noEmit` clean for `packages/lib`, `apps/web`, `apps/admin`
- [x] Confirmed `apps/web/.../account/export/route.ts` and `apps/admin/.../export/route.ts` need no changes (thin delegator + object-spread, respectively) — verified by reading both
- [x] `apps/web/src/app/api/account/export/__tests__/route.test.ts` — its `mockUserData` fixture was missing the 3 new required `AllUserData` fields, which made `buildNativeExportFiles`/`toPortableExport` throw a runtime `TypeError` once called with a stale fixture; fixed the fixture, updated two hardcoded `archive.append()` call-count assertions (+3), and added presence assertions for the 3 new files. All 17 tests in this file now pass, verified via the actual CI command (`bun run test:coverage`) after a full monorepo rebuild.
- [x] Independent 8-angle review pass (correctness, removed-behavior, cross-file breakage, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) surfaced only: a missing changelog entry (fixed), thin null-path test coverage (fixed), and a documented-but-not-fixed positional-destructuring readability risk in `collectAllUserData` (added a one-line invariant comment) — see commit history for details.

Refs #545

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>