### PR TITLE
fix(terminal): Epic-3 billing gate — storage-cron isolation + pricing doc fix

### DIFF
--- a/apps/web/src/app/api/cron/reconcile-terminal-storage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/reconcile-terminal-storage/__tests__/route.test.ts
@@ -47,7 +47,7 @@ describe('/api/cron/reconcile-terminal-storage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(validateSignedCronRequest).mockReturnValue(null);
-    mockReconcile.mockResolvedValue({ processed: 3, charged: 2, skipped: 1, totalCostDollars: 0.001234 });
+    mockReconcile.mockResolvedValue({ processed: 3, charged: 2, skipped: 1, failed: 0, totalCostDollars: 0.001234 });
   });
 
   it('returns the auth error and never reconciles when auth fails', async () => {
@@ -71,10 +71,10 @@ describe('/api/cron/reconcile-terminal-storage', () => {
         eventType: 'data.write',
         resourceType: 'cron_job',
         resourceId: 'reconcile_terminal_storage',
-        details: expect.objectContaining({ processed: 3, charged: 2, skipped: 1 }),
+        details: expect.objectContaining({ processed: 3, charged: 2, skipped: 1, failed: 0 }),
       }),
     );
-    expect(body).toMatchObject({ success: true, processed: 3, charged: 2, skipped: 1 });
+    expect(body).toMatchObject({ success: true, processed: 3, charged: 2, skipped: 1, failed: 0 });
   });
 
   it('returns a 500 with the error message when reconcile throws', async () => {

--- a/apps/web/src/app/api/cron/reconcile-terminal-storage/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-terminal-storage/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: Request) {
     const result = await reconcileTerminalStorage(defaultReconcileTerminalStorageDeps);
 
     console.log(
-      `[Cron] Terminal storage reconcile: processed ${result.processed}, charged ${result.charged}, skipped ${result.skipped}, total $${result.totalCostDollars.toFixed(6)}`,
+      `[Cron] Terminal storage reconcile: processed ${result.processed}, charged ${result.charged}, skipped ${result.skipped}, failed ${result.failed}, total $${result.totalCostDollars.toFixed(6)}`,
     );
 
     audit({
@@ -40,6 +40,7 @@ export async function GET(request: Request) {
         processed: result.processed,
         charged: result.charged,
         skipped: result.skipped,
+        failed: result.failed,
         totalCostDollars: result.totalCostDollars,
       },
     });

--- a/packages/lib/src/monitoring/__tests__/terminal-pricing.test.ts
+++ b/packages/lib/src/monitoring/__tests__/terminal-pricing.test.ts
@@ -56,13 +56,19 @@ describe('calculateTerminalChargeCents', () => {
     expect(calculateTerminalChargeCents({ activeSeconds: 3600 })).toBe(12);
   });
 
-  it('enforces the 1.5x floor: charge is never less than 1.5x the real substrate cost', () => {
-    expect(MARKUP_BPS).toBeGreaterThanOrEqual(15000); // 1.5x pinned as the floor bps
+  it('pins the shared MARKUP_BPS default at >=1.5x — NOT an independent per-source floor', () => {
+    // This only asserts the GLOBAL constant every AI surface shares is still >=15000bps.
+    // calculateTerminalChargeCents applies whatever MARKUP_BPS currently is, same as
+    // every other source — it has no terminal-specific floor logic of its own (see
+    // terminal-pricing.ts's module doc). If this default is ever lowered, or split
+    // per-source, this test — and the "amount never less than 1.5x" check below — stop
+    // meaning what their names say; they'd need a real per-source floor to test instead.
+    expect(MARKUP_BPS).toBeGreaterThanOrEqual(15000);
     for (const activeSeconds of [1, 60, 900, 3600, 7200]) {
       const cost = calculateTerminalCostDollars({ activeSeconds });
       const chargeCents = calculateTerminalChargeCents({ activeSeconds });
-      // Allow for cent-rounding: the charge must be within half a cent of the exact
-      // 1.5x-of-cost figure, and never systematically under it.
+      // Formula consistency, not floor enforcement: this holds for ANY positive
+      // MARKUP_BPS >= ~1.0x, so it does not by itself prove a 1.5x floor exists.
       expect(chargeCents).toBeGreaterThanOrEqual(Math.floor(cost * 1.5 * 100));
     }
   });

--- a/packages/lib/src/monitoring/terminal-pricing.ts
+++ b/packages/lib/src/monitoring/terminal-pricing.ts
@@ -22,8 +22,17 @@
  * defaults to 15000 bps (1.5x), which is the floor the founder has set for
  * substrate runtime: the charge must never fall below 1.5x actual substrate
  * cost, regardless of which substrate (Sprites today, Modal/GPU later) produced
- * that cost. `calculateTerminalChargeCents` mirrors that exact formula so the
- * rule is independently pure-tested here, substrate-neutral and env-overridable.
+ * that cost.
+ *
+ * `calculateTerminalChargeCents` mirrors that same formula for pure unit-test
+ * coverage of the arithmetic, but it is NOT itself in the real settle path —
+ * `machine-billing.ts` hands `calculateTerminalCostDollars` (pre-markup) to
+ * `AIMonitoring.trackUsage`, which applies `MARKUP_BPS` generically for every
+ * source, terminal included. The "1.5x floor" holds today only because
+ * `MARKUP_BPS` itself defaults to 15000 bps for every surface — there is no
+ * terminal-specific enforcement independent of that shared, global constant.
+ * If `MARKUP_BPS` is ever split per-source, this function's result would
+ * silently stop matching what terminal is actually billed at.
  */
 
 import { markupCents } from '../billing/credit-core';
@@ -56,11 +65,12 @@ export function calculateTerminalCostDollars(quantity: TerminalUsageQuantity): n
 }
 
 /**
- * Customer-facing charge (whole cents) for one machine run: real substrate cost
- * marked up by `MARKUP_BPS` — the same formula `consumeCredits` applies at
- * settle, reused here so the "at minimum 1.5x actual substrate cost" rule is
- * pinned and pure-tested independent of the shared billing pipeline. Returns 0
- * for a missing/invalid/zero-duration window (nothing to charge).
+ * Reference calculation (whole cents) of what a machine run's real substrate
+ * cost marked up by `MARKUP_BPS` comes to — the same formula `consumeCredits`
+ * applies at settle, reused here for arithmetic unit-test coverage. NOT called
+ * by the real settle path (see module doc): the actual charge is computed by
+ * `consumeCredits` from `calculateTerminalCostDollars`'s pre-markup output, not
+ * by this function. Returns 0 for a missing/invalid/zero-duration window.
  */
 export function calculateTerminalChargeCents(quantity: TerminalUsageQuantity): number {
   return markupCents(calculateTerminalCostDollars(quantity), MARKUP_BPS);

--- a/packages/lib/src/services/sandbox/__tests__/terminal-storage-reconcile.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/terminal-storage-reconcile.test.ts
@@ -127,6 +127,25 @@ describe('reconcileTerminalStorage', () => {
     expect(advanceCalls).toEqual([]);
   });
 
+  it('isolates a per-machine failure: one row throwing does not abort the rest of the batch', async () => {
+    const { deps, chargeCalls, advanceCalls } = makeDeps({
+      listMachines: async () => [
+        machine({ pageId: 'boom' }),
+        machine({ pageId: 'fine' }),
+      ],
+      chargeStorage: async (input) => {
+        if (input.pageId === 'boom') throw new Error('ledger write failed');
+        chargeCalls.push(input);
+      },
+    });
+
+    const result = await reconcileTerminalStorage(deps);
+
+    expect(result).toMatchObject({ processed: 2, charged: 1, skipped: 0, failed: 1 });
+    expect(chargeCalls).toEqual([expect.objectContaining({ pageId: 'fine' })]);
+    expect(advanceCalls).toEqual([expect.objectContaining({ pageId: 'fine' })]);
+  });
+
   it('processes multiple machines independently, summing total cost', async () => {
     const { deps } = makeDeps({
       listMachines: async () => [

--- a/packages/lib/src/services/sandbox/terminal-storage-reconcile.ts
+++ b/packages/lib/src/services/sandbox/terminal-storage-reconcile.ts
@@ -13,7 +13,7 @@
  * `planTerminalLifecycle`) — so iterating this table covers both active and
  * hibernating machines with no separate registry needed.
  *
- * Idempotent / drift-correcting: each row tracks its own
+ * Idempotent / drift-correcting on the happy path: each row tracks its own
  * `storageLastBilledAt` watermark, so a run only bills the window that has
  * ACTUALLY elapsed since it last billed that row. Two runs back-to-back (or
  * any rerun before real time has passed) see zero elapsed time, which prices
@@ -22,9 +22,21 @@
  * untouched, a pure no-op. A missed run is caught up exactly on the next one
  * (the watermark never silently advances without a matching charge), so
  * there's no drift either way.
+ *
+ * `chargeStorage` and `advanceWatermark` are two separate un-transactioned
+ * writes (the charge goes through the shared credit pipeline; the watermark
+ * is a plain column update) — deliberately charge-before-advance so a crash
+ * before charging never loses a window. The flip side: if the process dies
+ * BETWEEN the two (rare — no I/O happens in between), that row's window is
+ * billed again on the next run, since the watermark never moved. Each row is
+ * isolated in its own try/catch (below) so this failure mode stays scoped to
+ * one machine and never aborts the rest of the batch; it does not eliminate
+ * the residual double-bill risk, which would need the charge and the
+ * watermark update to commit atomically to close entirely.
  */
 
 import { calculateTerminalStorageCostDollars } from '../../monitoring/terminal-pricing';
+import { loggers } from '../../logging/logger-config';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 /** A billing month, for prorating the monthly storage rate over an elapsed span. Not tied to any subscription's actual renewal cycle — storage accrual is metered independently of it. */
@@ -60,6 +72,8 @@ export interface ReconcileTerminalStorageResult {
   charged: number;
   /** Rows with a positive accrual whose owner could not be resolved — left unbilled (watermark untouched) for a future run to retry. */
   skipped: number;
+  /** Rows where `chargeStorage`/`advanceWatermark` threw — isolated so one bad row doesn't abort the batch; see module doc on the residual double-bill risk this leaves for a future run to retry. */
+  failed: number;
   totalCostDollars: number;
 }
 
@@ -71,31 +85,45 @@ export async function reconcileTerminalStorage(
 
   let charged = 0;
   let skipped = 0;
+  let failed = 0;
   let totalCostDollars = 0;
 
   for (const machine of machines) {
-    const elapsedMs = now.getTime() - machine.storageLastBilledAt.getTime();
-    const gbMonths = computeElapsedGbMonths({ storageGB: deps.storageGB, elapsedMs });
-    const costDollars = calculateTerminalStorageCostDollars(gbMonths);
+    try {
+      const elapsedMs = now.getTime() - machine.storageLastBilledAt.getTime();
+      const gbMonths = computeElapsedGbMonths({ storageGB: deps.storageGB, elapsedMs });
+      const costDollars = calculateTerminalStorageCostDollars(gbMonths);
 
-    // Nothing has accrued (zero/negative elapsed window) — no-op, watermark
-    // stays put since there is nothing to advance it past.
-    if (costDollars <= 0) continue;
+      // Nothing has accrued (zero/negative elapsed window) — no-op, watermark
+      // stays put since there is nothing to advance it past.
+      if (costDollars <= 0) continue;
 
-    const ownerId = await deps.lookupPageOwnerId(machine.pageId);
-    if (!ownerId) {
-      // Can't resolve who to bill (e.g. the page/drive vanished). Leave the
-      // watermark untouched so this window keeps accruing until it either
-      // resolves on a later run or the session row itself is torn down.
-      skipped += 1;
-      continue;
+      const ownerId = await deps.lookupPageOwnerId(machine.pageId);
+      if (!ownerId) {
+        // Can't resolve who to bill (e.g. the page/drive vanished). Leave the
+        // watermark untouched so this window keeps accruing until it either
+        // resolves on a later run or the session row itself is torn down.
+        skipped += 1;
+        continue;
+      }
+
+      await deps.chargeStorage({ payerId: ownerId, pageId: machine.pageId, costDollars, gbMonths });
+      await deps.advanceWatermark({ pageId: machine.pageId, billedThrough: now });
+      totalCostDollars += costDollars;
+      charged += 1;
+    } catch (error) {
+      // Isolated per-row: one machine's charge/advance failure must not drop
+      // every other machine in this run from being billed. Left unresolved: if
+      // chargeStorage already committed before advanceWatermark threw, this
+      // row's window bills again next run (see module doc).
+      failed += 1;
+      loggers.ai.error(
+        'Terminal storage reconcile failed for machine',
+        error instanceof Error ? error : new Error(String(error)),
+        { pageId: machine.pageId },
+      );
     }
-
-    await deps.chargeStorage({ payerId: ownerId, pageId: machine.pageId, costDollars, gbMonths });
-    await deps.advanceWatermark({ pageId: machine.pageId, billedThrough: now });
-    totalCostDollars += costDollars;
-    charged += 1;
   }
 
-  return { processed: machines.length, charged, skipped, totalCostDollars };
+  return { processed: machines.length, charged, skipped, failed, totalCostDollars };
 }


### PR DESCRIPTION
## Summary
Fixes from the Terminal Epic 3 (Metering) billing-correctness GATE review (PageSpace page `e2k6ykyukm6nkgq8yo3ahh6m`), verified against the gate rubric: bill-once, no leaked holds, pricing floor, owner-pays, storage-cron idempotency, daily-cap coverage.

- **`terminal-storage-reconcile.ts`**: the per-machine loop had no try/catch and its two writes (`chargeStorage`, `advanceWatermark`) aren't transactional — one machine's failure aborted the whole cron batch, and a crash between the two writes would double-bill that machine's window on the next run. Isolated each row in its own try/catch, added a `failed` counter (surfaced in the cron's log/audit), and corrected the module doc to state the residual crash-window double-bill risk honestly instead of claiming unconditional idempotency.
- **`terminal-pricing.ts`**: `calculateTerminalChargeCents` (the "1.5x floor" function) is never called by the real settle path — the actual charge is computed by the shared `consumeCredits` via the global `MARKUP_BPS`, same as every other AI surface. Today's charge complies with the 1.5x floor only because `MARKUP_BPS` itself defaults to that value for everyone, not because of independent per-source enforcement. Corrected the docstrings and the misleading "enforces the 1.5x floor" test name/framing. **No production behavior change** — billing was never actually wrong, this is a documentation/dead-code clarity fix.

## Test plan
- [x] `bun run typecheck` — 16/16 turbo tasks green
- [x] `bunx vitest run` on `packages/lib/src/{billing,monitoring,services/sandbox,services/machines}`, `apps/realtime/src/terminal`, `apps/web/src/app/api/cron` — 79 files / 1397 tests green
- [x] New test: one machine's `chargeStorage` throw doesn't drop other machines from being billed in the same cron run
- [ ] Live ledger verification against a real Sprite — not possible in this environment (no Sprites API token); verified via code tracing + the mocked test suites instead. Flagged on the gate page as an open item if/when a token is available.

Full findings + evidence: PageSpace page `e2k6ykyukm6nkgq8yo3ahh6m`.

https://claude.ai/code/session_01DGZ6CfbMJsd5a27yNYwqN3