### PR TITLE
fix(realtime): decrypt PII at the edge in presence + terminal-audit reads (GDPR #965)

### DIFF
--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -47,6 +47,13 @@ vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
   verifyBroadcastSignature: vi.fn(),
 }));
 
+// field-crypto mock — defaults to passthrough (matches real decryptField's
+// behavior on non-ciphertext-shaped strings); tests override to simulate
+// actual ciphertext decryption.
+vi.mock('@pagespace/lib/encryption/field-crypto', () => ({
+  decryptField: vi.fn(async (value: string | null | undefined) => value),
+}));
+
 // permissions mock
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getUserAccessLevel: vi.fn(),
@@ -236,6 +243,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { verifyBroadcastSignature } from '@pagespace/lib/auth/broadcast-auth';
 import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import { sessionService } from '@pagespace/lib/auth/session-service';
+import { decryptField } from '@pagespace/lib/encryption/field-crypto';
 import { emitValidationError } from '../validation';
 
 // ---------------------------------------------------------------------------
@@ -1691,6 +1699,36 @@ describe('populateUserMetadata', () => {
 
     expect(next).toHaveBeenCalledTimes(1);
     expect((socket.data.user as { name: string }).name).toBe('User Name');
+  });
+
+  it('given no profile and a ciphertext user name (GDPR #965 post-cutover), should decrypt before using as fallback', async () => {
+    mockDbLimit
+      .mockResolvedValueOnce([{ name: 'ciphertext-blob', image: null }]) // users query
+      .mockResolvedValueOnce([]); // no profile
+
+    vi.mocked(decryptField).mockImplementation(async (value) =>
+      value === 'ciphertext-blob' ? 'Decrypted Name' : value
+    );
+
+    vi.mocked(sessionService.validateSession).mockResolvedValue({
+      userId: 'user-meta-cipher',
+    } as Awaited<ReturnType<typeof sessionService.validateSession>>);
+
+    const socket = createMockSocket({
+      data: { user: { id: 'user-meta-cipher', name: 'Unknown', avatarUrl: null } },
+      handshake: {
+        auth: { token: 'ps_sess_metacipher' },
+        headers: { origin: undefined },
+        address: '127.0.0.1',
+      },
+    });
+    const next = vi.fn();
+
+    await capturedIoUseCallback!(socket, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(decryptField).toHaveBeenCalledWith('ciphertext-blob');
+    expect((socket.data.user as { name: string }).name).toBe('Decrypted Name');
   });
 
   it('given no user data at all, should use Unknown fallback', async () => {

--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -250,7 +250,7 @@ import { emitValidationError } from '../validation';
 // 4. Dynamically import index.ts (runs module-level code with mocks in place)
 // ---------------------------------------------------------------------------
 // We do this at the top level outside describe so it runs once
-await import('../index');
+const { resolveActorEmail } = await import('../index');
 
 // ---------------------------------------------------------------------------
 // Helper factories
@@ -1731,6 +1731,32 @@ describe('populateUserMetadata', () => {
     expect((socket.data.user as { name: string }).name).toBe('Decrypted Name');
   });
 
+  it('given a profile displayName, should not decrypt users.name at all (a stale/corrupt ciphertext must not discard a valid displayName)', async () => {
+    mockDbLimit
+      .mockResolvedValueOnce([{ name: 'ciphertext-blob', image: null }]) // users query
+      .mockResolvedValueOnce([{ displayName: 'Profile Name', avatarUrl: null }]);
+
+    vi.mocked(sessionService.validateSession).mockResolvedValue({
+      userId: 'user-meta-skip-decrypt',
+    } as Awaited<ReturnType<typeof sessionService.validateSession>>);
+
+    const socket = createMockSocket({
+      data: { user: { id: 'user-meta-skip-decrypt', name: 'Unknown', avatarUrl: null } },
+      handshake: {
+        auth: { token: 'ps_sess_metaskipdecrypt' },
+        headers: { origin: undefined },
+        address: '127.0.0.1',
+      },
+    });
+    const next = vi.fn();
+
+    await capturedIoUseCallback!(socket, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(decryptField).not.toHaveBeenCalled();
+    expect((socket.data.user as { name: string }).name).toBe('Profile Name');
+  });
+
   it('given no user data at all, should use Unknown fallback', async () => {
     mockDbLimit
       .mockResolvedValueOnce([]) // no user
@@ -1779,5 +1805,41 @@ describe('populateUserMetadata', () => {
     expect(next).toHaveBeenCalledWith(/* no error */);
     expect(next.mock.calls[0]).toHaveLength(0);
     expect((socket.data.user as { name: string }).name).toBe('Unknown');
+  });
+});
+
+describe('resolveActorEmail', () => {
+  // Extracted from makeTerminalCheckAuth (terminal code-execution auth) so the
+  // decrypt-before-audit behavior is directly unit-testable without mocking
+  // the rest of that pipeline (sandbox provisioning, sprites SDK, audit sink).
+  // Guards against ciphertext users.email reaching writeCodeExecutionAudit's
+  // plaintext activity_logs.actorEmail snapshot (GDPR #965).
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given a ciphertext email, should return the decrypted value', async () => {
+    vi.mocked(decryptField).mockResolvedValue('user@example.com');
+
+    const result = await resolveActorEmail('ciphertext-blob');
+
+    expect(decryptField).toHaveBeenCalledWith('ciphertext-blob');
+    expect(result).toBe('user@example.com');
+  });
+
+  it('given legacy plaintext email, should pass it through (decryptField is a no-op)', async () => {
+    vi.mocked(decryptField).mockImplementation(async (value) => value);
+
+    const result = await resolveActorEmail('plaintext@example.com');
+
+    expect(result).toBe('plaintext@example.com');
+  });
+
+  it('given no email, should return an empty string without calling decryptField', async () => {
+    const result = await resolveActorEmail(undefined);
+
+    expect(decryptField).not.toHaveBeenCalled();
+    expect(result).toBe('');
   });
 });

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -33,6 +33,7 @@ import {
   emitValidationError,
 } from './validation';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { decryptField } from '@pagespace/lib/encryption/field-crypto';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { socketRegistry } from './socket-registry';
 import { handleKickRequest } from './kick-handler';
@@ -82,7 +83,9 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
   }
   const tenantId = driveRow.ownerId;
   const tier = (userRow?.subscriptionTier ?? 'free') as SubscriptionTier;
-  const actorEmail = userRow?.email ?? '';
+  // Decrypt PII at the edge (GDPR #965): actorEmail is denormalized into a
+  // plaintext activity-log/audit snapshot downstream, not an encrypted column.
+  const actorEmail = userRow?.email ? await decryptField(userRow.email) : '';
 
   // Acquire a concurrency slot; deny if the user is at their per-tier limit.
   const slotAcquired = acquireCodeExecutionSlot({ userId, tier });
@@ -527,7 +530,11 @@ async function populateUserMetadata(socket: AuthSocket): Promise<void> {
       db.select({ displayName: userProfiles.displayName, avatarUrl: userProfiles.avatarUrl }).from(userProfiles).where(eq(userProfiles.userId, userId)).limit(1),
     ]);
 
-    const name = profileResult[0]?.displayName || userResult[0]?.name || 'Unknown';
+    // Decrypt PII at the edge (GDPR #965): users.name may be ciphertext;
+    // userProfiles.displayName is never encrypted and takes precedence anyway.
+    const rawName = userResult[0]?.name;
+    const decryptedName = rawName ? await decryptField(rawName) : undefined;
+    const name = profileResult[0]?.displayName || decryptedName || 'Unknown';
     const avatarUrl = profileResult[0]?.avatarUrl || userResult[0]?.image || null;
 
     socket.data.user = { id: userId, name, avatarUrl };

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -48,6 +48,18 @@ const terminalSessionMap = createTerminalSessionMap();
 // Cache the DB terminal session store promise at module level (created once, not per-connection).
 const dbTerminalSessionStorePromise = createDbTerminalSessionStore();
 
+/**
+ * Decrypt PII at the edge (GDPR #965): actorEmail is denormalized into a
+ * plaintext activity-log/audit snapshot downstream (writeCodeExecutionAudit),
+ * not an encrypted column, so a ciphertext users.email must never reach it.
+ * Extracted as a pure helper (rather than inlined in makeTerminalCheckAuth) so
+ * it's directly unit-testable without mocking the rest of the terminal-auth
+ * pipeline (sandbox provisioning, sprites SDK, audit sink).
+ */
+export async function resolveActorEmail(rawEmail: string | null | undefined): Promise<string> {
+  return rawEmail ? await decryptField(rawEmail) : '';
+}
+
 async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageId: string }): Promise<CheckAuthResult> {
   const [pageRow] = await db
     .select({ driveId: pages.driveId })
@@ -83,9 +95,7 @@ async function makeTerminalCheckAuth({ userId, pageId }: { userId: string; pageI
   }
   const tenantId = driveRow.ownerId;
   const tier = (userRow?.subscriptionTier ?? 'free') as SubscriptionTier;
-  // Decrypt PII at the edge (GDPR #965): actorEmail is denormalized into a
-  // plaintext activity-log/audit snapshot downstream, not an encrypted column.
-  const actorEmail = userRow?.email ? await decryptField(userRow.email) : '';
+  const actorEmail = await resolveActorEmail(userRow?.email);
 
   // Acquire a concurrency slot; deny if the user is at their per-tier limit.
   const slotAcquired = acquireCodeExecutionSlot({ userId, tier });
@@ -531,10 +541,13 @@ async function populateUserMetadata(socket: AuthSocket): Promise<void> {
     ]);
 
     // Decrypt PII at the edge (GDPR #965): users.name may be ciphertext;
-    // userProfiles.displayName is never encrypted and takes precedence anyway.
+    // userProfiles.displayName is never encrypted and takes precedence anyway,
+    // so only decrypt when it's actually needed — a decrypt failure on a
+    // stale/corrupt users.name must not discard an otherwise-valid displayName.
     const rawName = userResult[0]?.name;
-    const decryptedName = rawName ? await decryptField(rawName) : undefined;
-    const name = profileResult[0]?.displayName || decryptedName || 'Unknown';
+    const displayName = profileResult[0]?.displayName;
+    const decryptedName = !displayName && rawName ? await decryptField(rawName) : undefined;
+    const name = displayName || decryptedName || 'Unknown';
     const avatarUrl = profileResult[0]?.avatarUrl || userResult[0]?.image || null;
 
     socket.data.user = { id: userId, name, avatarUrl };


### PR DESCRIPTION
## Summary
- `apps/realtime` never went through the `packages/lib/src/auth/user-repository` decryption edge added in #1728 — flagged by Codex on #1886, verified real.
- `populateUserMetadata` broadcasts `users.name` as the presence-join fallback name whenever a user has no `userProfiles.displayName` override — post-cutover that's ciphertext for backfilled users, currently visible to other connected clients as an AES-GCM blob.
- `makeTerminalCheckAuth` reads `users.email` as `actorEmail`, denormalized into a plaintext `activity_logs` snapshot via `writeCodeExecutionAudit` — same bug class already fixed for `account/route.ts`'s `getActorInfo`, different call site this PR's original sweep missed (never searched `apps/realtime`).
- Both now decrypt via `decryptField` before use; legacy plaintext passes through unchanged.

## Test plan
- [x] `bunx tsc --noEmit` in `apps/realtime` — clean
- [x] `bun run --filter 'realtime' test` — 466/466 passing, including a new test proving ciphertext is decrypted before use in `populateUserMetadata`
- [x] `eslint src` in `apps/realtime` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3csWPUnuGXBm3yZ8nSZae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of user names and actor email in realtime sessions by properly decrypting encrypted PII before use.
  * If a profile display name is missing, the app now decrypts the stored fallback name; otherwise it uses the profile value without decrypting the stored name.
  * Terminal sign-in actor email is now shown consistently after processing.
* **Tests**
  * Added/expanded unit test coverage for the updated fallback and decryption behavior, including scenarios for missing or overridden values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->