### PR TITLE
fix(gdpr): decrypt drive owner PII in members list

### DIFF
--- a/packages/lib/src/services/__tests__/drive-member-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-member-service.test.ts
@@ -71,7 +71,9 @@ import {
   updateMemberRole,
   updateMemberPermissions,
   listDriveMembers,
+  getDriveOwnerAsMember,
 } from '../drive-member-service';
+import { encryptField } from '../../encryption/field-crypto';
 
 type MockFn = ReturnType<typeof vi.fn>;
 type MockDb = {
@@ -278,6 +280,45 @@ describe('drive-member-service', () => {
       expect(result).not.toBeNull();
       expect(result!.userId).toBe('user-1');
       expect(result!.customRole).toBeNull();
+    });
+  });
+
+  describe('getDriveOwnerAsMember', () => {
+    it('should return null when drive not found', async () => {
+      const chain = {
+        innerJoin: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+      };
+      mockDb.select.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await getDriveOwnerAsMember('drive-1');
+      expect(result).toBeNull();
+    });
+
+    it('should decrypt the owner PII before returning', async () => {
+      const encryptedEmail = await encryptField('owner@example.com');
+      const encryptedName = await encryptField('Drive Owner');
+      const row = {
+        id: 'owner-1',
+        email: encryptedEmail,
+        name: encryptedName,
+        username: 'owner1',
+        displayName: 'Owner Display',
+        avatarUrl: null,
+      };
+      const chain = {
+        innerJoin: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([row]) }),
+      };
+      mockDb.select.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await getDriveOwnerAsMember('drive-1');
+      expect(result).not.toBeNull();
+      expect(result!.role).toBe('OWNER');
+      expect(result!.user.email).toBe('owner@example.com');
+      expect(result!.user.name).toBe('Drive Owner');
     });
   });
 

--- a/packages/lib/src/services/__tests__/drive-member-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-member-service.test.ts
@@ -317,8 +317,8 @@ describe('drive-member-service', () => {
       const result = await getDriveOwnerAsMember('drive-1');
       expect(result).not.toBeNull();
       expect(result!.role).toBe('OWNER');
-      expect(result!.user.email).toBe('owner@example.com');
-      expect(result!.user.name).toBe('Drive Owner');
+      expect(result!.user!.email).toBe('owner@example.com');
+      expect(result!.user!.name).toBe('Drive Owner');
     });
   });
 

--- a/packages/lib/src/services/__tests__/drive-member-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-member-service.test.ts
@@ -320,6 +320,27 @@ describe('drive-member-service', () => {
       expect(result!.user!.email).toBe('owner@example.com');
       expect(result!.user!.name).toBe('Drive Owner');
     });
+
+    it('should pass through legacy plaintext PII unchanged', async () => {
+      const row = {
+        id: 'owner-1',
+        email: 'owner@example.com',
+        name: 'Drive Owner',
+        username: 'owner1',
+        displayName: 'Owner Display',
+        avatarUrl: null,
+      };
+      const chain = {
+        innerJoin: vi.fn().mockReturnThis(),
+        leftJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([row]) }),
+      };
+      mockDb.select.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const result = await getDriveOwnerAsMember('drive-1');
+      expect(result!.user!.email).toBe('owner@example.com');
+      expect(result!.user!.name).toBe('Drive Owner');
+    });
   });
 
   describe('getMemberPermissions', () => {

--- a/packages/lib/src/services/drive-member-service.ts
+++ b/packages/lib/src/services/drive-member-service.ts
@@ -307,7 +307,7 @@ export async function getDriveOwnerAsMember(driveId: string): Promise<MemberWith
     invitedAt: null,
     acceptedAt: null,
     lastAccessedAt: null,
-    user: { id: row.id, email: row.email, name: row.name },
+    user: await decryptUserRow({ id: row.id, email: row.email, name: row.name }),
     profile: { username: row.username, displayName: row.displayName, avatarUrl: row.avatarUrl },
     customRole: null,
     permissionCounts: { view: 0, edit: 0, share: 0 },


### PR DESCRIPTION
## Summary
- `getDriveOwnerAsMember()` returned the drive owner's `name`/`email` straight from the DB without decrypting, unlike its sibling functions `listDriveMembers()`/`getDriveMemberDetails()` in the same file (`packages/lib/src/services/drive-member-service.ts`)
- It was added by PR #1794 after the PII encryption cutover (#1728) and was missed by that sweep
- Since the owner row is always prepended first in `GET /api/drives/:driveId/members`, this surfaced as raw `salt:iv:authTag:ciphertext` text in place of the owner's name/email in the members list UI (once a user's row was backfilled to ciphertext)
- Fix pipes the owner's user object through the existing `decryptUserRow()` helper, matching the pattern already used by the two sibling functions
- Added regression coverage in `drive-member-service.test.ts` for `getDriveOwnerAsMember` (previously had zero direct test coverage): null-drive-not-found, ciphertext-decrypt round trip, and legacy-plaintext passthrough

## Test plan
- [x] `bunx vitest run src/services/__tests__/drive-member-service.test.ts` — 23/23 tests pass, including the new decrypt-round-trip cases
- [x] `bun run typecheck` — no new errors introduced
- [ ] Manual check: `GET /api/drives/:driveId/members` for a drive whose owner has an encrypted row returns plaintext `name`/`email`, and the members list UI renders the owner's real name/email instead of ciphertext

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3jcHfeNKbZoGsDMtKvRum