### PR TITLE
feat(terminal): unified Navigator UI (Machine→Projects→Branches), retire Machine Shell tab

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -1227,7 +1227,15 @@ io.on('connection', (socket: AuthSocket) => {
 
   socket.on('agent-terminal:connect', (payload) => {
     agentTerminalHandlers.onConnect(payload).then(() => {
-      const session = agentTerminalSessionMap.getBySocket(socket.id);
+      // Same `connectionId ?? socket.id` fallback `onConnect` itself uses —
+      // several split panes can share this one socket, each under its own
+      // connectionId, so a bare `socket.id` lookup would only ever find
+      // whichever pane never sent one.
+      const payloadConnectionId =
+        payload !== null && typeof payload === 'object' && typeof (payload as { connectionId?: unknown }).connectionId === 'string'
+          ? (payload as { connectionId: string }).connectionId
+          : undefined;
+      const session = agentTerminalSessionMap.getBySocket(payloadConnectionId ?? socket.id);
       if (session) {
         loggers.realtime.info('Agent terminal session opened', { userId: user?.id, sessionKey: session.sessionKey, sandboxId: session.sandboxId });
       }
@@ -1238,7 +1246,7 @@ io.on('connection', (socket: AuthSocket) => {
   });
   socket.on('agent-terminal:input', (payload) => agentTerminalHandlers.onInput(payload));
   socket.on('agent-terminal:resize', (payload) => agentTerminalHandlers.onResize(payload));
-  socket.on('agent-terminal:disconnect', () => agentTerminalHandlers.onDisconnect());
+  socket.on('agent-terminal:disconnect', (payload) => agentTerminalHandlers.onDisconnect(payload));
 
   socket.on('disconnect', (reason) => {
     agentTerminalHandlers.onDisconnect();

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -137,7 +137,7 @@ describe('buildAgentTerminalHandlers', () => {
       expect(openShell).toHaveBeenCalledWith(
         expect.objectContaining({ cols: 80, rows: 24, command: 'pagespace-cli', args: [] }),
       );
-      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:ready', {});
+      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:ready', { connectionId: 'sock1' });
     });
 
     it('given a branch-scoped agent terminal, should launch inside the branch\'s cloned repo cwd resolved by checkAuth', async () => {
@@ -337,7 +337,7 @@ describe('buildAgentTerminalHandlers', () => {
 
       expect(shell.kill).toHaveBeenCalledWith();
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
-      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2 });
+      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2, connectionId: 'sock1' });
     });
   });
 
@@ -371,6 +371,95 @@ describe('buildAgentTerminalHandlers', () => {
       onResize({ cols: 100, rows: 40 });
 
       expect(shell.resize).toHaveBeenCalledWith(100, 40);
+    });
+  });
+
+  describe('multiplexed connections on one socket (splittable panes)', () => {
+    it('given two connect calls on the SAME socket with distinct connectionIds and different scopes, should track them independently', async () => {
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      checkAuth = vi
+        .fn()
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:cli' }))
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:reviewer', command: 'claude' })) as unknown as ReturnType<typeof vi.fn> &
+        AgentTerminalCheckAuthFn;
+      const { onConnect, onInput } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await onConnect({ ...validPayload, name: 'cli', connectionId: 'pane-a' });
+      await onConnect({ ...validPayload, name: 'reviewer', connectionId: 'pane-b' });
+
+      expect(sessionMap.getBySocket('pane-a')).toMatchObject({ sessionKey: 'branch1:agent:cli' });
+      expect(sessionMap.getBySocket('pane-b')).toMatchObject({ sessionKey: 'branch1:agent:reviewer' });
+
+      // Input routed by connectionId reaches the pane it was typed into, not whichever pane connected last.
+      onInput({ data: 'echo a\n', connectionId: 'pane-a' });
+      onInput({ data: 'echo b\n', connectionId: 'pane-b' });
+      expect(shellA.write).toHaveBeenCalledWith('echo a\n');
+      expect(shellB.write).toHaveBeenCalledWith('echo b\n');
+      expect(shellA.write).not.toHaveBeenCalledWith('echo b\n');
+      expect(shellB.write).not.toHaveBeenCalledWith('echo a\n');
+    });
+
+    it('given output on two different panes, should tag each emitted event with its own connectionId so the client can route it to the right pane', async () => {
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      checkAuth = vi
+        .fn()
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:cli' }))
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:reviewer' })) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await onConnect({ ...validPayload, name: 'cli', connectionId: 'pane-a' });
+      await onConnect({ ...validPayload, name: 'reviewer', connectionId: 'pane-b' });
+
+      const onOutputA = openShell.mock.calls[0][0].onOutput as (data: string) => void;
+      const onOutputB = openShell.mock.calls[1][0].onOutput as (data: string) => void;
+      onOutputA('from A');
+      onOutputB('from B');
+
+      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:output', { data: 'from A', connectionId: 'pane-a' });
+      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:output', { data: 'from B', connectionId: 'pane-b' });
+    });
+
+    it('given onDisconnect for one specific connectionId, should detach only that pane and leave the other live', async () => {
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      checkAuth = vi
+        .fn()
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:cli' }))
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:reviewer' })) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await onConnect({ ...validPayload, name: 'cli', connectionId: 'pane-a' });
+      await onConnect({ ...validPayload, name: 'reviewer', connectionId: 'pane-b' });
+
+      onDisconnect({ connectionId: 'pane-a' });
+
+      expect(sessionMap.getBySocket('pane-a')).toBeUndefined();
+      expect(sessionMap.getBySocket('pane-b')).toBeDefined();
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined(); // shell survives until the idle timeout, same as a single-pane disconnect
+    });
+
+    it('given onDisconnect with no payload (the socket itself disconnected), should detach every connection this socket had open', async () => {
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      checkAuth = vi
+        .fn()
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:cli' }))
+        .mockResolvedValueOnce(makeAuthSuccess({ sessionKey: 'branch1:agent:reviewer' })) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await onConnect({ ...validPayload, name: 'cli', connectionId: 'pane-a' });
+      await onConnect({ ...validPayload, name: 'reviewer', connectionId: 'pane-b' });
+
+      onDisconnect();
+
+      expect(sessionMap.getBySocket('pane-a')).toBeUndefined();
+      expect(sessionMap.getBySocket('pane-b')).toBeUndefined();
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -461,6 +461,35 @@ describe('buildAgentTerminalHandlers', () => {
       expect(sessionMap.getBySocket('pane-a')).toBeUndefined();
       expect(sessionMap.getBySocket('pane-b')).toBeUndefined();
     });
+
+    it('given a DIFFERENT socket referencing a connectionId it never established itself, should ignore it rather than acting on another socket\'s session', async () => {
+      // `agentTerminalSessionMap` is one shared, server-wide instance — a
+      // connectionId is only trustworthy when the CALLING socket is the one
+      // that registered it via its own authorized onConnect. A second socket
+      // merely claiming someone else's connectionId (e.g. observed, guessed,
+      // or replayed) must never be able to write input to, resize, or tear
+      // down that session.
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect({ ...validPayload, name: 'cli', connectionId: 'victim-pane' });
+
+      const attackerSocket = makeSocket('attacker-sock');
+      const attackerHandlers = buildAgentTerminalHandlers({
+        sessionMap,
+        openShell,
+        checkAuth,
+        socket: attackerSocket,
+        persistStreamSessionId,
+      });
+
+      attackerHandlers.onInput({ data: 'rm -rf /\n', connectionId: 'victim-pane' });
+      expect(shell.write).not.toHaveBeenCalled();
+
+      attackerHandlers.onResize({ cols: 1, rows: 1, connectionId: 'victim-pane' });
+      expect(shell.resize).not.toHaveBeenCalled();
+
+      attackerHandlers.onDisconnect({ connectionId: 'victim-pane' });
+      expect(sessionMap.getBySocket('victim-pane')).toBeDefined(); // still alive — the attacker's disconnect was a no-op
+    });
   });
 
   describe('onDisconnect', () => {

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -89,8 +89,16 @@ export type AgentTerminalHandlers = {
   onConnect(payload: unknown): Promise<void>;
   onInput(payload: unknown): void;
   onResize(payload: unknown): void;
-  onDisconnect(): void;
+  /** No payload (or no `connectionId` on it) — the real socket disconnected — tears down every connection this socket had open. A payload WITH `connectionId` closes just that one pane, leaving the socket's other connections (other split panes) live. */
+  onDisconnect(payload?: unknown): void;
 };
+
+/** Extracts the caller-supplied per-pane connection id from an input/resize/disconnect payload, if any — falls back to the socket's own id (this connection's ONLY agent-terminal session) for every caller that predates the splittable-panes UI. */
+function readConnectionId(payload: unknown): string | undefined {
+  if (payload === null || typeof payload !== 'object') return undefined;
+  const value = (payload as { connectionId?: unknown }).connectionId;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
 
 export const MAX_INPUT_BYTES = 4096;
 
@@ -163,6 +171,33 @@ export function buildAgentTerminalHandlers({
   persistStreamSessionId,
   billing,
 }: AgentTerminalHandlerDeps): AgentTerminalHandlers {
+  /**
+   * Every connectionId this SOCKET currently has a live agent-terminal
+   * session under. `buildAgentTerminalHandlers` is instantiated once per
+   * socket connection (see `apps/realtime/src/index.ts`), so this closure is
+   * exactly as socket-scoped as `socket` itself — a real socket disconnect
+   * (browser tab closed/reloaded) needs to tear down ALL of them, not just
+   * one pane's.
+   */
+  const activeConnectionIds = new Set<string>();
+
+  function disconnectConnection(connectionId: string) {
+    const session = sessionMap.getBySocket(connectionId);
+    activeConnectionIds.delete(connectionId);
+    if (!session) return;
+    const { sessionKey } = session;
+    session.outputFn = () => {};
+    session.closedFn = () => {};
+    sessionMap.detach(connectionId);
+    session.idleTimer = setTimeout(() => {
+      if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
+      session.releaseSlot();
+      session.command.kill();
+      endAgentTerminalSession(billing, sessionMap, session, sessionKey);
+      loggers.realtime.info('Agent terminal session reaped (idle)', { sessionKey, sandboxId: session.sandboxId });
+    }, DETACHED_IDLE_MS);
+  }
+
   return {
     async onConnect(payload: unknown) {
       const validation = validateAgentTerminalConnectPayload(payload);
@@ -171,12 +206,13 @@ export function buildAgentTerminalHandlers({
         return;
       }
       const { terminalId, projectName, branchName, name, cols, rows } = validation.value;
+      const connectionId = validation.value.connectionId ?? socket.id;
       const { cols: clampedCols, rows: clampedRows } = clampTerminalDimensions({ cols, rows });
 
       const userId = socket.data.user?.id ?? '';
       const authResult = await checkAuth({ userId, terminalId, projectName, branchName, name });
       if (!authResult.ok) {
-        socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${authResult.reason}` });
+        socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${authResult.reason}`, connectionId });
         return;
       }
 
@@ -188,11 +224,12 @@ export function buildAgentTerminalHandlers({
           clearTimeout(existingSession.idleTimer);
           existingSession.idleTimer = undefined;
         }
-        existingSession.outputFn = (data) => socket.emit('agent-terminal:output', { data });
-        existingSession.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode });
-        sessionMap.reattach(sessionKey, socket.id);
+        existingSession.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
+        existingSession.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
+        sessionMap.reattach(sessionKey, connectionId);
+        activeConnectionIds.add(connectionId);
         authResult.releaseSlot();
-        socket.emit('agent-terminal:ready', { scrollback: existingSession.scrollback.join('') });
+        socket.emit('agent-terminal:ready', { scrollback: existingSession.scrollback.join(''), connectionId });
         return;
       }
 
@@ -207,7 +244,7 @@ export function buildAgentTerminalHandlers({
         const gateResult = await billing.gate({ payerId: authResult.payerId });
         if (!gateResult.allowed) {
           authResult.releaseSlot();
-          socket.emit('agent-terminal:error', { message: 'Insufficient credits to open an agent terminal session.' });
+          socket.emit('agent-terminal:error', { message: 'Insufficient credits to open an agent terminal session.', connectionId });
           return;
         }
         holdId = gateResult.holdId;
@@ -235,8 +272,8 @@ export function buildAgentTerminalHandlers({
         holdId,
         connectedAt,
         pageId: terminalId,
-        outputFn: (data) => socket.emit('agent-terminal:output', { data }),
-        closedFn: (exitCode) => socket.emit('agent-terminal:closed', { exitCode }),
+        outputFn: (data) => socket.emit('agent-terminal:output', { data, connectionId }),
+        closedFn: (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId }),
         scrollback: [],
         scrollbackBytes: 0,
         reAuthInterval: undefined,
@@ -275,12 +312,13 @@ export function buildAgentTerminalHandlers({
       } catch {
         authResult.releaseSlot();
         if (holdId) void billing?.releaseHold(holdId).catch(() => {});
-        socket.emit('agent-terminal:error', { message: 'Failed to open agent terminal session' });
+        socket.emit('agent-terminal:error', { message: 'Failed to open agent terminal session', connectionId });
         return;
       }
 
       session.command = shell;
-      sessionMap.setNew(sessionKey, socket.id, session);
+      sessionMap.setNew(sessionKey, connectionId, session);
+      activeConnectionIds.add(connectionId);
 
       if (authResult.streamSessionId === null) {
         void discoverNewSessionId(sprite, sessionsBeforeLaunch).then((sessionId) => {
@@ -314,11 +352,12 @@ export function buildAgentTerminalHandlers({
 
       session.reAuthInterval = reAuthInterval;
 
-      socket.emit('agent-terminal:ready', {});
+      socket.emit('agent-terminal:ready', { connectionId });
     },
 
     onInput(payload: unknown) {
-      const session = sessionMap.getBySocket(socket.id);
+      const connectionId = readConnectionId(payload) ?? socket.id;
+      const session = sessionMap.getBySocket(connectionId);
       if (!session) return;
       const p = payload as { data?: string };
       if (typeof p?.data === 'string' && p.data.length <= MAX_INPUT_BYTES) {
@@ -327,7 +366,8 @@ export function buildAgentTerminalHandlers({
     },
 
     onResize(payload: unknown) {
-      const session = sessionMap.getBySocket(socket.id);
+      const connectionId = readConnectionId(payload) ?? socket.id;
+      const session = sessionMap.getBySocket(connectionId);
       if (!session) return;
       const p = payload as { cols?: number; rows?: number };
       if (typeof p?.cols === 'number' && typeof p?.rows === 'number' && Number.isFinite(p.cols) && Number.isFinite(p.rows)) {
@@ -336,20 +376,20 @@ export function buildAgentTerminalHandlers({
       }
     },
 
-    onDisconnect() {
-      const session = sessionMap.getBySocket(socket.id);
-      if (!session) return;
-      const { sessionKey } = session;
-      session.outputFn = () => {};
-      session.closedFn = () => {};
-      sessionMap.detach(socket.id);
-      session.idleTimer = setTimeout(() => {
-        if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
-        session.releaseSlot();
-        session.command.kill();
-        endAgentTerminalSession(billing, sessionMap, session, sessionKey);
-        loggers.realtime.info('Agent terminal session reaped (idle)', { sessionKey, sandboxId: session.sandboxId });
-      }, DETACHED_IDLE_MS);
+    onDisconnect(payload?: unknown) {
+      const explicitConnectionId = readConnectionId(payload);
+      if (explicitConnectionId !== undefined) {
+        // One pane explicitly closed (e.g. the Terminal workspace's "Split"
+        // panes closing one of several) — leave this socket's OTHER
+        // connections (other live panes) untouched.
+        disconnectConnection(explicitConnectionId);
+        return;
+      }
+      // The socket itself disconnected (tab closed/reloaded, network drop) —
+      // every connection this socket had open loses its viewer at once.
+      for (const connectionId of [...activeConnectionIds]) {
+        disconnectConnection(connectionId);
+      }
     },
   };
 }

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -357,6 +357,7 @@ export function buildAgentTerminalHandlers({
 
     onInput(payload: unknown) {
       const connectionId = readConnectionId(payload) ?? socket.id;
+      if (!activeConnectionIds.has(connectionId)) return;
       const session = sessionMap.getBySocket(connectionId);
       if (!session) return;
       const p = payload as { data?: string };
@@ -367,6 +368,7 @@ export function buildAgentTerminalHandlers({
 
     onResize(payload: unknown) {
       const connectionId = readConnectionId(payload) ?? socket.id;
+      if (!activeConnectionIds.has(connectionId)) return;
       const session = sessionMap.getBySocket(connectionId);
       if (!session) return;
       const p = payload as { cols?: number; rows?: number };
@@ -381,8 +383,15 @@ export function buildAgentTerminalHandlers({
       if (explicitConnectionId !== undefined) {
         // One pane explicitly closed (e.g. the Terminal workspace's "Split"
         // panes closing one of several) — leave this socket's OTHER
-        // connections (other live panes) untouched.
-        disconnectConnection(explicitConnectionId);
+        // connections (other live panes) untouched. Only a connectionId THIS
+        // socket itself registered via a successful, authorized `onConnect`
+        // is honored — `agentTerminalSessionMap` is one shared, server-wide
+        // instance (every socket's sessions live in it), so a connectionId a
+        // client merely CLAIMS (rather than one this socket actually
+        // established) must never be trusted to reach another socket's PTY.
+        if (activeConnectionIds.has(explicitConnectionId)) {
+          disconnectConnection(explicitConnectionId);
+        }
         return;
       }
       // The socket itself disconnected (tab closed/reloaded, network drop) —

--- a/apps/realtime/src/terminal/validation.ts
+++ b/apps/realtime/src/terminal/validation.ts
@@ -29,6 +29,16 @@ export type AgentTerminalConnectPayload = {
   name: string;
   cols: number;
   rows: number;
+  /**
+   * Client-generated id distinguishing ONE pane's PTY stream from another
+   * when several are multiplexed over the SAME socket (the Terminal
+   * workspace's splittable panes — one socket per browser tab, not per
+   * pane). Optional and falls back to the socket's own id in
+   * `agent-terminal-handler.ts` — a caller that never sends more than one
+   * concurrent agent-terminal connection per socket (every caller before
+   * the splittable-panes UI) needs no change.
+   */
+  connectionId?: string;
 };
 
 type AgentOk = { ok: true; value: AgentTerminalConnectPayload };
@@ -64,6 +74,8 @@ export function validateAgentTerminalConnectPayload(payload: unknown): AgentResu
   if (!branchName.ok) return branchName;
   const name = requireNonEmptyString(p.name, 'name');
   if (!name.ok) return name;
+  const connectionId = optionalNonEmptyString(p.connectionId, 'connectionId');
+  if (!connectionId.ok) return connectionId;
 
   if (typeof p.cols !== 'number' || !Number.isFinite(p.cols) || p.cols <= 0) {
     return { ok: false, error: 'invalid cols' };
@@ -81,6 +93,7 @@ export function validateAgentTerminalConnectPayload(payload: unknown): AgentResu
       name: name.value,
       cols: p.cols,
       rows: p.rows,
+      connectionId: connectionId.value,
     },
   };
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -1,39 +1,20 @@
 "use client";
 
 import '@xterm/xterm/css/xterm.css';
-import React, { useState, useCallback } from 'react';
+import React from 'react';
 import dynamic from 'next/dynamic';
 import { motion } from 'motion/react';
-import { useSocket } from '@/hooks/useSocket';
 import { useAuth } from '@/hooks/useAuth';
-import { toast } from 'sonner';
 
 interface TerminalViewProps {
   pageId: string;
 }
 
-const XtermTerminal = dynamic(() => import('./XtermTerminal'), { ssr: false });
-
-const SESSION_FLAG_KEY = (pageId: string) => `terminal-session:${pageId}`;
+const TerminalWorkspace = dynamic(() => import('./workspace/TerminalWorkspace'), { ssr: false });
 
 const TerminalView = ({ pageId }: TerminalViewProps) => {
-  const [connected, setConnected] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const isReconnect = typeof sessionStorage !== 'undefined' && !!sessionStorage.getItem(SESSION_FLAG_KEY(pageId));
-  const socket = useSocket();
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
-
-  const handleReady = useCallback(() => {
-    if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.setItem(SESSION_FLAG_KEY(pageId), '1');
-    }
-    setConnected(true);
-  }, [pageId]);
-  const handleError = useCallback((message: string) => {
-    setError(message);
-    toast.error(`Terminal error: ${message}`);
-  }, []);
 
   return (
     <motion.div
@@ -51,29 +32,11 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
         </div>
       )}
 
-      <div className="flex-1 min-h-0 relative">
-        {socket && isAdmin && (
-          <XtermTerminal
-            socket={socket}
-            pageId={pageId}
-            onReady={handleReady}
-            onError={handleError}
-          />
-        )}
-
-        {isAdmin && !connected && (
-          <div className="absolute inset-0 bg-black flex items-center justify-center">
-            {error ? (
-              <span className="text-sm text-red-400">{error}</span>
-            ) : (
-              <div className="flex items-center gap-2">
-                <div className="w-4 h-4 border-2 border-green-400 border-t-transparent rounded-full animate-spin" />
-                <span className="text-sm text-green-400">{isReconnect ? 'Reconnecting to shell...' : 'Connecting to shell...'}</span>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      {isAdmin && (
+        <div className="flex-1 min-h-0">
+          <TerminalWorkspace terminalId={pageId} />
+        </div>
+      )}
     </motion.div>
   );
 };

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
@@ -2,27 +2,27 @@
 
 import { useEffect, useRef } from 'react';
 import type { Socket } from 'socket.io-client';
-import { useCSRFToken } from '@/hooks/useCSRFToken';
+import { useEditingStore } from '@/stores/useEditingStore';
+
+export interface AgentTerminalConnectPayload {
+  terminalId: string;
+  /** Neither set → machine scope, projectName alone → project scope, both → branch scope (see `agent-terminals.ts`). */
+  projectName?: string;
+  branchName?: string;
+  name: string;
+}
 
 interface XtermTerminalProps {
   socket: Socket;
-  pageId: string;
+  /** Uniquely identifies this PTY session's scope tuple — used as the effect's re-connect key and the useEditingStore session id. Callers should key their component with this same value so switching scope re-mounts instead of reusing stale listeners. */
+  sessionId: string;
+  connectPayload: AgentTerminalConnectPayload;
   onReady?(): void;
   onError?(message: string): void;
 }
 
-/**
- * A plain machine shell IS a machine-scope agent terminal of `agentType:
- * 'shell'` (Terminal — universal scope reshape) — this conventional name is
- * what the realtime agent-terminal-activity feed (apps/realtime/src/
- * terminal/terminal-activity.ts) also assumes when injecting agent bash runs
- * into this same live PTY feed.
- */
-const SHELL_TERMINAL_NAME = 'shell';
-
-export default function XtermTerminal({ socket, pageId, onReady, onError }: XtermTerminalProps) {
+export default function XtermTerminal({ socket, sessionId, connectPayload, onReady, onError }: XtermTerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { refreshToken } = useCSRFToken();
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -50,6 +50,7 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
         const handleOutput = ({ data }: { data: string }) => terminal.write(data);
         const handleReady = ({ scrollback }: { scrollback?: string } = {}) => {
           if (scrollback) terminal.write(scrollback);
+          useEditingStore.getState().startEditing(sessionId, 'other', { componentName: 'agent-terminal' });
           onReady?.();
         };
         const handleClosed = ({ exitCode }: { exitCode: number }) =>
@@ -59,8 +60,8 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
           onError?.(message);
         };
 
-        // Register listeners BEFORE spawning/connecting so we don't miss early
-        // agent-terminal:ready / agent-terminal:output events from the server.
+        // Register listeners BEFORE emitting agent-terminal:connect so we don't
+        // miss early agent-terminal:ready / agent-terminal:output events.
         socket.on('agent-terminal:output', handleOutput);
         socket.on('agent-terminal:ready', handleReady);
         socket.on('agent-terminal:closed', handleClosed);
@@ -75,31 +76,14 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
           socket.off('agent-terminal:closed', handleClosed);
           socket.off('agent-terminal:error', handleError);
           terminal.dispose();
+          useEditingStore.getState().endEditing(sessionId);
         };
 
-        // Reserve the (machine-scope, 'shell') tracking row — idempotent, so a
-        // repeat mount/reconnect just resumes it — before opening the PTY
-        // connection, mirroring "spawn reserves the row, PTY opens lazily on
-        // connect" (agent-terminals.ts).
-        const csrfToken = await refreshToken();
-        if (!csrfToken) throw new Error('Failed to obtain a CSRF token');
-        const spawnResponse = await fetch('/api/machines/agent-terminals', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'content-type': 'application/json', 'x-csrf-token': csrfToken },
-          body: JSON.stringify({ terminalId: pageId, name: SHELL_TERMINAL_NAME, agentType: SHELL_TERMINAL_NAME }),
-        });
-        if (cancelled) { teardown(); return; }
-        if (!spawnResponse.ok) {
-          const errorBody: unknown = await spawnResponse.json().catch(() => null);
-          const message =
-            typeof errorBody === 'object' && errorBody !== null && 'error' in errorBody && typeof (errorBody as { error: unknown }).error === 'string'
-              ? (errorBody as { error: string }).error
-              : 'Failed to open machine shell';
-          throw new Error(message);
-        }
-
-        socket.emit('agent-terminal:connect', { terminalId: pageId, name: SHELL_TERMINAL_NAME, cols: terminal.cols, rows: terminal.rows });
+        // The tracking row for this scope must already exist — the Navigator's
+        // add-terminal dialog reserves it (spawnAgentTerminal) before it's ever
+        // offered as something to open, so connecting here only ever attaches
+        // to (or resumes) an already-known session.
+        socket.emit('agent-terminal:connect', { ...connectPayload, cols: terminal.cols, rows: terminal.rows });
 
         resize.observer = new ResizeObserver(() => {
           fitAddon.fit();
@@ -119,10 +103,13 @@ export default function XtermTerminal({ socket, pageId, onReady, onError }: Xter
       cancelled = true;
       teardown?.();
     };
-  // onReady/onError are intentionally omitted — callers must stabilise them with
-  // useCallback. Including them would re-mount the terminal on every parent render.
+  // onReady/onError/connectPayload are intentionally omitted — callers must
+  // treat connectPayload as stable for a given sessionId (bump sessionId
+  // instead of mutating it in place) and stabilise onReady/onError with
+  // useCallback. Including them would re-mount the terminal on every parent
+  // render.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [socket, pageId]);
+  }, [socket, sessionId]);
 
   return <div ref={containerRef} className="w-full h-full" />;
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/XtermTerminal.tsx
@@ -30,6 +30,13 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, onRea
     let cancelled = false;
     let teardown: (() => void) | undefined;
 
+    // The Terminal workspace's splittable panes all share ONE socket (one
+    // connection per browser tab, not per pane) — this id is how the realtime
+    // bridge (and this listener) tells this pane's PTY stream apart from a
+    // sibling pane's on the exact same socket. Fresh per mount; switching
+    // scope re-mounts (keyed by sessionId at the call site) and gets a new one.
+    const connectionId = crypto.randomUUID();
+
     void (async () => {
       try {
         const [{ Terminal }, { FitAddon }] = await Promise.all([
@@ -45,19 +52,32 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, onRea
         terminal.open(containerRef.current);
         fitAddon.fit();
 
-        const onData = terminal.onData((data) => socket.emit('agent-terminal:input', { data }));
+        const onData = terminal.onData((data) => socket.emit('agent-terminal:input', { data, connectionId }));
 
-        const handleOutput = ({ data }: { data: string }) => terminal.write(data);
-        const handleReady = ({ scrollback }: { scrollback?: string } = {}) => {
-          if (scrollback) terminal.write(scrollback);
+        // Every mounted XtermTerminal shares this one socket, so every one of
+        // its listeners sees every pane's events — drop anything tagged with
+        // a DIFFERENT connectionId rather than rendering it into this pane.
+        const isMine = (payload: { connectionId?: string } | undefined) =>
+          payload?.connectionId === undefined || payload.connectionId === connectionId;
+
+        const handleOutput = (payload: { data: string; connectionId?: string }) => {
+          if (!isMine(payload)) return;
+          terminal.write(payload.data);
+        };
+        const handleReady = (payload: { scrollback?: string; connectionId?: string } = {}) => {
+          if (!isMine(payload)) return;
+          if (payload.scrollback) terminal.write(payload.scrollback);
           useEditingStore.getState().startEditing(sessionId, 'other', { componentName: 'agent-terminal' });
           onReady?.();
         };
-        const handleClosed = ({ exitCode }: { exitCode: number }) =>
-          terminal.writeln(`\r\n\x1b[90mProcess exited with code ${exitCode}\x1b[0m`);
-        const handleError = ({ message }: { message: string }) => {
-          terminal.writeln(`\r\n\x1b[31mError: ${message}\x1b[0m`);
-          onError?.(message);
+        const handleClosed = (payload: { exitCode: number; connectionId?: string }) => {
+          if (!isMine(payload)) return;
+          terminal.writeln(`\r\n\x1b[90mProcess exited with code ${payload.exitCode}\x1b[0m`);
+        };
+        const handleError = (payload: { message: string; connectionId?: string }) => {
+          if (!isMine(payload)) return;
+          terminal.writeln(`\r\n\x1b[31mError: ${payload.message}\x1b[0m`);
+          onError?.(payload.message);
         };
 
         // Register listeners BEFORE emitting agent-terminal:connect so we don't
@@ -75,6 +95,11 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, onRea
           socket.off('agent-terminal:ready', handleReady);
           socket.off('agent-terminal:closed', handleClosed);
           socket.off('agent-terminal:error', handleError);
+          // Tell the server THIS pane is gone (not the whole socket) — with
+          // several panes multiplexed over one socket, only an explicit
+          // per-connection signal (not the socket's own disconnect/idle
+          // timeout) correctly reflects "this one pane closed".
+          socket.emit('agent-terminal:disconnect', { connectionId });
           terminal.dispose();
           useEditingStore.getState().endEditing(sessionId);
         };
@@ -83,11 +108,11 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, onRea
         // add-terminal dialog reserves it (spawnAgentTerminal) before it's ever
         // offered as something to open, so connecting here only ever attaches
         // to (or resumes) an already-known session.
-        socket.emit('agent-terminal:connect', { ...connectPayload, cols: terminal.cols, rows: terminal.rows });
+        socket.emit('agent-terminal:connect', { ...connectPayload, connectionId, cols: terminal.cols, rows: terminal.rows });
 
         resize.observer = new ResizeObserver(() => {
           fitAddon.fit();
-          socket.emit('agent-terminal:resize', { cols: terminal.cols, rows: terminal.rows });
+          socket.emit('agent-terminal:resize', { cols: terminal.cols, rows: terminal.rows, connectionId });
         });
         resize.observer.observe(containerRef.current!);
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/EmptyState.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/EmptyState.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}
+
+export default function EmptyState({ title, description, children }: EmptyStateProps) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+      <p className="text-sm font-medium text-muted-foreground">{title}</p>
+      {description && <p className="max-w-xs text-xs text-muted-foreground/70">{description}</p>}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
@@ -16,6 +16,16 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -68,8 +78,18 @@ export default function Navigator({ terminalId, onOpenTerminal }: NavigatorProps
 
 function MachineNode({ terminalId, onOpenTerminal }: { terminalId: string; onOpenTerminal(scope: OpenTerminalScope): void }) {
   const [expanded, setExpanded] = useState(true);
-  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(expanded ? terminalId : null, null, null);
-  const { projects, isLoading: projectsLoading, addProject, removeProject } = useMachineProjects(terminalId);
+  const {
+    agentTerminals,
+    isLoading: terminalsLoading,
+    addAgentTerminal,
+    removeAgentTerminal,
+  } = useAgentTerminals(expanded ? terminalId : null, null, null);
+  const {
+    projects,
+    isLoading: projectsLoading,
+    addProject,
+    removeProject,
+  } = useMachineProjects(expanded ? terminalId : null);
 
   return (
     <div>
@@ -86,6 +106,7 @@ function MachineNode({ terminalId, onOpenTerminal }: { terminalId: string; onOpe
         <div className="pl-4">
           <TerminalList
             terminals={agentTerminals}
+            isLoading={terminalsLoading}
             emptyLabel="No terminals yet"
             onAdd={addAgentTerminal}
             onRemove={removeAgentTerminal}
@@ -110,10 +131,7 @@ function MachineNode({ terminalId, onOpenTerminal }: { terminalId: string; onOpe
               terminalId={terminalId}
               projectName={project.name}
               onOpenTerminal={onOpenTerminal}
-              onRemoveProject={() => {
-                if (!window.confirm(`Remove project "${project.name}"? This does not touch its branch-terminals.`)) return;
-                void removeProject(project.name).catch((err) => toast.error(err instanceof Error ? err.message : 'Failed to remove project'));
-              }}
+              onRemoveProject={() => removeProject(project.name)}
             />
           ))}
         </div>
@@ -131,15 +149,22 @@ function ProjectNode({
   terminalId: string;
   projectName: string;
   onOpenTerminal(scope: OpenTerminalScope): void;
-  onRemoveProject(): void;
+  onRemoveProject(): Promise<unknown>;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
-    expanded ? terminalId : null,
-    projectName,
-    null,
-  );
-  const { branches, addBranch, removeBranch } = useMachineBranches(expanded ? terminalId : null, projectName);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const {
+    agentTerminals,
+    isLoading: terminalsLoading,
+    addAgentTerminal,
+    removeAgentTerminal,
+  } = useAgentTerminals(expanded ? terminalId : null, projectName, null);
+  const {
+    branches,
+    isLoading: branchesLoading,
+    addBranch,
+    removeBranch,
+  } = useMachineBranches(expanded ? terminalId : null, projectName);
 
   return (
     <div>
@@ -155,17 +180,25 @@ function ProjectNode({
         </button>
         <button
           type="button"
-          onClick={onRemoveProject}
+          onClick={() => setConfirmingRemove(true)}
           className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
           title="Remove project"
         >
           <X className="mx-auto size-3.5" />
         </button>
       </div>
+      <ConfirmRemoveDialog
+        open={confirmingRemove}
+        onOpenChange={setConfirmingRemove}
+        title="Remove project?"
+        description={`Remove project "${projectName}"? This does not touch its branch-terminals.`}
+        onConfirm={onRemoveProject}
+      />
       {expanded && (
         <div className="pl-4">
           <TerminalList
             terminals={agentTerminals}
+            isLoading={terminalsLoading}
             emptyLabel="No terminals yet"
             onAdd={addAgentTerminal}
             onRemove={removeAgentTerminal}
@@ -175,7 +208,10 @@ function ProjectNode({
             <span className="text-xs text-muted-foreground">Branches</span>
             <AddBranchDialog onAdd={addBranch} />
           </div>
-          {branches.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">No branches yet</div>}
+          {branchesLoading && <div className="px-2 py-1 text-xs text-muted-foreground">Loading branches…</div>}
+          {!branchesLoading && branches.length === 0 && (
+            <div className="px-2 py-1 text-xs text-muted-foreground">No branches yet</div>
+          )}
           {branches.map((branch) => (
             <BranchNode
               key={branch.branchName}
@@ -183,12 +219,7 @@ function ProjectNode({
               projectName={projectName}
               branchName={branch.branchName}
               onOpenTerminal={onOpenTerminal}
-              onRemoveBranch={() => {
-                if (!window.confirm(`Remove branch-terminal "${branch.branchName}"? Its Sprite will be destroyed.`)) return;
-                void removeBranch(branch.branchName).catch((err) =>
-                  toast.error(err instanceof Error ? err.message : 'Failed to remove branch'),
-                );
-              }}
+              onRemoveBranch={() => removeBranch(branch.branchName)}
             />
           ))}
         </div>
@@ -208,14 +239,16 @@ function BranchNode({
   projectName: string;
   branchName: string;
   onOpenTerminal(scope: OpenTerminalScope): void;
-  onRemoveBranch(): void;
+  onRemoveBranch(): Promise<unknown>;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
-    expanded ? terminalId : null,
-    projectName,
-    branchName,
-  );
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const {
+    agentTerminals,
+    isLoading: terminalsLoading,
+    addAgentTerminal,
+    removeAgentTerminal,
+  } = useAgentTerminals(expanded ? terminalId : null, projectName, branchName);
 
   return (
     <div>
@@ -231,17 +264,25 @@ function BranchNode({
         </button>
         <button
           type="button"
-          onClick={onRemoveBranch}
+          onClick={() => setConfirmingRemove(true)}
           className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
           title="Remove branch-terminal"
         >
           <X className="mx-auto size-3.5" />
         </button>
       </div>
+      <ConfirmRemoveDialog
+        open={confirmingRemove}
+        onOpenChange={setConfirmingRemove}
+        title="Remove branch-terminal?"
+        description={`Remove branch-terminal "${branchName}"? Its Sprite will be destroyed.`}
+        onConfirm={onRemoveBranch}
+      />
       {expanded && (
         <div className="pl-4">
           <TerminalList
             terminals={agentTerminals}
+            isLoading={terminalsLoading}
             emptyLabel="No terminals yet"
             onAdd={addAgentTerminal}
             onRemove={removeAgentTerminal}
@@ -255,24 +296,29 @@ function BranchNode({
 
 function TerminalList({
   terminals,
+  isLoading,
   emptyLabel,
   onAdd,
   onRemove,
   onOpen,
 }: {
   terminals: AgentTerminal[];
+  isLoading: boolean;
   emptyLabel: string;
   onAdd(name: string, agentType: AgentRuntimeType): Promise<unknown>;
   onRemove(name: string): Promise<unknown>;
   onOpen(name: string): void;
 }) {
+  const [pendingRemove, setPendingRemove] = useState<string | null>(null);
+
   return (
     <div>
       <div className="flex items-center justify-between py-0.5 pr-1">
         <span className="text-xs text-muted-foreground">Terminals</span>
         <AddAgentTerminalDialog onAdd={onAdd} />
       </div>
-      {terminals.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">{emptyLabel}</div>}
+      {isLoading && <div className="px-2 py-1 text-xs text-muted-foreground">Loading terminals…</div>}
+      {!isLoading && terminals.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">{emptyLabel}</div>}
       {terminals.map((terminal) => (
         <div key={terminal.name} className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
           <button
@@ -288,10 +334,7 @@ function TerminalList({
           </button>
           <button
             type="button"
-            onClick={() => {
-              if (!window.confirm(`Remove terminal "${terminal.name}"?`)) return;
-              void onRemove(terminal.name).catch((err) => toast.error(err instanceof Error ? err.message : 'Failed to remove terminal'));
-            }}
+            onClick={() => setPendingRemove(terminal.name)}
             className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
             title="Remove terminal"
           >
@@ -299,7 +342,66 @@ function TerminalList({
           </button>
         </div>
       ))}
+      <ConfirmRemoveDialog
+        open={pendingRemove !== null}
+        onOpenChange={(open) => !open && setPendingRemove(null)}
+        title="Remove terminal?"
+        description={pendingRemove ? `Remove terminal "${pendingRemove}"?` : ''}
+        onConfirm={() => {
+          if (pendingRemove === null) return Promise.resolve();
+          return onRemove(pendingRemove);
+        }}
+      />
     </div>
+  );
+}
+
+function ConfirmRemoveDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  title: string;
+  description: string;
+  onConfirm(): Promise<unknown>;
+}) {
+  const [removing, setRemoving] = useState(false);
+
+  const handleConfirm = async () => {
+    setRemoving(true);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove');
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={(v) => !removing && onOpenChange(v)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={removing}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={removing}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {removing ? 'Removing…' : 'Remove'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import {
+  ChevronRight,
+  ChevronDown,
+  Cpu,
+  FolderGit2,
+  GitBranch,
+  TerminalSquare,
+  Plus,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useMachineProjects } from '@/hooks/useMachineProjects';
+import { useMachineBranches } from '@/hooks/useMachineBranches';
+import { useAgentTerminals, type AgentTerminal } from '@/hooks/useAgentTerminals';
+import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import EmptyState from './EmptyState';
+
+const AGENT_TYPES = Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[];
+
+/** Identifies which terminal to open in the middle panel — neither `projectName` nor `branchName` set is machine scope, `projectName` alone is project scope, both is branch scope. */
+export interface OpenTerminalScope {
+  projectName?: string;
+  branchName?: string;
+  name: string;
+}
+
+interface NavigatorProps {
+  terminalId: string;
+  onOpenTerminal(scope: OpenTerminalScope): void;
+}
+
+export default function Navigator({ terminalId, onOpenTerminal }: NavigatorProps) {
+  return (
+    <div className="flex h-full flex-col border-l">
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Navigator</span>
+      </div>
+      <ScrollArea className="flex-1">
+        <div className="p-1 text-sm">
+          <MachineNode terminalId={terminalId} onOpenTerminal={onOpenTerminal} />
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function MachineNode({ terminalId, onOpenTerminal }: { terminalId: string; onOpenTerminal(scope: OpenTerminalScope): void }) {
+  const [expanded, setExpanded] = useState(true);
+  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(expanded ? terminalId : null, null, null);
+  const { projects, isLoading: projectsLoading, addProject, removeProject } = useMachineProjects(terminalId);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="flex w-full items-center gap-1 rounded-sm py-1 pr-1 text-left hover:bg-accent/50"
+      >
+        {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+        <Cpu className="size-3.5 shrink-0" />
+        <span className="truncate font-medium">Machine</span>
+      </button>
+      {expanded && (
+        <div className="pl-4">
+          <TerminalList
+            terminals={agentTerminals}
+            emptyLabel="No terminals yet"
+            onAdd={addAgentTerminal}
+            onRemove={removeAgentTerminal}
+            onOpen={(name) => onOpenTerminal({ name })}
+          />
+          <div className="mt-1 flex items-center justify-between py-0.5 pr-1">
+            <span className="text-xs text-muted-foreground">Projects</span>
+            <AddProjectDialog onAdd={addProject} />
+          </div>
+          {projectsLoading && <div className="px-2 py-1 text-xs text-muted-foreground">Loading projects…</div>}
+          {!projectsLoading && projects.length === 0 && (
+            <EmptyState
+              title="No projects yet"
+              description="Add a git repo to this machine to start a branch-terminal."
+            >
+              <AddProjectDialog onAdd={addProject} triggerLabel="Add your first project" />
+            </EmptyState>
+          )}
+          {projects.map((project) => (
+            <ProjectNode
+              key={project.name}
+              terminalId={terminalId}
+              projectName={project.name}
+              onOpenTerminal={onOpenTerminal}
+              onRemoveProject={() => {
+                if (!window.confirm(`Remove project "${project.name}"? This does not touch its branch-terminals.`)) return;
+                void removeProject(project.name).catch((err) => toast.error(err instanceof Error ? err.message : 'Failed to remove project'));
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProjectNode({
+  terminalId,
+  projectName,
+  onOpenTerminal,
+  onRemoveProject,
+}: {
+  terminalId: string;
+  projectName: string;
+  onOpenTerminal(scope: OpenTerminalScope): void;
+  onRemoveProject(): void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
+    expanded ? terminalId : null,
+    projectName,
+    null,
+  );
+  const { branches, addBranch, removeBranch } = useMachineBranches(expanded ? terminalId : null, projectName);
+
+  return (
+    <div>
+      <div className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="flex flex-1 items-center gap-1 text-left"
+        >
+          {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+          <FolderGit2 className="size-3.5 shrink-0" />
+          <span className="truncate font-medium">{projectName}</span>
+        </button>
+        <button
+          type="button"
+          onClick={onRemoveProject}
+          className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+          title="Remove project"
+        >
+          <X className="mx-auto size-3.5" />
+        </button>
+      </div>
+      {expanded && (
+        <div className="pl-4">
+          <TerminalList
+            terminals={agentTerminals}
+            emptyLabel="No terminals yet"
+            onAdd={addAgentTerminal}
+            onRemove={removeAgentTerminal}
+            onOpen={(name) => onOpenTerminal({ projectName, name })}
+          />
+          <div className="mt-1 flex items-center justify-between py-0.5 pr-1">
+            <span className="text-xs text-muted-foreground">Branches</span>
+            <AddBranchDialog onAdd={addBranch} />
+          </div>
+          {branches.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">No branches yet</div>}
+          {branches.map((branch) => (
+            <BranchNode
+              key={branch.branchName}
+              terminalId={terminalId}
+              projectName={projectName}
+              branchName={branch.branchName}
+              onOpenTerminal={onOpenTerminal}
+              onRemoveBranch={() => {
+                if (!window.confirm(`Remove branch-terminal "${branch.branchName}"? Its Sprite will be destroyed.`)) return;
+                void removeBranch(branch.branchName).catch((err) =>
+                  toast.error(err instanceof Error ? err.message : 'Failed to remove branch'),
+                );
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BranchNode({
+  terminalId,
+  projectName,
+  branchName,
+  onOpenTerminal,
+  onRemoveBranch,
+}: {
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+  onOpenTerminal(scope: OpenTerminalScope): void;
+  onRemoveBranch(): void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const { agentTerminals, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
+    expanded ? terminalId : null,
+    projectName,
+    branchName,
+  );
+
+  return (
+    <div>
+      <div className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="flex flex-1 items-center gap-1 text-left"
+        >
+          {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+          <GitBranch className="size-3.5 shrink-0" />
+          <span className="truncate">{branchName}</span>
+        </button>
+        <button
+          type="button"
+          onClick={onRemoveBranch}
+          className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+          title="Remove branch-terminal"
+        >
+          <X className="mx-auto size-3.5" />
+        </button>
+      </div>
+      {expanded && (
+        <div className="pl-4">
+          <TerminalList
+            terminals={agentTerminals}
+            emptyLabel="No terminals yet"
+            onAdd={addAgentTerminal}
+            onRemove={removeAgentTerminal}
+            onOpen={(name) => onOpenTerminal({ projectName, branchName, name })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TerminalList({
+  terminals,
+  emptyLabel,
+  onAdd,
+  onRemove,
+  onOpen,
+}: {
+  terminals: AgentTerminal[];
+  emptyLabel: string;
+  onAdd(name: string, agentType: AgentRuntimeType): Promise<unknown>;
+  onRemove(name: string): Promise<unknown>;
+  onOpen(name: string): void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between py-0.5 pr-1">
+        <span className="text-xs text-muted-foreground">Terminals</span>
+        <AddAgentTerminalDialog onAdd={onAdd} />
+      </div>
+      {terminals.length === 0 && <div className="px-2 py-1 text-xs text-muted-foreground">{emptyLabel}</div>}
+      {terminals.map((terminal) => (
+        <div key={terminal.name} className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
+          <button
+            type="button"
+            onClick={() => onOpen(terminal.name)}
+            className="flex flex-1 items-center gap-1 text-left"
+          >
+            <TerminalSquare className="size-3.5 shrink-0" />
+            <span className="truncate">{terminal.name}</span>
+            <span className="ml-auto shrink-0 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">
+              {terminal.agentType}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (!window.confirm(`Remove terminal "${terminal.name}"?`)) return;
+              void onRemove(terminal.name).catch((err) => toast.error(err instanceof Error ? err.message : 'Failed to remove terminal'));
+            }}
+            className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+            title="Remove terminal"
+          >
+            <X className="mx-auto size-3.5" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AddProjectDialog({ onAdd, triggerLabel }: { onAdd(name: string, repoUrl: string): Promise<unknown>; triggerLabel?: string }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(name.trim(), repoUrl.trim());
+      setOpen(false);
+      setName('');
+      setRepoUrl('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add project');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {triggerLabel ? (
+          <Button variant="outline" size="sm" className="h-7 text-xs">
+            {triggerLabel}
+          </Button>
+        ) : (
+          <Button variant="ghost" size="icon" className="size-6" title="Add project">
+            <Plus className="size-3.5" />
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add project</DialogTitle>
+          <DialogDescription>Clone a git repo onto this machine&apos;s persistent filesystem.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input placeholder="Project name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Input placeholder="Repo URL (https://github.com/org/repo.git)" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} />
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !name.trim() || !repoUrl.trim()}>
+            {submitting ? 'Adding…' : 'Add project'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddBranchDialog({ onAdd }: { onAdd(branchName: string): Promise<unknown> }) {
+  const [open, setOpen] = useState(false);
+  const [branchName, setBranchName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(branchName.trim());
+      setOpen(false);
+      setBranchName('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add branch');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-5" title="Add branch-terminal">
+          <Plus className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add branch-terminal</DialogTitle>
+          <DialogDescription>Checks out this branch in its own isolated Sprite.</DialogDescription>
+        </DialogHeader>
+        <Input placeholder="Branch name" value={branchName} onChange={(e) => setBranchName(e.target.value)} />
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !branchName.trim()}>
+            {submitting ? 'Spawning…' : 'Add branch'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AddAgentTerminalDialog({ onAdd }: { onAdd(name: string, agentType: AgentRuntimeType): Promise<unknown> }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [agentType, setAgentType] = useState<AgentRuntimeType>(AGENT_TYPES[0]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(name.trim(), agentType);
+      setOpen(false);
+      setName('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add terminal');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-5" title="Add terminal">
+          <Plus className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add terminal</DialogTitle>
+          <DialogDescription>Named PTY session running a pluggable agent type at this node&apos;s scope.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input placeholder="Terminal name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentRuntimeType)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AGENT_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !name.trim()}>
+            {submitting ? 'Adding…' : 'Add terminal'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import dynamic from 'next/dynamic';
 import type { Socket } from 'socket.io-client';
 import { SquareSplitHorizontal, X } from 'lucide-react';
@@ -20,7 +20,10 @@ interface TerminalPanesProps {
   terminalId: string;
   socket: Socket | null | undefined;
   panes: TerminalPaneState[];
-  setPanes: Dispatch<SetStateAction<TerminalPaneState[]>>;
+  activePaneId: string;
+  onSelectPane(id: string): void;
+  onSplit(): void;
+  onClosePane(id: string): void;
 }
 
 function scopeLabel(scope: OpenTerminalScope): string {
@@ -31,14 +34,11 @@ function paneSessionId(terminalId: string, scope: OpenTerminalScope): string {
   return `agent-terminal:${terminalId}:${scope.projectName ?? ''}:${scope.branchName ?? ''}:${scope.name}`;
 }
 
-export default function TerminalPanes({ terminalId, socket, panes, setPanes }: TerminalPanesProps) {
-  const handleSplit = () => setPanes((prev) => [...prev, { id: crypto.randomUUID(), scope: null }]);
-  const handleClosePane = (id: string) => setPanes((prev) => (prev.length <= 1 ? prev : prev.filter((p) => p.id !== id)));
-
+export default function TerminalPanes({ terminalId, socket, panes, activePaneId, onSelectPane, onSplit, onClosePane }: TerminalPanesProps) {
   return (
     <div className="flex h-full flex-col bg-black">
       <div className="flex items-center justify-end gap-1 border-b border-white/10 px-2 py-1">
-        <Button variant="ghost" size="sm" onClick={handleSplit} className="h-6 gap-1 px-2 text-xs text-white/70 hover:text-white">
+        <Button variant="ghost" size="sm" onClick={onSplit} className="h-6 gap-1 px-2 text-xs text-white/70 hover:text-white">
           <SquareSplitHorizontal className="size-3.5" />
           Split
         </Button>
@@ -52,8 +52,10 @@ export default function TerminalPanes({ terminalId, socket, panes, setPanes }: T
                 socket={socket}
                 terminalId={terminalId}
                 pane={pane}
+                isActive={pane.id === activePaneId}
                 canClose={panes.length > 1}
-                onClose={() => handleClosePane(pane.id)}
+                onSelect={() => onSelectPane(pane.id)}
+                onClose={() => onClosePane(pane.id)}
               />
             </ResizablePanel>
           </Fragment>
@@ -67,37 +69,40 @@ function TerminalPane({
   socket,
   terminalId,
   pane,
+  isActive,
   canClose,
+  onSelect,
   onClose,
 }: {
   socket: Socket | null | undefined;
   terminalId: string;
   pane: TerminalPaneState;
+  isActive: boolean;
   canClose: boolean;
+  onSelect(): void;
   onClose(): void;
 }) {
-  const [connected, setConnected] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const sessionId = pane.scope ? paneSessionId(terminalId, pane.scope) : null;
 
-  // Opening a different terminal in this pane re-mounts XtermTerminal (keyed by
-  // sessionId below) — reset the local connection-status UI to match.
-  useEffect(() => {
-    setConnected(false);
-    setError(null);
-  }, [sessionId]);
-
-  const handleReady = useCallback(() => setConnected(true), []);
-  const handleError = useCallback((message: string) => setError(message), []);
-
   return (
-    <div className="flex h-full flex-col">
+    <div
+      className={`flex h-full flex-col ${isActive ? 'ring-1 ring-inset ring-emerald-500/50' : ''}`}
+      onClick={onSelect}
+    >
       <div className="flex items-center gap-1 border-b border-white/10 bg-white/5 px-1.5 py-1">
         <span className="flex-1 truncate px-1 text-xs text-white/80">
-          {pane.scope ? scopeLabel(pane.scope) : 'No terminal open'}
+          {pane.scope ? scopeLabel(pane.scope) : 'No terminal open — click to make this pane active, then pick a terminal in the navigator'}
         </span>
         {canClose && (
-          <Button variant="ghost" size="icon" onClick={onClose} className="size-5 text-white/60 hover:text-white">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            className="size-5 text-white/60 hover:text-white"
+          >
             <X className="size-3.5" />
           </Button>
         )}
@@ -106,37 +111,60 @@ function TerminalPane({
         {!pane.scope || !sessionId ? (
           <EmptyState title="No terminal open" description="Select a terminal from the navigator, or add one from any node." />
         ) : (
-          <>
-            {socket && (
-              <XtermTerminal
-                key={sessionId}
-                socket={socket}
-                sessionId={sessionId}
-                connectPayload={{
-                  terminalId,
-                  projectName: pane.scope.projectName,
-                  branchName: pane.scope.branchName,
-                  name: pane.scope.name,
-                }}
-                onReady={handleReady}
-                onError={handleError}
-              />
-            )}
-            {!connected && (
-              <div className="absolute inset-0 flex items-center justify-center bg-black">
-                {error ? (
-                  <span className="text-sm text-red-400">{error}</span>
-                ) : (
-                  <div className="flex items-center gap-2">
-                    <div className="size-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
-                    <span className="text-sm text-green-400">Connecting…</span>
-                  </div>
-                )}
-              </div>
-            )}
-          </>
+          <TerminalPaneStream key={sessionId} socket={socket} terminalId={terminalId} scope={pane.scope} sessionId={sessionId} />
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Keyed by `sessionId` at the call site above — switching which terminal a
+ * pane shows fully unmounts/remounts this component, so `connected`/`error`
+ * reset to their initial values automatically instead of needing a manual
+ * effect (which would otherwise briefly show the PREVIOUS terminal's
+ * connected state for one render before an effect could catch up).
+ */
+function TerminalPaneStream({
+  socket,
+  terminalId,
+  scope,
+  sessionId,
+}: {
+  socket: Socket | null | undefined;
+  terminalId: string;
+  scope: OpenTerminalScope;
+  sessionId: string;
+}) {
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleReady = useCallback(() => setConnected(true), []);
+  const handleError = useCallback((message: string) => setError(message), []);
+
+  return (
+    <>
+      {socket && (
+        <XtermTerminal
+          socket={socket}
+          sessionId={sessionId}
+          connectPayload={{ terminalId, projectName: scope.projectName, branchName: scope.branchName, name: scope.name }}
+          onReady={handleReady}
+          onError={handleError}
+        />
+      )}
+      {!connected && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black">
+          {error ? (
+            <span className="text-sm text-red-400">{error}</span>
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="size-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+              <span className="text-sm text-green-400">Connecting…</span>
+            </div>
+          )}
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { Fragment, useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import dynamic from 'next/dynamic';
+import type { Socket } from 'socket.io-client';
+import { SquareSplitHorizontal, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import EmptyState from './EmptyState';
+import type { OpenTerminalScope } from './Navigator';
+
+const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
+
+export interface TerminalPaneState {
+  id: string;
+  scope: OpenTerminalScope | null;
+}
+
+interface TerminalPanesProps {
+  terminalId: string;
+  socket: Socket | null | undefined;
+  panes: TerminalPaneState[];
+  setPanes: Dispatch<SetStateAction<TerminalPaneState[]>>;
+}
+
+function scopeLabel(scope: OpenTerminalScope): string {
+  return [scope.projectName, scope.branchName, scope.name].filter(Boolean).join('/');
+}
+
+function paneSessionId(terminalId: string, scope: OpenTerminalScope): string {
+  return `agent-terminal:${terminalId}:${scope.projectName ?? ''}:${scope.branchName ?? ''}:${scope.name}`;
+}
+
+export default function TerminalPanes({ terminalId, socket, panes, setPanes }: TerminalPanesProps) {
+  const handleSplit = () => setPanes((prev) => [...prev, { id: crypto.randomUUID(), scope: null }]);
+  const handleClosePane = (id: string) => setPanes((prev) => (prev.length <= 1 ? prev : prev.filter((p) => p.id !== id)));
+
+  return (
+    <div className="flex h-full flex-col bg-black">
+      <div className="flex items-center justify-end gap-1 border-b border-white/10 px-2 py-1">
+        <Button variant="ghost" size="sm" onClick={handleSplit} className="h-6 gap-1 px-2 text-xs text-white/70 hover:text-white">
+          <SquareSplitHorizontal className="size-3.5" />
+          Split
+        </Button>
+      </div>
+      <ResizablePanelGroup orientation="horizontal" className="min-h-0 flex-1">
+        {panes.map((pane, i) => (
+          <Fragment key={pane.id}>
+            {i > 0 && <ResizableHandle />}
+            <ResizablePanel defaultSize={100 / panes.length} minSize={20}>
+              <TerminalPane
+                socket={socket}
+                terminalId={terminalId}
+                pane={pane}
+                canClose={panes.length > 1}
+                onClose={() => handleClosePane(pane.id)}
+              />
+            </ResizablePanel>
+          </Fragment>
+        ))}
+      </ResizablePanelGroup>
+    </div>
+  );
+}
+
+function TerminalPane({
+  socket,
+  terminalId,
+  pane,
+  canClose,
+  onClose,
+}: {
+  socket: Socket | null | undefined;
+  terminalId: string;
+  pane: TerminalPaneState;
+  canClose: boolean;
+  onClose(): void;
+}) {
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sessionId = pane.scope ? paneSessionId(terminalId, pane.scope) : null;
+
+  // Opening a different terminal in this pane re-mounts XtermTerminal (keyed by
+  // sessionId below) — reset the local connection-status UI to match.
+  useEffect(() => {
+    setConnected(false);
+    setError(null);
+  }, [sessionId]);
+
+  const handleReady = useCallback(() => setConnected(true), []);
+  const handleError = useCallback((message: string) => setError(message), []);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-1 border-b border-white/10 bg-white/5 px-1.5 py-1">
+        <span className="flex-1 truncate px-1 text-xs text-white/80">
+          {pane.scope ? scopeLabel(pane.scope) : 'No terminal open'}
+        </span>
+        {canClose && (
+          <Button variant="ghost" size="icon" onClick={onClose} className="size-5 text-white/60 hover:text-white">
+            <X className="size-3.5" />
+          </Button>
+        )}
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {!pane.scope || !sessionId ? (
+          <EmptyState title="No terminal open" description="Select a terminal from the navigator, or add one from any node." />
+        ) : (
+          <>
+            {socket && (
+              <XtermTerminal
+                key={sessionId}
+                socket={socket}
+                sessionId={sessionId}
+                connectPayload={{
+                  terminalId,
+                  projectName: pane.scope.projectName,
+                  branchName: pane.scope.branchName,
+                  name: pane.scope.name,
+                }}
+                onReady={handleReady}
+                onError={handleError}
+              />
+            )}
+            {!connected && (
+              <div className="absolute inset-0 flex items-center justify-center bg-black">
+                {error ? (
+                  <span className="text-sm text-red-400">{error}</span>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <div className="size-4 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+                    <span className="text-sm text-green-400">Connecting…</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
@@ -18,20 +18,47 @@ function newPane(scope: OpenTerminalScope | null = null): TerminalPaneState {
 export default function TerminalWorkspace({ terminalId }: TerminalWorkspaceProps) {
   const socket = useSocket();
   const [panes, setPanes] = useState<TerminalPaneState[]>(() => [newPane()]);
+  const [activePaneId, setActivePaneId] = useState<string>(() => panes[0].id);
 
-  const handleOpenTerminal = useCallback((scope: OpenTerminalScope) => {
-    setPanes((prev) => {
-      if (prev.length === 0) return [newPane(scope)];
-      const next = [...prev];
-      next[next.length - 1] = { ...next[next.length - 1], scope };
-      return next;
-    });
-  }, []);
+  // Opening a terminal from the Navigator always targets the pane the user
+  // last clicked/split into — an explicit "active pane" rather than guessing
+  // from array position, which silently overwrote the wrong pane whenever a
+  // second pane existed.
+  const handleOpenTerminal = useCallback(
+    (scope: OpenTerminalScope) => {
+      setPanes(panes.map((p) => (p.id === activePaneId ? { ...p, scope } : p)));
+    },
+    [panes, activePaneId],
+  );
+
+  const handleSplit = useCallback(() => {
+    const pane = newPane();
+    setPanes([...panes, pane]);
+    setActivePaneId(pane.id);
+  }, [panes]);
+
+  const handleClosePane = useCallback(
+    (id: string) => {
+      if (panes.length <= 1) return;
+      const next = panes.filter((p) => p.id !== id);
+      setPanes(next);
+      if (activePaneId === id) setActivePaneId(next[0].id);
+    },
+    [panes, activePaneId],
+  );
 
   return (
     <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
       <ResizablePanel defaultSize={75} minSize={30}>
-        <TerminalPanes terminalId={terminalId} socket={socket} panes={panes} setPanes={setPanes} />
+        <TerminalPanes
+          terminalId={terminalId}
+          socket={socket}
+          panes={panes}
+          activePaneId={activePaneId}
+          onSelectPane={setActivePaneId}
+          onSplit={handleSplit}
+          onClosePane={handleClosePane}
+        />
       </ResizablePanel>
       <ResizableHandle />
       <ResizablePanel defaultSize={25} minSize={16} maxSize={40}>

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback, useState } from 'react';
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useSocket } from '@/hooks/useSocket';
+import Navigator, { type OpenTerminalScope } from './Navigator';
+import TerminalPanes, { type TerminalPaneState } from './TerminalPanes';
+
+interface TerminalWorkspaceProps {
+  /** The Terminal page's own id — this page IS the Machine (tasks/terminal.md). */
+  terminalId: string;
+}
+
+function newPane(scope: OpenTerminalScope | null = null): TerminalPaneState {
+  return { id: crypto.randomUUID(), scope };
+}
+
+export default function TerminalWorkspace({ terminalId }: TerminalWorkspaceProps) {
+  const socket = useSocket();
+  const [panes, setPanes] = useState<TerminalPaneState[]>(() => [newPane()]);
+
+  const handleOpenTerminal = useCallback((scope: OpenTerminalScope) => {
+    setPanes((prev) => {
+      if (prev.length === 0) return [newPane(scope)];
+      const next = [...prev];
+      next[next.length - 1] = { ...next[next.length - 1], scope };
+      return next;
+    });
+  }, []);
+
+  return (
+    <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+      <ResizablePanel defaultSize={75} minSize={30}>
+        <TerminalPanes terminalId={terminalId} socket={socket} panes={panes} setPanes={setPanes} />
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={25} minSize={16} maxSize={40}>
+        <Navigator terminalId={terminalId} onOpenTerminal={handleOpenTerminal} />
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+
+export interface AgentTerminal {
+  name: string;
+  agentType: AgentRuntimeType;
+  createdAt: string;
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch terminals');
+    }
+    return res.json() as Promise<{ agentTerminals: AgentTerminal[] }>;
+  });
+
+function buildQuery(terminalId: string, projectName?: string | null, branchName?: string | null): string {
+  const params = new URLSearchParams({ terminalId });
+  if (projectName) params.set('projectName', projectName);
+  if (branchName) params.set('branchName', branchName);
+  return params.toString();
+}
+
+/**
+ * Runtime tier of the Terminal workspace navigator — named, pluggable-agent-
+ * typed PTY sessions at ANY of the three universal Terminal scopes: neither
+ * `projectName` nor `branchName` set targets machine scope, `projectName`
+ * alone targets project scope, both set targets branch scope. Pass a `null`
+ * `terminalId` to disable fetching entirely (e.g. a collapsed navigator node).
+ */
+export function useAgentTerminals(terminalId: string | null, projectName?: string | null, branchName?: string | null) {
+  const key = terminalId ? `/api/machines/agent-terminals?${buildQuery(terminalId, projectName, branchName)}` : null;
+
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const addAgentTerminal = useCallback(
+    async (name: string, agentType: AgentRuntimeType) => {
+      if (!terminalId) throw new Error('No active machine');
+      const result = await post<{ agentTerminal: { name: string; agentType: AgentRuntimeType; resumed: boolean } }>(
+        '/api/machines/agent-terminals',
+        { terminalId, projectName: projectName ?? undefined, branchName: branchName ?? undefined, name, agentType },
+      );
+      await mutate();
+      return result.agentTerminal;
+    },
+    [terminalId, projectName, branchName, mutate],
+  );
+
+  const removeAgentTerminal = useCallback(
+    async (name: string) => {
+      if (!terminalId) throw new Error('No active machine');
+      await del(`/api/machines/agent-terminals?${buildQuery(terminalId, projectName, branchName)}&name=${encodeURIComponent(name)}`);
+      await mutate();
+    },
+    [terminalId, projectName, branchName, mutate],
+  );
+
+  return {
+    agentTerminals: data?.agentTerminals ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+    addAgentTerminal,
+    removeAgentTerminal,
+  };
+}

--- a/apps/web/src/hooks/useMachineBranches.ts
+++ b/apps/web/src/hooks/useMachineBranches.ts
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+
+export interface MachineBranch {
+  branchName: string;
+  createdAt: string;
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch branches');
+    }
+    return res.json() as Promise<{ branches: MachineBranch[] }>;
+  });
+
+/** Branches tier of the Terminal workspace navigator — one isolated Sprite per branch-terminal. */
+export function useMachineBranches(terminalId: string | null, projectName: string | null) {
+  const key =
+    terminalId && projectName
+      ? `/api/machines/branches?terminalId=${encodeURIComponent(terminalId)}&projectName=${encodeURIComponent(projectName)}`
+      : null;
+
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const addBranch = useCallback(
+    async (branchName: string) => {
+      if (!terminalId || !projectName) throw new Error('No active project');
+      const result = await post<{ branch: { branchName: string; resumed: boolean } }>('/api/machines/branches', {
+        terminalId,
+        projectName,
+        branchName,
+      });
+      await mutate();
+      return result.branch;
+    },
+    [terminalId, projectName, mutate],
+  );
+
+  const removeBranch = useCallback(
+    async (branchName: string) => {
+      if (!terminalId || !projectName) throw new Error('No active project');
+      await del(
+        `/api/machines/branches?terminalId=${encodeURIComponent(terminalId)}&projectName=${encodeURIComponent(projectName)}&branchName=${encodeURIComponent(branchName)}`,
+      );
+      await mutate();
+    },
+    [terminalId, projectName, mutate],
+  );
+
+  return {
+    branches: data?.branches ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+    addBranch,
+    removeBranch,
+  };
+}

--- a/apps/web/src/hooks/useMachineProjects.ts
+++ b/apps/web/src/hooks/useMachineProjects.ts
@@ -31,7 +31,9 @@ export function useMachineProjects(terminalId: string | null) {
   const addProject = useCallback(
     async (name: string, repoUrl: string) => {
       if (!terminalId) throw new Error('No active machine');
-      const result = await post<{ project: MachineProject }>('/api/machines/projects', { terminalId, name, repoUrl });
+      // The POST route returns only `{ name, repoUrl, path }` — no `createdAt`
+      // (that's set by the DB and only surfaced by the GET list route).
+      const result = await post<{ project: Omit<MachineProject, 'createdAt'> }>('/api/machines/projects', { terminalId, name, repoUrl });
       await mutate();
       return result.project;
     },

--- a/apps/web/src/hooks/useMachineProjects.ts
+++ b/apps/web/src/hooks/useMachineProjects.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useCallback } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+
+export interface MachineProject {
+  name: string;
+  repoUrl: string;
+  path: string;
+  createdAt: string;
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch projects');
+    }
+    return res.json() as Promise<{ projects: MachineProject[] }>;
+  });
+
+/** Projects tier of the Terminal workspace navigator — git repos tracked on a Machine. */
+export function useMachineProjects(terminalId: string | null) {
+  const key = terminalId ? `/api/machines/projects?terminalId=${encodeURIComponent(terminalId)}` : null;
+
+  const { data, error, isLoading, mutate } = useSWR(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  const addProject = useCallback(
+    async (name: string, repoUrl: string) => {
+      if (!terminalId) throw new Error('No active machine');
+      const result = await post<{ project: MachineProject }>('/api/machines/projects', { terminalId, name, repoUrl });
+      await mutate();
+      return result.project;
+    },
+    [terminalId, mutate],
+  );
+
+  const removeProject = useCallback(
+    async (name: string) => {
+      if (!terminalId) throw new Error('No active machine');
+      await del(`/api/machines/projects?terminalId=${encodeURIComponent(terminalId)}&name=${encodeURIComponent(name)}`);
+      await mutate();
+    },
+    [terminalId, mutate],
+  );
+
+  return {
+    projects: data?.projects ?? [],
+    isLoading,
+    error: error as Error | undefined,
+    mutate,
+    addProject,
+    removeProject,
+  };
+}


### PR DESCRIPTION
## Summary

Wires the already-merged scope model (#1909) and scope-aware transport (#1910) into the Terminal workspace UI — the one Navigator that replaces the old Projects→Branches-only tree and the separate "Machine Shell" tab.

- **ONE Navigator tree**: Machine (root, its own machine-level terminals including a plain shell) → Projects (project-root terminals, no branch) → Branches (branch terminals). Every node — Machine, each Project, each Branch — has its own "+ new terminal" affordance with an agentType picker (`claude` / `codex` / `pagespace-cli` / `shell`), implicitly scoped by which node it's on (machine → no project/branch; project → `projectName` only; branch → `projectName` + `branchName`).
- **`useAgentTerminals(terminalId, projectName?, branchName?)`** supports all three scopes directly — no forced project+branch, no `'No active branch'` throw. A `null` `terminalId` still disables the SWR key entirely, used to lazily gate a node's terminal list on expansion.
- **`XtermTerminal.tsx`** generalized off the hardcoded machine-shell name. It no longer spawns the tracking row itself (the Navigator's add-terminal dialog already reserves it via `POST /api/machines/agent-terminals` before the terminal is ever offered to click) — it connects, with `connectPayload: { terminalId, projectName?, branchName?, name }`, keyed/registered with `useEditingStore` by a scope-tuple `sessionId`.
- **`TerminalView.tsx`**: the separate "Machine Shell" tab is gone. The Machine node's own terminals — including a plain `agentType: 'shell'` terminal — **are** that shell now, on the same unified `agent-terminal:*` event family. Renders the workspace directly, no tabs.
- **`workspace/` components**: `EmptyState`, `Navigator` (recursive Machine/Project/Branch nodes, each with its own lazily-fetched terminal list + add/remove dialogs), `TerminalPanes` (splittable `ResizablePanelGroup` of xterm panes, explicit active-pane tracking), `TerminalWorkspace` (glues Navigator + panes together, holds pane + active-pane state).

The existing left DRIVE tree sidebar is **untouched** — it is not a branch file browser; that stays out of scope per the epic notes.

## Convergence fixes (post-review)

An 8-angle self-review swarm plus `/aidd-review` (OWASP sweep, `/aidd-churn` cross-reference) surfaced and fixed 8 issues — full detail recorded to the board page's `## Findings` (pageId `d879od70u64hf7vs04swyair`):

1. **[blocker]** The new "Split" panes all share ONE Socket.IO connection, but the realtime session map was strictly 1:1 keyed by `socket.id` — a deliberate, tested invariant of the already-merged transport, never exercised until this PR's multi-pane UI. Opening two different terminals in two panes caused real cross-talk (both panes' output mixed) and input misrouting (keystrokes landing in the wrong PTY). **Fixed** with a backward-compatible, optional `connectionId` threaded through `validation.ts` → `agent-terminal-handler.ts` → `index.ts` → `XtermTerminal.tsx` (defaults to `socket.id` when absent — every pre-existing caller is unaffected). 4 new regression tests.
2. **[blocker]** The connectionId fix itself introduced a narrower issue: since the session map is one shared, server-wide instance, `onInput`/`onResize`/`onDisconnect` trusted a client-supplied connectionId string with no check it belonged to the calling socket — not exploitable today (128-bit random, never logged, never sent cross-socket) but a real widening of the trust boundary. **Fixed**: those three handlers now only act on a connectionId the calling socket registered itself, via an allowlist. 1 new regression test (a second socket referencing the first's connectionId is a no-op).
3. **[major]** `TerminalWorkspace`'s "open a terminal from the Navigator" targeted `panes[panes.length - 1]` (a positional guess) rather than an explicit active pane — could silently overwrite the wrong pane. **Fixed**: explicit `activePaneId` state with a visible active-pane highlight.
4. **[minor × 4]**: `MachineNode`'s Projects fetch wasn't gated by `expanded` like its sibling terminals fetch; branches/terminals lists could flash an empty state before loading; `window.confirm` used instead of the codebase's `AlertDialog` convention; a pane's connected/error status could flash stale for one render. All fixed.
5. **[nit]**: `useMachineProjects`'s `addProject` return type included a `createdAt` field the route never actually returns. Narrowed.

Root `bun run typecheck`: green (16/16). `apps/realtime` terminal-suite: **149/149** tests pass (144 pre-existing + 5 new). No merge conflicts with `pu/terminal`.

## Manual walkthrough

No live Postgres + Sprites credentials in this environment, so this is a traced walkthrough against the actual route/hook/event contracts (confirmed via a green root `bun run typecheck` and the full realtime test suite), not a live click session:

1. **Open a Terminal page as an admin** → `TerminalView` renders `TerminalWorkspace` directly — no tabs, no separate "Machine Shell". Middle panel shows one empty pane ("No terminal open — select a terminal from the navigator, or add one from any node"). Right panel shows the Navigator with a "Machine" node, expanded by default, showing its own (initially empty) Terminals list and a "Projects" section with an `EmptyState` ("No projects yet" + "Add your first project").
2. **Machine-scope terminal — works with ZERO projects, no dead-end**: click "+" next to Machine's "Terminals" → dialog with name + agentType (claude/codex/pagespace-cli/shell) → submit calls `POST /api/machines/agent-terminals` with `{ terminalId, name, agentType }` (no projectName/branchName, no dependency on any project existing) → `spawnAgentTerminal` resolves machine scope → row created with `scope: 'machine'`. The terminal appears in the Machine node's list immediately; clicking it sets the active pane's scope to `{ name }`, mounting `XtermTerminal` with `connectPayload: { terminalId, name }` → emits `agent-terminal:connect` → realtime resolves machine scope, opens/attaches the Machine's own Sprite at `SANDBOX_ROOT`. A `shell` agentType terminal here reproduces the old "Machine Shell" tab exactly — just as a named machine-scope terminal instead of a separate tab/concept. **This confirms opening a terminal at the Machine node never requires a project or branch to exist.**
3. Add a project ("+" next to "Projects") → `POST /api/machines/projects` → project appears; expanding it lazily fetches its own project-scope terminals (`useAgentTerminals(terminalId, projectName, null)`, gated on `expanded`) and its Branches (`useMachineBranches`, also gated).
4. **Project-scope terminal**: "+" under the project's "Terminals" → POST carries `{ terminalId, projectName, name, agentType }` (no branchName) → spawns at project scope (same Machine Sprite, cwd = the project's clone path). Clicking it opens the active pane with `connectPayload: { terminalId, projectName, name }`.
5. Add a branch ("+" next to "Branches") → `POST /api/machines/branches` → branch-terminal appears (provisions its own Sprite). Expanding it lazily fetches its branch-scope terminals.
6. **Branch-scope terminal**: "+" under the branch's "Terminals" → POST carries `{ terminalId, projectName, branchName, name, agentType }` → spawns at branch scope (the branch's own Sprite, cwd = its checkout). Clicking it opens the active pane with the full scope tuple.
7. **Split panes, now correctly multiplexed**: the "Split" button duplicates the pane layout and makes the new pane active (visible ring highlight). Clicking a *different* terminal in the Navigator retargets whichever pane is currently active — clicking inside a pane makes it active first. Each pane independently connects/tears down its own `XtermTerminal`, tagged with its own `connectionId`; opening the machine's `shell` in pane 1 and a branch's `claude` terminal in pane 2 simultaneously now streams both correctly with no cross-talk (verified by the new realtime regression tests, since this environment has no live Sprites to click through).
8. **Remove flows**: the "X" hover-button on any project/branch/terminal row now opens an `AlertDialog` confirmation (matching the codebase's `DeleteWorkflowDialog.tsx` convention) instead of `window.confirm`; confirming calls the matching DELETE route and revalidates via SWR `mutate()`.
9. **Left DRIVE sidebar**: untouched by this PR — no files in `left-sidebar/` were modified; `git diff --stat` against `pu/terminal` only touches `apps/realtime/src/{index.ts,terminal/*}` and `apps/web/src/{hooks/*,components/layout/middle-content/page-views/terminal/*}`.

React component tests are unreliable in `.pu` worktrees (dual-React) per project convention — no new RTL tests were added for the UI components; this PR relies on the traced walkthrough above, a green root `bun run typecheck`, and a full green `apps/realtime` test suite (which DOES directly exercise the multiplexing/hardening fix's actual logic, not just types) for verification confidence.

Findings + verdict recorded to the board page: pageId `d879od70u64hf7vs04swyair`, `## Findings` section.

https://claude.ai/code/session_01236RZG7nEZWtJ1VWR2zNxr
