### PR TITLE
feat(terminal): usage surface — per-machine runtime + cost (Epic 3)

### DIFF
--- a/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-handler.test.ts
@@ -459,7 +459,7 @@ describe('buildTerminalHandlers', () => {
 
       expect(billing.trackUsage).toHaveBeenCalledTimes(1);
       const call = billing.trackUsage.mock.calls[0][0];
-      expect(call).toMatchObject({ payerId: 'owner-1', holdId: 'hold-1' });
+      expect(call).toMatchObject({ payerId: 'owner-1', holdId: 'hold-1', pageId: 'page1' });
       expect(call.activeSeconds).toBeCloseTo(7, 0);
       expect(billing.releaseHold).not.toHaveBeenCalled();
       expect(sessionMap.getByKey('key1')).toBeUndefined();
@@ -477,6 +477,7 @@ describe('buildTerminalHandlers', () => {
       const call = billing.trackUsage.mock.calls[0][0];
       expect(call.payerId).toBe('owner-1');
       expect(call.holdId).toBe('hold-1');
+      expect(call.pageId).toBe('page1');
       expect(call.activeSeconds).toBeCloseTo(DETACHED_IDLE_MS / 1000, 0);
       expect(billing.releaseHold).not.toHaveBeenCalled();
     });

--- a/apps/realtime/src/terminal/terminal-handler.ts
+++ b/apps/realtime/src/terminal/terminal-handler.ts
@@ -72,7 +72,7 @@ function endTerminalSession(
   if (billing && session.holdId && session.payerId && session.connectedAt !== undefined) {
     const activeSeconds = Math.max(0, (Date.now() - session.connectedAt) / 1000);
     void billing
-      .trackUsage({ payerId: session.payerId, holdId: session.holdId, activeSeconds })
+      .trackUsage({ payerId: session.payerId, holdId: session.holdId, activeSeconds, pageId: session.pageId })
       .catch((error) => {
         loggers.realtime.error('Terminal session billing settle failed', error instanceof Error ? error : new Error(String(error)), {
           sessionKey,
@@ -158,6 +158,7 @@ export function buildTerminalHandlers({ sessionMap, openShell, checkAuth, socket
         payerId: authResult.payerId,
         holdId,
         connectedAt,
+        pageId,
         outputFn: (data) => socket.emit('terminal:output', { data }),
         closedFn: (exitCode) => socket.emit('terminal:closed', { exitCode }),
         scrollback: [],

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -24,6 +24,8 @@ export type TerminalSession = {
   payerId?: string;
   holdId?: string;
   connectedAt?: number;
+  /** The Terminal page this session is for — the usage-breakdown's per-machine attribution key. */
+  pageId?: string;
 };
 
 export type TerminalSessionMap = {

--- a/apps/web/src/app/settings/usage/page.tsx
+++ b/apps/web/src/app/settings/usage/page.tsx
@@ -7,6 +7,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ArrowLeft, CheckCircle, AlertTriangle } from 'lucide-react';
 import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
 import { UsageBreakdownCard } from '@/components/billing/UsageBreakdownCard';
+import { TerminalUsageCard } from '@/components/billing/TerminalUsageCard';
 import { AutomationsCard } from '@/components/billing/AutomationsCard';
 import { StorageUsageCard } from '@/components/billing/StorageUsageCard';
 
@@ -63,6 +64,7 @@ export default function UsagePage() {
 
       <CreditBalanceCard />
       <UsageBreakdownCard />
+      <TerminalUsageCard />
       <AutomationsCard />
       <StorageUsageCard />
     </div>

--- a/apps/web/src/components/billing/TerminalUsageCard.tsx
+++ b/apps/web/src/components/billing/TerminalUsageCard.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useEffect } from 'react';
+import useSWR from 'swr';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { SquareTerminal } from 'lucide-react';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { formatCreditCount } from '@/lib/subscription/credits';
+import { useSocketStore } from '@/stores/useSocketStore';
+
+interface MachineRow {
+  pageId: string | null;
+  label: string;
+  activeSeconds: number;
+  spendCents: number;
+  calls: number;
+  sharePct: number;
+}
+
+interface TerminalUsageResponse {
+  byMachine: MachineRow[];
+}
+
+const fetcher = async (url: string): Promise<TerminalUsageResponse> => {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+  return response.json();
+};
+
+const formatRuntime = (seconds: number): string => {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainderMinutes = minutes % 60;
+  return remainderMinutes > 0 ? `${hours}h ${remainderMinutes}m` : `${hours}h`;
+};
+
+/**
+ * Per-machine Terminal runtime + cost this billing period — reads the same
+ * `GET /api/credits/breakdown` payload as UsageBreakdownCard (its `byMachine` field),
+ * so it shares that request's SWR cache entry rather than issuing a second one.
+ * Rows are already owner-scoped by the query (see usage-breakdown-query.ts).
+ */
+export function TerminalUsageCard() {
+  const socket = useSocketStore((state) => state.socket);
+  const connect = useSocketStore((state) => state.connect);
+
+  const { data, error, isLoading, mutate } = useSWR<TerminalUsageResponse>(
+    '/api/credits/breakdown',
+    fetcher,
+    { refreshInterval: 0, revalidateOnFocus: false },
+  );
+
+  useEffect(() => {
+    connect();
+  }, [connect]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onUpdate = () => mutate();
+    socket.on('credits:updated', onUpdate);
+    return () => {
+      socket.off('credits:updated', onUpdate);
+    };
+  }, [socket, mutate]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <SquareTerminal className="h-5 w-5" />
+          Terminals
+        </CardTitle>
+        <CardDescription>Machine runtime and cost this period</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-full" />
+          </div>
+        ) : error || !data ? (
+          <p className="text-sm text-muted-foreground">
+            Could not load your terminal usage. Please refresh and try again.
+          </p>
+        ) : data.byMachine.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No terminal usage yet this period. Open a Terminal page to spin up a machine.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {data.byMachine.map((machine) => (
+              <div
+                key={machine.pageId ?? machine.label}
+                className="flex items-center justify-between gap-2 text-sm"
+              >
+                <span className="truncate font-medium">{machine.label}</span>
+                <span className="shrink-0 tabular-nums text-xs text-muted-foreground">
+                  {formatRuntime(machine.activeSeconds)} · {formatCreditCount(machine.spendCents)} cr
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
@@ -9,6 +9,9 @@ const row = (over: Partial<UsageLedgerRow>): UsageLedgerRow => ({
   provider: 'openrouter',
   chargeMillicents: 25_000, // 25 cents
   totalTokens: 1000,
+  pageId: null,
+  pageTitle: null,
+  durationMs: null,
   ...over,
 });
 
@@ -18,6 +21,7 @@ describe('aggregateUsageBreakdown', () => {
     expect(r.totalSpendCents).toBe(0);
     expect(r.byFeature).toEqual([]);
     expect(r.byModel).toEqual([]);
+    expect(r.byMachine).toEqual([]);
     expect(r.periodStart).toBe(PERIOD.periodStart);
     expect(r.periodEnd).toBe(PERIOD.periodEnd);
   });
@@ -91,5 +95,86 @@ describe('aggregateUsageBreakdown', () => {
     expect(r.byFeature[0].spendCents).toBe(0);
     expect(r.byFeature[0].tokens).toBe(0);
     expect(r.byFeature[0].calls).toBe(1);
+  });
+
+  describe('byMachine (Terminal Epic 3 usage surface)', () => {
+    const terminalRow = (over: Partial<UsageLedgerRow>): UsageLedgerRow =>
+      row({
+        source: 'terminal',
+        model: 'terminal-machine',
+        provider: 'sprites',
+        totalTokens: 0,
+        ...over,
+      });
+
+    it('groups terminal rows by pageId, summing spend and active seconds', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          terminalRow({ pageId: 'page-a', pageTitle: 'My Project', chargeMillicents: 10_000, durationMs: 30_000 }),
+          terminalRow({ pageId: 'page-a', pageTitle: 'My Project', chargeMillicents: 5_000, durationMs: 10_000 }),
+          terminalRow({ pageId: 'page-b', pageTitle: 'Scratch', chargeMillicents: 20_000, durationMs: 60_000 }),
+        ],
+        PERIOD,
+      );
+      expect(r.byMachine).toHaveLength(2);
+      const a = r.byMachine.find((m) => m.pageId === 'page-a')!;
+      expect(a).toMatchObject({ label: 'My Project', spendCents: 15, calls: 2, activeSeconds: 40 });
+      const b = r.byMachine.find((m) => m.pageId === 'page-b')!;
+      expect(b).toMatchObject({ label: 'Scratch', spendCents: 20, calls: 1, activeSeconds: 60 });
+    });
+
+    it('excludes non-terminal rows entirely, even ones that happen to carry a pageId', () => {
+      const r = aggregateUsageBreakdown(
+        [row({ source: 'chat', pageId: 'page-a', pageTitle: 'My Project', chargeMillicents: 50_000 })],
+        PERIOD,
+      );
+      expect(r.byMachine).toEqual([]);
+    });
+
+    it('collapses rows with no resolvable page into one "Unattributed machine" bucket rather than dropping them', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          terminalRow({ pageId: null, pageTitle: null, chargeMillicents: 5_000, durationMs: 5_000 }),
+          terminalRow({ pageId: null, pageTitle: null, chargeMillicents: 5_000, durationMs: 5_000 }),
+        ],
+        PERIOD,
+      );
+      expect(r.byMachine).toHaveLength(1);
+      expect(r.byMachine[0]).toMatchObject({ pageId: null, label: 'Unattributed machine', calls: 2 });
+    });
+
+    it('falls back to "Untitled machine" when the page has no title (deleted/unresolvable page)', () => {
+      const r = aggregateUsageBreakdown(
+        [terminalRow({ pageId: 'page-c', pageTitle: null, chargeMillicents: 5_000, durationMs: 5_000 })],
+        PERIOD,
+      );
+      expect(r.byMachine[0]).toMatchObject({ pageId: 'page-c', label: 'Untitled machine' });
+    });
+
+    it('computes sharePct against TOTAL TERMINAL spend, not overall spend across all features', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          row({ source: 'chat', chargeMillicents: 900_000 }), // huge non-terminal spend
+          terminalRow({ pageId: 'page-a', pageTitle: 'A', chargeMillicents: 7_500 }),
+          terminalRow({ pageId: 'page-b', pageTitle: 'B', chargeMillicents: 2_500 }),
+        ],
+        PERIOD,
+      );
+      const a = r.byMachine.find((m) => m.pageId === 'page-a')!;
+      const b = r.byMachine.find((m) => m.pageId === 'page-b')!;
+      expect(a.sharePct).toBe(75);
+      expect(b.sharePct).toBe(25);
+    });
+
+    it('sorts byMachine by spend descending', () => {
+      const r = aggregateUsageBreakdown(
+        [
+          terminalRow({ pageId: 'small', pageTitle: 'Small', chargeMillicents: 1_000 }),
+          terminalRow({ pageId: 'big', pageTitle: 'Big', chargeMillicents: 50_000 }),
+        ],
+        PERIOD,
+      );
+      expect(r.byMachine.map((m) => m.pageId)).toEqual(['big', 'small']);
+    });
   });
 });

--- a/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
@@ -151,6 +151,14 @@ describe('aggregateUsageBreakdown', () => {
       expect(r.byMachine[0]).toMatchObject({ pageId: 'page-c', label: 'Untitled machine' });
     });
 
+    it('tolerates a null durationMs (e.g. an idle-storage charge, which has no wall-clock window) as 0 runtime without dropping its cost', () => {
+      const r = aggregateUsageBreakdown(
+        [terminalRow({ pageId: 'page-d', pageTitle: 'Storage-billed page', chargeMillicents: 5_000, durationMs: null })],
+        PERIOD,
+      );
+      expect(r.byMachine[0]).toMatchObject({ pageId: 'page-d', activeSeconds: 0, spendCents: 5, calls: 1 });
+    });
+
     it('computes sharePct against TOTAL TERMINAL spend, not overall spend across all features', () => {
       const r = aggregateUsageBreakdown(
         [

--- a/apps/web/src/lib/subscription/usage-breakdown-query.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown-query.ts
@@ -9,16 +9,24 @@ import { db } from '@pagespace/db/db';
 import { and, eq, gte, lte } from '@pagespace/db/operators';
 import { creditBalances, creditLedger } from '@pagespace/db/schema/credits';
 import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
+import { pages } from '@pagespace/db/schema/core';
 import { aggregateUsageBreakdown, type UsageBreakdown } from './usage-breakdown';
 
 /** Fallback lookback when the user has no billing-period window yet. */
 const DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
- * Spend-by-feature and spend-by-model for the user's current billing period. Spend is
- * the ledger's precise charged amount (`chargeMillicents`, post-markup) — never the
- * raw provider `cost`. The join drops usage rows whose AI log has been purged by
- * retention, which is acceptable for a "recent usage" view.
+ * Spend-by-feature, spend-by-model, and (for source:'terminal') spend-by-machine for
+ * the user's current billing period. Spend is the ledger's precise charged amount
+ * (`chargeMillicents`, post-markup) — never the raw provider `cost`. The join drops
+ * usage rows whose AI log has been purged by retention, which is acceptable for a
+ * "recent usage" view.
+ *
+ * `byMachine` needs no separate drive-ownership filter: `creditLedger.userId` IS the
+ * PAYER (`resolveTerminalPayerId` in terminal-payer.ts always resolves to the backing
+ * page's drive owner, falling back to the acting tenant only when unresolvable), so
+ * every row this query returns for `userId` is already scoped to a machine they own
+ * or a run they footed the bill for directly.
  */
 export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakdown> {
   const [balance] = await db
@@ -40,9 +48,18 @@ export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakd
       provider: aiUsageLogs.provider,
       totalTokens: aiUsageLogs.totalTokens,
       chargeMillicents: creditLedger.chargeMillicents,
+      // Per-machine attribution (Terminal Epic 3): pageId + its active-window
+      // duration are only ever set on source:'terminal' rows; the pure
+      // aggregator ignores them for every other source. `pages` is left-joined
+      // (not inner) so a deleted/unresolvable page still surfaces its spend,
+      // under a "Untitled machine" label, rather than disappearing.
+      pageId: aiUsageLogs.pageId,
+      pageTitle: pages.title,
+      durationMs: aiUsageLogs.duration,
     })
     .from(creditLedger)
     .innerJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
+    .leftJoin(pages, eq(aiUsageLogs.pageId, pages.id))
     .where(
       and(
         eq(creditLedger.userId, userId),

--- a/apps/web/src/lib/subscription/usage-breakdown.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown.ts
@@ -22,6 +22,12 @@ export interface UsageLedgerRow {
   provider: string | null;
   chargeMillicents: number | null;
   totalTokens: number | null;
+  /** The machine's backing Terminal page (source:'terminal' rows only; null for every other source). */
+  pageId: string | null;
+  /** The backing page's title, pre-joined by the query — null when the page was deleted or unresolvable. */
+  pageTitle: string | null;
+  /** Active-window duration in milliseconds (source:'terminal' rows only). */
+  durationMs: number | null;
 }
 
 export interface UsageBreakdownPeriod {
@@ -47,10 +53,22 @@ export interface UsageModelRow {
   sharePct: number;
 }
 
+export interface UsageMachineRow {
+  /** Null when the row predates pageId attribution or has no backing page (e.g. the global assistant). */
+  pageId: string | null;
+  label: string;
+  activeSeconds: number;
+  spendCents: number;
+  calls: number;
+  /** Share of TERMINAL spend (not overall spend) this machine accounts for. */
+  sharePct: number;
+}
+
 export interface UsageBreakdown extends UsageBreakdownPeriod {
   totalSpendCents: number;
   byFeature: UsageFeatureRow[];
   byModel: UsageModelRow[];
+  byMachine: UsageMachineRow[];
 }
 
 /** Internal accumulator (spend tracked in millicents for precision). */
@@ -76,7 +94,9 @@ export function aggregateUsageBreakdown(
 ): UsageBreakdown {
   const featureBuckets = new Map<AIUsageSource, Bucket>();
   const modelBuckets = new Map<string, Bucket & { model: string; provider: string }>();
+  const machineBuckets = new Map<string, { millicents: number; calls: number; activeSeconds: number; pageId: string | null; label: string }>();
   let totalMillicents = 0;
+  let terminalMillicents = 0;
 
   for (const r of rows) {
     const charge = r.chargeMillicents ?? 0;
@@ -99,6 +119,20 @@ export function aggregateUsageBreakdown(
     mb.tokens += tokens;
     mb.calls += 1;
     modelBuckets.set(key, mb);
+
+    if (source === 'terminal') {
+      terminalMillicents += charge;
+      // Rows without a resolvable page (pre-attribution history, or a machine with
+      // no backing page e.g. the global assistant) collapse into one bucket rather
+      // than being dropped, so terminal spend is never silently under-reported.
+      const machineKey = r.pageId ?? '__unattributed__';
+      const label = r.pageId ? (r.pageTitle ?? 'Untitled machine') : 'Unattributed machine';
+      const mkb = machineBuckets.get(machineKey) ?? { millicents: 0, calls: 0, activeSeconds: 0, pageId: r.pageId, label };
+      mkb.millicents += charge;
+      mkb.calls += 1;
+      mkb.activeSeconds += (r.durationMs ?? 0) / 1000;
+      machineBuckets.set(machineKey, mkb);
+    }
   }
 
   const byFeature: UsageFeatureRow[] = Array.from(featureBuckets.entries())
@@ -123,11 +157,23 @@ export function aggregateUsageBreakdown(
     }))
     .sort((a, b) => b.spendCents - a.spendCents);
 
+  const byMachine: UsageMachineRow[] = Array.from(machineBuckets.values())
+    .map((b) => ({
+      pageId: b.pageId,
+      label: b.label,
+      activeSeconds: Math.round(b.activeSeconds),
+      spendCents: millicentsToCents(b.millicents),
+      calls: b.calls,
+      sharePct: sharePct(b.millicents, terminalMillicents),
+    }))
+    .sort((a, b) => b.spendCents - a.spendCents);
+
   return {
     periodStart: period.periodStart,
     periodEnd: period.periodEnd,
     totalSpendCents: millicentsToCents(totalMillicents),
     byFeature,
     byModel,
+    byMachine,
   };
 }

--- a/packages/lib/src/services/sandbox/__tests__/machine-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-billing.test.ts
@@ -139,6 +139,18 @@ describe('defaultSandboxBillingDeps.trackUsage', () => {
     const call = mockTrackUsage.mock.calls[0][0];
     expect(call.providerCostDollars).toBe(0);
   });
+
+  it('forwards pageId to AIMonitoring.trackUsage so usage-breakdown can attribute spend per machine', async () => {
+    mockTrackUsage.mockResolvedValue(undefined);
+    await defaultSandboxBillingDeps.trackUsage({
+      payerId: 'owner-1',
+      holdId: 'hold-1',
+      activeSeconds: 60,
+      pageId: 'terminal-page-1',
+    });
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.pageId).toBe('terminal-page-1');
+  });
 });
 
 describe('defaultSandboxBillingDeps.releaseHold', () => {

--- a/packages/lib/src/services/sandbox/__tests__/terminal-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-storage-billing.test.ts
@@ -70,6 +70,20 @@ describe('defaultReconcileTerminalStorageDeps.chargeStorage', () => {
     expect(call.holdId).toBeUndefined();
     expect(call.metadata).toMatchObject({ type: 'terminal_storage', pageId: 'page-1', gbMonths: 2.5 });
   });
+
+  it('forwards pageId as a TOP-LEVEL field (not just inside metadata), so usage-breakdown can attribute the charge to the right machine', async () => {
+    mockTrackUsage.mockResolvedValue(undefined);
+
+    await defaultReconcileTerminalStorageDeps.chargeStorage({
+      payerId: 'owner-1',
+      pageId: 'page-1',
+      costDollars: 0.05,
+      gbMonths: 2.5,
+    });
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.pageId).toBe('page-1');
+  });
 });
 
 describe('defaultReconcileTerminalStorageDeps.advanceWatermark', () => {

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -736,12 +736,12 @@ function makeBilling(over: Partial<SandboxRunDeps['billing']> = {}): {
   billing: NonNullable<SandboxRunDeps['billing']>;
   resolvePayerIdCalls: Array<{ tenantId: string; machinePageId?: string }>;
   gateCalls: Array<{ payerId: string }>;
-  trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number }>;
+  trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string }>;
   releaseHoldCalls: string[];
 } {
   const resolvePayerIdCalls: Array<{ tenantId: string; machinePageId?: string }> = [];
   const gateCalls: Array<{ payerId: string }> = [];
-  const trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number }> = [];
+  const trackUsageCalls: Array<{ payerId: string; holdId?: string; activeSeconds: number; pageId?: string }> = [];
   const releaseHoldCalls: string[] = [];
   const billing: NonNullable<SandboxRunDeps['billing']> = {
     resolvePayerId: async (input) => {
@@ -874,6 +874,31 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
     ]);
   });
 
+  it("forwards the resolved machinePageId as pageId to trackUsage, so usage-breakdown can attribute cost to the right machine", async () => {
+    const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
+    const sandbox = makeSandbox({
+      runCommand: async () => {
+        clock.advance(3000);
+        return { exitCode: 0, stdout: 'ok', stderr: '' };
+      },
+    });
+    const { billing, trackUsageCalls } = makeBilling();
+    const { deps } = makeDeps({ billing, reconnect: async () => sandbox, now: clock.now });
+
+    await runBashInSandbox({
+      command: 'echo hi',
+      ctx: makeCtx({
+        tenantId: 'acting-user',
+        activeMachine: { kind: 'existing', terminalId: 'other-terminal-page' },
+      }),
+      deps,
+    });
+
+    expect(trackUsageCalls).toEqual([
+      { payerId: 'acting-user', holdId: 'hold-1', activeSeconds: 3, pageId: 'other-terminal-page' },
+    ]);
+  });
+
   it("gates and settles usage against the PAYER resolvePayerId returns, not the raw tenantId, when they differ (owner-pays for a machine owned by someone else)", async () => {
     const clock = makeMutableClock(new Date('2026-06-01T12:00:00.000Z').getTime());
     const sandbox = makeSandbox({
@@ -898,6 +923,8 @@ describe('runBashInSandbox — machine billing (Terminal Epic 3)', () => {
 
     expect(result).toMatchObject({ success: true });
     expect(gateCalls).toEqual([{ payerId: 'real-owner-99' }]);
-    expect(trackUsageCalls).toEqual([{ payerId: 'real-owner-99', holdId: 'hold-1', activeSeconds: 2 }]);
+    expect(trackUsageCalls).toEqual([
+      { payerId: 'real-owner-99', holdId: 'hold-1', activeSeconds: 2, pageId: 'other-terminal-page' },
+    ]);
   });
 });

--- a/packages/lib/src/services/sandbox/machine-billing.ts
+++ b/packages/lib/src/services/sandbox/machine-billing.ts
@@ -54,12 +54,15 @@ export const defaultSandboxBillingDeps: SandboxBillingDeps = {
     return { allowed: result.allowed, holdId: result.holdId, reason: result.allowed ? undefined : result.reason };
   },
 
-  async trackUsage({ payerId, holdId, activeSeconds }) {
+  async trackUsage({ payerId, holdId, activeSeconds, pageId }) {
     await AIMonitoring.trackUsage({
       userId: payerId,
       provider: 'sprites',
       model: 'terminal-machine',
       source: 'terminal',
+      // The machine's identifying page (resolveMachinePageId's output) — the ONE
+      // attribution field the usage-breakdown's per-machine view groups on.
+      pageId,
       providerCostDollars: calculateTerminalCostDollars({ activeSeconds }),
       // Active-window duration (ms), matching the quantity that was billed —
       // not a request-latency figure, since there is no single "request" here.

--- a/packages/lib/src/services/sandbox/terminal-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/terminal-storage-billing.ts
@@ -30,6 +30,9 @@ export const defaultReconcileTerminalStorageDeps: ReconcileTerminalStorageDeps =
       provider: 'sprites',
       model: 'terminal-machine-storage',
       source: 'terminal',
+      // The machine's identifying page — the usage-breakdown's per-machine view
+      // groups on this (see machine-billing.ts's trackUsage for the same field).
+      pageId,
       providerCostDollars: costDollars,
       // Not a wall-clock duration (this is a background storage charge, not a
       // single timed run) — 0 mirrors the shape of every other non-timed

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -92,7 +92,7 @@ export interface SandboxBillingDeps {
   /** Places a flat-estimate hold for this payer before the machine run begins. */
   gate: (input: { payerId: string }) => Promise<{ allowed: boolean; holdId?: string; reason?: string }>;
   /** Settles the hold to the real active-window cost. Only called on a successful run. */
-  trackUsage: (input: { payerId: string; holdId?: string; activeSeconds: number }) => Promise<void>;
+  trackUsage: (input: { payerId: string; holdId?: string; activeSeconds: number; pageId?: string }) => Promise<void>;
   /** Releases a hold without billing. Called on every exit that never reaches `trackUsage`. */
   releaseHold: (holdId: string) => Promise<void>;
 }
@@ -370,7 +370,7 @@ async function withMachineBilling<S>(
     if (result.success) {
       handedOff = true;
       const activeSeconds = Math.max(0, (deps.now().getTime() - startedAt) / 1000);
-      await billing.trackUsage({ payerId, holdId, activeSeconds });
+      await billing.trackUsage({ payerId, holdId, activeSeconds, pageId: machinePageId });
     }
     return result;
   } finally {


### PR DESCRIPTION
## Summary
- Adds a **Terminals** block to `/settings/usage`: the viewer's machines, active runtime this period, and cost — alongside the existing AI/voice usage breakdown.
- Wires the missing per-machine attribution: `SandboxBillingDeps.trackUsage` (agent tool runs) and the realtime terminal handler's session-settle (interactive PTY) now thread the machine's backing `pageId` through to `AIMonitoring.trackUsage`, so `source:'terminal'` `credit_ledger` rows carry `pageId`. Previously this field was never set for terminal usage.
- Extends the **existing** usage-breakdown pipeline rather than building a parallel one: `usage-breakdown-query.ts` left-joins `pages` for the title, and the pure `aggregateUsageBreakdown` (`usage-breakdown.ts`) groups `source:'terminal'` rows into a new `byMachine` bucket (runtime, cost, share of terminal spend) — same shape/conventions as the existing `byFeature`/`byModel` buckets.
- `TerminalUsageCard.tsx` reads the same `GET /api/credits/breakdown` payload as `UsageBreakdownCard` (shares its SWR cache entry, no second request) and shows a clean empty state for free/zero-usage users.

**Owner-pays scoping**: no separate drive-ownership filter was needed — `credit_ledger.userId` is already the resolved PAYER (`terminal-payer.ts`'s owner-pays resolution: the backing page's drive owner, falling back to the acting tenant only when unresolvable), so every row this query returns for a viewer is already a machine they own or a run they footed the bill for.

## Test plan
- [x] `bun run typecheck` — green across the monorepo (full Next.js build succeeds, `/settings/usage` route compiles with the new card)
- [x] `packages/lib` — `machine-billing.test.ts`, `tool-runners.test.ts` (68 tests): pageId now asserted end-to-end through `withMachineBilling` → `trackUsage`
- [x] `apps/realtime` — `terminal-handler.test.ts` (37 tests): pageId asserted on both the natural-exit and idle-timeout-reap settle paths
- [x] `apps/web` — `usage-breakdown.test.ts` (14 tests, 6 new): `byMachine` grouping, sharePct-vs-terminal-total, unattributed/untitled fallback labels, sort order
- [ ] Manual walkthrough (React component, not regression-tested per .pu worktree dual-React caveat): open a Terminal page, run a few commands/an interactive session, then visit `/settings/usage` — the Terminals card should show the machine's page title, active runtime (e.g. "2m"), and cost in credits, reconciling with the raw `credit_ledger` rows for that user/period. A user with no terminal usage yet should see "No terminal usage yet this period."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kj5jP71tD9ZksQQWoasi3g