### PR TITLE
feat(terminal): universal Terminal scope for agent terminals (machine/project/branch)

### DIFF
--- a/apps/web/src/lib/machines/agent-terminals-runtime.ts
+++ b/apps/web/src/lib/machines/agent-terminals-runtime.ts
@@ -10,6 +10,15 @@
  * branch's Sprite directly, so only it needs a `MachineHost`
  * (`getMachineHostForBranches`); spawning/listing/resolving never provision
  * or touch the Sprite.
+ *
+ * `projectStore`/`machineSandbox` (project/machine-scope support) are left
+ * unwired here — today's only consumer (the navigator API route) is
+ * branch-scoped only, and wiring the Machine's own Sprite acquisition would
+ * require threading the acting user's resume-re-authz through this module's
+ * callers (a route-surface change — separate PR node, see tasks/terminal.md).
+ * `branchStore.findById` IS wired, since the level-agnostic resolve/kill path
+ * needs no such threading (a branch lookup by its own row id carries no actor
+ * context either way).
  */
 
 import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
@@ -42,13 +51,15 @@ function buildBaseDeps(): Pick<SpawnAgentTerminalDeps & KillAgentTerminalDeps, '
     branchStore: {
       findByName: async (terminalId, projectName, branchName) =>
         (await getMachineBranchStore()).findByName(terminalId, projectName, branchName),
+      findById: async (id) => (await getMachineBranchStore()).findById(id),
     },
     store: {
-      list: async (machineBranchId) => (await getMachineAgentTerminalStore()).list(machineBranchId),
-      findByName: async (machineBranchId, name) => (await getMachineAgentTerminalStore()).findByName(machineBranchId, name),
+      list: async (scope) => (await getMachineAgentTerminalStore()).list(scope),
+      findByName: async (scope, name) => (await getMachineAgentTerminalStore()).findByName(scope, name),
+      findById: async (id) => (await getMachineAgentTerminalStore()).findById(id),
       create: async (input) => (await getMachineAgentTerminalStore()).create(input),
       updateStreamSessionId: async (input) => (await getMachineAgentTerminalStore()).updateStreamSessionId(input),
-      remove: async (machineBranchId, name) => (await getMachineAgentTerminalStore()).remove(machineBranchId, name),
+      remove: async (scope, name) => (await getMachineAgentTerminalStore()).remove(scope, name),
     },
   };
 }

--- a/apps/web/src/lib/machines/machine-branches-runtime.ts
+++ b/apps/web/src/lib/machines/machine-branches-runtime.ts
@@ -126,6 +126,7 @@ export function buildMachineBranchesDeps(): MachineBranchesDeps {
       list: async (terminalId, projectName) => (await getMachineBranchStore()).list(terminalId, projectName),
       findByName: async (terminalId, projectName, branchName) =>
         (await getMachineBranchStore()).findByName(terminalId, projectName, branchName),
+      findById: async (id) => (await getMachineBranchStore()).findById(id),
       create: async (input) => (await getMachineBranchStore()).create(input),
       updateSandboxId: async (input) => (await getMachineBranchStore()).updateSandboxId(input),
       remove: async (terminalId, projectName, branchName) =>

--- a/packages/db/drizzle/0187_adorable_meltdown.sql
+++ b/packages/db/drizzle/0187_adorable_meltdown.sql
@@ -1,9 +1,13 @@
 CREATE TABLE IF NOT EXISTS "machine_agent_terminals" (
 	"id" text PRIMARY KEY NOT NULL,
 	"ownerId" text NOT NULL,
-	"machineBranchId" text NOT NULL,
+	"terminalId" text NOT NULL,
+	"scope" text NOT NULL,
+	"projectName" text,
+	"machineBranchId" text,
 	"name" text NOT NULL,
 	"agentType" text NOT NULL,
+	"command" text,
 	"streamSessionId" text,
 	"createdAt" timestamp DEFAULT now() NOT NULL,
 	"updatedAt" timestamp NOT NULL
@@ -16,10 +20,17 @@ EXCEPTION
 END $$;
 --> statement-breakpoint
 DO $$ BEGIN
+ ALTER TABLE "machine_agent_terminals" ADD CONSTRAINT "machine_agent_terminals_terminalId_pages_id_fk" FOREIGN KEY ("terminalId") REFERENCES "public"."pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
  ALTER TABLE "machine_agent_terminals" ADD CONSTRAINT "machine_agent_terminals_machineBranchId_machine_branches_id_fk" FOREIGN KEY ("machineBranchId") REFERENCES "public"."machine_branches"("id") ON DELETE cascade ON UPDATE no action;
 EXCEPTION
  WHEN duplicate_object THEN null;
 END $$;
 --> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "machine_agent_terminals_terminal_id_idx" ON "machine_agent_terminals" USING btree ("terminalId");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "machine_agent_terminals_branch_id_idx" ON "machine_agent_terminals" USING btree ("machineBranchId");--> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS "machine_agent_terminals_branch_name_idx" ON "machine_agent_terminals" USING btree ("machineBranchId","name");
+CREATE UNIQUE INDEX IF NOT EXISTS "machine_agent_terminals_scope_name_idx" ON "machine_agent_terminals" USING btree ("terminalId",coalesce("projectName", ''),coalesce("machineBranchId", ''),"name");

--- a/packages/db/drizzle/meta/0187_snapshot.json
+++ b/packages/db/drizzle/meta/0187_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "a539e109-efa6-4298-a448-11c5af32150b",
+  "id": "93c57e49-ef72-4160-99e2-5f86bbe631ec",
   "prevId": "915b16c4-6afc-4899-83c3-2425c9f12dad",
   "version": "7",
   "dialect": "postgresql",
@@ -18638,11 +18638,29 @@
           "primaryKey": false,
           "notNull": true
         },
+        "terminalId": {
+          "name": "terminalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "machineBranchId": {
           "name": "machineBranchId",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "name": {
           "name": "name",
@@ -18655,6 +18673,12 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "streamSessionId": {
           "name": "streamSessionId",
@@ -18677,6 +18701,21 @@
         }
       },
       "indexes": {
+        "machine_agent_terminals_terminal_id_idx": {
+          "name": "machine_agent_terminals_terminal_id_idx",
+          "columns": [
+            {
+              "expression": "terminalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
         "machine_agent_terminals_branch_id_idx": {
           "name": "machine_agent_terminals_branch_id_idx",
           "columns": [
@@ -18692,13 +18731,25 @@
           "method": "btree",
           "with": {}
         },
-        "machine_agent_terminals_branch_name_idx": {
-          "name": "machine_agent_terminals_branch_name_idx",
+        "machine_agent_terminals_scope_name_idx": {
+          "name": "machine_agent_terminals_scope_name_idx",
           "columns": [
             {
-              "expression": "machineBranchId",
+              "expression": "terminalId",
               "isExpression": false,
               "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"projectName\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"machineBranchId\", '')",
+              "asc": true,
+              "isExpression": true,
               "nulls": "last"
             },
             {
@@ -18721,6 +18772,19 @@
           "tableTo": "users",
           "columnsFrom": [
             "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_agent_terminals_terminalId_pages_id_fk": {
+          "name": "machine_agent_terminals_terminalId_pages_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "terminalId"
           ],
           "columnsTo": [
             "id"

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1314,8 +1314,8 @@
     {
       "idx": 187,
       "version": "7",
-      "when": 1783343552201,
-      "tag": "0187_even_outlaw_kid",
+      "when": 1783353566001,
+      "tag": "0187_adorable_meltdown",
       "breakpoints": true
     }
   ]

--- a/packages/db/src/schema/machine-agent-terminals.ts
+++ b/packages/db/src/schema/machine-agent-terminals.ts
@@ -1,24 +1,55 @@
 import { pgTable, text, timestamp, index, uniqueIndex } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
+import { relations, sql } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 import { users } from './auth';
+import { pages } from './core';
 import { machineBranches } from './machine-branches';
 
 /**
  * Machine Agent Terminals
  *
- * The "Runtime" tier of the Terminal workspace navigator (Machine → Projects →
- * Branches → Runtime). An agent terminal is a named, pluggable-agent-typed PTY
- * session running INSIDE one branch-terminal's own Sprite (`machine_branches`)
- * — NOT a separate Sprite. A branch's Sprite can host many concurrent agent
- * terminals (e.g. a `pagespace-cli` one and a `claude` one side by side),
- * addressed by (machineBranchId, name).
+ * A named, pluggable-agent-typed PTY session running at one of the three
+ * universal Terminal scopes (tasks/terminal.md): `machine` (the owning
+ * Machine's OWN persistent Sprite, cwd = its home dir), `project` (the SAME
+ * Machine Sprite, cwd = a cloned project's checkout), or `branch` (the
+ * branch-terminal's OWN isolated Sprite, `machine_branches`). Isolation is by
+ * Machine vs Branch — machine- and project-scoped agent terminals share the
+ * owning Machine's Sprite; only a branch-scoped one gets a separate Sprite.
+ *
+ * `scope` is an EXPLICIT discriminant — `'machine' | 'project' | 'branch'` —
+ * mirroring PurePoint's `AgentLocation::Root`/`AgentLocation::Worktree`
+ * (`crates/pu-core/src/types/manifest.rs`): a caller (or a query) can read a
+ * row's scope directly rather than re-deriving a union from a nullable-column
+ * bag. It is set exactly once at creation (by
+ * `deriveAgentTerminalScope`/`services/machines/agent-terminals-store.ts`,
+ * the single write path — see `agent-terminals.ts`'s `spawnAgentTerminal`)
+ * and never changes: `machine` ↔ both `projectName`/`machineBranchId` null,
+ * `project` ↔ only `projectName` set, `branch` ↔ `machineBranchId` set.
+ * `machineBranchId` implies its `projectName` (a branch always belongs to a
+ * project), but `projectName` is stored redundantly alongside it rather than
+ * requiring a join through `machine_branches` to resolve a branch-scoped
+ * row's project — the same denormalization `machine_branches` itself uses
+ * against `machine_projects`.
+ *
+ * Addressed by (terminalId, projectName, machineBranchId, name) for
+ * spawn/list, or by the row's OWN `id` alone for attach/kill — level-agnostic,
+ * exactly like PurePoint's `Attach{agent_id}` (no scope path required to
+ * resolve an existing agent terminal's Sprite once you have its id). A
+ * machine can have at most one agent terminal named `name` per scope,
+ * enforced by `machine_agent_terminals_scope_name_idx` (coalescing the two
+ * nullable scope columns so two NULLs still collide as the SAME machine
+ * scope, which a plain multi-column unique index would not do — Postgres
+ * treats NULL <> NULL).
  *
  * `agentType` selects a pluggable launch spec (binary + args — see
  * `services/machines/agent-terminal-types.ts`; first-party `pagespace-cli`,
- * adapters for `claude`/`codex`). `streamSessionId` is the Sprite exec
- * session id this agent terminal's PTY was created/reattached under — set
- * lazily by the realtime PTY bridge on first connect (mirrors how
+ * adapters for `claude`/`codex`, and `shell` — a bare interactive shell is
+ * just a machine-scope agent terminal of this type, not a separate concept).
+ * `command` is an OPTIONAL per-terminal program override — an agent terminal
+ * can run an arbitrary command in its PTY instead of `agentType`'s default
+ * binary (mirrors PurePoint's `AgentEntry.command`). `streamSessionId` is the
+ * Sprite exec session id this agent terminal's PTY was created/reattached
+ * under — set lazily by the realtime PTY bridge on first connect (mirrors how
  * `terminal_sessions` never eagerly opens a shell either), so a row can exist
  * with `streamSessionId: null` before anyone has connected to it yet.
  */
@@ -29,20 +60,28 @@ export const machineAgentTerminals = pgTable('machine_agent_terminals', {
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
 
-  machineBranchId: text('machineBranchId')
+  terminalId: text('terminalId')
     .notNull()
-    .references(() => machineBranches.id, { onDelete: 'cascade' }),
+    .references(() => pages.id, { onDelete: 'cascade' }),
+
+  scope: text('scope').notNull(),
+  projectName: text('projectName'),
+  machineBranchId: text('machineBranchId').references(() => machineBranches.id, { onDelete: 'cascade' }),
 
   name: text('name').notNull(),
   agentType: text('agentType').notNull(),
+  command: text('command'),
   streamSessionId: text('streamSessionId'),
 
   createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
   updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
 }, (table) => ({
+  terminalIdIdx: index('machine_agent_terminals_terminal_id_idx').on(table.terminalId),
   machineBranchIdIdx: index('machine_agent_terminals_branch_id_idx').on(table.machineBranchId),
-  machineBranchNameUnique: uniqueIndex('machine_agent_terminals_branch_name_idx').on(
-    table.machineBranchId,
+  scopeNameUnique: uniqueIndex('machine_agent_terminals_scope_name_idx').on(
+    table.terminalId,
+    sql`coalesce(${table.projectName}, '')`,
+    sql`coalesce(${table.machineBranchId}, '')`,
     table.name,
   ),
 }));
@@ -51,6 +90,10 @@ export const machineAgentTerminalsRelations = relations(machineAgentTerminals, (
   owner: one(users, {
     fields: [machineAgentTerminals.ownerId],
     references: [users.id],
+  }),
+  terminal: one(pages, {
+    fields: [machineAgentTerminals.terminalId],
+    references: [pages.id],
   }),
   branch: one(machineBranches, {
     fields: [machineAgentTerminals.machineBranchId],

--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -4,6 +4,7 @@ import {
   isAgentRuntimeType,
   resolveAgentLaunchSpec,
   isValidAgentTerminalName,
+  isValidAgentTerminalCommand,
 } from '../agent-terminal-types';
 
 describe('isAgentRuntimeType', () => {
@@ -11,6 +12,7 @@ describe('isAgentRuntimeType', () => {
     expect(isAgentRuntimeType('pagespace-cli')).toBe(true);
     expect(isAgentRuntimeType('claude')).toBe(true);
     expect(isAgentRuntimeType('codex')).toBe(true);
+    expect(isAgentRuntimeType('shell')).toBe(true);
   });
 
   it('given an unknown type, should reject it', () => {
@@ -33,6 +35,10 @@ describe('resolveAgentLaunchSpec', () => {
     expect(resolveAgentLaunchSpec('codex')).toEqual({ command: 'codex', args: [] });
   });
 
+  it('given shell, should resolve the "shell" sentinel command (resolved to $SHELL by the launching layer)', () => {
+    expect(resolveAgentLaunchSpec('shell')).toEqual({ command: 'shell', args: [] });
+  });
+
   it('given two resolutions, should return independent arrays (no shared mutable state)', () => {
     const a = resolveAgentLaunchSpec('claude');
     a.args.push('--danger');
@@ -41,7 +47,7 @@ describe('resolveAgentLaunchSpec', () => {
   });
 
   it('should expose a registry entry for every AgentRuntimeType', () => {
-    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['pagespace-cli', 'claude', 'codex']);
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['pagespace-cli', 'claude', 'codex', 'shell']);
   });
 });
 
@@ -71,5 +77,22 @@ describe('isValidAgentTerminalName', () => {
   it('given a name longer than 100 chars, should reject it', () => {
     expect(isValidAgentTerminalName('a'.repeat(101))).toBe(false);
     expect(isValidAgentTerminalName('a'.repeat(100))).toBe(true);
+  });
+});
+
+describe('isValidAgentTerminalCommand', () => {
+  it('given a normal command string, should accept it', () => {
+    expect(isValidAgentTerminalCommand('htop')).toBe(true);
+    expect(isValidAgentTerminalCommand('npm run dev')).toBe(true);
+  });
+
+  it('given an empty or whitespace-only command, should reject it', () => {
+    expect(isValidAgentTerminalCommand('')).toBe(false);
+    expect(isValidAgentTerminalCommand('   ')).toBe(false);
+  });
+
+  it('given a command longer than 500 chars, should reject it', () => {
+    expect(isValidAgentTerminalCommand('a'.repeat(501))).toBe(false);
+    expect(isValidAgentTerminalCommand('a'.repeat(500))).toBe(true);
   });
 });

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -3,44 +3,83 @@ import {
   planSpawnAgentTerminal,
   spawnAgentTerminal,
   resolveAgentTerminal,
+  resolveAgentTerminalById,
   killAgentTerminal,
+  killAgentTerminalById,
   listAgentTerminals,
+  deriveAgentTerminalScope,
   type AgentTerminalsDeps,
   type AgentTerminalBranchLookup,
+  type AgentTerminalProjectLookup,
+  type AgentTerminalMachineSandbox,
 } from '../agent-terminals';
-import type { MachineAgentTerminalStore, MachineAgentTerminalRecord } from '../agent-terminals-store';
+import type { MachineAgentTerminalStore, MachineAgentTerminalRecord, AgentTerminalScopeKey } from '../agent-terminals-store';
 import type { MachineHost, MachineHandle } from '../../sandbox/machine-host';
+import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
+import { BRANCH_REPO_PATH } from '../machine-branches';
 
 const NOW = new Date('2026-07-06T12:00:00.000Z');
 const TERMINAL_ID = 'terminal-1';
 const PROJECT_NAME = 'my-repo';
 const BRANCH_NAME = 'feature-x';
 const BRANCH_ID = 'branch-1';
-const SANDBOX_ID = 'sprite-branch-1';
+const BRANCH_SANDBOX_ID = 'sprite-branch-1';
+const MACHINE_SANDBOX_ID = 'sprite-machine-1';
+const PROJECT_PATH = '/workspace/projects/my-repo';
 
 const actor = { userId: 'user-1' };
 
 function makeBranchLookup(rows: Record<string, { id: string; sandboxId: string }> = {}): AgentTerminalBranchLookup {
+  const byId = new Map<string, { sandboxId: string }>();
+  for (const row of Object.values(rows)) byId.set(row.id, { sandboxId: row.sandboxId });
   return {
     findByName: async (terminalId, projectName, branchName) =>
       rows[`${terminalId}\0${projectName}\0${branchName}`] ?? null,
+    findById: async (id) => byId.get(id) ?? null,
   };
 }
 
 const defaultBranchLookup = makeBranchLookup({
-  [`${TERMINAL_ID}\0${PROJECT_NAME}\0${BRANCH_NAME}`]: { id: BRANCH_ID, sandboxId: SANDBOX_ID },
+  [`${TERMINAL_ID}\0${PROJECT_NAME}\0${BRANCH_NAME}`]: { id: BRANCH_ID, sandboxId: BRANCH_SANDBOX_ID },
 });
+
+function makeProjectLookup(rows: Record<string, { path: string }> = {}): AgentTerminalProjectLookup {
+  return {
+    findByName: async (terminalId, name) => rows[`${terminalId}\0${name}`] ?? null,
+  };
+}
+
+const defaultProjectLookup = makeProjectLookup({
+  [`${TERMINAL_ID}\0${PROJECT_NAME}`]: { path: PROJECT_PATH },
+});
+
+function makeMachineSandbox(over: Partial<AgentTerminalMachineSandbox> = {}): AgentTerminalMachineSandbox {
+  return {
+    acquire: async () => ({ ok: true, sandboxId: MACHINE_SANDBOX_ID }),
+    ...over,
+  };
+}
+
+function scopeKeyOf(row: MachineAgentTerminalRecord): AgentTerminalScopeKey {
+  return { terminalId: row.terminalId, projectName: row.projectName, machineBranchId: row.machineBranchId };
+}
+
+function sameScope(a: AgentTerminalScopeKey, b: AgentTerminalScopeKey): boolean {
+  return a.terminalId === b.terminalId && a.projectName === b.projectName && a.machineBranchId === b.machineBranchId;
+}
 
 function makeStore(seed: MachineAgentTerminalRecord[] = []) {
   const rows = new Map<string, MachineAgentTerminalRecord>();
-  const key = (machineBranchId: string, name: string) => `${machineBranchId}\0${name}`;
-  for (const row of seed) rows.set(key(row.machineBranchId, row.name), row);
+  const key = (scope: AgentTerminalScopeKey, name: string) =>
+    `${scope.terminalId}\0${scope.projectName ?? ''}\0${scope.machineBranchId ?? ''}\0${name}`;
+  for (const row of seed) rows.set(key(scopeKeyOf(row), row.name), row);
   let counter = 0;
   const store: MachineAgentTerminalStore = {
-    list: async (machineBranchId) => [...rows.values()].filter((r) => r.machineBranchId === machineBranchId),
-    findByName: async (machineBranchId, name) => rows.get(key(machineBranchId, name)) ?? null,
+    list: async (scope) => [...rows.values()].filter((r) => sameScope(scopeKeyOf(r), scope)),
+    findByName: async (scope, name) => rows.get(key(scope, name)) ?? null,
+    findById: async (id) => [...rows.values()].find((r) => r.id === id) ?? null,
     create: async (input) => {
-      const k = key(input.machineBranchId, input.name);
+      const k = key({ terminalId: input.terminalId, projectName: input.projectName, machineBranchId: input.machineBranchId }, input.name);
       if (rows.has(k)) {
         throw Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
       }
@@ -48,9 +87,13 @@ function makeStore(seed: MachineAgentTerminalRecord[] = []) {
       const row: MachineAgentTerminalRecord = {
         id: `agent-terminal-${counter}`,
         ownerId: input.ownerId,
+        terminalId: input.terminalId,
+        scope: input.scope,
+        projectName: input.projectName,
         machineBranchId: input.machineBranchId,
         name: input.name,
         agentType: input.agentType,
+        command: input.command,
         streamSessionId: null,
         createdAt: input.now,
         updatedAt: input.now,
@@ -66,8 +109,8 @@ function makeStore(seed: MachineAgentTerminalRecord[] = []) {
         }
       }
     },
-    remove: async (machineBranchId, name) => {
-      rows.delete(key(machineBranchId, name));
+    remove: async (scope, name) => {
+      rows.delete(key(scope, name));
     },
   };
   return { store, rows };
@@ -86,7 +129,7 @@ function makeHost(over: Partial<MachineHost> = {}): MachineHost {
 
 function makeHandle(over: Partial<MachineHandle> = {}): MachineHandle {
   return {
-    machineId: SANDBOX_ID,
+    machineId: BRANCH_SANDBOX_ID,
     exec: async () => ({ success: true, exitCode: 0, stdout: '', stderr: '' }),
     writeFiles: async () => {},
     readFile: async () => null,
@@ -106,12 +149,28 @@ function makeHandle(over: Partial<MachineHandle> = {}): MachineHandle {
 function makeDeps(overrides: Partial<AgentTerminalsDeps> = {}): AgentTerminalsDeps {
   return {
     branchStore: defaultBranchLookup,
+    projectStore: defaultProjectLookup,
+    machineSandbox: makeMachineSandbox(),
     store: makeStore().store,
     host: makeHost(),
     now: () => NOW,
     ...overrides,
   };
 }
+
+describe('deriveAgentTerminalScope', () => {
+  it('given machineBranchId set, should classify branch (regardless of projectName)', () => {
+    expect(deriveAgentTerminalScope({ projectName: PROJECT_NAME, machineBranchId: BRANCH_ID })).toBe('branch');
+  });
+
+  it('given only projectName set, should classify project', () => {
+    expect(deriveAgentTerminalScope({ projectName: PROJECT_NAME, machineBranchId: null })).toBe('project');
+  });
+
+  it('given neither set, should classify machine', () => {
+    expect(deriveAgentTerminalScope({ projectName: null, machineBranchId: null })).toBe('machine');
+  });
+});
 
 describe('planSpawnAgentTerminal', () => {
   it('given a valid name and known agent type, should allow it', () => {
@@ -131,9 +190,20 @@ describe('planSpawnAgentTerminal', () => {
       reason: 'invalid_agent_type',
     });
   });
+
+  it('given an empty command override, should reject it', () => {
+    expect(planSpawnAgentTerminal({ name: 'reviewer', agentType: 'shell', command: '   ' })).toEqual({
+      ok: false,
+      reason: 'invalid_command',
+    });
+  });
+
+  it('given a valid command override, should allow it', () => {
+    expect(planSpawnAgentTerminal({ name: 'reviewer', agentType: 'shell', command: 'htop' })).toEqual({ ok: true });
+  });
 });
 
-describe('spawnAgentTerminal', () => {
+describe('spawnAgentTerminal — branch scope', () => {
   it('given a branch that does not exist, should deny', async () => {
     const deps = makeDeps({ branchStore: makeBranchLookup() });
     const result = await spawnAgentTerminal({
@@ -148,7 +218,20 @@ describe('spawnAgentTerminal', () => {
     expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
   });
 
-  it('given a fresh name, should reserve a pagespace-cli agent terminal', async () => {
+  it('given branchName without projectName, should reject as an invalid target', async () => {
+    const deps = makeDeps();
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      branchName: BRANCH_NAME,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'invalid_target' });
+  });
+
+  it('given a fresh name, should reserve a pagespace-cli agent terminal keyed to the branch with scope="branch"', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
     const result = await spawnAgentTerminal({
@@ -161,7 +244,25 @@ describe('spawnAgentTerminal', () => {
       deps,
     });
     expect(result).toMatchObject({ ok: true, agentType: 'pagespace-cli', resumed: false });
-    expect(rows.get(`${BRANCH_ID}\0cli`)?.agentType).toBe('pagespace-cli');
+    const row = [...rows.values()][0];
+    expect(row).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, projectName: PROJECT_NAME, agentType: 'pagespace-cli', command: null });
+  });
+
+  it('given a command override, should persist it on the row', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'top',
+      agentType: 'shell',
+      command: 'htop',
+      actor,
+      deps,
+    });
+    const row = [...rows.values()][0];
+    expect(row.command).toBe('htop');
   });
 
   it('given a second, differently-named spawn in the SAME branch, should let a claude terminal coexist with the pagespace-cli one', async () => {
@@ -246,6 +347,94 @@ describe('spawnAgentTerminal', () => {
   });
 });
 
+describe('spawnAgentTerminal — project scope', () => {
+  it('given a project that does not exist, should deny', async () => {
+    const deps = makeDeps({ projectStore: makeProjectLookup() });
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'project_not_found' });
+  });
+
+  it('given no projectStore wired, should report scope_unsupported rather than provisioning anything', async () => {
+    const deps = makeDeps({ projectStore: undefined });
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'scope_unsupported' });
+  });
+
+  it('given a valid project, should reserve an agent terminal keyed to the project (scope="project", no machineBranchId)', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace-cli', resumed: false });
+    const row = [...rows.values()][0];
+    expect(row).toMatchObject({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
+  });
+});
+
+describe('spawnAgentTerminal — machine scope', () => {
+  it('given neither projectName nor branchName, should reserve an agent terminal with ZERO projects on the machine Sprite (scope="machine")', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace-cli', resumed: false });
+    const row = [...rows.values()][0];
+    expect(row).toMatchObject({ scope: 'machine', terminalId: TERMINAL_ID, projectName: null, machineBranchId: null });
+  });
+
+  it('given a bare shell agentType, should reserve it (the plain shell IS a machine-scope agent terminal, not a separate concept)', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      name: 'shell',
+      agentType: 'shell',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'shell' });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'machine', agentType: 'shell' });
+  });
+
+  it('should not require projectStore/machineSandbox at spawn time (spawn never touches the Sprite)', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: undefined, machineSandbox: undefined });
+    const result = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, resumed: false });
+  });
+});
+
 describe('resolveAgentTerminal', () => {
   it('given an unknown branch, should deny', async () => {
     const deps = makeDeps({ branchStore: makeBranchLookup() });
@@ -271,7 +460,7 @@ describe('resolveAgentTerminal', () => {
     expect(result).toEqual({ ok: false, reason: 'not_found' });
   });
 
-  it('given a spawned agent terminal, should resolve its Sprite, launch spec, and known session id', async () => {
+  it('given a branch-scoped agent terminal, should resolve the isolated branch Sprite and its repo cwd', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
     await spawnAgentTerminal({
@@ -295,24 +484,211 @@ describe('resolveAgentTerminal', () => {
     expect(result).toEqual({
       ok: true,
       agentTerminalId: 'agent-terminal-1',
-      sandboxId: SANDBOX_ID,
+      sandboxId: BRANCH_SANDBOX_ID,
+      cwd: BRANCH_REPO_PATH,
       agentType: 'pagespace-cli',
+      command: null,
       streamSessionId: null,
     });
+  });
+
+  it('given a project-scoped agent terminal, should resolve the SAME machine Sprite with cwd=project.path', async () => {
+    const { store } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      machineSandbox: makeMachineSandbox({
+        acquire: async (terminalId) => {
+          acquireCalls.push(terminalId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+
+    const result = await resolveAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      deps,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: MACHINE_SANDBOX_ID,
+      cwd: PROJECT_PATH,
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+    });
+    expect(acquireCalls).toEqual([TERMINAL_ID]);
+  });
+
+  it('given a machine-scoped agent terminal spawned with ZERO projects, should resolve the machine Sprite with cwd=SANDBOX_ROOT', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+
+    const result = await resolveAgentTerminal({
+      terminalId: TERMINAL_ID,
+      name: 'cli',
+      deps,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: MACHINE_SANDBOX_ID,
+      cwd: SANDBOX_ROOT,
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+    });
+  });
+
+  it('given the machine Sprite fails to acquire, should deny as machine_unavailable', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    await spawnAgentTerminal({ terminalId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const failingDeps = { ...deps, machineSandbox: makeMachineSandbox({ acquire: async () => ({ ok: false, reason: 'provision_failed' }) }) };
+    const result = await resolveAgentTerminal({ terminalId: TERMINAL_ID, name: 'cli', deps: failingDeps });
+
+    expect(result).toEqual({ ok: false, reason: 'machine_unavailable' });
+  });
+});
+
+describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} parity)', () => {
+  it('given an unknown id, should return not_found', async () => {
+    const deps = makeDeps();
+    const result = await resolveAgentTerminalById({ agentTerminalId: 'ghost', deps });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('given a branch-scoped row id, should resolve its isolated branch Sprite WITHOUT any project/branch name lookup', async () => {
+    const { store } = makeStore();
+    const findByNameCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      branchStore: {
+        ...defaultBranchLookup,
+        findByName: async (...args) => {
+          findByNameCalls.push(args.join(':'));
+          return defaultBranchLookup.findByName(...args);
+        },
+      },
+    });
+    const spawned = await spawnAgentTerminal({
+      terminalId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'cli',
+      agentType: 'pagespace-cli',
+      actor,
+      deps,
+    });
+    expect(spawned.ok).toBe(true);
+    findByNameCalls.length = 0; // clear the spawn-time lookup; only care about resolve-time calls below
+
+    const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({
+      ok: true,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: BRANCH_SANDBOX_ID,
+      cwd: BRANCH_REPO_PATH,
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+    });
+    expect(findByNameCalls).toEqual([]); // level-agnostic: resolved purely by id, no name-based branch lookup
+  });
+
+  it('given a project-scoped row id, should resolve the SAME machine Sprite with cwd=project.path', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store });
+    const spawned = await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({
+      ok: true,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: MACHINE_SANDBOX_ID,
+      cwd: PROJECT_PATH,
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+    });
+  });
+
+  it('given a machine-scoped row id, should resolve the machine Sprite with cwd=SANDBOX_ROOT', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const spawned = await spawnAgentTerminal({ terminalId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({
+      ok: true,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: MACHINE_SANDBOX_ID,
+      cwd: SANDBOX_ROOT,
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+    });
+  });
+
+  it('given a row whose branch has vanished, should deny as branch_not_found', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store });
+    const spawned = await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const goneDeps = { ...deps, branchStore: makeBranchLookup() };
+    const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps: goneDeps });
+
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
   });
 });
 
 describe('listAgentTerminals', () => {
-  it('given two agent terminals spawned in one branch, should list both', async () => {
+  it('given two agent terminals spawned in one branch, should list both without leaking the project/machine-scoped ones', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
     await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
     await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'reviewer', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'project-cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ terminalId: TERMINAL_ID, name: 'machine-cli', agentType: 'pagespace-cli', actor, deps });
 
     const result = await listAgentTerminals({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, deps });
 
     expect(result.ok).toBe(true);
     expect(result.ok && result.terminals.map((t) => t.name).sort()).toEqual(['cli', 'reviewer']);
+  });
+
+  it('given a machine scope with zero spawned terminals, should list empty rather than surfacing project/branch ones', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store });
+    await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const result = await listAgentTerminals({ terminalId: TERMINAL_ID, deps });
+
+    expect(result).toEqual({ ok: true, terminals: [] });
   });
 });
 
@@ -329,7 +705,7 @@ describe('killAgentTerminal', () => {
     expect(result).toEqual({ ok: false, reason: 'not_found' });
   });
 
-  it('given an agent terminal whose PTY was never opened (no streamSessionId), should drop the row without touching the Sprite', async () => {
+  it('given a branch-scoped agent terminal whose PTY was never opened (no streamSessionId), should drop the row without touching the Sprite', async () => {
     const { store, rows } = makeStore();
     const attachCalls: string[] = [];
     const deps = makeDeps({
@@ -345,26 +721,32 @@ describe('killAgentTerminal', () => {
     expect(rows.size).toBe(0);
   });
 
-  it('given an agent terminal whose PTY IS running, should attach the branch Sprite, kill that specific session, and drop the row', async () => {
+  it('given a branch-scoped agent terminal whose PTY IS running, should attach the ISOLATED branch Sprite, kill that specific session, and drop the row', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
         ownerId: 'user-1',
+        terminalId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
         agentType: 'pagespace-cli',
+        command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
         updatedAt: NOW,
       },
     ]);
     const killed: string[] = [];
+    let attachedMachineId: string | undefined;
     let attachedSessionId: string | undefined;
     const deps = makeDeps({
       store,
       host: makeHost({
-        attach: async ({ machineId }) =>
-          machineId === SANDBOX_ID
+        attach: async ({ machineId }) => {
+          attachedMachineId = machineId;
+          return machineId === BRANCH_SANDBOX_ID
             ? makeHandle({
                 stream: async ({ sessionId }) => {
                   attachedSessionId = sessionId;
@@ -378,14 +760,111 @@ describe('killAgentTerminal', () => {
                   };
                 },
               })
-            : null,
+            : null;
+        },
       }),
     });
 
     const result = await killAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
     expect(result).toEqual({ ok: true });
+    expect(attachedMachineId).toBe(BRANCH_SANDBOX_ID);
     expect(attachedSessionId).toBe('sess-abc');
+    expect(killed).toEqual(['SIGKILL']);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a project-scoped agent terminal whose PTY IS running, should attach the SAME machine Sprite, kill that session, and drop the row', async () => {
+    const { store, rows } = makeStore([
+      {
+        id: 'agent-terminal-1',
+        ownerId: 'user-1',
+        terminalId: TERMINAL_ID,
+        scope: 'project',
+        projectName: PROJECT_NAME,
+        machineBranchId: null,
+        name: 'cli',
+        agentType: 'pagespace-cli',
+        command: null,
+        streamSessionId: 'sess-proj',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    let attachedMachineId: string | undefined;
+    const killed: string[] = [];
+    const deps = makeDeps({
+      store,
+      host: makeHost({
+        attach: async ({ machineId }) => {
+          attachedMachineId = machineId;
+          return makeHandle({
+            machineId,
+            stream: async () => ({
+              write: () => {},
+              resize: () => {},
+              onData: () => {},
+              onExit: () => {},
+              onError: () => {},
+              kill: (signal) => killed.push(signal ?? 'SIGTERM'),
+            }),
+          });
+        },
+      }),
+    });
+
+    const result = await killAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(attachedMachineId).toBe(MACHINE_SANDBOX_ID);
+    expect(killed).toEqual(['SIGKILL']);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a machine-scoped agent terminal whose PTY IS running, should attach the machine Sprite, kill that session, and drop the row', async () => {
+    const { store, rows } = makeStore([
+      {
+        id: 'agent-terminal-1',
+        ownerId: 'user-1',
+        terminalId: TERMINAL_ID,
+        scope: 'machine',
+        projectName: null,
+        machineBranchId: null,
+        name: 'cli',
+        agentType: 'pagespace-cli',
+        command: null,
+        streamSessionId: 'sess-machine',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    let attachedMachineId: string | undefined;
+    const killed: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      host: makeHost({
+        attach: async ({ machineId }) => {
+          attachedMachineId = machineId;
+          return makeHandle({
+            machineId,
+            stream: async () => ({
+              write: () => {},
+              resize: () => {},
+              onData: () => {},
+              onExit: () => {},
+              onError: () => {},
+              kill: (signal) => killed.push(signal ?? 'SIGTERM'),
+            }),
+          });
+        },
+      }),
+    });
+
+    const result = await killAgentTerminal({ terminalId: TERMINAL_ID, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(attachedMachineId).toBe(MACHINE_SANDBOX_ID);
     expect(killed).toEqual(['SIGKILL']);
     expect(rows.size).toBe(0);
   });
@@ -395,9 +874,13 @@ describe('killAgentTerminal', () => {
       {
         id: 'agent-terminal-1',
         ownerId: 'user-1',
+        terminalId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
         agentType: 'pagespace-cli',
+        command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
         updatedAt: NOW,
@@ -416,9 +899,13 @@ describe('killAgentTerminal', () => {
       {
         id: 'agent-terminal-1',
         ownerId: 'user-1',
+        terminalId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
         agentType: 'pagespace-cli',
+        command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
         updatedAt: NOW,
@@ -437,5 +924,49 @@ describe('killAgentTerminal', () => {
 
     expect(result).toEqual({ ok: false, reason: 'error' });
     expect(rows.size).toBe(1);
+  });
+});
+
+describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} parity)', () => {
+  it('given an unknown id, should return not_found', async () => {
+    const deps = makeDeps();
+    const result = await killAgentTerminalById({ agentTerminalId: 'ghost', deps });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('given a branch-scoped row id whose PTY IS running, should kill it purely by id (no project/branch name needed)', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    const spawned = await spawnAgentTerminal({ terminalId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    const id = spawned.ok ? spawned.id : '';
+    await store.updateStreamSessionId({ id, streamSessionId: 'sess-abc', now: NOW });
+
+    const killed: string[] = [];
+    const killDeps = {
+      ...deps,
+      host: makeHost({
+        attach: async ({ machineId }) =>
+          machineId === BRANCH_SANDBOX_ID
+            ? makeHandle({ stream: async () => ({ write: () => {}, resize: () => {}, onData: () => {}, onExit: () => {}, onError: () => {}, kill: (s) => killed.push(s ?? 'SIGTERM') }) })
+            : null,
+      }),
+    };
+
+    const result = await killAgentTerminalById({ agentTerminalId: id, deps: killDeps });
+
+    expect(result).toEqual({ ok: true });
+    expect(killed).toEqual(['SIGKILL']);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a machine-scoped row id, should acquire the machine Sprite and drop the row', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const spawned = await spawnAgentTerminal({ terminalId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(rows.size).toBe(0);
   });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -37,6 +37,7 @@ function makeStore(seed: MachineBranchRecord[] = []) {
     list: async (terminalId, projectName) =>
       [...rows.values()].filter((r) => r.terminalId === terminalId && r.projectName === projectName),
     findByName: async (terminalId, projectName, branchName) => rows.get(key(terminalId, projectName, branchName)) ?? null,
+    findById: async (id) => [...rows.values()].find((r) => r.id === id) ?? null,
     create: async (input) => {
       const k = key(input.terminalId, input.projectName, input.branchName);
       if (rows.has(k)) {

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -11,10 +11,22 @@
  * nothing that resolves a spec by type branches on which one it got.
  */
 
+/**
+ * `shell`'s `command` is the literal string `'shell'` — a SENTINEL, not a real
+ * binary — mirroring PurePoint's `default_agents()` (`crates/pu-core/src/
+ * types/config.rs`), which maps its `terminal` agent to the command `"shell"`
+ * and resolves it to `$SHELL` at spawn time (`parse_agent_command`,
+ * `crates/pu-engine/src/engine/helpers.rs`). A bare machine shell is just a
+ * machine-scope agent terminal of this type — not a separate concept.
+ * Resolving the sentinel to an actual shell binary is an IO concern (reading
+ * `process.env.SHELL`) that belongs to whichever layer actually spawns the
+ * PTY (the realtime bridge), not this pure module.
+ */
 export const AGENT_LAUNCH_SPECS = {
   'pagespace-cli': { command: 'pagespace-cli', args: [] },
   claude: { command: 'claude', args: [] },
   codex: { command: 'codex', args: [] },
+  shell: { command: 'shell', args: [] },
 } as const satisfies Record<string, { command: string; args: readonly string[] }>;
 
 export type AgentRuntimeType = keyof typeof AGENT_LAUNCH_SPECS;
@@ -43,4 +55,19 @@ export function isValidAgentTerminalName(name: string): boolean {
     return false;
   }
   return AGENT_TERMINAL_NAME_RE.test(name);
+}
+
+const MAX_AGENT_TERMINAL_COMMAND_LENGTH = 500;
+
+/**
+ * An optional per-terminal program override — an agent terminal can run an
+ * arbitrary command in its PTY instead of just the `agentType`'s default
+ * binary (mirrors PurePoint's `AgentEntry.command` / `SpawnParams.
+ * terminal_command`, `crates/pu-core/src/types/agent.rs`). Only rejects
+ * obviously-invalid input (empty, absurdly long) — interpreting the command
+ * string (splitting args, deciding whether to wrap it in `$SHELL -c` for
+ * metacharacters) is the launching layer's job, not this validator's.
+ */
+export function isValidAgentTerminalCommand(command: string): boolean {
+  return typeof command === 'string' && command.trim().length > 0 && command.length <= MAX_AGENT_TERMINAL_COMMAND_LENGTH;
 }

--- a/packages/lib/src/services/machines/agent-terminals-store.ts
+++ b/packages/lib/src/services/machines/agent-terminals-store.ts
@@ -2,20 +2,27 @@
  * Agent Terminals store (IO, dependency-injected).
  *
  * DB-backed CRUD for the `machine_agent_terminals` table — the durable record
- * of which named, pluggable-agent-typed PTY sessions exist inside a
- * branch-terminal's Sprite. Kept separate from the spawn/attach/kill
- * orchestration (agent-terminals.ts) so that orchestration logic is testable
- * against an in-memory fake without a real database.
+ * of which named, pluggable-agent-typed PTY sessions exist at a given
+ * Terminal scope (machine / project / branch — see the schema module doc).
+ * Kept separate from the spawn/attach/kill orchestration (agent-terminals.ts)
+ * so that orchestration logic is testable against an in-memory fake without a
+ * real database.
  */
 
 import { isUniqueViolation } from '../subdomain-allocation';
 
+export type AgentTerminalScope = 'machine' | 'project' | 'branch';
+
 export interface MachineAgentTerminalRecord {
   id: string;
   ownerId: string;
-  machineBranchId: string;
+  terminalId: string;
+  scope: AgentTerminalScope;
+  projectName: string | null;
+  machineBranchId: string | null;
   name: string;
   agentType: string;
+  command: string | null;
   streamSessionId: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -23,19 +30,48 @@ export interface MachineAgentTerminalRecord {
 
 export interface NewMachineAgentTerminalInput {
   ownerId: string;
-  machineBranchId: string;
+  terminalId: string;
+  scope: AgentTerminalScope;
+  projectName: string | null;
+  machineBranchId: string | null;
   name: string;
   agentType: string;
+  command: string | null;
   now: Date;
 }
 
+/** Identifies WHICH machine/project/branch scope a row (or a lookup) belongs to — the store's addressing key for spawn/list. */
+export interface AgentTerminalScopeKey {
+  terminalId: string;
+  projectName: string | null;
+  machineBranchId: string | null;
+}
+
+/**
+ * Classify a scope key's discriminant: `machineBranchId` set → branch, else
+ * `projectName` set → project, else machine. The SINGLE derivation used to
+ * populate the explicit `scope` column at creation (see `spawnAgentTerminal`
+ * in `agent-terminals.ts`) — never recomputed afterward, since a row's scope
+ * is immutable for its lifetime.
+ */
+export function deriveAgentTerminalScope(key: {
+  projectName: string | null;
+  machineBranchId: string | null;
+}): AgentTerminalScope {
+  if (key.machineBranchId) return 'branch';
+  if (key.projectName) return 'project';
+  return 'machine';
+}
+
 export interface MachineAgentTerminalStore {
-  list(machineBranchId: string): Promise<MachineAgentTerminalRecord[]>;
-  findByName(machineBranchId: string, name: string): Promise<MachineAgentTerminalRecord | null>;
-  /** Throws a unique-violation error (see `isUniqueViolation`) if this (machineBranchId, name) already exists. */
+  list(scope: AgentTerminalScopeKey): Promise<MachineAgentTerminalRecord[]>;
+  findByName(scope: AgentTerminalScopeKey, name: string): Promise<MachineAgentTerminalRecord | null>;
+  /** Level-agnostic lookup by the row's OWN id — no scope path required (mirrors PurePoint's `Attach{agent_id}`). */
+  findById(id: string): Promise<MachineAgentTerminalRecord | null>;
+  /** Throws a unique-violation error (see `isUniqueViolation`) if this (scope, name) already exists. */
   create(input: NewMachineAgentTerminalInput): Promise<MachineAgentTerminalRecord>;
   updateStreamSessionId(input: { id: string; streamSessionId: string; now: Date }): Promise<void>;
-  remove(machineBranchId: string, name: string): Promise<void>;
+  remove(scope: AgentTerminalScopeKey, name: string): Promise<void>;
 }
 
 /** Re-exported so callers can classify a `create` rejection without importing the DB layer directly. */
@@ -47,30 +83,44 @@ export { isUniqueViolation };
  * the DB module graph.
  */
 export async function createDbMachineAgentTerminalStore(): Promise<MachineAgentTerminalStore> {
-  const [{ db }, { eq, and }, { machineAgentTerminals }] = await Promise.all([
+  const [{ db }, { eq, and, isNull }, { machineAgentTerminals }] = await Promise.all([
     import('@pagespace/db/db'),
     import('@pagespace/db/operators'),
     import('@pagespace/db/schema/machine-agent-terminals'),
   ]);
 
+  // Coalescing equality: a NULL scope column (machine/project scope) must
+  // match other NULLs, not just itself — plain `eq` never matches NULL in SQL.
+  function scopeCondition(scope: AgentTerminalScopeKey) {
+    return and(
+      eq(machineAgentTerminals.terminalId, scope.terminalId),
+      scope.projectName === null
+        ? isNull(machineAgentTerminals.projectName)
+        : eq(machineAgentTerminals.projectName, scope.projectName),
+      scope.machineBranchId === null
+        ? isNull(machineAgentTerminals.machineBranchId)
+        : eq(machineAgentTerminals.machineBranchId, scope.machineBranchId),
+    );
+  }
+
   return {
-    async list(machineBranchId) {
-      const rows = await db
-        .select()
-        .from(machineAgentTerminals)
-        .where(eq(machineAgentTerminals.machineBranchId, machineBranchId));
-      return rows;
+    async list(scope) {
+      const rows = await db.select().from(machineAgentTerminals).where(scopeCondition(scope));
+      return rows as MachineAgentTerminalRecord[];
     },
 
-    async findByName(machineBranchId, name) {
+    async findByName(scope, name) {
       const [row] = await db
         .select()
         .from(machineAgentTerminals)
-        .where(
-          and(eq(machineAgentTerminals.machineBranchId, machineBranchId), eq(machineAgentTerminals.name, name)),
-        )
+        .where(and(scopeCondition(scope), eq(machineAgentTerminals.name, name)))
         .limit(1);
-      return row ?? null;
+      return (row as MachineAgentTerminalRecord) ?? null;
+    },
+
+    async findById(id) {
+      const [row] = await db.select().from(machineAgentTerminals).where(eq(machineAgentTerminals.id, id)).limit(1);
+      return (row as MachineAgentTerminalRecord) ?? null;
     },
 
     async create(input) {
@@ -78,15 +128,19 @@ export async function createDbMachineAgentTerminalStore(): Promise<MachineAgentT
         .insert(machineAgentTerminals)
         .values({
           ownerId: input.ownerId,
+          terminalId: input.terminalId,
+          scope: input.scope,
+          projectName: input.projectName,
           machineBranchId: input.machineBranchId,
           name: input.name,
           agentType: input.agentType,
+          command: input.command,
           streamSessionId: null,
           createdAt: input.now,
           updatedAt: input.now,
         })
         .returning();
-      return row;
+      return row as MachineAgentTerminalRecord;
     },
 
     async updateStreamSessionId({ id, streamSessionId, now }) {
@@ -96,12 +150,10 @@ export async function createDbMachineAgentTerminalStore(): Promise<MachineAgentT
         .where(eq(machineAgentTerminals.id, id));
     },
 
-    async remove(machineBranchId, name) {
+    async remove(scope, name) {
       await db
         .delete(machineAgentTerminals)
-        .where(
-          and(eq(machineAgentTerminals.machineBranchId, machineBranchId), eq(machineAgentTerminals.name, name)),
-        );
+        .where(and(scopeCondition(scope), eq(machineAgentTerminals.name, name)));
     },
   };
 }

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -1,69 +1,250 @@
 /**
  * Agent Terminals: spawn / resolve (attach) / kill / list named, pluggable-
- * agent-typed PTY sessions inside a branch-terminal's Sprite (IO,
- * dependency-injected where it touches the DB/sandbox).
+ * agent-typed PTY sessions at one of the three universal Terminal scopes
+ * (tasks/terminal.md), mirroring PurePoint's `AgentLocation::Root` /
+ * `AgentLocation::Worktree` (`crates/pu-core/src/types/manifest.rs`):
+ * `machine` (the owning Machine's OWN persistent Sprite, cwd = its home dir),
+ * `project` (the SAME Machine Sprite, cwd = a cloned project's checkout), or
+ * `branch` (the branch-terminal's OWN isolated Sprite, `machine_branches`).
  *
- * "An agent spawns multiple terminals = multiple sessions, pluggable agent
- * type" (tasks/terminal.md, Terminal Epic 2 Runtime tier). UNLIKE Branches —
- * where each branch gets its OWN Sprite — an agent terminal does NOT
- * provision a new Sprite: it is a named PTY session running INSIDE the
- * branch's already-provisioned Sprite (`machine_branches`), addressed by
- * (machineBranchId, name). A branch's Sprite can host many concurrent agent
- * terminals side by side (e.g. a `pagespace-cli` one and a `claude` one).
+ * `spawnAgentTerminal` and `listAgentTerminals` are addressed by scope
+ * (`terminalId` + optional `projectName`/`branchName` — neither → machine,
+ * `projectName` only → project, both → branch), since creating or enumerating
+ * within a scope requires knowing which one. `resolveAgentTerminal` and
+ * `killAgentTerminal` (by-name equivalents, kept for today's only wired
+ * consumer — the branch-scoped realtime PTY bridge / navigator API) also take
+ * a scope target. `resolveAgentTerminalById`/`killAgentTerminalById` are
+ * LEVEL-AGNOSTIC — keyed purely on the row's own id, exactly like PurePoint's
+ * `Attach{agent_id}` (`Manifest::find_agent` searches root + every worktree by
+ * id, no location path needed): once an agent terminal exists, attaching to
+ * or killing it never requires re-supplying which scope it lives in.
  *
- * `spawnAgentTerminal` only reserves the (name, agentType) tracking row — it
- * does NOT eagerly open the Sprite exec session. The actual PTY is created
- * lazily by the realtime bridge on first connect (mirrors how a Terminal
- * page's shell is never opened until a socket connects — see
+ * `spawnAgentTerminal` only reserves the (scope, name, agentType) tracking
+ * row — it does NOT eagerly open the Sprite exec session, and (for
+ * machine/project scope) does NOT acquire the Machine's Sprite either, since
+ * that Sprite is provisioned/reconnected elsewhere (the Terminal page's own
+ * shell, or a page-agent's "own machine" tool calls). The actual PTY is
+ * created lazily by the realtime bridge on first connect (mirrors how a
+ * Terminal page's shell is never opened until a socket connects — see
  * `apps/realtime/src/terminal/terminal-handler.ts`), which then persists the
  * discovered/created Sprite session id back via `updateStreamSessionId` so a
  * later reconnect can reattach instead of spawning a duplicate process.
- * `killAgentTerminal` is the one place THIS module drives the Sprite directly
- * (through the `MachineHost` seam), since killing a still-open session must
- * happen even if no realtime connection is currently attached to it.
+ * Resolving/killing DOES need a live sandbox: a branch's Sprite is looked up
+ * directly (by name or by id), but machine/project scope goes through the
+ * injected `machineSandbox.acquire` (the same `acquireTerminalSandbox`-backed
+ * path a Terminal page shell uses) since that Sprite may need to be
+ * reconnected or resumed from hibernation.
  */
 
 import type { MachineHost } from '../sandbox/machine-host';
-import { isUniqueViolation, type MachineAgentTerminalStore, type MachineAgentTerminalRecord } from './agent-terminals-store';
-import { isValidAgentTerminalName, isAgentRuntimeType, type AgentRuntimeType } from './agent-terminal-types';
+import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
+import { BRANCH_REPO_PATH } from './machine-branches';
+import {
+  isUniqueViolation,
+  type MachineAgentTerminalStore,
+  type MachineAgentTerminalRecord,
+  type AgentTerminalScopeKey,
+  type AgentTerminalScope,
+  deriveAgentTerminalScope,
+} from './agent-terminals-store';
+import { isValidAgentTerminalName, isValidAgentTerminalCommand, isAgentRuntimeType, type AgentRuntimeType } from './agent-terminal-types';
 
-/** The minimal slice of the Branches store this module needs — just enough to resolve a branch's Sprite (`sandboxId`) by name. */
+export type { AgentTerminalScopeKey, AgentTerminalScope };
+export { deriveAgentTerminalScope };
+
+/** The minimal slice of the Branches store this module needs — resolving a branch's Sprite (`sandboxId`) either by (project, branch) name or by the branch row's OWN id. */
 export interface AgentTerminalBranchLookup {
   findByName(terminalId: string, projectName: string, branchName: string): Promise<{ id: string; sandboxId: string } | null>;
+  /** Level-agnostic lookup, used by the id-keyed resolve/kill path — no project/branch name required. */
+  findById(machineBranchId: string): Promise<{ sandboxId: string } | null>;
+}
+
+/** The minimal slice of the Projects store this module needs — just enough to resolve a project's clone path. */
+export interface AgentTerminalProjectLookup {
+  findByName(terminalId: string, name: string): Promise<{ path: string } | null>;
+}
+
+export type AgentTerminalMachineSandboxResult =
+  | { ok: true; sandboxId: string }
+  | { ok: false; reason: string };
+
+/** Acquires the OWNING Machine's persistent Sprite (machine/project scope share this one Sprite) — see `services/sandbox/machine-session.ts` for the production implementation. */
+export interface AgentTerminalMachineSandbox {
+  acquire(terminalId: string): Promise<AgentTerminalMachineSandboxResult>;
 }
 
 export interface AgentTerminalsDeps {
   branchStore: AgentTerminalBranchLookup;
+  /** Required only for project/machine-scope targets — a branch-only caller (today's only wired consumer) never needs it. */
+  projectStore?: AgentTerminalProjectLookup;
+  /** Required only for project/machine-scope targets. */
+  machineSandbox?: AgentTerminalMachineSandbox;
   store: MachineAgentTerminalStore;
   host: MachineHost;
   now: () => Date;
 }
 
 /** Each function below asks for exactly the slice of `AgentTerminalsDeps` it touches — e.g. a read-only resolver never needs `host`, so a caller (like the realtime PTY bridge) doesn't have to fabricate one just to satisfy the type. */
-export type SpawnAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'store' | 'now'>;
-export type ResolveAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'store'>;
-export type ListAgentTerminalsDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'store'>;
-export type KillAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'store' | 'host'>;
+export type SpawnAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'store' | 'now'>;
+export type ResolveAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox' | 'store'>;
+export type ListAgentTerminalsDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'store'>;
+export type KillAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox' | 'store' | 'host'>;
 
 export interface AgentTerminalActor {
   userId: string;
 }
 
+/**
+ * `projectName`/`branchName` together select the scope: neither set →
+ * machine, `projectName` only → project, both set → branch. `branchName`
+ * without `projectName` is not a valid target (a branch always belongs to a
+ * named project) and is rejected as `invalid_target`.
+ */
 export interface AgentTerminalTarget {
   terminalId: string;
-  projectName: string;
-  branchName: string;
+  projectName?: string;
+  branchName?: string;
   name: string;
 }
 
-export type SpawnAgentTerminalDenialReason = 'invalid_name' | 'invalid_agent_type' | 'branch_not_found' | 'name_in_use' | 'error';
+export type AgentTerminalScopeDenialReason =
+  | 'invalid_target'
+  | 'project_not_found'
+  | 'branch_not_found'
+  | 'machine_unavailable'
+  /** A project/machine-scope target was requested but the caller's deps didn't wire `projectStore`/`machineSandbox`. */
+  | 'scope_unsupported';
 
-/** Pure decision: is this (name, agentType) safe to reserve as an agent terminal? */
-export function planSpawnAgentTerminal(input: { name: string; agentType: string }):
+type ScopeKeyResolution =
+  | { ok: true; scopeKey: AgentTerminalScopeKey }
+  | { ok: false; reason: 'invalid_target' | 'project_not_found' | 'branch_not_found' | 'scope_unsupported' };
+
+/** Resolve WHICH scope row a target addresses, without touching any Sprite — enough for spawn/list. */
+async function resolveScopeKey({
+  terminalId,
+  projectName,
+  branchName,
+  deps,
+}: {
+  terminalId: string;
+  projectName?: string;
+  branchName?: string;
+  deps: Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore'>;
+}): Promise<ScopeKeyResolution> {
+  if (branchName !== undefined) {
+    if (!projectName) return { ok: false, reason: 'invalid_target' };
+    const branch = await deps.branchStore.findByName(terminalId, projectName, branchName);
+    if (!branch) return { ok: false, reason: 'branch_not_found' };
+    return { ok: true, scopeKey: { terminalId, projectName, machineBranchId: branch.id } };
+  }
+
+  if (projectName !== undefined) {
+    if (!deps.projectStore) return { ok: false, reason: 'scope_unsupported' };
+    const project = await deps.projectStore.findByName(terminalId, projectName);
+    if (!project) return { ok: false, reason: 'project_not_found' };
+    return { ok: true, scopeKey: { terminalId, projectName, machineBranchId: null } };
+  }
+
+  return { ok: true, scopeKey: { terminalId, projectName: null, machineBranchId: null } };
+}
+
+type LocationResolution =
+  | { ok: true; sandboxId: string; cwd: string }
+  | { ok: false; reason: AgentTerminalScopeDenialReason };
+
+/** Shared project/machine-scope location resolution — the SAME Machine Sprite either way, differing only in `cwd`. */
+async function resolveProjectOrMachineLocation({
+  terminalId,
+  projectName,
+  deps,
+}: {
+  terminalId: string;
+  projectName: string | null;
+  deps: Pick<AgentTerminalsDeps, 'projectStore' | 'machineSandbox'>;
+}): Promise<LocationResolution> {
+  let cwd = SANDBOX_ROOT;
+  if (projectName !== null) {
+    if (!deps.projectStore) return { ok: false, reason: 'scope_unsupported' };
+    const project = await deps.projectStore.findByName(terminalId, projectName);
+    if (!project) return { ok: false, reason: 'project_not_found' };
+    cwd = project.path;
+  }
+
+  if (!deps.machineSandbox) return { ok: false, reason: 'scope_unsupported' };
+  const acquired = await deps.machineSandbox.acquire(terminalId);
+  if (!acquired.ok) return { ok: false, reason: 'machine_unavailable' };
+  return { ok: true, sandboxId: acquired.sandboxId, cwd };
+}
+
+type ScopeLocationResolution =
+  | { ok: true; scopeKey: AgentTerminalScopeKey; sandboxId: string; cwd: string }
+  | { ok: false; reason: AgentTerminalScopeDenialReason };
+
+/** Resolve WHERE a scope target's Sprite + working directory live, by (project, branch) NAME — used by the by-name resolve/kill path. */
+async function resolveScopeLocation({
+  terminalId,
+  projectName,
+  branchName,
+  deps,
+}: {
+  terminalId: string;
+  projectName?: string;
+  branchName?: string;
+  deps: Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox'>;
+}): Promise<ScopeLocationResolution> {
+  if (branchName !== undefined) {
+    if (!projectName) return { ok: false, reason: 'invalid_target' };
+    const branch = await deps.branchStore.findByName(terminalId, projectName, branchName);
+    if (!branch) return { ok: false, reason: 'branch_not_found' };
+    return {
+      ok: true,
+      scopeKey: { terminalId, projectName, machineBranchId: branch.id },
+      sandboxId: branch.sandboxId,
+      cwd: BRANCH_REPO_PATH,
+    };
+  }
+
+  const resolvedProjectName = projectName ?? null;
+  const located = await resolveProjectOrMachineLocation({ terminalId, projectName: resolvedProjectName, deps });
+  if (!located.ok) return located;
+  return {
+    ok: true,
+    scopeKey: { terminalId, projectName: resolvedProjectName, machineBranchId: null },
+    sandboxId: located.sandboxId,
+    cwd: located.cwd,
+  };
+}
+
+/** Resolve WHERE an already-known ROW's Sprite + working directory live, by its OWN scope columns — the level-agnostic path (no name lookup at all). */
+async function resolveLocationForRow(
+  row: Pick<MachineAgentTerminalRecord, 'terminalId' | 'projectName' | 'machineBranchId'>,
+  deps: Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox'>,
+): Promise<LocationResolution> {
+  if (row.machineBranchId) {
+    const branch = await deps.branchStore.findById(row.machineBranchId);
+    if (!branch) return { ok: false, reason: 'branch_not_found' };
+    return { ok: true, sandboxId: branch.sandboxId, cwd: BRANCH_REPO_PATH };
+  }
+  return resolveProjectOrMachineLocation({ terminalId: row.terminalId, projectName: row.projectName, deps });
+}
+
+export type SpawnAgentTerminalDenialReason =
+  | 'invalid_name'
+  | 'invalid_agent_type'
+  | 'invalid_command'
+  | AgentTerminalScopeDenialReason
+  | 'name_in_use'
+  | 'error';
+
+/** Pure decision: is this (name, agentType, command?) safe to reserve as an agent terminal? */
+export function planSpawnAgentTerminal(input: { name: string; agentType: string; command?: string }):
   | { ok: true }
-  | { ok: false; reason: 'invalid_name' | 'invalid_agent_type' } {
+  | { ok: false; reason: 'invalid_name' | 'invalid_agent_type' | 'invalid_command' } {
   if (!isValidAgentTerminalName(input.name)) return { ok: false, reason: 'invalid_name' };
   if (!isAgentRuntimeType(input.agentType)) return { ok: false, reason: 'invalid_agent_type' };
+  if (input.command !== undefined && !isValidAgentTerminalCommand(input.command)) {
+    return { ok: false, reason: 'invalid_command' };
+  }
   return { ok: true };
 }
 
@@ -72,11 +253,14 @@ export type SpawnAgentTerminalResult =
   | { ok: false; reason: SpawnAgentTerminalDenialReason };
 
 /**
- * Spawn (or resume) a named agent terminal in a branch's Sprite. Idempotent
- * by (machineBranchId, name) with the SAME agentType — a second call for an
- * already-reserved name returns the existing reservation instead of erroring;
- * reusing the name under a DIFFERENT agentType is rejected (`name_in_use`)
- * rather than silently repurposing an existing session's identity.
+ * Spawn (or resume) a named agent terminal at a scope. Idempotent by (scope,
+ * name) with the SAME agentType — a second call for an already-reserved name
+ * returns the existing reservation instead of erroring; reusing the name
+ * under a DIFFERENT agentType is rejected (`name_in_use`) rather than
+ * silently repurposing an existing session's identity. `command` (an
+ * optional program override, PurePoint `AgentEntry.command` parity) is only
+ * consulted on a FRESH reservation — a resume reattaches to whatever the
+ * original spawn already fixed.
  */
 export async function spawnAgentTerminal({
   terminalId,
@@ -84,17 +268,18 @@ export async function spawnAgentTerminal({
   branchName,
   name,
   agentType,
+  command,
   actor,
   deps,
-}: AgentTerminalTarget & { agentType: string; actor: AgentTerminalActor; deps: SpawnAgentTerminalDeps }): Promise<SpawnAgentTerminalResult> {
-  const plan = planSpawnAgentTerminal({ name, agentType });
+}: AgentTerminalTarget & { agentType: string; command?: string; actor: AgentTerminalActor; deps: SpawnAgentTerminalDeps }): Promise<SpawnAgentTerminalResult> {
+  const plan = planSpawnAgentTerminal({ name, agentType, command });
   if (!plan.ok) return plan;
   const resolvedType = agentType as AgentRuntimeType;
 
-  const branch = await deps.branchStore.findByName(terminalId, projectName, branchName);
-  if (!branch) return { ok: false, reason: 'branch_not_found' };
+  const scope = await resolveScopeKey({ terminalId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
 
-  const existing = await deps.store.findByName(branch.id, name);
+  const existing = await deps.store.findByName(scope.scopeKey, name);
   if (existing) {
     if (existing.agentType !== resolvedType) return { ok: false, reason: 'name_in_use' };
     return { ok: true, id: existing.id, agentType: resolvedType, resumed: true };
@@ -103,16 +288,20 @@ export async function spawnAgentTerminal({
   try {
     const row = await deps.store.create({
       ownerId: actor.userId,
-      machineBranchId: branch.id,
+      terminalId: scope.scopeKey.terminalId,
+      scope: deriveAgentTerminalScope(scope.scopeKey),
+      projectName: scope.scopeKey.projectName,
+      machineBranchId: scope.scopeKey.machineBranchId,
       name,
       agentType: resolvedType,
+      command: command ?? null,
       now: deps.now(),
     });
     return { ok: true, id: row.id, agentType: resolvedType, resumed: false };
   } catch (error) {
     if (isUniqueViolation(error)) {
       // Lost a race against a concurrent spawn of the same name.
-      const reconciled = await deps.store.findByName(branch.id, name);
+      const reconciled = await deps.store.findByName(scope.scopeKey, name);
       if (reconciled && reconciled.agentType === resolvedType) {
         return { ok: true, id: reconciled.id, agentType: resolvedType, resumed: true };
       }
@@ -123,14 +312,38 @@ export async function spawnAgentTerminal({
 }
 
 export type ResolveAgentTerminalResult =
-  | { ok: true; agentTerminalId: string; sandboxId: string; agentType: AgentRuntimeType; streamSessionId: string | null }
-  | { ok: false; reason: 'branch_not_found' | 'not_found' };
+  | {
+      ok: true;
+      agentTerminalId: string;
+      sandboxId: string;
+      cwd: string;
+      agentType: AgentRuntimeType;
+      command: string | null;
+      streamSessionId: string | null;
+    }
+  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' };
+
+function toResolveResult(row: MachineAgentTerminalRecord, location: { sandboxId: string; cwd: string }): ResolveAgentTerminalResult {
+  if (!isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
+  return {
+    ok: true,
+    agentTerminalId: row.id,
+    sandboxId: location.sandboxId,
+    cwd: location.cwd,
+    agentType: row.agentType,
+    command: row.command,
+    streamSessionId: row.streamSessionId,
+  };
+}
 
 /**
  * Resolve a named agent terminal down to what the realtime PTY bridge needs
- * to open (or reattach) its stream: which Sprite (`sandboxId`), which launch
- * spec (`agentType`), and any already-known Sprite session id to reattach to.
- * Read-only — never provisions or drives the Sprite.
+ * to open (or reattach) its stream: which Sprite (`sandboxId`), which working
+ * directory (`cwd`), which launch spec (`agentType`/`command`), and any
+ * already-known Sprite session id to reattach to. Read-only for branch scope
+ * (never provisions); for machine/project scope it may reconnect/resume the
+ * Machine's Sprite via `machineSandbox.acquire`, since that Sprite can be
+ * hibernating.
  */
 export async function resolveAgentTerminal({
   terminalId,
@@ -139,19 +352,33 @@ export async function resolveAgentTerminal({
   name,
   deps,
 }: AgentTerminalTarget & { deps: ResolveAgentTerminalDeps }): Promise<ResolveAgentTerminalResult> {
-  const branch = await deps.branchStore.findByName(terminalId, projectName, branchName);
-  if (!branch) return { ok: false, reason: 'branch_not_found' };
+  const location = await resolveScopeLocation({ terminalId, projectName, branchName, deps });
+  if (!location.ok) return location;
 
-  const row = await deps.store.findByName(branch.id, name);
-  if (!row || !isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
+  const row = await deps.store.findByName(location.scopeKey, name);
+  if (!row) return { ok: false, reason: 'not_found' };
+  return toResolveResult(row, location);
+}
 
-  return {
-    ok: true,
-    agentTerminalId: row.id,
-    sandboxId: branch.sandboxId,
-    agentType: row.agentType,
-    streamSessionId: row.streamSessionId,
-  };
+/**
+ * Level-agnostic resolve, keyed PURELY on the agent terminal's own id —
+ * mirrors PurePoint's `Attach{agent_id}` (`Manifest::find_agent` searches
+ * root + every worktree by id; no scope path needed). The row's own
+ * `projectName`/`machineBranchId` columns tell us where its Sprite lives.
+ */
+export async function resolveAgentTerminalById({
+  agentTerminalId,
+  deps,
+}: {
+  agentTerminalId: string;
+  deps: ResolveAgentTerminalDeps;
+}): Promise<ResolveAgentTerminalResult> {
+  const row = await deps.store.findById(agentTerminalId);
+  if (!row) return { ok: false, reason: 'not_found' };
+
+  const location = await resolveLocationForRow(row, deps);
+  if (!location.ok) return location;
+  return toResolveResult(row, location);
 }
 
 export async function listAgentTerminals({
@@ -161,42 +388,26 @@ export async function listAgentTerminals({
   deps,
 }: {
   terminalId: string;
-  projectName: string;
-  branchName: string;
+  projectName?: string;
+  branchName?: string;
   deps: ListAgentTerminalsDeps;
-}): Promise<{ ok: true; terminals: MachineAgentTerminalRecord[] } | { ok: false; reason: 'branch_not_found' }> {
-  const branch = await deps.branchStore.findByName(terminalId, projectName, branchName);
-  if (!branch) return { ok: false, reason: 'branch_not_found' };
-  const terminals = await deps.store.list(branch.id);
+}): Promise<{ ok: true; terminals: MachineAgentTerminalRecord[] } | { ok: false; reason: 'invalid_target' | 'project_not_found' | 'branch_not_found' | 'scope_unsupported' }> {
+  const scope = await resolveScopeKey({ terminalId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
+  const terminals = await deps.store.list(scope.scopeKey);
   return { ok: true, terminals };
 }
 
-export type KillAgentTerminalResult = { ok: true } | { ok: false; reason: 'branch_not_found' | 'not_found' | 'error' };
+export type KillAgentTerminalResult = { ok: true } | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' | 'error' };
 
-/**
- * Tear down a named agent terminal: if its process was ever actually
- * launched (`streamSessionId` set), attach the branch's Sprite through the
- * `MachineHost` seam and kill that specific PTY session, then drop the
- * tracking row. A vanished Sprite (the whole branch is gone) has nothing left
- * to kill, so the row is still dropped rather than orphaned; a live Sprite
- * that fails to kill its session keeps the row so a retry can find it again.
- */
-export async function killAgentTerminal({
-  terminalId,
-  projectName,
-  branchName,
-  name,
-  deps,
-}: AgentTerminalTarget & { deps: KillAgentTerminalDeps }): Promise<KillAgentTerminalResult> {
-  const branch = await deps.branchStore.findByName(terminalId, projectName, branchName);
-  if (!branch) return { ok: false, reason: 'branch_not_found' };
-
-  const row = await deps.store.findByName(branch.id, name);
-  if (!row) return { ok: false, reason: 'not_found' };
-
+async function killAtLocation(
+  row: MachineAgentTerminalRecord,
+  location: { sandboxId: string },
+  deps: Pick<AgentTerminalsDeps, 'store' | 'host'>,
+): Promise<KillAgentTerminalResult> {
   if (row.streamSessionId) {
     try {
-      const handle = await deps.host.attach({ machineId: branch.sandboxId });
+      const handle = await deps.host.attach({ machineId: location.sandboxId });
       if (handle) {
         const stream = await handle.stream({ sessionId: row.streamSessionId });
         stream.kill('SIGKILL');
@@ -206,6 +417,50 @@ export async function killAgentTerminal({
     }
   }
 
-  await deps.store.remove(branch.id, name);
+  await deps.store.remove({ terminalId: row.terminalId, projectName: row.projectName, machineBranchId: row.machineBranchId }, row.name);
   return { ok: true };
+}
+
+/**
+ * Tear down a named agent terminal: if its process was ever actually
+ * launched (`streamSessionId` set), attach the scope's Sprite through the
+ * `MachineHost` seam and kill that specific PTY session, then drop the
+ * tracking row. A vanished Sprite has nothing left to kill, so the row is
+ * still dropped rather than orphaned; a live Sprite that fails to kill its
+ * session keeps the row so a retry can find it again.
+ */
+export async function killAgentTerminal({
+  terminalId,
+  projectName,
+  branchName,
+  name,
+  deps,
+}: AgentTerminalTarget & { deps: KillAgentTerminalDeps }): Promise<KillAgentTerminalResult> {
+  const location = await resolveScopeLocation({ terminalId, projectName, branchName, deps });
+  if (!location.ok) return location;
+
+  const row = await deps.store.findByName(location.scopeKey, name);
+  if (!row) return { ok: false, reason: 'not_found' };
+
+  return killAtLocation(row, location, deps);
+}
+
+/**
+ * Level-agnostic kill, keyed PURELY on the agent terminal's own id — same
+ * PurePoint `Attach{agent_id}` parity as `resolveAgentTerminalById`.
+ */
+export async function killAgentTerminalById({
+  agentTerminalId,
+  deps,
+}: {
+  agentTerminalId: string;
+  deps: KillAgentTerminalDeps;
+}): Promise<KillAgentTerminalResult> {
+  const row = await deps.store.findById(agentTerminalId);
+  if (!row) return { ok: false, reason: 'not_found' };
+
+  const location = await resolveLocationForRow(row, deps);
+  if (!location.ok) return location;
+
+  return killAtLocation(row, location, deps);
 }

--- a/packages/lib/src/services/machines/machine-branches-store.ts
+++ b/packages/lib/src/services/machines/machine-branches-store.ts
@@ -36,6 +36,8 @@ export interface NewMachineBranchInput {
 export interface MachineBranchStore {
   list(terminalId: string, projectName: string): Promise<MachineBranchRecord[]>;
   findByName(terminalId: string, projectName: string, branchName: string): Promise<MachineBranchRecord | null>;
+  /** Level-agnostic lookup by the branch-terminal's own row id — no project/branch name path required (mirrors PurePoint's `Attach{agent_id}`). */
+  findById(id: string): Promise<MachineBranchRecord | null>;
   /** Throws a unique-violation error (see `isUniqueViolation`) if this (terminalId, projectName, branchName) already exists. */
   create(input: NewMachineBranchInput): Promise<MachineBranchRecord>;
   /**
@@ -86,6 +88,11 @@ export async function createDbMachineBranchStore(): Promise<MachineBranchStore> 
           ),
         )
         .limit(1);
+      return row ?? null;
+    },
+
+    async findById(id) {
+      const [row] = await db.select().from(machineBranches).where(eq(machineBranches.id, id)).limit(1);
       return row ?? null;
     },
 


### PR DESCRIPTION
## Summary

Backend-only reshape of `machine_agent_terminals` from branch-only to a universal Terminal scope model (`machine | project | branch`), grounded on both `tasks/terminal.md` and PurePoint's `AgentLocation::Root`/`AgentLocation::Worktree` union (`~/production/purepoint/crates/pu-core/src/types/manifest.rs`).

- **machine scope** — the owning Machine's own persistent Sprite, cwd = home dir (`SANDBOX_ROOT`), no git.
- **project scope** — the SAME Machine Sprite, cwd = a cloned project's checkout (`project.path`).
- **branch scope** — the branch-terminal's own isolated Sprite (unchanged behavior).

Isolation boundary is machine vs. branch: machine/project agent terminals share the Machine's Sprite; only branch gets its own.

### Schema (`packages/db/src/schema/machine-agent-terminals.ts`)
- `terminalId` (machine page id) NOT NULL, nullable `projectName`, nullable `machineBranchId`.
- New explicit `scope` discriminant column (`'machine' | 'project' | 'branch'`) — set once at creation via `deriveAgentTerminalScope`, never recomputed.
- New optional `command` column — an agent terminal can run an arbitrary program override, not just its `agentType`'s default binary (PurePoint `AgentEntry.command` parity).
- Migration regenerated clean — a single `CREATE TABLE`, not an ALTER on top of the prior branch-only shape (this table's only prior migration, #1906, was rewritten in place).
- Uniqueness re-keyed on `(terminalId, coalesce(projectName,''), coalesce(machineBranchId,''), name)` so two NULL scope columns still collide as the same machine scope.

### Resolver (`packages/lib/src/services/machines/agent-terminals.ts`)
- `spawnAgentTerminal`/`resolveAgentTerminal`/`listAgentTerminals`/`killAgentTerminal` resolve sandbox + cwd **by scope**: machine/project acquire the Machine's persistent Sprite via an injected `machineSandbox.acquire` (mirrors `acquireTerminalSandbox`); branch reads its own Sprite directly.
- Added `resolveAgentTerminalById`/`killAgentTerminalById` — **level-agnostic**, keyed purely on the row's own id, mirroring PurePoint's `Attach{agent_id}` (`Manifest::find_agent` searches root + every worktree by id, no location path needed). Once an agent terminal exists, attaching to or killing it never requires re-supplying which scope it lives in.
- Added `shell` as a first-party `agentType` — a bare interactive shell is just a machine-scope agent terminal of this type, not a separate concept (mirrors PurePoint's `terminal` → `"shell"` sentinel, resolved to `$SHELL` by whichever layer actually spawns the PTY).

### Scope boundary
`projectStore`/`machineSandbox` are **optional** deps — today's only wired consumer (the branch-scoped navigator API route + realtime PTY bridge) needs neither, so `apps/web/src/app/api/machines/agent-terminals/route.ts` and `apps/realtime/src/index.ts` are **unchanged**. Only the DI wiring file (`agent-terminals-runtime.ts`) needed updates to match the new store method shapes and wire the level-agnostic `branchStore.findById` lookup. Full production wiring for machine/project scope (threading actor resume-re-authz through a route surface) is a separate PR node.

## Test plan
- [x] `packages/lib` full suite: 294 files / 6526 tests passing (44 in the reshaped `agent-terminals.test.ts`, covering all 3 scopes for spawn/resolve/list/kill + the by-id level-agnostic path)
- [x] `apps/web` machines API route tests (agent-terminals/branches/projects): 50/50 passing, unchanged
- [x] `apps/realtime` agent-terminal-handler tests: 18/18 passing, unchanged
- [x] Root `bun run typecheck`: green across all 15 packages
- [x] Migration regenerated via `bun run db:generate` — verified as a single clean `CREATE TABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrUPwcsCtsnb3rKdXghHJ8