### PR TITLE
refactor(sandbox): collapse session-key derivation to one per-drive namespace

### DIFF
--- a/packages/lib/src/services/sandbox/__tests__/session-key.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/session-key.test.ts
@@ -4,7 +4,6 @@ import { deriveSessionKey } from '../session-key';
 const base = {
   tenantId: 'tenant-1',
   driveId: 'drive-1',
-  conversationId: 'conv-1',
   secret: 'a'.repeat(32),
 };
 
@@ -13,19 +12,13 @@ describe('deriveSessionKey', () => {
     expect(deriveSessionKey(base)).toBe(deriveSessionKey(base));
   });
 
-  it('given a different conversation, should derive a different key', () => {
-    expect(deriveSessionKey({ ...base, conversationId: 'conv-2' })).not.toBe(
-      deriveSessionKey(base),
-    );
-  });
-
-  it('given a different drive, should derive a different key (drive namespacing)', () => {
+  it('given a different drive (same tenant), should derive a different key (drive namespacing)', () => {
     expect(deriveSessionKey({ ...base, driveId: 'drive-2' })).not.toBe(
       deriveSessionKey(base),
     );
   });
 
-  it('given a different tenant, should derive a different key (tenant namespacing)', () => {
+  it('given a different tenant (same drive), should derive a different key (tenant namespacing)', () => {
     expect(deriveSessionKey({ ...base, tenantId: 'tenant-2' })).not.toBe(
       deriveSessionKey(base),
     );
@@ -37,9 +30,8 @@ describe('deriveSessionKey', () => {
     );
   });
 
-  it('given any inputs, should not embed the raw conversation id (opaque)', () => {
+  it('given any inputs, should not embed the raw drive or tenant id (opaque)', () => {
     const key = deriveSessionKey(base);
-    expect(key).not.toContain(base.conversationId);
     expect(key).not.toContain(base.driveId);
     expect(key).not.toContain(base.tenantId);
   });
@@ -51,23 +43,29 @@ describe('deriveSessionKey', () => {
     expect(key).toMatch(/^pgs-sbx-[0-9a-f]{64}$/);
   });
 
+  it('given the same drive, should derive the same key regardless of caller (agent chat vs terminal)', () => {
+    // The whole point of the per-drive namespace: two independent call sites
+    // addressing the same (tenantId, driveId) land on the same Sprite.
+    const fromAgentChat = deriveSessionKey({ tenantId: base.tenantId, driveId: base.driveId, secret: base.secret });
+    const fromTerminal = deriveSessionKey({ tenantId: base.tenantId, driveId: base.driveId, secret: base.secret });
+    expect(fromAgentChat).toBe(fromTerminal);
+  });
+
   it('given an empty secret, should throw (fail closed — never derive a guessable key)', () => {
     expect(() => deriveSessionKey({ ...base, secret: '' })).toThrow(/non-empty secret/);
   });
 
-  it('given no driveId, should derive a key using empty string for the drive segment', () => {
-    const { driveId: _, ...withoutDrive } = base;
-    const key = deriveSessionKey(withoutDrive);
-    expect(key).toMatch(/^pgs-sbx-[0-9a-f]{64}$/);
+  it('given a missing driveId, should throw (fail closed — no drive means no sandbox identity)', () => {
+    const { driveId: _driveId, ...withoutDrive } = base;
+    expect(() => deriveSessionKey(withoutDrive as typeof base)).toThrow(/non-empty driveId/);
   });
 
-  it('given no driveId, should produce identical keys for identical inputs (deterministic)', () => {
-    const { driveId: _, ...withoutDrive } = base;
-    expect(deriveSessionKey(withoutDrive)).toBe(deriveSessionKey(withoutDrive));
+  it('given an empty-string driveId, should throw (fail closed)', () => {
+    expect(() => deriveSessionKey({ ...base, driveId: '' })).toThrow(/non-empty driveId/);
   });
 
-  it('given undefined driveId vs a real driveId, should produce distinct keys', () => {
-    const { driveId: _, ...withoutDrive } = base;
-    expect(deriveSessionKey(withoutDrive)).not.toBe(deriveSessionKey(base));
+  it('given a missing tenantId, should throw (fail closed)', () => {
+    const { tenantId: _tenantId, ...withoutTenant } = base;
+    expect(() => deriveSessionKey(withoutTenant as typeof base)).toThrow(/non-empty tenantId/);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
@@ -18,7 +18,7 @@ const namespacing = { tenantId: 't1', driveId: 'd1', conversationId: 'c1' };
 const actor = { userId: 'u1', ...namespacing };
 
 function keyFor() {
-  return deriveSessionKey({ ...namespacing, secret: SECRET });
+  return deriveSessionKey({ tenantId: namespacing.tenantId, driveId: namespacing.driveId, secret: SECRET });
 }
 
 // In-memory store with call tracking, so tests assert what the orchestrator did
@@ -236,7 +236,7 @@ describe('acquireConversationSandbox', () => {
     expect(result).toEqual({ ok: true, sandboxId: 'sbx-existing', resumed: true });
   });
 
-  it('given no driveId and all other required fields present, should pass the guard and proceed to provisioning', async () => {
+  it('given no driveId, should deny without provisioning (fail closed — no drive-less sandbox identity)', async () => {
     const { store } = makeStore();
     const { client, calls } = makeClient();
     const result = await acquireConversationSandbox({
@@ -245,8 +245,8 @@ describe('acquireConversationSandbox', () => {
       userId: 'u1',
       deps: { store, client, authorize: async () => ({ ok: true }), now: () => NOW, secret: SECRET, checkFullEgressEnablement: passGate },
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-new', resumed: false });
-    expect(calls.getOrCreate.length).toBe(1);
+    expect(result).toEqual({ ok: false, reason: 'error' });
+    expect(calls.getOrCreate).toEqual([]);
   });
 
   it('agent path: provisions with OPEN egress via the shared resolver (full-egress unification)', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-session-manager.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
-  deriveTerminalSessionKey,
   planTerminalLifecycle,
   acquireTerminalSandbox,
   type TerminalSessionStore,
   type TerminalSessionRecord,
 } from '../terminal-session-manager';
 import type { SandboxClient } from '../session-manager';
+import { deriveSessionKey } from '../session-key';
 import { resolveSandboxNetworkOptions } from '../network-options';
 
 const SECRET = 'x'.repeat(32);
@@ -20,7 +20,7 @@ const namespacing = { tenantId: 't1', driveId: 'd1', pageId: 'p1' };
 const actor = { userId: 'u1', ...namespacing };
 
 function keyFor() {
-  return deriveTerminalSessionKey({ ...namespacing, secret: SECRET });
+  return deriveSessionKey({ tenantId: namespacing.tenantId, driveId: namespacing.driveId, secret: SECRET });
 }
 
 function makeStore(seed?: TerminalSessionRecord) {
@@ -85,26 +85,6 @@ function seedRecord(over: Partial<TerminalSessionRecord> = {}): TerminalSessionR
     ...over,
   };
 }
-
-describe('deriveTerminalSessionKey', () => {
-  it('given the same inputs, returns the same key every time', () => {
-    const a = deriveTerminalSessionKey({ ...namespacing, secret: SECRET });
-    const b = deriveTerminalSessionKey({ ...namespacing, secret: SECRET });
-    expect(a).toBe(b);
-  });
-
-  it('given different pageIds (same tenantId+driveId), returns different keys', () => {
-    const a = deriveTerminalSessionKey({ ...namespacing, pageId: 'p1', secret: SECRET });
-    const b = deriveTerminalSessionKey({ ...namespacing, pageId: 'p2', secret: SECRET });
-    expect(a).not.toBe(b);
-  });
-
-  it('given an empty string secret, throws', () => {
-    expect(() => deriveTerminalSessionKey({ ...namespacing, secret: '' })).toThrow(
-      'deriveTerminalSessionKey requires a non-empty secret',
-    );
-  });
-});
 
 describe('planTerminalLifecycle', () => {
   it('given canRun=false and no session, returns { action: deny }', () => {
@@ -232,6 +212,20 @@ describe('acquireTerminalSandbox', () => {
       deps: { store, client, now: () => NOW, secret: '', checkFullEgressEnablement: passGate },
     });
     expect(result).toEqual({ ok: false, reason: 'error' });
+  });
+
+  it('given a different pageId in the same drive, derives the SAME session key (drive is the machine, not the page)', async () => {
+    const { store } = makeStore();
+    const { client, calls } = makeClient();
+    const result = await acquireTerminalSandbox({
+      ...actor,
+      pageId: 'some-other-page',
+      canRun: true,
+      deps: { store, client, now: () => NOW, secret: SECRET, checkFullEgressEnablement: passGate },
+    });
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-new' });
+    if (result.ok) expect(result.sessionKey).toBe(keyFor());
+    expect(calls.getOrCreate).toMatchObject([{ name: keyFor() }]);
   });
 
   it('given no existing session, calls client.getOrCreate and store.save; returns { ok: true, resumed: false }', async () => {

--- a/packages/lib/src/services/sandbox/session-key.ts
+++ b/packages/lib/src/services/sandbox/session-key.ts
@@ -1,17 +1,21 @@
 /**
  * Sandbox session-key derivation (pure).
  *
- * A conversation's warm sandbox is addressed by `getOrCreate({ name })`,
- * so the name IS the access boundary: anyone who can name a sandbox can resume
- * it (subject to the resume re-authz gate in the lifecycle layer). The key must
- * therefore be both:
+ * "A drive is a computer": every shell into a drive — agent chat turns, terminal
+ * pages, concurrent tabs — addresses the SAME Sprite, keyed only by
+ * `(tenantId, driveId)`. There is exactly one derivation; conversation and page
+ * identity no longer participate in sandbox addressing (they stay in audit
+ * logging only).
  *
- *  - **Namespaced** by `tenant + drive + conversation` (drive defaults to `''`
- *    for global/non-drive contexts, which is unambiguous given the `\0`
- *    delimiters), so two different conversations — or the same conversation id
- *    reused across drives/tenants — never collide onto one shared sandbox.
- *  - **Unguessable**, so an actor who knows (or guesses) a conversation id cannot
- *    reconstruct the sandbox name and probe for another session's warm VM.
+ * The drive's warm sandbox is addressed by `getOrCreate({ name })`, so the name
+ * IS the access boundary: anyone who can name a sandbox can resume it (subject
+ * to the resume re-authz gate in the lifecycle layer). The key must therefore be
+ * both:
+ *
+ *  - **Namespaced** by `tenant + drive`, so two different drives — or the same
+ *    drive id reused across tenants — never collide onto one shared sandbox.
+ *  - **Unguessable**, so an actor who knows (or guesses) a drive id cannot
+ *    reconstruct the sandbox name and probe for another drive's warm VM.
  *
  * A bare hash of the tuple would be namespaced but NOT unguessable — the inputs
  * are values the client already holds. We therefore key the digest with a
@@ -31,32 +35,36 @@ import { createHmac } from 'crypto';
 
 export interface SessionKeyInput {
   tenantId: string;
-  /** Absent for global (non-drive) contexts; '' is used in the payload so the
-   *  '\0'-delimited tuple remains unambiguous. */
-  driveId?: string;
-  conversationId: string;
+  driveId: string;
   /** Server-held secret; sourced from validated env by the caller. */
   secret: string;
 }
 
-// Versioned, '\0'-delimited so the three components are unambiguous — without a
+// Versioned, '\0'-delimited so the two components are unambiguous — without a
 // delimiter ("ab" + "c" vs "a" + "bc") distinct tuples could hash identically.
 // The version prefix lets the scheme rotate without silently aliasing old keys.
-const NAMESPACE_VERSION = 'sandbox-session:v1';
+// This namespace supersedes the two retired per-conversation and per-page
+// namespaces by construction: bumping the namespace orphans every Sprite named
+// under the old schemes (swept separately by the cutover migration task).
+const NAMESPACE_VERSION = 'drive-sandbox:v1';
 
-export function deriveSessionKey({
-  tenantId,
-  driveId,
-  conversationId,
-  secret,
-}: SessionKeyInput): string {
+export function deriveSessionKey({ tenantId, driveId, secret }: SessionKeyInput): string {
   // Fail closed at the boundary: an empty secret collapses the HMAC into a plain
   // digest of public ids, making the sandbox name guessable. Don't rely solely on
   // upstream env validation — refuse to derive a non-secret key here.
   if (secret.length === 0) {
     throw new Error('deriveSessionKey requires a non-empty secret');
   }
-  const payload = [NAMESPACE_VERSION, tenantId, driveId ?? '', conversationId].join('\0');
+  // A drive is the entire addressing scope now — there is no drive-less
+  // fallback (the old global no-drive path is retired). Refuse rather than
+  // silently deriving a key that would collide across every drive-less caller.
+  if (!driveId) {
+    throw new Error('deriveSessionKey requires a non-empty driveId');
+  }
+  if (!tenantId) {
+    throw new Error('deriveSessionKey requires a non-empty tenantId');
+  }
+  const payload = [NAMESPACE_VERSION, tenantId, driveId].join('\0');
   const digest = createHmac('sha3-256', secret).update(payload).digest('hex');
   return `pgs-sbx-${digest}`;
 }

--- a/packages/lib/src/services/sandbox/session-manager.ts
+++ b/packages/lib/src/services/sandbox/session-manager.ts
@@ -66,8 +66,10 @@ export interface AcquireSandboxDeps {
 
 export interface AcquireSandboxInput {
   tenantId: string;
-  /** Absent for global (non-drive) contexts. Session key uses '' for the drive
-   *  segment when driveId is not provided. */
+  /** Required for session-key derivation (drive-scoped sandboxes only); a
+   *  missing driveId fails the acquire closed — see the guard below. Optional
+   *  in this type only because the no-drive global caller has not yet been
+   *  migrated to resolve a Home-drive id (tracked separately). */
   driveId?: string;
   conversationId: string;
   userId: string;
@@ -214,13 +216,14 @@ export async function acquireConversationSandbox(
   const { deps, tenantId, driveId, conversationId, userId, requestOrigin, agentPageId, hardExpiryMs } = input;
 
   // Fail closed if any required namespacing component or the secret is missing.
-  // driveId is intentionally optional (absent for global context) — its absence is
-  // handled by deriveSessionKey which substitutes '' for the drive segment.
-  if (!deps.secret || !tenantId || !conversationId || !userId) {
+  // driveId is now REQUIRED for key derivation — the no-drive global path is
+  // retired (see the epic's Home-drive task); a caller with no driveId is denied
+  // here rather than falling back to a shared drive-less sandbox.
+  if (!deps.secret || !tenantId || !driveId || !conversationId || !userId) {
     return { ok: false, reason: 'error' };
   }
 
-  const key = deriveSessionKey({ tenantId, driveId, conversationId, secret: deps.secret });
+  const key = deriveSessionKey({ tenantId, driveId, secret: deps.secret });
 
   // Fail closed on any unexpected IO error (store lookup/remove, client.get): a
   // failure here means we cannot establish session state safely, so we deny
@@ -312,7 +315,7 @@ export async function teardownConversationSandbox({
     return { torn: false };
   }
 
-  const key = deriveSessionKey({ tenantId, driveId, conversationId, secret: deps.secret });
+  const key = deriveSessionKey({ tenantId, driveId, secret: deps.secret });
 
   // The lookup is the only throwing IO before we know there is anything to tear
   // down. If the store is unavailable we cannot proceed, but cleanup must never

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -1,33 +1,10 @@
-import { createHmac } from 'crypto';
 import type { SandboxCreateOptions } from './sandbox-options';
 import { resolveSandboxNetworkOptions } from './network-options';
 import { getConfiguredEgressIpTag } from './egress-ip';
 import type { FullEgressEnablement, FullEgressDenialReason } from './containment';
 import type { SandboxClient } from './session-manager';
+import { deriveSessionKey } from './session-key';
 import { loggers } from '../../logging/logger-config';
-
-export interface TerminalSessionKeyInput {
-  tenantId: string;
-  driveId: string;
-  pageId: string;
-  secret: string;
-}
-
-const NAMESPACE_VERSION = 'terminal-session:v1';
-
-export function deriveTerminalSessionKey({
-  tenantId,
-  driveId,
-  pageId,
-  secret,
-}: TerminalSessionKeyInput): string {
-  if (secret.length === 0) {
-    throw new Error('deriveTerminalSessionKey requires a non-empty secret');
-  }
-  const payload = [NAMESPACE_VERSION, tenantId, driveId, pageId].join('\0');
-  const digest = createHmac('sha3-256', secret).update(payload).digest('hex');
-  return `pgs-sbx-${digest}`;
-}
 
 export type TerminalTeardownReason = 'idle' | 'session_end';
 export type TerminalLifecycleIntent = 'run' | 'end';
@@ -223,7 +200,10 @@ export async function acquireTerminalSandbox(
     return { ok: false, reason: 'error' };
   }
 
-  const key = deriveTerminalSessionKey({ tenantId, driveId, pageId, secret: deps.secret });
+  // The terminal shares the SAME drive-scoped key as agent chat: a terminal page
+  // is a window onto the drive's one machine, not a machine of its own —
+  // `pageId` no longer participates in sandbox addressing (kept for audit only).
+  const key = deriveSessionKey({ tenantId, driveId, secret: deps.secret });
 
   try {
     const existing = await deps.store.findBySessionKey(key);


### PR DESCRIPTION
## Summary

Root cut of the **Sandboxes Per Drive** epic (`pu/sandboxes-per-drive`): collapses the two existing sandbox session-key derivations into one per-drive derivation, per the epic's "drive-scoped session key" spec (`tasks/sandboxes-per-drive.md`).

**Mental model**: "a drive is a computer" — agent chats and terminal pages in the same drive must address the *same* Sprite. Today they don't: conversations get `sandbox-session:v1` keys (`tenant+drive+conversation`) and terminal pages get `terminal-session:v1` keys (`tenant+drive+page`), so sandbox count grows unbounded with conversations/pages instead of drives.

## Changes

- **`session-key.ts`**: `deriveSessionKey` now takes `(tenantId, driveId, secret)` only, under a new `drive-sandbox:v1` namespace. `conversationId`/`pageId` no longer participate in sandbox identity (they remain available to callers for audit logging). Fails closed (throws) on a missing/empty `driveId` or `tenantId`, matching the existing fail-closed throw for an empty `secret`. Output shape is unchanged (`pgs-sbx-` + 64 hex chars), so the 63-char Sprite-name (DNS label) truncation in `sandbox-client/sprites.ts` needs no change — verified by the existing sprites test suite passing untouched.
- **`terminal-session-manager.ts`**: deleted `deriveTerminalSessionKey` and the `terminal-session:v1` namespace entirely. `acquireTerminalSandbox` now calls the shared `deriveSessionKey` — a terminal page is a window onto the drive's machine, not a machine of its own.
- **`session-manager.ts`**: `acquireConversationSandbox` / `teardownConversationSandbox` derive the key from `(tenantId, driveId)` only. `driveId` is now **required** for a successful acquire (previously optional, defaulting to `''` for the global no-drive path) — a caller with no `driveId` is denied (`reason: 'error'`) rather than falling back to a shared drive-less sandbox. Retiring the no-drive path fully (routing the global assistant to the user's Home drive) is a separate sibling task in this epic.

Exactly one exported derivation remains (`deriveSessionKey`). `session-manager.ts` and `terminal-session-manager.ts` are being reworked more deeply by sibling PRs in this epic (schema + persistent lifecycle) — this PR gives them the new signature as the only one that exists, so those PRs can't miss the cutover.

No compat shims: `CODE_EXECUTION_ENABLED` is default-off and prod-gated to admins, so this is a hard cutover with no released consumers to protect. Existing Sprites are orphaned by the namespace bump; sweeping them is the epic's separate cutover-migration task.

## Test plan

- [x] New/updated colocated unit tests prove: deterministic derivation, drive/tenant namespacing, secret-keying (unguessable), opaque output, fail-closed on missing/empty `driveId`/`tenantId`/`secret`, and that agent-chat and terminal call sites resolve to the identical key for the same drive.
- [x] `bunx vitest run src/services/sandbox` — 374/374 tests pass (26 files), including `sprites.test.ts` (truncation untouched) and updated `session-manager.test.ts` / `terminal-session-manager.test.ts`.
- [x] `bun run typecheck` — 16/16 tasks green across the monorepo.
- [x] `bun run lint` — clean.
- [x] `grep -rn "sandbox-session:v1\|terminal-session:v1\|deriveTerminalSessionKey" packages apps` — no matches.

https://claude.ai/code/session_01QzJk3Cpx6VDfDrbBBhaeuY