### PR TITLE
fix(gdpr): decrypt PII in activities, commands, and passkey registration

### DIFF
--- a/apps/web/src/app/api/activities/__tests__/route.test.ts
+++ b/apps/web/src/app/api/activities/__tests__/route.test.ts
@@ -16,15 +16,14 @@ vi.mock('@pagespace/db/db', () => ({
   db: {
     select: vi.fn().mockReturnValue({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockReturnValue({
-            limit: vi.fn().mockReturnValue({
-              offset: vi.fn().mockResolvedValue([]),
-            }),
-          }),
-        }),
+        where: vi.fn().mockResolvedValue([{ total: 0 }]),
       }),
     }),
+    query: {
+      activityLogs: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    },
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
@@ -58,8 +57,10 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 }));
 
 import { GET } from '../route';
-import { authenticateRequestWithOptions } from '@/lib/auth';
+import { authenticateRequestWithOptions, getAllowedDriveIds } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { db } from '@pagespace/db/db';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
 
 const mockUserId = 'user_123';
 
@@ -87,5 +88,57 @@ describe('GET /api/activities audit', () => {
       expect.any(Request),
       expect.objectContaining({ eventType: 'data.read', userId: mockUserId, resourceType: 'activities', resourceId: 'self' })
     );
+  });
+});
+
+describe('GET /api/activities PII decryption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
+  });
+
+  it('decrypts ciphertext user name/email before responding', async () => {
+    const encryptedName = await encryptField('Real Name');
+    const encryptedEmail = await encryptField('real@example.com');
+    vi.mocked(db.query.activityLogs.findMany).mockResolvedValue([
+      {
+        id: 'act-1',
+        user: { id: 'user-1', name: encryptedName, email: encryptedEmail, image: null },
+      },
+    ] as never);
+
+    const res = await GET(new Request('http://localhost/api/activities?context=user'));
+    const body = await res.json();
+
+    expect(body.activities[0].user.name).toBe('Real Name');
+    expect(body.activities[0].user.email).toBe('real@example.com');
+  });
+
+  it('passes through legacy plaintext user name/email unchanged', async () => {
+    vi.mocked(db.query.activityLogs.findMany).mockResolvedValue([
+      {
+        id: 'act-1',
+        user: { id: 'user-1', name: 'Legacy Name', email: 'legacy@example.com', image: null },
+      },
+    ] as never);
+
+    const res = await GET(new Request('http://localhost/api/activities?context=user'));
+    const body = await res.json();
+
+    expect(body.activities[0].user.name).toBe('Legacy Name');
+    expect(body.activities[0].user.email).toBe('legacy@example.com');
+  });
+
+  it('does not crash when the activity has no joined user (deleted user)', async () => {
+    vi.mocked(db.query.activityLogs.findMany).mockResolvedValue([
+      { id: 'act-1', user: null, actorDisplayName: 'Deleted User', actorEmail: 'deleted@example.com' },
+    ] as never);
+
+    const res = await GET(new Request('http://localhost/api/activities?context=user'));
+    const body = await res.json();
+
+    expect(body.activities[0].user).toBeNull();
+    expect(body.activities[0].actorDisplayName).toBe('Deleted User');
   });
 });

--- a/apps/web/src/app/api/activities/route.ts
+++ b/apps/web/src/app/api/activities/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod/v4';
 import { db } from '@pagespace/db/db'
 import { eq, and, desc, count, gte, lt, inArray } from '@pagespace/db/operators'
 import { activityLogs } from '@pagespace/db/schema/monitoring';
+import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPPageScope, canPrincipalViewPage, isPrincipalDriveMember, getAllowedDriveIds } from '@/lib/auth';
@@ -232,8 +233,14 @@ export async function GET(request: Request) {
       resultCount: activities.length,
     } });
 
+    const decryptedActivities = await Promise.all(
+      activities.map(async (activity) =>
+        activity.user ? { ...activity, user: await decryptUserRow(activity.user) } : activity
+      )
+    );
+
     return NextResponse.json({
-      activities,
+      activities: decryptedActivities,
       pagination: {
         total,
         limit: params.limit,

--- a/apps/web/src/app/api/commands/__tests__/route.test.ts
+++ b/apps/web/src/app/api/commands/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
@@ -212,6 +213,22 @@ describe('GET /api/commands', () => {
       entryPageAvailable: false,
       authorName: 'Alice',
     });
+  });
+
+  it('decrypts ciphertext author names before responding', async () => {
+    const encryptedName = await encryptField('Real Author');
+    mockedDb.select.mockReset();
+    mockedDb.select
+      .mockReturnValueOnce(selectChain([]) as never)
+      .mockReturnValueOnce(selectChain([]) as never);
+    mockedDb.query.commands.findMany.mockResolvedValue([storedCommand] as never);
+    mockedDb.query.users.findMany.mockResolvedValue([
+      { id: USER_ID, name: encryptedName },
+    ] as never);
+
+    const response = await GET(getRequest());
+    const json = await response.json();
+    expect(json.commands[0].authorName).toBe('Real Author');
   });
 
   it('marks the entry page unavailable when it no longer exists', async () => {

--- a/apps/web/src/app/api/commands/route.ts
+++ b/apps/web/src/app/api/commands/route.ts
@@ -5,6 +5,7 @@ import { commands } from '@pagespace/db/schema/commands';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveMembers } from '@pagespace/db/schema/members';
 import { users } from '@pagespace/db/schema/auth';
+import { decryptUserRows } from '@pagespace/lib/auth/user-repository';
 import { authenticateRequestWithOptions, isAuthError, filterDrivesByMCPScope, checkMCPDriveScope, canPrincipalViewPage } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -108,7 +109,8 @@ export async function GET(request: Request) {
           columns: { id: true, name: true },
         })
       : [];
-    const authorNameById = new Map(authors.map((author) => [author.id, author.name]));
+    const decryptedAuthors = await decryptUserRows(authors);
+    const authorNameById = new Map(decryptedAuthors.map((author) => [author.id, author.name]));
 
     return NextResponse.json({
       commands: sorted.map((command) => {

--- a/packages/lib/src/auth/__tests__/passkey-service.test.ts
+++ b/packages/lib/src/auth/__tests__/passkey-service.test.ts
@@ -84,6 +84,7 @@ vi.mock('@paralleldrive/cuid2', () => ({
 }));
 
 import { db } from '@pagespace/db/db';
+import { encryptField } from '../../encryption/field-crypto';
 import {
   PASSKEY_CONFIG,
   generateRegistrationOptions,
@@ -192,6 +193,47 @@ describe('passkey-service', () => {
       const result = await generateRegistrationOptions({ userId: 'user-1' });
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.data.options.challenge).toBe('challenge123');
+    });
+
+    it('decrypts ciphertext email/name before passing them to WebAuthn options', async () => {
+      const encryptedEmail = await encryptField('real@example.com');
+      const encryptedName = await encryptField('Real Name');
+      mockDb.query.users.findFirst.mockResolvedValueOnce({
+        id: 'user-1', email: encryptedEmail, name: encryptedName, suspendedAt: null,
+      });
+      mockDb.query.passkeys.findMany.mockResolvedValueOnce([]);
+      mockGenRegOptions.mockResolvedValueOnce({ challenge: 'challenge123', rp: {} });
+      mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDb.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+      const result = await generateRegistrationOptions({ userId: 'user-1' });
+
+      expect(result.ok).toBe(true);
+      const simpleWebAuthnArgs = mockGenRegOptions.mock.calls[0]?.[0] as {
+        userName?: string;
+        userDisplayName?: string;
+      };
+      expect(simpleWebAuthnArgs.userName).toBe('real@example.com');
+      expect(simpleWebAuthnArgs.userDisplayName).toBe('Real Name');
+    });
+
+    it('passes through legacy plaintext email/name unchanged', async () => {
+      mockDb.query.users.findFirst.mockResolvedValueOnce({
+        id: 'user-1', email: 'legacy@example.com', name: 'Legacy Name', suspendedAt: null,
+      });
+      mockDb.query.passkeys.findMany.mockResolvedValueOnce([]);
+      mockGenRegOptions.mockResolvedValueOnce({ challenge: 'challenge123', rp: {} });
+      mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDb.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+      await generateRegistrationOptions({ userId: 'user-1' });
+
+      const simpleWebAuthnArgs = mockGenRegOptions.mock.calls[0]?.[0] as {
+        userName?: string;
+        userDisplayName?: string;
+      };
+      expect(simpleWebAuthnArgs.userName).toBe('legacy@example.com');
+      expect(simpleWebAuthnArgs.userDisplayName).toBe('Legacy Name');
     });
 
     // WebAuthn L3 hint — tells the browser to prefer the OS platform authenticator

--- a/packages/lib/src/auth/passkey-service.ts
+++ b/packages/lib/src/auth/passkey-service.ts
@@ -22,7 +22,7 @@ import {
   type AuthenticatorTransportFuture,
 } from '@simplewebauthn/server';
 import { hashToken, generateToken } from './token-utils';
-import { userEmailMatch, prepareUserWrite } from './user-repository';
+import { decryptUserRow, userEmailMatch, prepareUserWrite } from './user-repository';
 import { PASSKEY_CHALLENGE_EXPIRY_MINUTES } from './passkey-client-constants';
 
 // Configuration
@@ -191,6 +191,8 @@ export async function generateRegistrationOptions(
     return { ok: false, error: { code: 'USER_SUSPENDED', userId } };
   }
 
+  const decryptedUser = await decryptUserRow(user);
+
   // Check passkey limit
   const existingPasskeys = await db.query.passkeys.findMany({
     where: eq(passkeys.userId, userId),
@@ -212,8 +214,8 @@ export async function generateRegistrationOptions(
   const rawOptions = await simpleGenerateRegistrationOptions({
     rpName: PASSKEY_CONFIG.rpName,
     rpID: PASSKEY_CONFIG.rpId,
-    userName: user.email,
-    userDisplayName: user.name,
+    userName: decryptedUser.email,
+    userDisplayName: decryptedUser.name,
     attestationType: 'none',
     excludeCredentials,
     authenticatorSelection: {


### PR DESCRIPTION
## Summary
Follow-on to #1916 (merged), which fixed one missed spot (`getDriveOwnerAsMember`) in the GDPR PII-at-rest encryption cutover (#1728). User reported ciphertext still showing up in Activity pages/sidebar; a parallel sweep confirmed the root cause plus two more unrelated instances of the identical missed-decrypt pattern.

- **`apps/web/src/app/api/activities/route.ts`** — `GET /api/activities` joined `users` for the activity actor's name/email but never decrypted before returning JSON. This single route backs *both* broken surfaces: the Activity Log pages (`ActivityDashboard.tsx`) and the right-sidebar Activity tab (`SidebarActivityTab.tsx`). Fixed by decrypting the nested `user` on each activity, mirroring the pattern already used correctly in the sibling `/api/activities/actors` and `/api/activities/export` routes.
- **`apps/web/src/app/api/commands/route.ts`** — `authorName` in the commands list was built from an un-decrypted `users.findMany` query. Fixed by decrypting `authors` before building the id→name map.
- **`packages/lib/src/auth/passkey-service.ts`** — passkey registration options passed the raw DB `email`/`name` straight into `userName`/`userDisplayName`, so the OS/browser passkey-creation prompt showed ciphertext. Fixed by decrypting the user row before building the WebAuthn options.

## Test plan
- [x] Extended `apps/web/src/app/api/activities/__tests__/route.test.ts` — ciphertext-decrypt, legacy-plaintext-passthrough, and null-user (deleted user) cases
- [x] Extended `apps/web/src/app/api/commands/__tests__/route.test.ts` — ciphertext author-name decrypt case
- [x] Extended `packages/lib/src/auth/__tests__/passkey-service.test.ts` — ciphertext-decrypt and legacy-plaintext-passthrough cases for registration options
- [x] `bunx vitest run` on all three touched test files — all pass
- [x] `bun run typecheck` — clean
- [ ] Manual check: load Activity Log page, right-sidebar Activity tab, commands/settings list, and trigger passkey registration for a user with encrypted PII — confirm real names/emails render instead of ciphertext

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3jcHfeNKbZoGsDMtKvRum