### PR TITLE
docs(gdpr): privacy policy rewrite + subprocessors/cookies pages + in-flow notices

### DIFF
--- a/apps/marketing/src/app/cookies/page.tsx
+++ b/apps/marketing/src/app/cookies/page.tsx
@@ -1,0 +1,108 @@
+import { SiteNavbar } from "@/components/SiteNavbar";
+import { SiteFooter } from "@/components/SiteFooter";
+import { LegalTodo } from "@/components/LegalTodo";
+import { pageMetadata, LEGAL_LAST_UPDATED } from "@/lib/metadata";
+
+export const metadata = pageMetadata.cookies;
+
+export default function CookiePolicy() {
+  return (
+    <div className="min-h-screen bg-background">
+      <SiteNavbar />
+
+      <div className="container mx-auto px-4 py-12 md:py-16 max-w-4xl">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold mb-2">Cookie Policy</h1>
+          <p className="text-muted-foreground">Last updated: {LEGAL_LAST_UPDATED}</p>
+        </div>
+
+        <div className="prose prose-lg max-w-none dark:prose-invert">
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">1. Introduction</h2>
+            <p className="mb-4">
+              This Cookie Policy explains how PageSpace uses cookies and similar technologies (such as
+              browser local storage) when you use our service, and how you can control your
+              preferences. See our <a href="/privacy" className="text-primary hover:underline">Privacy Policy</a> for
+              how this fits into our overall data-processing practices.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">2. Strictly Necessary Cookies</h2>
+            <p className="mb-4">
+              These cookies are required for the service to function and cannot be switched off. They
+              are always on and do not require consent under ePrivacy rules:
+            </p>
+            <ul className="list-disc pl-6 mb-4">
+              <li><strong>Session cookie:</strong> an opaque session token that keeps you signed in between requests. Session tokens are hashed at rest and are never readable as plaintext credentials.</li>
+              <li><strong><code>ps_consent</code>:</strong> stores your cookie-preference choices (necessary / analytics / preferences) so we don&#39;t re-ask on every visit. Expires after 1 year.</li>
+              <li><strong><code>login_csrf</code>:</strong> a short-lived token that protects the sign-in flow against cross-site request forgery.</li>
+            </ul>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">3. Analytics</h2>
+            <p className="mb-4">
+              With your consent, we use a first-party, self-hosted usage tracker — not a third-party
+              analytics SDK — to understand how the product is used (e.g. feature usage, page views).
+              Events are sent directly to our own backend, not to an external analytics vendor.
+              Analytics is off by default, only fires once you opt in via the cookie banner, and is
+              disabled entirely on self-hosted (on-premises) deployments.
+            </p>
+            <p className="mb-4">
+              To distinguish returning devices for this first-party analytics, we may also store a
+              device identifier in your browser&#39;s local storage.
+            </p>
+            <LegalTodo>confirm the exact analytics event schema, any additional cookie/local-storage key names beyond the consent and device-id storage described above, and how long device-identifier data is retained.</LegalTodo>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">4. Preferences</h2>
+            <p className="mb-4">
+              With your consent, this category enables optional third-party sign-in convenience
+              features — currently, Google Identity Services (used for the &quot;Sign in with Google&quot;
+              one-tap flow). Google may set its own cookies once this script loads. This category is
+              off by default.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">5. No Third-Party Advertising Cookies</h2>
+            <p className="mb-4">
+              PageSpace does not use third-party advertising or cross-site tracking cookies, and we do
+              not sell your data to advertisers.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">6. Managing Your Preferences</h2>
+            <p className="mb-4">
+              You can accept all cookies, reject all optional cookies, or customize your choices for
+              Analytics and Preferences at any time using the cookie consent banner shown on your
+              first visit. Necessary cookies cannot be disabled, since the service cannot function
+              without them.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">7. Changes to This Policy</h2>
+            <p className="mb-4">
+              We may update this Cookie Policy from time to time. We will notify you of any changes by
+              posting the new policy on this page and updating the &quot;Last updated&quot; date.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">8. Contact Us</h2>
+            <p className="mb-4">
+              If you have questions about this Cookie Policy, please contact us at{" "}
+              <strong>hello@pagespace.ai</strong>.
+            </p>
+          </section>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -1,5 +1,6 @@
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
+import { LegalTodo } from "@/components/LegalTodo";
 import { pageMetadata, LEGAL_LAST_UPDATED } from "@/lib/metadata";
 
 export const metadata = pageMetadata.privacy;
@@ -19,12 +20,28 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">1. Introduction</h2>
             <p className="mb-4">
-              PageSpace is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and protect information in our cloud-based workspace platform.
+              PageSpace is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and protect information in our cloud-based workspace platform, and describes your rights under the General Data Protection Regulation (GDPR) and similar data protection laws.
             </p>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">2. Cloud-Based Privacy Approach</h2>
+            <h2 className="text-2xl font-semibold mb-4">2. Who We Are (Data Controller)</h2>
+            <p className="mb-4">
+              PageSpace is operated by Jonathan Woodall, as a sole proprietorship, who is the data controller responsible for your personal data under this Privacy Policy.
+            </p>
+            <LegalTodo>legal entity name (if different from the above) and registered/postal address for the data controller.</LegalTodo>
+            <p className="mb-4">
+              <strong>Data Protection Officer (DPO):</strong> our recommended-default position is that a DPO is not required — GDPR Art 37 only mandates one where core activities involve large-scale, regular, and systematic monitoring of data subjects, or large-scale processing of special-category data, which is unlikely to describe PageSpace at its current size.
+            </p>
+            <LegalTodo>confirm current headcount and processing scale still support the &quot;no DPO required&quot; conclusion above; revisit as the company grows.</LegalTodo>
+            <p className="mb-4">
+              <strong>EU representative:</strong> PageSpace is operated from the United States and has no establishment in the EU. If we offer services to EU-based data subjects on more than an occasional basis, Art 27 GDPR likely requires us to appoint an EU representative (unless a recognized exemption applies, e.g. only occasional, low-risk processing).
+            </p>
+            <LegalTodo>confirm whether Art 27 applies given our actual EU user base, and if so, name an appointed EU representative — or document the exemption rationale if it does not apply.</LegalTodo>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">3. Cloud-Based Privacy Approach</h2>
             <p className="mb-4">
               PageSpace is designed with privacy and security as core principles:
             </p>
@@ -37,8 +54,8 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">3. Information We Collect</h2>
-            <h3 className="text-xl font-semibold mb-3">3.1 Account and Content Data</h3>
+            <h2 className="text-2xl font-semibold mb-4">4. Information We Collect</h2>
+            <h3 className="text-xl font-semibold mb-3">4.1 Account and Content Data</h3>
             <p className="mb-4">
               Information we collect and store includes:
             </p>
@@ -52,7 +69,7 @@ export default function PrivacyPolicy() {
               <li>OAuth tokens for connected integrations such as Google Calendar and Google Drive (encrypted using AES-256-GCM)</li>
             </ul>
 
-            <h3 className="text-xl font-semibold mb-3">3.2 Technical Information</h3>
+            <h3 className="text-xl font-semibold mb-3">4.2 Technical Information</h3>
             <p className="mb-4">
               We collect technical information to maintain and improve the service:
             </p>
@@ -66,12 +83,28 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">4. Third-Party AI Services</h2>
+            <h2 className="text-2xl font-semibold mb-4">5. Lawful Basis for Processing</h2>
+            <p className="mb-4">
+              Under GDPR Art 6, we rely on the following lawful bases for each purpose we process personal data for. This is our recommended-default mapping:
+            </p>
+            <ul className="list-disc pl-6 mb-4">
+              <li><strong>Account provision</strong> (creating and operating your account, storing your content) — <strong>Contract</strong> (Art 6(1)(b)): necessary to provide the service you signed up for</li>
+              <li><strong>Billing and subscriptions</strong> — <strong>Contract</strong> (Art 6(1)(b)): necessary to perform our agreement with you</li>
+              <li><strong>Security and audit logs</strong> — <strong>Legitimate interest</strong> (Art 6(1)(f)): protecting the service, our users, and detecting abuse</li>
+              <li><strong>Marketing emails</strong> — <strong>Consent</strong> (Art 6(1)(a)): only sent if you opt in, and withdrawable at any time</li>
+              <li><strong>AI processing</strong> (sending your prompts/content to AI providers) — <strong>Consent / Contract</strong>: providing AI features is part of the service you signed up for; where required, we also seek explicit consent</li>
+            </ul>
+            <LegalTodo>legal review of the legitimate-interest balancing test for security/audit logging, to confirm this mapping holds up to scrutiny.</LegalTodo>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">6. Third-Party AI Services</h2>
             <p className="mb-4">
               When you use AI features, we work with external AI providers, each subject to that provider&#39;s own privacy policy. Provider routing is managed by PageSpace at the deployment level — you no longer supply or store provider API keys yourself. Supported providers include:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li><strong>Model providers:</strong> your prompts and the relevant context are sent to AI model providers — including OpenAI (GPT), Anthropic (Claude), Google (Gemini), xAI (Grok), and others — to generate responses. Models are reached using credentials and routing managed by PageSpace on your behalf (including through routing providers such as OpenRouter), and the specific providers we use may change over time. AI usage is metered against your plan&#39;s monthly credit allowance; Free plans use a curated set of models, and paid plans unlock the full catalogue</li>
+              <li><strong>Model providers:</strong> your prompts and the relevant context are sent to AI model providers — including Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok), and, via the OpenRouter routing provider, additional third-party models — to generate responses. AI usage is metered against your plan&#39;s monthly credit allowance; Free plans use a curated set of models, and paid plans unlock the full catalogue.</li>
+              <li><strong>Ollama (on-premises/local option):</strong> for self-hosted deployments, PageSpace supports Ollama, which runs models locally — your prompts and content never leave your own infrastructure when using this option.</li>
             </ul>
             <p className="mb-4">
               <strong>Important:</strong> When using AI services, we send your prompts and relevant context to AI providers to generate responses. We do not share your personal information or unrelated workspace data with AI providers.
@@ -79,8 +112,8 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">5. Data Processing and Storage</h2>
-            <h3 className="text-xl font-semibold mb-3">5.1 Cloud Processing</h3>
+            <h2 className="text-2xl font-semibold mb-4">7. Data Processing and Storage</h2>
+            <h3 className="text-xl font-semibold mb-3">7.1 Cloud Processing</h3>
             <p className="mb-4">
               Data processing occurs on our secure cloud infrastructure, including:
             </p>
@@ -92,7 +125,7 @@ export default function PrivacyPolicy() {
               <li>AI model inference through third-party providers</li>
             </ul>
 
-            <h3 className="text-xl font-semibold mb-3">5.2 Database Storage</h3>
+            <h3 className="text-xl font-semibold mb-3">7.2 Database Storage</h3>
             <p className="mb-4">
               Your data is stored in our cloud database infrastructure with security measures appropriate for a service of this type, including:
             </p>
@@ -109,21 +142,21 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">6. Data Sharing</h2>
+            <h2 className="text-2xl font-semibold mb-4">8. Data Sharing</h2>
             <p className="mb-4">
               PageSpace does not sell or rent your personal data. We may share your data only in these situations:
             </p>
             <ul className="list-disc pl-6 mb-4">
               <li>With AI service providers when you use AI features</li>
               <li>When you explicitly share or collaborate with other users</li>
-              <li>With service providers who help us operate the platform (under strict confidentiality agreements)</li>
+              <li>With service providers who help us operate the platform (under strict confidentiality agreements) — see our <a href="/subprocessors" className="text-primary hover:underline">Subprocessors</a> page for the full list</li>
               <li>When required by law or to protect our legal rights</li>
               <li>In connection with a business transfer (merger, acquisition, etc.)</li>
             </ul>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">7. Data Security</h2>
+            <h2 className="text-2xl font-semibold mb-4">9. Data Security</h2>
             <p className="mb-4">
               We implement security measures appropriate for a cloud-based workspace service, including:
             </p>
@@ -143,60 +176,71 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">8. Your Rights and Control</h2>
+            <h2 className="text-2xl font-semibold mb-4">10. Your Rights and Control</h2>
             <p className="mb-4">
-              You have complete control over your data:
+              Under GDPR and similar laws, you have the following rights over your personal data:
             </p>
             <ul className="list-disc pl-6 mb-4">
               <li><strong>Access:</strong> All your data is accessible through the application interface</li>
-              <li><strong>Modification:</strong> Edit or update any content at any time</li>
-              <li><strong>Deletion:</strong> Delete individual items or your entire workspace</li>
-              <li><strong>Export:</strong> Data export available by request - contact us for assistance</li>
-              <li><strong>Portability:</strong> Your data is stored in standard formats</li>
+              <li><strong>Modification (Rectification):</strong> Edit or update any content at any time</li>
+              <li><strong>Deletion (Erasure):</strong> Delete individual items or your entire workspace</li>
+              <li><strong>Export (Data Portability):</strong> Data export available by request - contact us for assistance</li>
+              <li><strong>Restriction (Art 18):</strong> Request that we limit processing of your data in certain circumstances (e.g. while a dispute about accuracy is resolved)</li>
+              <li><strong>Objection (Art 21):</strong> Object to processing based on legitimate interest, including for direct marketing purposes</li>
+              <li><strong>Withdraw Consent (Art 7(3)):</strong> Where processing is based on consent (e.g. marketing emails), withdraw it at any time without affecting the lawfulness of processing before withdrawal</li>
+              <li><strong>Complain to a supervisory authority (Art 13(2)(d)):</strong> You have the right to lodge a complaint with a data protection supervisory authority</li>
             </ul>
+            <LegalTodo>name your supervisory authority if PageSpace is EU-established; otherwise state that this right applies to lodging a complaint with any EU Data Protection Authority (DPA), typically the one in the data subject&#39;s member state.</LegalTodo>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">9. Children&#39;s Privacy</h2>
+            <h2 className="text-2xl font-semibold mb-4">11. Automated Decision-Making</h2>
+            <p className="mb-4">
+              We do not make solely-automated decisions that produce legal effects concerning you or similarly significantly affect you (GDPR Art 22).
+            </p>
+            <LegalTodo>confirm no such use case currently exists in the product (e.g. automatic billing-suspension or account-lockout logic that acts without human review) — revisit this statement if one is introduced.</LegalTodo>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">12. Children&#39;s Privacy</h2>
             <p className="mb-4">
               PageSpace is not intended for children under 13. We do not knowingly collect personal information from children under 13. If you believe a child has provided personal information, please contact us.
             </p>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">10. Changes to This Policy</h2>
+            <h2 className="text-2xl font-semibold mb-4">13. Changes to This Policy</h2>
             <p className="mb-4">
               We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the &quot;Last updated&quot; date.
             </p>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">11. Data Retention</h2>
+            <h2 className="text-2xl font-semibold mb-4">14. Data Retention</h2>
             <p className="mb-4">
-              We retain your data for as long as:
+              We retain different categories of data for different lengths of time, depending on why we hold it:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li>Your account remains active</li>
-              <li>Needed to provide you with services</li>
-              <li>Required by law or for legitimate business purposes</li>
+              <li><strong>Account and content data:</strong> retained while your account is active. Upon a deletion request, we complete erasure within 30 days (our internal Art 12(3) service-level target), except where we are required to retain specific records by law</li>
+              <li><strong>Security and monitoring logs:</strong> retention varies by log type — API metrics, error logs, and AI-usage logs are kept for 90 days by default; system logs for 30 days; general user-activity logs for 180 days. Our tamper-evident security audit log and activity log are retained indefinitely because deleting entries would break the cryptographic hash chain that proves they haven&#39;t been altered — this is justified under GDPR Art 17(3)(b) as necessary for compliance with a legal obligation</li>
+              <li><strong>Backups:</strong> retained separately from primary storage for disaster-recovery purposes</li>
             </ul>
-            <p className="mb-4">
-              When you delete your account, we will delete your personal data within a reasonable timeframe, except where we are required to retain it by law.
-            </p>
+            <LegalTodo>pull the exact backup retention day-count once it&#39;s documented — it is not currently codified alongside the other retention policies.</LegalTodo>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">12. International Users and Data Processing</h2>
+            <h2 className="text-2xl font-semibold mb-4">15. International Users and Data Processing</h2>
             <p className="mb-4">
-              PageSpace is operated from the United States. If you are accessing our services from outside the United States, please be aware that your information may be transferred to, stored, and processed in the United States where our servers are located and our central database is operated.
+              PageSpace is operated from the United States. If you are accessing our services from outside the United States, including from the European Economic Area (EEA) or United Kingdom, your information will be transferred to, stored, and processed in the United States.
             </p>
             <p className="mb-4">
-              By using our service, you consent to the transfer of your information to the United States and processing in accordance with this Privacy Policy.
+              Where we transfer personal data from the EEA or UK to the United States, we rely on the European Commission&#39;s Standard Contractual Clauses (SCCs) as our transfer mechanism, rather than relying on your consent alone. Our subprocessors are listed on our <a href="/subprocessors" className="text-primary hover:underline">Subprocessors</a> page.
             </p>
+            <LegalTodo>confirm which SCC Module is used for each vendor relationship, and confirm whether any transfers can instead rely on an adequacy decision (e.g. the UK&#39;s adequacy regulations) rather than SCCs.</LegalTodo>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">13. Payment and Billing Information</h2>
+            <h2 className="text-2xl font-semibold mb-4">16. Payment and Billing Information</h2>
             <p className="mb-4">
               When you purchase a subscription, payment processing is handled by Stripe, Inc. We do not store your credit card information on our servers. Stripe&#39;s privacy policy governs the collection and use of payment information.
             </p>
@@ -206,14 +250,28 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">14. Data Security Incidents</h2>
+            <h2 className="text-2xl font-semibold mb-4">17. Data Security Incidents</h2>
             <p className="mb-4">
-              In the event of a data security incident that affects your personal information, we will notify affected users via email within 72 hours of discovering the incident, where technically feasible and in accordance with applicable data protection laws. Notification will include information about the nature of the incident, the data affected, and steps we are taking to address it.
+              In the event of a personal data breach, we follow GDPR&#39;s two-part notification model:
+            </p>
+            <ul className="list-disc pl-6 mb-4">
+              <li>We notify the competent supervisory authority without undue delay and, where feasible, within 72 hours of becoming aware of the breach (Art 33), unless the breach is unlikely to result in a risk to your rights and freedoms.</li>
+              <li>Where a breach is likely to result in a <em>high</em> risk to your rights and freedoms, we also communicate it to you directly, without undue delay, in clear and plain language (Art 34). This notification has no fixed hour deadline, but we aim to act as quickly as the circumstances allow.</li>
+            </ul>
+            <p className="mb-4">
+              Notifications will include information about the nature of the incident, the data affected, and the steps we are taking to address it.
             </p>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">15. Contact Us</h2>
+            <h2 className="text-2xl font-semibold mb-4">18. Records of Processing Activities</h2>
+            <p className="mb-4">
+              A full Records of Processing Activities (RoPA) register is maintained internally per GDPR Art 30. GDPR does not require us to publish this register, so it is not reproduced here.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">19. Contact Us</h2>
             <p className="mb-4">
               If you have any questions about this Privacy Policy or our privacy practices, please contact us at:
             </p>

--- a/apps/marketing/src/app/subprocessors/page.tsx
+++ b/apps/marketing/src/app/subprocessors/page.tsx
@@ -1,0 +1,186 @@
+import { SiteNavbar } from "@/components/SiteNavbar";
+import { SiteFooter } from "@/components/SiteFooter";
+import { LegalTodo } from "@/components/LegalTodo";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import { pageMetadata, LEGAL_LAST_UPDATED } from "@/lib/metadata";
+
+export const metadata = pageMetadata.subprocessors;
+
+interface SubprocessorRow {
+  vendor: string;
+  purpose: string;
+  dataCategories: string;
+  location: string;
+  transferMechanism: string;
+  dpaStatus: string;
+}
+
+const subprocessors: SubprocessorRow[] = [
+  {
+    vendor: "Stripe, Inc.",
+    purpose: "Payment processing and subscription billing",
+    dataCategories: "Name, email, payment method, billing address, subscription/plan metadata",
+    location: "United States",
+    transferMechanism: "Standard Contractual Clauses (SCCs)",
+    dpaStatus: "TODO",
+  },
+  {
+    vendor: "Google LLC",
+    purpose: "“Sign in with Google”; optional Google Calendar and Drive integration",
+    dataCategories: "Email, profile name, OAuth tokens (encrypted at rest), connected calendar/file metadata",
+    location: "United States",
+    transferMechanism: "Standard Contractual Clauses (SCCs)",
+    dpaStatus: "TODO",
+  },
+  {
+    vendor: "GitHub, Inc.",
+    purpose: "OAuth sign-in and optional repository integration",
+    dataCategories: "Email, profile name, OAuth tokens (encrypted at rest), connected repository metadata",
+    location: "United States",
+    transferMechanism: "Standard Contractual Clauses (SCCs)",
+    dpaStatus: "TODO",
+  },
+  {
+    vendor: "Apple Inc. (APNs)",
+    purpose: "Push notifications to the iOS app",
+    dataCategories: "Device push token, notification payload",
+    location: "United States",
+    transferMechanism: "Standard Contractual Clauses (SCCs)",
+    dpaStatus: "TODO",
+  },
+  {
+    vendor: "Let's Encrypt (ISRG)",
+    purpose: "TLS certificate issuance for custom domains",
+    dataCategories: "Domain name and certificate validation records — no end-user personal data",
+    location: "United States",
+    transferMechanism: "Not applicable — no personal data processed",
+    dpaStatus: "TODO",
+  },
+  {
+    vendor: "DNS provider(s)",
+    purpose: "DNS resolution for pagespace.ai and customer custom domains",
+    dataCategories: "Domain names and DNS records — no end-user personal data",
+    location: "TODO",
+    transferMechanism: "TODO",
+    dpaStatus: "TODO",
+  },
+  {
+    vendor: "Control-plane host",
+    purpose: "Hosts tenant provisioning, billing orchestration, and lifecycle management",
+    dataCategories: "Tenant owner email, Stripe customer IDs, tenant metadata",
+    location: "TODO",
+    transferMechanism: "TODO",
+    dpaStatus: "TODO",
+  },
+];
+
+export default function Subprocessors() {
+  return (
+    <div className="min-h-screen bg-background">
+      <SiteNavbar />
+
+      <div className="container mx-auto px-4 py-12 md:py-16 max-w-4xl">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold mb-2">Subprocessors</h1>
+          <p className="text-muted-foreground">Last updated: {LEGAL_LAST_UPDATED}</p>
+        </div>
+
+        <div className="prose prose-lg max-w-none dark:prose-invert">
+          <section className="mb-8">
+            <p className="mb-4">
+              PageSpace uses a small number of third-party service providers (&quot;subprocessors&quot;) to
+              deliver the product. This page lists each subprocessor, what it does for us, what
+              categories of data it processes, where it&#39;s located, and the mechanism we rely on for
+              any international transfer of personal data. See our{" "}
+              <a href="/privacy" className="text-primary hover:underline">Privacy Policy</a> for how
+              this fits into our overall data-processing practices.
+            </p>
+            <p className="mb-4">
+              Note: our control-plane host stores tenant owner email addresses and Stripe customer
+              IDs as part of provisioning and billing tenant workspaces — this is disclosed
+              explicitly in the table below.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <div className="not-prose overflow-x-auto rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Vendor</TableHead>
+                    <TableHead>Purpose</TableHead>
+                    <TableHead>Data categories</TableHead>
+                    <TableHead>Location</TableHead>
+                    <TableHead>Transfer mechanism</TableHead>
+                    <TableHead>DPA status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {subprocessors.map((row) => (
+                    <TableRow key={row.vendor}>
+                      <TableCell className="font-medium whitespace-normal">{row.vendor}</TableCell>
+                      <TableCell className="whitespace-normal">{row.purpose}</TableCell>
+                      <TableCell className="whitespace-normal">{row.dataCategories}</TableCell>
+                      <TableCell className="whitespace-normal">
+                        {row.location === "TODO" ? (
+                          <span className="text-amber-600 dark:text-amber-400 font-medium">[TODO]</span>
+                        ) : (
+                          row.location
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-normal">
+                        {row.transferMechanism === "TODO" ? (
+                          <span className="text-amber-600 dark:text-amber-400 font-medium">[TODO]</span>
+                        ) : (
+                          row.transferMechanism
+                        )}
+                      </TableCell>
+                      <TableCell className="whitespace-normal">
+                        <span className="text-amber-600 dark:text-amber-400 font-medium">[TODO: confirm]</span>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            <LegalTodo>
+              Full DPA sign-off status per vendor, plus the DNS provider name and control-plane
+              hosting provider, are tracked internally in
+              <code className="mx-1">docs/security/gdpr-dpa-inventory.md</code>
+              and need legal/ops confirmation before this table can be marked complete.
+            </LegalTodo>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">AI model providers</h2>
+            <p className="mb-4">
+              AI model providers (Anthropic, OpenAI, Google, xAI, and OpenRouter as a routing
+              provider) receive your prompts and relevant context on a per-request basis to generate
+              responses — see the Third-Party AI Services section of our{" "}
+              <a href="/privacy" className="text-primary hover:underline">Privacy Policy</a> for
+              details. PageSpace also supports Ollama as a fully on-premises/local model option that
+              does not send data to any third party.
+            </p>
+          </section>
+
+          <section className="mb-8">
+            <h2 className="text-2xl font-semibold mb-4">Changes to this list</h2>
+            <p className="mb-4">
+              We will post material changes to our subprocessor list on this page, along with an
+              updated &quot;Last updated&quot; date, before or as those changes take effect.
+            </p>
+          </section>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/apps/marketing/src/components/LegalTodo.tsx
+++ b/apps/marketing/src/components/LegalTodo.tsx
@@ -1,0 +1,20 @@
+import { TriangleAlert } from "lucide-react";
+
+/**
+ * Visually distinct callout for unresolved legal/business facts on GDPR-related pages
+ * (controller address, DPO status, retention day-counts, etc.) so they can't ship to
+ * production unnoticed as plain prose text.
+ */
+export function LegalTodo({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      role="note"
+      className="not-prose my-3 flex items-start gap-2 rounded-lg border-2 border-dashed border-amber-500/70 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-200"
+    >
+      <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+      <span>
+        <strong className="font-semibold">TODO:</strong> {children}
+      </span>
+    </div>
+  );
+}

--- a/apps/marketing/src/components/SiteFooter.tsx
+++ b/apps/marketing/src/components/SiteFooter.tsx
@@ -22,6 +22,8 @@ const companyLinks = [
   { label: "Contact", href: "/contact" },
   { label: "Privacy", href: "/privacy" },
   { label: "Terms", href: "/terms" },
+  { label: "Cookies", href: "/cookies" },
+  { label: "Subprocessors", href: "/subprocessors" },
 ];
 
 function FooterLinkGroup({ title, links }: { title: string; links: { label: string; href: string }[] }) {

--- a/apps/marketing/src/lib/metadata.ts
+++ b/apps/marketing/src/lib/metadata.ts
@@ -154,7 +154,7 @@ export const siteMetadata: Metadata = {
   category: "technology",
 };
 
-export const LEGAL_LAST_UPDATED = "February 17, 2026";
+export const LEGAL_LAST_UPDATED = "July 5, 2026";
 
 /**
  * Pre-defined metadata for common pages
@@ -229,6 +229,22 @@ export const pageMetadata = {
       "Terms of Service for PageSpace, the AI-powered unified workspace platform.",
     path: "/terms",
     keywords: ["terms of service", "terms", "legal", "agreement"],
+  }),
+
+  subprocessors: createMetadata({
+    title: "Subprocessors",
+    description:
+      "The third-party subprocessors PageSpace uses to deliver its service, what data they process, and where they're located.",
+    path: "/subprocessors",
+    keywords: ["subprocessors", "vendors", "data processing", "GDPR", "third parties"],
+  }),
+
+  cookies: createMetadata({
+    title: "Cookie Policy",
+    description:
+      "How PageSpace uses cookies and similar technologies, and how to control your preferences.",
+    path: "/cookies",
+    keywords: ["cookies", "cookie policy", "tracking", "consent", "GDPR"],
   }),
 
   contact: createMetadata({

--- a/apps/web/src/components/billing/EmbeddedCheckoutForm.tsx
+++ b/apps/web/src/components/billing/EmbeddedCheckoutForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useStripe, useElements, PaymentElement } from '@stripe/react-stripe-js';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -249,7 +250,16 @@ export function EmbeddedCheckoutForm({
 
       {/* Terms */}
       <p className="text-xs text-muted-foreground text-center">
-        By subscribing, you agree to our terms of service. You can cancel anytime.
+        By subscribing, you agree to our terms of service. You can cancel anytime. Payment is
+        processed by Stripe. See our{' '}
+        <Link href="/privacy" className="underline hover:text-foreground">
+          Privacy Policy
+        </Link>{' '}
+        and{' '}
+        <Link href="/subprocessors" className="underline hover:text-foreground">
+          Subprocessors
+        </Link>{' '}
+        page.
       </p>
     </form>
   );

--- a/apps/web/src/components/consent/CookieBanner.tsx
+++ b/apps/web/src/components/consent/CookieBanner.tsx
@@ -10,8 +10,6 @@ import { useConsentStore } from '@/stores/useConsentStore';
 /**
  * GDPR/ePrivacy cookie consent banner. All decision logic lives in the pure
  * @pagespace/lib/consent functions (via useConsentStore); this is a thin UI shell.
- *
- * The legal cookie-policy copy is owned separately — see the FILL slot below.
  */
 export function CookieBanner() {
   const acceptAll = useConsentStore((s) => s.acceptAll);
@@ -31,7 +29,6 @@ export function CookieBanner() {
     >
       <div className="mx-auto flex max-w-3xl flex-col gap-3">
         <div className="text-sm text-muted-foreground">
-          {/* FILL: cookie policy copy */}
           <p>
             We use strictly necessary cookies to run PageSpace, plus optional cookies for analytics
             and preferences. Necessary cookies are always on. You can accept all, reject the
@@ -40,9 +37,7 @@ export function CookieBanner() {
               Privacy Policy
             </Link>{' '}
             and{' '}
-            {/* Cookie Policy lives within the Privacy Policy until a dedicated /cookies page
-                ships as part of the user-owned legal-copy task; avoids a 404 in the meantime. */}
-            <Link href="/privacy" className="underline hover:text-foreground">
+            <Link href="/cookies" className="underline hover:text-foreground">
               Cookie Policy
             </Link>{' '}
             for details.

--- a/docs/security/gdpr-dpa-inventory.md
+++ b/docs/security/gdpr-dpa-inventory.md
@@ -1,0 +1,37 @@
+# GDPR Sub-Processor DPA Inventory
+
+Internal tracking doc for the Data Processing Agreement (DPA) status of every sub-processor
+that touches personal data on PageSpace's behalf. This is the factual source that the public
+`/subprocessors` marketing page summarizes — keep the two in sync when a vendor is added,
+removed, or its DPA status changes. Closes #949.
+
+Not legal advice. Every `DPA Status` cell below is a `TODO` because signed-DPA status isn't
+tracked anywhere in this repo (contracts live outside version control) — someone with access to
+the vendor agreements needs to fill these in and update the last-reviewed date.
+
+**Last reviewed:** `[TODO: date of last inventory review]`
+
+| Vendor | Purpose | Data Shared / Processed | DPA Status |
+|---|---|---|---|
+| Stripe, Inc. | Payment processing, subscription billing | Customer name, email, payment method, billing address, subscription/plan metadata | `[TODO: confirm signed DPA on file — Y/N/date]` |
+| Google (OAuth + Calendar API) | "Sign in with Google"; optional Google Calendar/Drive integration | Email, profile name, OAuth tokens (encrypted at rest, AES-256-GCM), calendar/file metadata the user chooses to connect | `[TODO: confirm signed DPA on file — Y/N/date]` |
+| GitHub, Inc. | OAuth sign-in / repository integration | Email, profile name, OAuth tokens (encrypted at rest, AES-256-GCM), repo metadata the user chooses to connect | `[TODO: confirm signed DPA on file — Y/N/date]` |
+| Apple Inc. (APNs) | Push notifications to iOS app | Device push token, notification payload (no message content beyond what's needed to render the notification) | `[TODO: confirm signed DPA on file — Y/N/date]` |
+| Let's Encrypt (ISRG) | TLS certificate issuance for custom domains | Domain name, certificate validation records — no end-user personal data | `[TODO: confirm signed DPA on file — Y/N/date]` |
+| DNS provider(s) | DNS resolution for pagespace.ai and customer custom domains | Domain names, DNS records — no end-user personal data | `[TODO: identify current DNS provider(s) and confirm signed DPA on file — Y/N/date]` |
+| Control-plane host | Hosts the control-plane service: tenant provisioning, Stripe billing orchestration, lifecycle management | Tenant owner email, Stripe customer IDs, tenant metadata | `[TODO: confirm current control-plane hosting provider (Fly.io per project deployment history — verify still accurate) and signed DPA on file — Y/N/date]` |
+
+## AI model providers
+
+AI model providers (Anthropic, OpenAI, Google, xAI, OpenRouter) are covered separately in the
+Privacy Policy's Third-Party AI Services section and the `/subprocessors` page — they receive
+prompts/context on a per-request basis, not a standing data-processing relationship in the same
+sense as the vendors above. `[TODO: confirm DPA status for each AI provider if required by legal
+review]`.
+
+## Maintenance
+
+- Update this table whenever a sub-processor is added, removed, or replaced.
+- Update `apps/marketing/src/app/subprocessors/page.tsx` in the same change — it's a public
+  summary of this doc and must not drift from it.
+- Re-review at least annually or whenever a new data category is introduced.

--- a/packages/lib/src/email-templates/DriveInvitationEmail.tsx
+++ b/packages/lib/src/email-templates/DriveInvitationEmail.tsx
@@ -63,6 +63,14 @@ export function DriveInvitationEmail({
             <Text style={emailStyles.footerText}>
               You&apos;re receiving this email because you were added to a PageSpace workspace.
             </Text>
+            <Text style={emailStyles.footerText}>
+              PageSpace received your email address from {inviterName} to send you this invitation
+              — see our{' '}
+              <Link href="https://pagespace.ai/privacy" style={emailStyles.link}>
+                Privacy Policy
+              </Link>{' '}
+              for details.
+            </Text>
             {unsubscribeUrl && (
               <Text style={emailStyles.footerText}>
                 <Link href={unsubscribeUrl} style={emailStyles.link}>


### PR DESCRIPTION
## Summary

Marketing-site content slice of the GDPR compliance backlog (code fixes are landing separately in other worktrees). Every legal/business fact not verifiable from this repo ships as a visually distinct TODO callout (new `LegalTodo` component) — nothing is invented.

- **Privacy Policy rewrite** (`apps/marketing/src/app/privacy/page.tsx`): controller identity (Jonathan Woodall, sole proprietorship — per existing Terms page — address TODO), DPO/EU-rep recommended defaults, Art 6 lawful-basis mapping, expanded rights (restriction/objection/withdraw consent/complain to a supervisory authority), automated-decision-making statement, a real per-category retention table (grounded in `docs/security/audit-log-retention-policy.md` + `data-subject-request-runbook.md`), SCC-based international transfers cross-referencing the new subprocessors page, explicit AI provider list (Anthropic/OpenAI/Google/xAI/OpenRouter/Ollama), corrected breach-notification copy to match Art 33 (authority, 72h) vs Art 34 (data subjects, undue delay, high-risk only) per `breach-runbook.md`, and a one-line RoPA pointer. `LEGAL_LAST_UPDATED` bumped.
- **`docs/security/gdpr-dpa-inventory.md`** (new, internal): per-vendor DPA sign-off tracking doc — the factual source the public page below summarizes.
- **`/subprocessors`** (new public page): dated vendor table (Stripe, Google, GitHub, Apple APNs, Let's Encrypt, DNS provider(s), control-plane host) with transfer mechanism and DPA status per row; explicitly discloses that the control-plane host stores tenant owner email + Stripe customer IDs.
- **`/cookies`** (new public page): strictly-necessary / analytics / preferences categories grounded in the actual `@pagespace/lib/consent` implementation (`ps_consent`, `login_csrf`, first-party client tracker, Google Identity Services gating) rather than generic boilerplate. Also fixes `CookieBanner.tsx`'s "Cookie Policy" link, which was pointing at `/privacy` as an explicitly-commented stopgap pending this exact page.
- **In-flow notices**: GDPR Art 14 notice in `DriveInvitationEmail.tsx`'s footer (#932); Stripe/Privacy/Subprocessors disclosure in `EmbeddedCheckoutForm.tsx`'s fine print (#933).

Footer (`SiteFooter.tsx`) and metadata (`metadata.ts`) updated for both new pages.

## Issues

Relates to #926, #927, #928, #929, #932, #933, #934, #935, #936, #937, #938, #943, #945, #946, #947, #949, #950, #955, #958, #962, #963 — this PR does not auto-close them; leaving that for verification.

## Test plan

- [x] `bun run --filter marketing build` — clean, `/privacy`, `/cookies`, `/subprocessors` all prerender statically
- [x] `bun run --filter web typecheck` and `bun run --filter '@pagespace/lib' typecheck` — clean
- [x] `bun run --filter marketing lint` and `bun run --filter web lint` — clean (pre-existing warnings in web are unrelated to this diff)
- [x] Ran the marketing dev server and fetched `/privacy`, `/subprocessors`, `/cookies` — all 200, TODO callout markup present, subprocessors table rows render, footer links to `/subprocessors` and `/cookies` present on the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAsydFsgiLrsZ4mcGQPAB