### PR TITLE
fix(gdpr): scrub resourceTitle PII in account-erasure anonymization + pseudonymization (#541)

### DIFF
--- a/apps/processor/src/workers/__tests__/account-erasure-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/account-erasure-worker.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression test for #541: the durable account-erasure job's
+ * `anonymize-activity-logs` step must run after `log-account-deletion` and
+ * target the same userId, so the resourceTitle scrub in
+ * activityLogRepository.anonymizeForUser (packages/lib) actually reaches the
+ * account_delete row this worker just wrote. The hash-chain-safety of that
+ * scrub itself is proven against real logActivity/anonymizeForUser code in
+ * packages/lib/src/monitoring/__tests__/anonymize-resource-title.test.ts —
+ * this test only verifies the worker's step wiring (order + arguments), so
+ * every collaborator is mocked, matching this repo's convention of not
+ * exercising cross-package (@pagespace/lib) internals from apps/processor
+ * worker tests.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { callOrder, mockLogActivity, mockGetActorInfo, mockAnonymizeForUser } = vi.hoisted(() => {
+  const callOrder: string[] = [];
+  const mockLogActivity = vi.fn().mockImplementation(async () => {
+    callOrder.push('logActivity');
+  });
+  const mockGetActorInfo = vi.fn().mockResolvedValue({ actorEmail: 'actor@test.com', actorDisplayName: 'Actor' });
+  const mockAnonymizeForUser = vi.fn().mockImplementation(async () => {
+    callOrder.push('anonymizeForUser');
+    return { success: true };
+  });
+  return { callOrder, mockLogActivity, mockGetActorInfo, mockAnonymizeForUser };
+});
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  logActivity: mockLogActivity,
+  getActorInfo: mockGetActorInfo,
+}));
+
+vi.mock('@pagespace/lib/repositories/activity-log-repository', () => ({
+  activityLogRepository: { anonymizeForUser: mockAnonymizeForUser },
+}));
+
+vi.mock('@pagespace/lib/repositories/account-repository', () => ({
+  accountRepository: {
+    findById: vi.fn().mockResolvedValue({ id: 'user-1', email: 'user@leaked.example', image: null }),
+    getOwnedDrives: vi.fn().mockResolvedValue([]),
+    getDriveMemberCount: vi.fn().mockResolvedValue(0),
+    deleteDrive: vi.fn().mockResolvedValue(undefined),
+    deleteUser: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@pagespace/lib/repositories/data-subject-request-repository', () => ({
+  dataSubjectRequestRepository: {
+    findById: vi.fn().mockResolvedValue({ status: 'pending', attempts: 0, forceDelete: false }),
+    incrementAttempts: vi.fn().mockResolvedValue(undefined),
+    appendStepResult: vi.fn().mockResolvedValue(undefined),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
+  deleteAiUsageLogsForUser: vi.fn().mockResolvedValue(0),
+  getDistinctAiProvidersForUser: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
+  deleteMonitoringDataForUser: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/revoke-integration-tokens', () => ({
+  revokeUserIntegrationTokens: vi.fn().mockResolvedValue({ revoked: 0, failed: 0 }),
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/email-suppression', () => ({
+  syncEmailSuppression: vi.fn().mockResolvedValue({ skipped: true }),
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/resend-suppression-client', () => ({
+  createResendSuppressionClient: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/ai-provider-erasure', () => ({
+  eraseAiProviderData: vi.fn().mockResolvedValue({ evidence: [], forwarded: 0 }),
+}));
+
+vi.mock('@pagespace/lib/audit/security-audit', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('@pagespace/lib/deployment-mode', () => ({
+  isOnPrem: vi.fn().mockReturnValue(false),
+  isTenantMode: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../api/avatar', () => ({
+  deleteUserAvatars: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { runAccountErasureJob } from '../account-erasure-worker';
+
+describe('runAccountErasureJob — resourceTitle PII scrub wiring (#541)', () => {
+  beforeEach(() => {
+    callOrder.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('logs the account_delete row with resourceTitle=email, then anonymizes the same user', async () => {
+    await runAccountErasureJob({ requestId: 'dsr-1', userId: 'user-1' });
+
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        operation: 'account_delete',
+        resourceType: 'user',
+        resourceId: 'user-1',
+        resourceTitle: 'user@leaked.example',
+        driveId: null,
+      })
+    );
+
+    expect(mockAnonymizeForUser).toHaveBeenCalledWith('user-1', expect.any(String));
+
+    // The anonymize step must run AFTER the write step, or its WHERE userId
+    // clause can't reach the row the write step just created (#541's root cause).
+    expect(callOrder).toEqual(['logActivity', 'anonymizeForUser']);
+  });
+});

--- a/apps/processor/src/workers/__tests__/account-erasure-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/account-erasure-worker.test.ts
@@ -7,9 +7,10 @@
  * scrub itself is proven against real logActivity/anonymizeForUser code in
  * packages/lib/src/monitoring/__tests__/anonymize-resource-title.test.ts —
  * this test only verifies the worker's step wiring (order + arguments), so
- * every collaborator is mocked, matching this repo's convention of not
- * exercising cross-package (@pagespace/lib) internals from apps/processor
- * worker tests.
+ * every collaborator is mocked. (Vitest's mock registry can't intercept
+ * @pagespace/db/db from within @pagespace/lib's compiled dist output when
+ * imported cross-package like this, so partial-mocking real logActivity here
+ * would hit a live Postgres connection instead of a fake — hence the split.)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 

--- a/docs/security/gdpr-pseudonymization-runbook.md
+++ b/docs/security/gdpr-pseudonymization-runbook.md
@@ -25,7 +25,7 @@ PII **without** deleting rows or disturbing the hash chain.
 
 | Table | Overwritten | Never touched |
 |-------|-------------|---------------|
-| `activity_logs` | `actorEmail` → `erased@pseudonymized`, `actorDisplayName` → `null` | hash inputs (`operation`, `resourceType`, `resourceId`, `driveId`, `pageId`, `contentSnapshot`, `previousValues`, `newValues`, `metadata`, `timestamp`, `id`), chain columns (`logHash`, `previousLogHash`, `chainSeed`, `chainSeq`) |
+| `activity_logs` | `actorEmail` → `erased@pseudonymized`, `actorDisplayName` → `null`, `resourceTitle` → `null` (can carry the subject's own PII, e.g. their email on an `account_delete` row — #541) | hash inputs (`operation`, `resourceType`, `resourceId`, `driveId`, `pageId`, `contentSnapshot`, `previousValues`, `newValues`, `metadata`, `timestamp`, `id`), chain columns (`logHash`, `previousLogHash`, `chainSeed`, `chainSeq`) |
 | `security_audit_log` | `ipAddress`, `userAgent`, `geoLocation`, `sessionId` → `null` | hash inputs (`eventType`, `serviceId`, `resourceType`, `resourceId`, `details`, `riskScore`, `anomalyFlags`, `timestamp`), chain columns (`eventHash`, `previousHash`, `chainSeq`) |
 
 `userId` on both tables is `onDelete: 'set null'`, so it drops automatically when

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize-repository.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize-repository.test.ts
@@ -33,6 +33,7 @@ describe('pseudonymizeActivityLogsForUser', () => {
     expect(setFn.mock.calls[0][0]).toEqual({
       actorEmail: 'erased@pseudonymized',
       actorDisplayName: null,
+      resourceTitle: null,
     });
   });
 });

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize.test.ts
@@ -8,11 +8,12 @@ import {
 } from '../pseudonymize';
 
 describe('activity-log pseudonymization patch', () => {
-  it('should overwrite only the denormalized actor columns', () => {
+  it('should overwrite only the denormalized PII columns (actor + resourceTitle)', () => {
     const patch = buildActivityLogPseudonymizationPatch();
     expect(patch).toEqual({
       actorEmail: 'erased@pseudonymized',
       actorDisplayName: null,
+      resourceTitle: null,
     });
   });
 

--- a/packages/lib/src/compliance/erasure/pseudonymize.ts
+++ b/packages/lib/src/compliance/erasure/pseudonymize.ts
@@ -58,6 +58,7 @@ export const SECURITY_AUDIT_HASHED_FIELDS: ReadonlySet<string> = new Set([
 export interface ActivityLogPseudonymPatch {
   actorEmail: string;
   actorDisplayName: null;
+  resourceTitle: null;
 }
 
 export interface SecurityAuditPseudonymPatch {
@@ -68,7 +69,10 @@ export interface SecurityAuditPseudonymPatch {
 }
 
 export function buildActivityLogPseudonymizationPatch(): ActivityLogPseudonymPatch {
-  return { actorEmail: PSEUDONYM_EMAIL, actorDisplayName: null };
+  // resourceTitle can also carry the subject's own PII (e.g. their email on an
+  // account_delete row — #541) and, like actorEmail/actorDisplayName, is a
+  // denormalized non-hash-input column, so it's safe and necessary to clear here too.
+  return { actorEmail: PSEUDONYM_EMAIL, actorDisplayName: null, resourceTitle: null };
 }
 
 export function buildSecurityAuditPseudonymizationPatch(): SecurityAuditPseudonymPatch {

--- a/packages/lib/src/monitoring/__tests__/anonymize-resource-title.test.ts
+++ b/packages/lib/src/monitoring/__tests__/anonymize-resource-title.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for #541: after logActivity writes an account_delete row
+ * carrying the deleted user's email in resourceTitle,
+ * activityLogRepository.anonymizeForUser must null it — and the row's
+ * tamper-evident hash must still validate, since resourceTitle is excluded
+ * from HashableLogData (see serializeLogDataForHash below).
+ *
+ * Only @pagespace/db/db is faked (in-memory table, same pattern as
+ * hash-chain-verifier.test.ts); logActivity and anonymizeForUser run for
+ * real, so this proves the actual fix rather than a mock of it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let activityLogRows: Array<Record<string, unknown>> = [];
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        execute: vi.fn().mockResolvedValue(undefined),
+        query: {
+          activityLogs: {
+            // Only one row is ever inserted before this is consulted here,
+            // so "most recent" is simply "last pushed".
+            findFirst: vi.fn().mockImplementation(async () =>
+              activityLogRows.length > 0 ? activityLogRows[activityLogRows.length - 1] : null
+            ),
+          },
+        },
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockImplementation(async (vals: Record<string, unknown>) => {
+            activityLogRows.push({ ...vals });
+          }),
+        }),
+      };
+      return cb(tx);
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockImplementation((setVals: Record<string, unknown>) => ({
+        where: vi.fn().mockImplementation(async () => {
+          for (const row of activityLogRows) {
+            Object.assign(row, setVals);
+          }
+        }),
+      })),
+    }),
+  },
+}));
+
+import { logActivity, computeLogHash } from '../activity-logger';
+import { activityLogRepository } from '../../repositories/activity-log-repository';
+import { createAnonymizedActorEmail } from '../../compliance/anonymize';
+
+describe('anonymizeForUser + logActivity integration (#541)', () => {
+  beforeEach(() => {
+    activityLogRows = [];
+    vi.clearAllMocks();
+  });
+
+  it('nulls resourceTitle without breaking the hash chain', async () => {
+    const userId = 'user-1';
+
+    await logActivity({
+      userId,
+      actorEmail: 'actor@test.com',
+      actorDisplayName: 'Actor',
+      operation: 'account_delete',
+      resourceType: 'user',
+      resourceId: userId,
+      resourceTitle: 'leaked@example.com',
+      driveId: null,
+    });
+
+    const anonymizedEmail = createAnonymizedActorEmail(userId);
+    const result = await activityLogRepository.anonymizeForUser(userId, anonymizedEmail);
+    expect(result.success).toBe(true);
+
+    const row = activityLogRows.find((r) => r.operation === 'account_delete');
+    expect(row).toBeDefined();
+    if (!row) throw new Error('unreachable');
+
+    // (a) PII scrubbed
+    expect(row.resourceTitle).toBeNull();
+
+    // (c) actor identity still anonymized, same as before this fix
+    expect(row.actorEmail).toBe(anonymizedEmail);
+    expect(row.actorDisplayName).toBe('Deleted User');
+
+    // (b) hash chain still validates — resourceTitle is excluded from
+    // HashableLogData, so nulling it must not change the stored hash.
+    const previousHash = (row.previousLogHash as string | null) ?? (row.chainSeed as string | null) ?? '';
+    const recomputed = computeLogHash(
+      {
+        id: row.id as string,
+        timestamp: row.timestamp as Date,
+        operation: row.operation as string,
+        resourceType: row.resourceType as string,
+        resourceId: row.resourceId as string,
+        driveId: row.driveId as string | null,
+        pageId: row.pageId as string | undefined,
+        contentSnapshot: row.contentSnapshot as string | undefined,
+        previousValues: row.previousValues as Record<string, unknown> | undefined,
+        newValues: row.newValues as Record<string, unknown> | undefined,
+        metadata: row.metadata as Record<string, unknown> | undefined,
+      },
+      previousHash
+    );
+    expect(recomputed).toBe(row.logHash);
+  });
+});

--- a/packages/lib/src/repositories/__tests__/activity-log-repository.test.ts
+++ b/packages/lib/src/repositories/__tests__/activity-log-repository.test.ts
@@ -10,7 +10,12 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({
-  activityLogs: { userId: 'userId', actorEmail: 'actorEmail', actorDisplayName: 'actorDisplayName' },
+  activityLogs: {
+    userId: 'userId',
+    actorEmail: 'actorEmail',
+    actorDisplayName: 'actorDisplayName',
+    resourceTitle: 'resourceTitle',
+  },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_a, _b) => 'eq'),
@@ -58,6 +63,7 @@ describe('activityLogRepository.anonymizeForUser', () => {
     expect(setFn).toHaveBeenCalledWith({
       actorEmail: 'anon@anonymized.invalid',
       actorDisplayName: 'Deleted User',
+      resourceTitle: null,
     });
   });
 

--- a/packages/lib/src/repositories/__tests__/activity-log-repository.test.ts
+++ b/packages/lib/src/repositories/__tests__/activity-log-repository.test.ts
@@ -10,12 +10,7 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({
-  activityLogs: {
-    userId: 'userId',
-    actorEmail: 'actorEmail',
-    actorDisplayName: 'actorDisplayName',
-    resourceTitle: 'resourceTitle',
-  },
+  activityLogs: { userId: 'userId', actorEmail: 'actorEmail', actorDisplayName: 'actorDisplayName' },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_a, _b) => 'eq'),

--- a/packages/lib/src/repositories/activity-log-repository.ts
+++ b/packages/lib/src/repositories/activity-log-repository.ts
@@ -17,8 +17,11 @@ export interface AnonymizeResult {
 export const activityLogRepository = {
   /**
    * Anonymize activity logs for a user (GDPR compliance).
-   * Replaces actor email with anonymized identifier and sets display name to 'Deleted User'.
-   * This preserves the audit trail while removing PII.
+   * Replaces actor email with anonymized identifier, sets display name to 'Deleted User',
+   * and clears resourceTitle (#541 — resourceTitle can carry the user's own email, e.g. on
+   * account_delete rows). resourceTitle is excluded from the tamper-evident hash chain
+   * (see serializeLogDataForHash in monitoring/activity-logger.ts), so nulling it here does
+   * not invalidate any stored hash.
    */
   anonymizeForUser: async (
     userId: string,
@@ -30,6 +33,7 @@ export const activityLogRepository = {
         .set({
           actorEmail: anonymizedEmail,
           actorDisplayName: 'Deleted User',
+          resourceTitle: null,
         })
         .where(eq(activityLogs.userId, userId));
 

--- a/tasks/reviews/pu-gdpr-541-resourcetitle.md
+++ b/tasks/reviews/pu-gdpr-541-resourcetitle.md
@@ -1,0 +1,58 @@
+# Review: PR #1883 — fix(gdpr): scrub resourceTitle PII in account-erasure anonymization (#541)
+
+Branch: `pu/gdpr-541-resourcetitle` · Base: `master`
+Reviewer: Claude (self-review via `/aidd-review`, no human/bot reviewer feedback available — Codex and
+CodeRabbit both hit account rate limits on this PR at the time of review)
+
+## Scope
+
+- `packages/lib/src/repositories/activity-log-repository.ts` — `anonymizeForUser` now also nulls
+  `resourceTitle`.
+- `packages/lib/src/repositories/__tests__/activity-log-repository.test.ts` — updated assertion.
+- `packages/lib/src/monitoring/__tests__/anonymize-resource-title.test.ts` (new) — real
+  `logActivity` + real `anonymizeForUser` round-trip against a fake in-memory table; confirms
+  `resourceTitle` is nulled and the hash chain still validates.
+- `apps/processor/src/workers/__tests__/account-erasure-worker.test.ts` (new) — worker-level test
+  confirming `log-account-deletion` runs before `anonymize-activity-logs` against the same userId.
+
+## Checks performed
+
+- `npx aidd churn --json`: none of the touched files appear in the top-20 hotspot list (all are small,
+  low-churn) — no elevated risk from file size/complexity/churn.
+- OWASP Top 10 pass: no injection (Drizzle ORM `.set`/`.where(eq(...))`, no raw SQL), no access-control
+  change, no crypto weakening (hash-chain fields unaffected — verified by test), no logging/monitoring
+  regression (this *is* the audit-log system, and the fix strictly removes PII while behavior is
+  otherwise preserved).
+- `bunx eslint` on all four touched files: clean (test files are excluded from lint by
+  `packages/lib`'s eslint config, by existing project convention — not specific to this PR).
+- `bunx tsc --noEmit` in both `packages/lib` and `apps/processor`: clean.
+- `bunx vitest run` in both packages: full suites green (packages/lib: 281 files / 6280+ tests;
+  apps/processor: new test passes; 2 pre-existing unrelated failures in `content-detector`/
+  `processing-pipeline` tests due to a magika ML-model-loading issue in this environment, confirmed
+  untouched by this diff).
+- Manually confirmed (via `git stash` of the fix) that the new `anonymize-resource-title.test.ts` test
+  fails without the fix and passes with it — a real regression test, not a tautology.
+- Confirmed no stray files, no dead code, no `any` types, no TODO/FIXME added.
+
+## Findings
+
+- [x] MINOR · `packages/lib/src/repositories/__tests__/activity-log-repository.test.ts:12-18` · the
+  mocked `activityLogs` schema stub had an unused `resourceTitle: 'resourceTitle'` entry — the real
+  code sets `resourceTitle: null` as a literal object property in `.set({...})`, it never dereferences
+  `activityLogs.resourceTitle` as a column reference (only `activityLogs.userId` is referenced, in the
+  `.where(eq(...))` clause) · what correct looks like: schema stub only includes keys actually
+  referenced by the code under test — fixed in 14e8700b2 (verified: removing it left all 5 tests green).
+- [x] NIT · `apps/processor/src/workers/__tests__/account-erasure-worker.test.ts` docblock · framed
+  "every collaborator is mocked" as matching "this repo's convention," which overstated it as a
+  stylistic choice rather than a discovered hard constraint (Vitest's mock registry cannot intercept
+  `@pagespace/db/db` through `@pagespace/lib`'s compiled dist output when imported cross-package —
+  confirmed empirically: attempting a partial mock there hit a live Postgres connection) · what correct
+  looks like: comment states the actual technical reason so a future reader doesn't waste time
+  re-attempting the cross-package partial-mock approach — fixed in 14e8700b2.
+
+## Verdict
+
+0 blockers / 0 majors / 2 minor-or-nit findings, both fixed in commit 14e8700b2. No unresolved review
+threads exist on the PR (Codex and CodeRabbit both hit rate limits and posted no substantive findings).
+Mergeability: MERGEABLE / CLEAN. All CI checks green as of this review. Recommend merge once a human
+or bot reviewer has had a chance to look, per the `/loop`'s own convergence-sweep policy.


### PR DESCRIPTION
## Summary

Re-verification of issue #541 against current `origin/master` found the fix from PR #866 (which excluded `actorEmail` from the tamper-evident hash chain) is incomplete: the account-deletion flow was later rewritten into the durable `account-erasure-worker.ts` job, and the new code reintroduced a plaintext PII leak.

- `log-account-deletion` step writes `resourceTitle: user.email` on the `account_delete` activity-log row (`apps/processor/src/workers/account-erasure-worker.ts:120`).
- The `anonymize-activity-logs` step (runs immediately after, same job) calls `activityLogRepository.anonymizeForUser(userId, anonymizedEmail)`, whose `.set({...})` only touched `actorEmail`/`actorDisplayName` — `resourceTitle` was never cleared, so the row's `WHERE userId = ...` matched but the plaintext email survived forever.
- Fix: `anonymizeForUser` now also sets `resourceTitle: null`.

## Hash-chain safety

`resourceTitle` is not part of `HashableLogData`/`serializeLogDataForHash` in `packages/lib/src/monitoring/activity-logger.ts` — only `id, timestamp, operation, resourceType, resourceId, driveId, pageId, contentSnapshot, previousValues, newValues, metadata` are hashed. Nulling `resourceTitle` cannot invalidate any previously-stored `logHash`. This is verified end-to-end by a new test (see below) that runs the real `logActivity` + real `anonymizeForUser` against a fake in-memory `activity_logs` table and recomputes the hash after anonymization to confirm it still matches.

Every existing read-site of `resourceTitle` already null-coalesces (`?? undefined`, `|| 'Untitled'`, etc.), so this changes no UI/export/SIEM-mapper behavior for the field's absence. `resourceTitle` legitimately carries other PII for other operation types (e.g. `targetUserEmail` on `member_add`/`member_remove`) — that's unchanged and out of scope; only the `anonymizeForUser` path is touched.

## Tests

- `packages/lib/src/monitoring/__tests__/anonymize-resource-title.test.ts` (new): runs real `logActivity` + real `activityLogRepository.anonymizeForUser` against a fake in-memory `activity_logs` table (only `@pagespace/db/db` is mocked). Confirms `resourceTitle` is nulled, `actorEmail`/`actorDisplayName` are still anonymized, and the hash chain still validates after the update. Verified this test actually catches the regression (fails without the fix, passes with it).
- `apps/processor/src/workers/__tests__/account-erasure-worker.test.ts` (new): worker-level test (all collaborators mocked, per this repo's existing convention for processor worker tests) confirming `log-account-deletion` runs before `anonymize-activity-logs` and both target the same `userId` — the ordering precondition that makes the fix effective.
- `packages/lib/src/repositories/__tests__/activity-log-repository.test.ts`: updated to assert `resourceTitle: null` is included in the `db.update().set(...)` call.

## Residual risk (not addressed here, flagging for awareness)

`apps/processor/src/services/siem-adapter.ts` and `siem-event-mapper.ts` forward `resourceTitle` verbatim into SIEM webhook/syslog payloads with no redaction. If the SIEM delivery worker ships the `account_delete` row before (or, prior to this fix, even after) anonymization, the plaintext email could already be exfiltrated to an external system that this DB-level fix can't retroactively clean up. Out of scope for this PR — flagging as a follow-up.

## Test plan

- [x] `bunx vitest run` in `packages/lib` — 281 files / 6280 tests pass
- [x] `bunx vitest run` in `apps/processor` — new worker test passes (2 unrelated pre-existing failures in `content-detector`/`processing-pipeline` tests, due to a magika ML model loading issue in this environment, untouched by this change)
- [x] `bunx tsc --noEmit` clean in both `packages/lib` and `apps/processor`
- [x] Manually confirmed the new `packages/lib` test fails without the fix and passes with it (real regression test, not a tautology)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcWyREcswkDwdCzkBiK8ja

## Self-review

Ran `/aidd-review` on this diff (churn analysis, OWASP Top 10 pass, lint, typecheck, full test suites).
Two minor findings, both fixed:
- Removed a dead `resourceTitle` key from a mocked schema stub (never dereferenced by the code under test).
- Tightened a test docblock to state the actual technical reason for mocking every worker collaborator (Vitest can't intercept `@pagespace/db/db` through `@pagespace/lib`'s compiled dist output across the package boundary — confirmed empirically), rather than framing it as a stylistic convention.

Full findings recorded in `tasks/reviews/pu-gdpr-541-resourcetitle.md`.


## Follow-up: second instance of the same leak found and fixed

While converging this PR (checking whether the leak class exists anywhere else touching `resourceTitle`), found that `buildActivityLogPseudonymizationPatch()` (`packages/lib/src/compliance/erasure/pseudonymize.ts`) — the Art 17(3)(b) disputed-retention pseudonymization path used via `POST /api/admin/gdpr/pseudonymize` — has the **same gap**: it only cleared `actorEmail`/`actorDisplayName`, never `resourceTitle`, despite its own runbook (`docs/security/gdpr-pseudonymization-runbook.md`) promising "no content or identifying actor field remains" after the run.

Fixed with the same safety reasoning: `resourceTitle` is not in `ACTIVITY_LOG_HASHED_FIELDS`, so adding it to the patch is safe and `assertPseudonymizationPatchSafe` still passes. Updated the runbook's column table and both existing unit tests (verified via git-stash revert that they fail without the fix and pass with it).

## Also: merged latest master

Rebased onto `origin/master` mid-review to pick up the newly-merged GDPR PII-encryption cutover (#1728). Confirmed no interaction risk: `accountRepository.findById()` now decrypts `user.email` at the edge specifically "so the ... erasure payload use[s] plaintext" (per its own new comment), so `resourceTitle: user.email` in the worker still captures plaintext as this fix assumes — no changes needed to this PR's logic. Full test suites + typecheck re-verified green after the merge.
