### PR TITLE
fix(terminal): close terminalAccess bypass via implicit own-machine fallback

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -827,6 +827,19 @@ describe('active machine access', () => {
     expect(result).toMatchObject({ success: false });
     expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
   });
+
+  it('git_status: given no configured machines (terminalAccess off), should deny instead of falling back to the own machine', async () => {
+    const deps = makeDeps();
+    // createMachineDirectory.listMachines returns [] exactly when terminalAccess
+    // is off — this must deny the call, not silently resolve to { kind: 'own' }
+    // (which used to key an implicit persistent machine off the agent's own
+    // page, bypassing the terminalAccess gate entirely).
+    deps.machines.listMachines = vi.fn().mockResolvedValue([]);
+    const { git_status } = createSandboxGitTools(deps);
+    const result = await git_status.execute!({}, {} as never);
+    expect(result).toMatchObject({ success: false });
+    expect(deps.gitRunDeps.acquireSandbox).not.toHaveBeenCalled();
+  });
 });
 
 // ── schema strictness ────────────────────────────────────────────────────

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -80,6 +80,28 @@ describe('createSandboxTools', () => {
     expect(acquired).toBe(false);
   });
 
+  it('bash: given no configured machines (terminalAccess off), should deny instead of falling back to the own machine', async () => {
+    let acquired = false;
+    const runDeps = fakeRunDeps();
+    runDeps.acquireSandbox = async () => {
+      acquired = true;
+      return { ok: true, sandboxId: 'sbx', resumed: false };
+    };
+    // createMachineDirectory.listMachines returns [] exactly when terminalAccess
+    // is off — this must deny the call, not silently resolve to { kind: 'own' }
+    // (which used to key an implicit persistent machine off the agent's own
+    // page, bypassing the terminalAccess gate entirely).
+    const machines: MachineDirectoryDeps = {
+      listMachines: async () => [],
+      describeMachine: async () => ({ name: 'My Machine' }),
+      isMachineAccessible: async () => true,
+    };
+    const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines });
+    const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+    expect(result).toMatchObject({ success: false });
+    expect(acquired).toBe(false);
+  });
+
   it('bash: given an unresolvable context, should surface the resolver error without running', async () => {
     let acquired = false;
     const runDeps = fakeRunDeps();

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -95,6 +95,15 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate, machin
     const decision = await gate(ctx);
     if (!decision.ok) return { ok: false, error: { success: false, error: decision.error } };
     const activeMachine = await resolveActiveMachine(rawContext, machines);
+    if (!activeMachine) {
+      return {
+        ok: false,
+        error: {
+          success: false,
+          error: 'Terminal access is not enabled for this agent. Ask an admin to turn on Terminal Access in this agent\'s settings.',
+        },
+      };
+    }
     // Re-verify page-view access on EVERY call, mirroring sandbox-tools.ts —
     // the actual execution boundary must not trust a machine reference that
     // was accessible only at a past switch_machine call (OWASP A01).

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -137,15 +137,24 @@ export interface MachineDirectoryDeps {
  * Terminal tools (bash/file/git) call this to determine which machine's
  * session to operate on — `resolveMachinePageId` (packages/lib/services/
  * sandbox/machine-session.ts) then keys the persistent session by it.
+ *
+ * Returns `undefined` when the actor has no configured machines at all —
+ * `listMachines` (createMachineDirectory) already returns `[]` exactly when
+ * `terminalAccess` is off, so an empty list here is never "no preference,
+ * default to 'own'"; it is "not entitled." Callers MUST treat `undefined` as
+ * a denial, not silently fall back to `{ kind: 'own' }` — that fallback used
+ * to key an implicit persistent machine off the agent's own page even with
+ * terminalAccess off, defeating the gate (OWASP A01).
  */
 export async function resolveActiveMachine(
   rawContext: ToolExecutionContext | undefined,
   machines: MachineDirectoryDeps,
-): Promise<MachineRef> {
+): Promise<MachineRef | undefined> {
   const configured = await machines.listMachines(rawContext);
+  if (configured.length === 0) return undefined;
   const active = rawContext?.activeMachine;
   if (active && configured.some((m) => machineRefEquals(m, active))) return active;
-  return configured[0] ?? { kind: 'own' };
+  return configured[0];
 }
 
 /** Resolves the actor context for a turn, or an error to surface to the model. */
@@ -205,6 +214,15 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
     const decision = await gate(ctx);
     if (!decision.ok) return { ok: false, error: gateDenial(decision) };
     const activeMachine = await resolveActiveMachine(rawContext, machines);
+    if (!activeMachine) {
+      return {
+        ok: false,
+        error: {
+          success: false,
+          error: 'Terminal access is not enabled for this agent. Ask an admin to turn on Terminal Access in this agent\'s settings.',
+        },
+      };
+    }
     // Re-verify page-view access to the resolved machine on EVERY call — not
     // just at switch_machine time. A machine's page permissions (or the
     // Terminal page itself) can change between calls, and this is the actual
@@ -347,7 +365,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
                 id: machineRefId(m),
                 name: desc.name,
                 ...(desc.description ? { description: desc.description } : {}),
-                active: machineRefEquals(m, active),
+                active: active !== undefined && machineRefEquals(m, active),
               };
             }),
         );


### PR DESCRIPTION
## Summary
- Epic 1 GATE review (Terminal — Agent Comms) found that `resolveActiveMachine()`'s `configured[0] ?? { kind: 'own' }` fallback let `bash`/`writeFile`/`readFile`/`editFile`/all git tools execute against an implicit "own" machine (keyed to the agent's own page) even when `terminalAccess` was OFF — `switch_machine`/`list_machines` were correctly gated (return `[]`/typed `unconfigured`), but the direct execution tools silently fell back to 'own' instead of denying.
- `resolveActiveMachine` now returns `undefined` when no machines are configured (which is unambiguous with `terminalAccess` off by construction, since `createMachineDirectory.listMachines` only ever returns `[]` in that case), and both `sandbox-tools.ts` and `sandbox-git-tools.ts`'s `open()` deny with a clear error instead of falling back.
- Adds regression tests in `sandbox-tools.test.ts` and `sandbox-git-tools.test.ts` covering "no configured machines → deny, sandbox never acquired."

Full findings + evidence recorded on the gate page: PageSpace `xo42x706p3sqidy4ip58hve3`.

## Test plan
- [x] `bun run --filter web typecheck` — clean
- [x] `sandbox-tools.test.ts` (30 tests), `sandbox-git-tools.test.ts` (85 tests), `sandbox-tools-runtime.test.ts` (29 tests) — all pass
- [x] Full `bun run test:unit` — 0 failures in Terminal-epic-scoped files; 16 pre-existing unrelated failures elsewhere (DB-role provisioning gap + 1 timezone test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBmnJPb5Cqo8eXRXyrGAhA