### PR TITLE
fix(perf): memoize blind-index key derivation

### DIFF
--- a/packages/lib/src/encryption/blind-index.test.ts
+++ b/packages/lib/src/encryption/blind-index.test.ts
@@ -5,12 +5,22 @@
  * equality lookups and uniqueness for columns we still need to query
  * (email, security-audit IP) while the stored value itself is random AES-GCM.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const scryptSyncSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('crypto')>();
+  scryptSyncSpy.mockImplementation(actual.scryptSync);
+  return { ...actual, scryptSync: scryptSyncSpy };
+});
+
 import {
   deriveIndexKey,
   computeBlindIndex,
   normalizeEmail,
   emailBlindIndex,
+  __resetIndexKeyCacheForTests,
 } from './blind-index';
 
 const MASTER = 'test-master-key-at-least-32-characters-long!!';
@@ -34,6 +44,40 @@ describe('deriveIndexKey', () => {
 
   it('given an empty master key, should throw', () => {
     expect(() => deriveIndexKey('')).toThrow();
+  });
+
+  describe('memoization', () => {
+    beforeEach(() => {
+      scryptSyncSpy.mockClear();
+      __resetIndexKeyCacheForTests();
+    });
+
+    it('given repeated calls with the same master key, should only run scrypt once', () => {
+      const key = 'memo-test-master-key-at-least-32-chars!!';
+
+      const a = deriveIndexKey(key);
+      const b = deriveIndexKey(key);
+      const c = deriveIndexKey(key);
+
+      expect(scryptSyncSpy).toHaveBeenCalledTimes(1);
+      expect(a.equals(b)).toBe(true);
+      expect(b.equals(c)).toBe(true);
+    });
+
+    it('given calls with different master keys, should compute a distinct, correct key for each (not serve the wrong cache entry)', () => {
+      const keyA = 'memo-test-master-key-a-at-least-32-chars!!';
+      const keyB = 'memo-test-master-key-b-at-least-32-chars!!';
+
+      const derivedA = deriveIndexKey(keyA);
+      const derivedB = deriveIndexKey(keyB);
+      const derivedAAgain = deriveIndexKey(keyA);
+
+      expect(scryptSyncSpy).toHaveBeenCalledTimes(2);
+      expect(derivedA.equals(derivedB)).toBe(false);
+      expect(derivedA.equals(derivedAAgain)).toBe(true);
+      expect(derivedA.equals(scryptSyncSpy(keyA, 'pii-blind-index-v1', 32))).toBe(true);
+      expect(derivedB.equals(scryptSyncSpy(keyB, 'pii-blind-index-v1', 32))).toBe(true);
+    });
   });
 });
 

--- a/packages/lib/src/encryption/blind-index.test.ts
+++ b/packages/lib/src/encryption/blind-index.test.ts
@@ -46,6 +46,20 @@ describe('deriveIndexKey', () => {
     expect(() => deriveIndexKey('')).toThrow();
   });
 
+  it('given repeated calls with the same master key, should return equal but distinct buffer instances, so mutating one result cannot corrupt the shared cache or later calls', () => {
+    const a = deriveIndexKey(MASTER);
+    const b = deriveIndexKey(MASTER);
+
+    expect(a).not.toBe(b);
+    expect(a.equals(b)).toBe(true);
+
+    a.fill(0);
+
+    const c = deriveIndexKey(MASTER);
+    expect(c.equals(a)).toBe(false);
+    expect(c.equals(b)).toBe(true);
+  });
+
   describe('memoization', () => {
     beforeEach(() => {
       scryptSyncSpy.mockClear();

--- a/packages/lib/src/encryption/blind-index.ts
+++ b/packages/lib/src/encryption/blind-index.ts
@@ -68,7 +68,10 @@ export function __resetIndexKeyCacheForTests(): void {
  * deterministic function of its input (fixed salt `INDEX_KEY_INFO`): scrypt
  * only needs to run once per distinct masterKey rather than once per call.
  * In production there is exactly one real `ENCRYPTION_KEY` per process, so
- * the cache never grows unbounded.
+ * the cache never grows unbounded. Returns a fresh copy of the cached buffer
+ * on every call — the cache entry is never handed out directly — so a caller
+ * mutating its result (e.g. zeroing a key after use) can't corrupt the shared
+ * cache and silently break every subsequent call for that masterKey.
  */
 export function deriveIndexKey(masterKey: string): Buffer {
   if (!masterKey || typeof masterKey !== 'string') {
@@ -80,7 +83,7 @@ export function deriveIndexKey(masterKey: string): Buffer {
     );
   }
 
-  return indexKeyCache.get(masterKey);
+  return Buffer.from(indexKeyCache.get(masterKey));
 }
 
 /**

--- a/packages/lib/src/encryption/blind-index.ts
+++ b/packages/lib/src/encryption/blind-index.ts
@@ -9,6 +9,9 @@
  * The HMAC key is DERIVED from the master `ENCRYPTION_KEY` with a fixed,
  * domain-separated label so that the index secret is cryptographically
  * distinct from the at-rest AES key — leaking one does not reveal the other.
+ * `deriveIndexKey` memoizes this derivation (keyed by `masterKey`) so the
+ * CPU-hard scrypt call runs once per distinct master key, not once per call —
+ * safe because the derivation is a pure, deterministic function of its input.
  *
  * Pure module: no env reads, no I/O. The master key is passed in; the env-bound
  * edge lives in `field-crypto.ts` / repository edges.
@@ -22,8 +25,50 @@ const MIN_MASTER_KEY_LENGTH = 32;
 const MIN_INDEX_KEY_BYTES = 16;
 
 /**
+ * Sync mirror of `memoizeAsyncOnce` (see `encryption-utils.ts`), but keyed
+ * rather than single-value: `compute` may legitimately be called with more
+ * than one distinct key in a process (blind-index derivation takes
+ * `masterKey` as a parameter, and tests exercise multiple values), so each
+ * key gets its own cached result instead of the whole cache being "once".
+ */
+function memoizeSyncByKey<K, T>(compute: (key: K) => T): { get: (key: K) => T; reset: () => void } {
+  let cache = new Map<K, T>();
+  return {
+    get: (key: K) => {
+      const cached = cache.get(key);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const value = compute(key);
+      cache.set(key, value);
+      return value;
+    },
+    reset: () => {
+      cache = new Map<K, T>();
+    },
+  };
+}
+
+const indexKeyCache = memoizeSyncByKey((masterKey: string) =>
+  scryptSync(masterKey, INDEX_KEY_INFO, INDEX_KEY_LENGTH),
+);
+
+/**
+ * Test-only seam: clears the memoized index-key cache. Mirrors
+ * `__resetMasterKeyCacheForTests` in `encryption-utils.ts`.
+ */
+export function __resetIndexKeyCacheForTests(): void {
+  indexKeyCache.reset();
+}
+
+/**
  * Derive the blind-index HMAC key from the master encryption key.
- * Deterministic and domain-separated from the at-rest AES key.
+ * Deterministic and domain-separated from the at-rest AES key. Memoized by
+ * `masterKey` value — see `indexKeyCache` above — since this is a pure,
+ * deterministic function of its input (fixed salt `INDEX_KEY_INFO`): scrypt
+ * only needs to run once per distinct masterKey rather than once per call.
+ * In production there is exactly one real `ENCRYPTION_KEY` per process, so
+ * the cache never grows unbounded.
  */
 export function deriveIndexKey(masterKey: string): Buffer {
   if (!masterKey || typeof masterKey !== 'string') {
@@ -34,7 +79,8 @@ export function deriveIndexKey(masterKey: string): Buffer {
       `Master key must be at least ${MIN_MASTER_KEY_LENGTH} characters for blind-index derivation`,
     );
   }
-  return scryptSync(masterKey, INDEX_KEY_INFO, INDEX_KEY_LENGTH);
+
+  return indexKeyCache.get(masterKey);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `deriveIndexKey()` in `packages/lib/src/encryption/blind-index.ts` ran `scryptSync` (~40ms) on every call instead of once per `masterKey` — the same shape of bug fixed for the AES master key in #1930.
- Unlike that fix, this one is a pure caching optimization with zero legacy-format concern: `INDEX_KEY_INFO` is a fixed constant, so `deriveIndexKey(masterKey)` is 100% deterministic per `masterKey`.
- Adds `memoizeSyncByKey`, a sync mirror of `encryption-utils.ts`'s `memoizeAsyncOnce`, keyed by `masterKey` (not single-value, since tests and, in principle, key rotation legitimately call it with different values in one process).
- Four call sites benefit without any changes: `user-crypto.ts` (email lookups/login), `user-repository.ts`, `security-audit.ts` (audit log writes — possibly hotter than login), `audit-query.ts` (IP filtering).
- **Follow-up (791e7aa08):** CodeRabbit correctly flagged that `deriveIndexKey` was returning the memoized `Buffer` instance directly, so a caller mutating its result (e.g. zeroing a key after use) would corrupt the shared cache for every subsequent call with that `masterKey`. Fixed by returning `Buffer.from(indexKeyCache.get(masterKey))` — a fresh copy on every call — with a regression test proving repeated calls return equal-but-distinct instances and that mutating one doesn't affect later derivations.

## Test plan
- [x] Existing tests for `blind-index.ts`, `user-crypto.ts`, `user-repository.ts`, `security-audit.ts`, `audit-query.ts` pass unchanged (`bunx vitest run` — 75+14 tests green).
- [x] New tests prove repeated calls with the same `masterKey` invoke `scryptSync` only once, calls with different `masterKey` values compute distinct, correct keys (not served from the wrong cache entry), and that the returned buffers are distinct instances so mutating one can't corrupt the cache.
- [x] `bunx tsc --noEmit` shows zero new errors vs. pre-change baseline (668 pre-existing errors unrelated to this file, from unbuilt workspace deps in this worktree).
- [x] CI: Lint & TypeScript Check green; Unit Tests running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xaj1xB4PDHs8Z9P1gpWCVT