### PR TITLE
feat(terminal): Branches tier — one isolated Sprite per branch-terminal

### DIFF
--- a/apps/web/src/app/api/machines/branches/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/branches/__tests__/route.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Contract tests for GET/POST/DELETE /api/machines/branches
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockAuthenticateRequest,
+  mockIsAuthError,
+  mockCanAccessMachine,
+  mockCanViewMachine,
+  mockBuildMachineBranchesDeps,
+  mockGetMachineHostForBranches,
+  mockResolveMachineActorContext,
+  mockCreateDbMachineBranchStore,
+  mockSpawnBranch,
+  mockKillBranch,
+  mockListBranches,
+} = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
+  mockCanAccessMachine: vi.fn(),
+  mockCanViewMachine: vi.fn(),
+  mockBuildMachineBranchesDeps: vi.fn(),
+  mockGetMachineHostForBranches: vi.fn(),
+  mockResolveMachineActorContext: vi.fn(),
+  mockCreateDbMachineBranchStore: vi.fn(),
+  mockSpawnBranch: vi.fn(),
+  mockKillBranch: vi.fn(),
+  mockListBranches: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => mockIsAuthError(result),
+}));
+
+vi.mock('@/lib/machines/machine-branches-runtime', () => ({
+  buildMachineBranchesDeps: (...args: unknown[]) => mockBuildMachineBranchesDeps(...args),
+  canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
+  canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
+  getMachineHostForBranches: (...args: unknown[]) => mockGetMachineHostForBranches(...args),
+  resolveMachineActorContext: (...args: unknown[]) => mockResolveMachineActorContext(...args),
+}));
+
+vi.mock('@pagespace/lib/services/machines/machine-branches-store', () => ({
+  createDbMachineBranchStore: (...args: unknown[]) => mockCreateDbMachineBranchStore(...args),
+}));
+
+vi.mock('@pagespace/lib/services/machines/machine-branches', () => ({
+  spawnBranch: (...args: unknown[]) => mockSpawnBranch(...args),
+  killBranch: (...args: unknown[]) => mockKillBranch(...args),
+  listBranches: (...args: unknown[]) => mockListBranches(...args),
+}));
+
+import { GET, POST, DELETE } from '../route';
+
+const AUTH_OK = { userId: 'user-1' };
+const AUTH_DENIED = { error: new Response(null, { status: 401 }) };
+
+const FAKE_DEPS = { store: {} } as never;
+const FAKE_STORE = {} as never;
+const FAKE_HOST = {} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH_OK);
+  mockBuildMachineBranchesDeps.mockReturnValue(FAKE_DEPS);
+  mockCreateDbMachineBranchStore.mockResolvedValue(FAKE_STORE);
+  mockGetMachineHostForBranches.mockResolvedValue(FAKE_HOST);
+  mockResolveMachineActorContext.mockResolvedValue({ userId: 'user-1', tenantId: 'user-1', actorEmail: 'u1@example.com', tier: 'pro' });
+});
+
+describe('GET /api/machines/branches', () => {
+  it('given no auth, returns the auth error', async () => {
+    mockAuthenticateRequest.mockResolvedValue(AUTH_DENIED);
+    const res = await GET(new Request('https://x.test/api/machines/branches?terminalId=term-1&projectName=repo'));
+    expect(res.status).toBe(401);
+  });
+
+  it('given view access to the machine, lists its branches', async () => {
+    mockCanViewMachine.mockResolvedValue(true);
+    mockListBranches.mockResolvedValue([{ branchName: 'main', createdAt: new Date('2026-01-01') }]);
+    const res = await GET(new Request('https://x.test/api/machines/branches?terminalId=term-1&projectName=repo'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.branches).toHaveLength(1);
+    expect(mockCanViewMachine).toHaveBeenCalledWith('user-1', 'term-1');
+    expect(mockListBranches).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalId: 'term-1', projectName: 'repo' }),
+    );
+  });
+
+  it('given no terminalId, returns 400', async () => {
+    const res = await GET(new Request('https://x.test/api/machines/branches?projectName=repo'));
+    expect(res.status).toBe(400);
+  });
+
+  it('given no projectName, returns 400', async () => {
+    const res = await GET(new Request('https://x.test/api/machines/branches?terminalId=term-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('given no view access, returns 403 without listing', async () => {
+    mockCanViewMachine.mockResolvedValue(false);
+    const res = await GET(new Request('https://x.test/api/machines/branches?terminalId=term-1&projectName=repo'));
+    expect(res.status).toBe(403);
+    expect(mockListBranches).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/machines/branches', () => {
+  function req(body: unknown) {
+    return new Request('https://x.test/api/machines/branches', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('given no edit access to the machine, returns 403 without spawning', async () => {
+    mockCanAccessMachine.mockResolvedValue(false);
+    const res = await POST(req({ terminalId: 't1', projectName: 'repo', branchName: 'main' }));
+    expect(res.status).toBe(403);
+    expect(mockSpawnBranch).not.toHaveBeenCalled();
+  });
+
+  it('given a fresh spawn, returns 201', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnBranch.mockResolvedValue({ ok: true, sandboxId: 'sbx-1', resumed: false });
+    const res = await POST(req({ terminalId: 't1', projectName: 'repo', branchName: 'main' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.branch).toMatchObject({ branchName: 'main', resumed: false });
+    expect(mockSpawnBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalId: 't1', projectName: 'repo', branchName: 'main' }),
+    );
+  });
+
+  it('given a resumed spawn, returns 200', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnBranch.mockResolvedValue({ ok: true, sandboxId: 'sbx-1', resumed: true });
+    const res = await POST(req({ terminalId: 't1', projectName: 'repo', branchName: 'main' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('given no such project, returns 404', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnBranch.mockResolvedValue({ ok: false, reason: 'project_not_found' });
+    const res = await POST(req({ terminalId: 't1', projectName: 'nope', branchName: 'main' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('given a clone failure, returns 502', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnBranch.mockResolvedValue({ ok: false, reason: 'clone_failed', detail: 'fatal: repository not found' });
+    const res = await POST(req({ terminalId: 't1', projectName: 'repo', branchName: 'main' }));
+    expect(res.status).toBe(502);
+  });
+
+  it('given a missing branchName, returns 400 without checking access', async () => {
+    const res = await POST(req({ terminalId: 't1', projectName: 'repo' }));
+    expect(res.status).toBe(400);
+    expect(mockCanAccessMachine).not.toHaveBeenCalled();
+  });
+
+  it('given no terminalId, returns 400', async () => {
+    const res = await POST(req({ projectName: 'repo', branchName: 'main' }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/machines/branches', () => {
+  it('given no edit access, returns 403 without killing', async () => {
+    mockCanAccessMachine.mockResolvedValue(false);
+    const res = await DELETE(
+      new Request('https://x.test/api/machines/branches?terminalId=t1&projectName=repo&branchName=main', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockKillBranch).not.toHaveBeenCalled();
+  });
+
+  it('given the branch does not exist, returns 404', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockKillBranch.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await DELETE(
+      new Request('https://x.test/api/machines/branches?terminalId=t1&projectName=repo&branchName=main', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('given a successful kill, returns 200', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockKillBranch.mockResolvedValue({ ok: true });
+    const res = await DELETE(
+      new Request('https://x.test/api/machines/branches?terminalId=t1&projectName=repo&branchName=main', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockKillBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalId: 't1', projectName: 'repo', branchName: 'main' }),
+    );
+  });
+
+  it('given no branchName, returns 400', async () => {
+    const res = await DELETE(new Request('https://x.test/api/machines/branches?terminalId=t1&projectName=repo', { method: 'DELETE' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('given no terminalId, returns 400', async () => {
+    const res = await DELETE(new Request('https://x.test/api/machines/branches?projectName=repo&branchName=main', { method: 'DELETE' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/machines/branches/route.ts
+++ b/apps/web/src/app/api/machines/branches/route.ts
@@ -1,0 +1,141 @@
+/**
+ * Machine Branches API — the navigator UI's surface onto a Project's
+ * branch-terminals (Terminal — Workspace, Branches tier).
+ *
+ * GET    ?terminalId=&projectName=                       → list
+ * POST   { terminalId, projectName, branchName }         → spawn (provisions its OWN Sprite, clones, checks out)
+ * DELETE ?terminalId=&projectName=&branchName=           → kill (DELETEs the Sprite, drops the tracking row)
+ *
+ * Session-only (no MCP/agent tokens) — this is a human/UI surface. Every
+ * request re-checks access for the named Machine page (view-level for GET,
+ * edit-level for POST/DELETE).
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { spawnBranch, killBranch, listBranches } from '@pagespace/lib/services/machines/machine-branches';
+import {
+  buildMachineBranchesDeps,
+  canAccessMachine,
+  canViewMachine,
+  getMachineHostForBranches,
+  resolveMachineActorContext,
+} from '@/lib/machines/machine-branches-runtime';
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { ok: false, error: NextResponse.json({ error: `${field} is required` }, { status: 400 }) };
+  }
+  return { ok: true, value };
+}
+
+const SPAWN_DENIAL_STATUS: Record<string, number> = {
+  invalid_branch_name: 400,
+  kill_switch_off: 503,
+  project_not_found: 404,
+  code_execution_disabled: 503,
+  containment_unverified: 503,
+  provision_failed: 502,
+  clone_failed: 502,
+  checkout_failed: 502,
+  error: 500,
+};
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const terminalId = requireString(url.searchParams.get('terminalId'), 'terminalId');
+  if (!terminalId.ok) return terminalId.error;
+  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
+  if (!projectName.ok) return projectName.error;
+
+  if (!(await canViewMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const store = await createDbMachineBranchStore();
+  const branches = await listBranches({ terminalId: terminalId.value, projectName: projectName.value, store });
+  return NextResponse.json({
+    branches: branches.map((b) => ({ branchName: b.branchName, createdAt: b.createdAt })),
+  });
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  let body: { terminalId?: unknown; projectName?: unknown; branchName?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const terminalId = requireString(body.terminalId, 'terminalId');
+  if (!terminalId.ok) return terminalId.error;
+  const projectName = requireString(body.projectName, 'projectName');
+  if (!projectName.ok) return projectName.error;
+  const branchName = requireString(body.branchName, 'branchName');
+  if (!branchName.ok) return branchName.error;
+
+  if (!(await canAccessMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const [actor, deps] = [await resolveMachineActorContext(auth.userId), buildMachineBranchesDeps()];
+
+  const result = await spawnBranch({
+    terminalId: terminalId.value,
+    projectName: projectName.value,
+    branchName: branchName.value,
+    actor,
+    deps,
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.detail ?? result.reason, reason: result.reason },
+      { status: SPAWN_DENIAL_STATUS[result.reason] ?? 500 },
+    );
+  }
+  return NextResponse.json(
+    { branch: { branchName: branchName.value, resumed: result.resumed } },
+    { status: result.resumed ? 200 : 201 },
+  );
+}
+
+export async function DELETE(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const terminalId = requireString(url.searchParams.get('terminalId'), 'terminalId');
+  if (!terminalId.ok) return terminalId.error;
+  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
+  if (!projectName.ok) return projectName.error;
+  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
+  if (!branchName.ok) return branchName.error;
+
+  if (!(await canAccessMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const store = await createDbMachineBranchStore();
+  const host = await getMachineHostForBranches();
+  const result = await killBranch({
+    terminalId: terminalId.value,
+    projectName: projectName.value,
+    branchName: branchName.value,
+    store,
+    host,
+  });
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: result.reason === 'not_found' ? 404 : 500 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/lib/machines/machine-branches-runtime.ts
+++ b/apps/web/src/lib/machines/machine-branches-runtime.ts
@@ -1,0 +1,165 @@
+/**
+ * Production wiring for Machine Branches (Terminal — Workspace, Branches tier).
+ *
+ * Binds the provider-agnostic orchestration (`@pagespace/lib/services/machines/
+ * machine-branches`) to the real implementations. Unlike Projects (which clone
+ * onto the OWNING Machine's own persistent Sprite session), a branch-terminal
+ * is its OWN, SEPARATE Sprite — provisioned directly through the `MachineHost`
+ * seam (`createProductionMachineHost`, `apps/web/src/lib/sandbox/sprites-client.ts`),
+ * never through `acquireTerminalSandbox`/`terminal_sessions`. Real isolation
+ * between two branches of one project comes from two distinct Sprites, which
+ * requires never routing through the single page-keyed session Projects share.
+ *
+ * Every operation re-checks page access for the CURRENT actor (resume
+ * re-authz, the same invariant the Terminal sandbox lifecycle enforces).
+ */
+
+import { eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { decideFullEgressEnablement, isContainmentVerified } from '@pagespace/lib/services/sandbox/containment';
+import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/terminal-session-manager';
+import { resolveSandboxNetworkOptions } from '@pagespace/lib/services/sandbox/network-options';
+import { getConfiguredEgressIpTag } from '@pagespace/lib/services/sandbox/egress-ip';
+import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
+import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
+import { defaultBuildEnv } from '@pagespace/lib/services/sandbox/tool-runners';
+import { resolveGitHubTokenForSandbox } from '@pagespace/lib/services/sandbox/github-token';
+import { isTerminalPage } from '@pagespace/lib/content/page-types.config';
+import type { PageType } from '@pagespace/lib/utils/enums';
+import type { MachineHost } from '@pagespace/lib/services/sandbox/machine-host';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
+import { createDbMachineProjectStore } from '@pagespace/lib/services/machines/machine-projects-store';
+import type { MachineActorContext, MachineBranchesDeps } from '@pagespace/lib/services/machines/machine-branches';
+
+// The Fly Sprites driver is loaded via a DYNAMIC import, never a static one —
+// @fly/sprites is ESM-only and @pagespace/lib compiles to CJS. Mirrors the
+// same guard as machine-projects-runtime.ts / sandbox-tools-runtime.ts.
+const MIN_SANDBOX_NODE_MAJOR = 24;
+
+function assertSandboxRuntime(): void {
+  const major = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+  if (Number.isNaN(major) || major < MIN_SANDBOX_NODE_MAJOR) {
+    throw new Error(
+      `Machine sandbox access requires Node.js >= ${MIN_SANDBOX_NODE_MAJOR} ` +
+        `(the @fly/sprites SDK is Node ${MIN_SANDBOX_NODE_MAJOR}+ / ESM-only); ` +
+        `this process is Node ${process.versions.node}.`,
+    );
+  }
+}
+
+let machineHostPromise: Promise<MachineHost> | null = null;
+function getMachineHost(): Promise<MachineHost> {
+  machineHostPromise ??= (async () => {
+    assertSandboxRuntime();
+    const { createProductionMachineHost } = await import('@/lib/sandbox/sprites-client');
+    return createProductionMachineHost();
+  })().catch((error) => {
+    machineHostPromise = null;
+    throw error;
+  });
+  return machineHostPromise;
+}
+
+let branchStorePromise: ReturnType<typeof createDbMachineBranchStore> | null = null;
+function getMachineBranchStore() {
+  branchStorePromise ??= createDbMachineBranchStore();
+  return branchStorePromise;
+}
+
+let projectStorePromise: ReturnType<typeof createDbMachineProjectStore> | null = null;
+function getMachineProjectStore() {
+  projectStorePromise ??= createDbMachineProjectStore();
+  return projectStorePromise;
+}
+
+const VALID_TIERS: ReadonlySet<string> = new Set(['free', 'pro', 'founder', 'business']);
+function toTier(value: string | null | undefined): SubscriptionTier {
+  return value && VALID_TIERS.has(value) ? (value as SubscriptionTier) : 'free';
+}
+
+export async function resolveMachineActorContext(userId: string): Promise<MachineActorContext> {
+  const [user, actorInfo] = await Promise.all([
+    db.query.users.findFirst({ where: eq(users.id, userId), columns: { subscriptionTier: true } }),
+    getActorInfo(userId),
+  ]);
+  return {
+    userId,
+    tenantId: userId,
+    actorEmail: actorInfo.actorEmail,
+    actorDisplayName: actorInfo.actorDisplayName,
+    tier: toTier(user?.subscriptionTier),
+  };
+}
+
+async function findTerminalPage(terminalId: string) {
+  const page = await db.query.pages.findFirst({
+    where: eq(pages.id, terminalId),
+    columns: { type: true, driveId: true },
+  });
+  if (!page || !isTerminalPage(page.type as PageType)) return null;
+  return page;
+}
+
+/** Edit-level access (spawn/kill) — re-checked on every acquire, not cached. */
+export async function canAccessMachine(actorUserId: string, terminalId: string): Promise<boolean> {
+  const page = await findTerminalPage(terminalId);
+  if (!page) return false;
+  return canUserEditPage(actorUserId, terminalId);
+}
+
+/** View-level access (list/attach) — looser than edit-level. */
+export async function canViewMachine(actorUserId: string, terminalId: string): Promise<boolean> {
+  const page = await findTerminalPage(terminalId);
+  if (!page) return false;
+  return canUserViewPage(actorUserId, terminalId);
+}
+
+export function buildMachineBranchesDeps(): MachineBranchesDeps {
+  return {
+    store: {
+      list: async (terminalId, projectName) => (await getMachineBranchStore()).list(terminalId, projectName),
+      findByName: async (terminalId, projectName, branchName) =>
+        (await getMachineBranchStore()).findByName(terminalId, projectName, branchName),
+      create: async (input) => (await getMachineBranchStore()).create(input),
+      updateSandboxId: async (input) => (await getMachineBranchStore()).updateSandboxId(input),
+      remove: async (terminalId, projectName, branchName) =>
+        (await getMachineBranchStore()).remove(terminalId, projectName, branchName),
+    },
+    projectStore: {
+      findByName: async (terminalId, name) => (await getMachineProjectStore()).findByName(terminalId, name),
+    },
+    isEnabled: isCodeExecutionEnabled,
+    now: () => new Date(),
+    host: {
+      provision: async (args) => (await getMachineHost()).provision(args),
+      attach: async (args) => (await getMachineHost()).attach(args),
+      kill: async (args) => (await getMachineHost()).kill(args),
+    },
+    substrate: { kind: 'sprite' },
+    options: resolveSandboxNetworkOptions({ surface: 'terminal', egressIpTag: getConfiguredEgressIpTag() }),
+    secret: getSandboxSessionSecret(),
+    checkFullEgressEnablement: async () =>
+      decideFullEgressEnablement({
+        adminGateEnabled: isCodeExecutionEnabled(),
+        containment: isContainmentVerified() ? { contained: true } : null,
+      }),
+    resolveGitHubToken: (userId) => resolveGitHubTokenForSandbox({ userId, db }),
+    quota: {
+      acquireSlot: acquireCodeExecutionSlot,
+      releaseSlot: releaseCodeExecutionSlot,
+    },
+    buildEnv: defaultBuildEnv,
+    audit: (input) => writeCodeExecutionAudit({ input }),
+  };
+}
+
+/** The raw `MachineHost`, for `attachBranch`/`killBranch` which don't need the full spawn deps. */
+export async function getMachineHostForBranches(): Promise<MachineHost> {
+  return getMachineHost();
+}

--- a/apps/web/src/lib/sandbox/sprites-client.ts
+++ b/apps/web/src/lib/sandbox/sprites-client.ts
@@ -20,6 +20,7 @@ import {
 import { createSpriteMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-machine-host';
 import { createExecClientFromMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/machine-host-adapter';
 import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/types';
+import type { MachineHost } from '@pagespace/lib/services/sandbox/machine-host';
 
 let cachedSdk: SpritesSdk | null = null;
 
@@ -36,11 +37,19 @@ async function getSpritesSDK(): Promise<SpritesSdk> {
 }
 
 export async function createProductionSpritesSandboxClient(): Promise<ExecSandboxClient> {
+  const host = await createProductionMachineHost();
+  return createExecClientFromMachineHost(host, { kind: 'sprite' });
+}
+
+/**
+ * The raw `MachineHost` (not re-adapted back to `ExecSandboxClient`), for
+ * callers that provision/attach/kill Sprites directly rather than through a
+ * page-keyed persistent session — e.g. the Branches tier
+ * (`services/machines/machine-branches.ts`), where each branch-terminal is
+ * its OWN Sprite, addressed by its own derived session key.
+ */
+export async function createProductionMachineHost(): Promise<MachineHost> {
   const sdk = await getSpritesSDK();
   const client = createSpritesSandboxClient({ sdk });
-  // Route through the MachineHost seam (Terminal Epic 2, T2.1) rather than
-  // handing the raw Sprite client straight to callers — the adapter re-expresses
-  // it as the same ExecSandboxClient shape, so nothing downstream changes.
-  const host = createSpriteMachineHost({ sdk, client });
-  return createExecClientFromMachineHost(host, { kind: 'sprite' });
+  return createSpriteMachineHost({ sdk, client });
 }

--- a/packages/db/drizzle/0186_empty_the_watchers.sql
+++ b/packages/db/drizzle/0186_empty_the_watchers.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS "machine_branches" (
+	"id" text PRIMARY KEY NOT NULL,
+	"ownerId" text NOT NULL,
+	"terminalId" text NOT NULL,
+	"projectName" text NOT NULL,
+	"branchName" text NOT NULL,
+	"sessionKey" text NOT NULL,
+	"sandboxId" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp NOT NULL,
+	CONSTRAINT "machine_branches_sessionKey_unique" UNIQUE("sessionKey")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "machine_branches" ADD CONSTRAINT "machine_branches_ownerId_users_id_fk" FOREIGN KEY ("ownerId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "machine_branches" ADD CONSTRAINT "machine_branches_terminalId_pages_id_fk" FOREIGN KEY ("terminalId") REFERENCES "public"."pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "machine_branches_terminal_id_idx" ON "machine_branches" USING btree ("terminalId");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "machine_branches_terminal_project_branch_idx" ON "machine_branches" USING btree ("terminalId","projectName","branchName");

--- a/packages/db/drizzle/meta/0185_snapshot.json
+++ b/packages/db/drizzle/meta/0185_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "bdb82f18-fdff-4d35-98cc-74b8efb1d22e",
+  "id": "667608d3-410b-4cf3-beb6-bf86d33eb2db",
   "prevId": "4b65b843-b281-4366-b4e8-6abe5c4a4c3f",
   "version": "7",
   "dialect": "postgresql",
@@ -15999,13 +15999,6 @@
           "notNull": true,
           "default": "now()"
         },
-        "storageLastBilledAt": {
-          "name": "storageLastBilledAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
         "createdAt": {
           "name": "createdAt",
           "type": "timestamp",
@@ -18478,6 +18471,149 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {}
+    },
+    "public.machine_branches": {
+      "name": "machine_branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminalId": {
+          "name": "terminalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_branches_terminal_id_idx": {
+          "name": "machine_branches_terminal_id_idx",
+          "columns": [
+            {
+              "expression": "terminalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_branches_terminal_project_branch_idx": {
+          "name": "machine_branches_terminal_project_branch_idx",
+          "columns": [
+            {
+              "expression": "terminalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branchName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_branches_ownerId_users_id_fk": {
+          "name": "machine_branches_ownerId_users_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_branches_terminalId_pages_id_fk": {
+          "name": "machine_branches_terminalId_pages_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "terminalId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_branches_sessionKey_unique": {
+          "name": "machine_branches_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
     }
   },
   "enums": {

--- a/packages/db/drizzle/meta/0186_snapshot.json
+++ b/packages/db/drizzle/meta/0186_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "bdb82f18-fdff-4d35-98cc-74b8efb1d22e",
-  "prevId": "4b65b843-b281-4366-b4e8-6abe5c4a4c3f",
+  "id": "915b16c4-6afc-4899-83c3-2425c9f12dad",
+  "prevId": "bdb82f18-fdff-4d35-98cc-74b8efb1d22e",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -18478,6 +18478,149 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {}
+    },
+    "public.machine_branches": {
+      "name": "machine_branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminalId": {
+          "name": "terminalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_branches_terminal_id_idx": {
+          "name": "machine_branches_terminal_id_idx",
+          "columns": [
+            {
+              "expression": "terminalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_branches_terminal_project_branch_idx": {
+          "name": "machine_branches_terminal_project_branch_idx",
+          "columns": [
+            {
+              "expression": "terminalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branchName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_branches_ownerId_users_id_fk": {
+          "name": "machine_branches_ownerId_users_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_branches_terminalId_pages_id_fk": {
+          "name": "machine_branches_terminalId_pages_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "terminalId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_branches_sessionKey_unique": {
+          "name": "machine_branches_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
     }
   },
   "enums": {

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1300,8 +1300,15 @@
     {
       "idx": 185,
       "version": "7",
-      "when": 1783337961184,
-      "tag": "0185_empty_frightful_four",
+      "when": 1783338155352,
+      "tag": "0185_sour_gamma_corps",
+      "breakpoints": true
+    },
+    {
+      "idx": 186,
+      "version": "7",
+      "when": 1783339634383,
+      "tag": "0186_empty_the_watchers",
       "breakpoints": true
     }
   ]

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1300,8 +1300,8 @@
     {
       "idx": 185,
       "version": "7",
-      "when": 1783338155352,
-      "tag": "0185_sour_gamma_corps",
+      "when": 1783337961184,
+      "tag": "0185_empty_frightful_four",
       "breakpoints": true
     }
   ]

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,6 +35,10 @@
       "types": "./dist/schema/machine-projects.d.ts",
       "default": "./dist/schema/machine-projects.js"
     },
+    "./schema/machine-branches": {
+      "types": "./dist/schema/machine-branches.d.ts",
+      "default": "./dist/schema/machine-branches.js"
+    },
     "./schema/share-links": {
       "types": "./dist/schema/share-links.d.ts",
       "default": "./dist/schema/share-links.js"

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -51,6 +51,7 @@ export * from './schema/incidents';
 export * from './schema/data-subject-requests';
 export * from './schema/oauth';
 export * from './schema/machine-projects';
+export * from './schema/machine-branches';
 
 import * as auth from './schema/auth';
 import * as sessions from './schema/sessions';
@@ -105,6 +106,7 @@ import * as incidents from './schema/incidents';
 import * as dataSubjectRequests from './schema/data-subject-requests';
 import * as oauth from './schema/oauth';
 import * as machineProjects from './schema/machine-projects';
+import * as machineBranches from './schema/machine-branches';
 
 export const schema = {
   ...auth,
@@ -160,4 +162,5 @@ export const schema = {
   ...dataSubjectRequests,
   ...oauth,
   ...machineProjects,
+  ...machineBranches,
 };

--- a/packages/db/src/schema/machine-branches.ts
+++ b/packages/db/src/schema/machine-branches.ts
@@ -1,0 +1,69 @@
+import { pgTable, text, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { createId } from '@paralleldrive/cuid2';
+import { users } from './auth';
+import { pages } from './core';
+
+/**
+ * Machine Branches
+ *
+ * The "Branches" tier of the Terminal workspace navigator (Machine → Projects
+ * → Branches). A branch-terminal is an isolated checked-out branch of a
+ * Project (`machine_projects`) — but UNLIKE a Project, it is NOT cloned onto
+ * the owning Machine's own filesystem. Each branch-terminal gets its OWN,
+ * SEPARATE Sprite (see services/machines/branch-session.ts /
+ * machine-branches.ts): on Sprites the container IS the Sprite, so real
+ * isolation between two branches of the same project means two distinct
+ * Sprites, never a shared filesystem.
+ *
+ * Addressed by (terminalId, projectName, branchName) — the same
+ * (terminalId, name) identity Projects already use, rather than a
+ * project-row id FK, so this stays consistent with how `machine_projects` is
+ * looked up everywhere else and needs no join to resolve a project's
+ * `repoUrl` before cloning. `sessionKey` is the opaque HMAC name this
+ * branch's Sprite is provisioned under (`deriveBranchSessionKey`) — unique
+ * per row, and distinct per branch, so two branches never resolve to the
+ * same underlying Sprite. `sandboxId` is that Sprite's id, used to
+ * reconnect/kill it directly through the MachineHost seam.
+ */
+export const machineBranches = pgTable('machine_branches', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+
+  ownerId: text('ownerId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+
+  terminalId: text('terminalId')
+    .notNull()
+    .references(() => pages.id, { onDelete: 'cascade' }),
+
+  projectName: text('projectName').notNull(),
+  branchName: text('branchName').notNull(),
+
+  sessionKey: text('sessionKey').notNull().unique(),
+  sandboxId: text('sandboxId').notNull(),
+
+  createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
+  updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
+}, (table) => ({
+  terminalIdIdx: index('machine_branches_terminal_id_idx').on(table.terminalId),
+  terminalProjectBranchUnique: uniqueIndex('machine_branches_terminal_project_branch_idx').on(
+    table.terminalId,
+    table.projectName,
+    table.branchName,
+  ),
+}));
+
+export const machineBranchesRelations = relations(machineBranches, ({ one }) => ({
+  owner: one(users, {
+    fields: [machineBranches.ownerId],
+    references: [users.id],
+  }),
+  terminal: one(pages, {
+    fields: [machineBranches.terminalId],
+    references: [pages.id],
+  }),
+}));
+
+export type MachineBranch = typeof machineBranches.$inferSelect;
+export type NewMachineBranch = typeof machineBranches.$inferInsert;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -477,6 +477,21 @@
       "import": "./dist/services/machines/machine-projects.js",
       "require": "./dist/services/machines/machine-projects.js"
     },
+    "./services/machines/branch-session": {
+      "types": "./dist/services/machines/branch-session.d.ts",
+      "import": "./dist/services/machines/branch-session.js",
+      "require": "./dist/services/machines/branch-session.js"
+    },
+    "./services/machines/machine-branches-store": {
+      "types": "./dist/services/machines/machine-branches-store.d.ts",
+      "import": "./dist/services/machines/machine-branches-store.js",
+      "require": "./dist/services/machines/machine-branches-store.js"
+    },
+    "./services/machines/machine-branches": {
+      "types": "./dist/services/machines/machine-branches.d.ts",
+      "import": "./dist/services/machines/machine-branches.js",
+      "require": "./dist/services/machines/machine-branches.js"
+    },
     "./services/sandbox/tool-gate": {
       "types": "./dist/services/sandbox/tool-gate.d.ts",
       "import": "./dist/services/sandbox/tool-gate.js",
@@ -1481,6 +1496,15 @@
       ],
       "services/machines/machine-projects": [
         "./dist/services/machines/machine-projects.d.ts"
+      ],
+      "services/machines/branch-session": [
+        "./dist/services/machines/branch-session.d.ts"
+      ],
+      "services/machines/machine-branches-store": [
+        "./dist/services/machines/machine-branches-store.d.ts"
+      ],
+      "services/machines/machine-branches": [
+        "./dist/services/machines/machine-branches.d.ts"
       ],
       "services/sandbox/sandbox-client/types": [
         "./dist/services/sandbox/sandbox-client/types.d.ts"

--- a/packages/lib/src/services/machines/__tests__/branch-session.test.ts
+++ b/packages/lib/src/services/machines/__tests__/branch-session.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { deriveBranchSessionKey, isValidBranchName } from '../branch-session';
+
+const base = {
+  tenantId: 'tenant-1',
+  terminalId: 'terminal-1',
+  projectName: 'my-repo',
+  branchName: 'main',
+  secret: 'a'.repeat(32),
+};
+
+describe('deriveBranchSessionKey', () => {
+  it('given the same inputs, should be deterministic', () => {
+    expect(deriveBranchSessionKey(base)).toBe(deriveBranchSessionKey(base));
+  });
+
+  it('given two different branch names, should derive two DIFFERENT session keys', () => {
+    const a = deriveBranchSessionKey({ ...base, branchName: 'feature-a' });
+    const b = deriveBranchSessionKey({ ...base, branchName: 'feature-b' });
+    expect(a).not.toBe(b);
+  });
+
+  it('given two different projects on the same machine, should derive two different session keys', () => {
+    const a = deriveBranchSessionKey({ ...base, projectName: 'repo-a' });
+    const b = deriveBranchSessionKey({ ...base, projectName: 'repo-b' });
+    expect(a).not.toBe(b);
+  });
+
+  it('given two different machines, should derive two different session keys', () => {
+    const a = deriveBranchSessionKey({ ...base, terminalId: 'terminal-1' });
+    const b = deriveBranchSessionKey({ ...base, terminalId: 'terminal-2' });
+    expect(a).not.toBe(b);
+  });
+
+  it('given an empty secret, should throw rather than derive an unkeyed value', () => {
+    expect(() => deriveBranchSessionKey({ ...base, secret: '' })).toThrow(/non-empty secret/);
+  });
+
+  it('should produce an opaque, namespaced key', () => {
+    expect(deriveBranchSessionKey(base)).toMatch(/^pgs-brn-[0-9a-f]{64}$/);
+  });
+});
+
+describe('isValidBranchName', () => {
+  it.each(['main', 'feature/foo', 'fix-123', 'release/1.2.3', 'a', 'a_b-c.d'])(
+    'given a well-formed branch name %s, should accept',
+    (name) => {
+      expect(isValidBranchName(name)).toBe(true);
+    },
+  );
+
+  it.each([
+    '',
+    '../etc',
+    'a..b',
+    '.hidden',
+    'feature/.hidden',
+    'a/./b',
+    'a//b',
+    'a.lock',
+    'feature/a.lock',
+    '/leading-slash',
+    'trailing-slash/',
+    'trailing-dot.',
+    'has space',
+    'a~b',
+    'a^b',
+    'a:b',
+    'a?b',
+    'a*b',
+    'a[b',
+    'a\\b',
+    'a'.repeat(201),
+  ])('given a malformed branch name %s, should reject', (name) => {
+    expect(isValidBranchName(name)).toBe(false);
+  });
+});

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -10,6 +10,7 @@ import {
   type MachineBranchProjectLookup,
 } from '../machine-branches';
 import type { MachineBranchStore, MachineBranchRecord } from '../machine-branches-store';
+import { deriveBranchSessionKey } from '../branch-session';
 import type { MachineHost, MachineHandle } from '../../sandbox/machine-host';
 import type { RunCommandArgs, SandboxRunResult } from '../../sandbox/sandbox-client/types';
 import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
@@ -56,10 +57,15 @@ function makeStore(seed: MachineBranchRecord[] = []) {
       rows.set(k, row);
       return row;
     },
-    updateSandboxId: async ({ id, sandboxId, now }) => {
+    updateSandboxId: async ({ id, previousSandboxId, sandboxId, now }) => {
       for (const [k, row] of rows) {
-        if (row.id === id) rows.set(k, { ...row, sandboxId, updatedAt: now });
+        if (row.id === id) {
+          if (row.sandboxId !== previousSandboxId) return false;
+          rows.set(k, { ...row, sandboxId, updatedAt: now });
+          return true;
+        }
       }
+      return false;
     },
     remove: async (terminalId, projectName, branchName) => {
       rows.delete(key(terminalId, projectName, branchName));
@@ -254,6 +260,117 @@ describe('spawnBranch', () => {
     expect(result).toMatchObject({ ok: false, reason: 'clone_failed' });
     expect(killCalls).toHaveLength(1);
     expect(await store.list(TERMINAL_ID, PROJECT_NAME)).toEqual([]);
+  });
+
+  it('given clone fails because a concurrent spawn already committed the SAME shared Sprite, should NOT kill it and should report resumed', async () => {
+    // MachineHost.provision is name-keyed/idempotent — two concurrent
+    // spawnBranch calls for the same new branch can both resolve to the SAME
+    // physical Sprite. Simulate that here: the moment OUR clone runs, a
+    // "concurrent" call has already recorded THIS SAME Sprite (state.machineId)
+    // as the winning row, so our own clone fails as redundant (e.g. the
+    // destination directory already exists).
+    const { store } = makeStore();
+    const { host, killCalls } = makeFakeHost((state, args) => {
+      if (args.cmd === 'git' && args.args?.[0] === 'clone') {
+        void store.create({
+          ownerId: 'other-user',
+          terminalId: TERMINAL_ID,
+          projectName: PROJECT_NAME,
+          branchName: 'main',
+          sessionKey: deriveBranchSessionKey({
+            tenantId: actor.tenantId,
+            terminalId: TERMINAL_ID,
+            projectName: PROJECT_NAME,
+            branchName: 'main',
+            secret: SECRET,
+          }),
+          sandboxId: state.machineId,
+          now: NOW,
+        });
+        return { exitCode: 128, stdout: '', stderr: 'fatal: destination path already exists' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const { deps } = makeDeps({ host, store });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.resumed).toBe(true);
+    // The shared Sprite must NOT have been killed — that would destroy the
+    // concurrent winner's already-tracked, live branch-terminal.
+    expect(killCalls).toHaveLength(0);
+    expect((await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main'))?.sandboxId).toBe(result.sandboxId);
+  });
+
+  it('given the unique-violation race with a genuinely DIFFERENT winning Sprite, should kill its own redundant Sprite and return the winner\'s', async () => {
+    const store = makeStore().store;
+    const { host, killCalls, provisionCalls } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'git' && args.args?.[0] === 'checkout' && args.args?.includes('origin/main')) {
+        // Simulate a concurrent spawnBranch call finishing first on its OWN,
+        // genuinely independent Sprite (not the one we hold).
+        void store.create({
+          ownerId: 'other-user',
+          terminalId: TERMINAL_ID,
+          projectName: PROJECT_NAME,
+          branchName: 'main',
+          sessionKey: deriveBranchSessionKey({
+            tenantId: actor.tenantId,
+            terminalId: TERMINAL_ID,
+            projectName: PROJECT_NAME,
+            branchName: 'main',
+            secret: SECRET,
+          }),
+          sandboxId: 'sbx-other-winner',
+          now: NOW,
+        });
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const { deps } = makeDeps({ host, store });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result).toEqual({ ok: true, sandboxId: 'sbx-other-winner', resumed: true });
+    // Our own redundant Sprite is killed, but NEVER the winner's.
+    expect(provisionCalls).toHaveLength(1);
+    expect(killCalls).toHaveLength(1);
+    expect(killCalls).not.toContain('sbx-other-winner');
+  });
+
+  it('given a concurrent re-provision-after-vanish race, should not overwrite the winner\'s row and should kill its own redundant Sprite', async () => {
+    let armed = false;
+    let raceRowId = '';
+    let racePreviousSandboxId = '';
+    const { host, killCalls } = makeFakeHost((_state, args) => {
+      if (armed && args.cmd === 'git' && args.args?.[0] === 'clone') {
+        armed = false;
+        // Simulate a truly concurrent racer winning the re-provision update
+        // for the SAME vanished branch just before we do.
+        void store.updateSandboxId({
+          id: raceRowId,
+          previousSandboxId: racePreviousSandboxId,
+          sandboxId: 'sbx-concurrent-winner',
+          now: NOW,
+        });
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const { deps, store } = makeDeps({ host });
+
+    const first = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!first.ok) throw new Error('expected ok');
+    const before = await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main');
+    if (!before) throw new Error('expected row');
+    await host.kill({ machineId: first.sandboxId });
+
+    raceRowId = before.id;
+    racePreviousSandboxId = before.sandboxId;
+    armed = true;
+
+    const second = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(second).toEqual({ ok: true, sandboxId: 'sbx-concurrent-winner', resumed: true });
+    // Our own re-provisioned (now-redundant) Sprite is killed; the winner's never is.
+    expect(killCalls).not.toContain('sbx-concurrent-winner');
   });
 
   it('given the branch does not exist upstream, should fall back to creating a fresh local branch', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -1,0 +1,489 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planSpawnBranch,
+  spawnBranch,
+  attachBranch,
+  killBranch,
+  listBranches,
+  BRANCH_REPO_PATH,
+  type MachineBranchesDeps,
+  type MachineBranchProjectLookup,
+} from '../machine-branches';
+import type { MachineBranchStore, MachineBranchRecord } from '../machine-branches-store';
+import type { MachineHost, MachineHandle } from '../../sandbox/machine-host';
+import type { RunCommandArgs, SandboxRunResult } from '../../sandbox/sandbox-client/types';
+import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
+
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+const TERMINAL_ID = 'terminal-1';
+const PROJECT_NAME = 'my-repo';
+const REPO_URL = 'https://github.com/o/r.git';
+const SECRET = 'a'.repeat(32);
+
+const actor = {
+  userId: 'user-1',
+  tenantId: 'user-1',
+  actorEmail: 'user-1@example.com',
+  tier: 'pro' as const,
+};
+
+function makeStore(seed: MachineBranchRecord[] = []) {
+  const rows = new Map<string, MachineBranchRecord>();
+  const key = (terminalId: string, projectName: string, branchName: string) => `${terminalId}\0${projectName}\0${branchName}`;
+  for (const row of seed) rows.set(key(row.terminalId, row.projectName, row.branchName), row);
+  let counter = 0;
+  const store: MachineBranchStore = {
+    list: async (terminalId, projectName) =>
+      [...rows.values()].filter((r) => r.terminalId === terminalId && r.projectName === projectName),
+    findByName: async (terminalId, projectName, branchName) => rows.get(key(terminalId, projectName, branchName)) ?? null,
+    create: async (input) => {
+      const k = key(input.terminalId, input.projectName, input.branchName);
+      if (rows.has(k)) {
+        throw Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
+      }
+      counter += 1;
+      const row: MachineBranchRecord = {
+        id: `branch-${counter}`,
+        ownerId: input.ownerId,
+        terminalId: input.terminalId,
+        projectName: input.projectName,
+        branchName: input.branchName,
+        sessionKey: input.sessionKey,
+        sandboxId: input.sandboxId,
+        createdAt: input.now,
+        updatedAt: input.now,
+      };
+      rows.set(k, row);
+      return row;
+    },
+    updateSandboxId: async ({ id, sandboxId, now }) => {
+      for (const [k, row] of rows) {
+        if (row.id === id) rows.set(k, { ...row, sandboxId, updatedAt: now });
+      }
+    },
+    remove: async (terminalId, projectName, branchName) => {
+      rows.delete(key(terminalId, projectName, branchName));
+    },
+  };
+  return { store, rows };
+}
+
+function makeProjectStore(repoUrl: string | null = REPO_URL): MachineBranchProjectLookup {
+  return {
+    findByName: async () => (repoUrl ? { repoUrl } : null),
+  };
+}
+
+interface SpriteState {
+  machineId: string;
+  execLog: RunCommandArgs[];
+  files: Map<string, string>;
+}
+
+/**
+ * A fake `MachineHost` that gives each provisioned NAME its own independent
+ * in-memory Sprite state (exec log + filesystem) — modeling the real
+ * contract: `provision` auto-resumes by name (same name -> same Sprite), and
+ * two DIFFERENT names never share state. This is what proves the isolation
+ * acceptance criterion below: two branches provisioned under two different
+ * derived session keys get two completely independent "filesystems".
+ */
+function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => SandboxRunResult) {
+  const byName = new Map<string, SpriteState>();
+  const byId = new Map<string, SpriteState>();
+  const provisionCalls: string[] = [];
+  const killCalls: string[] = [];
+  let counter = 0;
+
+  function makeHandle(state: SpriteState): MachineHandle {
+    return {
+      machineId: state.machineId,
+      exec: async (args) => {
+        state.execLog.push(args);
+        return execImpl ? execImpl(state, args) : { exitCode: 0, stdout: '', stderr: '' };
+      },
+      writeFiles: async (files) => {
+        for (const f of files) state.files.set(f.path, String(f.content));
+      },
+      readFile: async ({ path }) => {
+        const content = state.files.get(path);
+        return content === undefined ? null : Buffer.from(content);
+      },
+      stream: async () => {
+        throw new Error('not used by machine-branches');
+      },
+      listStreams: async () => [],
+    };
+  }
+
+  const host: MachineHost = {
+    provision: async ({ name }) => {
+      provisionCalls.push(name);
+      let state = byName.get(name);
+      if (!state) {
+        counter += 1;
+        state = { machineId: `sbx-${counter}`, execLog: [], files: new Map() };
+        byName.set(name, state);
+        byId.set(state.machineId, state);
+      }
+      return makeHandle(state);
+    },
+    attach: async ({ machineId }) => {
+      const state = byId.get(machineId);
+      return state ? makeHandle(state) : null;
+    },
+    kill: async ({ machineId }) => {
+      killCalls.push(machineId);
+      const state = byId.get(machineId);
+      if (state) {
+        byId.delete(machineId);
+        for (const [name, s] of byName) if (s === state) byName.delete(name);
+      }
+    },
+  };
+  return { host, byName, byId, provisionCalls, killCalls };
+}
+
+function makeDeps(overrides: Partial<MachineBranchesDeps> = {}, storeSeed: MachineBranchRecord[] = []) {
+  const { store } = makeStore(storeSeed);
+  const { host } = makeFakeHost();
+  const auditCalls: unknown[] = [];
+  const deps: MachineBranchesDeps = {
+    store,
+    projectStore: makeProjectStore(),
+    isEnabled: () => true,
+    now: () => NOW,
+    host,
+    substrate: { kind: 'sprite' },
+    options: {},
+    secret: SECRET,
+    checkFullEgressEnablement: async () => ({ ok: true }),
+    resolveGitHubToken: async () => 'ghp_secret_token',
+    quota: { acquireSlot: () => true, releaseSlot: () => {} },
+    buildEnv: () => ({ NODE_ENV: 'test' }),
+    audit: async (input) => {
+      auditCalls.push(input);
+    },
+    ...overrides,
+  };
+  return { deps, store, host, auditCalls };
+}
+
+describe('planSpawnBranch', () => {
+  it('given a valid branch name, should accept', () => {
+    expect(planSpawnBranch({ branchName: 'feature/foo' })).toEqual({ ok: true });
+  });
+
+  it('given an invalid branch name, should reject', () => {
+    expect(planSpawnBranch({ branchName: '../etc' })).toEqual({ ok: false, reason: 'invalid_branch_name' });
+  });
+});
+
+describe('spawnBranch', () => {
+  it('given a valid spawn, should provision exactly one Sprite, clone the repo, checkout the branch off origin, and persist the row', async () => {
+    const { host, provisionCalls, byId } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+
+    expect(result).toMatchObject({ ok: true, resumed: false });
+    if (!result.ok) throw new Error('expected ok');
+    expect(provisionCalls).toHaveLength(1);
+
+    const row = await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main');
+    expect(row).toMatchObject({ sandboxId: result.sandboxId, branchName: 'main', projectName: PROJECT_NAME });
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.execLog).toEqual([
+      { cmd: 'git', args: ['clone', REPO_URL, BRANCH_REPO_PATH], cwd: SANDBOX_ROOT, env: expect.any(Object), timeoutMs: expect.any(Number), maxBytes: expect.any(Number) },
+      { cmd: 'git', args: ['checkout', '-b', 'main', 'origin/main'], cwd: BRANCH_REPO_PATH, env: expect.any(Object), timeoutMs: expect.any(Number), maxBytes: expect.any(Number) },
+    ]);
+    // Token is injected into env for these commands only, never persisted.
+    expect(state?.execLog[0]?.env).toMatchObject({ GH_TOKEN: 'ghp_secret_token', GITHUB_TOKEN: 'ghp_secret_token' });
+  });
+
+  it('given the kill switch is off, should refuse without touching the host', async () => {
+    const { host, provisionCalls } = makeFakeHost();
+    const { deps } = makeDeps({ host, isEnabled: () => false });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result).toEqual({ ok: false, reason: 'kill_switch_off' });
+    expect(provisionCalls).toHaveLength(0);
+  });
+
+  it('given an invalid branch name, should refuse before looking up the project', async () => {
+    let lookedUp = false;
+    const { deps } = makeDeps({
+      projectStore: {
+        findByName: async () => {
+          lookedUp = true;
+          return { repoUrl: REPO_URL };
+        },
+      },
+    });
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: '../etc', actor, deps });
+    expect(result).toEqual({ ok: false, reason: 'invalid_branch_name' });
+    expect(lookedUp).toBe(false);
+  });
+
+  it('given no such project on this machine, should refuse', async () => {
+    const { deps } = makeDeps({ projectStore: makeProjectStore(null) });
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: 'nope', branchName: 'main', actor, deps });
+    expect(result).toEqual({ ok: false, reason: 'project_not_found' });
+  });
+
+  it('given containment is unverified, should refuse without provisioning', async () => {
+    const { host, provisionCalls } = makeFakeHost();
+    const { deps } = makeDeps({ host, checkFullEgressEnablement: async () => ({ ok: false, reason: 'containment_unverified' }) });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result).toEqual({ ok: false, reason: 'containment_unverified' });
+    expect(provisionCalls).toHaveLength(0);
+  });
+
+  it('given git clone fails, should kill the freshly provisioned Sprite and not persist a row', async () => {
+    const { host, killCalls } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'git' && args.args?.[0] === 'clone') {
+        return { exitCode: 128, stdout: '', stderr: 'fatal: repository not found' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const { deps, store } = makeDeps({ host });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result).toMatchObject({ ok: false, reason: 'clone_failed' });
+    expect(killCalls).toHaveLength(1);
+    expect(await store.list(TERMINAL_ID, PROJECT_NAME)).toEqual([]);
+  });
+
+  it('given the branch does not exist upstream, should fall back to creating a fresh local branch', async () => {
+    const checkoutAttempts: (string[] | undefined)[] = [];
+    const { host } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'git' && args.args?.[0] === 'checkout') {
+        checkoutAttempts.push(args.args);
+        if (args.args?.includes('origin/feature-new')) {
+          return { exitCode: 1, stdout: '', stderr: "fatal: 'origin/feature-new' is not a commit" };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const { deps } = makeDeps({ host });
+
+    const result = await spawnBranch({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: 'feature-new',
+      actor,
+      deps,
+    });
+    expect(result.ok).toBe(true);
+    expect(checkoutAttempts).toEqual([
+      ['checkout', '-b', 'feature-new', 'origin/feature-new'],
+      ['checkout', '-b', 'feature-new'],
+    ]);
+  });
+
+  it('given both checkout attempts fail, should report checkout_failed and kill the Sprite', async () => {
+    const { host, killCalls } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'git' && args.args?.[0] === 'checkout') {
+        return { exitCode: 1, stdout: '', stderr: 'checkout failed' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const { deps, store } = makeDeps({ host });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result).toMatchObject({ ok: false, reason: 'checkout_failed' });
+    expect(killCalls).toHaveLength(1);
+    expect(await store.list(TERMINAL_ID, PROJECT_NAME)).toEqual([]);
+  });
+
+  it('given an already-spawned branch with a live Sprite, should resume without re-cloning', async () => {
+    const { host, provisionCalls } = makeFakeHost();
+    const { deps } = makeDeps({ host });
+
+    const first = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(first).toMatchObject({ ok: true, resumed: false });
+
+    const second = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(second).toMatchObject({ ok: true, resumed: true });
+    if (!first.ok || !second.ok) throw new Error('expected ok');
+    expect(second.sandboxId).toBe(first.sandboxId);
+    // Only ONE provision call — resume reattaches instead of re-provisioning.
+    expect(provisionCalls).toHaveLength(1);
+  });
+
+  it('given a tracked branch whose Sprite has vanished, should re-provision under the SAME session key', async () => {
+    const { host, provisionCalls } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+
+    const first = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!first.ok) throw new Error('expected ok');
+
+    const before = await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main');
+    // Simulate the Sprite vanishing (reaped) without going through killBranch.
+    await host.kill({ machineId: first.sandboxId });
+
+    const second = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(second).toMatchObject({ ok: true, resumed: false });
+    if (!second.ok) throw new Error('expected ok');
+
+    const after = await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main');
+    expect(after?.sessionKey).toBe(before?.sessionKey);
+    expect(after?.sandboxId).toBe(second.sandboxId);
+    expect(provisionCalls).toEqual([before?.sessionKey, before?.sessionKey]);
+  });
+
+  it('given no GitHub token available (public repo), should still clone without token env vars', async () => {
+    const { host, byId } = makeFakeHost();
+    const { deps } = makeDeps({ host, resolveGitHubToken: async () => null });
+
+    const result = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    const state = byId.get(result.sandboxId);
+    expect(state?.execLog[0]?.env).not.toHaveProperty('GH_TOKEN');
+    expect(state?.execLog[0]?.env).not.toHaveProperty('GITHUB_TOKEN');
+  });
+});
+
+describe('spawnBranch — isolation between two branches of one project', () => {
+  it('should provision two DIFFERENT Sprites under two different session keys', async () => {
+    const { host, provisionCalls } = makeFakeHost();
+    const { deps } = makeDeps({ host });
+
+    const a = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'branch-a', actor, deps });
+    const b = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'branch-b', actor, deps });
+    if (!a.ok || !b.ok) throw new Error('expected both spawns to succeed');
+
+    expect(a.sandboxId).not.toBe(b.sandboxId);
+    expect(provisionCalls).toHaveLength(2);
+    expect(new Set(provisionCalls).size).toBe(2);
+  });
+
+  it("a file written into branch A's Sprite must be ABSENT from branch B's Sprite (no shared filesystem)", async () => {
+    const { host } = makeFakeHost();
+    const { deps } = makeDeps({ host });
+
+    const a = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'branch-a', actor, deps });
+    const b = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'branch-b', actor, deps });
+    if (!a.ok || !b.ok) throw new Error('expected both spawns to succeed');
+
+    const handleA = await host.attach({ machineId: a.sandboxId });
+    const handleB = await host.attach({ machineId: b.sandboxId });
+    if (!handleA || !handleB) throw new Error('expected both handles to be live');
+
+    await handleA.writeFiles([{ path: `${BRANCH_REPO_PATH}/MARKER`, content: 'only-in-branch-a' }]);
+
+    expect((await handleA.readFile({ path: `${BRANCH_REPO_PATH}/MARKER` }))?.toString('utf8')).toBe('only-in-branch-a');
+    expect(await handleB.readFile({ path: `${BRANCH_REPO_PATH}/MARKER` })).toBeNull();
+  });
+
+  it("each branch's clone+checkout only ever runs against its OWN Sprite's exec log", async () => {
+    const { host, byId } = makeFakeHost();
+    const { deps } = makeDeps({ host });
+
+    const a = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'branch-a', actor, deps });
+    const b = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'branch-b', actor, deps });
+    if (!a.ok || !b.ok) throw new Error('expected both spawns to succeed');
+
+    const stateA = byId.get(a.sandboxId);
+    const stateB = byId.get(b.sandboxId);
+
+    expect(stateA?.execLog.some((c) => c.args?.includes('branch-a'))).toBe(true);
+    expect(stateA?.execLog.some((c) => c.args?.includes('branch-b'))).toBe(false);
+    expect(stateB?.execLog.some((c) => c.args?.includes('branch-b'))).toBe(true);
+    expect(stateB?.execLog.some((c) => c.args?.includes('branch-a'))).toBe(false);
+  });
+});
+
+describe('attachBranch', () => {
+  it('given an existing, live branch, should reattach to its Sprite', async () => {
+    const { host } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+    const spawned = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!spawned.ok) throw new Error('expected ok');
+
+    const result = await attachBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', store, host });
+    expect(result).toEqual({ ok: true, sandboxId: spawned.sandboxId });
+  });
+
+  it('given no tracked branch, should return not_found', async () => {
+    const { host } = makeFakeHost();
+    const { store } = makeDeps({ host });
+    const result = await attachBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'nope', store, host });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('given a tracked branch whose Sprite has vanished, should return vanished', async () => {
+    const { host } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+    const spawned = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!spawned.ok) throw new Error('expected ok');
+
+    await host.kill({ machineId: spawned.sandboxId });
+
+    const result = await attachBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', store, host });
+    expect(result).toEqual({ ok: false, reason: 'vanished' });
+  });
+});
+
+describe('killBranch', () => {
+  it('given an existing branch, should DELETE its Sprite through the MachineHost seam and drop the tracking row', async () => {
+    const { host, killCalls } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+    const spawned = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!spawned.ok) throw new Error('expected ok');
+
+    const result = await killBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', store, host });
+    expect(result).toEqual({ ok: true });
+    expect(killCalls).toContain(spawned.sandboxId);
+    expect(await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main')).toBeNull();
+  });
+
+  it('given no such tracked branch, should return not_found without touching the host', async () => {
+    const { host, killCalls } = makeFakeHost();
+    const { store } = makeDeps({ host });
+    const result = await killBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'nope', store, host });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+    expect(killCalls).toHaveLength(0);
+  });
+
+  it('given the Sprite is unreachable, should keep the tracking row so a retry can still find it (no orphans)', async () => {
+    const { host } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+    const spawned = await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!spawned.ok) throw new Error('expected ok');
+
+    const failingHost: MachineHost = {
+      ...host,
+      kill: async () => {
+        throw new Error('unreachable');
+      },
+    };
+
+    const result = await killBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', store, host: failingHost });
+    expect(result).toEqual({ ok: false, reason: 'error' });
+    expect(await store.findByName(TERMINAL_ID, PROJECT_NAME, 'main')).not.toBeNull();
+  });
+});
+
+describe('listBranches', () => {
+  it('given branches tracked on a project, should list only that project\'s branches', async () => {
+    const { host } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+    await spawnBranch({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    await spawnBranch({
+      terminalId: TERMINAL_ID,
+      projectName: 'other-repo',
+      branchName: 'main',
+      actor,
+      deps: { ...deps, projectStore: makeProjectStore(REPO_URL) },
+    });
+
+    const result = await listBranches({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, store });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ branchName: 'main', projectName: PROJECT_NAME });
+  });
+});

--- a/packages/lib/src/services/machines/branch-session.ts
+++ b/packages/lib/src/services/machines/branch-session.ts
@@ -1,0 +1,60 @@
+/**
+ * Branch-terminal session identity (pure).
+ *
+ * A branch-terminal is its OWN Sprite — never the owning Machine's, and never
+ * shared with any other branch of the same Project. `deriveBranchSessionKey`
+ * mirrors `deriveTerminalSessionKey` (services/sandbox/terminal-session-manager.ts):
+ * an opaque HMAC name, namespaced so a (tenant, machine, project, branch)
+ * tuple ALWAYS resolves to the same Sprite name — and, critically, two
+ * different branch names always resolve to two DIFFERENT Sprite names, so
+ * `MachineHost.provision` (which auto-resumes "same name, same filesystem")
+ * can never accidentally hand two branches the same underlying Sprite.
+ */
+
+import { createHmac } from 'crypto';
+
+export interface BranchSessionKeyInput {
+  tenantId: string;
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  secret: string;
+}
+
+const NAMESPACE_VERSION = 'branch-session:v1';
+
+export function deriveBranchSessionKey({
+  tenantId,
+  terminalId,
+  projectName,
+  branchName,
+  secret,
+}: BranchSessionKeyInput): string {
+  if (secret.length === 0) {
+    throw new Error('deriveBranchSessionKey requires a non-empty secret');
+  }
+  const payload = [NAMESPACE_VERSION, tenantId, terminalId, projectName, branchName].join('\0');
+  const digest = createHmac('sha3-256', secret).update(payload).digest('hex');
+  return `pgs-brn-${digest}`;
+}
+
+const MAX_BRANCH_NAME_LENGTH = 200;
+
+// Mirrors `git check-ref-format --branch` intent without shelling out: the
+// allowed charset already excludes whitespace/control chars and
+// `~^:?*[\` — the remaining checks below rule out `..`, doubled `/`, a path
+// segment starting with `.`, and a `.lock` suffix. Conservative on purpose —
+// this becomes both a Sprite name component and a literal `git checkout -b`
+// argument (never shell-interpreted, but still worth confining tightly).
+const BRANCH_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+const FORBIDDEN_SEGMENT_RE = /(^|\/)\.|\.\.|\/{2,}|\.lock$/;
+
+export function isValidBranchName(name: string): boolean {
+  if (typeof name !== 'string' || name.length === 0 || name.length > MAX_BRANCH_NAME_LENGTH) {
+    return false;
+  }
+  if (name.endsWith('/') || name.endsWith('.')) return false;
+  if (!BRANCH_NAME_RE.test(name)) return false;
+  if (FORBIDDEN_SEGMENT_RE.test(name)) return false;
+  return true;
+}

--- a/packages/lib/src/services/machines/machine-branches-store.ts
+++ b/packages/lib/src/services/machines/machine-branches-store.ts
@@ -38,7 +38,15 @@ export interface MachineBranchStore {
   findByName(terminalId: string, projectName: string, branchName: string): Promise<MachineBranchRecord | null>;
   /** Throws a unique-violation error (see `isUniqueViolation`) if this (terminalId, projectName, branchName) already exists. */
   create(input: NewMachineBranchInput): Promise<MachineBranchRecord>;
-  updateSandboxId(input: { id: string; sandboxId: string; now: Date }): Promise<void>;
+  /**
+   * Conditional update — only writes if the row's CURRENT `sandboxId` still
+   * equals `previousSandboxId`, returning whether it actually updated. This
+   * is a compare-and-swap: two concurrent re-provisions racing to record a
+   * replacement Sprite for the same vanished one must not silently
+   * last-write-wins (the loser's win would orphan its own live Sprite,
+   * untracked) — the loser instead sees `updated: false` and can react.
+   */
+  updateSandboxId(input: { id: string; previousSandboxId: string; sandboxId: string; now: Date }): Promise<boolean>;
   remove(terminalId: string, projectName: string, branchName: string): Promise<void>;
 }
 
@@ -98,11 +106,13 @@ export async function createDbMachineBranchStore(): Promise<MachineBranchStore> 
       return row;
     },
 
-    async updateSandboxId({ id, sandboxId, now }) {
-      await db
+    async updateSandboxId({ id, previousSandboxId, sandboxId, now }) {
+      const updated = await db
         .update(machineBranches)
         .set({ sandboxId, updatedAt: now })
-        .where(eq(machineBranches.id, id));
+        .where(and(eq(machineBranches.id, id), eq(machineBranches.sandboxId, previousSandboxId)))
+        .returning({ id: machineBranches.id });
+      return updated.length > 0;
     },
 
     async remove(terminalId, projectName, branchName) {

--- a/packages/lib/src/services/machines/machine-branches-store.ts
+++ b/packages/lib/src/services/machines/machine-branches-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Machine Branches store (IO, dependency-injected).
+ *
+ * DB-backed CRUD for the `machine_branches` table — the durable record of
+ * which branch-terminals exist for a Project, and which Sprite (`sandboxId`,
+ * addressed by the opaque `sessionKey`) each one is provisioned as. Kept
+ * separate from the spawn/attach/kill orchestration (machine-branches.ts) so
+ * that orchestration logic is testable against an in-memory fake without a
+ * real database.
+ */
+
+import { isUniqueViolation } from '../subdomain-allocation';
+
+export interface MachineBranchRecord {
+  id: string;
+  ownerId: string;
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  sessionKey: string;
+  sandboxId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewMachineBranchInput {
+  ownerId: string;
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  sessionKey: string;
+  sandboxId: string;
+  now: Date;
+}
+
+export interface MachineBranchStore {
+  list(terminalId: string, projectName: string): Promise<MachineBranchRecord[]>;
+  findByName(terminalId: string, projectName: string, branchName: string): Promise<MachineBranchRecord | null>;
+  /** Throws a unique-violation error (see `isUniqueViolation`) if this (terminalId, projectName, branchName) already exists. */
+  create(input: NewMachineBranchInput): Promise<MachineBranchRecord>;
+  updateSandboxId(input: { id: string; sandboxId: string; now: Date }): Promise<void>;
+  remove(terminalId: string, projectName: string, branchName: string): Promise<void>;
+}
+
+/** Re-exported so callers can classify a `create` rejection without importing the DB layer directly. */
+export { isUniqueViolation };
+
+/**
+ * Production DB-backed implementation. Lazily resolves the db client, schema
+ * table, and operators so callers that inject a fake (in tests) never load
+ * the DB module graph.
+ */
+export async function createDbMachineBranchStore(): Promise<MachineBranchStore> {
+  const [{ db }, { eq, and }, { machineBranches }] = await Promise.all([
+    import('@pagespace/db/db'),
+    import('@pagespace/db/operators'),
+    import('@pagespace/db/schema/machine-branches'),
+  ]);
+
+  return {
+    async list(terminalId, projectName) {
+      const rows = await db
+        .select()
+        .from(machineBranches)
+        .where(and(eq(machineBranches.terminalId, terminalId), eq(machineBranches.projectName, projectName)));
+      return rows;
+    },
+
+    async findByName(terminalId, projectName, branchName) {
+      const [row] = await db
+        .select()
+        .from(machineBranches)
+        .where(
+          and(
+            eq(machineBranches.terminalId, terminalId),
+            eq(machineBranches.projectName, projectName),
+            eq(machineBranches.branchName, branchName),
+          ),
+        )
+        .limit(1);
+      return row ?? null;
+    },
+
+    async create(input) {
+      const [row] = await db
+        .insert(machineBranches)
+        .values({
+          ownerId: input.ownerId,
+          terminalId: input.terminalId,
+          projectName: input.projectName,
+          branchName: input.branchName,
+          sessionKey: input.sessionKey,
+          sandboxId: input.sandboxId,
+          createdAt: input.now,
+          updatedAt: input.now,
+        })
+        .returning();
+      return row;
+    },
+
+    async updateSandboxId({ id, sandboxId, now }) {
+      await db
+        .update(machineBranches)
+        .set({ sandboxId, updatedAt: now })
+        .where(eq(machineBranches.id, id));
+    },
+
+    async remove(terminalId, projectName, branchName) {
+      await db
+        .delete(machineBranches)
+        .where(
+          and(
+            eq(machineBranches.terminalId, terminalId),
+            eq(machineBranches.projectName, projectName),
+            eq(machineBranches.branchName, branchName),
+          ),
+        );
+    },
+  };
+}

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -1,0 +1,339 @@
+/**
+ * Machine Branches: spawn / attach / kill / list branch-terminals of a
+ * Project (IO, dependency-injected where it touches the sandbox/DB).
+ *
+ * "A terminal IS a worktree — an isolated checked-out branch — and each runs
+ * in its OWN isolated container" (tasks/terminal.md). On Sprites the
+ * container IS the Sprite, so a branch-terminal is a SEPARATE Sprite from the
+ * one its owning Machine (`terminalId`) or any other branch of the same
+ * Project uses — never a shared filesystem, never a git worktree on a shared
+ * checkout. `spawnBranch` provisions that Sprite directly through the
+ * `MachineHost` seam (`../sandbox/machine-host.ts`), under a name derived by
+ * `deriveBranchSessionKey` — distinct per (tenant, machine, project, branch),
+ * so two branches of one project always resolve to two distinct Sprites.
+ *
+ * Cloning reuses `runGitInSandbox` (the same hardened git execution path the
+ * agent's `git_clone` tool and the Projects tier's `addProject` use): the
+ * acting user's GitHub token is fetched per-call and injected into the child
+ * process env for that one command only, via the existing one-shot
+ * credential helper — never written to argv, disk, or persisted git config.
+ * Unlike Projects (which acquires the OWNING Machine's persistent session),
+ * a branch-terminal's git commands run against the Sprite THIS call just
+ * provisioned/attached — `acquireSandbox`/`reconnect` below are bound
+ * directly to that handle, never to a page-keyed Machine lookup.
+ */
+
+import type { SubscriptionTier } from '../subscription-utils';
+import { runGitInSandbox, type GitSandboxRunDeps } from '../sandbox/git-tool-runners';
+import type { SandboxActorContext, SandboxQuotaDeps } from '../sandbox/tool-runners';
+import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
+import type { MachineHost, MachineHandle, MachineSubstrateSpec } from '../sandbox/machine-host';
+import { adaptMachineHandleToExecutableSandbox } from '../sandbox/sandbox-client/machine-host-adapter';
+import type { SandboxCreateOptions } from '../sandbox/sandbox-options';
+import type { FullEgressEnablement, FullEgressDenialReason } from '../sandbox/containment';
+import type { CodeExecutionAuditInput } from '../sandbox/audit';
+import { deriveBranchSessionKey, isValidBranchName } from './branch-session';
+import { isUniqueViolation, type MachineBranchStore, type MachineBranchRecord } from './machine-branches-store';
+
+/** The directory on a branch-terminal's OWN Sprite the project is cloned into. */
+export const BRANCH_REPO_PATH = `${SANDBOX_ROOT}/repo`;
+
+export type SpawnBranchDenialReason =
+  | 'invalid_branch_name'
+  | 'kill_switch_off'
+  | 'project_not_found'
+  | 'provision_failed'
+  | 'clone_failed'
+  | 'checkout_failed'
+  | 'error';
+
+/** Pure decision: is this branch name safe to use as a git ref / Sprite name component? */
+export function planSpawnBranch(input: { branchName: string }): { ok: true } | { ok: false; reason: 'invalid_branch_name' } {
+  if (!isValidBranchName(input.branchName)) return { ok: false, reason: 'invalid_branch_name' };
+  return { ok: true };
+}
+
+export interface MachineActorContext {
+  userId: string;
+  tenantId: string;
+  actorEmail: string;
+  actorDisplayName?: string;
+  tier: SubscriptionTier;
+}
+
+/** The minimal slice of the Projects store Branches needs — just enough to resolve a project's `repoUrl`. */
+export interface MachineBranchProjectLookup {
+  findByName(terminalId: string, name: string): Promise<{ repoUrl: string } | null>;
+}
+
+export interface MachineBranchesDeps {
+  store: MachineBranchStore;
+  projectStore: MachineBranchProjectLookup;
+  isEnabled: () => boolean;
+  now: () => Date;
+  /** The provider-neutral Sprite lifecycle seam — see `../sandbox/machine-host.ts`. */
+  host: MachineHost;
+  substrate: MachineSubstrateSpec;
+  options: SandboxCreateOptions;
+  /** Server-held secret for session-key derivation (same secret as terminal-session-manager.ts). */
+  secret: string;
+  /** REQUIRED full-egress enablement gate — a branch-terminal's Sprite runs open egress, same as a human Terminal. */
+  checkFullEgressEnablement: () => Promise<FullEgressEnablement>;
+  resolveGitHubToken: (userId: string) => Promise<string | null>;
+  quota: SandboxQuotaDeps;
+  buildEnv: () => Record<string, string>;
+  audit: (input: CodeExecutionAuditInput) => Promise<void>;
+  screenOutput?: (text: string) => Promise<string>;
+}
+
+export type SpawnBranchResult =
+  | { ok: true; sandboxId: string; resumed: boolean }
+  | { ok: false; reason: SpawnBranchDenialReason | FullEgressDenialReason; detail?: string };
+
+function buildActorCtx(scopeKey: string, actor: MachineActorContext): SandboxActorContext {
+  return {
+    userId: actor.userId,
+    tenantId: actor.tenantId,
+    driveId: undefined,
+    // See module doc: a branch-terminal op has no conversation, so this
+    // opaque scope key (ignored by the acquireSandbox closure below) just
+    // satisfies the field.
+    conversationId: scopeKey,
+    actorEmail: actor.actorEmail,
+    actorDisplayName: actor.actorDisplayName,
+    tier: actor.tier,
+  };
+}
+
+/**
+ * Build `runGitInSandbox` deps bound directly to an already-provisioned
+ * `MachineHandle` — no page-keyed acquire/reconnect lookup, because Branches
+ * (unlike Projects) hold the live handle from the moment they provision it.
+ */
+function buildGitDepsForHandle(handle: MachineHandle, deps: MachineBranchesDeps): GitSandboxRunDeps {
+  const sandbox = adaptMachineHandleToExecutableSandbox(handle);
+  return {
+    isEnabled: deps.isEnabled,
+    resolveGitHubToken: deps.resolveGitHubToken,
+    acquireSandbox: async () => ({ ok: true, sandboxId: handle.machineId, resumed: false }),
+    reconnect: async () => sandbox,
+    quota: deps.quota,
+    buildEnv: deps.buildEnv,
+    audit: deps.audit,
+    screenOutput: deps.screenOutput,
+    now: deps.now,
+  };
+}
+
+type CloneResult = { ok: true } | { ok: false; reason: 'clone_failed' | 'checkout_failed'; detail?: string };
+
+async function cloneAndCheckoutBranch({
+  handle,
+  repoUrl,
+  branchName,
+  scopeKey,
+  actor,
+  deps,
+}: {
+  handle: MachineHandle;
+  repoUrl: string;
+  branchName: string;
+  scopeKey: string;
+  actor: MachineActorContext;
+  deps: MachineBranchesDeps;
+}): Promise<CloneResult> {
+  const ctx = buildActorCtx(scopeKey, actor);
+  const gitDeps = buildGitDepsForHandle(handle, deps);
+
+  const clone = await runGitInSandbox({ cmd: 'git', args: ['clone', repoUrl, BRANCH_REPO_PATH], ctx, deps: gitDeps });
+  if (!clone.success) return { ok: false, reason: 'clone_failed', detail: clone.error };
+  if (clone.exitCode !== 0) return { ok: false, reason: 'clone_failed', detail: clone.stderr || clone.stdout };
+
+  // Prefer an existing remote branch; fall back to a fresh local branch off
+  // the clone's default HEAD when it doesn't exist upstream yet.
+  const checkoutExisting = await runGitInSandbox({
+    cmd: 'git',
+    args: ['checkout', '-b', branchName, `origin/${branchName}`],
+    cwd: BRANCH_REPO_PATH,
+    ctx,
+    deps: gitDeps,
+  });
+  if (checkoutExisting.success && checkoutExisting.exitCode === 0) return { ok: true };
+
+  const checkoutNew = await runGitInSandbox({
+    cmd: 'git',
+    args: ['checkout', '-b', branchName],
+    cwd: BRANCH_REPO_PATH,
+    ctx,
+    deps: gitDeps,
+  });
+  if (!checkoutNew.success) return { ok: false, reason: 'checkout_failed', detail: checkoutNew.error };
+  if (checkoutNew.exitCode !== 0) {
+    return { ok: false, reason: 'checkout_failed', detail: checkoutNew.stderr || checkoutNew.stdout };
+  }
+  return { ok: true };
+}
+
+async function safeKillSprite(host: MachineHost, machineId: string): Promise<void> {
+  try {
+    await host.kill({ machineId });
+  } catch {
+    // best-effort — a partially-provisioned Sprite that fails to clone is
+    // still torn down on a best-effort basis rather than left orphaned.
+  }
+}
+
+/**
+ * Spawn (or resume) a branch-terminal: an isolated Sprite with `branchName`
+ * checked out from the named Project. Idempotent by (terminalId,
+ * projectName, branchName) — a second call reattaches to the same Sprite
+ * (or transparently re-provisions under the same name if it has since
+ * vanished) instead of creating a duplicate.
+ */
+export async function spawnBranch({
+  terminalId,
+  projectName,
+  branchName,
+  actor,
+  deps,
+}: {
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  actor: MachineActorContext;
+  deps: MachineBranchesDeps;
+}): Promise<SpawnBranchResult> {
+  if (!deps.isEnabled()) return { ok: false, reason: 'kill_switch_off' };
+
+  const plan = planSpawnBranch({ branchName });
+  if (!plan.ok) return plan;
+
+  const project = await deps.projectStore.findByName(terminalId, projectName);
+  if (!project) return { ok: false, reason: 'project_not_found' };
+
+  const enablement = await deps.checkFullEgressEnablement();
+  if (!enablement.ok) return enablement;
+
+  const existing = await deps.store.findByName(terminalId, projectName, branchName);
+  const scopeKey = `${terminalId}:${projectName}:${branchName}`;
+
+  if (existing) {
+    const handle = await deps.host.attach({ machineId: existing.sandboxId });
+    if (handle) return { ok: true, sandboxId: handle.machineId, resumed: true };
+    // Vanished — fall through and re-provision under the SAME session key.
+  }
+
+  const sessionKey =
+    existing?.sessionKey ??
+    deriveBranchSessionKey({ tenantId: actor.tenantId, terminalId, projectName, branchName, secret: deps.secret });
+
+  let handle: MachineHandle;
+  try {
+    handle = await deps.host.provision({ name: sessionKey, substrate: deps.substrate, options: deps.options });
+  } catch (error) {
+    return { ok: false, reason: 'provision_failed', detail: error instanceof Error ? error.message : String(error) };
+  }
+
+  const cloned = await cloneAndCheckoutBranch({ handle, repoUrl: project.repoUrl, branchName, scopeKey, actor, deps });
+  if (!cloned.ok) {
+    await safeKillSprite(deps.host, handle.machineId);
+    return { ok: false, reason: cloned.reason, detail: cloned.detail };
+  }
+
+  try {
+    if (existing) {
+      await deps.store.updateSandboxId({ id: existing.id, sandboxId: handle.machineId, now: deps.now() });
+    } else {
+      await deps.store.create({
+        ownerId: actor.userId,
+        terminalId,
+        projectName,
+        branchName,
+        sessionKey,
+        sandboxId: handle.machineId,
+        now: deps.now(),
+      });
+    }
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      // Lost a race against a concurrent spawn of the same branch — the
+      // Sprite we just provisioned is redundant, not orphaned state.
+      await safeKillSprite(deps.host, handle.machineId);
+      const winner = await deps.store.findByName(terminalId, projectName, branchName);
+      if (winner) return { ok: true, sandboxId: winner.sandboxId, resumed: true };
+    }
+    return { ok: false, reason: 'error', detail: error instanceof Error ? error.message : String(error) };
+  }
+
+  return { ok: true, sandboxId: handle.machineId, resumed: false };
+}
+
+export type AttachBranchResult =
+  | { ok: true; sandboxId: string }
+  | { ok: false; reason: 'not_found' | 'vanished' };
+
+/** Reconnect to a branch-terminal's existing Sprite without provisioning a new one. */
+export async function attachBranch({
+  terminalId,
+  projectName,
+  branchName,
+  store,
+  host,
+}: {
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  store: MachineBranchStore;
+  host: MachineHost;
+}): Promise<AttachBranchResult> {
+  const existing = await store.findByName(terminalId, projectName, branchName);
+  if (!existing) return { ok: false, reason: 'not_found' };
+
+  const handle = await host.attach({ machineId: existing.sandboxId });
+  if (!handle) return { ok: false, reason: 'vanished' };
+  return { ok: true, sandboxId: handle.machineId };
+}
+
+export async function listBranches({
+  terminalId,
+  projectName,
+  store,
+}: {
+  terminalId: string;
+  projectName: string;
+  store: MachineBranchStore;
+}): Promise<MachineBranchRecord[]> {
+  return store.list(terminalId, projectName);
+}
+
+export type KillBranchResult = { ok: true } | { ok: false; reason: 'not_found' | 'error' };
+
+/** Tear down a branch-terminal: DELETE its Sprite through the MachineHost seam and drop the tracking row. */
+export async function killBranch({
+  terminalId,
+  projectName,
+  branchName,
+  store,
+  host,
+}: {
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  store: MachineBranchStore;
+  host: MachineHost;
+}): Promise<KillBranchResult> {
+  const existing = await store.findByName(terminalId, projectName, branchName);
+  if (!existing) return { ok: false, reason: 'not_found' };
+
+  try {
+    await host.kill({ machineId: existing.sandboxId });
+  } catch {
+    // Sprite may still be running — keep the tracking row so a retry (or the
+    // idle reaper) can still find and reclaim it. An untracked-but-live
+    // Sprite would otherwise be an unkillable orphan.
+    return { ok: false, reason: 'error' };
+  }
+
+  await store.remove(terminalId, projectName, branchName);
+  return { ok: true };
+}

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -184,6 +184,37 @@ async function safeKillSprite(host: MachineHost, machineId: string): Promise<voi
 }
 
 /**
+ * Reconcile after losing a provisioning collision (a concurrent `spawnBranch`
+ * call for the same branch beat us to persisting a row). `MachineHost.provision`
+ * is name-keyed and auto-resumes ("same name, same filesystem" — see
+ * `../sandbox/machine-host.ts`), so two concurrent calls deriving the same
+ * session key can both end up holding a handle to the SAME physical Sprite —
+ * in that case the Sprite must NOT be killed, since it's the one the winner
+ * already recorded and is live. Only a genuinely distinct (or absent) tracked
+ * Sprite is safe to tear down.
+ */
+async function reconcileProvisionCollision({
+  deps,
+  terminalId,
+  projectName,
+  branchName,
+  handle,
+}: {
+  deps: MachineBranchesDeps;
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  handle: MachineHandle;
+}): Promise<{ ok: true; sandboxId: string; resumed: true } | { row: MachineBranchRecord | null }> {
+  const row = await deps.store.findByName(terminalId, projectName, branchName);
+  if (row && row.sandboxId === handle.machineId) {
+    return { ok: true, sandboxId: row.sandboxId, resumed: true };
+  }
+  await safeKillSprite(deps.host, handle.machineId);
+  return { row };
+}
+
+/**
  * Spawn (or resume) a branch-terminal: an isolated Sprite with `branchName`
  * checked out from the named Project. Idempotent by (terminalId,
  * projectName, branchName) — a second call reattaches to the same Sprite
@@ -236,31 +267,49 @@ export async function spawnBranch({
 
   const cloned = await cloneAndCheckoutBranch({ handle, repoUrl: project.repoUrl, branchName, scopeKey, actor, deps });
   if (!cloned.ok) {
-    await safeKillSprite(deps.host, handle.machineId);
+    // A concurrent spawnBranch call for this SAME branch may have already won
+    // (and may be sharing our exact Sprite — provision is name-keyed/idempotent),
+    // in which case our redundant clone/checkout failing (e.g. "dir already
+    // exists") doesn't mean the branch-terminal is broken.
+    const reconciled = await reconcileProvisionCollision({ deps, terminalId, projectName, branchName, handle });
+    if ('ok' in reconciled) return reconciled;
     return { ok: false, reason: cloned.reason, detail: cloned.detail };
   }
 
-  try {
-    if (existing) {
-      await deps.store.updateSandboxId({ id: existing.id, sandboxId: handle.machineId, now: deps.now() });
-    } else {
-      await deps.store.create({
-        ownerId: actor.userId,
-        terminalId,
-        projectName,
-        branchName,
-        sessionKey,
-        sandboxId: handle.machineId,
-        now: deps.now(),
-      });
+  if (existing) {
+    const updated = await deps.store.updateSandboxId({
+      id: existing.id,
+      previousSandboxId: existing.sandboxId,
+      sandboxId: handle.machineId,
+      now: deps.now(),
+    });
+    if (!updated) {
+      // Lost a race against a concurrent re-provision of the same vanished
+      // branch — do not silently overwrite; the winner already wrote its own.
+      const reconciled = await reconcileProvisionCollision({ deps, terminalId, projectName, branchName, handle });
+      if ('ok' in reconciled) return reconciled;
+      if (reconciled.row) return { ok: true, sandboxId: reconciled.row.sandboxId, resumed: true };
+      return { ok: false, reason: 'error', detail: 'lost a concurrent branch-terminal spawn race' };
     }
+    return { ok: true, sandboxId: handle.machineId, resumed: false };
+  }
+
+  try {
+    await deps.store.create({
+      ownerId: actor.userId,
+      terminalId,
+      projectName,
+      branchName,
+      sessionKey,
+      sandboxId: handle.machineId,
+      now: deps.now(),
+    });
   } catch (error) {
     if (isUniqueViolation(error)) {
-      // Lost a race against a concurrent spawn of the same branch — the
-      // Sprite we just provisioned is redundant, not orphaned state.
-      await safeKillSprite(deps.host, handle.machineId);
-      const winner = await deps.store.findByName(terminalId, projectName, branchName);
-      if (winner) return { ok: true, sandboxId: winner.sandboxId, resumed: true };
+      // Lost a race against a concurrent spawn of the same branch.
+      const reconciled = await reconcileProvisionCollision({ deps, terminalId, projectName, branchName, handle });
+      if ('ok' in reconciled) return reconciled;
+      if (reconciled.row) return { ok: true, sandboxId: reconciled.row.sandboxId, resumed: true };
     }
     return { ok: false, reason: 'error', detail: error instanceof Error ? error.message : String(error) };
   }

--- a/packages/lib/src/services/sandbox/sandbox-client/machine-host-adapter.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/machine-host-adapter.ts
@@ -20,7 +20,15 @@
 import type { MachineHost, MachineHandle, MachineSubstrateSpec } from '../machine-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
 
-function adapt(handle: MachineHandle): ExecutableSandbox {
+/**
+ * Adapt a single `MachineHandle` into the `ExecutableSandbox` shape. Exported
+ * (not just used internally by `createExecClientFromMachineHost`) for callers
+ * that already hold a freshly-provisioned handle and want to drive it through
+ * an `ExecutableSandbox`-shaped helper (e.g. `runGitInSandbox`) without a
+ * round-trip through a `MachineHost.attach` lookup — see
+ * `services/machines/machine-branches.ts`.
+ */
+export function adaptMachineHandleToExecutableSandbox(handle: MachineHandle): ExecutableSandbox {
   return {
     sandboxId: handle.machineId,
     runCommand: (args) => handle.exec(args),
@@ -40,11 +48,11 @@ export function createExecClientFromMachineHost(
 ): ExecSandboxClient {
   return {
     async getOrCreate({ name, options }) {
-      return adapt(await host.provision({ name, substrate, options }));
+      return adaptMachineHandleToExecutableSandbox(await host.provision({ name, substrate, options }));
     },
     async get({ sandboxId }) {
       const handle = await host.attach({ machineId: sandboxId });
-      return handle ? adapt(handle) : null;
+      return handle ? adaptMachineHandleToExecutableSandbox(handle) : null;
     },
     async stop({ sandboxId }) {
       await host.kill({ machineId: sandboxId });


### PR DESCRIPTION
## Summary

Terminal — Workspace (Epic 2), Branches tier: **a branch-terminal is an isolated checked-out branch of a Project, running in its OWN Sprite** — never a shared filesystem, never a git worktree on a shared checkout. On Sprites the container IS the Sprite, so real isolation between two branches of one project means two distinct Sprites, provisioned directly through the `MachineHost` seam (never the owning Machine's persistent session, which Projects reuse).

- **`packages/db`**: `machine_branches` table (terminalId/projectName/branchName → sessionKey/sandboxId), unique per (terminalId, projectName, branchName). Migration `0186_empty_the_watchers.sql` (renumbered from an initial 0185 after rebasing onto pu/terminal's #1902, which also landed a 0185).
- **`packages/lib/services/machines`**:
  - `branch-session.ts` — `deriveBranchSessionKey` (HMAC, namespaced by tenant + machine + project + branch, mirrors `deriveTerminalSessionKey`) so two different branches always derive two different Sprite names; `isValidBranchName` (git-ref-safe slug validation).
  - `machine-branches-store.ts` — DB-backed CRUD, mirrors `machine-projects-store.ts`. `updateSandboxId` is a compare-and-swap (`previousSandboxId` must still match) rather than an unconditional write.
  - `machine-branches.ts` — `spawnBranch` provisions a Sprite directly via `MachineHost.provision`, clones the Project's `repoUrl`, checks out the branch (prefers an existing upstream branch, falls back to a fresh local branch), and persists the tracking row. Idempotent: a second spawn reattaches to the live Sprite, or transparently re-provisions under the *same* session key if it has vanished. Every provisioning collision (clone/checkout failure, update-conflict, create-unique-violation) reconciles against the tracking row before ever killing a Sprite — since `MachineHost.provision` is name-keyed/idempotent, two concurrent calls can share one physical Sprite, so only a genuinely different (or absent) tracked Sprite is safe to tear down. `attachBranch` / `killBranch` / `listBranches` round out reconnect / teardown / listing. Cloning reuses `runGitInSandbox` — same token-injection security invariants as the Projects tier and the agent's `git_clone` tool (never written to argv/disk/git config).
  - Exported `adaptMachineHandleToExecutableSandbox` from `machine-host-adapter.ts` so a freshly-provisioned handle can drive `runGitInSandbox` directly, without a page-keyed acquire/reconnect lookup.
- **`apps/web`**: `createProductionMachineHost` (`sprites-client.ts`) exposes the raw `MachineHost` for direct provisioning; `machine-branches-runtime.ts` wires production deps (DB stores, quota, audit, egress gate); `/api/machines/branches` (GET list, POST spawn, DELETE kill) is the navigator UI's surface, re-checking page access on every request.

## Acceptance criteria (from the task brief)

- ✅ A branch-terminal = an isolated Sprite with a specific branch checked out from its project (spawn/attach/kill/list) — `machine-branches.ts`.
- ✅ Two branches of one project = TWO SEPARATE Sprites, no shared filesystem — proven with a fake `MachineHost` that gives each derived session-key name its own independent in-memory filesystem: a file written into branch A's Sprite is asserted absent from branch B's.
- ✅ Provision/kill go through the `MachineHost` seam (Sprite impl today; a second backend needs no caller change) — `spawnBranch`/`killBranch` call `host.provision`/`host.attach`/`host.kill` exclusively.
- ✅ Teardown stops each branch-terminal's Sprite cleanly (`killBranch` → `MachineHost.kill`, i.e. DELETE) and drops the tracking row — but keeps the row if the Sprite is unreachable, so a retry can still find and reclaim it (no untracked-but-live orphans). Concurrent double-spawn races (two callers provisioning the same branch at once) are also reconciled without destroying or orphaning a Sprite — see review findings below.

## Review

`/aidd-review` findings recorded to PageSpace page `g1n0k76m8t97owr85g12h2qe` under `## Findings`. 3 major / 2 minor / 1 nit, no blockers. **2 of 3 majors fixed** (commit `6a48e4042`): two provisioning-collision races (a losing racer's clone/checkout failure could kill the winner's shared Sprite; a losing re-provision-after-vanish could silently overwrite the winner's tracking row) are closed via a `reconcileProvisionCollision` helper + compare-and-swap `updateSandboxId`, each proven by a new colocated test. The remaining major — removing a Project doesn't cascade to its branch-terminals — touches the already-merged Projects tier (#1901) and is recorded as an open cross-tier follow-up rather than expanded in this PR. The 2 minor + 1 nit are non-blocking and left open.

## Test plan

- [x] `bun run typecheck` verified green — `@pagespace/db`, `@pagespace/lib`, and `apps/web` each build + typecheck cleanly when run directly per-package (the root `turbo`-orchestrated `bun run typecheck` was flaky in this dev sandbox due to a shared build cache colliding with a concurrent, unrelated build in a sibling worktree — not a code issue)
- [x] 29 new `packages/lib` unit tests (branch-session + machine-branches, including the two-Sprite isolation proof and 3 race-condition tests) — all passing
- [x] 17 new `apps/web` route contract tests (`/api/machines/branches`) — all passing
- [x] Full `packages/lib` suite — 292 files / 6462+ tests, all green
- [x] Full `bun run test:unit` — 763/767 files pass; the 4 failures are pre-existing environment issues (missing local test-DB role `"test"`, one unrelated message-grouping midnight test), none touching this change
- [x] Rebased onto latest `pu/terminal` (picked up #1901 Projects tier + #1902 owner-pays/idle-storage); migration renumbered 0185→0186 to resolve the collision; PR mergeStateStatus=CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WukT1TwHT6t6Ps8EQU2CF6