### PR TITLE
docs(gdpr): RoPA register, AI-processing DPIA, onprem region guidance

### DIFF
--- a/.env.onprem.example
+++ b/.env.onprem.example
@@ -52,7 +52,10 @@ OLLAMA_BASE_URL=http://localhost:11434
 # LMSTUDIO_BASE_URL=http://localhost:1234/v1
 
 # Azure OpenAI (BAA-covered cloud AI). Both vars must be set for the provider
-# to appear; the endpoint URL is SSRF-validated at request time.
+# to appear; the endpoint URL is SSRF-validated at request time, but no region
+# is enforced. If you serve EU data subjects, provision your Azure OpenAI
+# resource in an EU region (e.g. swedencentral, westeurope) — see
+# docs/security/gdpr-onprem-ai-region-guidance.md.
 # AZURE_OPENAI_API_KEY=your_azure_api_key
 # AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/openai/deployments/your-deployment/
 

--- a/docs/security/gdpr-dpia-ai-processing.md
+++ b/docs/security/gdpr-dpia-ai-processing.md
@@ -1,0 +1,93 @@
+# Data Protection Impact Assessment: AI Prompt/Content Processing
+
+**Issue:** #930 · **Articles:** GDPR Art 35, Art 25, Art 32 · **Audience:** Security/compliance, engineering leads
+
+## 1. Description of processing
+
+**Nature.** Users submit prompts and content (chat messages, channel messages,
+page content referenced in AI actions) that are sent to a large-language-model
+provider for inference, and the resulting conversation is persisted. A
+first-party analytics table (`ai_usage_logs`) separately records usage metadata
+for billing/observability.
+
+**Scope.** All AI chat, assistance, and search-adjacent features across the
+product. Every cloud AI vendor (OpenAI, Anthropic, Google, xAI) is reached
+through a single subprocessor, **OpenRouter**, which forwards the
+vendor-prefixed model ID verbatim (`apps/web/src/lib/ai/core/ai-providers-config.ts`,
+`provider-factory.ts`) — there are no separate direct SDK integrations for
+these vendors. Onprem deployments instead route to Ollama (runs locally, no
+third-party transfer), or to an operator-configured Azure OpenAI or LM Studio
+endpoint.
+
+**Context.** `chat_messages.content` and `channel_messages.content` are stored
+in Postgres as plaintext (`packages/db/src/schema/core.ts`, `schema/chat.ts`).
+`ai_usage_logs` is retained for `RETENTION_AI_USAGE_LOGS_DAYS` (default 90 —
+`docs/security/audit-log-retention-policy.md`).
+
+**Purpose.** AI inference is core product functionality (chat, assistance,
+search), not incidental analytics. `ai_usage_logs` supports billing accuracy
+and abuse/anomaly monitoring.
+
+## 2. Necessity and proportionality assessment
+
+- AI processing is the product's primary value proposition — there is no
+  lesser-data way to deliver conversational AI features; the content sent to a
+  provider is exactly the content the user chose to submit.
+- Data minimization is structural rather than per-request: routing all cloud
+  vendors through a single OpenRouter funnel means one subprocessor
+  relationship to govern instead of four, and the erasure pipeline already
+  distinguishes ZDR-reliant (zero-data-retention) gateway providers from
+  others (`docs/security/data-subject-request-runbook.md`, "Sub-processor
+  propagation").
+- No payment/card data ever enters this pipeline (see the RoPA billing row).
+- Onprem operators can eliminate third-party transfer entirely by running
+  Ollama locally; Azure OpenAI/LM Studio remain operator-configured
+  alternatives for cases requiring a specific vendor relationship (e.g.
+  existing BAAs).
+
+## 3. Risk assessment
+
+| # | Risk | Current mitigation | Residual risk |
+|---|---|---|---|
+| R1 | Compromised or malicious AI provider/subprocessor exposes in-flight or logged prompt content | Single-funnel OpenRouter reduces subprocessor surface vs. direct multi-vendor integration; ZDR-reliant providers preferred where available (`data-subject-request-runbook.md`) | Medium — depends on OpenRouter and downstream vendor security posture, outside our direct control |
+| R2 | `chat_messages.content`/`pages.content` are stored **plaintext** in our own database, with no encryption-at-rest scheme — this is explicitly scoped out of the field-encryption epic (not "in progress"), because the existing substring search (`ilike(pages.content, ...)`) has no working encrypted equivalent (`docs/security/pii-encryption-design.md`, "Why content is scoped OUT") | Access to content is gated by `packages/lib/src/permissions/` (message/page visibility checks); all reads/writes/exports are logged to `security_audit_log` | Medium-High — a database compromise exposes this content in the clear; mitigation is access-control depth, not encryption, until a searchable-encryption design ships |
+| R3 | Cross-border transfer: OpenRouter forwards content to underlying vendors (potentially outside the EEA) | ZDR-reliant provider preference; erasure pipeline tracks per-provider retention behavior | `[TODO: confirm OpenRouter and underlying-vendor DPA/SCC coverage — legal follow-up]` |
+| R4 | Onprem Azure OpenAI region misconfiguration could route EU data subjects' content outside the EEA — today there is zero region enforcement or guidance (`.env.onprem.example`, `provider-factory.ts` + `validateLocalProviderURL` perform only SSRF checks, no region awareness) | New onprem guidance doc recommends an EU-region Azure OpenAI resource for EU-serving deployments (see [`gdpr-onprem-ai-region-guidance.md`](gdpr-onprem-ai-region-guidance.md)) | Medium, pending `[TODO: confirm whether region should be enforced in config validation or left as operator guidance]` in that doc |
+| R5 | Users may inadvertently include third-party personal data in prompts, which then flows to the AI provider and is persisted | No content-level PII redaction exists; relies on user judgment and access control on the stored conversation | Low-Medium — inherent to any free-text AI product; not specific to this codebase |
+| R6 | Unauthorized access to stored chat/page history (insider or compromised-account access) | `packages/lib/src/permissions/` centralizes all message/page visibility checks; `security_audit_log` records data.read/write/export events with tamper-evident hash chaining (`packages/lib/src/audit/security-audit.ts`) | Low, contingent on permission-check coverage remaining complete as features are added |
+
+## 4. Mitigations already in place
+
+- **Access control** — `packages/lib/src/permissions/` is the single, centralized
+  gate for message/page visibility (`canUserViewPage`, `getUserAccessLevel`,
+  etc.); no scattered ad-hoc permission checks were found guarding this data.
+- **Audit trail** — `security-audit.ts` logs `data.read`/`data.write`/`data.export`
+  events with a tamper-evident hash chain, plus AES-256-GCM IP encryption
+  (conditional on `ENCRYPTION_KEY`).
+- **Erasure propagation** — the Right-to-Erasure pipeline builds a per-provider
+  manifest and records ZDR-reliant vs. skipped vs. `manual_review` status per
+  AI provider actually invoked by the subject
+  (`docs/security/data-subject-request-runbook.md`).
+- **Breach response** — if an AI provider or subprocessor is compromised, the
+  Art 33/34 notification lifecycle in `docs/security/breach-runbook.md`
+  applies.
+- **Pseudonymization escape hatch** — if a supervisory authority disputes
+  retained audit-log rows referencing AI-related events,
+  `docs/security/gdpr-pseudonymization-runbook.md` provides the operational
+  path.
+- **In progress** — onprem EU-region guidance for Azure OpenAI
+  ([`gdpr-onprem-ai-region-guidance.md`](gdpr-onprem-ai-region-guidance.md))
+  directly reduces R4.
+
+## 5. Residual risk conclusion
+
+The two live residual risks are (a) plaintext storage of chat/page content in
+our own database, pending a searchable-encryption design that doesn't yet
+exist, and (b) third-party subprocessor transfer via OpenRouter to vendors
+whose DPA/SCC coverage has not been confirmed by legal. Both are bounded today
+by centralized access control, a tamper-evident audit trail, and an erasure
+pipeline that already accounts for provider-specific data-retention behavior —
+but a DPIA is not complete without a named, accountable sign-off on whether
+this residual risk level is acceptable.
+
+[TODO: risk-owner sign-off — name + date]

--- a/docs/security/gdpr-onprem-ai-region-guidance.md
+++ b/docs/security/gdpr-onprem-ai-region-guidance.md
@@ -1,0 +1,47 @@
+# Onprem AI Provider Region Guidance
+
+**Issue:** #961 · **Articles:** GDPR Art 44–49 (transfers), Art 32 · **Audience:** Onprem operators, engineering
+
+## Context
+
+Onprem deployments (`DEPLOYMENT_MODE=onprem`, `packages/lib/src/deployment-mode.ts`)
+allow three AI providers: Ollama and LM Studio (both local runtimes — no
+third-party transfer) and Azure OpenAI (a BAA-covered cloud provider,
+`ONPREM_ALLOWED_PROVIDERS` in `apps/web/src/lib/ai/core/ai-providers-config.ts`).
+
+Azure OpenAI configuration is exactly two env vars — `AZURE_OPENAI_API_KEY` and
+`AZURE_OPENAI_ENDPOINT` (`.env.onprem.example`). The endpoint is a full URL
+including the Azure resource name and deployment path
+(`https://your-resource.openai.azure.com/openai/deployments/your-deployment/`);
+there is no separate region field.
+
+`apps/web/src/lib/ai/core/provider-factory.ts` reads that endpoint and validates
+it through `validateLocalProviderURL`
+(`packages/lib/src/security/url-validator.ts`) before use. That check is a
+**pure SSRF guard** — it blocks localhost, private IPs, link-local addresses,
+and cloud metadata endpoints (`169.254.169.254`, `metadata.azure.com`,
+`168.63.129.16`). It has no concept of Azure region at all. In other words: an
+operator can point `AZURE_OPENAI_ENDPOINT` at any Azure OpenAI resource in any
+Azure region worldwide, and nothing in the codebase notices or cares.
+
+## Recommendation
+
+Onprem operators serving EU data subjects should provision their Azure OpenAI
+resource in an **EU region** (e.g. `swedencentral`, `westeurope`) so that
+prompt/content data processed via Azure OpenAI stays within the EEA, rather
+than relying on Azure's cross-border transfer mechanisms (Standard Contractual
+Clauses / EU Data Boundary) as the only control.
+
+This is operator-facing guidance, not a code change — see the pointer added to
+`.env.onprem.example` next to the Azure OpenAI variables.
+
+[TODO: confirm whether the product should enforce this via config validation
+(e.g. rejecting non-EU Azure OpenAI hostnames when an EU-residency flag is set)
+or continue to document it as operator guidance only — this is a product
+decision, not something this doc should decide unilaterally]
+
+## Cross-references
+
+- `.env.onprem.example` — where the Azure OpenAI env vars are configured
+- `docs/security/encryption-in-transit.md` — §2 covers the related self-host/
+  multi-host TLS requirement for onprem/tenant deployments

--- a/docs/security/gdpr-ropa-register.md
+++ b/docs/security/gdpr-ropa-register.md
@@ -1,0 +1,50 @@
+# GDPR Records of Processing Activities (RoPA) Register
+
+**Issue:** #931, #951 · **Articles:** GDPR Art 30 · **Audience:** Security/compliance, engineering leads
+
+## Context
+
+Article 30 requires a controller to maintain a record of processing activities.
+This register covers the processing activities we actually have code for today —
+authentication, billing, AI inference, notifications, security/audit logging, and
+file storage. "Categories of data" below draws on the canonical per-user data
+inventory already enumerated for data-portability exports in
+`docs/security/gdpr-export-format.md` (`profile`, `drives`, `pages`, `messages`,
+`files-metadata`, `activity`, `ai-usage`, `tasks`, `sessions`, `notifications`,
+`display-preferences`, `personalization`).
+
+Every cell below is either a fact backed by a file/line citation, or an explicit
+`[TODO]` where the answer requires legal/ops input this document can't
+manufacture (subprocessor DPAs, infra-level bucket regions, log-table retention
+that isn't governed by a retention-policy doc yet). Do not treat a `[TODO]` as
+"no risk" — treat it as "not yet answered."
+
+## Register
+
+| Processing activity | Purpose | Categories of data subjects/data | Recipients | Retention | Transfers | Security measures |
+|---|---|---|---|---|---|---|
+| **Authentication** (passkeys, magic links, sessions) | Verify identity and authorize account access | Data subjects: registered users. Data: `users.email`/`name`, passkey public keys (`passkeys` table — private key never leaves the authenticator), hashed session/device/magic-link/MCP tokens, IP/user-agent on `deviceTokens` | Internal only, plus Resend for magic-link email delivery | Magic link 5 min · email-verify token 24h default · web session 7d + 7d post-expiry purge · device token 90d · desktop WS token 7d · passkeys: no expiry (`packages/lib/src/auth/magic-link-constants.ts`, `constants.ts`, `device-auth-utils.ts`, `token-lifecycle-policy.ts`) | None (internal DB) | Tokens are SHA3-256 hash-only at rest, never the raw value (`packages/lib/src/auth/token-utils.ts:42-44`); access gated by `packages/lib/src/permissions/` |
+| **Billing** (Stripe) | Process subscriptions and payment | Data subjects: paying customers. Data: email, name, internal `userId` (sent to Stripe as metadata), `subscriptions`/`stripeEvents` tables | Stripe (payment-processor subprocessor; card data is collected client-side via Stripe Elements and never reaches app servers — `apps/web/src/components/billing/StripeProvider.tsx`) | `[TODO: engineering/legal to confirm retention window for `subscriptions`/`stripeEvents` — not covered by `docs/security/audit-log-retention-policy.md`]` | `[TODO: confirm Stripe DPA/SCC coverage for the account's region]` | Access to billing data gated by `packages/lib/src/permissions/`; webhook processing is idempotency-ledgered (`stripeEvents`) |
+| **AI inference** (prompt/content processing) | Provide AI chat, assistance, and search across the product | Data subjects: users submitting prompts (and any third parties named in that content). Data: `chat_messages.content`/`channel_messages.content` (plaintext), tool calls/results | **OpenRouter** is the single subprocessor for every cloud vendor (OpenAI/Anthropic/Google/xAI model IDs are forwarded verbatim — `apps/web/src/lib/ai/core/ai-providers-config.ts`, `provider-factory.ts`); onprem deployments instead use Ollama (local, no transfer) or Azure OpenAI/LM Studio (deployment-configured endpoint) | `ai_usage_logs`: `RETENTION_AI_USAGE_LOGS_DAYS`, default 90 (`docs/security/audit-log-retention-policy.md`). Message/page content itself: `[TODO: no retention policy exists for `chat_messages`/`pages` content tables]` | `[TODO: confirm OpenRouter DPA/SCC status]` — the erasure pipeline already records gateway-routed cloud providers as ZDR-reliant, skips local providers, and flags unrecognized ones `manual_review` (`docs/security/data-subject-request-runbook.md`, "Sub-processor propagation") | Message/page visibility gated by `packages/lib/src/permissions/`; erasure pipeline propagates deletion to AI providers. **Content is plaintext at rest** — explicitly scoped out of the field-encryption epic pending a searchable-encryption design (`docs/security/pii-encryption-design.md`, "Per-column decisions" + "Why content is scoped OUT"). See risk R2 in the [AI-processing DPIA](gdpr-dpia-ai-processing.md). |
+| **Notifications** (email, push) | Deliver transactional and product notifications | Data subjects: users. Data: email address + notification content, push tokens (APNs live; FCM/Web Push stubs exist in schema but sends are unimplemented) | Resend (email subprocessor), Apple APNs (iOS push subprocessor) | `[TODO: no TTL found for `emailNotificationLog`/`pushNotificationTokens` — confirm with engineering]` | `[TODO: confirm Resend/Apple DPA/SCC coverage]` | Per-user opt-in preferences (`emailNotificationPreferences`); Resend suppression-list is wired into the erasure pipeline (`packages/lib/src/compliance/erasure/resend-suppression-client.ts`) |
+| **Security/audit logging** | Security monitoring, forensic investigation, legal-obligation record-keeping | Data subjects: all users and admins. Data: event type, `userId`, IP address, user-agent, geolocation, risk score, per `security_audit_log` schema | Internal only, admin-role restricted | **Infinite** — tamper-evident hash chain, Art 17(3)(b) legal-obligation basis (`docs/security/audit-log-retention-policy.md`) | None | IP address is AES-256-GCM encrypted with a blind index for equality lookups whenever `ENCRYPTION_KEY` is set (`packages/lib/src/encryption/audit-ip-crypto.ts`); tamper-evident hash chain; disputed-retention path via `docs/security/gdpr-pseudonymization-runbook.md`; admin-only access via `packages/lib/src/permissions/` |
+| **File storage** | Store user-uploaded files and attachments | Data subjects: users uploading files (and any third parties captured in file content). Data: file bytes, `files` table metadata, `AttachmentMeta` (originalName, size, mimeType, contentHash) | Tigris (S3-compatible object storage, configured subprocessor) or AWS S3 as an alternative (`apps/processor/src/s3-client.ts`) | `[TODO: bucket lifecycle/region are infra/env config, not in this repo — confirm with deployment ops]` | `[TODO: same — deployment-specific, not determinable from code]` | AES-256-GCM envelope encryption for server-side-only extracted-text caches whenever `ENCRYPTION_KEY` is set; original files/binary previews encrypted only if `FILE_ENCRYPTION_ENABLED=true` (default OFF — cloud relies on Tigris/infra disk encryption instead, since browsers can't decrypt an app-layer envelope through a presigned URL); `metadata.json` sidecars are not yet encrypted (tracked follow-up) (`docs/security/file-encryption-at-rest.md`); access gated by `packages/lib/src/permissions/file-access.ts: canUserAccessFile` |
+
+## Cross-references
+
+- `docs/security/pii-encryption-design.md` — field-level encryption decisions and current cutover status
+- `docs/security/file-encryption-at-rest.md` — object-storage envelope encryption
+- `docs/security/encryption-in-transit.md` — transport security (HSTS, internal service-to-service, mobile cert pinning)
+- `docs/security/audit-log-retention-policy.md` — retention windows and archival mechanics
+- `docs/security/data-subject-request-runbook.md` — erasure pipeline and sub-processor propagation
+- `packages/lib/src/permissions/` — centralized access-control functions cited throughout this register
+- [`docs/security/gdpr-dpia-ai-processing.md`](gdpr-dpia-ai-processing.md) — risk assessment for the AI inference row
+
+## Out of scope
+
+This register documents processing activities as implemented in code. It does
+not attempt to verify subprocessor Data Processing Agreements, Standard
+Contractual Clauses, or the actual deployed cloud region for third-party
+services (Stripe, OpenRouter, Resend, Apple, Tigris/AWS) — those are legal and
+deployment-ops follow-ups tracked as `[TODO]` above, not engineering facts this
+document can assert.


### PR DESCRIPTION
## Summary

Internal-compliance-docs slice of the GDPR backlog effort — three new/updated `docs/security/` documents, no code changes beyond a one-line comment pointer.

- **`docs/security/gdpr-ropa-register.md`** (new) — Art 30 Records of Processing Activities register covering authentication, billing, AI inference, notifications, security/audit logging, and file storage. Every row is grounded in a code citation (retention windows, encryption mechanisms, subprocessors, access-control functions); anything requiring legal/ops input that isn't knowable from code is left as an explicit `[TODO]` rather than guessed.
- **`docs/security/gdpr-dpia-ai-processing.md`** (new) — Data Protection Impact Assessment for AI prompt/content processing: description of processing, necessity/proportionality, a 6-item risk assessment, mitigations already in place, and a residual-risk conclusion. Ends with `[TODO: risk-owner sign-off — name + date]` since a DPIA requires named accountability this doc can't supply.
- **`docs/security/gdpr-onprem-ai-region-guidance.md`** (new) + **`.env.onprem.example`** (pointer comment) — recommends EU-region Azure OpenAI deployment for onprem operators serving EU data subjects, since today's SSRF validation on the endpoint URL has no region awareness at all. Ends with `[TODO: confirm whether this should be enforced via config validation or left as operator guidance]` — a product decision, not mine to make.

Two notable facts surfaced during research that the docs state plainly rather than assume: `users.email`/`users.name` are still plaintext in all live code paths (the field-encryption cutover hasn't shipped, despite an aspirational schema comment), and `chat_messages.content`/`pages.content` have no encryption-at-rest scheme at all (explicitly scoped out pending a searchable-encryption design, not "in progress").

Addresses #931, #951, #930, #961 — left open intentionally for point-guard verification before closing.

## Test plan

- [x] Cross-checked doc structure (header, metadata line, table style, cross-references) against the 8 existing `docs/security/*.md` files for consistency
- [x] Spot-checked citations (`RETENTION_AI_USAGE_LOGS_DAYS`, `canUserAccessFile`, token hashing) directly against source files
- [x] No code changes beyond the `.env.onprem.example` comment — no typecheck/test impact