### PR TITLE
feat(ai): tell the model about the Canvas Forms hand-wired path

### DIFF
--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -34,7 +34,7 @@ const PAGE_TYPES = `PAGE TYPES:
 • DOCUMENT: Rich text stored as HTML. Use insert_content to add lines before/after a heading or landmark, or replace_lines for precise line-range edits.
 • CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
-• CANVAS: Raw HTML/CSS rendered in a sandboxed iframe. Author HTML renders into a real <body> — write standard HTML/CSS/JS. For uploaded FILE pages embedded in canvas HTML, use /dashboard/{driveId}/{filePageId}/view (not /api/files) so the same link works in unpublished iframes and can be rewritten for published canvases.
+• CANVAS: Raw HTML/CSS rendered in a sandboxed iframe. Author HTML renders into a real <body> — write standard HTML/CSS/JS. For uploaded FILE pages embedded in canvas HTML, use /dashboard/{driveId}/{filePageId}/view (not /api/files) so the same link works in unpublished iframes and can be rewritten for published canvases. For a signup/waitlist/contact form, call provision_form_target first — a hand-written <form> instead needs a human to finish wiring it to a Sheet in the page's Forms tab, since there's no tool for that step.
 • TASK_LIST: Task manager where each task auto-creates a linked child TASK_LIST page for its description and sub-tasks.
 • AI_CHAT: Custom AI agent with configurable system prompt and tool permissions.
 • CHANNEL: Team discussion thread with real-time messaging.

--- a/apps/web/src/lib/ai/tools/form-tools.ts
+++ b/apps/web/src/lib/ai/tools/form-tools.ts
@@ -34,7 +34,8 @@ export const formTools = {
       'then embed the returned formHtml verbatim into the Canvas page body — do not modify the ' +
       'hidden honeypot field or the fetch() call, those are required for spam protection. Returns ' +
       'a public submit token embedded in formHtml — safe to publish, it authorizes ONLY appending ' +
-      'rows to this one sheet, nothing else.',
+      'rows to this one sheet, nothing else. If a plain <form> already exists on the page instead, ' +
+      'tell the user to open the Forms tab to wire it up — there is no tool for that step.',
     inputSchema: z.object({
       sheetPageId: z.string().describe('The target SHEET page that will receive one new row per submission'),
       fields: formFieldsSchema,


### PR DESCRIPTION
## Summary

Canvas Forms has two ways to get a form wired up:
1. **`provision_form_target` tool** — fully agent-automatable; generates a complete form from scratch and returns ready-to-embed HTML.
2. **Hand-written `<form>` tag** — a human (or an agent writing raw HTML) writes a plain `<form>`, then a **human** must open the page's Forms tab and click "Wire this form" to link it to a Sheet. There's no AI tool for this step, by design (see the recent Canvas Forms redesign in #1894 — fields are derived from markup already written, not authored through an AI-facing API).

**The gap:** nothing told the model path #2 existed, or that it needs a human to finish it. If an agent chose to hand-write a `<form>` (e.g. a user pastes one and asks for help), it had no way to know to mention the Forms tab — it would just silently leave the form unwired with no explanation.

`docs/specs/canvas-forms.md` describes both paths in detail, but a repo-wide grep confirms it's never read by the AI at runtime — it's a human/reviewer-only reference, so it can't be the fix.

## Changes

Two small, additive text edits — no new files, no logic/schema changes:

- **`apps/web/src/lib/ai/core/inline-instructions.ts`** — one sentence appended to the `CANVAS` bullet in `PAGE_TYPES`. This is injected into every session's system prompt whenever the model is told it's working on a Canvas page, independent of which tools happen to be bound (unlike a tool's own description, which is only visible if that specific tool is bound to the session).
- **`apps/web/src/lib/ai/tools/form-tools.ts`** — matching one-clause addition to `provision_form_target`'s description, reinforcing the same point at the moment of tool selection.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing unrelated warnings)
- [x] `bun run test:unit` on affected suites — `inline-instructions.test.ts` (30 tests), `form-tools.test.ts` (11 tests), `ai-tools.test.ts` (11 tests) — all green, none assert on the exact instructional text (no regression risk)
- [ ] Manual: ask an agent on a Canvas page to "add a waitlist signup form" — confirm it still calls `provision_form_target` (no regression to the primary path)
- [ ] Manual: paste a bare `<form><input name="email"></form>` into a Canvas page and ask "can you make this form work?" — confirm the agent now mentions opening the Forms tab to wire it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJ29scnNV4GhfqHVq3utD4