### PR TITLE
refactor(web): dedup DRIVE_SCOPED_OAUTH test fixture into manage-keys-fixture.ts

### DIFF
--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/manage-keys-scope.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextRequest } from 'next/server';
-import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+import { manageKeysScopedAuthResult, driveScopedOAuthAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
 
 vi.mock('@/lib/repositories/session-repository', () => ({
   sessionRepository: {
@@ -70,23 +70,6 @@ const createContext = (tokenId = 'token-123') => ({
   params: Promise.resolve({ tokenId }),
 });
 
-const DRIVE_SCOPED_OAUTH = {
-  tokenType: 'oauth' as const,
-  userId: 'test-user-id',
-  role: 'user' as const,
-  tokenVersion: 0,
-  adminRoleVersion: 0,
-  tokenId: 'oauth-token-1',
-  scopes: {
-    account: false,
-    offlineAccess: false,
-    manageKeys: false,
-    drives: new Map([['drive-1', { kind: 'drive' as const, driveId: 'drive-1', role: { kind: 'inherit' as const } }]]),
-  },
-  driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
-  allowedDriveIds: ['drive-1'],
-};
-
 describe('mcp-tokens/[tokenId] routes — manage_keys-only vs drive-scoped OAuth (real isScopedOAuthAuth/isManageKeysOnly)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -111,7 +94,7 @@ describe('mcp-tokens/[tokenId] routes — manage_keys-only vs drive-scoped OAuth
     });
 
     it('still rejects a drive-scoped OAuth credential, never reaching the repository', async () => {
-      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(driveScopedOAuthAuthResult());
 
       const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', { method: 'DELETE' });
       const response = await DELETE(request, createContext());
@@ -139,7 +122,7 @@ describe('mcp-tokens/[tokenId] routes — manage_keys-only vs drive-scoped OAuth
     });
 
     it('still rejects a drive-scoped OAuth credential the same way — step-up gate fires before any scope check, never reaching the repository', async () => {
-      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(driveScopedOAuthAuthResult());
 
       const request = new NextRequest('http://localhost/api/auth/mcp-tokens/token-123', {
         method: 'PATCH',

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/manage-keys-scope.test.ts
@@ -19,7 +19,7 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextRequest } from 'next/server';
-import { manageKeysScopedAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+import { manageKeysScopedAuthResult, driveScopedOAuthAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
 
 vi.mock('@/lib/repositories/session-repository', () => ({
   sessionRepository: {
@@ -74,23 +74,6 @@ import { POST, GET } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 
-const DRIVE_SCOPED_OAUTH = {
-  tokenType: 'oauth' as const,
-  userId: 'test-user-id',
-  role: 'user' as const,
-  tokenVersion: 0,
-  adminRoleVersion: 0,
-  tokenId: 'oauth-token-1',
-  scopes: {
-    account: false,
-    offlineAccess: false,
-    manageKeys: false,
-    drives: new Map([['drive-1', { kind: 'drive' as const, driveId: 'drive-1', role: { kind: 'inherit' as const } }]]),
-  },
-  driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
-  allowedDriveIds: ['drive-1'],
-};
-
 describe('mcp-tokens routes — manage_keys-only vs drive-scoped OAuth (real isScopedOAuthAuth/isManageKeysOnly)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -122,7 +105,7 @@ describe('mcp-tokens routes — manage_keys-only vs drive-scoped OAuth (real isS
     });
 
     it('still rejects a drive-scoped OAuth credential the same way — step-up gate fires before any scope check, never reaching the repository', async () => {
-      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(driveScopedOAuthAuthResult());
 
       const request = new NextRequest('http://localhost/api/auth/mcp-tokens', {
         method: 'POST',
@@ -151,7 +134,7 @@ describe('mcp-tokens routes — manage_keys-only vs drive-scoped OAuth (real isS
     });
 
     it('still rejects a drive-scoped OAuth credential, never reaching the repository', async () => {
-      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(DRIVE_SCOPED_OAUTH as never);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(driveScopedOAuthAuthResult());
 
       const request = new NextRequest('http://localhost/api/auth/mcp-tokens', { method: 'GET' });
       const response = await GET(request);

--- a/apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts
+++ b/apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts
@@ -24,3 +24,31 @@ export function manageKeysScopedAuthResult(
     ...overrides,
   };
 }
+
+/**
+ * A drive-scoped OAuth credential (app member for one drive only, ADR 0002
+ * Decision 2) — the negative counterpart to `manageKeysScopedAuthResult`,
+ * used to prove the mcp-tokens scope-guard still rejects this shape while
+ * admitting a manage_keys-only one.
+ */
+export function driveScopedOAuthAuthResult(
+  overrides: Partial<OAuthAuthResult> = {}
+): OAuthAuthResult {
+  return {
+    tokenType: 'oauth',
+    userId: 'test-user-id',
+    role: 'user',
+    tokenVersion: 0,
+    adminRoleVersion: 0,
+    tokenId: 'oauth-token-1',
+    scopes: {
+      account: false,
+      offlineAccess: false,
+      manageKeys: false,
+      drives: new Map([['drive-1', { kind: 'drive', driveId: 'drive-1', role: { kind: 'inherit' } }]]),
+    },
+    driveScopes: [{ driveId: 'drive-1', role: null, customRoleId: null }],
+    allowedDriveIds: ['drive-1'],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Small follow-up to #1878 (merged) — a proactive `/code-review` pass on that
PR's final diff (8 finder angles + independent verification) found one real,
low-severity issue that landed on the branch just after it was merged, so
it's being applied here as a standalone cherry-pick instead.

- `DRIVE_SCOPED_OAUTH` was a hand-built `OAuthAuthResult` object literal
  duplicated byte-for-byte across both `manage-keys-scope.test.ts` files
  (`mcp-tokens/__tests__/` and `mcp-tokens/[tokenId]/__tests__/`), while its
  sibling fixture (`manageKeysScopedAuthResult`) was correctly extracted to
  a shared factory in `apps/web/src/lib/auth/__tests__/manage-keys-fixture.ts`.
- Added the matching `driveScopedOAuthAuthResult()` factory next to it and
  pointed both test files at it, removing the duplicated literals.

No production code changes — test-only cleanup.

## Test plan
- [x] `bun run test src/app/api/auth/mcp-tokens` — 5 files / 55 tests pass
- [x] `web` typecheck clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>