### PR TITLE
feat(terminal): Terminal — Workspace UI (Epic 2)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -7,33 +7,20 @@ import { motion } from 'motion/react';
 import { useSocket } from '@/hooks/useSocket';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
 interface TerminalViewProps {
   pageId: string;
 }
 
 const XtermTerminal = dynamic(() => import('./XtermTerminal'), { ssr: false });
+const TerminalWorkspace = dynamic(() => import('./workspace/TerminalWorkspace'), { ssr: false });
 
 const SESSION_FLAG_KEY = (pageId: string) => `terminal-session:${pageId}`;
 
 const TerminalView = ({ pageId }: TerminalViewProps) => {
-  const [connected, setConnected] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const isReconnect = typeof sessionStorage !== 'undefined' && !!sessionStorage.getItem(SESSION_FLAG_KEY(pageId));
-  const socket = useSocket();
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
-
-  const handleReady = useCallback(() => {
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem(SESSION_FLAG_KEY(pageId), '1');
-    }
-    setConnected(true);
-  }, [pageId]);
-  const handleError = useCallback((message: string) => {
-    setError(message);
-    toast.error(`Terminal error: ${message}`);
-  }, []);
 
   return (
     <motion.div
@@ -51,31 +38,68 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
         </div>
       )}
 
-      <div className="flex-1 min-h-0 relative">
-        {socket && isAdmin && (
-          <XtermTerminal
-            socket={socket}
-            pageId={pageId}
-            onReady={handleReady}
-            onError={handleError}
-          />
-        )}
-
-        {isAdmin && !connected && (
-          <div className="absolute inset-0 bg-black flex items-center justify-center">
-            {error ? (
-              <span className="text-sm text-red-400">{error}</span>
-            ) : (
-              <div className="flex items-center gap-2">
-                <div className="w-4 h-4 border-2 border-green-400 border-t-transparent rounded-full animate-spin" />
-                <span className="text-sm text-green-400">{isReconnect ? 'Reconnecting to shell...' : 'Connecting to shell...'}</span>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      {isAdmin && (
+        <Tabs defaultValue="workspace" className="flex-1 min-h-0 flex flex-col gap-0">
+          <TabsList className="w-fit rounded-none border-b border-white/10 bg-black">
+            <TabsTrigger value="workspace">Workspace</TabsTrigger>
+            <TabsTrigger value="shell">Machine Shell</TabsTrigger>
+          </TabsList>
+          <TabsContent value="workspace" className="flex-1 min-h-0 m-0">
+            <TerminalWorkspace terminalId={pageId} />
+          </TabsContent>
+          <TabsContent value="shell" className="flex-1 min-h-0 m-0">
+            <MachineShell pageId={pageId} />
+          </TabsContent>
+        </Tabs>
+      )}
     </motion.div>
   );
 };
+
+/** The Machine's own persistent shell — a direct root session on the Machine itself, separate from any branch-terminal's Sprite. */
+function MachineShell({ pageId }: { pageId: string }) {
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isReconnect = typeof sessionStorage !== 'undefined' && !!sessionStorage.getItem(SESSION_FLAG_KEY(pageId));
+  const socket = useSocket();
+
+  const handleReady = useCallback(() => {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(SESSION_FLAG_KEY(pageId), '1');
+    }
+    setConnected(true);
+  }, [pageId]);
+  const handleError = useCallback((message: string) => {
+    setError(message);
+    toast.error(`Terminal error: ${message}`);
+  }, []);
+
+  return (
+    <div className="h-full min-h-0 relative bg-black">
+      {socket && (
+        <XtermTerminal
+          socket={socket}
+          sessionId={`terminal:${pageId}`}
+          connectPayload={{ pageId }}
+          onReady={handleReady}
+          onError={handleError}
+        />
+      )}
+
+      {!connected && (
+        <div className="absolute inset-0 bg-black flex items-center justify-center">
+          {error ? (
+            <span className="text-sm text-red-400">{error}</span>
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 border-2 border-green-400 border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm text-green-400">{isReconnect ? 'Reconnecting to shell...' : 'Connecting to shell...'}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default React.memo(TerminalView);

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
@@ -2,15 +2,33 @@
 
 import { useEffect, useRef } from 'react';
 import type { Socket } from 'socket.io-client';
+import { useEditingStore } from '@/stores/useEditingStore';
 
 interface XtermTerminalProps {
   socket: Socket;
-  pageId: string;
+  /**
+   * Uniquely identifies this PTY session (e.g. `terminal:${pageId}` for a
+   * human Machine shell, or `agent-terminal:${terminalId}:${projectName}:
+   * ${branchName}:${name}` for a workspace agent-terminal pane). Used as the
+   * effect's re-connect key and as the useEditingStore session id.
+   */
+  sessionId: string;
+  /** Which realtime event family to speak — see apps/realtime/src/terminal/. Defaults to the human Machine shell. */
+  eventPrefix?: 'terminal' | 'agent-terminal';
+  /** Payload merged with `{ cols, rows }` on `${eventPrefix}:connect` — e.g. `{ pageId }` or `{ terminalId, projectName, branchName, name }`. */
+  connectPayload: Record<string, unknown>;
   onReady?(): void;
   onError?(message: string): void;
 }
 
-export default function XtermTerminal({ socket, pageId, onReady, onError }: XtermTerminalProps) {
+export default function XtermTerminal({
+  socket,
+  sessionId,
+  eventPrefix = 'terminal',
+  connectPayload,
+  onReady,
+  onError,
+}: XtermTerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -34,11 +52,12 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
         terminal.open(containerRef.current);
         fitAddon.fit();
 
-        const onData = terminal.onData((data) => socket.emit('terminal:input', { data }));
+        const onData = terminal.onData((data) => socket.emit(`${eventPrefix}:input`, { data }));
 
         const handleOutput = ({ data }: { data: string }) => terminal.write(data);
         const handleReady = ({ scrollback }: { scrollback?: string } = {}) => {
           if (scrollback) terminal.write(scrollback);
+          useEditingStore.getState().startEditing(sessionId, 'other', { componentName: eventPrefix });
           onReady?.();
         };
         const handleClosed = ({ exitCode }: { exitCode: number }) =>
@@ -48,29 +67,30 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
           onError?.(message);
         };
 
-        // Register listeners BEFORE emitting terminal:connect so we don't miss
-        // early terminal:ready / terminal:output events from the server.
-        socket.on('terminal:output', handleOutput);
-        socket.on('terminal:ready', handleReady);
-        socket.on('terminal:closed', handleClosed);
-        socket.on('terminal:error', handleError);
+        // Register listeners BEFORE emitting ${eventPrefix}:connect so we don't
+        // miss early ${eventPrefix}:ready / ${eventPrefix}:output events.
+        socket.on(`${eventPrefix}:output`, handleOutput);
+        socket.on(`${eventPrefix}:ready`, handleReady);
+        socket.on(`${eventPrefix}:closed`, handleClosed);
+        socket.on(`${eventPrefix}:error`, handleError);
 
-        socket.emit('terminal:connect', { pageId, cols: terminal.cols, rows: terminal.rows });
+        socket.emit(`${eventPrefix}:connect`, { ...connectPayload, cols: terminal.cols, rows: terminal.rows });
 
         const ro = new ResizeObserver(() => {
           fitAddon.fit();
-          socket.emit('terminal:resize', { cols: terminal.cols, rows: terminal.rows });
+          socket.emit(`${eventPrefix}:resize`, { cols: terminal.cols, rows: terminal.rows });
         });
         ro.observe(containerRef.current!);
 
         teardown = () => {
           ro.disconnect();
           onData.dispose();
-          socket.off('terminal:output', handleOutput);
-          socket.off('terminal:ready', handleReady);
-          socket.off('terminal:closed', handleClosed);
-          socket.off('terminal:error', handleError);
+          socket.off(`${eventPrefix}:output`, handleOutput);
+          socket.off(`${eventPrefix}:ready`, handleReady);
+          socket.off(`${eventPrefix}:closed`, handleClosed);
+          socket.off(`${eventPrefix}:error`, handleError);
           terminal.dispose();
+          useEditingStore.getState().endEditing(sessionId);
         };
 
         if (cancelled) teardown();
@@ -84,10 +104,13 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
       cancelled = true;
       teardown?.();
     };
-  // onReady/onError are intentionally omitted — callers must stabilise them with
-  // useCallback. Including them would re-mount the terminal on every parent render.
+  // onReady/onError/connectPayload are intentionally omitted — callers must
+  // treat connectPayload as stable for a given sessionId (bump sessionId
+  // instead of mutating it in place) and stabilise onReady/onError with
+  // useCallback. Including them would re-mount the terminal on every parent
+  // render.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [socket, pageId]);
+  }, [socket, sessionId, eventPrefix]);
 
   return <div ref={containerRef} className="w-full h-full" />;
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/EmptyState.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/EmptyState.tsx
@@ -1,0 +1,15 @@
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  children?: React.ReactNode;
+}
+
+export default function EmptyState({ title, description, children }: EmptyStateProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+      <p className="text-sm font-medium text-muted-foreground">{title}</p>
+      {description && <p className="max-w-xs text-xs text-muted-foreground/70">{description}</p>}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  ChevronRight,
+  ChevronDown,
+  FolderGit2,
+  GitBranch,
+  TerminalSquare,
+  Plus,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useMachineProjects } from '@/hooks/useMachineProjects';
+import { useMachineBranches } from '@/hooks/useMachineBranches';
+import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import EmptyState from './EmptyState';
+
+const AGENT_TYPES = Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[];
+
+interface NavigatorProps {
+  terminalId: string;
+  selectedProject: string | null;
+  selectedBranch: string | null;
+  onSelectProject(name: string): void;
+  onSelectBranch(name: string): void;
+  onOpenTerminal(name: string): void;
+}
+
+export default function Navigator({
+  terminalId,
+  selectedProject,
+  selectedBranch,
+  onSelectProject,
+  onSelectBranch,
+  onOpenTerminal,
+}: NavigatorProps) {
+  const { projects, isLoading, addProject, removeProject } = useMachineProjects(terminalId);
+
+  return (
+    <div className="flex h-full flex-col border-l">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Navigator</span>
+        <AddProjectDialog onAdd={addProject} />
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-1 text-sm">
+          {isLoading && <div className="px-2 py-1 text-xs text-muted-foreground">Loading projects…</div>}
+          {!isLoading && projects.length === 0 && (
+            <EmptyState
+              title="No projects yet"
+              description="Add a git repo to this machine to start a branch-terminal."
+            >
+              <AddProjectDialog onAdd={addProject} triggerLabel="Add your first project" />
+            </EmptyState>
+          )}
+          {projects.map((project) => (
+            <ProjectNode
+              key={project.name}
+              terminalId={terminalId}
+              projectName={project.name}
+              selectedProject={selectedProject}
+              selectedBranch={selectedBranch}
+              onSelectProject={onSelectProject}
+              onSelectBranch={onSelectBranch}
+              onOpenTerminal={onOpenTerminal}
+              onRemoveProject={() => {
+                if (!window.confirm(`Remove project "${project.name}"? This does not touch its branch-terminals.`)) return;
+                void removeProject(project.name).catch((err) => toast.error(err instanceof Error ? err.message : 'Failed to remove project'));
+              }}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function ProjectNode({
+  terminalId,
+  projectName,
+  selectedProject,
+  selectedBranch,
+  onSelectProject,
+  onSelectBranch,
+  onOpenTerminal,
+  onRemoveProject,
+}: {
+  terminalId: string;
+  projectName: string;
+  selectedProject: string | null;
+  selectedBranch: string | null;
+  onSelectProject(name: string): void;
+  onSelectBranch(name: string): void;
+  onOpenTerminal(name: string): void;
+  onRemoveProject(): void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isSelected = selectedProject === projectName;
+  const { branches, addBranch, removeBranch } = useMachineBranches(terminalId, expanded ? projectName : null);
+
+  return (
+    <div>
+      <div
+        className={`group flex items-center gap-1 rounded-sm py-1 pr-1 ${isSelected ? 'bg-accent' : 'hover:bg-accent/50'}`}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded((e) => !e);
+            onSelectProject(projectName);
+          }}
+          className="flex flex-1 items-center gap-1 text-left"
+        >
+          {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+          <FolderGit2 className="size-3.5 shrink-0" />
+          <span className="truncate font-medium">{projectName}</span>
+        </button>
+        <button
+          type="button"
+          onClick={onRemoveProject}
+          className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+          title="Remove project"
+        >
+          <X className="mx-auto size-3.5" />
+        </button>
+      </div>
+      {expanded && (
+        <div className="pl-4">
+          <div className="flex items-center justify-between py-0.5 pr-1">
+            <span className="text-xs text-muted-foreground">Branches</span>
+            <AddBranchDialog onAdd={addBranch} />
+          </div>
+          {branches.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">No branches yet</div>}
+          {branches.map((branch) => (
+            <BranchNode
+              key={branch.branchName}
+              terminalId={terminalId}
+              projectName={projectName}
+              branchName={branch.branchName}
+              selectedBranch={selectedBranch}
+              onSelectBranch={onSelectBranch}
+              onOpenTerminal={onOpenTerminal}
+              onRemoveBranch={() => {
+                if (!window.confirm(`Remove branch-terminal "${branch.branchName}"? Its Sprite will be destroyed.`)) return;
+                void removeBranch(branch.branchName).catch((err) =>
+                  toast.error(err instanceof Error ? err.message : 'Failed to remove branch'),
+                );
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BranchNode({
+  terminalId,
+  projectName,
+  branchName,
+  selectedBranch,
+  onSelectBranch,
+  onOpenTerminal,
+  onRemoveBranch,
+}: {
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  selectedBranch: string | null;
+  onSelectBranch(name: string): void;
+  onOpenTerminal(name: string): void;
+  onRemoveBranch(): void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isSelected = selectedBranch === branchName;
+  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
+    terminalId,
+    projectName,
+    expanded ? branchName : null,
+  );
+
+  return (
+    <div>
+      <div className={`group flex items-center gap-1 rounded-sm py-1 pr-1 ${isSelected ? 'bg-accent' : 'hover:bg-accent/50'}`}>
+        <button
+          type="button"
+          onClick={() => {
+            setExpanded((e) => !e);
+            onSelectBranch(branchName);
+          }}
+          className="flex flex-1 items-center gap-1 text-left"
+        >
+          {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+          <GitBranch className="size-3.5 shrink-0" />
+          <span className="truncate">{branchName}</span>
+        </button>
+        <button
+          type="button"
+          onClick={onRemoveBranch}
+          className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+          title="Remove branch-terminal"
+        >
+          <X className="mx-auto size-3.5" />
+        </button>
+      </div>
+      {expanded && (
+        <div className="pl-4">
+          <div className="flex items-center justify-between py-0.5 pr-1">
+            <span className="text-xs text-muted-foreground">Terminals</span>
+            <AddAgentTerminalDialog onAdd={addAgentTerminal} />
+          </div>
+          {agentTerminals.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">No terminals yet</div>}
+          {agentTerminals.map((terminal) => (
+            <div
+              key={terminal.name}
+              className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50"
+            >
+              <button
+                type="button"
+                onClick={() => onOpenTerminal(terminal.name)}
+                className="flex flex-1 items-center gap-1 text-left"
+              >
+                <TerminalSquare className="size-3.5 shrink-0" />
+                <span className="truncate">{terminal.name}</span>
+                <span className="ml-auto shrink-0 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+                  {terminal.agentType}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (!window.confirm(`Remove terminal "${terminal.name}"?`)) return;
+                  void removeAgentTerminal(terminal.name).catch((err) =>
+                    toast.error(err instanceof Error ? err.message : 'Failed to remove terminal'),
+                  );
+                }}
+                className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+                title="Remove terminal"
+              >
+                <X className="mx-auto size-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AddProjectDialog({ onAdd, triggerLabel }: { onAdd(name: string, repoUrl: string): Promise<unknown>; triggerLabel?: string }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(name.trim(), repoUrl.trim());
+      setOpen(false);
+      setName('');
+      setRepoUrl('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add project');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {triggerLabel ? (
+          <Button variant="outline" size="sm" className="h-7 text-xs">
+            {triggerLabel}
+          </Button>
+        ) : (
+          <Button variant="ghost" size="icon" className="size-6" title="Add project">
+            <Plus className="size-3.5" />
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add project</DialogTitle>
+          <DialogDescription>Clone a git repo onto this machine&apos;s persistent filesystem.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input placeholder="Project name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Input placeholder="Repo URL (https://github.com/org/repo.git)" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} />
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !name.trim() || !repoUrl.trim()}>
+            {submitting ? 'Adding…' : 'Add project'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddBranchDialog({ onAdd }: { onAdd(branchName: string): Promise<unknown> }) {
+  const [open, setOpen] = useState(false);
+  const [branchName, setBranchName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(branchName.trim());
+      setOpen(false);
+      setBranchName('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add branch');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-5" title="Add branch-terminal">
+          <Plus className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add branch-terminal</DialogTitle>
+          <DialogDescription>Checks out this branch in its own isolated Sprite.</DialogDescription>
+        </DialogHeader>
+        <Input placeholder="Branch name" value={branchName} onChange={(e) => setBranchName(e.target.value)} />
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !branchName.trim()}>
+            {submitting ? 'Spawning…' : 'Add branch'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddAgentTerminalDialog({ onAdd }: { onAdd(name: string, agentType: AgentRuntimeType): Promise<unknown> }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [agentType, setAgentType] = useState<AgentRuntimeType>(AGENT_TYPES[0]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(name.trim(), agentType);
+      setOpen(false);
+      setName('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add terminal');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-5" title="Add terminal">
+          <Plus className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add terminal</DialogTitle>
+          <DialogDescription>Named PTY session inside this branch&apos;s Sprite, running a pluggable agent type.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input placeholder="Terminal name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentRuntimeType)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AGENT_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !name.trim()}>
+            {submitting ? 'Adding…' : 'Add terminal'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { Fragment, useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import dynamic from 'next/dynamic';
+import type { Socket } from 'socket.io-client';
+import { SquareSplitHorizontal, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import EmptyState from './EmptyState';
+
+const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
+
+export interface TerminalPaneState {
+  id: string;
+  terminalName: string | null;
+}
+
+interface TerminalPanesProps {
+  terminalId: string;
+  projectName: string | null;
+  branchName: string | null;
+  socket: Socket | null | undefined;
+  panes: TerminalPaneState[];
+  setPanes: Dispatch<SetStateAction<TerminalPaneState[]>>;
+}
+
+export default function TerminalPanes({ terminalId, projectName, branchName, socket, panes, setPanes }: TerminalPanesProps) {
+  const { agentTerminals } = useAgentTerminals(terminalId, projectName, branchName);
+
+  if (!projectName || !branchName) {
+    return <EmptyState title="No branch selected" description="Select a branch in the navigator to open a terminal." />;
+  }
+
+  const handleSplit = () => setPanes((prev) => [...prev, { id: crypto.randomUUID(), terminalName: null }]);
+  const handleClosePane = (id: string) => setPanes((prev) => (prev.length <= 1 ? prev : prev.filter((p) => p.id !== id)));
+  const handleSelectPaneTerminal = (id: string, name: string | null) =>
+    setPanes((prev) => prev.map((p) => (p.id === id ? { ...p, terminalName: name } : p)));
+
+  return (
+    <div className="flex h-full flex-col bg-black">
+      <div className="flex items-center justify-end gap-1 border-b border-white/10 px-2 py-1">
+        <Button variant="ghost" size="sm" onClick={handleSplit} className="h-6 gap-1 px-2 text-xs text-white/70 hover:text-white">
+          <SquareSplitHorizontal className="size-3.5" />
+          Split
+        </Button>
+      </div>
+      <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+        {panes.map((pane, i) => (
+          <Fragment key={pane.id}>
+            {i > 0 && <ResizableHandle />}
+            <ResizablePanel defaultSize={100 / panes.length} minSize={20}>
+              <TerminalPane
+                socket={socket}
+                terminalId={terminalId}
+                projectName={projectName}
+                branchName={branchName}
+                pane={pane}
+                agentTerminalNames={agentTerminals.map((t) => t.name)}
+                canClose={panes.length > 1}
+                onClose={() => handleClosePane(pane.id)}
+                onSelectTerminal={(name) => handleSelectPaneTerminal(pane.id, name)}
+              />
+            </ResizablePanel>
+          </Fragment>
+        ))}
+      </ResizablePanelGroup>
+    </div>
+  );
+}
+
+function TerminalPane({
+  socket,
+  terminalId,
+  projectName,
+  branchName,
+  pane,
+  agentTerminalNames,
+  canClose,
+  onClose,
+  onSelectTerminal,
+}: {
+  socket: Socket | null | undefined;
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  pane: TerminalPaneState;
+  agentTerminalNames: string[];
+  canClose: boolean;
+  onClose(): void;
+  onSelectTerminal(name: string | null): void;
+}) {
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Switching which terminal this pane shows re-mounts XtermTerminal (keyed by
+  // sessionId below) — reset the local connection-status UI to match.
+  useEffect(() => {
+    setConnected(false);
+    setError(null);
+  }, [pane.terminalName]);
+
+  const handleReady = useCallback(() => setConnected(true), []);
+  const handleError = useCallback((message: string) => setError(message), []);
+
+  const sessionId = `agent-terminal:${terminalId}:${projectName}:${branchName}:${pane.terminalName ?? ''}`;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-1 border-b border-white/10 bg-white/5 px-1.5 py-1">
+        <Select value={pane.terminalName ?? undefined} onValueChange={(value) => onSelectTerminal(value)}>
+          <SelectTrigger size="sm" className="h-6 flex-1 border-none bg-transparent text-xs text-white/80 shadow-none">
+            <SelectValue placeholder="Select a terminal…" />
+          </SelectTrigger>
+          <SelectContent>
+            {agentTerminalNames.map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {canClose && (
+          <Button variant="ghost" size="icon" onClick={onClose} className="size-5 text-white/60 hover:text-white">
+            <X className="size-3.5" />
+          </Button>
+        )}
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {!pane.terminalName ? (
+          <EmptyState title="No terminal open" description="Choose a terminal above, or add one from the navigator." />
+        ) : (
+          <>
+            {socket && (
+              <XtermTerminal
+                key={sessionId}
+                socket={socket}
+                sessionId={sessionId}
+                eventPrefix="agent-terminal"
+                connectPayload={{ terminalId, projectName, branchName, name: pane.terminalName }}
+                onReady={handleReady}
+                onError={handleError}
+              />
+            )}
+            {!connected && (
+              <div className="absolute inset-0 flex items-center justify-center bg-black">
+                {error ? (
+                  <span className="text-sm text-red-400">{error}</span>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <div className="size-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+                    <span className="text-sm text-green-400">Connecting…</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useCallback, useState } from 'react';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useSocket } from '@/hooks/useSocket';
+import Navigator from './Navigator';
+import TerminalPanes, { type TerminalPaneState } from './TerminalPanes';
+
+interface TerminalWorkspaceProps {
+  /** The Terminal page's own id — this page IS the Machine (tasks/terminal.md). */
+  terminalId: string;
+}
+
+function newPane(terminalName: string | null = null): TerminalPaneState {
+  return { id: crypto.randomUUID(), terminalName };
+}
+
+export default function TerminalWorkspace({ terminalId }: TerminalWorkspaceProps) {
+  const socket = useSocket();
+  const [selectedProject, setSelectedProject] = useState<string | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState<string | null>(null);
+  const [panes, setPanes] = useState<TerminalPaneState[]>(() => [newPane()]);
+
+  const handleSelectProject = useCallback((name: string) => {
+    setSelectedProject((prev) => {
+      if (prev === name) return prev;
+      setSelectedBranch(null);
+      setPanes([newPane()]);
+      return name;
+    });
+  }, []);
+
+  const handleSelectBranch = useCallback((name: string) => {
+    setSelectedBranch((prev) => {
+      if (prev === name) return prev;
+      setPanes([newPane()]);
+      return name;
+    });
+  }, []);
+
+  const handleOpenTerminal = useCallback((name: string) => {
+    setPanes((prev) => {
+      if (prev.length === 0) return [newPane(name)];
+      const next = [...prev];
+      next[next.length - 1] = { ...next[next.length - 1], terminalName: name };
+      return next;
+    });
+  }, []);
+
+  return (
+    <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+      <ResizablePanel defaultSize={75} minSize={30}>
+        <TerminalPanes
+          terminalId={terminalId}
+          projectName={selectedProject}
+          branchName={selectedBranch}
+          socket={socket}
+          panes={panes}
+          setPanes={setPanes}
+        />
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={25} minSize={16} maxSize={40}>
+        <Navigator
+          terminalId={terminalId}
+          selectedProject={selectedProject}
+          selectedBranch={selectedBranch}
+          onSelectProject={handleSelectProject}
+          onSelectBranch={handleSelectBranch}
+          onOpenTerminal={handleOpenTerminal}
+        />
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useCallback } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+
+export interface AgentTerminal {
+  name: string;
+  agentType: AgentRuntimeType;
+  createdAt: string;
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch terminals');
+    }
+    return res.json() as Promise<{ agentTerminals: AgentTerminal[] }>;
+  });
+
+/** Runtime tier of the Terminal workspace navigator — named, pluggable-agent-typed PTY sessions in a branch's Sprite. */
+export function useAgentTerminals(terminalId: string | null, projectName: string | null, branchName: string | null) {
+  const key =
+    terminalId && projectName && branchName
+      ? `/api/machines/agent-terminals?terminalId=${encodeURIComponent(terminalId)}&projectName=${encodeURIComponent(projectName)}&branchName=${encodeURIComponent(branchName)}`
+      : null;
+
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const addAgentTerminal = useCallback(
+    async (name: string, agentType: AgentRuntimeType) => {
+      if (!terminalId || !projectName || !branchName) throw new Error('No active branch');
+      const result = await post<{ agentTerminal: { name: string; agentType: AgentRuntimeType; resumed: boolean } }>(
+        '/api/machines/agent-terminals',
+        { terminalId, projectName, branchName, name, agentType },
+      );
+      await mutate();
+      return result.agentTerminal;
+    },
+    [terminalId, projectName, branchName, mutate],
+  );
+
+  const removeAgentTerminal = useCallback(
+    async (name: string) => {
+      if (!terminalId || !projectName || !branchName) throw new Error('No active branch');
+      await del(
+        `/api/machines/agent-terminals?terminalId=${encodeURIComponent(terminalId)}&projectName=${encodeURIComponent(projectName)}&branchName=${encodeURIComponent(branchName)}&name=${encodeURIComponent(name)}`,
+      );
+      await mutate();
+    },
+    [terminalId, projectName, branchName, mutate],
+  );
+
+  return {
+    agentTerminals: data?.agentTerminals ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+    addAgentTerminal,
+    removeAgentTerminal,
+  };
+}

--- a/apps/web/src/hooks/useMachineBranches.ts
+++ b/apps/web/src/hooks/useMachineBranches.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+
+export interface MachineBranch {
+  branchName: string;
+  createdAt: string;
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch branches');
+    }
+    return res.json() as Promise<{ branches: MachineBranch[] }>;
+  });
+
+/** Branches tier of the Terminal workspace navigator — one isolated Sprite per branch-terminal. */
+export function useMachineBranches(terminalId: string | null, projectName: string | null) {
+  const key =
+    terminalId && projectName
+      ? `/api/machines/branches?terminalId=${encodeURIComponent(terminalId)}&projectName=${encodeURIComponent(projectName)}`
+      : null;
+
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const addBranch = useCallback(
+    async (branchName: string) => {
+      if (!terminalId || !projectName) throw new Error('No active project');
+      const result = await post<{ branch: { branchName: string; resumed: boolean } }>('/api/machines/branches', {
+        terminalId,
+        projectName,
+        branchName,
+      });
+      await mutate();
+      return result.branch;
+    },
+    [terminalId, projectName, mutate],
+  );
+
+  const removeBranch = useCallback(
+    async (branchName: string) => {
+      if (!terminalId || !projectName) throw new Error('No active project');
+      await del(
+        `/api/machines/branches?terminalId=${encodeURIComponent(terminalId)}&projectName=${encodeURIComponent(projectName)}&branchName=${encodeURIComponent(branchName)}`,
+      );
+      await mutate();
+    },
+    [terminalId, projectName, mutate],
+  );
+
+  return {
+    branches: data?.branches ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+    addBranch,
+    removeBranch,
+  };
+}

--- a/apps/web/src/hooks/useMachineProjects.ts
+++ b/apps/web/src/hooks/useMachineProjects.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useCallback } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+
+export interface MachineProject {
+  name: string;
+  repoUrl: string;
+  path: string;
+  createdAt: string;
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch projects');
+    }
+    return res.json() as Promise<{ projects: MachineProject[] }>;
+  });
+
+/** Projects tier of the Terminal workspace navigator — git repos tracked on a Machine. */
+export function useMachineProjects(terminalId: string | null) {
+  const key = terminalId ? `/api/machines/projects?terminalId=${encodeURIComponent(terminalId)}` : null;
+
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const addProject = useCallback(
+    async (name: string, repoUrl: string) => {
+      if (!terminalId) throw new Error('No active machine');
+      const result = await post<{ project: MachineProject }>('/api/machines/projects', { terminalId, name, repoUrl });
+      await mutate();
+      return result.project;
+    },
+    [terminalId, mutate],
+  );
+
+  const removeProject = useCallback(
+    async (name: string) => {
+      if (!terminalId) throw new Error('No active machine');
+      await del(`/api/machines/projects?terminalId=${encodeURIComponent(terminalId)}&name=${encodeURIComponent(name)}`);
+      await mutate();
+    },
+    [terminalId, mutate],
+  );
+
+  return {
+    projects: data?.projects ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+    addProject,
+    removeProject,
+  };
+}


### PR DESCRIPTION
## Summary

Wires the already-merged Projects / Branches / Runtime tier backend (#1901, #1903, #1906) into a usable workspace UI for the Terminal page:

- **Right panel — Navigator**: tree `Projects -> Branches -> terminals`. Each tier is fetched lazily on expand (`useMachineProjects` / `useMachineBranches` / `useAgentTerminals`, new SWR hooks matching the existing `useWorkflows.ts` convention). Add/remove affordances at every tier (add project clones a repo onto the Machine; add branch spawns an isolated Sprite + checks out the branch; add terminal reserves a named, pluggable-agent-typed PTY session — `pagespace-cli` / `claude` / `codex`). Empty states at every tier (no projects yet / no branches yet / no terminals yet).
- **Middle panel — splittable terminal panes**: a `ResizablePanelGroup` of independent panes, each with its own terminal picker. "Split" duplicates the layout so two terminals render side by side; each pane streams its PTY over the existing realtime `agent-terminal:*` events.
- **`XtermTerminal.tsx` generalized**: previously hardcoded to a `pageId` + `terminal:*` human Machine shell. Now takes `eventPrefix` + `connectPayload` + `sessionId`, so the exact same component drives both the human Machine shell and workspace agent-terminals — no parallel PTY implementation. Registers/unregisters with `useEditingStore` on connect/teardown.
- **`TerminalView.tsx`**: now tabs "Workspace" (new, default) and "Machine Shell" (the pre-existing single admin shell, unchanged behavior) — the direct root session on the Machine itself is a distinct, still-useful capability from any branch-terminal's own Sprite, so it's preserved rather than removed.

**Left panel is intentionally untouched** — per correction mid-PR, the existing app-level drive/page tree sidebar continues to handle navigation as-is. A branch's checked-out file tree is explicitly out of scope here (if ever added, it should be a separate interior sidebar following the calendar pattern, not a rework of the left sidebar).

No new backend surface beyond the UI — the three API routes it consumes (`/api/machines/projects`, `/api/machines/branches`, `/api/machines/agent-terminals`) and the realtime `agent-terminal:*` PTY bridge were all already merged into `pu/terminal`.

## Manual walkthrough

This environment has no live Postgres + Sprites credentials wired up, so this is a traced code walkthrough (confirmed via typecheck + the existing route/hook contracts) rather than a live click session:

1. Open a Terminal page as an admin → `TerminalView` renders the `Workspace` / `Machine Shell` tabs, defaulting to `Workspace`.
2. `Workspace` mounts `TerminalWorkspace`, which renders `TerminalPanes` (middle, one empty pane, "Select a branch from the navigator to open a terminal") and `Navigator` (right, `useMachineProjects(terminalId)` — with zero projects, shows "No projects yet" + an "Add your first project" dialog).
3. Clicking "Add project" → `POST /api/machines/projects` with `{terminalId, name, repoUrl}` → on success the project row appears and expands; `useMachineBranches` fires for that project → "No branches yet" + an inline "+" opens the add-branch dialog.
4. Adding a branch → `POST /api/machines/branches` (`spawnBranch` provisions the branch's own Sprite, clones, checks out) → branch row appears; expanding it fires `useAgentTerminals` → "No terminals yet".
5. Adding a terminal (name + agent type dropdown: pagespace-cli/claude/codex) → `POST /api/machines/agent-terminals` (reserves the row; PTY opens lazily on first realtime connect) → terminal leaf appears under the branch, tagged with its `agentType`.
6. Clicking the terminal leaf → `onOpenTerminal` fills the last (only) pane in the middle panel → that pane's `XtermTerminal` mounts with `eventPrefix="agent-terminal"` and `connectPayload={{terminalId, projectName, branchName, name}}` → emits `agent-terminal:connect`, shows "Connecting…" until `agent-terminal:ready` fires, then streams `agent-terminal:output` into the xterm instance exactly like the existing human-shell path.
7. Clicking "Split" in the pane toolbar adds a second empty pane beside the first (`ResizablePanelGroup`); its own terminal-picker `Select` lists the same branch's terminals, so a second one can stream side by side.
8. Selecting a different branch (or project) in the Navigator resets the open panes to one empty pane, matching the acceptance criteria ("selecting a branch shows ... its terminals").
9. Switching to the "Machine Shell" tab renders the original single admin-only PTY into the Machine's own persistent session, byte-for-byte the pre-existing behavior (same `XtermTerminal`, `eventPrefix` defaults to `"terminal"`).

## Test plan

- [x] Root `bun run typecheck` — 16/16 packages green (had to clear a stale `apps/web/tsconfig.tsbuildinfo` + let `next build` finish once to regenerate `.next/types` before the monorepo-wide run was clean — no code issue, just local cache staleness).
- [x] `bun run test:unit` — same 3 pre-existing failing test files as `master`/`pu/terminal` today (missing local test-DB role + one unrelated message-grouping test), nothing introduced by this change.
- [x] `bun run --filter web lint` — no new warnings/errors.
- [ ] Live click-through in a real deployed environment (no Sprites/Postgres credentials available in this sandbox) — recommend a manual pass before merge if reviewers have a live stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcQ11BLYP9hP5Y8zdPALm9