### PR TITLE
docs(terminal): warn by-id agent-terminal resolve/kill has no access check

### DIFF
--- a/packages/lib/src/services/machines/agent-terminals-store.ts
+++ b/packages/lib/src/services/machines/agent-terminals-store.ts
@@ -66,7 +66,12 @@ export function deriveAgentTerminalScope(key: {
 export interface MachineAgentTerminalStore {
   list(scope: AgentTerminalScopeKey): Promise<MachineAgentTerminalRecord[]>;
   findByName(scope: AgentTerminalScopeKey, name: string): Promise<MachineAgentTerminalRecord | null>;
-  /** Level-agnostic lookup by the row's OWN id — no scope path required (mirrors PurePoint's `Attach{agent_id}`). */
+  /**
+   * Level-agnostic lookup by the row's OWN id — no scope path required
+   * (mirrors PurePoint's `Attach{agent_id}`). Performs no access check; a
+   * caller learns the row's `terminalId` only from the returned record, so it
+   * must authorize against that before trusting or acting on the result.
+   */
   findById(id: string): Promise<MachineAgentTerminalRecord | null>;
   /** Throws a unique-violation error (see `isUniqueViolation`) if this (scope, name) already exists. */
   create(input: NewMachineAgentTerminalInput): Promise<MachineAgentTerminalRecord>;

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -365,6 +365,13 @@ export async function resolveAgentTerminal({
  * mirrors PurePoint's `Attach{agent_id}` (`Manifest::find_agent` searches
  * root + every worktree by id; no scope path needed). The row's own
  * `projectName`/`machineBranchId` columns tell us where its Sprite lives.
+ *
+ * PERFORMS NO ACCESS CHECK — unlike the by-name path (whose callers already
+ * hold a `terminalId` from the request and check page access to it BEFORE
+ * calling in), a by-id caller only learns which page a row belongs to AFTER
+ * this resolves. No route wires this today; whoever adds one MUST check the
+ * caller's access to the *resolved* `row.terminalId` (e.g. via
+ * `packages/lib/src/permissions/`) before trusting or acting on the result.
  */
 export async function resolveAgentTerminalById({
   agentTerminalId,
@@ -448,6 +455,11 @@ export async function killAgentTerminal({
 /**
  * Level-agnostic kill, keyed PURELY on the agent terminal's own id — same
  * PurePoint `Attach{agent_id}` parity as `resolveAgentTerminalById`.
+ *
+ * PERFORMS NO ACCESS CHECK — see the identical warning on
+ * `resolveAgentTerminalById`. A future caller MUST authorize against the
+ * resolved row's `terminalId` itself; this function will happily kill any
+ * agent terminal on the machine's Sprite given only its id.
  */
 export async function killAgentTerminalById({
   agentTerminalId,


### PR DESCRIPTION
## Summary

Gate review (PageSpace page `mk6o9cd2h24sfzzddmgb9ot8`) for the Terminal universal-scope reshape (#1909/#1910/#1914) found that `resolveAgentTerminalById`/`killAgentTerminalById` (`packages/lib/src/services/machines/agent-terminals.ts`) and the store's `findById` (`agent-terminals-store.ts`) perform **no access-control check** — unlike every by-name path, whose callers already hold a `terminalId` from the request and check page access to it *before* calling in.

- A by-id caller only learns which page (`terminalId`) a row belongs to *after* the lookup resolves, so it's easy for a future route to forget to authorize against the resolved id.
- **Not exploitable today** — there are zero live callers of these functions anywhere (API routes, realtime bridge, MCP tools all key by scope + name, not by id). This is a documentation-only warning for whoever wires a by-id route next.

No behavior change. Typecheck green; full `packages/lib` suite (294 files / 6526 tests) passes unchanged.

## Test plan
- [x] `bun run --filter '@pagespace/lib' typecheck` — green
- [x] `bun run --filter '@pagespace/lib' test` — 294/294 files, 6526/6526 tests pass (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)