### PR TITLE
feat(terminal): relocate Navigator into main right-sidebar tab (missing from #1919)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/Navigator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 import {
   ChevronRight,
@@ -45,25 +45,26 @@ import { useMachineProjects } from '@/hooks/useMachineProjects';
 import { useMachineBranches } from '@/hooks/useMachineBranches';
 import { useAgentTerminals, type AgentTerminal } from '@/hooks/useAgentTerminals';
 import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { useTerminalWorkspaceStore, type OpenTerminalScope } from '@/stores/terminal-workspace/useTerminalWorkspaceStore';
 import EmptyState from './EmptyState';
 
 const AGENT_TYPES = Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[];
 
-/** Identifies which terminal to open in the middle panel — neither `projectName` nor `branchName` set is machine scope, `projectName` alone is project scope, both is branch scope. */
-export interface OpenTerminalScope {
-  projectName?: string;
-  branchName?: string;
-  name: string;
-}
+export type { OpenTerminalScope };
 
 interface NavigatorProps {
   terminalId: string;
-  onOpenTerminal(scope: OpenTerminalScope): void;
 }
 
-export default function Navigator({ terminalId, onOpenTerminal }: NavigatorProps) {
+export default function Navigator({ terminalId }: NavigatorProps) {
+  const openTerminal = useTerminalWorkspaceStore((state) => state.openTerminal);
+  const onOpenTerminal = useCallback(
+    (scope: OpenTerminalScope) => openTerminal(terminalId, scope),
+    [openTerminal, terminalId],
+  );
+
   return (
-    <div className="flex h-full flex-col border-l">
+    <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b px-3 py-2">
         <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Navigator</span>
       </div>

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalPanes.tsx
@@ -6,24 +6,16 @@ import type { Socket } from 'socket.io-client';
 import { SquareSplitHorizontal, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useTerminalWorkspaceStore, selectWorkspace, type OpenTerminalScope, type TerminalPaneState } from '@/stores/terminal-workspace/useTerminalWorkspaceStore';
 import EmptyState from './EmptyState';
-import type { OpenTerminalScope } from './Navigator';
 
 const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
 
-export interface TerminalPaneState {
-  id: string;
-  scope: OpenTerminalScope | null;
-}
+export type { TerminalPaneState };
 
 interface TerminalPanesProps {
   terminalId: string;
   socket: Socket | null | undefined;
-  panes: TerminalPaneState[];
-  activePaneId: string;
-  onSelectPane(id: string): void;
-  onSplit(): void;
-  onClosePane(id: string): void;
 }
 
 function scopeLabel(scope: OpenTerminalScope): string {
@@ -34,11 +26,27 @@ function paneSessionId(terminalId: string, scope: OpenTerminalScope): string {
   return `agent-terminal:${terminalId}:${scope.projectName ?? ''}:${scope.branchName ?? ''}:${scope.name}`;
 }
 
-export default function TerminalPanes({ terminalId, socket, panes, activePaneId, onSelectPane, onSplit, onClosePane }: TerminalPanesProps) {
+export default function TerminalPanes({ terminalId, socket }: TerminalPanesProps) {
+  const workspace = useTerminalWorkspaceStore(selectWorkspace(terminalId));
+  const split = useTerminalWorkspaceStore((state) => state.split);
+  const closePane = useTerminalWorkspaceStore((state) => state.closePane);
+  const selectPane = useTerminalWorkspaceStore((state) => state.selectPane);
+
+  // Briefly undefined between this component's first render and the
+  // mounting TerminalWorkspace's ensureWorkspace effect committing.
+  if (!workspace) return null;
+
+  const { panes, activePaneId } = workspace;
+
   return (
     <div className="flex h-full flex-col bg-black">
       <div className="flex items-center justify-end gap-1 border-b border-white/10 px-2 py-1">
-        <Button variant="ghost" size="sm" onClick={onSplit} className="h-6 gap-1 px-2 text-xs text-white/70 hover:text-white">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => split(terminalId)}
+          className="h-6 gap-1 px-2 text-xs text-white/70 hover:text-white"
+        >
           <SquareSplitHorizontal className="size-3.5" />
           Split
         </Button>
@@ -54,8 +62,8 @@ export default function TerminalPanes({ terminalId, socket, panes, activePaneId,
                 pane={pane}
                 isActive={pane.id === activePaneId}
                 canClose={panes.length > 1}
-                onSelect={() => onSelectPane(pane.id)}
-                onClose={() => onClosePane(pane.id)}
+                onSelect={() => selectPane(terminalId, pane.id)}
+                onClose={() => closePane(terminalId, pane.id)}
               />
             </ResizablePanel>
           </Fragment>

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/TerminalWorkspace.tsx
@@ -1,69 +1,27 @@
 "use client";
 
-import { useCallback, useState } from 'react';
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useEffect } from 'react';
 import { useSocket } from '@/hooks/useSocket';
-import Navigator, { type OpenTerminalScope } from './Navigator';
-import TerminalPanes, { type TerminalPaneState } from './TerminalPanes';
+import { useTerminalWorkspaceStore } from '@/stores/terminal-workspace/useTerminalWorkspaceStore';
+import TerminalPanes from './TerminalPanes';
 
 interface TerminalWorkspaceProps {
   /** The Terminal page's own id — this page IS the Machine (tasks/terminal.md). */
   terminalId: string;
 }
 
-function newPane(scope: OpenTerminalScope | null = null): TerminalPaneState {
-  return { id: crypto.randomUUID(), scope };
-}
-
 export default function TerminalWorkspace({ terminalId }: TerminalWorkspaceProps) {
   const socket = useSocket();
-  const [panes, setPanes] = useState<TerminalPaneState[]>(() => [newPane()]);
-  const [activePaneId, setActivePaneId] = useState<string>(() => panes[0].id);
+  const ensureWorkspace = useTerminalWorkspaceStore((state) => state.ensureWorkspace);
+  const disposeWorkspace = useTerminalWorkspaceStore((state) => state.disposeWorkspace);
 
-  // Opening a terminal from the Navigator always targets the pane the user
-  // last clicked/split into — an explicit "active pane" rather than guessing
-  // from array position, which silently overwrote the wrong pane whenever a
-  // second pane existed.
-  const handleOpenTerminal = useCallback(
-    (scope: OpenTerminalScope) => {
-      setPanes(panes.map((p) => (p.id === activePaneId ? { ...p, scope } : p)));
-    },
-    [panes, activePaneId],
-  );
+  // The Navigator (right sidebar) and TerminalPanes (here) share this
+  // workspace by composition through the store — no common parent to hold
+  // local state now that they live in different parts of the layout.
+  useEffect(() => {
+    ensureWorkspace(terminalId);
+    return () => disposeWorkspace(terminalId);
+  }, [terminalId, ensureWorkspace, disposeWorkspace]);
 
-  const handleSplit = useCallback(() => {
-    const pane = newPane();
-    setPanes([...panes, pane]);
-    setActivePaneId(pane.id);
-  }, [panes]);
-
-  const handleClosePane = useCallback(
-    (id: string) => {
-      if (panes.length <= 1) return;
-      const next = panes.filter((p) => p.id !== id);
-      setPanes(next);
-      if (activePaneId === id) setActivePaneId(next[0].id);
-    },
-    [panes, activePaneId],
-  );
-
-  return (
-    <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-      <ResizablePanel defaultSize={75} minSize={30}>
-        <TerminalPanes
-          terminalId={terminalId}
-          socket={socket}
-          panes={panes}
-          activePaneId={activePaneId}
-          onSelectPane={setActivePaneId}
-          onSplit={handleSplit}
-          onClosePane={handleClosePane}
-        />
-      </ResizablePanel>
-      <ResizableHandle />
-      <ResizablePanel defaultSize={25} minSize={16} maxSize={40}>
-        <Navigator terminalId={terminalId} onOpenTerminal={handleOpenTerminal} />
-      </ResizablePanel>
-    </ResizablePanelGroup>
-  );
+  return <TerminalPanes terminalId={terminalId} socket={socket} />;
 }

--- a/apps/web/src/components/layout/right-sidebar/TerminalNavigatorTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/TerminalNavigatorTab.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import Navigator from '@/components/layout/middle-content/page-views/terminal/workspace/Navigator';
+
+interface TerminalNavigatorTabProps {
+  terminalId: string;
+}
+
+/** Thin wrapper so the right sidebar's Terminal tab renders the same
+ * Navigator the middle content used to render inline — relocated by
+ * composition through the shared terminal-workspace store, not by
+ * prop-threading. */
+export default function TerminalNavigatorTab({ terminalId }: TerminalNavigatorTabProps) {
+  return <Navigator terminalId={terminalId} />;
+}

--- a/apps/web/src/components/layout/right-sidebar/index.tsx
+++ b/apps/web/src/components/layout/right-sidebar/index.tsx
@@ -1,23 +1,36 @@
 "use client";
 
 import { useState, useEffect, useRef, memo, useCallback } from "react";
-import { History, MessageSquare, Activity } from "lucide-react";
+import { useParams } from "next/navigation";
+import { History, MessageSquare, Activity, TerminalSquare } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/hooks/useAuth";
 import { useSidebarAgentStore } from "@/hooks/page-agents";
 import { useDashboardContext } from "@/hooks/useDashboardContext";
 import { usePageAgentDashboardStore, type SidebarTab } from "@/stores/page-agents";
+import { useTabsStore, type Tab } from "@/stores/useTabsStore";
+import { useLayoutStore } from "@/stores/useLayoutStore";
+import { useTabMeta } from "@/hooks/useTabMeta";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useMobileKeyboard } from "@/hooks/useMobileKeyboard";
+import { PageType } from "@pagespace/lib/utils/enums";
 
 import SidebarChatTab from "./ai-assistant/SidebarChatTab";
 import SidebarHistoryTab from "./ai-assistant/SidebarHistoryTab";
 import SidebarActivityTab from "./ai-assistant/SidebarActivityTab";
+import TerminalNavigatorTab from "./TerminalNavigatorTab";
 
 export interface RightPanelProps {
   className?: string;
   variant?: "desktop" | "overlay";
 }
+
+// Stable placeholder passed to useTabMeta when there's no active tab (e.g.
+// dashboard context) — useTabMeta must be called unconditionally (rules of
+// hooks), and an empty path resolves to its inert "unknown" fallback branch
+// with no fetch triggered.
+const NO_ACTIVE_TAB: Tab = { id: '', path: '', history: [], historyIndex: 0, isPinned: false };
 
 /**
  * Right sidebar panel - contains AI Assistant chat, history, and activity.
@@ -37,6 +50,9 @@ export interface RightPanelProps {
  */
 function RightPanel({ className, variant }: RightPanelProps) {
   const { isDashboardContext } = useDashboardContext();
+  const params = useParams();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
 
   // Mobile keyboard support - adjust height when keyboard is open
   const { isOpen: isKeyboardOpen, height: keyboardHeight } = useMobileKeyboard();
@@ -47,12 +63,26 @@ function RightPanel({ className, variant }: RightPanelProps) {
   const dashboardAgent = usePageAgentDashboardStore((state) => state.selectedAgent);
   const dashboardActiveTab = usePageAgentDashboardStore((state) => state.activeTab);
   const setDashboardActiveTab = usePageAgentDashboardStore((state) => state.setActiveTab);
+  const rightSidebarOpen = useLayoutStore((state) => state.rightSidebarOpen);
 
   // On dashboard context, use the central agent store; otherwise use sidebar's own store
   const selectedAgent = isDashboardContext ? dashboardAgent : sidebarAgent;
 
   // Chat tab is only shown when NOT on dashboard context
   const showChatTab = !isDashboardContext;
+
+  // Terminal tab is only shown while the active page is a Terminal page AND
+  // the user is an admin — TerminalWorkspace (the middle-content component
+  // that actually creates the pane workspace) is itself admin-gated, so a
+  // non-admin Terminal tab here would be all dead clicks. `useTabMeta` is
+  // called directly (not just read off the cached tab) so the fetch that
+  // resolves `pageType` is triggered from here too, not only from whichever
+  // TabItem happens to be mounted in the tab bar — narrowing the window
+  // where a freshly-opened Terminal page's tab hasn't resolved its type yet.
+  const activeTabItem = useTabsStore((state) => state.selectActiveTab(state));
+  const activeTabMeta = useTabMeta(activeTabItem ?? NO_ACTIVE_TAB);
+  const showTerminalTab = isAdmin && activeTabMeta.pageType === PageType.TERMINAL;
+  const activeTerminalPageId = showTerminalTab ? (params.pageId as string | undefined) : undefined;
 
   // Local tab state for page context (independent from dashboard)
   const [localActiveTab, setLocalActiveTab] = useState<SidebarTab>(showChatTab ? "chat" : "history");
@@ -78,6 +108,29 @@ function RightPanel({ className, variant }: RightPanelProps) {
     }
     prevIsDashboardContext.current = isDashboardContext;
   }, [isDashboardContext]);
+
+  // Default the sidebar to the Terminal tab whenever a Terminal page becomes
+  // active while the sidebar is open, OR the sidebar is opened while already
+  // on a Terminal page (e.g. navigate to a Terminal page with the sidebar
+  // closed, then open it) — both are "a Terminal page just became visible
+  // with the sidebar open" from the user's perspective. Forcing the switch
+  // on every render where both happen to be true would fight the user's own
+  // tab clicks, so it only fires on the transition into that state, tracked
+  // via both refs. When navigating away from a Terminal page, fall back off
+  // the now-hidden tab.
+  const prevTerminalPageId = useRef<string | undefined>(undefined);
+  const prevRightSidebarOpen = useRef(rightSidebarOpen);
+  useEffect(() => {
+    const pageIdChanged = activeTerminalPageId !== prevTerminalPageId.current;
+    const sidebarJustOpened = rightSidebarOpen && !prevRightSidebarOpen.current;
+    if (activeTerminalPageId && rightSidebarOpen && (pageIdChanged || sidebarJustOpened)) {
+      setLocalActiveTab('terminal');
+    } else if (!activeTerminalPageId && prevTerminalPageId.current) {
+      setLocalActiveTab((tab) => (tab === 'terminal' ? 'chat' : tab));
+    }
+    prevTerminalPageId.current = activeTerminalPageId;
+    prevRightSidebarOpen.current = rightSidebarOpen;
+  }, [activeTerminalPageId, rightSidebarOpen]);
 
   // Use appropriate tab state based on context
   const activeTab = isDashboardContext ? dashboardActiveTab : localActiveTab;
@@ -128,7 +181,7 @@ function RightPanel({ className, variant }: RightPanelProps) {
           <TabsList
             className={cn(
               "grid gap-1 px-1 py-1 w-full h-auto bg-transparent rounded-none",
-              showChatTab ? "grid-cols-3" : "grid-cols-2"
+              showTerminalTab ? "grid-cols-4" : showChatTab ? "grid-cols-3" : "grid-cols-2"
             )}
           >
             {showChatTab && (
@@ -174,6 +227,22 @@ function RightPanel({ className, variant }: RightPanelProps) {
                 )}
               />
             </TabsTrigger>
+
+            {showTerminalTab && (
+              <TabsTrigger
+                value="terminal"
+                className={triggerBaseStyles}
+              >
+                <TerminalSquare className="h-4 w-4" />
+                <span className="hidden @[180px]:inline">Terminal</span>
+                <div
+                  className={cn(
+                    "absolute bottom-0 left-1/2 h-0.5 w-1/2 -translate-x-1/2 bg-primary transition-opacity",
+                    activeTab === "terminal" ? "opacity-100" : "opacity-0"
+                  )}
+                />
+              </TabsTrigger>
+            )}
           </TabsList>
         </div>
 
@@ -218,6 +287,19 @@ function RightPanel({ className, variant }: RightPanelProps) {
           >
             <SidebarActivityTab />
           </TabsContent>
+
+          {showTerminalTab && activeTerminalPageId && (
+            <TabsContent
+              value="terminal"
+              forceMount
+              className={cn(
+                "h-full m-0 outline-none",
+                activeTab === "terminal" ? "flex flex-col" : "hidden"
+              )}
+            >
+              <TerminalNavigatorTab terminalId={activeTerminalPageId} />
+            </TabsContent>
+          )}
         </div>
       </Tabs>
     </aside>

--- a/apps/web/src/stores/page-agents/__tests__/usePageAgentDashboardStore.test.ts
+++ b/apps/web/src/stores/page-agents/__tests__/usePageAgentDashboardStore.test.ts
@@ -685,7 +685,7 @@ describe('usePageAgentDashboardStore', () => {
     it('should accept valid SidebarTab values', () => {
       const { result } = renderHook(() => usePageAgentDashboardStore());
 
-      const validTabs: SidebarTab[] = ['chat', 'history', 'activity'];
+      const validTabs: SidebarTab[] = ['chat', 'history', 'activity', 'terminal'];
 
       validTabs.forEach((tab) => {
         act(() => {

--- a/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
+++ b/apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts
@@ -20,7 +20,7 @@ import { AgentInfo } from '@/types/agent';
 export type { AgentInfo } from '@/types/agent';
 
 /** Tab types for the right sidebar */
-export type SidebarTab = 'chat' | 'history' | 'activity';
+export type SidebarTab = 'chat' | 'history' | 'activity' | 'terminal';
 
 interface AgentState {
   // Selected agent (null = Global Assistant mode)

--- a/apps/web/src/stores/terminal-workspace/__tests__/useTerminalWorkspaceStore.test.ts
+++ b/apps/web/src/stores/terminal-workspace/__tests__/useTerminalWorkspaceStore.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTerminalWorkspaceStore, selectWorkspace } from '../useTerminalWorkspaceStore';
+
+const reset = () => useTerminalWorkspaceStore.setState({ workspaces: {} });
+
+describe('useTerminalWorkspaceStore', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('given a fresh store, should have no workspaces', () => {
+    const actual = useTerminalWorkspaceStore.getState().workspaces;
+
+    expect({
+      given: 'a fresh store',
+      should: 'have no workspaces',
+      actual,
+      expected: {},
+    }).toEqual({
+      given: 'a fresh store',
+      should: 'have no workspaces',
+      actual: {},
+      expected: {},
+    });
+  });
+
+  it('given ensureWorkspace is called for a new terminalId, should create a single-pane workspace', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+
+    const workspace = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'ensureWorkspace is called for a new terminalId',
+      should: 'create a single-pane workspace',
+      actual: workspace?.panes.length,
+      expected: 1,
+    }).toEqual({
+      given: 'ensureWorkspace is called for a new terminalId',
+      should: 'create a single-pane workspace',
+      actual: 1,
+      expected: 1,
+    });
+  });
+
+  it('given ensureWorkspace is called twice, should not replace the existing workspace', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    const first = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    const second = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'ensureWorkspace is called twice',
+      should: 'not replace the existing workspace',
+      actual: second,
+      expected: first,
+    }).toEqual({
+      given: 'ensureWorkspace is called twice',
+      should: 'not replace the existing workspace',
+      actual: first,
+      expected: first,
+    });
+  });
+
+  it('given disposeWorkspace is called, should remove the workspace entry', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    useTerminalWorkspaceStore.getState().disposeWorkspace('terminal-1');
+
+    const workspace = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'disposeWorkspace is called',
+      should: 'remove the workspace entry',
+      actual: workspace,
+      expected: undefined,
+    }).toEqual({
+      given: 'disposeWorkspace is called',
+      should: 'remove the workspace entry',
+      actual: undefined,
+      expected: undefined,
+    });
+  });
+
+  it('given two ensured workspaces, should keep them independent', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-2');
+    useTerminalWorkspaceStore.getState().openTerminal('terminal-1', { name: 'only-in-1' });
+
+    const state = useTerminalWorkspaceStore.getState();
+    const workspace1 = selectWorkspace('terminal-1')(state);
+    const workspace2 = selectWorkspace('terminal-2')(state);
+
+    expect({
+      given: 'two ensured workspaces',
+      should: 'keep them independent',
+      actual: { w1Scope: workspace1?.panes[0].scope, w2Scope: workspace2?.panes[0].scope },
+      expected: { w1Scope: { name: 'only-in-1' }, w2Scope: null },
+    }).toEqual({
+      given: 'two ensured workspaces',
+      should: 'keep them independent',
+      actual: { w1Scope: { name: 'only-in-1' }, w2Scope: null },
+      expected: { w1Scope: { name: 'only-in-1' }, w2Scope: null },
+    });
+  });
+
+  it('given openTerminal, should write the scope into the active pane', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    useTerminalWorkspaceStore.getState().openTerminal('terminal-1', { name: 'my-terminal' });
+
+    const workspace = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'openTerminal',
+      should: 'write the scope into the active pane',
+      actual: workspace?.panes.find((p) => p.id === workspace.activePaneId)?.scope,
+      expected: { name: 'my-terminal' },
+    }).toEqual({
+      given: 'openTerminal',
+      should: 'write the scope into the active pane',
+      actual: { name: 'my-terminal' },
+      expected: { name: 'my-terminal' },
+    });
+  });
+
+  it('given split, should add a second pane and activate it', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    useTerminalWorkspaceStore.getState().split('terminal-1');
+
+    const workspace = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'split',
+      should: 'add a second pane and activate it',
+      actual: { paneCount: workspace?.panes.length, activeIsNewPane: workspace?.activePaneId !== workspace?.panes[0].id },
+      expected: { paneCount: 2, activeIsNewPane: true },
+    }).toEqual({
+      given: 'split',
+      should: 'add a second pane and activate it',
+      actual: { paneCount: 2, activeIsNewPane: true },
+      expected: { paneCount: 2, activeIsNewPane: true },
+    });
+  });
+
+  it('given closePane on the last pane, should be a no-op', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    const before = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    useTerminalWorkspaceStore.getState().closePane('terminal-1', before!.panes[0].id);
+    const after = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'closePane on the last pane',
+      should: 'be a no-op',
+      actual: after,
+      expected: before,
+    }).toEqual({
+      given: 'closePane on the last pane',
+      should: 'be a no-op',
+      actual: before,
+      expected: before,
+    });
+  });
+
+  it('given selectPane, should activate the chosen pane', () => {
+    useTerminalWorkspaceStore.getState().ensureWorkspace('terminal-1');
+    useTerminalWorkspaceStore.getState().split('terminal-1');
+
+    const workspace = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+    const firstPaneId = workspace!.panes[0].id;
+    useTerminalWorkspaceStore.getState().selectPane('terminal-1', firstPaneId);
+
+    const after = selectWorkspace('terminal-1')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'selectPane',
+      should: 'activate the chosen pane',
+      actual: after?.activePaneId,
+      expected: firstPaneId,
+    }).toEqual({
+      given: 'selectPane',
+      should: 'activate the chosen pane',
+      actual: firstPaneId,
+      expected: firstPaneId,
+    });
+  });
+
+  it('given actions on a terminalId that was never ensured, should be a no-op', () => {
+    useTerminalWorkspaceStore.getState().openTerminal('never-ensured', { name: 'ghost' });
+    useTerminalWorkspaceStore.getState().split('never-ensured');
+    useTerminalWorkspaceStore.getState().closePane('never-ensured', 'anything');
+    useTerminalWorkspaceStore.getState().selectPane('never-ensured', 'anything');
+
+    const workspace = selectWorkspace('never-ensured')(useTerminalWorkspaceStore.getState());
+
+    expect({
+      given: 'actions on a terminalId that was never ensured',
+      should: 'be a no-op',
+      actual: workspace,
+      expected: undefined,
+    }).toEqual({
+      given: 'actions on a terminalId that was never ensured',
+      should: 'be a no-op',
+      actual: undefined,
+      expected: undefined,
+    });
+  });
+});

--- a/apps/web/src/stores/terminal-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/terminal-workspace/__tests__/workspace-reducer.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest';
+import {
+  initialWorkspace,
+  openTerminal,
+  split,
+  closePane,
+  selectPane,
+  type WorkspaceState,
+} from '../workspace-reducer';
+
+describe('initialWorkspace', () => {
+  it('given a first pane id, should create a single active pane with no scope', () => {
+    const actual = initialWorkspace('pane-1');
+    const expected: WorkspaceState = {
+      panes: [{ id: 'pane-1', scope: null }],
+      activePaneId: 'pane-1',
+    };
+
+    expect({
+      given: 'a first pane id',
+      should: 'create a single active pane with no scope',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'a first pane id',
+      should: 'create a single active pane with no scope',
+      actual: expected,
+      expected,
+    });
+  });
+});
+
+describe('openTerminal', () => {
+  it('given two panes, should write the scope into only the active pane', () => {
+    const state: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-2', scope: null },
+      ],
+      activePaneId: 'pane-2',
+    };
+    const scope = { name: 'my-terminal' };
+
+    const actual = openTerminal(state, scope);
+    const expected: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-2', scope },
+      ],
+      activePaneId: 'pane-2',
+    };
+
+    expect({
+      given: 'two panes',
+      should: 'write the scope into only the active pane',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'two panes',
+      should: 'write the scope into only the active pane',
+      actual: expected,
+      expected,
+    });
+  });
+
+  it('given openTerminal is called, should not mutate the input state', () => {
+    const state: WorkspaceState = initialWorkspace('pane-1');
+    const snapshot = JSON.parse(JSON.stringify(state));
+
+    openTerminal(state, { name: 'my-terminal' });
+
+    expect({
+      given: 'openTerminal is called',
+      should: 'not mutate the input state',
+      actual: state,
+      expected: snapshot,
+    }).toEqual({
+      given: 'openTerminal is called',
+      should: 'not mutate the input state',
+      actual: snapshot,
+      expected: snapshot,
+    });
+  });
+});
+
+describe('split', () => {
+  it('given a single pane, should append a new empty pane and activate it', () => {
+    const state = initialWorkspace('pane-1');
+
+    const actual = split(state, 'pane-2');
+    const expected: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-2', scope: null },
+      ],
+      activePaneId: 'pane-2',
+    };
+
+    expect({
+      given: 'a single pane',
+      should: 'append a new empty pane and activate it',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'a single pane',
+      should: 'append a new empty pane and activate it',
+      actual: expected,
+      expected,
+    });
+  });
+
+  it('given a pane with a scope, splitting should leave the existing pane untouched', () => {
+    const scope = { name: 'my-terminal' };
+    const state: WorkspaceState = {
+      panes: [{ id: 'pane-1', scope }],
+      activePaneId: 'pane-1',
+    };
+
+    const result = split(state, 'pane-2');
+
+    expect({
+      given: 'a pane with a scope',
+      should: 'leave the existing pane untouched',
+      actual: result.panes[0],
+      expected: { id: 'pane-1', scope },
+    }).toEqual({
+      given: 'a pane with a scope',
+      should: 'leave the existing pane untouched',
+      actual: { id: 'pane-1', scope },
+      expected: { id: 'pane-1', scope },
+    });
+  });
+});
+
+describe('closePane', () => {
+  it('given the last remaining pane, should be a no-op', () => {
+    const state = initialWorkspace('pane-1');
+
+    const actual = closePane(state, 'pane-1');
+
+    expect({
+      given: 'the last remaining pane',
+      should: 'be a no-op',
+      actual,
+      expected: state,
+    }).toEqual({
+      given: 'the last remaining pane',
+      should: 'be a no-op',
+      actual: state,
+      expected: state,
+    });
+  });
+
+  it('given the active pane is closed, should re-target active to the first remaining pane', () => {
+    const state: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-2', scope: null },
+        { id: 'pane-3', scope: null },
+      ],
+      activePaneId: 'pane-2',
+    };
+
+    const actual = closePane(state, 'pane-2');
+    const expected: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-3', scope: null },
+      ],
+      activePaneId: 'pane-1',
+    };
+
+    expect({
+      given: 'the active pane is closed',
+      should: 're-target active to the first remaining pane',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'the active pane is closed',
+      should: 're-target active to the first remaining pane',
+      actual: expected,
+      expected,
+    });
+  });
+
+  it('given a non-active pane is closed, should leave the active pane untouched', () => {
+    const state: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-2', scope: null },
+      ],
+      activePaneId: 'pane-2',
+    };
+
+    const actual = closePane(state, 'pane-1');
+    const expected: WorkspaceState = {
+      panes: [{ id: 'pane-2', scope: null }],
+      activePaneId: 'pane-2',
+    };
+
+    expect({
+      given: 'a non-active pane is closed',
+      should: 'leave the active pane untouched',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'a non-active pane is closed',
+      should: 'leave the active pane untouched',
+      actual: expected,
+      expected,
+    });
+  });
+});
+
+describe('selectPane', () => {
+  it('given a valid pane id, should activate it', () => {
+    const state: WorkspaceState = {
+      panes: [
+        { id: 'pane-1', scope: null },
+        { id: 'pane-2', scope: null },
+      ],
+      activePaneId: 'pane-1',
+    };
+
+    const actual = selectPane(state, 'pane-2');
+
+    expect({
+      given: 'a valid pane id',
+      should: 'activate it',
+      actual: actual.activePaneId,
+      expected: 'pane-2',
+    }).toEqual({
+      given: 'a valid pane id',
+      should: 'activate it',
+      actual: 'pane-2',
+      expected: 'pane-2',
+    });
+  });
+
+  it('given an unknown pane id, should be a no-op', () => {
+    const state = initialWorkspace('pane-1');
+
+    const actual = selectPane(state, 'does-not-exist');
+
+    expect({
+      given: 'an unknown pane id',
+      should: 'be a no-op',
+      actual,
+      expected: state,
+    }).toEqual({
+      given: 'an unknown pane id',
+      should: 'be a no-op',
+      actual: state,
+      expected: state,
+    });
+  });
+});

--- a/apps/web/src/stores/terminal-workspace/useTerminalWorkspaceStore.ts
+++ b/apps/web/src/stores/terminal-workspace/useTerminalWorkspaceStore.ts
@@ -1,0 +1,99 @@
+/**
+ * Terminal Workspace Store
+ *
+ * Thin imperative shell over the pure workspace-reducer. Keyed by
+ * `terminalId` (the Terminal page's own id) so several Terminal pages can
+ * hold independent pane layouts at once. Fresh ids are generated here
+ * (crypto.randomUUID) — the reducer itself never generates ids, keeping it
+ * deterministic and trivially testable.
+ *
+ * This is the single source of truth shared, by composition, between the
+ * Navigator (right sidebar) and TerminalPanes (middle content) — they no
+ * longer need a common parent to share `panes`/`activePaneId` local state.
+ *
+ * Navigation cleanup (dispose on unmount) is performed by the mounting
+ * component via `useEffect`, not from inside the store — same pattern as
+ * useThreadPanelStore.
+ */
+
+import { create } from 'zustand';
+import {
+  initialWorkspace,
+  openTerminal as openTerminalTransition,
+  split as splitTransition,
+  closePane as closePaneTransition,
+  selectPane as selectPaneTransition,
+  type OpenTerminalScope,
+  type TerminalPaneState,
+  type WorkspaceState,
+} from './workspace-reducer';
+
+export type { OpenTerminalScope, TerminalPaneState, WorkspaceState };
+
+interface TerminalWorkspaceStoreState {
+  workspaces: Record<string, WorkspaceState>;
+  ensureWorkspace: (terminalId: string) => void;
+  disposeWorkspace: (terminalId: string) => void;
+  openTerminal: (terminalId: string, scope: OpenTerminalScope) => void;
+  split: (terminalId: string) => void;
+  closePane: (terminalId: string, paneId: string) => void;
+  selectPane: (terminalId: string, paneId: string) => void;
+}
+
+/** Applies a pure reducer transition to the workspace at `terminalId`, if it
+ * exists — a missing workspace (not yet ensured, or already disposed) is a
+ * no-op rather than an error. */
+function applyTransition(
+  state: TerminalWorkspaceStoreState,
+  terminalId: string,
+  transition: (workspace: WorkspaceState) => WorkspaceState
+): Pick<TerminalWorkspaceStoreState, 'workspaces'> {
+  const workspace = state.workspaces[terminalId];
+  if (!workspace) return { workspaces: state.workspaces };
+  return {
+    workspaces: { ...state.workspaces, [terminalId]: transition(workspace) },
+  };
+}
+
+export const useTerminalWorkspaceStore = create<TerminalWorkspaceStoreState>((set, get) => ({
+  workspaces: {},
+
+  ensureWorkspace: (terminalId) => {
+    if (get().workspaces[terminalId]) return;
+    set((state) => ({
+      workspaces: {
+        ...state.workspaces,
+        [terminalId]: initialWorkspace(crypto.randomUUID()),
+      },
+    }));
+  },
+
+  disposeWorkspace: (terminalId) => {
+    set((state) => {
+      if (!(terminalId in state.workspaces)) return state;
+      const workspaces = { ...state.workspaces };
+      delete workspaces[terminalId];
+      return { workspaces };
+    });
+  },
+
+  openTerminal: (terminalId, scope) => {
+    set((state) => applyTransition(state, terminalId, (workspace) => openTerminalTransition(workspace, scope)));
+  },
+
+  split: (terminalId) => {
+    const newId = crypto.randomUUID();
+    set((state) => applyTransition(state, terminalId, (workspace) => splitTransition(workspace, newId)));
+  },
+
+  closePane: (terminalId, paneId) => {
+    set((state) => applyTransition(state, terminalId, (workspace) => closePaneTransition(workspace, paneId)));
+  },
+
+  selectPane: (terminalId, paneId) => {
+    set((state) => applyTransition(state, terminalId, (workspace) => selectPaneTransition(workspace, paneId)));
+  },
+}));
+
+export const selectWorkspace = (terminalId: string) => (state: TerminalWorkspaceStoreState) =>
+  state.workspaces[terminalId];

--- a/apps/web/src/stores/terminal-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/terminal-workspace/workspace-reducer.ts
@@ -1,0 +1,70 @@
+/**
+ * Terminal Workspace — functional core.
+ *
+ * Pure, framework-free state transitions for the pane layout shared between
+ * the Terminal page's Navigator (right sidebar) and TerminalPanes (middle
+ * content). IDs are passed in rather than generated here, so every
+ * transition is deterministic and independently testable.
+ */
+
+/** Identifies which terminal to open in a pane — neither `projectName` nor
+ * `branchName` set is machine scope, `projectName` alone is project scope,
+ * both is branch scope. */
+export interface OpenTerminalScope {
+  projectName?: string;
+  branchName?: string;
+  name: string;
+}
+
+export interface TerminalPaneState {
+  id: string;
+  scope: OpenTerminalScope | null;
+}
+
+export interface WorkspaceState {
+  panes: TerminalPaneState[];
+  activePaneId: string;
+}
+
+export function initialWorkspace(firstId: string): WorkspaceState {
+  return {
+    panes: [{ id: firstId, scope: null }],
+    activePaneId: firstId,
+  };
+}
+
+/** Opens a terminal into the ACTIVE pane — an explicit target rather than
+ * guessing from array position, which would silently overwrite the wrong
+ * pane whenever a second pane existed. */
+export function openTerminal(state: WorkspaceState, scope: OpenTerminalScope): WorkspaceState {
+  return {
+    ...state,
+    panes: state.panes.map((pane) =>
+      pane.id === state.activePaneId ? { ...pane, scope } : pane
+    ),
+  };
+}
+
+export function split(state: WorkspaceState, newId: string): WorkspaceState {
+  return {
+    panes: [...state.panes, { id: newId, scope: null }],
+    activePaneId: newId,
+  };
+}
+
+/** Removing the last remaining pane is a no-op — a workspace never has zero
+ * panes. Removing the active pane re-targets active to the first remaining
+ * pane. */
+export function closePane(state: WorkspaceState, id: string): WorkspaceState {
+  if (state.panes.length <= 1) return state;
+
+  const panes = state.panes.filter((pane) => pane.id !== id);
+  const activePaneId = state.activePaneId === id ? panes[0].id : state.activePaneId;
+
+  return { panes, activePaneId };
+}
+
+export function selectPane(state: WorkspaceState, id: string): WorkspaceState {
+  if (!state.panes.some((pane) => pane.id === id)) return state;
+  return { ...state, activePaneId: id };
+}


### PR DESCRIPTION
## Why
The Terminal feature merged to master via #1919 (squash). That squash snapshot of `pu/terminal` was taken **before** the navigator-relocation PR #1926 landed on `pu/terminal`, so the navigator fix was left stranded on `pu/terminal` and never reached master. This brings it in.

## What
Cherry-pick of #1926 (`cfd827256`) — applies cleanly on master:
- Moves the Terminal **Navigator** (Projects→Branches→terminals) out of the cramped ~25% middle panel into a **4th tab in the app's main right sidebar** (page-type-gated to Terminal pages; inherits the resizable 18–50% sidebar width). The middle content becomes full-width terminal panes.
- **Eric-Elliott design**: a pure `workspace-reducer.ts` (functional core, unit-tested, ids passed in) + a thin Zustand `useTerminalWorkspaceStore` keyed by `terminalId` (single source of truth); `Navigator` and `TerminalPanes` decoupled — each reads/dispatches to the store instead of prop-threading across the layout.

## Notes
- Part of the Terminal feature; all behind `CODE_EXECUTION_ENABLED` (OFF in prod).
- Reducer + store have unit tests; React component tests omitted (unreliable in worktrees) — validated via typecheck + manual walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)