### PR TITLE
Phase 9: key-management-only login foundation (Tasks 1-2)

### DIFF
--- a/apps/web/src/app/api/activities/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/activities/__tests__/manage-keys-scope.test.ts
@@ -1,6 +1,6 @@
 /**
- * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
- * reachable via any real request — see ScopeSet.manageKeys) must not see the
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must not see the
  * activity feed for every drive its owning user belongs to. GET /api/activities
  * in the default 'user' context with no driveId reads allowedDriveIds directly
  * (bypassing checkMCPDriveScope/checkMCPPageScope entirely) — this is exactly

--- a/apps/web/src/app/api/activities/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/activities/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
+ * reachable via any real request — see ScopeSet.manageKeys) must not see the
+ * activity feed for every drive its owning user belongs to. GET /api/activities
+ * in the default 'user' context with no driveId reads allowedDriveIds directly
+ * (bypassing checkMCPDriveScope/checkMCPPageScope entirely) — this is exactly
+ * the shape of "6th place using the same empty-array-means-full-access
+ * convention" the task called out. Uses the REAL getAllowedDriveIds /
+ * isManageKeysOnly implementation (not mocked).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+const { mockActivityLogsFindMany, mockCountWhere, mockInArray } = vi.hoisted(() => ({
+  mockActivityLogsFindMany: vi.fn().mockResolvedValue([]),
+  mockCountWhere: vi.fn().mockResolvedValue([{ total: 0 }]),
+  mockInArray: vi.fn((...args: unknown[]) => ({ __op: 'inArray', args })),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      activityLogs: { findMany: (...args: unknown[]) => mockActivityLogsFindMany(...args) },
+    },
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: (...args: unknown[]) => mockCountWhere(...args),
+      })),
+    })),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((...args: unknown[]) => ({ __op: 'eq', args })),
+  and: vi.fn((...args: unknown[]) => ({ __op: 'and', args })),
+  desc: vi.fn(),
+  count: vi.fn(),
+  gte: vi.fn(),
+  lt: vi.fn(),
+  inArray: mockInArray,
+}));
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  activityLogs: { userId: 'userId', driveId: 'driveId', isArchived: 'isArchived', timestamp: 'timestamp', operation: 'operation', resourceType: 'resourceType', pageId: 'pageId' },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+// Only stub authentication — getAllowedDriveIds and isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+describe('GET /api/activities — manage-keys-only credential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActivityLogsFindMany.mockResolvedValue([]);
+    mockCountWhere.mockResolvedValue([{ total: 0 }]);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+  });
+
+  it('scopes the query to zero drives instead of skipping the drive filter (full-access default)', async () => {
+    const request = new Request('https://example.com/api/activities?context=user');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    // The empty-allowedDriveIds-means-full-access bug would skip this call
+    // entirely, returning the owning user's activity across every drive.
+    expect(mockInArray).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must be able to
+ * reach mcp-tokens/[tokenId] (that is exactly what the scope grants), while a
+ * drive-scoped OAuth credential must still be rejected exactly as before.
+ * Uses the REAL rejectScopedOAuth/isScopedOAuthAuth/isManageKeysOnly
+ * implementations (not mocked) so this fails if the carve-out regresses
+ * either direction.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+vi.mock('@/lib/repositories/session-repository', () => ({
+  sessionRepository: {
+    findMcpTokenByIdAndUser: vi.fn(),
+    revokeMcpToken: vi.fn(),
+    updateMcpTokenDriveScopes: vi.fn(),
+    findDrivesByIds: vi.fn(),
+  },
+}));
+
+// Only stub authentication — rejectScopedOAuth, isScopedOAuthAuth, and
+// isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    auth: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com' }),
+  logTokenActivity: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  validateDriveScopeAccess: vi.fn(),
+}));
+
+import { DELETE, PATCH } from '../route';
+import { sessionRepository } from '@/lib/repositories/session-repository';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const createContext = (tokenId = 'token-123') => ({
+  params: Promise.resolve({ tokenId }),
+});
+
+const DRIVE_SCOPED_OAUTH = {
+  tokenType: 'oauth' as const,
+  userId: 'test-user-id',
+  role: 'user' as const,
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  tokenId: 'oauth-token-1',
+  scopes: {
+    account: false,
+    offlineAccess: false,
+    manageKeys: false,
+    drives: new Map([['drive-1', { kind: 'drive' as const, driveId: 'drive-1', role: { kind: 'inherit' as const } }]]),
+  },
+  driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
+  allowedDriveIds: ['drive-1'],
+};
+
+describe('mcp-tokens/[tokenId] routes — manage_keys-only vs drive-scoped OAuth (real isScopedOAuthAuth/isManageKeysOnly)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockResolvedValue({
+      id: 'token-123',
+      name: 'Test Token',
+    } as never);
+    vi.mocked(sessionRepository.revokeMcpToken).mockResolvedValue(undefined as never);
+    vi.mocked(sessionRepository.updateMcpTokenDriveScopes).mockResolvedValue(undefined as never);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([]);
+  });
+
+  describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
+    it('lets a manage_keys-only OAuth credential revoke an mcp token', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', { method: 'DELETE' });
+      const response = await DELETE(request, createContext());
+
+      expect(response.status).toBe(200);
+      expect(sessionRepository.revokeMcpToken).toHaveBeenCalled();
+    });
+
+    it('still rejects a drive-scoped OAuth credential, never reaching the repository', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', { method: 'DELETE' });
+      const response = await DELETE(request, createContext());
+
+      expect(response.status).toBe(403);
+      expect(sessionRepository.revokeMcpToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
+    it('lets a manage_keys-only OAuth credential update drive scopes', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ driveIds: [] }),
+      });
+      const response = await PATCH(request, createContext());
+
+      expect(response.status).toBe(200);
+      expect(sessionRepository.updateMcpTokenDriveScopes).toHaveBeenCalled();
+    });
+
+    it('still rejects a drive-scoped OAuth credential, never reaching the repository', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ driveIds: [] }),
+      });
+      const response = await PATCH(request, createContext());
+
+      expect(response.status).toBe(403);
+      expect(sessionRepository.updateMcpTokenDriveScopes).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
   isScopedOAuthAuth: vi.fn(),
+  isManageKeysOnly: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
@@ -60,7 +61,7 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 
 import { DELETE, PATCH } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth, isManageKeysOnly } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
@@ -107,6 +108,7 @@ describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
       (result: unknown) => result != null && typeof result === 'object' && 'error' in result
     );
     mockIsScopedOAuthAuth();
+    vi.mocked(isManageKeysOnly).mockReturnValue(false);
 
     vi.mocked(getActorInfo).mockResolvedValue({ actorEmail: 'test@example.com' } as never);
 
@@ -235,6 +237,7 @@ describe('PATCH /api/auth/mcp-tokens/[tokenId]', () => {
     } as never);
     vi.mocked(isAuthError).mockReturnValue(false);
     mockIsScopedOAuthAuth();
+    vi.mocked(isManageKeysOnly).mockReturnValue(false);
     vi.mocked(sessionRepository.findMcpTokenByIdAndUser).mockResolvedValue({
       id: 'token-123',
       name: 'My Token',

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must be able to
+ * reach mcp-tokens (that is exactly what the scope grants), while a
+ * drive-scoped OAuth credential must still be rejected exactly as before.
+ * Uses the REAL rejectScopedOAuth/isScopedOAuthAuth/isManageKeysOnly
+ * implementations (not mocked) so this fails if the carve-out regresses
+ * either direction.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+vi.mock('@/lib/repositories/session-repository', () => ({
+  sessionRepository: {
+    createMcpTokenWithDriveScopes: vi.fn(),
+    findDrivesByIds: vi.fn(),
+    findUserMcpTokensWithDrives: vi.fn(),
+  },
+}));
+
+// Only stub authentication — rejectScopedOAuth, isScopedOAuthAuth, and
+// isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    auth: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+  generateToken: vi.fn().mockReturnValue({
+    token: 'mcp_randomBase64UrlString',
+    hash: 'mockTokenHash123',
+    tokenPrefix: 'mcp_randomBas',
+  }),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com' }),
+  logTokenActivity: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  validateDriveScopeAccess: vi.fn(),
+}));
+
+import { POST, GET } from '../route';
+import { sessionRepository } from '@/lib/repositories/session-repository';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+const DRIVE_SCOPED_OAUTH = {
+  tokenType: 'oauth' as const,
+  userId: 'test-user-id',
+  role: 'user' as const,
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  tokenId: 'oauth-token-1',
+  scopes: {
+    account: false,
+    offlineAccess: false,
+    manageKeys: false,
+    drives: new Map([['drive-1', { kind: 'drive' as const, driveId: 'drive-1', role: { kind: 'inherit' as const } }]]),
+  },
+  driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
+  allowedDriveIds: ['drive-1'],
+};
+
+describe('mcp-tokens routes — manage_keys-only vs drive-scoped OAuth (real isScopedOAuthAuth/isManageKeysOnly)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionRepository.createMcpTokenWithDriveScopes).mockResolvedValue({
+      id: 'new-mcp-token-id',
+      name: 'Test Token',
+      createdAt: new Date(),
+    } as never);
+    vi.mocked(sessionRepository.findDrivesByIds).mockResolvedValue([]);
+    vi.mocked(sessionRepository.findUserMcpTokensWithDrives).mockResolvedValue([]);
+  });
+
+  describe('POST /api/auth/mcp-tokens', () => {
+    it('lets a manage_keys-only OAuth credential mint an unscoped mcp token', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'My Token' }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(sessionRepository.createMcpTokenWithDriveScopes).toHaveBeenCalled();
+    });
+
+    it('still rejects a drive-scoped OAuth credential, never reaching the repository', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'My Token' }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(403);
+      expect(sessionRepository.createMcpTokenWithDriveScopes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/auth/mcp-tokens', () => {
+    it('lets a manage_keys-only OAuth credential list mcp tokens', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens', { method: 'GET' });
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      expect(sessionRepository.findUserMcpTokensWithDrives).toHaveBeenCalled();
+    });
+
+    it('still rejects a drive-scoped OAuth credential, never reaching the repository', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+
+      const request = new NextRequest('http://localhost/api/auth/mcp-tokens', { method: 'GET' });
+      const response = await GET(request);
+
+      expect(response.status).toBe(403);
+      expect(sessionRepository.findUserMcpTokensWithDrives).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
   isScopedOAuthAuth: vi.fn(),
+  isManageKeysOnly: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -74,7 +75,7 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 
 import { POST, GET } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, isScopedOAuthAuth, isManageKeysOnly } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { validateDriveScopeAccess } from '@pagespace/lib/services/drive-service';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
@@ -126,6 +127,7 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
         (auth as { tokenType?: string }).tokenType === 'oauth' &&
         !(auth as { scopes?: { account?: boolean } }).scopes?.account
     );
+    vi.mocked(isManageKeysOnly).mockReturnValue(false);
 
     // Default mocks that need re-setup after resetAllMocks
     vi.mocked(getActorInfo).mockResolvedValue({ actorEmail: 'test@example.com' } as never);

--- a/apps/web/src/app/api/auth/mcp-tokens/scope-guard.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/scope-guard.ts
@@ -1,15 +1,23 @@
 import { NextResponse } from 'next/server';
-import { isScopedOAuthAuth } from '@/lib/auth';
+import { isScopedOAuthAuth, isManageKeysOnly } from '@/lib/auth';
 
 /**
- * A drive-scoped OAuth token acts as an app member for that drive only (ADR
- * 0002 Decision 2) — it must never mint, list, revoke, or manage the full
- * mcp_* credential surface. Only a full-user credential (session, or an
- * account-scoped OAuth token) may reach these routes. Shared by
+ * `isScopedOAuthAuth` covers two distinct credential shapes, which this guard
+ * must tell apart:
+ *
+ * - A drive-scoped OAuth token acts as an app member for that drive only
+ *   (ADR 0002 Decision 2) — it must never mint, list, revoke, or manage the
+ *   full mcp_* credential surface, so it is rejected here.
+ * - A manage_keys-only OAuth token carries no drive content access at all
+ *   (see `isManageKeysOnly`), but minting/listing/revoking mcp_* credentials
+ *   is exactly what that scope exists to grant, so it is let through.
+ *
+ * Only a full-user credential (session, account-scoped OAuth, or a
+ * manage_keys-only OAuth token) may reach these routes. Shared by
  * `mcp-tokens/route.ts` and `mcp-tokens/[tokenId]/route.ts`.
  */
 export function rejectScopedOAuth(auth: Parameters<typeof isScopedOAuthAuth>[0]): NextResponse | null {
-  if (isScopedOAuthAuth(auth)) {
+  if (isScopedOAuthAuth(auth) && !isManageKeysOnly(auth)) {
     return NextResponse.json({ error: 'insufficient_scope' }, { status: 403 });
   }
   return null;

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/manage-keys-scope.test.ts
@@ -1,6 +1,6 @@
 /**
- * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
- * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must not be able
  * to read a channel's messages. Uses the REAL checkMCPPageScope/
  * isManageKeysOnly implementation (not mocked) so this fails if the
  * hardening in apps/web/src/lib/auth/index.ts regresses.

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
+ * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * to read a channel's messages. Uses the REAL checkMCPPageScope/
+ * isManageKeysOnly implementation (not mocked) so this fails if the
+ * hardening in apps/web/src/lib/auth/index.ts regresses.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+const mockPageFindFirst = vi.fn().mockResolvedValue(null);
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: (...args: unknown[]) => mockPageFindFirst(...args) },
+      driveMembers: { findMany: vi.fn().mockResolvedValue([]) },
+    },
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  gt: vi.fn(),
+  inArray: vi.fn(),
+  isNull: vi.fn(),
+  or: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
+vi.mock('@pagespace/db/schema/members', () => ({ driveMembers: {}, pagePermissions: {} }));
+
+vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
+  channelMessageRepository: {
+    listChannelMessages: vi.fn(),
+    listChannelThreadReplies: vi.fn(),
+    findChannelMessageInPage: vi.fn(),
+    insertChannelMessageWithAttachment: vi.fn(),
+    insertChannelThreadReply: vi.fn(),
+    upsertChannelReadStatus: vi.fn(),
+    loadChannelMessageWithRelations: vi.fn(),
+    fileExists: vi.fn(),
+    listChannelThreadFollowers: vi.fn(),
+  },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    realtime: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  },
+}));
+vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
+  createSignedBroadcastHeaders: vi.fn(() => ({ 'x-signed': 'yes' })),
+}));
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastInboxEvent: vi.fn(),
+  broadcastThreadReplyCountUpdated: vi.fn(),
+}));
+
+// Only stub authentication — checkMCPPageScope and isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+
+describe('GET /api/channels/[pageId]/messages — manage-keys-only credential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPageFindFirst.mockResolvedValue(null);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+  });
+
+  it('denies reading channel messages with 403 instead of the empty-allowedDriveIds full-access default, without a page lookup', async () => {
+    const request = new Request('https://example.com/api/channels/page-1/messages');
+
+    const response = await GET(request, { params: Promise.resolve({ pageId: 'page-1' }) });
+
+    expect(response.status).toBe(403);
+    expect(mockPageFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/drives/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
+ * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * to create a drive. Uses the REAL checkMCPCreateScope/isManageKeysOnly
+ * implementation (not mocked) so this fails if the hardening in
+ * apps/web/src/lib/auth/index.ts regresses.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../route';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  listAccessibleDrives: vi.fn(),
+  createDrive: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackDriveOperation: vi.fn(),
+}));
+vi.mock('@pagespace/lib/utils/api-utils', () => ({
+  jsonResponse: vi.fn((data, options = {}) => Response.json(data, { status: options.status || 200 })),
+}));
+vi.mock('@/lib/websocket', () => ({
+  broadcastDriveEvent: vi.fn().mockResolvedValue(undefined),
+  createDriveEventPayload: vi.fn((driveId, event, data) => ({ driveId, event, data })),
+}));
+vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
+  getAppDriveMembership: vi.fn(),
+}));
+
+// Only stub authentication — checkMCPCreateScope and isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { createDrive } from '@pagespace/lib/services/drive-service';
+
+describe('POST /api/drives — manage-keys-only credential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+  });
+
+  it('denies drive creation with 403 instead of the empty-allowedDriveIds full-access default', async () => {
+    const request = new Request('https://example.com/api/drives', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Should Not Be Created' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+    expect(createDrive).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/drives/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/manage-keys-scope.test.ts
@@ -1,6 +1,6 @@
 /**
- * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
- * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must not be able
  * to create a drive. Uses the REAL checkMCPCreateScope/isManageKeysOnly
  * implementation (not mocked) so this fails if the hardening in
  * apps/web/src/lib/auth/index.ts regresses.

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -28,6 +28,10 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: (result: unknown) => 'error' in (result as object),
   isMCPAuthResult: (result: unknown) => !('error' in (result as object)) && (result as { tokenType?: string }).tokenType === 'mcp',
   isOAuthAuthResult: (result: unknown) => !('error' in (result as object)) && (result as { tokenType?: string }).tokenType === 'oauth',
+  isManageKeysOnly: (result: unknown) =>
+    !('error' in (result as object)) &&
+    (result as { tokenType?: string }).tokenType === 'oauth' &&
+    (result as { scopes?: { manageKeys?: boolean } }).scopes?.manageKeys === true,
   // Delegate to the REAL principal dispatch (unit-tested in
   // src/lib/auth/__tests__/principal-permissions.test.ts) so the security
   // assertions below still verify that scoped tokens resolve app-level

--- a/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
@@ -146,6 +146,16 @@ describe('POST /api/oauth/device_authorization/verify — outcomes', () => {
     expect(body.scopeDescriptions.length).toBeGreaterThan(0);
   });
 
+  it('narrates a manage_keys scope as key-management access with no content access', async () => {
+    verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['manage_keys'] });
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.scopeDescriptions).toEqual([expect.stringMatching(/manage.*keys/i)]);
+  });
+
   it('missing userCode → invalid_request', async () => {
     const res = await POST(verifyRequest({}) as never);
     expect(res.status).toBe(400);

--- a/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
@@ -73,6 +73,9 @@ export async function POST(req: NextRequest) {
     if (parsed.scopes.offlineAccess) {
       scopeDescriptions.push(describeScopeForConsent({ kind: 'offline_access' }, {}));
     }
+    if (parsed.scopes.manageKeys) {
+      scopeDescriptions.push(describeScopeForConsent({ kind: 'manage_keys' }, {}));
+    }
 
     const driveIds = [...parsed.scopes.drives.keys()];
     const drives = driveIds.length > 0 ? await sessionRepository.findDrivesByIds(driveIds) : [];

--- a/apps/web/src/app/api/pages/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/manage-keys-scope.test.ts
@@ -1,6 +1,6 @@
 /**
- * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
- * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must not be able
  * to create a page. Uses the REAL checkMCPCreateScope/isManageKeysOnly
  * implementation (not mocked) so this fails if the hardening in
  * apps/web/src/lib/auth/index.ts regresses.

--- a/apps/web/src/app/api/pages/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
+ * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * to create a page. Uses the REAL checkMCPCreateScope/isManageKeysOnly
+ * implementation (not mocked) so this fails if the hardening in
+ * apps/web/src/lib/auth/index.ts regresses.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../route';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+vi.mock('@/services/api', () => ({
+  pageService: { createPage: vi.fn() },
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn((driveId, pageId, type, data) => ({ driveId, pageId, type, ...data })),
+}));
+
+vi.mock('@/lib/ai/core/ai-tools', () => ({
+  pageSpaceTools: {
+    read_page: { description: 'Read a page' },
+    create_drive: { description: 'Create a drive' },
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com', actorDisplayName: 'Test User' }),
+  logPageActivity: vi.fn(),
+}));
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+  getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackPageOperation: vi.fn(),
+}));
+
+// Only stub authentication — checkMCPCreateScope and isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { pageService } from '@/services/api';
+
+describe('POST /api/pages — manage-keys-only credential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+  });
+
+  it('denies page creation with 403 instead of the empty-allowedDriveIds full-access default', async () => {
+    const request = new Request('https://example.com/api/pages', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'Should Not Be Created', type: 'DOCUMENT', driveId: 'drive-owned-by-token-user' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+    expect(pageService.createPage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/tasks/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/tasks/__tests__/manage-keys-scope.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
+ * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * to list tasks in a drive. Uses the REAL checkMCPDriveScope/isManageKeysOnly
+ * implementation (not mocked). isPrincipalDriveMember is stubbed to `true` —
+ * simulating a hypothetical bypass of that separate membership check — so
+ * this test isolates and proves checkMCPDriveScope independently fails
+ * closed rather than relying on the other layer to catch it.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findMany: vi.fn() },
+      taskLists: { findMany: vi.fn() },
+      taskItems: { findMany: vi.fn() },
+      taskStatusConfigs: { findMany: vi.fn() },
+    },
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })) })),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => args),
+  desc: vi.fn(),
+  count: vi.fn(),
+  gte: vi.fn(),
+  lt: vi.fn(),
+  lte: vi.fn(),
+  inArray: vi.fn(),
+  or: vi.fn(),
+  isNull: vi.fn(),
+  not: vi.fn(),
+  sql: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId', type: 'type', isTrashed: 'isTrashed', title: 'title' },
+}));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { assigneeId: 'assigneeId', pageId: 'pageId', status: 'status', priority: 'priority', createdAt: 'createdAt', updatedAt: 'updatedAt', description: 'description' },
+  taskLists: { id: 'id', pageId: 'pageId' },
+  taskStatusConfigs: { taskListId: 'taskListId' },
+}));
+vi.mock('@/lib/task-status-config', () => ({
+  DEFAULT_STATUS_CONFIG: {} as Record<string, { label: string; color: string; group: string }>,
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+// Only stub authentication + drive membership — checkMCPDriveScope and
+// isManageKeysOnly run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+    isPrincipalDriveMember: vi.fn(),
+  };
+});
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions, isPrincipalDriveMember } from '@/lib/auth';
+
+describe('GET /api/tasks — manage-keys-only credential', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+    vi.mocked(isPrincipalDriveMember).mockResolvedValue(true);
+  });
+
+  it('denies drive-context task listing with 403 instead of the empty-allowedDriveIds full-access default', async () => {
+    const request = new Request('https://example.com/api/tasks?context=drive&driveId=drive-1');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/tasks/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/tasks/__tests__/manage-keys-scope.test.ts
@@ -1,6 +1,6 @@
 /**
- * Red-team test: a manage-keys-only OAuth credential (Phase 9, not yet
- * reachable via any real request — see ScopeSet.manageKeys) must not be able
+ * Red-team test: a manage-keys-only OAuth credential (Phase 9, mintable today
+ * via the manage_keys scope token — see ScopeSet.manageKeys) must not be able
  * to list tasks in a drive. Uses the REAL checkMCPDriveScope/isManageKeysOnly
  * implementation (not mocked). isPrincipalDriveMember is stubbed to `true` —
  * simulating a hypothetical bypass of that separate membership check — so

--- a/apps/web/src/app/oauth/consent/page.tsx
+++ b/apps/web/src/app/oauth/consent/page.tsx
@@ -93,6 +93,9 @@ export default async function ConsentPage({ searchParams }: ConsentPageProps) {
   if (result.scopes.offlineAccess) {
     scopeDescriptions.push(describeScopeForConsent({ kind: 'offline_access' }, {}));
   }
+  if (result.scopes.manageKeys) {
+    scopeDescriptions.push(describeScopeForConsent({ kind: 'manage_keys' }, {}));
+  }
   for (const scope of result.scopes.drives.values()) {
     const driveName = driveNamesById.get(scope.driveId);
     if (scope.role.kind === 'custom') {

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -352,7 +352,7 @@ describe('Auth Middleware', () => {
         tokenVersion: 0,
         adminRoleVersion: 0,
         tokenId: 'oauth-token-id',
-        scopes: { account: true, offlineAccess: false, drives: new Map() },
+        scopes: { account: true, offlineAccess: false, drives: new Map(), manageKeys: false },
         driveScopes: [],
         allowedDriveIds: [],
       });

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -1179,7 +1179,7 @@ describe('Auth Middleware', () => {
           adminRoleVersion: 0,
           tokenType: 'oauth' as const,
           tokenId: 'oauth-token-id',
-          scopes: { account: true, offlineAccess: false, drives: new Map() },
+          scopes: { account: true, offlineAccess: false, drives: new Map(), manageKeys: false },
           driveScopes: [],
           allowedDriveIds: [],
         };

--- a/apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts
+++ b/apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts
@@ -1,11 +1,12 @@
 import type { OAuthAuthResult } from '../index';
 
 /**
- * A manage-keys-only OAuth credential. No scope parser can produce
- * `scopes.manageKeys: true` today (see ScopeSet.manageKeys) — this fixture
- * exists so tests can prove the drive-scope helpers already fail closed for
- * it, rather than applying the empty-driveScopes-means-full-access
- * convention every other credential relies on.
+ * A manage-keys-only OAuth credential. `parseScopeList` mints
+ * `scopes.manageKeys: true` today via the `manage_keys` token (see
+ * ScopeSet.manageKeys) — this fixture exists so tests can prove the
+ * drive-scope helpers already fail closed for it, rather than applying the
+ * empty-driveScopes-means-full-access convention every other credential
+ * relies on.
  */
 export function manageKeysScopedAuthResult(
   overrides: Partial<OAuthAuthResult> = {}

--- a/apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts
+++ b/apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts
@@ -1,0 +1,25 @@
+import type { OAuthAuthResult } from '../index';
+
+/**
+ * A manage-keys-only OAuth credential. No scope parser can produce
+ * `scopes.manageKeys: true` today (see ScopeSet.manageKeys) — this fixture
+ * exists so tests can prove the drive-scope helpers already fail closed for
+ * it, rather than applying the empty-driveScopes-means-full-access
+ * convention every other credential relies on.
+ */
+export function manageKeysScopedAuthResult(
+  overrides: Partial<OAuthAuthResult> = {}
+): OAuthAuthResult {
+  return {
+    tokenType: 'oauth',
+    userId: 'user-manage-keys',
+    role: 'user',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    tokenId: 'oauth-token-manage-keys',
+    scopes: { account: false, offlineAccess: false, drives: new Map(), manageKeys: true },
+    driveScopes: [],
+    allowedDriveIds: [],
+    ...overrides,
+  };
+}

--- a/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
@@ -491,11 +491,11 @@ describe('MCP Scope Enforcement', () => {
   });
 
   // ===========================================================================
-  // 7. MANAGE-KEYS-ONLY CREDENTIAL (future zero-content-scope OAuth token)
+  // 7. MANAGE-KEYS-ONLY CREDENTIAL (zero-content-scope OAuth token)
   // ===========================================================================
   //
-  // No scope parser can produce scopes.manageKeys: true today. These tests
-  // exist to pin down that once one does, every helper below already denies
+  // `parseScopeList` mints scopes.manageKeys: true today via the manage_keys
+  // token. These tests pin down that every helper below already denies
   // content access instead of applying the empty-driveScopes-means-full-access
   // convention every other credential relies on.
 

--- a/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
@@ -82,10 +82,12 @@ import {
   checkMCPCreateScope,
   filterDrivesByMCPScope,
   getAllowedDriveIds,
+  isManageKeysOnly,
   type MCPAuthResult,
   type SessionAuthResult,
   type OAuthAuthResult,
 } from '../index';
+import { manageKeysScopedAuthResult } from './manage-keys-fixture';
 
 describe('MCP Scope Enforcement', () => {
   beforeEach(() => {
@@ -485,6 +487,70 @@ describe('MCP Scope Enforcement', () => {
       // Scope check confirms filter result
       expect(checkMCPDriveScope(auth, 'drive-1')).toBeNull();
       expect(checkMCPDriveScope(auth, 'drive-3')).not.toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // 7. MANAGE-KEYS-ONLY CREDENTIAL (future zero-content-scope OAuth token)
+  // ===========================================================================
+  //
+  // No scope parser can produce scopes.manageKeys: true today. These tests
+  // exist to pin down that once one does, every helper below already denies
+  // content access instead of applying the empty-driveScopes-means-full-access
+  // convention every other credential relies on.
+
+  describe('manage-keys-only credential', () => {
+    it('isManageKeysOnly identifies a manage-keys-scoped OAuth credential', () => {
+      expect(isManageKeysOnly(manageKeysScopedAuthResult())).toBe(true);
+    });
+
+    it('isManageKeysOnly is false for every credential kind that exists today', () => {
+      expect(isManageKeysOnly(createSessionAuth())).toBe(false);
+      expect(isManageKeysOnly(createUnscopedMCPAuth())).toBe(false);
+      expect(isManageKeysOnly(createScopedMCPAuth(['drive-1']))).toBe(false);
+      expect(isManageKeysOnly(createAccountScopedOAuthAuth())).toBe(false);
+      expect(isManageKeysOnly(createScopedOAuthAuth(['drive-1']))).toBe(false);
+    });
+
+    it('getAllowedDriveIds never returns an empty array (which would mean full access)', () => {
+      const result = getAllowedDriveIds(manageKeysScopedAuthResult());
+
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('checkMCPDriveScope denies access to any drive', () => {
+      const result = checkMCPDriveScope(manageKeysScopedAuthResult(), 'any-drive');
+
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(403);
+    });
+
+    it('checkMCPPageScope denies access to any page without a DB lookup', async () => {
+      const result = await checkMCPPageScope(manageKeysScopedAuthResult(), 'any-page');
+
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(403);
+      expect(mockPageFindFirst).not.toHaveBeenCalled();
+    });
+
+    it('filterDrivesByMCPScope filters every drive out', () => {
+      const result = filterDrivesByMCPScope(manageKeysScopedAuthResult(), ['drive-1', 'drive-2']);
+
+      expect(result).toEqual([]);
+    });
+
+    it('checkMCPCreateScope denies creating a new drive', () => {
+      const result = checkMCPCreateScope(manageKeysScopedAuthResult(), null);
+
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(403);
+    });
+
+    it('checkMCPCreateScope denies creating a resource in any existing drive', () => {
+      const result = checkMCPCreateScope(manageKeysScopedAuthResult(), 'any-drive');
+
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(403);
     });
   });
 });

--- a/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
@@ -134,7 +134,7 @@ describe('MCP Scope Enforcement', () => {
     tokenVersion: 1,
     adminRoleVersion: 0,
     tokenId: 'oauth-token-abc',
-    scopes: { account: false, offlineAccess: false, drives: new Map() },
+    scopes: { account: false, offlineAccess: false, drives: new Map(), manageKeys: false },
     driveScopes: allowedDriveIds.map((driveId) => ({ driveId, role: null, customRoleId: null })),
     allowedDriveIds,
   });
@@ -146,7 +146,7 @@ describe('MCP Scope Enforcement', () => {
     tokenVersion: 1,
     adminRoleVersion: 0,
     tokenId: 'oauth-token-abc',
-    scopes: { account: true, offlineAccess: false, drives: new Map() },
+    scopes: { account: true, offlineAccess: false, drives: new Map(), manageKeys: false },
     driveScopes: [],
     allowedDriveIds: [],
   });

--- a/apps/web/src/lib/auth/__tests__/oauth-grant-authority.test.ts
+++ b/apps/web/src/lib/auth/__tests__/oauth-grant-authority.test.ts
@@ -20,7 +20,7 @@ import { resolveGrantAuthority } from '../oauth-grant-authority';
 import type { ScopeSet } from '@pagespace/lib/auth/oauth/scopes';
 
 function scopeSet(drives: Array<[string, ScopeSet['drives'] extends ReadonlyMap<string, infer V> ? V : never]>): ScopeSet {
-  return { account: false, offlineAccess: false, drives: new Map(drives) };
+  return { account: false, offlineAccess: false, drives: new Map(drives), manageKeys: false };
 }
 
 const USER_ID = 'user-1';

--- a/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
+++ b/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
@@ -445,4 +445,18 @@ describe('manage-keys-only credential — deny-first short-circuit', () => {
     expect(await getPrincipalDriveIds(auth)).toEqual([]);
     expect(getDriveIdsForUser).not.toHaveBeenCalled();
   });
+
+  it.each(cases)('getPrincipalDriveAccess denies (%s)', async (_label, auth) => {
+    expect(await getPrincipalDriveAccess(auth, DRIVE_ID)).toBe(false);
+    expect(getUserDriveAccess).not.toHaveBeenCalled();
+    expect(hasAppDriveMembership).not.toHaveBeenCalled();
+    expect(hasScopedDriveMembership).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('getPrincipalAccessiblePagesInDrive returns empty, never the owning user\'s pages (%s)', async (_label, auth) => {
+    expect(await getPrincipalAccessiblePagesInDrive(auth, DRIVE_ID)).toEqual([]);
+    expect(getUserAccessiblePagesInDriveWithDetails).not.toHaveBeenCalled();
+    expect(getAppAccessiblePagesInDrive).not.toHaveBeenCalled();
+    expect(getScopedAccessiblePagesInDrive).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
+++ b/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
@@ -65,6 +65,7 @@ import {
   getScopedAccessiblePagesInDrive,
   hasScopedDriveMembership,
 } from '@pagespace/lib/permissions/app-permissions';
+import { manageKeysScopedAuthResult } from './manage-keys-fixture';
 
 const USER_ID = 'user_aaaaaaaaaaaaaaaaaaaaaa';
 const TOKEN_ID = 'tok_bbbbbbbbbbbbbbbbbbbbbb';
@@ -79,12 +80,12 @@ const scopedMcpAuth: AuthResult = { ...base, userId: USER_ID, tokenType: 'mcp', 
 const DRIVE_SCOPES = [{ driveId: DRIVE_ID, role: null, customRoleId: null }];
 const accountOAuthAuth: AuthResult = {
   ...base, userId: USER_ID, tokenType: 'oauth', tokenId: TOKEN_ID,
-  scopes: { account: true, offlineAccess: false, drives: new Map() },
+  scopes: { account: true, offlineAccess: false, drives: new Map(), manageKeys: false },
   driveScopes: [], allowedDriveIds: [],
 };
 const scopedOAuthAuth: AuthResult = {
   ...base, userId: USER_ID, tokenType: 'oauth', tokenId: TOKEN_ID,
-  scopes: { account: false, offlineAccess: false, drives: new Map([[DRIVE_ID, { kind: 'drive' as const, driveId: DRIVE_ID, role: { kind: 'inherit' as const } }]]) },
+  scopes: { account: false, offlineAccess: false, drives: new Map([[DRIVE_ID, { kind: 'drive' as const, driveId: DRIVE_ID, role: { kind: 'inherit' as const } }]]), manageKeys: false },
   driveScopes: DRIVE_SCOPES, allowedDriveIds: [DRIVE_ID],
 };
 
@@ -363,5 +364,85 @@ describe('getPrincipalBatchPagePermissions', () => {
     vi.mocked(getBatchPagePermissions).mockResolvedValue(expected);
     expect(await getPrincipalBatchPagePermissions(accountOAuthAuth, [PAGE_ID])).toBe(expected);
     expect(getBatchPagePermissions).toHaveBeenCalledWith(USER_ID, [PAGE_ID]);
+  });
+});
+
+// =============================================================================
+// MANAGE-KEYS-ONLY CREDENTIAL — deny-first short-circuit
+// =============================================================================
+//
+// isScopedOAuthAuth returns true for a manage-keys-only credential too
+// (scopes.account is false), so absent an explicit guard every function here
+// would dispatch to the scoped/app path — which today happens to deny
+// because driveScopes/allowedDriveIds are empty for a well-formed manage-keys
+// credential. That's caller convention, not a guarantee this module itself
+// provides: a credential violating the manage_keys/account exclusivity
+// invariant (e.g. a future bug producing account:true + manageKeys:true) has
+// `!auth.scopes.account` false, so isScopedOAuthAuth is false too, and it
+// would fall through to the "acts as the user" branch — full unrestricted
+// access. These tests pin down that the explicit isManageKeysOnly check
+// denies first, regardless of the other scope fields.
+describe('manage-keys-only credential — deny-first short-circuit', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const manageKeysAuth = manageKeysScopedAuthResult();
+
+  // Simulates a future invariant violation: manageKeys + account both true,
+  // plus a non-empty allowedDriveIds — proves the guard doesn't rely on
+  // scopes.account being false or allowedDriveIds being empty.
+  const brokenManageKeysAuth = manageKeysScopedAuthResult({
+    scopes: { account: true, offlineAccess: false, drives: new Map(), manageKeys: true },
+    allowedDriveIds: ['drive-should-never-be-reachable'],
+  });
+
+  const cases: Array<[string, AuthResult]> = [
+    ['well-formed manage-keys credential', manageKeysAuth],
+    ['invariant-violated manage-keys credential (account=true, non-empty allowedDriveIds)', brokenManageKeysAuth],
+  ];
+
+  it.each(cases)('getPrincipalAccessLevel denies (%s)', async (_label, auth) => {
+    expect(await getPrincipalAccessLevel(auth, PAGE_ID)).toBeNull();
+    expect(getUserAccessLevel).not.toHaveBeenCalled();
+    expect(getAppAccessLevel).not.toHaveBeenCalled();
+    expect(getScopedAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('canPrincipalViewPage denies (%s)', async (_label, auth) => {
+    expect(await canPrincipalViewPage(auth, PAGE_ID)).toBe(false);
+    expect(canUserViewPage).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('canPrincipalEditPage denies (%s)', async (_label, auth) => {
+    expect(await canPrincipalEditPage(auth, PAGE_ID)).toBe(false);
+    expect(canUserEditPage).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('canPrincipalDeletePage denies (%s)', async (_label, auth) => {
+    expect(await canPrincipalDeletePage(auth, PAGE_ID)).toBe(false);
+    expect(canUserDeletePage).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('canPrincipalSharePage denies (%s)', async (_label, auth) => {
+    expect(await canPrincipalSharePage(auth, PAGE_ID)).toBe(false);
+    expect(canUserSharePage).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('isPrincipalDriveMember denies (%s)', async (_label, auth) => {
+    expect(await isPrincipalDriveMember(auth, DRIVE_ID)).toBe(false);
+    expect(isUserDriveMember).not.toHaveBeenCalled();
+    expect(hasAppDriveMembership).not.toHaveBeenCalled();
+    expect(hasScopedDriveMembership).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('isPrincipalDriveOwnerOrAdmin denies (%s)', async (_label, auth) => {
+    expect(await isPrincipalDriveOwnerOrAdmin(auth, DRIVE_ID)).toBe(false);
+    expect(isDriveOwnerOrAdmin).not.toHaveBeenCalled();
+    expect(getAppDriveMembership).not.toHaveBeenCalled();
+    expect(getScopedDriveMembership).not.toHaveBeenCalled();
+  });
+
+  it.each(cases)('getPrincipalDriveIds returns empty, never the owning user\'s drive list (%s)', async (_label, auth) => {
+    expect(await getPrincipalDriveIds(auth)).toEqual([]);
+    expect(getDriveIdsForUser).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
+++ b/apps/web/src/lib/auth/__tests__/principal-permissions.test.ts
@@ -459,4 +459,12 @@ describe('manage-keys-only credential — deny-first short-circuit', () => {
     expect(getAppAccessiblePagesInDrive).not.toHaveBeenCalled();
     expect(getScopedAccessiblePagesInDrive).not.toHaveBeenCalled();
   });
+
+  it.each(cases)('getPrincipalBatchPagePermissions denies every requested page, never the owning user\'s batch (%s)', async (_label, auth) => {
+    const result = await getPrincipalBatchPagePermissions(auth, [PAGE_ID]);
+    expect(result.get(PAGE_ID)).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+    expect(getBatchPagePermissions).not.toHaveBeenCalled();
+    expect(getAppAccessiblePagesInDrive).not.toHaveBeenCalled();
+    expect(getScopedAccessiblePagesInDrive).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -559,13 +559,42 @@ export async function authenticateWithEnforcedContext(
 // These helpers enforce drive-level access restrictions for scoped MCP tokens.
 // Policy: If allowedDriveIds is empty, the token has full access to all user's drives.
 //         If allowedDriveIds is non-empty, only those specific drives are accessible.
+// Exception: a manage-keys-only OAuth credential (auth.scopes.manageKeys) has no
+//            content access at all, so it must never benefit from the "empty means
+//            full access" convention below — every helper here fails it closed.
 // ============================================================================
+
+/**
+ * True iff this credential can only manage keys and must never resolve to
+ * content access. No scope parser sets this today (see ScopeSet.manageKeys),
+ * so this is always false for every credential that exists in production.
+ */
+export function isManageKeysOnly(auth: AuthResult): boolean {
+  return isOAuthAuthResult(auth) && auth.scopes.manageKeys === true;
+}
+
+function manageKeysOnlyDeniedResponse(): NextResponse {
+  return NextResponse.json(
+    { error: 'This credential is management-only and has no drive content access' },
+    { status: 403 }
+  );
+}
+
+// Never equals a real drive id (cuid2 ids are lowercase alphanumeric only).
+// Lets a manage-keys-only credential resolve through the same allowedDriveIds
+// contract as every other scoped credential, so any caller that reads
+// `allowedDriveIds.length` directly — not just the helpers below — also sees
+// "no drives" rather than the empty-array-means-full-access default.
+const manageKeysNoDriveAccess: readonly string[] = ['MANAGE_KEYS_ONLY_NO_DRIVE_ACCESS'];
 
 /**
  * Get allowed drive IDs from an authentication result.
  * Returns empty array for session auth (full access) or unscoped MCP tokens.
  */
 export function getAllowedDriveIds(auth: AuthResult): string[] {
+  if (isManageKeysOnly(auth)) {
+    return [...manageKeysNoDriveAccess];
+  }
   if (isMCPAuthResult(auth)) {
     return auth.allowedDriveIds;
   }
@@ -587,6 +616,10 @@ export function checkMCPDriveScope(
   auth: AuthResult,
   driveId: string
 ): NextResponse | null {
+  if (isManageKeysOnly(auth)) {
+    return manageKeysOnlyDeniedResponse();
+  }
+
   const allowedDriveIds = getAllowedDriveIds(auth);
 
   // Empty allowedDriveIds means full access (unscoped token or session auth)
@@ -618,6 +651,10 @@ export async function checkMCPPageScope(
   auth: AuthResult,
   pageId: string
 ): Promise<NextResponse | null> {
+  if (isManageKeysOnly(auth)) {
+    return manageKeysOnlyDeniedResponse();
+  }
+
   const allowedDriveIds = getAllowedDriveIds(auth);
 
   // Empty allowedDriveIds means full access
@@ -659,6 +696,10 @@ export function filterDrivesByMCPScope(
   auth: AuthResult,
   driveIds: string[]
 ): string[] {
+  if (isManageKeysOnly(auth)) {
+    return [];
+  }
+
   const allowedDriveIds = getAllowedDriveIds(auth);
 
   // Empty allowedDriveIds means full access
@@ -684,6 +725,10 @@ export function checkMCPCreateScope(
   auth: AuthResult,
   targetDriveId: string | null
 ): NextResponse | null {
+  if (isManageKeysOnly(auth)) {
+    return manageKeysOnlyDeniedResponse();
+  }
+
   const allowedDriveIds = getAllowedDriveIds(auth);
 
   // Unscoped tokens can create anywhere

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -566,8 +566,10 @@ export async function authenticateWithEnforcedContext(
 
 /**
  * True iff this credential can only manage keys and must never resolve to
- * content access. No scope parser sets this today (see ScopeSet.manageKeys),
- * so this is always false for every credential that exists in production.
+ * content access. `parseScopeList` (see ScopeSet.manageKeys) mints this today
+ * via the `manage_keys` token, through both the authorize and
+ * device-authorization flows — every helper below exists because this is a
+ * real, reachable credential shape, not a hypothetical one.
  */
 export function isManageKeysOnly(auth: AuthResult): boolean {
   return isOAuthAuthResult(auth) && auth.scopes.manageKeys === true;

--- a/apps/web/src/lib/auth/principal-permissions.ts
+++ b/apps/web/src/lib/auth/principal-permissions.ts
@@ -44,7 +44,7 @@ import {
   getScopedAccessiblePagesInDrive,
   hasScopedDriveMembership,
 } from '@pagespace/lib/permissions/app-permissions';
-import { isMCPAuthResult, isOAuthAuthResult, type AuthResult, type MCPAuthResult, type OAuthAuthResult } from './index';
+import { isMCPAuthResult, isOAuthAuthResult, isManageKeysOnly, type AuthResult, type MCPAuthResult, type OAuthAuthResult } from './index';
 
 /**
  * A scoped MCP token acts as an app member (its allowedDriveIds are exactly its
@@ -67,6 +67,7 @@ export async function getPrincipalAccessLevel(
   auth: AuthResult,
   pageId: string,
 ): Promise<PermissionLevel | null> {
+  if (isManageKeysOnly(auth)) return null;
   if (isScopedMCPAuth(auth)) {
     return getAppAccessLevel(auth.tokenId, pageId);
   }
@@ -77,6 +78,7 @@ export async function getPrincipalAccessLevel(
 }
 
 export async function canPrincipalViewPage(auth: AuthResult, pageId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     const level = await getAppAccessLevel(auth.tokenId, pageId);
     return level?.canView ?? false;
@@ -89,6 +91,7 @@ export async function canPrincipalViewPage(auth: AuthResult, pageId: string): Pr
 }
 
 export async function canPrincipalEditPage(auth: AuthResult, pageId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     const level = await getAppAccessLevel(auth.tokenId, pageId);
     return level?.canEdit ?? false;
@@ -101,6 +104,7 @@ export async function canPrincipalEditPage(auth: AuthResult, pageId: string): Pr
 }
 
 export async function canPrincipalDeletePage(auth: AuthResult, pageId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     const level = await getAppAccessLevel(auth.tokenId, pageId);
     return level?.canDelete ?? false;
@@ -113,6 +117,7 @@ export async function canPrincipalDeletePage(auth: AuthResult, pageId: string): 
 }
 
 export async function canPrincipalSharePage(auth: AuthResult, pageId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     const level = await getAppAccessLevel(auth.tokenId, pageId);
     return level?.canShare ?? false;
@@ -125,6 +130,7 @@ export async function canPrincipalSharePage(auth: AuthResult, pageId: string): P
 }
 
 export async function isPrincipalDriveMember(auth: AuthResult, driveId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     return hasAppDriveMembership(auth.tokenId, driveId);
   }
@@ -145,6 +151,7 @@ export async function getPrincipalDriveAccess(auth: AuthResult, driveId: string)
 }
 
 export async function isPrincipalDriveOwnerOrAdmin(auth: AuthResult, driveId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     const membership = await getAppDriveMembership(auth.tokenId, driveId);
     if (!membership) return false;
@@ -166,6 +173,7 @@ export async function isPrincipalDriveOwnerOrAdmin(auth: AuthResult, driveId: st
  * (NOT intersected with the owning user's drives), otherwise the user's drives.
  */
 export async function getPrincipalDriveIds(auth: AuthResult): Promise<string[]> {
+  if (isManageKeysOnly(auth)) return [];
   if (isScopedMCPAuth(auth)) {
     return auth.allowedDriveIds;
   }

--- a/apps/web/src/lib/auth/principal-permissions.ts
+++ b/apps/web/src/lib/auth/principal-permissions.ts
@@ -208,11 +208,20 @@ export async function getPrincipalBatchPagePermissions(
   auth: AuthResult,
   pageIds: string[],
 ): Promise<Map<string, PermissionLevel>> {
+  const deny: PermissionLevel = { canView: false, canEdit: false, canShare: false, canDelete: false };
+
+  if (isManageKeysOnly(auth)) {
+    const results = new Map<string, PermissionLevel>();
+    for (const pageId of pageIds) {
+      results.set(pageId, { ...deny });
+    }
+    return results;
+  }
+
   if (!isScopedMCPAuth(auth) && !isScopedOAuthAuth(auth)) {
     return getBatchPagePermissions(auth.userId, pageIds);
   }
 
-  const deny: PermissionLevel = { canView: false, canEdit: false, canShare: false, canDelete: false };
   const results = new Map<string, PermissionLevel>();
   for (const pageId of pageIds) {
     results.set(pageId, { ...deny });

--- a/apps/web/src/lib/auth/principal-permissions.ts
+++ b/apps/web/src/lib/auth/principal-permissions.ts
@@ -141,6 +141,7 @@ export async function isPrincipalDriveMember(auth: AuthResult, driveId: string):
 }
 
 export async function getPrincipalDriveAccess(auth: AuthResult, driveId: string): Promise<boolean> {
+  if (isManageKeysOnly(auth)) return false;
   if (isScopedMCPAuth(auth)) {
     return hasAppDriveMembership(auth.tokenId, driveId);
   }
@@ -188,6 +189,7 @@ export async function getPrincipalAccessiblePagesInDrive(
   auth: AuthResult,
   driveId: string,
 ): Promise<PageWithPermissions[]> {
+  if (isManageKeysOnly(auth)) return [];
   if (isScopedMCPAuth(auth)) {
     return getAppAccessiblePagesInDrive(auth.tokenId, driveId);
   }

--- a/packages/lib/src/auth/oauth/__tests__/consent.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/consent.test.ts
@@ -43,6 +43,13 @@ describe('describeScopeForConsent', () => {
     expect(text).toMatch(/Marketing/);
   });
 
+  it('describes manage_keys as key-management access with no content access', () => {
+    const text = describeScopeForConsent({ kind: 'manage_keys' }, {});
+    expect(text).toMatch(/manage/i);
+    expect(text).toMatch(/keys/i);
+    expect(text).toMatch(/cannot read or write/i);
+  });
+
   it('describes a custom-role drive scope by resolved role name + summary', () => {
     const scope: ParsedScope = { kind: 'drive', driveId: 'drv123', role: { kind: 'custom', customRoleId: 'role1' } };
     const text = describeScopeForConsent(scope, {

--- a/packages/lib/src/auth/oauth/__tests__/metadata.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/metadata.test.ts
@@ -83,6 +83,7 @@ describe('buildServerMetadata', () => {
 
     expect(metadata.scopes_supported).toContain('account');
     expect(metadata.scopes_supported).toContain('offline_access');
+    expect(metadata.scopes_supported).toContain('manage_keys');
     expect(metadata.scopes_supported.some((scope) => scope.startsWith('drive:'))).toBe(true);
   });
 

--- a/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
@@ -13,7 +13,7 @@ function drives(...entries: Array<[string, ScopeSet['drives'] extends ReadonlyMa
 }
 
 function emptySet(overrides: Partial<ScopeSet> = {}): ScopeSet {
-  return { account: false, offlineAccess: false, drives: new Map(), ...overrides };
+  return { account: false, offlineAccess: false, drives: new Map(), manageKeys: false, ...overrides };
 }
 
 describe('parseScopeList', () => {

--- a/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
+++ b/packages/lib/src/auth/oauth/__tests__/scopes.test.ts
@@ -91,6 +91,16 @@ describe('parseScopeList', () => {
       const result = parseScopeList(`drive:${id}`);
       expect(result.ok).toBe(true);
     });
+
+    it('parses "manage_keys" alone', () => {
+      const result = parseScopeList('manage_keys');
+      expect(result).toEqual({ ok: true, scopes: emptySet({ manageKeys: true }) });
+    });
+
+    it('parses "manage_keys offline_access" together — a long-lived key-management session', () => {
+      const result = parseScopeList('manage_keys offline_access');
+      expect(result).toEqual({ ok: true, scopes: emptySet({ manageKeys: true, offlineAccess: true }) });
+    });
   });
 
   describe('fail-closed rejections (rules 1-5, F1-F3)', () => {
@@ -207,6 +217,25 @@ describe('parseScopeList', () => {
         error: { code: 'offline_access_alone' },
       });
     });
+
+    it('rejects "manage_keys" mixed with "account" (manage_keys_conflict)', () => {
+      expect(parseScopeList('manage_keys account')).toEqual({
+        ok: false,
+        error: { code: 'manage_keys_conflict' },
+      });
+    });
+
+    it('rejects "manage_keys" mixed with any drive:* scope, regardless of order (manage_keys_conflict)', () => {
+      expect(parseScopeList('drive:abc manage_keys')).toEqual({
+        ok: false,
+        error: { code: 'manage_keys_conflict' },
+      });
+    });
+
+    it('does not reject "manage_keys offline_access" as offline_access_alone — manage_keys is its own principal shape', () => {
+      const result = parseScopeList('manage_keys offline_access');
+      expect(result.ok).toBe(true);
+    });
   });
 
   it('is total: never throws, even on garbage input', () => {
@@ -228,6 +257,14 @@ describe('formatScopeSet (canonical serialization, rule 9)', () => {
 
   it('orders account before offline_access regardless of construction order', () => {
     expect(formatScopeSet(emptySet({ account: true, offlineAccess: true }))).toBe('account offline_access');
+  });
+
+  it('formats manage_keys alone', () => {
+    expect(formatScopeSet(emptySet({ manageKeys: true }))).toBe('manage_keys');
+  });
+
+  it('orders manage_keys before offline_access regardless of construction order', () => {
+    expect(formatScopeSet(emptySet({ manageKeys: true, offlineAccess: true }))).toBe('manage_keys offline_access');
   });
 
   it('orders drive scopes by drive id ascending, independent of Map insertion order', () => {
@@ -274,6 +311,13 @@ describe('formatScopeSet (canonical serialization, rule 9)', () => {
     const original = emptySet({ account: true, offlineAccess: true });
     const reparsed = parseScopeList(formatScopeSet(original));
     expect(reparsed).toEqual({ ok: true, scopes: original });
+  });
+
+  it('round-trips "manage_keys offline_access" back to the same string (rule 9)', () => {
+    const formatted = formatScopeSet(emptySet({ manageKeys: true, offlineAccess: true }));
+    expect(formatted).toBe('manage_keys offline_access');
+    const reparsed = parseScopeList(formatted);
+    expect(reparsed).toEqual({ ok: true, scopes: emptySet({ manageKeys: true, offlineAccess: true }) });
   });
 
   it('formatting is idempotent: format(parse(format(s))) === format(s)', () => {
@@ -366,6 +410,18 @@ describe('isScopeSubset (narrowing, rule 8 / F5) — escalation must be structur
 
   it('not requesting offline_access is always fine, even if granted has it', () => {
     expect(isScopeSubset(emptySet(), emptySet({ offlineAccess: true }))).toBe(true);
+  });
+
+  it('manage_keys is a subset of manage_keys', () => {
+    expect(isScopeSubset(emptySet({ manageKeys: true }), emptySet({ manageKeys: true }))).toBe(true);
+  });
+
+  it('manage_keys requested but not granted is rejected', () => {
+    expect(isScopeSubset(emptySet({ manageKeys: true }), emptySet())).toBe(false);
+  });
+
+  it('not requesting manage_keys is always fine, even if granted has it', () => {
+    expect(isScopeSubset(emptySet(), emptySet({ manageKeys: true }))).toBe(true);
   });
 });
 

--- a/packages/lib/src/auth/oauth/consent.ts
+++ b/packages/lib/src/auth/oauth/consent.ts
@@ -21,6 +21,8 @@ export function describeScopeForConsent(scope: ParsedScope, ctx: ConsentNarratio
       return 'Full access to your PageSpace account — everything you can see and do, in every drive, now and in the future.';
     case 'offline_access':
       return 'Stay connected until you revoke access (issues a long-lived refresh credential).';
+    case 'manage_keys':
+      return 'Create and manage access keys on your behalf — cannot read or write any of your content directly.';
     case 'drive': {
       const driveName = ctx.driveName ?? scope.driveId;
       switch (scope.role.kind) {

--- a/packages/lib/src/auth/oauth/metadata.ts
+++ b/packages/lib/src/auth/oauth/metadata.ts
@@ -20,7 +20,7 @@ const CODE_CHALLENGE_METHODS_SUPPORTED = ['S256'] as const;
 const TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED = ['none'] as const;
 
 /** ADR 0002 Decision 1 grammar. `drive:*` stands for the templated `drive:<driveId>[:role]` family. */
-const SCOPES_SUPPORTED = ['account', 'offline_access', 'drive:*'] as const;
+const SCOPES_SUPPORTED = ['account', 'offline_access', 'manage_keys', 'drive:*'] as const;
 
 export interface OAuthServerConfig {
   /** Canonical deployment origin, e.g. `https://pagespace.ai`. Trailing slash tolerated. */

--- a/packages/lib/src/auth/oauth/scopes.ts
+++ b/packages/lib/src/auth/oauth/scopes.ts
@@ -14,6 +14,7 @@ const RESOURCE_ID_RE = /^[a-z0-9]{1,32}$/;
 export type ParsedScope =
   | { kind: 'account' }
   | { kind: 'offline_access' }
+  | { kind: 'manage_keys' }
   | {
       kind: 'drive';
       driveId: string;
@@ -24,10 +25,10 @@ export type ScopeSet = {
   account: boolean;
   offlineAccess: boolean;
   drives: ReadonlyMap<string, ParsedScope & { kind: 'drive' }>;
-  // Grants key-management access with zero content access. Optional and always
-  // false/absent today — no scope token in the grammar below can set this yet.
-  // It exists so downstream drive-scope checks (apps/web/src/lib/auth/index.ts)
-  // have a concrete signal to fail closed on once a `manage_keys` scope ships.
+  // Grants key-management access with zero content access. Mutually exclusive
+  // with `account` and any `drive:*` scope (see the manage_keys_conflict
+  // check below); downstream fail-closed checks live in
+  // apps/web/src/lib/auth/index.ts.
   manageKeys?: boolean;
 };
 
@@ -36,6 +37,7 @@ export type ScopeError =
   | { code: 'unknown_scope'; scope: string }
   | { code: 'empty_scope' }
   | { code: 'account_drive_conflict' }
+  | { code: 'manage_keys_conflict' }
   | { code: 'duplicate_drive'; driveId: string }
   | { code: 'offline_access_alone' };
 
@@ -91,6 +93,7 @@ export function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { 
 
   let account = false;
   let offlineAccess = false;
+  let manageKeys = false;
   const drives = new Map<string, ParsedScope & { kind: 'drive' }>();
 
   for (const token of tokens) {
@@ -100,6 +103,10 @@ export function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { 
     }
     if (token === 'offline_access') {
       offlineAccess = true;
+      continue;
+    }
+    if (token === 'manage_keys') {
+      manageKeys = true;
       continue;
     }
     if (token.startsWith('drive:')) {
@@ -120,15 +127,24 @@ export function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { 
     return { ok: false, error: { code: 'account_drive_conflict' } };
   }
 
+  // manage_keys grants key-management access with zero content access — mixing
+  // it with any content-access scope (account or drive:*) is ambiguous,
+  // mirroring the account/drive exclusion above.
+  if (manageKeys && (account || drives.size > 0)) {
+    return { ok: false, error: { code: 'manage_keys_conflict' } };
+  }
+
   // Rule 10: offline_access alone has no principal shape (Decision 2) — a
   // refresh token minted for it could only ever mint access tokens with no
   // access scope. Reject rather than grant a token that is structurally
-  // useless (fail closed, Codex #1754).
-  if (offlineAccess && !account && drives.size === 0) {
+  // useless (fail closed, Codex #1754). manage_keys is its own principal
+  // shape, so offline_access + manage_keys is a valid, expected combination
+  // (a long-lived key-management session).
+  if (offlineAccess && !account && !manageKeys && drives.size === 0) {
     return { ok: false, error: { code: 'offline_access_alone' } };
   }
 
-  return { ok: true, scopes: { account, offlineAccess, drives, manageKeys: false } };
+  return { ok: true, scopes: { account, offlineAccess, drives, manageKeys } };
 }
 
 function formatDriveScope(scope: ParsedScope & { kind: 'drive' }): string {
@@ -148,6 +164,7 @@ function formatDriveScope(scope: ParsedScope & { kind: 'drive' }): string {
 export function formatScopeSet(scopes: ScopeSet): string {
   const tokens: string[] = [];
   if (scopes.account) tokens.push('account');
+  if (scopes.manageKeys) tokens.push('manage_keys');
   if (scopes.offlineAccess) tokens.push('offline_access');
 
   const sortedDriveIds = [...scopes.drives.keys()].sort();
@@ -177,6 +194,10 @@ function roleEquals(
  */
 export function isScopeSubset(requested: ScopeSet, granted: ScopeSet): boolean {
   if (requested.offlineAccess && !granted.offlineAccess) return false;
+  // manage_keys is never combined with account or drive:* (parse-time exclusion),
+  // so it never reaches the account/drive narrowing checks below — its own
+  // granted-bit check is the whole story.
+  if (requested.manageKeys && !granted.manageKeys) return false;
 
   if (requested.account) {
     return granted.account;

--- a/packages/lib/src/auth/oauth/scopes.ts
+++ b/packages/lib/src/auth/oauth/scopes.ts
@@ -24,6 +24,11 @@ export type ScopeSet = {
   account: boolean;
   offlineAccess: boolean;
   drives: ReadonlyMap<string, ParsedScope & { kind: 'drive' }>;
+  // Grants key-management access with zero content access. Optional and always
+  // false/absent today — no scope token in the grammar below can set this yet.
+  // It exists so downstream drive-scope checks (apps/web/src/lib/auth/index.ts)
+  // have a concrete signal to fail closed on once a `manage_keys` scope ships.
+  manageKeys?: boolean;
 };
 
 export type ScopeError =
@@ -123,7 +128,7 @@ export function parseScopeList(raw: string): { ok: true; scopes: ScopeSet } | { 
     return { ok: false, error: { code: 'offline_access_alone' } };
   }
 
-  return { ok: true, scopes: { account, offlineAccess, drives } };
+  return { ok: true, scopes: { account, offlineAccess, drives, manageKeys: false } };
 }
 
 function formatDriveScope(scope: ParsedScope & { kind: 'drive' }): string {

--- a/packages/lib/src/auth/oauth/scopes.ts
+++ b/packages/lib/src/auth/oauth/scopes.ts
@@ -29,7 +29,7 @@ export type ScopeSet = {
   // with `account` and any `drive:*` scope (see the manage_keys_conflict
   // check below); downstream fail-closed checks live in
   // apps/web/src/lib/auth/index.ts.
-  manageKeys?: boolean;
+  manageKeys: boolean;
 };
 
 export type ScopeError =


### PR DESCRIPTION
## Summary

Foundation of Phase 9 ("Login Becomes Key-Management-Only") of the SDK/CLI/OAuth Provider epic.
Landing on this one branch as it grows, same pattern Phase 8 used — sequential task commits, one
PR, dual-review gate per task. **More commits from Tasks 3-6 are coming to this branch before the
whole phase is ready for final review/merge — please don't merge yet.**

### Task 1 — harden allowedDriveIds-based helpers (the landmine fix)

Pre-emptive hardening landed before the `manage_keys` scope it defends against exists. Content-
access authorization has two parallel deciders; the unsafe one
(`apps/web/src/lib/auth/index.ts`'s `getAllowedDriveIds`/`checkMCPDriveScope`/`checkMCPPageScope`/
`filterDrivesByMCPScope`/`checkMCPCreateScope`, used across ~35 routes) treats an empty
`allowedDriveIds` array as full access — a future zero-content-access credential would have
silently gotten full access via this exact path. Fixed with a scope-kind-aware short-circuit and a
non-drive-id sentinel array (protecting ~20 further direct callers beyond the 5 named functions,
including a real, independently-verified exploit path in `GET /api/activities`). Zero behavior
change for any credential that exists today. Reviewed twice (aidd:review + custom second-opinion),
0 blockers/majors across both.

### Task 2 — `manage_keys` OAuth scope grammar

Extends `packages/lib/src/auth/oauth/scopes.ts` so a credential can actually carry `manage_keys`
scope — Task 1 made the content-access helpers deny access when `manageKeys` is true, this is the
other half that lets the grammar produce it. New scope token, mutual exclusion vs `account`/
`drive:*`, valid alongside `offline_access`, round-trip-safe serialization, and consent-screen
copy on both rendering call sites.

## Test plan
- [x] `@pagespace/lib` full suite green (6368+ tests)
- [x] `apps/web` typecheck + touched-suite tests green
- [x] `gh pr checks` 10/10 green
- [x] Independent second-opinion review confirmed zero-behavior-change by construction (diff only
      adds guard clauses, never touches a pre-existing line) and spot-checked 3 additional callers
      beyond the 5 named functions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

### Follow-up — exhaustive `principal-permissions.ts` guard audit

Two prior remediation rounds each added the `isManageKeysOnly(auth)` deny-first guard to some of
this file's dispatch functions, and each round's follow-up review found the next round had missed
one. Rather than another single-function patch, did a full enumeration (`grep -n "^export"`, not
trusted from memory) of all 11 dispatch functions and verified each one's guard status:

| Function | Status |
|---|---|
| `getPrincipalAccessLevel` | guarded (pre-existing) |
| `canPrincipalViewPage` | guarded (pre-existing) |
| `canPrincipalEditPage` | guarded (pre-existing) |
| `canPrincipalDeletePage` | guarded (pre-existing) |
| `canPrincipalSharePage` | guarded (pre-existing) |
| `isPrincipalDriveMember` | guarded (pre-existing) |
| `getPrincipalDriveAccess` | guarded (pre-existing) |
| `isPrincipalDriveOwnerOrAdmin` | guarded (pre-existing) |
| `getPrincipalDriveIds` | guarded (pre-existing) |
| `getPrincipalAccessiblePagesInDrive` | guarded (pre-existing) |
| `getPrincipalBatchPagePermissions` | **was missing — fixed this commit** |

`getPrincipalBatchPagePermissions` only looked safe because its `!isScopedMCPAuth &&
!isScopedOAuthAuth` fallthrough to the real per-user batch lookup happened to be unreachable for a
*well-formed* manage-keys credential (`isScopedOAuthAuth` returns true since `scopes.account` is
false, routing it into the scoped path where empty `allowedDriveIds` denies by coincidence). An
invariant-violated credential (`manageKeys && account` both true) breaks that coincidence and
reaches full per-user permissions. Added the same `isManageKeysOnly(auth)` guard used by the other
10 functions, plus the missing case to the existing `it.each(cases)` guard-coverage block in
`principal-permissions.test.ts`.

Coverage count now mechanically verified to match, not eyeballed:
```
grep -c 'it.each(cases)(' apps/web/src/lib/auth/__tests__/principal-permissions.test.ts  # 11
grep -c '^export async function' apps/web/src/lib/auth/principal-permissions.ts          # 11
```

`bun run --filter 'web' typecheck` clean. `principal-permissions.test.ts` 57/57 green. Full
`apps/web` suite: 16 pre-existing failures unrelated to this file (DB-role-provisioning env issue
in `admin-role-version.test.ts`/`activity-tools.test.ts`, plus an unrelated midnight-boundary date
test in `grouping.test.ts`) — none touch `principal-permissions.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new **manage keys** OAuth scope in consent screens and device authorization verification.
  * Updated scope descriptions so users see clearer consent text for this access level.
* **Bug Fixes**
  * Strengthened fail-closed authorization so **manage-keys-only** credentials can’t access or create drives, pages, tasks, or channel messages, and can’t exploit “no allowed drives” cases.
  * Ensured MCP token operations follow the intended manage-keys-only carve-out.
* **Tests**
  * Added/expanded red-team scope-enforcement tests covering OAuth and MCP flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->