### PR TITLE
feat(terminal): page-agent Terminal Access toggle + machine selection

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/__tests__/route.test.ts
@@ -22,6 +22,7 @@ const {
   mockIsAuthError,
   mockCheckMCPPageScope,
   mockCanUserEditPage,
+  mockGetUserAccessiblePagesInDrive,
   mockDbSelect,
   mockGetActorInfo,
   mockLoggers,
@@ -43,6 +44,7 @@ const {
     mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
     mockCheckMCPPageScope: vi.fn().mockResolvedValue(null),
     mockCanUserEditPage: vi.fn(),
+    mockGetUserAccessiblePagesInDrive: vi.fn().mockResolvedValue([]),
     mockDbSelect: vi.fn(),
     mockGetActorInfo: vi.fn().mockResolvedValue({
       actorEmail: 'test@example.com',
@@ -88,6 +90,8 @@ vi.mock('@pagespace/db/db', () => ({
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id' },
@@ -96,6 +100,7 @@ vi.mock('@pagespace/db/schema/core', () => ({
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
     canUserEditPage: (...args: unknown[]) => mockCanUserEditPage(...args),
+    getUserAccessiblePagesInDrive: (...args: unknown[]) => mockGetUserAccessiblePagesInDrive(...args),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: mockLoggers,
@@ -217,6 +222,7 @@ describe('GET /api/pages/[pageId]/agent-config', () => {
     mockIsAuthError.mockImplementation((result: unknown) => result != null && typeof result === 'object' && 'error' in result);
     mockCheckMCPPageScope.mockResolvedValue(null);
     mockCanUserEditPage.mockResolvedValue(true);
+    mockGetUserAccessiblePagesInDrive.mockResolvedValue([]);
     mockGetActorInfo.mockResolvedValue({
       actorEmail: 'test@example.com',
       actorDisplayName: 'Test User',
@@ -376,6 +382,58 @@ describe('GET /api/pages/[pageId]/agent-config', () => {
       expect(response.status).toBe(200);
       expect(body.drivePrompt).toBeNull();
     });
+
+    it('returns an empty availableTerminals list by default', async () => {
+      const response = await GET(createGetRequest(), mockParams);
+      const body = await response.json();
+
+      expect(body.availableTerminals).toEqual([]);
+    });
+
+    it('returns configured terminalAccess and machines', async () => {
+      setupGetSelectChain(
+        [{ ...mockPage, terminalAccess: true, machines: [{ kind: 'own' }] }],
+        [{ drivePrompt: 'Drive system prompt' }]
+      );
+
+      const response = await GET(createGetRequest(), mockParams);
+      const body = await response.json();
+
+      expect(body.terminalAccess).toBe(true);
+      expect(body.machines).toEqual([{ kind: 'own' }]);
+    });
+
+    it('returns availableTerminals filtered to TERMINAL pages the user can access', async () => {
+      mockGetUserAccessiblePagesInDrive.mockResolvedValue(['term_1', 'term_2']);
+      let callCount = 0;
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([mockPage]); // page fetch
+            if (callCount === 2) {
+              return { limit: () => Promise.resolve([{ drivePrompt: 'Drive system prompt' }]) }; // drive fetch
+            }
+            return Promise.resolve([{ id: 'term_1', title: 'Terminal One' }]); // terminal listing
+          },
+        }),
+      }));
+
+      const response = await GET(createGetRequest(), mockParams);
+      const body = await response.json();
+
+      expect(body.availableTerminals).toEqual([{ id: 'term_1', title: 'Terminal One' }]);
+    });
+
+    it('returns an empty availableTerminals list when the accessible-pages lookup throws', async () => {
+      mockGetUserAccessiblePagesInDrive.mockRejectedValue(new Error('permissions error'));
+
+      const response = await GET(createGetRequest(), mockParams);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.availableTerminals).toEqual([]);
+    });
   });
 
   describe('error handling', () => {
@@ -398,6 +456,7 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
     mockIsAuthError.mockImplementation((result: unknown) => result != null && typeof result === 'object' && 'error' in result);
     mockCheckMCPPageScope.mockResolvedValue(null);
     mockCanUserEditPage.mockResolvedValue(true);
+    mockGetUserAccessiblePagesInDrive.mockResolvedValue([]);
     mockGetActorInfo.mockResolvedValue({
       actorEmail: 'test@example.com',
       actorDisplayName: 'Test User',
@@ -660,7 +719,9 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
     });
 
     it('updates machines with a valid MachineRef array', async () => {
-      const machines = [{ kind: 'own' }, { kind: 'existing', terminalId: 'term_1' }];
+      // Own-machine entries only — the "existing" terminalId path (which also
+      // needs an accessibility check) is covered in "machines validation" below.
+      const machines = [{ kind: 'own' }];
       await PATCH(createPatchRequest({ machines }), mockParams);
 
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
@@ -806,6 +867,148 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
         })
       );
     });
+
+    it('updates terminalAccess as boolean', async () => {
+      await PATCH(createPatchRequest({ terminalAccess: 1 }), mockParams);
+
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updates: expect.objectContaining({
+            terminalAccess: true,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('machines validation', () => {
+    it('returns 400 for malformed machine entries', async () => {
+      const response = await PATCH(
+        createPatchRequest({ machines: [{ kind: 'bogus' }] }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/machines must be an array/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when machines is not an array', async () => {
+      const response = await PATCH(
+        createPatchRequest({ machines: 'not-an-array' }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/machines must be an array/i);
+    });
+
+    it('accepts an own-machine entry with no extra DB lookup', async () => {
+      const response = await PATCH(
+        createPatchRequest({ machines: [{ kind: 'own' }] }),
+        mockParams
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updates: expect.objectContaining({
+            machines: [{ kind: 'own' }],
+          }),
+        })
+      );
+    });
+
+    it('updates machines when an existing terminalId resolves to a TERMINAL page the user can access', async () => {
+      mockGetUserAccessiblePagesInDrive.mockResolvedValue(['term_1']);
+      let callCount = 0;
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([mockPage]); // page fetch
+            if (callCount === 2) return Promise.resolve([{ id: 'term_1' }]); // terminal validation
+            return { limit: () => Promise.resolve([{ ...mockPage, machines: [{ kind: 'existing', terminalId: 'term_1' }] }]) }; // refetch
+          },
+        }),
+      }));
+
+      const response = await PATCH(
+        createPatchRequest({ machines: [{ kind: 'own' }, { kind: 'existing', terminalId: 'term_1' }] }),
+        mockParams
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          updates: expect.objectContaining({
+            machines: [{ kind: 'own' }, { kind: 'existing', terminalId: 'term_1' }],
+          }),
+        })
+      );
+    });
+
+    it('returns 400 when an existing machine references a terminal that cannot be found', async () => {
+      mockGetUserAccessiblePagesInDrive.mockResolvedValue(['missing_term']);
+      let callCount = 0;
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([mockPage]); // page fetch
+            return Promise.resolve([]); // terminal validation finds nothing
+          },
+        }),
+      }));
+
+      const response = await PATCH(
+        createPatchRequest({ machines: [{ kind: 'existing', terminalId: 'missing_term' }] }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/invalid terminal reference/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when an existing machine references a real TERMINAL page the user cannot access', async () => {
+      // getUserAccessiblePagesInDrive resolves without this terminalId — the page
+      // exists (and the DB query would find it) but is outside the user's access.
+      mockGetUserAccessiblePagesInDrive.mockResolvedValue([]);
+      let callCount = 0;
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([mockPage]); // page fetch
+            return Promise.resolve([{ id: 'other_drive_term' }]); // terminal exists, but inaccessible
+          },
+        }),
+      }));
+
+      const response = await PATCH(
+        createPatchRequest({ machines: [{ kind: 'existing', terminalId: 'other_drive_term' }] }),
+        mockParams
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/invalid terminal reference/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when machines exceeds the maximum length', async () => {
+      const machines = Array.from({ length: 21 }, () => ({ kind: 'own' as const }));
+      const response = await PATCH(createPatchRequest({ machines }), mockParams);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/machines must be an array/i);
+      expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    });
   });
 
   describe('model validation', () => {
@@ -922,7 +1125,9 @@ describe('PATCH /api/pages/[pageId]/agent-config', () => {
     });
 
     it('round-trips terminalAccess and machines in the response', async () => {
-      const machines = [{ kind: 'existing', terminalId: 'term_1' }];
+      // Own-machine entries only — the "existing" terminalId path is covered
+      // in "machines validation" below.
+      const machines = [{ kind: 'own' }];
       setupPatchSelectChain(
         [mockPage],
         [{ ...mockPage, terminalAccess: true, machines }]

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalEditPage, isScopedMCPAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
+import { eq, and, inArray } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
 import { filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { validateAgentModelSelection } from '@/lib/ai/core/ai-providers-config';
+import { getUserAccessiblePagesInDrive } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
@@ -15,6 +16,7 @@ import { isMachineRefArray } from '@/lib/repositories/page-agent-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+const MAX_MACHINES = 20;
 
 /**
  * GET - Get Page AI agent configuration
@@ -75,6 +77,23 @@ export async function GET(
       // Continue without drive prompt on error
     }
 
+    // Terminal pages in this drive the requesting user can see, for the
+    // "use existing machine" picker. Scoped to this page's own drive —
+    // additional agent drives are a separate follow-up.
+    let availableTerminals: Array<{ id: string; title: string }> = [];
+    try {
+      const accessiblePageIds = await getUserAccessiblePagesInDrive(userId, page.driveId);
+      if (accessiblePageIds.length > 0) {
+        availableTerminals = await db
+          .select({ id: pages.id, title: pages.title })
+          .from(pages)
+          .where(and(inArray(pages.id, accessiblePageIds), eq(pages.type, 'TERMINAL'), eq(pages.isTrashed, false)));
+      }
+    } catch (error) {
+      loggers.api.error('Error fetching available terminals:', error as Error);
+      // Continue with an empty list on error
+    }
+
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'agent_config', resourceId: pageId, details: { action: 'get_agent_config' } });
 
     return NextResponse.json({
@@ -93,6 +112,7 @@ export async function GET(
       toolExposureMode: page.toolExposureMode ?? 'upfront',
       terminalAccess: page.terminalAccess ?? false,
       machines: isMachineRefArray(page.machines) ? page.machines : [],
+      availableTerminals,
     });
   } catch (error) {
     loggers.api.error('Error fetching page agent configuration:', error as Error);
@@ -171,13 +191,36 @@ export async function PATCH(
       }
     }
 
-    // Validate machines shape: each entry is either `{ kind: 'own' }` or
-    // `{ kind: 'existing', terminalId }`; machines[0] is the default active machine.
-    if (machines !== undefined && !isMachineRefArray(machines)) {
-      return NextResponse.json(
-        { error: 'machines must be an array of MachineRef objects' },
-        { status: 400 }
-      );
+    // Validate machines: shape-check each entry (MachineRef contract), cap the
+    // array length, then verify every "existing" terminalId points to a
+    // non-trashed TERMINAL page the requesting user can access — mirrors the
+    // GET availableTerminals scoping, so a caller can't attach a Terminal
+    // outside their access via a direct API call.
+    if (machines !== undefined) {
+      if (!isMachineRefArray(machines) || machines.length > MAX_MACHINES) {
+        return NextResponse.json(
+          { error: `machines must be an array of MachineRef objects (max ${MAX_MACHINES})` },
+          { status: 400 }
+        );
+      }
+      const terminalIds = machines
+        .filter((m): m is { kind: 'existing'; terminalId: string } => m.kind === 'existing')
+        .map((m) => m.terminalId);
+      if (terminalIds.length > 0) {
+        const accessiblePageIds = new Set(await getUserAccessiblePagesInDrive(userId, page.driveId));
+        const validTerminals = await db
+          .select({ id: pages.id })
+          .from(pages)
+          .where(and(inArray(pages.id, terminalIds), eq(pages.type, 'TERMINAL'), eq(pages.isTrashed, false)));
+        const validIds = new Set(validTerminals.filter((t) => accessiblePageIds.has(t.id)).map((t) => t.id));
+        const invalidIds = terminalIds.filter((id) => !validIds.has(id));
+        if (invalidIds.length > 0) {
+          return NextResponse.json(
+            { error: `Invalid terminal reference(s): ${invalidIds.join(', ')}` },
+            { status: 400 }
+          );
+        }
+      }
     }
 
     // Validate the model selection against the real catalog (anti-hallucination).
@@ -194,20 +237,20 @@ export async function PATCH(
 
     // Update page configuration
     const updateData: Partial<typeof page> = {};
-    
+
     if (systemPrompt !== undefined) {
       updateData.systemPrompt = systemPrompt.trim() || null;
     }
-    
+
     if (enabledTools !== undefined) {
       // Preserve empty arrays - don't convert to null
       updateData.enabledTools = Array.isArray(enabledTools) ? enabledTools : null;
     }
-    
+
     if (aiProvider !== undefined) {
       updateData.aiProvider = aiProvider.trim() || null;
     }
-    
+
     if (aiModel !== undefined) {
       updateData.aiModel = aiModel.trim() || null;
     }

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useImperativeHandle, forwardRef, useCallback } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
@@ -7,14 +7,22 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { Loader2, Bot, FolderTree, Shield, Copy, Check, Code2, Wrench } from 'lucide-react';
+import { Loader2, Bot, FolderTree, Shield, Copy, Check, Code2, Wrench, TerminalSquare, ArrowUp, ArrowDown, X } from 'lucide-react';
 import { toast } from 'sonner';
-import { useForm, Controller } from 'react-hook-form';
+import { useForm, useFieldArray, useFormState, Controller } from 'react-hook-form';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import Link from 'next/link';
 import { AI_PROVIDERS, getVisibleProviders } from '@/lib/ai/core/ai-providers-config';
 import { getRoleColorClasses } from '@/lib/utils';
 import { AgentDrivesCard } from './AgentDrivesCard';
+import { useEditingStore } from '@/stores/useEditingStore';
+import type { MachineRef } from '@/lib/repositories/page-agent-repository';
+
+// The Terminal tool group: gated behind the Terminal Access toggle below and
+// hidden from the Default Tools list when access is off. switch_machine/
+// list_machines are named ahead of their registration landing in ai-tools.ts
+// so this list needs no changes once they ship.
+const TERMINAL_TOOL_NAMES = new Set(['bash', 'writeFile', 'readFile', 'editFile', 'switch_machine', 'list_machines']);
 
 interface AgentConfig {
   systemPrompt: string;
@@ -29,6 +37,9 @@ interface AgentConfig {
   includePageTree?: boolean;
   pageTreeScope?: 'children' | 'drive';
   toolExposureMode?: 'upfront' | 'search';
+  terminalAccess?: boolean;
+  machines?: MachineRef[];
+  availableTerminals?: Array<{ id: string; title: string }>;
 }
 
 interface AgentMembership {
@@ -107,6 +118,8 @@ interface FormData {
   includePageTree: boolean;
   pageTreeScope: 'children' | 'drive';
   toolExposureMode: 'upfront' | 'search';
+  terminalAccess: boolean;
+  machines: MachineRef[];
 }
 
 const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettingsTabProps>(({
@@ -126,6 +139,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   const [membershipUserRole, setMembershipUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
   const [driveRoles, setDriveRoles] = useState<DriveRole[]>([]);
   const [membershipSaving, setMembershipSaving] = useState(false);
+  const [selectedTerminalId, setSelectedTerminalId] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -201,7 +215,14 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
       includePageTree: config?.includePageTree ?? false,
       pageTreeScope: config?.pageTreeScope ?? 'children',
       toolExposureMode: config?.toolExposureMode ?? 'upfront',
+      terminalAccess: config?.terminalAccess ?? false,
+      machines: config?.machines ?? [],
     }
+  });
+
+  const { fields: machineFields, append: appendMachine, remove: removeMachine, move: moveMachine } = useFieldArray({
+    control,
+    name: 'machines',
   });
 
   // Reset form when config changes
@@ -218,6 +239,8 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
         includePageTree: config.includePageTree ?? false,
         pageTreeScope: config.pageTreeScope ?? 'children',
         toolExposureMode: config.toolExposureMode ?? 'upfront',
+        terminalAccess: config.terminalAccess ?? false,
+        machines: config.machines ?? [],
       });
     }
   }, [config, reset, selectedProvider, selectedModel]);
@@ -301,6 +324,8 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
         visibleToGlobalAssistant: data.visibleToGlobalAssistant,
         includePageTree: data.includePageTree,
         pageTreeScope: data.pageTreeScope,
+        terminalAccess: data.terminalAccess,
+        machines: data.machines,
       };
 
       await patch(`/api/pages/${pageId}/agent-config`, requestData);
@@ -315,6 +340,8 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
         visibleToGlobalAssistant: data.visibleToGlobalAssistant,
         includePageTree: data.includePageTree,
         pageTreeScope: data.pageTreeScope,
+        terminalAccess: data.terminalAccess,
+        machines: data.machines,
       } as AgentConfig;
       onConfigUpdate(updatedConfig);
       toast.success('Agent configuration saved successfully');
@@ -350,17 +377,48 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedProvider]); // Only selectedProvider - fetch functions are stable, models checked inline
 
+  // Watch enabledTools for the count display
+  const enabledTools = watch('enabledTools', []);
+  const terminalAccess = watch('terminalAccess', false);
+
+  const visibleTools = useMemo(
+    () => (config?.availableTools || []).filter(
+      (tool) => terminalAccess || !TERMINAL_TOOL_NAMES.has(tool.name)
+    ),
+    [config, terminalAccess]
+  );
+
   const handleSelectAllTools = () => {
-    const allToolNames = config?.availableTools.map(tool => tool.name) || [];
-    setValue('enabledTools', allToolNames);
+    setValue('enabledTools', visibleTools.map(tool => tool.name));
   };
 
   const handleDeselectAllTools = () => {
     setValue('enabledTools', []);
   };
 
-  // Watch enabledTools for the count display
-  const enabledTools = watch('enabledTools', []);
+  const availableTerminalsById = useMemo(
+    () => new Map((config?.availableTerminals || []).map((t) => [t.id, t])),
+    [config]
+  );
+  const usedTerminalIds = useMemo(
+    () => new Set(machineFields.filter((m) => m.kind === 'existing').map((m) => m.terminalId)),
+    [machineFields]
+  );
+  const hasOwnMachine = machineFields.some((m) => m.kind === 'own');
+  const terminalOptions = (config?.availableTerminals || []).filter((t) => !usedTerminalIds.has(t.id));
+
+  // Register with useEditingStore while dirty so SWR doesn't revalidate this
+  // page mid-edit and clobber unsaved changes.
+  const { isDirty: formIsDirty } = useFormState({ control });
+  useEffect(() => {
+    const componentId = `page-agent-settings-${pageId}`;
+    if (formIsDirty) {
+      useEditingStore.getState().startEditing(componentId, 'form', { pageId });
+    } else {
+      useEditingStore.getState().endEditing(componentId);
+    }
+    return () => { useEditingStore.getState().endEditing(componentId); };
+  }, [formIsDirty, pageId]);
 
   if (!config) {
     return (
@@ -595,6 +653,134 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
           )}
         </Card>
 
+        {/* Terminal Access */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <TerminalSquare className="h-5 w-5" />
+                <div>
+                  <CardTitle className="text-lg">Terminal Access</CardTitle>
+                  <CardDescription>
+                    Let this agent run commands on a persistent Machine and move between Machines.
+                  </CardDescription>
+                </div>
+              </div>
+              <Controller
+                name="terminalAccess"
+                control={control}
+                render={({ field }) => (
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(checked) => {
+                      field.onChange(checked);
+                      if (!checked) return;
+                      if (machineFields.length === 0) appendMachine({ kind: 'own' });
+                    }}
+                  />
+                )}
+              />
+            </div>
+          </CardHeader>
+          {terminalAccess && (
+            <CardContent className="space-y-4">
+              <div>
+                <label className="text-sm font-medium mb-2 block">Machines</label>
+                <p className="text-xs text-muted-foreground mb-3">
+                  The agent moves between these with switch_machine. The first Machine is the default active one.
+                </p>
+                {machineFields.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No machines configured yet.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {machineFields.map((field, index) => {
+                      const label = field.kind === 'own'
+                        ? 'Own machine'
+                        : availableTerminalsById.get(field.terminalId)?.title ?? 'Unknown terminal';
+                      return (
+                        <div
+                          key={field.id}
+                          className="flex items-center justify-between rounded-lg border px-3 py-2"
+                        >
+                          <div className="flex items-center gap-2">
+                            {index === 0 && <Badge variant="outline">Default</Badge>}
+                            <span className="text-sm font-medium">{label}</span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              disabled={index === 0}
+                              onClick={() => moveMachine(index, index - 1)}
+                              aria-label="Move machine up"
+                            >
+                              <ArrowUp className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              disabled={index === machineFields.length - 1}
+                              onClick={() => moveMachine(index, index + 1)}
+                              aria-label="Move machine down"
+                            >
+                              <ArrowDown className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => removeMachine(index)}
+                              aria-label="Remove machine"
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={hasOwnMachine}
+                  onClick={() => appendMachine({ kind: 'own' })}
+                >
+                  Add own machine
+                </Button>
+                <Select value={selectedTerminalId} onValueChange={setSelectedTerminalId} disabled={terminalOptions.length === 0}>
+                  <SelectTrigger className="h-8 w-56 text-sm">
+                    <SelectValue placeholder={terminalOptions.length === 0 ? 'No more terminals to add' : 'Use existing machine…'} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {terminalOptions.map((terminal) => (
+                      <SelectItem key={terminal.id} value={terminal.id}>
+                        {terminal.title}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={!selectedTerminalId}
+                  onClick={() => {
+                    appendMachine({ kind: 'existing', terminalId: selectedTerminalId });
+                    setSelectedTerminalId('');
+                  }}
+                >
+                  Add
+                </Button>
+              </div>
+            </CardContent>
+          )}
+        </Card>
+
         {/* Drive Membership */}
         <Card>
           <CardHeader>
@@ -707,40 +893,51 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
               <Controller
                 name="enabledTools"
                 control={control}
-                render={({ field: { value = [], onChange } }) => (
-                  <div className="space-y-3">
-                    {config.availableTools.map((tool) => (
-                      <div key={tool.name} className="flex items-start space-x-3 p-2 rounded-lg hover:bg-muted/50">
-                        <Checkbox
-                          id={tool.name}
-                          checked={value.includes(tool.name)}
-                          onCheckedChange={(checked) => {
-                            const newValue = checked
-                              ? [...value, tool.name]
-                              : value.filter(t => t !== tool.name);
-                            onChange(newValue);
-                          }}
-                          className="mt-1"
-                        />
-                        <div className="flex-1">
-                          <label 
-                            htmlFor={tool.name}
-                            className="text-sm font-medium cursor-pointer"
-                          >
-                            {tool.name}
-                          </label>
-                          <p className="text-xs text-muted-foreground">
-                            {tool.description}
-                          </p>
-                        </div>
+                render={({ field: { value = [], onChange } }) => {
+                  const toolRow = (tool: { name: string; description: string }) => (
+                    <div key={tool.name} className="flex items-start space-x-3 p-2 rounded-lg hover:bg-muted/50">
+                      <Checkbox
+                        id={tool.name}
+                        checked={value.includes(tool.name)}
+                        onCheckedChange={(checked) => {
+                          const newValue = checked
+                            ? [...value, tool.name]
+                            : value.filter(t => t !== tool.name);
+                          onChange(newValue);
+                        }}
+                        className="mt-1"
+                      />
+                      <div className="flex-1">
+                        <label
+                          htmlFor={tool.name}
+                          className="text-sm font-medium cursor-pointer"
+                        >
+                          {tool.name}
+                        </label>
+                        <p className="text-xs text-muted-foreground">
+                          {tool.description}
+                        </p>
                       </div>
-                    ))}
-                  </div>
-                )}
+                    </div>
+                  );
+                  const terminalTools = visibleTools.filter((tool) => TERMINAL_TOOL_NAMES.has(tool.name));
+                  const otherTools = visibleTools.filter((tool) => !TERMINAL_TOOL_NAMES.has(tool.name));
+                  return (
+                    <div className="space-y-3">
+                      {terminalTools.length > 0 && (
+                        <>
+                          <p className="text-xs font-semibold uppercase text-muted-foreground tracking-wide">Terminal</p>
+                          {terminalTools.map(toolRow)}
+                        </>
+                      )}
+                      {otherTools.map(toolRow)}
+                    </div>
+                  );
+                }}
               />
             </ScrollArea>
             <p className="text-xs text-muted-foreground mt-2">
-              Selected {enabledTools.length} of {config.availableTools.length} tools
+              Selected {enabledTools.length} of {visibleTools.length} tools
             </p>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary

Epic 1 (Agent ⇄ Terminal communication) — the page-agent settings surface: a **Terminal Access** toggle that gates the terminal tool group, plus **machine selection** (own / existing / add multiple), built against the shared config-model contract (`terminalAccess: boolean`, `machines: MachineRef[]`).

- **Schema** (`packages/db/src/schema/core.ts`): `pages.terminalAccess` (boolean, default off) + `pages.machines` (jsonb `MachineRef[]`); `MachineRef` type re-exported from `@pagespace/lib/types` (migration `0181_living_carlie_cooper.sql`, `bun run db:generate`).
- **API** (`apps/web/.../agent-config/route.ts`):
  - `GET` returns `terminalAccess`, `machines`, and `availableTerminals` — Terminal-type pages in this page's drive that the requesting user can access (via `getUserAccessiblePagesInDrive`), for the "use existing machine" picker.
  - `PATCH` validates `machines` shape (`{kind:'own'}` or `{kind:'existing', terminalId}`) and verifies every `existing` `terminalId` resolves to a real, non-trashed `TERMINAL` page before persisting.
- **UI** (`PageAgentSettingsTab.tsx`):
  - **Terminal Access** `Switch` (default off) in the toggle cluster, auto-adds an "own machine" entry the first time it's turned on.
  - Terminal Access OFF ⇒ the terminal tool group (`bash`/`writeFile`/`readFile`/`editFile` + reserved `switch_machine`/`list_machines`, named ahead of their registration in the sibling "terminal tools" PR) is filtered out of Default Tools.
  - Terminal Access ON ⇒ those tools reappear under a "Terminal" heading in Default Tools, plus a **Machines** block: add own machine, add an existing Terminal via `Select`, reorder (▲▼) and remove, index 0 labeled "Default".
  - Registers a `'form'` session with `useEditingStore` while the form is dirty, so a remote SWR revalidation can't clobber in-progress edits.
  - User-facing copy says "Terminal" throughout — no "sandbox" labels were introduced (none existed to rename; the codebase's only prior "sandbox" strings are internal module/tool descriptions, out of this PR's scope per the internal-names-may-stay note).

## Verification

- `bun run typecheck` — green across all 15 packages, including the Next.js production build.
- Unit tests: 178 passing (`apps/web`), including 12 new tests for `terminalAccess`/`machines` GET defaults, `availableTerminals` filtering, and PATCH accept/reject validation paths.
- **Real end-to-end walkthrough** against a local Postgres + seeded session (not mocks):
  - `GET` before any change → `terminalAccess: false`, `machines: []`, `availableTerminals` correctly lists the seeded Terminal page.
  - `PATCH` with `{kind:'bogus'}` → `400` with the shape-validation message.
  - `PATCH` with `{kind:'existing', terminalId: <nonexistent>}` → `400 Invalid terminal reference(s)`.
  - `PATCH` with valid `own` + `existing` machines → passed all validation and reached the mutation call (confirmed via server logs); the final page-version write then hit a real Tigris/S3 credential requirement, which I deliberately didn't configure against real infra from a throwaway local run — and it reproduces **identically** for a pre-existing, unrelated field (`visibleToGlobalAssistant`), confirming it's a generic `applyPageMutation` dependency, not something this PR introduced.
  - Auth/CSRF gating double-checked as genuinely enforced (401/403 without cookie/CSRF header).
- A live browser walkthrough of the Settings tab UI was blocked by a **pre-existing** dev-bundle crash (`pdfjs-dist` duplicate-version conflict in `FileViewer`/`PDFViewer`, unrelated to any page type). Confirmed via an isolation test: stashing all of this PR's changes and reloading the same page reproduces the identical crash on unmodified code, so it predates this change and is out of scope here.

## Test plan
- [x] `bun run typecheck`
- [x] Unit tests (`route.test.ts` × 3 files touched)
- [x] Real DB GET/PATCH walkthrough (see above)
- [ ] Visual UI walkthrough — blocked by the pre-existing pdfjs-dist dev crash noted above; logic was verified via typecheck + the API-level walkthrough instead

https://claude.ai/code/session_01498cXbzUroAXXYudpAewh1