### PR TITLE
fix(ai): make GitHub adapter suppression authorization-aware

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
@@ -173,6 +173,31 @@ describe('resolvePageAgentIntegrationTools', () => {
     expect(result).toHaveProperty('int__slack__send_message');
   });
 
+  it('forwards requestOrigin and agentPageId to canRunCode unchanged', async () => {
+    const mockGrants = [{ id: 'grant-1' }] as unknown as GrantWithConnectionAndProvider[];
+    mockResolveAgentIntegrations.mockResolvedValue(mockGrants);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    await resolvePageAgentIntegrationTools({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      driveId: 'drive-1',
+      currentTools: { git_clone: {} },
+      requestOrigin: 'agent',
+      agentPageId: 'calling-agent-1',
+    });
+
+    expect(mockCanRunCode).toHaveBeenCalledWith({
+      userId: 'user-1',
+      driveId: 'drive-1',
+      requestOrigin: 'agent',
+      agentPageId: 'calling-agent-1',
+    });
+  });
+
   it('given no sandbox git tools in currentTools, keeps GitHub integration tools', async () => {
     const mockGrants = [{ id: 'grant-1' }] as unknown as GrantWithConnectionAndProvider[];
     mockResolveAgentIntegrations.mockResolvedValue(mockGrants);
@@ -248,6 +273,30 @@ describe('resolveGlobalAssistantIntegrationTools', () => {
 
     expect(result).toHaveProperty('int__github__list_repos');
     expect(result).toHaveProperty('int__slack__send_message');
+  });
+
+  it('normalizes a null driveId to undefined and forwards requestOrigin/agentPageId to canRunCode', async () => {
+    mockResolveGlobalIntegrations.mockResolvedValue([{ id: 'grant-1' }] as never);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    await resolveGlobalAssistantIntegrationTools({
+      userId: 'user-1',
+      driveId: null,
+      userDriveRole: null,
+      currentTools: { gh_pr_view: {} },
+      requestOrigin: 'agent',
+      agentPageId: 'calling-agent-1',
+    });
+
+    expect(mockCanRunCode).toHaveBeenCalledWith({
+      userId: 'user-1',
+      driveId: undefined,
+      requestOrigin: 'agent',
+      agentPageId: 'calling-agent-1',
+    });
   });
 });
 

--- a/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
@@ -40,6 +40,9 @@ vi.mock('@pagespace/lib/integrations/repositories/grant-repository', () => ({
 vi.mock('@pagespace/lib/integrations/repositories/config-repository', () => ({
   getConfig: vi.fn(),
 }));
+vi.mock('@pagespace/lib/services/sandbox/can-run-code', () => ({
+  canRunCode: vi.fn(),
+}));
 
 import {
   resolveAgentIntegrations,
@@ -50,16 +53,19 @@ import {
   type GrantWithConnectionAndProvider,
 } from '@pagespace/lib/integrations/converter/ai-sdk';
 import { createToolExecutor } from '@pagespace/lib/integrations/saga/execute-tool';
+import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 import { resolvePageAgentIntegrationTools, resolveGlobalAssistantIntegrationTools } from '../integration-tool-resolver';
 
 const mockResolveAgentIntegrations = vi.mocked(resolveAgentIntegrations);
 const mockResolveGlobalIntegrations = vi.mocked(resolveGlobalAssistantIntegrations);
 const mockConvert = vi.mocked(convertIntegrationToolsToAISDK);
 const mockCreateExecutor = vi.mocked(createToolExecutor);
+const mockCanRunCode = vi.mocked(canRunCode);
 
 describe('resolvePageAgentIntegrationTools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanRunCode.mockResolvedValue({ ok: true });
   });
 
   it('given no grants, should return empty tool set', async () => {
@@ -146,6 +152,27 @@ describe('resolvePageAgentIntegrationTools', () => {
     expect(result).toHaveProperty('int__slack__send_message');
   });
 
+  it('given sandbox git tools present but not authorized for this caller, keeps GitHub integration tools', async () => {
+    mockCanRunCode.mockResolvedValue({ ok: false, reason: 'app_admin_required' });
+    const mockGrants = [{ id: 'grant-1' }] as unknown as GrantWithConnectionAndProvider[];
+    mockResolveAgentIntegrations.mockResolvedValue(mockGrants);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+      'int__slack__send_message': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    const result = await resolvePageAgentIntegrationTools({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      driveId: 'drive-1',
+      currentTools: { git_clone: {} },
+    });
+
+    expect(result).toHaveProperty('int__github__list_repos');
+    expect(result).toHaveProperty('int__slack__send_message');
+  });
+
   it('given no sandbox git tools in currentTools, keeps GitHub integration tools', async () => {
     const mockGrants = [{ id: 'grant-1' }] as unknown as GrantWithConnectionAndProvider[];
     mockResolveAgentIntegrations.mockResolvedValue(mockGrants);
@@ -168,6 +195,7 @@ describe('resolvePageAgentIntegrationTools', () => {
 describe('resolveGlobalAssistantIntegrationTools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanRunCode.mockResolvedValue({ ok: true });
   });
 
   it('given no grants, should return empty tool set', async () => {
@@ -199,6 +227,26 @@ describe('resolveGlobalAssistantIntegrationTools', () => {
     });
 
     expect(result).not.toHaveProperty('int__github__list_repos');
+    expect(result).toHaveProperty('int__slack__send_message');
+  });
+
+  it('given sandbox git tools present but not authorized for this caller, keeps GitHub integration tools', async () => {
+    mockCanRunCode.mockResolvedValue({ ok: false, reason: 'app_admin_required' });
+    mockResolveGlobalIntegrations.mockResolvedValue([{ id: 'grant-1' }] as never);
+    mockCreateExecutor.mockReturnValue(vi.fn());
+    mockConvert.mockReturnValue({
+      'int__github__list_repos': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+      'int__slack__send_message': { description: 'x', inputSchema: {} as never, execute: vi.fn() },
+    });
+
+    const result = await resolveGlobalAssistantIntegrationTools({
+      userId: 'user-1',
+      driveId: null,
+      userDriveRole: null,
+      currentTools: { gh_pr_view: {} },
+    });
+
+    expect(result).toHaveProperty('int__github__list_repos');
     expect(result).toHaveProperty('int__slack__send_message');
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/services/sandbox/can-run-code', () => ({
+  canRunCode: vi.fn(),
+}));
+
+import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 import {
   buildPageAITools,
   filterToolsForReadOnly,
@@ -10,6 +16,8 @@ import {
   hasSandboxGitTools,
   suppressGithubIntegrationTools,
 } from '../tool-filtering';
+
+const mockCanRunCode = vi.mocked(canRunCode);
 
 const baseline = {
   // read tools
@@ -325,20 +333,47 @@ describe('suppressGithubIntegrationTools', () => {
     int__slack__send_message: 'x',
   };
 
-  it('strips int__github__* tools when sandbox git tools are registered', () => {
-    const result = suppressGithubIntegrationTools(integrationTools, { git_clone: 'x' });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanRunCode.mockResolvedValue({ ok: true });
+  });
+
+  it('strips int__github__* tools when sandbox git tools are registered and authorized', async () => {
+    const result = await suppressGithubIntegrationTools(integrationTools, { git_clone: 'x' }, { userId: 'user-1' });
     expect(result).not.toHaveProperty('int__github__list_repos');
     expect(result).not.toHaveProperty('int__github__create_pr_review_comment');
     expect(result).toHaveProperty('int__slack__send_message');
   });
 
-  it('leaves integration tools untouched when no sandbox git tools are registered', () => {
-    const result = suppressGithubIntegrationTools(integrationTools, { read_page: 'x' });
+  it('leaves integration tools untouched when no sandbox git tools are registered', async () => {
+    const result = await suppressGithubIntegrationTools(integrationTools, { read_page: 'x' }, { userId: 'user-1' });
+    expect(result).toEqual(integrationTools);
+    expect(mockCanRunCode).not.toHaveBeenCalled();
+  });
+
+  it('leaves integration tools untouched against an empty current tool set', async () => {
+    const result = await suppressGithubIntegrationTools(integrationTools, {}, { userId: 'user-1' });
     expect(result).toEqual(integrationTools);
   });
 
-  it('leaves integration tools untouched against an empty current tool set', () => {
-    const result = suppressGithubIntegrationTools(integrationTools, {});
+  it('does NOT suppress GitHub tools when sandbox git tools are present but not authorized for this caller', async () => {
+    mockCanRunCode.mockResolvedValue({ ok: false, reason: 'app_admin_required' });
+    const result = await suppressGithubIntegrationTools(integrationTools, { git_clone: 'x' }, { userId: 'user-1' });
     expect(result).toEqual(integrationTools);
+    expect(result).toHaveProperty('int__github__list_repos');
+  });
+
+  it('forwards userId, driveId, requestOrigin, and agentPageId to canRunCode', async () => {
+    await suppressGithubIntegrationTools(
+      integrationTools,
+      { git_clone: 'x' },
+      { userId: 'user-1', driveId: 'drive-1', requestOrigin: 'agent', agentPageId: 'agent-1' }
+    );
+    expect(mockCanRunCode).toHaveBeenCalledWith({
+      userId: 'user-1',
+      driveId: 'drive-1',
+      requestOrigin: 'agent',
+      agentPageId: 'agent-1',
+    });
   });
 });

--- a/apps/web/src/lib/ai/core/integration-tool-resolver.ts
+++ b/apps/web/src/lib/ai/core/integration-tool-resolver.ts
@@ -86,9 +86,16 @@ function createConfiguredExecutor(userId: string, agentId: string | null, driveI
  * @param params.driveId - The drive containing the agent
  * @param params.currentTools - The agent's already-resolved tool set (before
  *   these integration tools are merged in), used to suppress GitHub OAuth
- *   integration tools when the sandbox git/gh CLI toolkit is already present.
+ *   integration tools when the sandbox git/gh CLI toolkit is both present AND
+ *   actually usable by this caller right now (per `canRunCode`).
  *   Callers must pass the pre-tool-exposure-mode set — search mode defers
  *   non-core tools behind execute_tool, hiding their names from a key scan.
+ * @param params.requestOrigin - Whether this request originates from the human
+ *   user or from another agent consulting this one; forwarded to `canRunCode`.
+ *   Defaults to 'user' when omitted.
+ * @param params.agentPageId - The acting agent's page ID (the agent whose
+ *   drive access is checked), required for `canRunCode`'s agent-origin
+ *   authorization check.
  * @returns AI SDK tool objects ready for merging into the tool set
  */
 export async function resolvePageAgentIntegrationTools(params: {
@@ -96,8 +103,10 @@ export async function resolvePageAgentIntegrationTools(params: {
   userId: string;
   driveId: string;
   currentTools: Record<string, unknown>;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
 }): Promise<Record<string, CoreTool>> {
-  const { agentId, userId, driveId, currentTools } = params;
+  const { agentId, userId, driveId, currentTools, requestOrigin, agentPageId } = params;
   const deps = createResolutionDeps();
 
   const grants = await resolveAgentIntegrations(deps, agentId);
@@ -106,9 +115,10 @@ export async function resolvePageAgentIntegrationTools(params: {
 
   const executor = createConfiguredExecutor(userId, agentId, driveId);
 
-  const tools = suppressGithubIntegrationTools(
+  const tools = await suppressGithubIntegrationTools(
     convertIntegrationToolsToAISDK(grants, { userId, agentId, driveId }, executor),
-    currentTools
+    currentTools,
+    { userId, driveId, requestOrigin, agentPageId }
   );
   // Sort keys so tool array order is deterministic across requests (only real config
   // changes — webSearch/readOnly/MCP/exposure-mode — may change the tool array).
@@ -127,10 +137,16 @@ export async function resolvePageAgentIntegrationTools(params: {
  * @param params.userDriveRole - The user's role in the current drive
  * @param params.currentTools - The assistant's already-resolved tool set
  *   (before these integration tools are merged in), used to suppress GitHub
- *   OAuth integration tools when the sandbox git/gh CLI toolkit is already
- *   present. Pass the full pre-core/non-core-split filtered tool set — the
- *   Global Assistant's final tool set never carries raw tool names as
- *   top-level keys (core tools + tool_search/execute_tool only).
+ *   OAuth integration tools when the sandbox git/gh CLI toolkit is both present
+ *   AND actually usable by this caller right now (per `canRunCode`). Pass the
+ *   full pre-core/non-core-split filtered tool set — the Global Assistant's
+ *   final tool set never carries raw tool names as top-level keys (core tools
+ *   + tool_search/execute_tool only).
+ * @param params.requestOrigin - Whether this request originates from the human
+ *   user or from another agent consulting the global assistant; forwarded to
+ *   `canRunCode`. Defaults to 'user' when omitted.
+ * @param params.agentPageId - The acting agent's page ID, required for
+ *   `canRunCode`'s agent-origin authorization check.
  * @returns AI SDK tool objects ready for merging into the tool set
  */
 export async function resolveGlobalAssistantIntegrationTools(params: {
@@ -138,8 +154,10 @@ export async function resolveGlobalAssistantIntegrationTools(params: {
   driveId: string | null;
   userDriveRole: DriveRole | null;
   currentTools: Record<string, unknown>;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
 }): Promise<Record<string, CoreTool>> {
-  const { userId, driveId, userDriveRole, currentTools } = params;
+  const { userId, driveId, userDriveRole, currentTools, requestOrigin, agentPageId } = params;
   const deps = createResolutionDeps();
 
   const grants = await resolveGlobalAssistantIntegrations(
@@ -153,9 +171,10 @@ export async function resolveGlobalAssistantIntegrationTools(params: {
 
   const executor = createConfiguredExecutor(userId, null, driveId);
 
-  const tools = suppressGithubIntegrationTools(
+  const tools = await suppressGithubIntegrationTools(
     convertIntegrationToolsToAISDK(grants, { userId, agentId: null, driveId }, executor),
-    currentTools
+    currentTools,
+    { userId, driveId: driveId ?? undefined, requestOrigin, agentPageId }
   );
   // Sort keys so tool array order is deterministic across requests (only real config
   // changes — webSearch/readOnly/MCP/exposure-mode — may change the tool array).

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -3,6 +3,10 @@
  *
  * Replaces the complex role-based permission system with simple
  * toggles that filter out specific tools based on user settings.
+ *
+ * Exception: suppressGithubIntegrationTools below calls canRunCode (a real,
+ * DB-backed authorization check) — do not "simplify" it back to a pure
+ * presence check, that's the exact regression it exists to prevent.
  */
 
 import { SANDBOX_GIT_TOOL_NAMES } from '../tools/sandbox-git-tools';
@@ -135,17 +139,16 @@ export function hasSandboxGitTools(tools: Record<string, unknown>): boolean {
 
 /**
  * Suppress GitHub OAuth integration tools when the sandbox git/gh CLI toolkit is
- * both registered in the current tool set AND actually usable by this caller
- * right now (per `canRunCode`) — the two overlap in capability (browsing repos,
- * reviewing PRs, filing issues), and offering both surfaces for the same GitHub
- * account is redundant and confuses tool selection. Other providers' integration
- * tools (Slack, etc.) are untouched.
+ * both registered in the current tool set AND authorized for this caller right
+ * now (per `canRunCode`) — the two overlap in capability, and offering both for
+ * the same GitHub account is redundant. Other providers (Slack, etc.) untouched.
  *
- * Presence alone is not enough: the sandbox toolkit is registered for every user
- * whenever the global `CODE_EXECUTION_ENABLED` kill-switch is on, regardless of
- * per-user authorization (e.g. the production admin-only gate). Suppressing the
- * GitHub OAuth tools for a caller who cannot actually invoke the sandbox tools
- * would leave them with no working GitHub surface at all.
+ * Presence alone is not enough: `buildPageSpaceTools` registers the sandbox
+ * toolkit for every user whenever the global kill-switch is on, regardless of
+ * per-user authorization — suppressing GitHub for a caller who can't actually
+ * invoke the sandbox tools would leave them with no GitHub surface at all. This
+ * is a listing/UX decision, not a security boundary: it never grants sandbox
+ * access, it only decides which already-permitted-or-not surface to show.
  */
 export async function suppressGithubIntegrationTools<T>(
   integrationTools: Record<string, T>,

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -11,7 +11,7 @@
 
 import { SANDBOX_GIT_TOOL_NAMES } from '../tools/sandbox-git-tools';
 import { parseIntegrationToolName } from '@pagespace/lib/integrations/converter/ai-sdk';
-import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
+import { canRunCode, type CanRunCodeInput } from '@pagespace/lib/services/sandbox/can-run-code';
 
 // Tools that modify content (excluded in read-only mode; also used by elision to protect side-effectful results)
 export const WRITE_TOOLS = new Set([
@@ -153,15 +153,10 @@ export function hasSandboxGitTools(tools: Record<string, unknown>): boolean {
 export async function suppressGithubIntegrationTools<T>(
   integrationTools: Record<string, T>,
   currentTools: Record<string, unknown>,
-  auth: { userId: string; driveId?: string; requestOrigin?: 'user' | 'agent'; agentPageId?: string }
+  auth: Omit<CanRunCodeInput, 'deps'>
 ): Promise<Record<string, T>> {
   if (!hasSandboxGitTools(currentTools)) return integrationTools;
-  const authorized = await canRunCode({
-    userId: auth.userId,
-    driveId: auth.driveId,
-    requestOrigin: auth.requestOrigin,
-    agentPageId: auth.agentPageId,
-  });
+  const authorized = await canRunCode(auth);
   if (!authorized.ok) return integrationTools;
   return Object.fromEntries(
     Object.entries(integrationTools).filter(([name]) => parseIntegrationToolName(name)?.providerSlug !== 'github')

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -7,6 +7,7 @@
 
 import { SANDBOX_GIT_TOOL_NAMES } from '../tools/sandbox-git-tools';
 import { parseIntegrationToolName } from '@pagespace/lib/integrations/converter/ai-sdk';
+import { canRunCode } from '@pagespace/lib/services/sandbox/can-run-code';
 
 // Tools that modify content (excluded in read-only mode; also used by elision to protect side-effectful results)
 export const WRITE_TOOLS = new Set([
@@ -134,16 +135,31 @@ export function hasSandboxGitTools(tools: Record<string, unknown>): boolean {
 
 /**
  * Suppress GitHub OAuth integration tools when the sandbox git/gh CLI toolkit is
- * already registered in the current tool set — the two overlap in capability
- * (browsing repos, reviewing PRs, filing issues), and offering both surfaces for
- * the same GitHub account is redundant and confuses tool selection. Other
- * providers' integration tools (Slack, etc.) are untouched.
+ * both registered in the current tool set AND actually usable by this caller
+ * right now (per `canRunCode`) — the two overlap in capability (browsing repos,
+ * reviewing PRs, filing issues), and offering both surfaces for the same GitHub
+ * account is redundant and confuses tool selection. Other providers' integration
+ * tools (Slack, etc.) are untouched.
+ *
+ * Presence alone is not enough: the sandbox toolkit is registered for every user
+ * whenever the global `CODE_EXECUTION_ENABLED` kill-switch is on, regardless of
+ * per-user authorization (e.g. the production admin-only gate). Suppressing the
+ * GitHub OAuth tools for a caller who cannot actually invoke the sandbox tools
+ * would leave them with no working GitHub surface at all.
  */
-export function suppressGithubIntegrationTools<T>(
+export async function suppressGithubIntegrationTools<T>(
   integrationTools: Record<string, T>,
-  currentTools: Record<string, unknown>
-): Record<string, T> {
+  currentTools: Record<string, unknown>,
+  auth: { userId: string; driveId?: string; requestOrigin?: 'user' | 'agent'; agentPageId?: string }
+): Promise<Record<string, T>> {
   if (!hasSandboxGitTools(currentTools)) return integrationTools;
+  const authorized = await canRunCode({
+    userId: auth.userId,
+    driveId: auth.driveId,
+    requestOrigin: auth.requestOrigin,
+    agentPageId: auth.agentPageId,
+  });
+  if (!authorized.ok) return integrationTools;
   return Object.fromEntries(
     Object.entries(integrationTools).filter(([name]) => parseIntegrationToolName(name)?.providerSlug !== 'github')
   );

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -1072,6 +1072,62 @@ describe('agent-communication-tools', () => {
         );
       });
 
+      it('passes the caller chatSource agentPageId (not the consulted target agentId) for the sandbox-authorization check', async () => {
+        vi.mocked(resolvePageAgentIntegrationTools).mockResolvedValue({});
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: {
+            userId: 'user-123',
+            chatSource: { type: 'page' as const, agentPageId: 'calling-agent' },
+          } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'List my repos' },
+          context
+        );
+
+        // agentId ('agent-1') is the CONSULTED target, not the acting agent that
+        // canRunCode will actually check at real invocation time — that's always
+        // resolved from chatSource.agentPageId (see resolveSandboxActorContext),
+        // which nested calls never override. Passing the target here instead would
+        // let the suppression decision diverge from the real authorization outcome.
+        expect(resolvePageAgentIntegrationTools).toHaveBeenCalledWith(
+          expect.objectContaining({
+            requestOrigin: 'agent',
+            agentPageId: 'calling-agent',
+          })
+        );
+      });
+
+      it('falls back to locationContext.currentPage.id for agentPageId when chatSource is absent', async () => {
+        vi.mocked(resolvePageAgentIntegrationTools).mockResolvedValue({});
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: {
+            userId: 'user-123',
+            locationContext: {
+              currentPage: { id: 'current-page-agent', title: 'X', type: 'AI_CHAT', path: '/x' },
+            },
+          } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'List my repos' },
+          context
+        );
+
+        expect(resolvePageAgentIntegrationTools).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentPageId: 'current-page-agent',
+          })
+        );
+      });
+
       it('falls back to built-in tools only when integration resolver throws', async () => {
         vi.mocked(resolvePageAgentIntegrationTools).mockRejectedValue(
           new Error('DB connection failed')

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -645,6 +645,8 @@ export const agentCommunicationTools = {
             userId,
             driveId: targetAgent.driveId,
             currentTools: agentTools,
+            requestOrigin: 'agent',
+            agentPageId: agentId,
           });
         } catch (error) {
           loggers.ai.error('ask_agent: failed to resolve integration tools, falling back to built-in tools only', error as Error);

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -646,14 +646,14 @@ export const agentCommunicationTools = {
             driveId: targetAgent.driveId,
             currentTools: agentTools,
             requestOrigin: 'agent',
-            // NOT `agentId` (the target being consulted): resolveSandboxActorContext
-            // resolves the real code-exec agentPageId from chatSource.agentPageId ??
-            // parentAgentId — nestedContext below inherits chatSource unchanged and
-            // sets parentAgentId to this same value, so this must match or the
-            // suppression decision here would authorize against a different agent
-            // than the one canRunCode actually checks when the target agent later
-            // tries to invoke a sandbox tool.
-            agentPageId: executionContext?.chatSource?.agentPageId ?? executionContext?.locationContext?.currentPage?.id,
+            // NOT `agentId` (the target being consulted): nestedContext below sets
+            // parentAgentId to callingPage?.id and inherits chatSource unchanged, and
+            // resolveSandboxActorContext resolves the real code-exec agentPageId from
+            // chatSource.agentPageId ?? parentAgentId — i.e. the CALLER's identity,
+            // never the target's, at any nesting depth. Must match or this suppression
+            // decision would authorize against a different agent than the one
+            // canRunCode actually checks when the target later invokes a sandbox tool.
+            agentPageId: executionContext?.chatSource?.agentPageId ?? callingPage?.id,
           });
         } catch (error) {
           loggers.ai.error('ask_agent: failed to resolve integration tools, falling back to built-in tools only', error as Error);
@@ -684,7 +684,7 @@ export const agentCommunicationTools = {
           currentAgentId: agentId,
           locationContext: executionContext?.locationContext, // Explicitly preserve location context
           // Chain tracking for audit trail
-          parentAgentId: executionContext?.locationContext?.currentPage?.id,
+          parentAgentId: callingPage?.id,
           parentConversationId: executionContext?.conversationId,
           agentChain: [
             ...(executionContext?.agentChain || []),

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -646,7 +646,14 @@ export const agentCommunicationTools = {
             driveId: targetAgent.driveId,
             currentTools: agentTools,
             requestOrigin: 'agent',
-            agentPageId: agentId,
+            // NOT `agentId` (the target being consulted): resolveSandboxActorContext
+            // resolves the real code-exec agentPageId from chatSource.agentPageId ??
+            // parentAgentId — nestedContext below inherits chatSource unchanged and
+            // sets parentAgentId to this same value, so this must match or the
+            // suppression decision here would authorize against a different agent
+            // than the one canRunCode actually checks when the target agent later
+            // tries to invoke a sandbox tool.
+            agentPageId: executionContext?.chatSource?.agentPageId ?? executionContext?.locationContext?.currentPage?.id,
           });
         } catch (error) {
           loggers.ai.error('ask_agent: failed to resolve integration tools, falling back to built-in tools only', error as Error);


### PR DESCRIPTION
## Summary

Non-admin users had no working GitHub surface in production at all — a side effect of two independently-correct pieces of code colliding:

- `buildPageSpaceTools` (`apps/web/src/lib/ai/core/ai-tools.ts`) registers the sandbox git/gh CLI toolkit for **every** user whenever the global `CODE_EXECUTION_ENABLED` env kill-switch is on, gated only by the env flag, with no per-user check.
- `suppressGithubIntegrationTools` (`apps/web/src/lib/ai/core/tool-filtering.ts`, added in #1879 to de-dupe the two GitHub surfaces) hid the always-working GitHub OAuth integration tools whenever the sandbox git/gh tool *names* were merely present in the resolved tool set — it never checked whether those tools would actually be authorized for this caller.

The real per-user authorization for sandbox code execution lives entirely in `canRunCode` (`packages/lib/src/services/sandbox/can-run-code.ts`), which in production requires app-admin (`app_admin_required`, from #1664's deliberate Fly Sprites rollout guard). **That gate is untouched by this PR.**

Net effect for a non-admin in production: sandbox tools are "present" (triggering suppression) but denied at execute-time by `canRunCode` — leaving no GitHub surface at all.

## Fix

- `suppressGithubIntegrationTools` is now `async` and calls `canRunCode({ userId, driveId, requestOrigin, agentPageId })`. It only suppresses the GitHub OAuth tools when the sandbox toolkit is both present **and** actually authorized for this caller right now. This is a listing/UX decision, not a new security boundary — it never grants sandbox access, only decides which already-permitted-or-not surface to show.
- `resolvePageAgentIntegrationTools` / `resolveGlobalAssistantIntegrationTools` gained optional `requestOrigin`/`agentPageId` params, threaded into the now-awaited suppression call.
- The `ask_agent` tool's nested consult call (the one agent-to-agent path) now passes `requestOrigin: 'agent'` and `agentPageId` derived from `chatSource.agentPageId ?? locationContext.currentPage.id` — **not** the consulted target agent's own ID. This matters: `resolveSandboxActorContext` (the code path that authorizes *real* sandbox tool execution) always resolves `agentPageId` from the calling agent's `chatSource`/`parentAgentId`, never the target's, and nested `ask_agent` calls never override `chatSource` at any depth. An earlier version of this fix passed the target agent's ID here, which would have let the suppression decision diverge from the real execute-time authorization outcome — reintroducing this exact bug via the one path this PR touches. Caught and fixed via self-review before merge; see the second commit for the full trace.
- The other four call sites (chat route, consult route, global assistant route, workflow executor) are unchanged — `'user'` is already the correct default for them (verified `page-agents/consult/route.ts` is a direct user/MCP-token entry point, structurally equivalent to the chat route, not an agent-to-agent path — it does not need `requestOrigin: 'agent'`).

## Test plan

- [x] `bun run --filter web typecheck` passes
- [x] `apps/web` test suite passes against a real Postgres test DB (790/791 files, 11641/11642 tests) — the one pre-existing failure (`grouping.test.ts` midnight-boundary test) is untouched by this diff and unrelated (message-grouping display logic)
- [x] New tests added: `tool-filtering.test.ts` and `integration-tool-resolver.test.ts` both cover the "sandbox tools present but not authorized → GitHub NOT suppressed" regression case for both resolvers, plus explicit assertions on the exact `canRunCode` call args (userId/driveId/requestOrigin/agentPageId)
- [x] `agent-communication-tools.test.ts` covers the `agentPageId` identity fix directly: asserts `resolvePageAgentIntegrationTools` is called with the *calling* agent's `chatSource.agentPageId` (or `locationContext.currentPage.id` fallback), never the consulted target's ID
- [x] `packages/lib/src/services/sandbox/can-run-code.ts` is completely untouched (`git diff` confirms zero changes)
- [x] `git diff --stat` scoped to: `tool-filtering.ts`, `integration-tool-resolver.ts`, `agent-communication-tools.ts`, and their test files — no unrelated refactors

## Known trade-offs (accepted, not blocking)

- **Fail-open on transient errors**: if `canRunCode`'s DB calls error transiently, it returns `{ok: false, reason: 'error'}`, and suppression treats that the same as "not authorized" — i.e. it fails open by *not* suppressing GitHub tools for that one turn. This is the safe direction (matches this PR's whole goal: never leave a user with zero GitHub surface) but means tool-set membership can very rarely vary turn-to-turn under DB flakiness, not just on real config changes.
- **Added DB round trips**: any request whose tool set includes the sandbox git/gh toolkit now pays `canRunCode`'s DB queries (permissions/role lookups) during tool-list resolution, in addition to the pre-existing execute-time check. This was a deliberate, explicit instruction for this fix (reuse `canRunCode` directly, avoid the heavier `resolveSandboxActorContext`) — an optimization to avoid double-querying would touch `can-run-code.ts` or call-site plumbing beyond this PR's scope.

https://claude.ai/code/session_01J3NZDRTyLssfCupNLHRgEr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool availability checks so GitHub-related tools are only hidden when sandbox code access is actually allowed.
  * Kept GitHub integration tools visible when authorization is denied, avoiding unexpected tool loss.
  * Fixed request context handling so agent/page identity is passed correctly during tool resolution, including nested tool calls.
  * Standardized how page and assistant requests resolve tool access across different chat sources and page contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->