### PR TITLE
fix(canvas): fall back to author's og:title before the page title

### DIFF
--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -503,6 +503,25 @@ describe('extractAndStripOgMeta', () => {
     expect(meta.ogImageUrl).toBe(IMG);
   });
 
+  it('extracts og:title and removes the tag from html', () => {
+    const { meta, html } = extractAndStripOgMeta(`<p>hi</p><meta property="og:title" content="My Custom Title">`);
+    expect(meta.ogTitle).toBe('My Custom Title');
+    expect(html).not.toContain('og:title');
+    expect(html).toContain('<p>hi</p>');
+  });
+
+  it('extracts og:title when content attribute comes before property', () => {
+    const { meta } = extractAndStripOgMeta(`<meta content="My Custom Title" property="og:title">`);
+    expect(meta.ogTitle).toBe('My Custom Title');
+  });
+
+  it('keeps only the first og:title when multiple are present', () => {
+    const { meta } = extractAndStripOgMeta(
+      `<meta property="og:title" content="First"><meta property="og:title" content="Second">`
+    );
+    expect(meta.ogTitle).toBe('First');
+  });
+
   it('extracts og:description and removes the tag', () => {
     const { meta, html } = extractAndStripOgMeta('<meta property="og:description" content="My page">');
     expect(meta.ogDescription).toBe('My page');

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -57,7 +57,7 @@ vi.mock('../asset-pipeline', () => ({
   rewriteCanvasAssets: vi.fn(async ({ html }: { html: string }) => ({ html })),
   rewriteInterPageLinksForDrive: vi.fn(async ({ html }: { html: string }) => ({ html })),
   extractAndStripOgMeta: vi.fn((html: string) => ({
-    meta: { faviconHref: null, ogImageUrl: null, ogDescription: null },
+    meta: { ogTitle: null, faviconHref: null, ogImageUrl: null, ogDescription: null },
     html,
   })),
 }));
@@ -395,7 +395,7 @@ describe('publishCanvasPage — SEO overrides', () => {
     vi.mocked(db.query.publishedPages.findMany).mockResolvedValue([]);
     vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
     vi.mocked(extractAndStripOgMeta).mockReturnValue({
-      meta: { faviconHref: undefined, ogImageUrl: undefined, ogDescription: undefined },
+      meta: { ogTitle: undefined, faviconHref: undefined, ogImageUrl: undefined, ogDescription: undefined },
       html: '<div>hi</div>',
     });
     valuesSpy = vi.fn(() => ({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) }));
@@ -466,6 +466,36 @@ describe('publishCanvasPage — SEO overrides', () => {
     const renderInput = vi.mocked(renderPublishedPage).mock.lastCall?.[0];
     expect(renderInput?.title).toBe('Custom Title');
     expect(renderInput?.robots).toBe('noindex');
+  });
+
+  it('uses the canvas-authored og:title when no title override is set', async () => {
+    setupPage();
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+    vi.mocked(extractAndStripOgMeta).mockReturnValueOnce({
+      meta: { ogTitle: 'Author OG Title', faviconHref: undefined, ogImageUrl: undefined, ogDescription: undefined },
+      html: '<div>hi</div>',
+    });
+
+    await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    const renderInput = vi.mocked(renderPublishedPage).mock.lastCall?.[0];
+    expect(renderInput?.title).toBe('Author OG Title');
+  });
+
+  it('prefers an explicit title override over the canvas-authored og:title', async () => {
+    setupPage();
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+    vi.mocked(extractAndStripOgMeta).mockReturnValueOnce({
+      meta: { ogTitle: 'Author OG Title', faviconHref: undefined, ogImageUrl: undefined, ogDescription: undefined },
+      html: '<div>hi</div>',
+    });
+
+    await publishCanvasPage({
+      pageId: 'page-1', driveId: 'drive-1', userId: 'user-1', title: 'Custom Title',
+    });
+
+    const renderInput = vi.mocked(renderPublishedPage).mock.lastCall?.[0];
+    expect(renderInput?.title).toBe('Custom Title');
   });
 
   it('falls back to the drive default OG image when neither override nor canvas set one', async () => {

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -34,6 +34,7 @@ const referenceKey = ({ id, kind, driveId }: FileReference): string =>
   driveId ? `dashboard:${driveId}:${id}:${kind}` : `api:${id}:${kind}`;
 
 export interface OgMeta {
+  ogTitle?: string;
   ogImageUrl?: string;
   ogDescription?: string;
   faviconHref?: string;
@@ -44,6 +45,7 @@ export interface OgMeta {
  * tags from the body so they can be hoisted into <head> by renderCanvasDocument.
  *
  * Reads standard HTML semantics the author placed directly in the canvas:
+ *   <meta property="og:title"       content="…">  → ogTitle
  *   <meta property="og:image"       content="…">  → ogImageUrl
  *   <meta property="og:description" content="…">  → ogDescription
  *   <link rel="icon" href="…">                    → faviconHref
@@ -63,6 +65,14 @@ export function extractAndStripOgMeta(html: string): { meta: OgMeta; html: strin
     })
     .replace(/<meta\b[^>]+content="([^"]*)"[^>]+property="og:image"[^>]*\/?>/gi, (_, content: string) => {
       meta.ogImageUrl ??= content || undefined;
+      return '';
+    })
+    .replace(/<meta\b[^>]+property="og:title"[^>]+content="([^"]*)"[^>]*\/?>/gi, (_, content: string) => {
+      meta.ogTitle ??= content || undefined;
+      return '';
+    })
+    .replace(/<meta\b[^>]+content="([^"]*)"[^>]+property="og:title"[^>]*\/?>/gi, (_, content: string) => {
+      meta.ogTitle ??= content || undefined;
       return '';
     })
     .replace(/<meta\b[^>]+property="og:description"[^>]+content="([^"]*)"[^>]*\/?>/gi, (_, content: string) => {

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -55,34 +55,39 @@ export interface OgMeta {
  *
  * Pure function: no I/O, no env reads.
  */
+/**
+ * Strip every `<meta property="{property}" content="…">` tag (either attribute
+ * order) from `html`, invoking `assign` with each match's `content`. Shared by
+ * the og:image/og:title/og:description extractions below, which differ only in
+ * the property name and where the captured content is stored.
+ */
+function stripMetaProperty(html: string, property: string, assign: (content: string) => void): string {
+  const propertyFirst = new RegExp(`<meta\\b[^>]+property="${property}"[^>]+content="([^"]*)"[^>]*/?>`, 'gi');
+  const contentFirst = new RegExp(`<meta\\b[^>]+content="([^"]*)"[^>]+property="${property}"[^>]*/?>`, 'gi');
+  return html
+    .replace(propertyFirst, (_, content: string) => {
+      assign(content);
+      return '';
+    })
+    .replace(contentFirst, (_, content: string) => {
+      assign(content);
+      return '';
+    });
+}
+
 export function extractAndStripOgMeta(html: string): { meta: OgMeta; html: string } {
   const meta: OgMeta = {};
 
-  const result = html
-    .replace(/<meta\b[^>]+property="og:image"[^>]+content="([^"]*)"[^>]*\/?>/gi, (_, content: string) => {
-      meta.ogImageUrl ??= content || undefined;
-      return '';
-    })
-    .replace(/<meta\b[^>]+content="([^"]*)"[^>]+property="og:image"[^>]*\/?>/gi, (_, content: string) => {
-      meta.ogImageUrl ??= content || undefined;
-      return '';
-    })
-    .replace(/<meta\b[^>]+property="og:title"[^>]+content="([^"]*)"[^>]*\/?>/gi, (_, content: string) => {
-      meta.ogTitle ??= content || undefined;
-      return '';
-    })
-    .replace(/<meta\b[^>]+content="([^"]*)"[^>]+property="og:title"[^>]*\/?>/gi, (_, content: string) => {
-      meta.ogTitle ??= content || undefined;
-      return '';
-    })
-    .replace(/<meta\b[^>]+property="og:description"[^>]+content="([^"]*)"[^>]*\/?>/gi, (_, content: string) => {
-      meta.ogDescription ??= content || undefined;
-      return '';
-    })
-    .replace(/<meta\b[^>]+content="([^"]*)"[^>]+property="og:description"[^>]*\/?>/gi, (_, content: string) => {
-      meta.ogDescription ??= content || undefined;
-      return '';
-    })
+  let result = stripMetaProperty(html, 'og:image', (content) => {
+    meta.ogImageUrl ??= content || undefined;
+  });
+  result = stripMetaProperty(result, 'og:title', (content) => {
+    meta.ogTitle ??= content || undefined;
+  });
+  result = stripMetaProperty(result, 'og:description', (content) => {
+    meta.ogDescription ??= content || undefined;
+  });
+  result = result
     .replace(/<link\b[^>]+rel="icon"[^>]+href="([^"]*)"[^>]*\/?>/gi, (_, href: string) => {
       meta.faviconHref ??= href || undefined;
       return '';

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -257,7 +257,7 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
     override: { title: effectiveTitle, description: effectiveDescription, ogImageUrl: effectiveOgImageUrl },
     noindex: effectiveNoindex,
     pageTitle: page.title,
-    canvasMeta: { ogImageUrl: meta.ogImageUrl, ogDescription: meta.ogDescription },
+    canvasMeta: { ogTitle: meta.ogTitle, ogImageUrl: meta.ogImageUrl, ogDescription: meta.ogDescription },
     driveDefaultOgImageUrl: drive.publishDefaultOgImageUrl,
     body: bodyHtml,
   });

--- a/packages/lib/src/canvas/__tests__/resolve-published-meta.test.ts
+++ b/packages/lib/src/canvas/__tests__/resolve-published-meta.test.ts
@@ -28,6 +28,34 @@ describe('resolvePublishedMeta — title', () => {
     const meta = resolvePublishedMeta({ body: BODY });
     expect(meta.title).toBeUndefined();
   });
+
+  it('falls back to the canvas og:title when no override is set', () => {
+    const meta = resolvePublishedMeta({
+      canvasMeta: { ogTitle: 'Canvas Title' },
+      pageTitle: 'Page',
+      body: BODY,
+    });
+    expect(meta.title).toBe('Canvas Title');
+  });
+
+  it('prefers the override title over the canvas og:title', () => {
+    const meta = resolvePublishedMeta({
+      override: { title: 'Override' },
+      canvasMeta: { ogTitle: 'Canvas Title' },
+      pageTitle: 'Page',
+      body: BODY,
+    });
+    expect(meta.title).toBe('Override');
+  });
+
+  it('falls back to the page title when the canvas og:title is blank/whitespace', () => {
+    const meta = resolvePublishedMeta({
+      canvasMeta: { ogTitle: '   ' },
+      pageTitle: 'Page',
+      body: BODY,
+    });
+    expect(meta.title).toBe('Page');
+  });
 });
 
 describe('resolvePublishedMeta — ogImageUrl', () => {

--- a/packages/lib/src/canvas/resolve-published-meta.ts
+++ b/packages/lib/src/canvas/resolve-published-meta.ts
@@ -27,7 +27,7 @@ export interface ResolvePublishedMetaInput {
   /** The live page title, used when no title override is set. */
   pageTitle?: string | null;
   /** OG meta the author embedded in the canvas (`<meta property="og:*">`). */
-  canvasMeta?: { ogImageUrl?: string | null; ogDescription?: string | null } | null;
+  canvasMeta?: { ogTitle?: string | null; ogImageUrl?: string | null; ogDescription?: string | null } | null;
   /** Drive-level default share image, used when neither override nor canvas set one. */
   driveDefaultOgImageUrl?: string | null;
   /** Rendered page body, used to derive a description when nothing else supplies one. */
@@ -57,8 +57,8 @@ function clean(value: string | null | undefined): string | undefined {
  * Resolve the effective SEO metadata for a published canvas page from the layered
  * sources, applying a fixed precedence:
  *
- *   title       = override.title          → pageTitle
- *   ogImageUrl  = override.ogImageUrl      → canvasMeta.ogImageUrl → driveDefaultOgImageUrl
+ *   title       = override.title          → canvasMeta.ogTitle       → pageTitle
+ *   ogImageUrl  = override.ogImageUrl      → canvasMeta.ogImageUrl    → driveDefaultOgImageUrl
  *   description = override.description      → canvasMeta.ogDescription → deriveDescription(body)
  *   robots      = noindex ? 'noindex' : 'index, follow'
  *
@@ -67,7 +67,7 @@ function clean(value: string | null | undefined): string | undefined {
 export function resolvePublishedMeta(input: ResolvePublishedMetaInput): ResolvedPublishedMeta {
   const { override, noindex, pageTitle, canvasMeta, driveDefaultOgImageUrl, body } = input;
 
-  const title = clean(override?.title) ?? clean(pageTitle);
+  const title = clean(override?.title) ?? clean(canvasMeta?.ogTitle) ?? clean(pageTitle);
 
   const ogImageUrl =
     clean(override?.ogImageUrl) ??


### PR DESCRIPTION
## Summary
- Eric reported that leaving the Publish Settings title field blank overrode the `og:title` he wrote himself in his canvas page's HTML, publishing a generic internal page name instead.
- Root cause: `resolvePublishedMeta()` resolved `og:image`/`description` with a 3-tier fallback (override → author's own canvas `<meta>` tag → default), but `title` only had 2 tiers (override → internal page name) — and `extractAndStripOgMeta()` never even extracted an author-written `og:title` in the first place.
- Fix: extract + strip `og:title` in `asset-pipeline.ts`, add the missing `canvasMeta.ogTitle` fallback tier in `resolve-published-meta.ts`, and thread it through in `publish-page.ts`. Favicon and `og:image`/`og:description` were already correct and are untouched.
- Follow-up (CodeRabbit nitpick): consolidated the duplicated property-first/content-first meta-parsing regex pair (now used 3x for image/title/description) into a shared `stripMetaProperty` helper in `asset-pipeline.ts`. Behavior-preserving, no test changes needed.

## Test plan
- [x] `resolve-published-meta.test.ts` — 20/20 passing (added: canvas og:title fallback, override still wins, blank canvas og:title falls back to page title)
- [x] `asset-pipeline.test.ts` + `publish-page.test.ts` — 98/98 passing (added: og:title extraction/strip both attribute orders + first-wins, publish-page wiring tests)
- [x] `bunx tsc --noEmit` clean in `packages/lib`
- [x] `bun run --filter 'web' typecheck` clean
- [x] `bun run --filter 'web' lint` clean (touched files only; pre-existing unrelated warnings elsewhere)
- [x] CI green: `ci / Unit Tests`, `ci / Lint & TypeScript Check` (initial Unit Tests run had one unrelated pre-existing flaky failure in `AiChatView.test.tsx` — zero file overlap with this diff, passes locally in isolation, passed on CI rerun)
- [x] CodeRabbit review addressed (1 nitpick, fixed); Codex review unavailable (hit account usage limits, unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188PYeK9QHiEk7hApybpeNH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published pages can now use a canvas-authored Open Graph title when no page title override is set.
  * Open Graph title data is now extracted from page metadata and carried through publishing.
* **Bug Fixes**
  * Improved title selection priority so explicit title overrides still take precedence.
  * Added handling for multiple metadata tag formats and blank metadata values.
* **Tests**
  * Expanded coverage for metadata extraction and published title resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
