### PR TITLE
feat(terminal): agent activity visibility + per-machine runtime guardrail

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -15,12 +15,13 @@ import {
   decideFullEgressEnablement,
   isContainmentVerified,
 } from '@pagespace/lib/services/sandbox/containment';
-import { getSandboxSessionSecret, acquireTerminalSandbox, createDbTerminalSessionStore } from '@pagespace/lib/services/sandbox/terminal-session-manager';
+import { getSandboxSessionSecret, acquireTerminalSandbox, createDbTerminalSessionStore, deriveTerminalSessionKey } from '@pagespace/lib/services/sandbox/terminal-session-manager';
 import { createSpritesSandboxClient, ensureSpriteAwake } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { buildTerminalHandlers, type CheckAuthResult, type SocketLike } from './terminal/terminal-handler';
+import { handleTerminalActivityRequest } from './terminal/terminal-activity';
 import { createTerminalSessionMap } from './terminal/terminal-session-map';
 import { openPtyShell } from './terminal/sprites-shell';
 import { getRealtimeSpritesSdk } from './terminal/realtime-sprites-client';
@@ -469,6 +470,33 @@ const requestListener = (req: IncomingMessage, res: ServerResponse) => {
                 res.writeHead(400, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify({ error: 'Invalid JSON' }));
             }
+        });
+    } else if (req.method === 'POST' && req.url === '/api/terminal-activity') {
+        // Streams an agent's bash run into a live Terminal's PTY/output feed
+        // (Terminal Epic 1 T1.5, activity visibility). Best-effort: a live
+        // session may not exist (nobody watching), which is not an error.
+        let body = '';
+        req.on('data', chunk => {
+            body += chunk.toString();
+        });
+        req.on('end', () => {
+            const signatureHeader = req.headers['x-broadcast-signature'] as string;
+            if (!verifySignature(signatureHeader, body)) {
+                res.writeHead(401, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ error: 'Authentication failed' }));
+                return;
+            }
+
+            const result = handleTerminalActivityRequest(
+                {
+                    sessionMap: terminalSessionMap,
+                    deriveSessionKey: ({ tenantId, driveId, pageId }) =>
+                        deriveTerminalSessionKey({ tenantId, driveId, pageId, secret: getSandboxSessionSecret() }),
+                },
+                body,
+            );
+            res.writeHead(result.status, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(result.body));
         });
     } else if (req.method === 'POST' && req.url === '/api/kick') {
         // Kick API: Remove user from rooms on permission revocation

--- a/apps/realtime/src/terminal/__tests__/terminal-activity.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-activity.test.ts
@@ -121,6 +121,40 @@ describe('formatTerminalActivityLine', () => {
     const text = formatTerminalActivityLine(makePayload({ output: big }));
     expect(Buffer.byteLength(text, 'utf8')).toBeLessThan(Buffer.byteLength(big, 'utf8'));
   });
+
+  it('given an ESC byte embedded in the command, should strip it instead of forwarding a raw escape sequence', () => {
+    // A model-chosen command could carry an ANSI/OSC escape sequence (e.g. via
+    // indirect prompt injection) intended to spoof output in the viewer's xterm.js
+    // feed. The header/footer's OWN color codes must survive; only the payload's
+    // control bytes should be stripped.
+    const malicious = 'echo hi\x1b[31mFAKE ERROR\x1b[0m';
+    const text = formatTerminalActivityLine(makePayload({ command: malicious }));
+    expect(text).toContain('echo hi[31mFAKE ERROR[0m');
+    expect(text).not.toContain('\x1b[31m');
+  });
+
+  it('given an ESC byte embedded in the output, should strip it (only the header/footer\'s own codes remain)', () => {
+    const text = formatTerminalActivityLine(makePayload({ output: 'safe\x1b]0;evil-title\x07text' }));
+    expect(text).toContain('safe]0;evil-titletext');
+    expect(text).not.toContain('\x1b]0;evil-title\x07');
+  });
+
+  it('given an ESC byte embedded in agentLabel, should strip it (only the header/footer\'s own codes remain)', () => {
+    const text = formatTerminalActivityLine(makePayload({ agentLabel: 'Bob\x1b[2J' }));
+    expect(text).toContain('Bob[2J ran:');
+    expect(text).not.toContain('\x1b[2J');
+  });
+
+  it('given the header/footer\'s own ANSI color codes, should still preserve them (only the payload is sanitized)', () => {
+    const text = formatTerminalActivityLine(makePayload());
+    expect(text).toContain('\x1b[36m');
+    expect(text).toContain('\x1b[90m');
+  });
+
+  it('given real newlines/tabs in output, should preserve them (only control/escape bytes are stripped)', () => {
+    const text = formatTerminalActivityLine(makePayload({ output: 'line1\nline2\ttabbed' }));
+    expect(text).toContain('line1\r\nline2\ttabbed');
+  });
 });
 
 describe('handleTerminalActivityRequest', () => {

--- a/apps/realtime/src/terminal/__tests__/terminal-activity.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-activity.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTerminalActivityRequest,
+  validateTerminalActivityPayload,
+  formatTerminalActivityLine,
+  handleTerminalActivityRequest,
+  type TerminalActivityPayload,
+  type TerminalActivityDeps,
+} from '../terminal-activity';
+import type { TerminalSession } from '../terminal-session-map';
+
+function makePayload(over: Partial<TerminalActivityPayload> = {}): TerminalActivityPayload {
+  return {
+    tenantId: 't1',
+    driveId: 'd1',
+    pageId: 'terminal-page-1',
+    command: 'echo hi',
+    output: 'hi',
+    exitCode: 0,
+    agentLabel: 'Agent Bob',
+    ...over,
+  };
+}
+
+function makeSession(): { session: TerminalSession; emitted: string[] } {
+  const emitted: string[] = [];
+  const session = {
+    command: {} as TerminalSession['command'],
+    sandboxId: 'sbx-1',
+    sessionKey: 'key-1',
+    releaseSlot: () => {},
+    outputFn: (data: string) => emitted.push(data),
+    closedFn: () => {},
+    scrollback: [],
+    scrollbackBytes: 0,
+  } as TerminalSession;
+  return { session, emitted };
+}
+
+describe('parseTerminalActivityRequest', () => {
+  it('given valid JSON, should parse it', () => {
+    const result = parseTerminalActivityRequest(JSON.stringify(makePayload()));
+    expect(result.success).toBe(true);
+    expect(result.payload?.command).toBe('echo hi');
+  });
+
+  it('given invalid JSON, should fail', () => {
+    const result = parseTerminalActivityRequest('not json');
+    expect(result).toEqual({ success: false, error: 'Invalid JSON' });
+  });
+});
+
+describe('validateTerminalActivityPayload', () => {
+  it('given a well-formed payload, should be valid', () => {
+    expect(validateTerminalActivityPayload(makePayload())).toEqual({ valid: true });
+  });
+
+  it('given a missing tenantId, should be invalid', () => {
+    const result = validateTerminalActivityPayload(makePayload({ tenantId: '' }));
+    expect(result.valid).toBe(false);
+  });
+
+  it('given a missing pageId, should be invalid', () => {
+    const result = validateTerminalActivityPayload(makePayload({ pageId: '' }));
+    expect(result.valid).toBe(false);
+  });
+
+  it('given a missing command, should be invalid', () => {
+    const result = validateTerminalActivityPayload(makePayload({ command: '' }));
+    expect(result.valid).toBe(false);
+  });
+
+  it('given a non-string output, should be invalid', () => {
+    const result = validateTerminalActivityPayload(
+      makePayload({ output: 123 as unknown as string }),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it('given a non-numeric exitCode, should be invalid', () => {
+    const result = validateTerminalActivityPayload(
+      makePayload({ exitCode: 'zero' as unknown as number }),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it('given a missing agentLabel, should be invalid', () => {
+    const result = validateTerminalActivityPayload(makePayload({ agentLabel: '' }));
+    expect(result.valid).toBe(false);
+  });
+
+  it('given no driveId, should still be valid (global-assistant "own" machine)', () => {
+    const result = validateTerminalActivityPayload(makePayload({ driveId: undefined }));
+    expect(result).toEqual({ valid: true });
+  });
+});
+
+describe('formatTerminalActivityLine', () => {
+  it('should annotate the command, output, and exit code with CRLF line endings', () => {
+    const text = formatTerminalActivityLine(makePayload());
+    expect(text).toContain('Agent Bob ran:');
+    expect(text).toContain('echo hi');
+    expect(text).toContain('hi\r\n');
+    expect(text).toContain('(exit 0)');
+    expect(text.startsWith('\r\n')).toBe(true);
+  });
+
+  it('given multi-line output, should normalize to CRLF', () => {
+    const text = formatTerminalActivityLine(makePayload({ output: 'line1\nline2' }));
+    expect(text).toContain('line1\r\nline2\r\n');
+  });
+
+  it('given empty output, should omit the body line', () => {
+    const text = formatTerminalActivityLine(makePayload({ output: '' }));
+    expect(text).toContain('ran:');
+    expect(text).toContain('(exit 0)');
+  });
+
+  it('given output over the feed cap, should truncate it', () => {
+    const big = 'x'.repeat(10 * 1024);
+    const text = formatTerminalActivityLine(makePayload({ output: big }));
+    expect(Buffer.byteLength(text, 'utf8')).toBeLessThan(Buffer.byteLength(big, 'utf8'));
+  });
+});
+
+describe('handleTerminalActivityRequest', () => {
+  function makeDeps(over: Partial<TerminalActivityDeps> = {}): TerminalActivityDeps {
+    return {
+      sessionMap: { getByKey: () => undefined },
+      deriveSessionKey: ({ tenantId, driveId, pageId }) => `${tenantId}:${driveId}:${pageId}`,
+      ...over,
+    };
+  }
+
+  it('given invalid JSON, should return 400', () => {
+    const result = handleTerminalActivityRequest(makeDeps(), 'not json');
+    expect(result.status).toBe(400);
+    expect(result.body.success).toBe(false);
+  });
+
+  it('given an invalid payload, should return 400', () => {
+    const result = handleTerminalActivityRequest(makeDeps(), JSON.stringify({ tenantId: 't1' }));
+    expect(result.status).toBe(400);
+    expect(result.body.success).toBe(false);
+  });
+
+  it('given no driveId, should return 200 with delivered: false without deriving a session key', () => {
+    let called = false;
+    const deps = makeDeps({ deriveSessionKey: () => { called = true; return 'x'; } });
+    const result = handleTerminalActivityRequest(deps, JSON.stringify(makePayload({ driveId: undefined })));
+    expect(result).toEqual({ status: 200, body: { success: true, delivered: false } });
+    expect(called).toBe(false);
+  });
+
+  it('given no live session for the derived key, should return 200 with delivered: false', () => {
+    const result = handleTerminalActivityRequest(makeDeps(), JSON.stringify(makePayload()));
+    expect(result).toEqual({ status: 200, body: { success: true, delivered: false } });
+  });
+
+  it('given a live session, should inject the formatted line into its scrollback and output feed', () => {
+    const { session, emitted } = makeSession();
+    const deps = makeDeps({
+      sessionMap: { getByKey: (key) => (key === 't1:d1:terminal-page-1' ? session : undefined) },
+    });
+
+    const result = handleTerminalActivityRequest(deps, JSON.stringify(makePayload()));
+
+    expect(result).toEqual({ status: 200, body: { success: true, delivered: true } });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toContain('Agent Bob ran:');
+    expect(session.scrollback).toEqual(emitted);
+  });
+
+  it('given a live session on a DIFFERENT key, should not deliver', () => {
+    const { session, emitted } = makeSession();
+    const deps = makeDeps({
+      sessionMap: { getByKey: (key) => (key === 'some-other-key' ? session : undefined) },
+    });
+
+    const result = handleTerminalActivityRequest(deps, JSON.stringify(makePayload()));
+
+    expect(result.body).toEqual({ success: true, delivered: false });
+    expect(emitted).toHaveLength(0);
+  });
+});

--- a/apps/realtime/src/terminal/terminal-activity.ts
+++ b/apps/realtime/src/terminal/terminal-activity.ts
@@ -1,0 +1,142 @@
+/**
+ * Agent activity → live Terminal feed (Terminal Epic 1 T1.5, activity visibility).
+ *
+ * An agent's `bash` tool runs on the SAME persistent machine a human Terminal
+ * page uses (packages/lib/src/services/sandbox/machine-session.ts), but
+ * through a separate one-off exec call — never through the interactive PTY a
+ * connected human is watching. Without this, a human viewing a Terminal has
+ * no visibility into what an agent just did on their machine.
+ *
+ * `apps/web` posts here (HMAC-signed, mirroring /api/broadcast and /api/kick)
+ * after a successful bash run. This handler derives the SAME session key the
+ * PTY path uses, looks up any LIVE session in this process's in-memory
+ * `terminalSessionMap`, and — if one exists — injects an annotated line into
+ * its output feed (both the live socket and its scrollback), so it reads like
+ * PTY output to anyone watching or reconnecting.
+ *
+ * A 200 with `delivered: false` (no live session, or no driveId) is the
+ * expected common case — most agent runs happen while nobody is watching the
+ * Terminal — and is NOT an error: the agent's command already succeeded
+ * independently of whether anyone is watching.
+ */
+
+import type { TerminalSessionMap } from './terminal-session-map';
+import { appendScrollback } from './terminal-handler';
+import { truncateToBytes } from '@pagespace/lib/services/sandbox/output-limit';
+
+/** Cap on the output preview injected into the feed — a live PTY pane, not a log viewer. */
+const MAX_FEED_OUTPUT_BYTES = 4 * 1024;
+
+export interface TerminalActivityPayload {
+  tenantId: string;
+  driveId?: string;
+  pageId: string;
+  command: string;
+  output: string;
+  exitCode: number;
+  agentLabel: string;
+}
+
+interface ParseResult {
+  success: boolean;
+  payload?: TerminalActivityPayload;
+  error?: string;
+}
+
+export function parseTerminalActivityRequest(body: string): ParseResult {
+  try {
+    const payload = JSON.parse(body) as TerminalActivityPayload;
+    return { success: true, payload };
+  } catch {
+    return { success: false, error: 'Invalid JSON' };
+  }
+}
+
+interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function validateTerminalActivityPayload(payload: TerminalActivityPayload): ValidationResult {
+  if (!isNonEmptyString(payload.tenantId)) return { valid: false, error: 'Missing or invalid tenantId' };
+  if (!isNonEmptyString(payload.pageId)) return { valid: false, error: 'Missing or invalid pageId' };
+  if (!isNonEmptyString(payload.command)) return { valid: false, error: 'Missing or invalid command' };
+  if (typeof payload.output !== 'string') return { valid: false, error: 'Missing or invalid output' };
+  if (typeof payload.exitCode !== 'number' || !Number.isFinite(payload.exitCode)) {
+    return { valid: false, error: 'Missing or invalid exitCode' };
+  }
+  if (!isNonEmptyString(payload.agentLabel)) return { valid: false, error: 'Missing or invalid agentLabel' };
+  if (payload.driveId !== undefined && !isNonEmptyString(payload.driveId)) {
+    return { valid: false, error: 'Invalid driveId' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Formats a bash run as an annotated PTY-style block: cyan header naming who
+ * ran what, the (truncated, CRLF-normalized) output, and a dim exit-code
+ * footer. `\r\n` line endings match real PTY output so xterm renders it
+ * identically to a shell echoing its own commands.
+ */
+export function formatTerminalActivityLine(payload: Pick<TerminalActivityPayload, 'command' | 'output' | 'exitCode' | 'agentLabel'>): string {
+  const { text: truncatedOutput } = truncateToBytes({ text: payload.output, maxBytes: MAX_FEED_OUTPUT_BYTES });
+  const header = `\r\n\x1b[36m▸ ${payload.agentLabel} ran:\x1b[0m ${payload.command}\r\n`;
+  const body = truncatedOutput.length > 0 ? `${truncatedOutput.replace(/\r?\n/g, '\r\n')}\r\n` : '';
+  const footer = `\x1b[90m(exit ${payload.exitCode})\x1b[0m\r\n`;
+  return header + body + footer;
+}
+
+export interface TerminalActivityDeps {
+  sessionMap: Pick<TerminalSessionMap, 'getByKey'>;
+  /** Derives the SAME session key the PTY acquisition path uses for this (tenant, drive, page). */
+  deriveSessionKey: (input: { tenantId: string; driveId: string; pageId: string }) => string;
+}
+
+export interface TerminalActivityResult {
+  success: boolean;
+  delivered?: boolean;
+  error?: string;
+}
+
+/**
+ * Handle the terminal-activity API request. Pure composition over injected
+ * deps — no HTTP/socket types here, so this is unit-tested directly.
+ */
+export function handleTerminalActivityRequest(
+  deps: TerminalActivityDeps,
+  body: string,
+): { status: number; body: TerminalActivityResult } {
+  const parsed = parseTerminalActivityRequest(body);
+  if (!parsed.success || !parsed.payload) {
+    return { status: 400, body: { success: false, error: parsed.error ?? /* c8 ignore next */ 'Parse error' } };
+  }
+
+  const validation = validateTerminalActivityPayload(parsed.payload);
+  if (!validation.valid) {
+    return { status: 400, body: { success: false, error: validation.error ?? /* c8 ignore next */ 'Validation error' } };
+  }
+
+  const { tenantId, driveId, pageId } = parsed.payload;
+  // No drive context (e.g. the global assistant's "own" machine) — a Terminal
+  // page's live session is always keyed by (tenant, drive, page), so there is
+  // no session to look up. Not an error: the agent's run already succeeded.
+  if (!driveId) {
+    return { status: 200, body: { success: true, delivered: false } };
+  }
+
+  const sessionKey = deps.deriveSessionKey({ tenantId, driveId, pageId });
+  const session = deps.sessionMap.getByKey(sessionKey);
+  if (!session) {
+    return { status: 200, body: { success: true, delivered: false } };
+  }
+
+  const text = formatTerminalActivityLine(parsed.payload);
+  appendScrollback(session, text);
+  session.outputFn(text);
+
+  return { status: 200, body: { success: true, delivered: true } };
+}

--- a/apps/realtime/src/terminal/terminal-activity.ts
+++ b/apps/realtime/src/terminal/terminal-activity.ts
@@ -27,6 +27,23 @@ import { truncateToBytes } from '@pagespace/lib/services/sandbox/output-limit';
 /** Cap on the output preview injected into the feed — a live PTY pane, not a log viewer. */
 const MAX_FEED_OUTPUT_BYTES = 4 * 1024;
 
+/**
+ * C0 control characters EXCEPT tab/LF/CR, and DEL. `command`, `agentLabel`,
+ * and `output` are agent-controlled (the model chose the command; its output
+ * can carry indirect prompt-injection payloads) and are about to be
+ * interpolated into a string that is written VERBATIM into a live,
+ * escape-sequence-interpreting xterm.js feed — the header/footer's OWN
+ * `\x1b[...m` color codes are added by this module, not by the payload, so
+ * anything the payload contributes must be stripped of control bytes first.
+ * Otherwise an embedded ESC (0x1B) sequence could spoof output (fake a
+ * different exit code, overwrite/hide prior lines) for the human watching.
+ */
+const CONTROL_CHARS_EXCEPT_WHITESPACE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+function stripControlChars(text: string): string {
+  return text.replace(CONTROL_CHARS_EXCEPT_WHITESPACE, '');
+}
+
 export interface TerminalActivityPayload {
   tenantId: string;
   driveId?: string;
@@ -84,8 +101,11 @@ export function validateTerminalActivityPayload(payload: TerminalActivityPayload
  */
 export function formatTerminalActivityLine(payload: Pick<TerminalActivityPayload, 'command' | 'output' | 'exitCode' | 'agentLabel'>): string {
   const { text: truncatedOutput } = truncateToBytes({ text: payload.output, maxBytes: MAX_FEED_OUTPUT_BYTES });
-  const header = `\r\n\x1b[36m▸ ${payload.agentLabel} ran:\x1b[0m ${payload.command}\r\n`;
-  const body = truncatedOutput.length > 0 ? `${truncatedOutput.replace(/\r?\n/g, '\r\n')}\r\n` : '';
+  const safeAgentLabel = stripControlChars(payload.agentLabel);
+  const safeCommand = stripControlChars(payload.command);
+  const safeOutput = stripControlChars(truncatedOutput);
+  const header = `\r\n\x1b[36m▸ ${safeAgentLabel} ran:\x1b[0m ${safeCommand}\r\n`;
+  const body = safeOutput.length > 0 ? `${safeOutput.replace(/\r?\n/g, '\r\n')}\r\n` : '';
   const footer = `\x1b[90m(exit ${payload.exitCode})\x1b[0m\r\n`;
   return header + body + footer;
 }

--- a/apps/realtime/src/terminal/terminal-handler.ts
+++ b/apps/realtime/src/terminal/terminal-handler.ts
@@ -36,7 +36,7 @@ export type TerminalHandlers = {
   onDisconnect(): void;
 };
 
-function appendScrollback(session: Pick<TerminalSession, 'scrollback' | 'scrollbackBytes'>, data: string): void {
+export function appendScrollback(session: Pick<TerminalSession, 'scrollback' | 'scrollbackBytes'>, data: string): void {
   const bytes = Buffer.byteLength(data, 'utf8');
   session.scrollback.push(data);
   session.scrollbackBytes += bytes;

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -36,6 +36,8 @@ import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-
 import {
   acquireCodeExecutionSlot,
   releaseCodeExecutionSlot,
+  checkMachineRuntimeGuardrail,
+  recordMachineActivity,
 } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import { gateSandboxToolCall } from '@pagespace/lib/services/sandbox/tool-gate';
@@ -48,6 +50,7 @@ import { createSandboxTools, type MachineDirectoryDeps, type ResolveSandboxConte
 import { canActorViewPage } from './actor-permissions';
 import { pageAgentRepository, type MachineRef } from '@/lib/repositories/page-agent-repository';
 import type { ToolExecutionContext } from '../core/types';
+import { notifyTerminalAgentActivity } from '@/lib/websocket/socket-utils';
 
 // The session store and Sprites client are process-wide singletons: the store
 // reconnects to one DB pool and the client is stateless. Both are built lazily
@@ -124,6 +127,8 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
               adminGateEnabled: isCodeExecutionEnabled(),
               containment: isContainmentVerified() ? { contained: true } : null,
             }),
+          checkMachineRuntimeGuardrail,
+          recordMachineActivity,
         },
       }),
     reconnect: async (sandboxId) => (await getSandboxClient()).get({ sandboxId }),
@@ -133,6 +138,19 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
     },
     buildEnv: defaultBuildEnv,
     audit: (input) => writeCodeExecutionAudit({ input }),
+    // Activity-visibility seam (Terminal Epic 1 T1.5): stream a successful bash
+    // run into the referenced Terminal's live PTY feed. Best-effort — errors are
+    // handled inside notifyTerminalAgentActivity itself (logged, never thrown).
+    notifyTerminalActivity: (input) =>
+      notifyTerminalAgentActivity({
+        tenantId: input.tenantId,
+        driveId: input.driveId,
+        pageId: input.pageId,
+        command: input.command,
+        output: input.output,
+        exitCode: input.exitCode,
+        agentLabel: input.agentLabel,
+      }),
     // Injection seam (DEFENSE-IN-DEPTH, fail-open): screen untrusted tool output
     // through the built-in heuristic classifier before it becomes a model message.
     // Annotates flagged content (never blocks); a classifier error fails open. A

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -53,6 +53,8 @@ import {
   broadcastAiMessageDeleted,
   broadcastAiUndoApplied,
   broadcastAiConversationAdded,
+  notifyTerminalAgentActivity,
+  type TerminalActivityEventPayload,
   type ChatUserMessagePayload,
   type ChatMessageEditedPayload,
   type ChatMessageDeletedPayload,
@@ -681,6 +683,41 @@ describe('socket-utils', () => {
         conversationId: 'conv-1',
         triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
       })).resolves.not.toThrow();
+    });
+  });
+
+  describe('notifyTerminalAgentActivity', () => {
+    const payload: TerminalActivityEventPayload = {
+      tenantId: 'tenant-1',
+      driveId: 'drive-1',
+      pageId: 'terminal-page-1',
+      command: 'echo hi',
+      output: 'hi',
+      exitCode: 0,
+      agentLabel: 'Agent Bob',
+    };
+
+    it('given a valid payload, should POST it to /api/terminal-activity (not the broadcast endpoint)', async () => {
+      await notifyTerminalAgentActivity(payload);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:3001/api/terminal-activity');
+      expect(JSON.parse(init.body)).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await notifyTerminalAgentActivity(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw (best-effort)', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(notifyTerminalAgentActivity(payload)).resolves.not.toThrow();
     });
   });
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -1249,6 +1249,53 @@ export async function broadcastActivityEvent(payload: ActivityEventPayload): Pro
 }
 
 // ============================================================================
+// Terminal Activity Feed (Terminal Epic 1 T1.5, activity visibility)
+// ============================================================================
+
+export interface TerminalActivityEventPayload {
+  tenantId: string;
+  driveId?: string;
+  pageId: string;
+  command: string;
+  output: string;
+  exitCode: number;
+  agentLabel: string;
+}
+
+/**
+ * Streams a successful agent bash run into the referenced Terminal's live
+ * PTY/output feed, via a dedicated (non-broadcast-room) realtime endpoint —
+ * the human viewer's live session is looked up by derived session key, not
+ * by Socket.IO room membership. Best-effort: a failure (or nobody watching)
+ * must never affect the tool call that already succeeded.
+ */
+export async function notifyTerminalAgentActivity(payload: TerminalActivityEventPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify(payload);
+    await fetch(`${realtimeUrl}/api/terminal-activity`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to notify terminal agent activity',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'terminal_activity',
+        pageId: maskIdentifier(payload.pageId),
+      }
+    );
+  }
+}
+
+// ============================================================================
 // Permission Revocation (Kick API)
 // ============================================================================
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-session.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-session.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../machine-session';
 import type { SandboxClient } from '../terminal-session-manager';
 import type { TerminalSessionStore, TerminalSessionRecord } from '../terminal-session-manager';
+import type { MachineRuntimeGuardrailDecision } from '../quota';
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
 const passGate = async (): Promise<{ ok: true }> => ({ ok: true });
@@ -79,6 +80,8 @@ function makeDeps(over: Partial<AcquireMachineSandboxDeps> = {}): AcquireMachine
     now: () => NOW,
     secret: 'x'.repeat(32),
     checkFullEgressEnablement: passGate,
+    checkMachineRuntimeGuardrail: (): MachineRuntimeGuardrailDecision => ({ allowed: true }),
+    recordMachineActivity: () => {},
     ...over,
   };
 }
@@ -114,7 +117,7 @@ describe('acquireMachineSandbox', () => {
       activeMachine: { kind: 'own' },
       deps: makeDeps({ store, client }),
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: false });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'agent-1' });
     expect(storeCalls.save).toBe(1);
     expect(calls.getOrCreate).toHaveLength(1);
   });
@@ -128,7 +131,12 @@ describe('acquireMachineSandbox', () => {
     const second = await acquireMachineSandbox({ ...base, activeMachine: { kind: 'own' }, deps });
 
     expect(first.ok).toBe(true);
-    expect(second).toEqual({ ok: true, sandboxId: first.ok ? first.sandboxId : undefined, resumed: true });
+    expect(second).toEqual({
+      ok: true,
+      sandboxId: first.ok ? first.sandboxId : undefined,
+      resumed: true,
+      pageId: 'agent-1',
+    });
   });
 
   it('given an "existing" machine, should key the persistent session by the Terminal page id, not the agent\'s own page', async () => {
@@ -139,7 +147,7 @@ describe('acquireMachineSandbox', () => {
       activeMachine: { kind: 'existing', terminalId: 'terminal-page-1' },
       deps: makeDeps({ store, client }),
     });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: false });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'terminal-page-1' });
     expect(storeCalls.save).toBe(1);
 
     // A DIFFERENT agentPageId sharing the same "existing" terminal reconnects to
@@ -153,14 +161,14 @@ describe('acquireMachineSandbox', () => {
       activeMachine: { kind: 'existing', terminalId: 'terminal-page-1' },
       deps: makeDeps({ store, client }),
     });
-    expect(second).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: true });
+    expect(second).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: true, pageId: 'terminal-page-1' });
   });
 
   it('given no activeMachine set (undefined), should default to the "own" machine', async () => {
     const { store } = makeStore();
     const { client, calls } = makeClient();
     const result = await acquireMachineSandbox({ ...base, deps: makeDeps({ store, client }) });
-    expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: false });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'agent-1' });
     expect(calls.getOrCreate).toHaveLength(1);
   });
 
@@ -224,5 +232,69 @@ describe('acquireMachineSandbox', () => {
       deps: makeDeps({ client }),
     });
     expect(result).toEqual({ ok: false, reason: 'provision_failed', cause });
+  });
+
+  it('given the machine runtime guardrail refuses, should deny machine_runtime_exceeded and never provision', async () => {
+    const { client, calls } = makeClient();
+    const result = await acquireMachineSandbox({
+      ...base,
+      activeMachine: { kind: 'own' },
+      deps: makeDeps({
+        client,
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'machine_runtime_exceeded' });
+    expect(calls.getOrCreate).toEqual([]);
+  });
+
+  it('given the runtime guardrail refuses for an UNAUTHORIZED actor, should surface the authz denial first', async () => {
+    const { client, calls } = makeClient();
+    const result = await acquireMachineSandbox({
+      ...base,
+      activeMachine: { kind: 'own' },
+      deps: makeDeps({
+        client,
+        authorize: async () => ({ ok: false, reason: 'insufficient_role' }),
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+    expect(calls.getOrCreate).toEqual([]);
+  });
+
+  it('given a successful acquisition, should key the guardrail by the resolved machine pageId and record activity after provisioning', async () => {
+    const seenCheck: Array<{ machineKey: string; now: number }> = [];
+    const seenRecord: Array<{ machineKey: string; now: number }> = [];
+    const result = await acquireMachineSandbox({
+      ...base,
+      activeMachine: { kind: 'existing', terminalId: 'terminal-page-1' },
+      deps: makeDeps({
+        checkMachineRuntimeGuardrail: (input) => {
+          seenCheck.push(input);
+          return { allowed: true };
+        },
+        recordMachineActivity: (input) => {
+          seenRecord.push(input);
+        },
+      }),
+    });
+    expect(result.ok).toBe(true);
+    expect(seenCheck).toEqual([{ machineKey: 'terminal-page-1', now: NOW.getTime() }]);
+    expect(seenRecord).toEqual([{ machineKey: 'terminal-page-1', now: NOW.getTime() }]);
+  });
+
+  it('given the runtime guardrail refuses, should never record activity', async () => {
+    const seenRecord: unknown[] = [];
+    const result = await acquireMachineSandbox({
+      ...base,
+      activeMachine: { kind: 'own' },
+      deps: makeDeps({
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+        recordMachineActivity: (input) => seenRecord.push(input),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'machine_runtime_exceeded' });
+    expect(seenRecord).toEqual([]);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/persistent-machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/persistent-machine-fs.test.ts
@@ -106,6 +106,8 @@ function makeRunDeps(world: ReturnType<typeof makeSpriteWorld>, store: TerminalS
     now: () => NOW,
     secret: 'x'.repeat(32),
     checkFullEgressEnablement: passGate,
+    checkMachineRuntimeGuardrail: () => ({ allowed: true }),
+    recordMachineActivity: () => {},
   };
   return {
     isEnabled: () => true,

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -10,6 +10,7 @@ import {
   recordMachineActivity,
   resetMachineRuntimeGuardrail,
   getMachineMaxActiveSeconds,
+  machineActivityMapSize,
   MACHINE_ACTIVITY_GRACE_MS,
   type CodeExecutionQuotaDeps,
 } from '../quota';
@@ -162,5 +163,30 @@ describe('machine runtime guardrail', () => {
   it('given an invalid env override, should fall back to the default', () => {
     process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = 'not-a-number';
     expect(getMachineMaxActiveSeconds()).toBe(4 * 60 * 60);
+  });
+
+  it('given a machine that has gone idle past the grace window, should evict its entry (bounded memory)', () => {
+    recordMachineActivity({ machineKey: 'stale-machine', now: 0 });
+    expect(machineActivityMapSize()).toBe(1);
+
+    // A later acquisition on a DIFFERENT machine, well past the first
+    // machine's grace window, should sweep the stale entry rather than
+    // accumulating it forever.
+    const now = MACHINE_ACTIVITY_GRACE_MS + 1;
+    recordMachineActivity({ machineKey: 'other-machine', now });
+
+    expect(machineActivityMapSize()).toBe(1);
+  });
+
+  it('given many machines that all go idle, should not grow unbounded across acquisitions', () => {
+    for (let i = 0; i < 50; i++) {
+      recordMachineActivity({ machineKey: `machine-${i}`, now: 0 });
+    }
+    expect(machineActivityMapSize()).toBe(50);
+
+    // One more acquisition, long after all 50 went idle, should sweep them all.
+    recordMachineActivity({ machineKey: 'fresh-machine', now: MACHINE_ACTIVITY_GRACE_MS + 1 });
+
+    expect(machineActivityMapSize()).toBe(1);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   acquireCodeExecutionSlot,
   releaseCodeExecutionSlot,
@@ -6,6 +6,11 @@ import {
   getCodeExecutionConcurrencyLimit,
   resetCodeExecutionConcurrency,
   checkCodeExecutionQuota,
+  checkMachineRuntimeGuardrail,
+  recordMachineActivity,
+  resetMachineRuntimeGuardrail,
+  getMachineMaxActiveSeconds,
+  MACHINE_ACTIVITY_GRACE_MS,
   type CodeExecutionQuotaDeps,
 } from '../quota';
 
@@ -79,5 +84,83 @@ describe('checkCodeExecutionQuota', () => {
       deps: makeDeps(),
     });
     expect(decision).toEqual({ allowed: true });
+  });
+});
+
+describe('machine runtime guardrail', () => {
+  const ORIGINAL_ENV = process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS;
+
+  beforeEach(() => {
+    resetMachineRuntimeGuardrail();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS;
+    } else {
+      process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = ORIGINAL_ENV;
+    }
+  });
+
+  it('given a fresh machine with no recorded activity, should allow', () => {
+    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm1', now: 1_000, maxActiveSeconds: 60 });
+    expect(decision).toEqual({ allowed: true });
+  });
+
+  it('given continuous activity under the cap, should allow', () => {
+    recordMachineActivity({ machineKey: 'm1', now: 0 });
+    recordMachineActivity({ machineKey: 'm1', now: 30_000 });
+    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm1', now: 59_000, maxActiveSeconds: 60 });
+    expect(decision).toEqual({ allowed: true });
+  });
+
+  it('given continuous activity that crosses the cap, should deny machine_runtime_exceeded', () => {
+    recordMachineActivity({ machineKey: 'm1', now: 0 });
+    recordMachineActivity({ machineKey: 'm1', now: 30_000 });
+    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm1', now: 61_000, maxActiveSeconds: 60 });
+    expect(decision).toEqual({ allowed: false, reason: 'machine_runtime_exceeded' });
+  });
+
+  it('given a gap longer than the grace window, should reset the continuous-activity clock', () => {
+    recordMachineActivity({ machineKey: 'm1', now: 0 });
+    // Exceed the cap, but only after a long idle gap — the clock should have reset.
+    const idleGapEnd = MACHINE_ACTIVITY_GRACE_MS + 1;
+    recordMachineActivity({ machineKey: 'm1', now: idleGapEnd });
+    const decision = checkMachineRuntimeGuardrail({
+      machineKey: 'm1',
+      now: idleGapEnd + 60_000,
+      maxActiveSeconds: 60,
+    });
+    // 60s since the reset at idleGapEnd — right at the cap, not yet over it.
+    expect(decision).toEqual({ allowed: false, reason: 'machine_runtime_exceeded' });
+
+    // A fresh key never touched near the deadline stays under budget.
+    const freshDecision = checkMachineRuntimeGuardrail({
+      machineKey: 'm1',
+      now: idleGapEnd + 1,
+      maxActiveSeconds: 60,
+    });
+    expect(freshDecision).toEqual({ allowed: true });
+  });
+
+  it('given activity on one machine, should track another machine independently', () => {
+    recordMachineActivity({ machineKey: 'm1', now: 0 });
+    const decision = checkMachineRuntimeGuardrail({ machineKey: 'm2', now: 61_000, maxActiveSeconds: 60 });
+    expect(decision).toEqual({ allowed: true });
+  });
+
+  it('given no env override, should default to 4 hours', () => {
+    delete process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS;
+    expect(getMachineMaxActiveSeconds()).toBe(4 * 60 * 60);
+  });
+
+  it('given a valid env override, should use it', () => {
+    process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = '120';
+    expect(getMachineMaxActiveSeconds()).toBe(120);
+  });
+
+  it('given an invalid env override, should fall back to the default', () => {
+    process.env.TERMINAL_MACHINE_MAX_ACTIVE_SECONDS = 'not-a-number';
+    expect(getMachineMaxActiveSeconds()).toBe(4 * 60 * 60);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -199,6 +199,57 @@ describe('runBashInSandbox', () => {
     expect(slots.released).toBe(1);
   });
 
+  it('given a successful run and a resolved machine pageId, should notify the terminal activity feed', async () => {
+    const notified: unknown[] = [];
+    const { deps } = makeDeps({
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'terminal-page-1' }),
+      notifyTerminalActivity: async (input) => {
+        notified.push(input);
+      },
+    });
+    const result = await runBashInSandbox({
+      command: 'echo hi',
+      ctx: makeCtx({ actorDisplayName: 'Agent Bob' }),
+      deps,
+    });
+    expect(result).toMatchObject({ success: true });
+    expect(notified).toEqual([
+      {
+        pageId: 'terminal-page-1',
+        driveId: 'd1',
+        tenantId: 't1',
+        command: 'echo hi',
+        output: 'ok',
+        exitCode: 0,
+        agentLabel: 'Agent Bob',
+      },
+    ]);
+  });
+
+  it('given no resolved machine pageId, should never call the terminal activity feed', async () => {
+    const notified: unknown[] = [];
+    const { deps } = makeDeps({
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+      notifyTerminalActivity: async (input) => {
+        notified.push(input);
+      },
+    });
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: true });
+    expect(notified).toEqual([]);
+  });
+
+  it('given a throwing terminal activity feed, should still return the successful result', async () => {
+    const { deps } = makeDeps({
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'terminal-page-1' }),
+      notifyTerminalActivity: async () => {
+        throw new Error('feed down');
+      },
+    });
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+    expect(result).toEqual({ success: true, stdout: 'ok', stderr: '', exitCode: 0, truncated: false });
+  });
+
   it('given output over the cap, should truncate and flag it', async () => {
     const big = 'x'.repeat(300 * 1024);
     const { deps } = makeDeps({

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -250,6 +250,55 @@ describe('runBashInSandbox', () => {
     expect(result).toEqual({ success: true, stdout: 'ok', stderr: '', exitCode: 0, truncated: false });
   });
 
+  it('given a slow-to-resolve terminal activity feed, should NOT block the tool result on it (fire-and-forget)', async () => {
+    let releaseFeed: (() => void) | undefined;
+    const feedGate = new Promise<void>((resolve) => {
+      releaseFeed = resolve;
+    });
+    const { deps } = makeDeps({
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'terminal-page-1' }),
+      notifyTerminalActivity: async () => {
+        await feedGate; // Never resolves during this test unless we release it.
+      },
+    });
+
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+
+    expect(result).toMatchObject({ success: true });
+    releaseFeed?.(); // Avoid leaving a dangling unresolved promise after the test.
+  });
+
+  it('given both stdout and stderr, should combine them for the terminal activity feed instead of dropping stderr', async () => {
+    const notified: Array<{ output: string }> = [];
+    const { deps } = makeDeps({
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'terminal-page-1' }),
+      reconnect: async () =>
+        makeSandbox({ runCommand: async () => ({ exitCode: 0, stdout: 'out-line', stderr: 'err-line' }) }),
+      notifyTerminalActivity: async (input) => {
+        notified.push(input);
+      },
+    });
+    await runBashInSandbox({ command: 'echo hi', ctx: makeCtx(), deps });
+    expect(notified[0]?.output).toBe('out-line\nerr-line');
+  });
+
+  it('given no actorDisplayName, should fall back to a generic label instead of the actor\'s raw email (PII)', async () => {
+    const notified: Array<{ agentLabel: string }> = [];
+    const { deps } = makeDeps({
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false, pageId: 'terminal-page-1' }),
+      notifyTerminalActivity: async (input) => {
+        notified.push(input);
+      },
+    });
+    await runBashInSandbox({
+      command: 'echo hi',
+      ctx: makeCtx({ actorEmail: 'someone@example.com', actorDisplayName: undefined }),
+      deps,
+    });
+    expect(notified[0]?.agentLabel).toBe('AI agent');
+    expect(notified[0]?.agentLabel).not.toContain('@');
+  });
+
   it('given output over the cap, should truncate and flag it', async () => {
     const big = 'x'.repeat(300 * 1024);
     const { deps } = makeDeps({

--- a/packages/lib/src/services/sandbox/machine-session.ts
+++ b/packages/lib/src/services/sandbox/machine-session.ts
@@ -19,6 +19,7 @@
 import type { CanRunCodeInput, CanRunCodeResult, CodeExecutionDenialReason } from './can-run-code';
 import type { FullEgressEnablement, FullEgressDenialReason } from './containment';
 import { acquireTerminalSandbox, type SandboxClient, type TerminalSessionStore } from './terminal-session-manager';
+import type { MachineRuntimeGuardrailDecision } from './quota';
 
 /**
  * Structural mirror of the canonical `MachineRef`
@@ -54,6 +55,15 @@ export interface AcquireMachineSandboxDeps {
   secret: string;
   /** REQUIRED full-egress enablement gate — see terminal-session-manager.ts. */
   checkFullEgressEnablement: () => Promise<FullEgressEnablement>;
+  /**
+   * Per-machine active-runtime cost backstop (Terminal Epic 1 T1.5, pulled
+   * forward from Epic 3's full metering) — see quota.ts. Checked AFTER authz
+   * (an unauthorized actor is denied on its own merits, not because the
+   * machine happens to be busy) and BEFORE provisioning.
+   */
+  checkMachineRuntimeGuardrail: (input: { machineKey: string; now: number }) => MachineRuntimeGuardrailDecision;
+  /** Record that the machine was just active, extending (or starting) its continuous-activity window. */
+  recordMachineActivity: (input: { machineKey: string; now: number }) => void;
 }
 
 export interface AcquireMachineSandboxInput {
@@ -68,10 +78,15 @@ export interface AcquireMachineSandboxInput {
 }
 
 export type AcquireMachineSandboxResult =
-  | { ok: true; sandboxId: string; resumed: boolean }
+  | { ok: true; sandboxId: string; resumed: boolean; pageId?: string }
   | {
       ok: false;
-      reason: CodeExecutionDenialReason | 'provision_failed' | 'no_machine' | FullEgressDenialReason;
+      reason:
+        | CodeExecutionDenialReason
+        | 'provision_failed'
+        | 'no_machine'
+        | FullEgressDenialReason
+        | 'machine_runtime_exceeded';
       cause?: unknown;
     };
 
@@ -85,6 +100,10 @@ export async function acquireMachineSandbox(
 
   const authorization = await deps.authorize({ userId, driveId, requestOrigin, agentPageId });
   if (!authorization.ok) return { ok: false, reason: authorization.reason };
+
+  const nowMs = deps.now().getTime();
+  const guardrail = deps.checkMachineRuntimeGuardrail({ machineKey: pageId, now: nowMs });
+  if (!guardrail.allowed) return { ok: false, reason: guardrail.reason };
 
   const result = await acquireTerminalSandbox({
     pageId,
@@ -105,5 +124,7 @@ export async function acquireMachineSandbox(
     // 'deny' cannot arise here (canRun is always true) — mapped defensively.
     return { ok: false, reason: result.reason === 'deny' ? 'error' : result.reason, cause: result.cause };
   }
-  return { ok: true, sandboxId: result.sandboxId, resumed: result.resumed };
+
+  deps.recordMachineActivity({ machineKey: pageId, now: nowMs });
+  return { ok: true, sandboxId: result.sandboxId, resumed: result.resumed, pageId };
 }

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -104,3 +104,89 @@ export async function checkCodeExecutionQuota({
   }
   return { allowed: true };
 }
+
+/**
+ * Per-machine active-runtime guardrail (Terminal Epic 1 T1.5).
+ *
+ * A pulled-forward, minimal cost backstop ahead of Epic 3's full usage
+ * metering: an agent that keeps a persistent machine continuously busy
+ * (back-to-back tool calls, no idle gaps) is capped at a configurable
+ * wall-clock duration instead of running unbounded. This tracks CONTINUOUS
+ * activity per machine, not lifetime usage — a gap longer than the grace
+ * window resets the clock, so a machine that goes idle (naturally, or via
+ * Sprite hibernation) recovers full budget rather than being capped forever.
+ *
+ * Deliberately separate from the per-user concurrency semaphore above: that
+ * bounds how many runs a USER has in flight; this bounds how long a single
+ * MACHINE has been kept continuously active, regardless of which user/agent
+ * is driving it.
+ */
+
+const MACHINE_MAX_ACTIVE_SECONDS_ENV = 'TERMINAL_MACHINE_MAX_ACTIVE_SECONDS';
+const DEFAULT_MACHINE_MAX_ACTIVE_SECONDS = 4 * 60 * 60; // 4 hours
+/** A gap longer than this between calls resets the continuous-activity clock. */
+export const MACHINE_ACTIVITY_GRACE_MS = 5 * 60 * 1000;
+
+export function getMachineMaxActiveSeconds(): number {
+  const raw = process.env[MACHINE_MAX_ACTIVE_SECONDS_ENV];
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MACHINE_MAX_ACTIVE_SECONDS;
+}
+
+interface MachineActivityState {
+  firstActiveAt: number;
+  lastActiveAt: number;
+}
+
+const machineActivityByKey = new Map<string, MachineActivityState>();
+
+export type MachineRuntimeGuardrailReason = 'machine_runtime_exceeded';
+
+export type MachineRuntimeGuardrailDecision =
+  | { allowed: true }
+  | { allowed: false; reason: MachineRuntimeGuardrailReason };
+
+/**
+ * Advisory check: has this machine been continuously active (no gap longer
+ * than `MACHINE_ACTIVITY_GRACE_MS`) for at least `maxActiveSeconds`? Pure
+ * read — does not itself record activity; callers must also call
+ * `recordMachineActivity` on every acquisition (allowed or not) so a stalled
+ * caller who never records still reflects real elapsed time.
+ */
+export function checkMachineRuntimeGuardrail({
+  machineKey,
+  now,
+  maxActiveSeconds = getMachineMaxActiveSeconds(),
+}: {
+  machineKey: string;
+  now: number;
+  maxActiveSeconds?: number;
+}): MachineRuntimeGuardrailDecision {
+  const state = machineActivityByKey.get(machineKey);
+  if (state && now - state.lastActiveAt <= MACHINE_ACTIVITY_GRACE_MS) {
+    const activeMs = now - state.firstActiveAt;
+    if (activeMs >= maxActiveSeconds * 1000) {
+      return { allowed: false, reason: 'machine_runtime_exceeded' };
+    }
+  }
+  return { allowed: true };
+}
+
+/**
+ * Record that this machine was just active. Starts (or continues) the
+ * continuous-activity window; a gap longer than the grace period starts a
+ * fresh window instead of extending the old one.
+ */
+export function recordMachineActivity({ machineKey, now }: { machineKey: string; now: number }): void {
+  const state = machineActivityByKey.get(machineKey);
+  if (!state || now - state.lastActiveAt > MACHINE_ACTIVITY_GRACE_MS) {
+    machineActivityByKey.set(machineKey, { firstActiveAt: now, lastActiveAt: now });
+  } else {
+    state.lastActiveAt = now;
+  }
+}
+
+/** Clear all machine-runtime guardrail state. Test-only seam. */
+export function resetMachineRuntimeGuardrail(): void {
+  machineActivityByKey.clear();
+}

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -147,6 +147,22 @@ export type MachineRuntimeGuardrailDecision =
   | { allowed: false; reason: MachineRuntimeGuardrailReason };
 
 /**
+ * Drop entries whose gap has already exceeded the grace window: once that's
+ * true, `checkMachineRuntimeGuardrail` treats the key as if it had no state
+ * anyway, so the entry is pure dead weight. Without this, every distinct
+ * machine ever acquired would occupy an entry for the life of the process —
+ * unlike the per-user semaphore above, this map has no symmetric
+ * acquire/release to hook a delete into, so eviction has to be opportunistic.
+ */
+function evictStaleMachineActivity(now: number): void {
+  for (const [key, state] of machineActivityByKey) {
+    if (now - state.lastActiveAt > MACHINE_ACTIVITY_GRACE_MS) {
+      machineActivityByKey.delete(key);
+    }
+  }
+}
+
+/**
  * Advisory check: has this machine been continuously active (no gap longer
  * than `MACHINE_ACTIVITY_GRACE_MS`) for at least `maxActiveSeconds`? Pure
  * read — does not itself record activity; callers must also call
@@ -178,6 +194,10 @@ export function checkMachineRuntimeGuardrail({
  * fresh window instead of extending the old one.
  */
 export function recordMachineActivity({ machineKey, now }: { machineKey: string; now: number }): void {
+  // Opportunistic sweep: every acquisition is a natural checkpoint to reclaim
+  // any OTHER machine's entry that has gone idle, keeping the map bounded by
+  // currently (or recently) active machines rather than every machine ever seen.
+  evictStaleMachineActivity(now);
   const state = machineActivityByKey.get(machineKey);
   if (!state || now - state.lastActiveAt > MACHINE_ACTIVITY_GRACE_MS) {
     machineActivityByKey.set(machineKey, { firstActiveAt: now, lastActiveAt: now });
@@ -189,4 +209,9 @@ export function recordMachineActivity({ machineKey, now }: { machineKey: string;
 /** Clear all machine-runtime guardrail state. Test-only seam. */
 export function resetMachineRuntimeGuardrail(): void {
   machineActivityByKey.clear();
+}
+
+/** Current guardrail map size — test-only seam for verifying eviction bounds memory. */
+export function machineActivityMapSize(): number {
+  return machineActivityByKey.size;
 }

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -63,6 +63,23 @@ export interface SandboxQuotaDeps {
   releaseSlot: (args: { userId: string }) => void;
 }
 
+/**
+ * A single bash command + its output, for streaming into the referenced
+ * Terminal's live PTY/output feed (Terminal Epic 1 T1.5 activity visibility) —
+ * so a human watching a Terminal page sees the agent's work as it happens.
+ */
+export interface TerminalActivityNotification {
+  /** The machine's identifying page (resolveMachinePageId's output). */
+  pageId: string;
+  driveId?: string;
+  tenantId: string;
+  command: string;
+  output: string;
+  exitCode: number;
+  /** Human-facing label for who ran this (actor display name or email). */
+  agentLabel: string;
+}
+
 export interface SandboxRunDeps {
   isEnabled: () => boolean;
   /** Pre-bound `acquireMachineSandbox` (lifecycle deps already injected). */
@@ -80,6 +97,14 @@ export interface SandboxRunDeps {
    * unchanged (seam disabled).
    */
   screenOutput?: (text: string) => Promise<string>;
+  /**
+   * Optional activity-visibility seam (Terminal Epic 1 T1.5): streams a
+   * successful bash run's command + output into the referenced Terminal's
+   * live feed. Best-effort — a failure here must never affect the tool
+   * result, and omitting it simply disables the feed (no Terminal epic
+   * consumer wired yet, or the machine has no live watcher).
+   */
+  notifyTerminalActivity?: (input: TerminalActivityNotification) => Promise<void>;
   now: () => Date;
   logger?: {
     warn?: (message: string, metadata?: Record<string, unknown>) => void;
@@ -112,6 +137,7 @@ function safeLogWarn(
 // vs infra failures that are genuinely unexpected (error-level).
 const AUTHZ_DENY_REASONS = new Set([
   'no_drive_access', 'insufficient_role', 'no_agent_access', 'app_admin_required', 'kill_switch_off', 'no_machine',
+  'machine_runtime_exceeded',
 ]);
 
 
@@ -122,6 +148,7 @@ export type SandboxToolDenialReason =
   | 'insufficient_role'
   | 'no_agent_access'
   | 'no_machine'
+  | 'machine_runtime_exceeded'
   | 'concurrency_limit'
   | 'empty_command'
   | 'command_too_large'
@@ -159,6 +186,8 @@ const DENIAL_MESSAGES: Record<SandboxToolDenialReason, string> = {
   insufficient_role: 'Running code requires drive owner or admin access.',
   no_agent_access: 'This agent is not permitted to run code in this drive.',
   no_machine: 'No machine is configured for this run.',
+  machine_runtime_exceeded:
+    'This machine has been running continuously for too long. Wait for it to go idle, or switch to a different machine.',
   concurrency_limit: 'Too many concurrent runs. Wait for a run to finish and retry.',
   empty_command: 'No command was provided.',
   command_too_large: 'The command is too large.',
@@ -226,6 +255,20 @@ async function safeAudit(
   }
 }
 
+// Best-effort, fire-and-forget: a failing/missing activity feed must never
+// affect the bash tool's result — it is a visibility nicety, not a safety gate.
+async function safeNotifyTerminalActivity(
+  deps: SandboxRunDeps,
+  input: TerminalActivityNotification,
+): Promise<void> {
+  if (!deps.notifyTerminalActivity) return;
+  try {
+    await deps.notifyTerminalActivity(input);
+  } catch {
+    // Intentionally swallowed.
+  }
+}
+
 // Map a denial from the lifecycle acquire onto the tool-facing reason set.
 function reasonFromAcquire(result: Extract<AcquireMachineSandboxResult, { ok: false }>): SandboxToolDenialReason {
   switch (result.reason) {
@@ -235,6 +278,7 @@ function reasonFromAcquire(result: Extract<AcquireMachineSandboxResult, { ok: fa
     case 'no_agent_access':
     case 'no_machine':
     case 'provision_failed':
+    case 'machine_runtime_exceeded':
       return result.reason;
     case 'kill_switch_off':
       return 'kill_switch_off';
@@ -260,7 +304,7 @@ async function openSession(
   ctx: SandboxActorContext,
   deps: SandboxRunDeps,
 ): Promise<
-  | { ok: true; sandbox: ExecutableSandbox; release: () => void }
+  | { ok: true; sandbox: ExecutableSandbox; release: () => void; pageId?: string }
   | { ok: false; reason: SandboxToolDenialReason }
 > {
   if (!deps.quota.acquireSlot({ userId: ctx.userId, tier: ctx.tier })) {
@@ -291,7 +335,12 @@ async function openSession(
       });
       return { ok: false, reason: 'provision_failed' };
     }
-    return { ok: true, sandbox, release: () => deps.quota.releaseSlot({ userId: ctx.userId }) };
+    return {
+      ok: true,
+      sandbox,
+      release: () => deps.quota.releaseSlot({ userId: ctx.userId }),
+      pageId: acquired.pageId,
+    };
   } catch (error) {
     safeLogError(
       deps.logger,
@@ -406,6 +455,17 @@ export async function runBashInSandbox({
       durationMs,
       anomaly: anomalyForExit(run.exitCode),
     });
+    if (session.pageId) {
+      await safeNotifyTerminalActivity(deps, {
+        pageId: session.pageId,
+        driveId: ctx.driveId,
+        tenantId: ctx.tenantId,
+        command,
+        output: stdout.text || stderr.text,
+        exitCode: run.exitCode,
+        agentLabel: ctx.actorDisplayName ?? ctx.actorEmail,
+      });
+    }
     return {
       success: true,
       stdout: stdout.text,

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -456,14 +456,24 @@ export async function runBashInSandbox({
       anomaly: anomalyForExit(run.exitCode),
     });
     if (session.pageId) {
-      await safeNotifyTerminalActivity(deps, {
+      // Fire-and-forget: this is a visibility nicety over a network hop to
+      // another service, not a safety gate. Awaiting it would tie every
+      // successful bash call's latency to the terminal-activity feed's
+      // availability (up to its own request timeout) for no benefit — the
+      // tool result below does not depend on it. safeNotifyTerminalActivity
+      // already swallows its own errors, so this can never surface as an
+      // unhandled rejection.
+      void safeNotifyTerminalActivity(deps, {
         pageId: session.pageId,
         driveId: ctx.driveId,
         tenantId: ctx.tenantId,
         command,
-        output: stdout.text || stderr.text,
+        output: [stdout.text, stderr.text].filter((text) => text.length > 0).join('\n'),
         exitCode: run.exitCode,
-        agentLabel: ctx.actorDisplayName ?? ctx.actorEmail,
+        // No display name is set for a plain email fallback — a raw email
+        // address is PII and this feed is visible to every viewer with edit
+        // access to the Terminal page, not just the acting user.
+        agentLabel: ctx.actorDisplayName ?? 'AI agent',
       });
     }
     return {


### PR DESCRIPTION
## Summary

Third PR node under Epic 1 (Agent ⇄ Terminal comms) — the "Permissions + activity visibility + runtime guardrail" task. Of the three acceptance criteria, the **permission gate** (an agent may only acquire a machine it can view) was already merged and verified in #1893/#1891 (`isMachineAccessible`, re-checked on every tool call via `canActorViewPage` → the centralized `agent-permissions.ts`/`can-run-code.ts`). This PR adds the remaining two:

- **Activity visibility**: a successful `bash` run now streams its command + output into the referenced Terminal's live PTY/output feed. An agent's bash execution runs through a one-off SDK exec call on the same persistent Sprite a human Terminal page's PTY uses — not through the PTY itself — so without this a human watching a Terminal has no visibility into agent work. `apps/web` posts to a new HMAC-signed `/api/terminal-activity` endpoint on `realtime` (mirrors `/api/broadcast` and `/api/kick`'s signing); the handler derives the same session key the PTY acquisition path uses and, if a live session exists in that process's `terminalSessionMap`, injects an annotated CRLF-formatted line into its scrollback and output feed. No live session (nobody watching) returns 200 with `delivered: false` — not an error, since the agent's command already succeeded independently.

- **Runtime guardrail**: `packages/lib/src/services/sandbox/quota.ts` now tracks per-machine CONTINUOUS active runtime — a gap longer than a 5-minute grace window resets the clock, so a machine that goes idle (naturally, or via Sprite hibernation) recovers full budget instead of being capped forever. Capped via `TERMINAL_MACHINE_MAX_ACTIVE_SECONDS` (default 4h, env-configurable). `acquireMachineSandbox` checks it after authz (an unauthorized actor is denied on its own merits) and before provisioning, denying with a typed `machine_runtime_exceeded` reason once exceeded — a minimal cost backstop pulled forward from Epic 3's full metering.

## Permission gate — confirmed centralized, no hand-rolled check

This PR does not touch `packages/lib/src/permissions/`, `apps/web/src/lib/ai/tools/actor-permissions.ts`, or `apps/web/src/lib/ai/tools/sandbox-tools.ts` — the gate is unchanged from #1893. Traced end-to-end: `sandbox-tools.ts`'s `open()` re-verifies `machines.isMachineAccessible` on every call (not just at `switch_machine` time) → `createMachineDirectory`'s `isMachineAccessible` (sandbox-tools-runtime.ts) → `canActorViewPage` (actor-permissions.ts) → `getAgentAccessLevel` (packages/lib/src/permissions/agent-permissions.ts) for agent origin, `getUserAccessLevel` (permissions.ts) otherwise. An inaccessible machine denies with a typed `'inaccessible'` reason (sandbox-tools.ts), fail-closed by construction — no direct DB/ACL check bypassing these functions.

## ⚠️ Integration-gate note: apps/realtime/src/index.ts has diverged from master

I edited `apps/realtime/src/index.ts` (new import + a new `/api/terminal-activity` branch in `requestListener`, before the existing `/api/kick` branch). Correcting the reviewer's earlier attribution: **PR #1879** ("Resolve GitHub integration/sandbox tool overlap") does **not** touch this file at all (verified via `gh pr view 1879 --json files`). The actual divergent PR is **master #1887** ("decrypt PII at the edge in presence + terminal-audit reads"), which is *not* an ancestor of `pu/terminal` and touches the same file at different hunks:

- #1887: import block (~line 34, adds `decryptField`), a new `resolveActorEmail` helper (~line 48–59), one line in `makeTerminalCheckAuth` (~line 95), and `populateUserMetadata` (~line 540+).
- This PR: import block (~line 15–16, different import group), and a new HTTP branch (~line 471–497), inserted before `/api/kick` and well before `populateUserMetadata`.

The hunks don't overlap, so a standard merge should apply cleanly, but **I did not merge master into this branch** per instructions — the integration gate (whoever reconciles `pu/terminal` → `master`) should verify the 3-way merge on this file resolves without semantic conflicts (e.g. that `resolveActorEmail`/PII-decrypt behavior and the new `/api/terminal-activity` route coexist correctly) before that merge lands.

## Test plan
- [x] `bun run --filter '@pagespace/lib' typecheck` / `--filter 'web'` / `--filter 'realtime'` all green (re-verified after confirming zero divergence from `pu/terminal`'s tip)
- [x] Zero merge conflicts with base `pu/terminal` — `origin/pu/terminal`'s tip is this branch's merge-base (branch created after #1893/#1891 merged; no rebase needed)
- [x] `packages/lib/src/services/sandbox/__tests__/quota.test.ts` — guardrail continuous-activity tracking, grace-window reset, env override (15 tests)
- [x] `packages/lib/src/services/sandbox/__tests__/machine-session.test.ts` — guardrail denies before provisioning, authz denial takes priority over guardrail, activity recorded only on success, keyed by resolved pageId (17 tests)
- [x] `packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts` — notify-on-success wiring, no-op without a resolved pageId, feed failure never affects the tool result (45 tests)
- [x] `apps/realtime/src/terminal/__tests__/terminal-activity.test.ts` — parse/validate/format/handler composition, live-session delivery vs no-op (20 tests)
- [x] `apps/web/src/lib/websocket/__tests__/socket-utils.test.ts` — new `notifyTerminalAgentActivity` POST/URL/best-effort tests (64 tests)
- [x] Full `packages/lib/src/services/sandbox/` suite: 380/380 passing; full `apps/realtime/src/terminal/__tests__`: 111/111 passing
- [x] Lint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKdoTjRVgeKRH6UoLQUKEQ