### PR TITLE
fix(web): middleware.ts has never been registered in any build

### DIFF
--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -26,6 +26,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 vi.mock('@/lib/auth', () => ({
   validateOriginForMiddleware: mockValidateOriginForMiddleware,
   isOriginValidationBlocking: mockIsOriginValidationBlocking,
+  // Real string values, not mocks — middleware.ts builds its bearer-prefix
+  // checks from these at module-load time (`Bearer ${MCP_TOKEN_PREFIX}` etc.),
+  // so a mocked-away value here would silently break every prefix check this
+  // file's tests exercise below, the same way a hand-duplicated copy already
+  // drifted out of sync once (see middleware.ts's import site comment).
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
@@ -36,7 +44,7 @@ vi.mock('@/lib/well-known/rewrites', () => ({
   WELL_KNOWN_REWRITES: [],
 }));
 
-import { middleware } from '../../middleware';
+import { middleware } from '../middleware';
 
 const buildRequest = (pathname: string, headers: Record<string, string> = {}) =>
   new NextRequest(new URL(`http://localhost${pathname}`), { headers });
@@ -79,5 +87,45 @@ describe('middleware — /api/public/forms carve-outs', () => {
     // Origin validation must never even run for this route — it's inapplicable
     // by design (valid callers have unbounded custom-domain origins).
     expect(mockValidateOriginForMiddleware).not.toHaveBeenCalled();
+  });
+});
+
+// Regression coverage for a real bug: middleware.ts used to hand-duplicate two
+// of the three bearer prefixes `@/lib/auth` actually authenticates (mcp_,
+// ps_sess_), silently missing ps_at_ (OAuth access tokens, `pagespace login`).
+// Any ps_at_-authenticated request to a non-allowlisted API route would fall
+// through to the session-cookie check and get a false 401 — undetected until
+// now because this middleware was never actually registered/executed in any
+// deployed build (wrong Next.js discovery path). All three prefixes must
+// bypass the session-cookie gate identically.
+describe('middleware — bearer-token prefix carve-out (all three token types)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionFromCookies.mockReturnValue(undefined);
+    mockValidateOriginForMiddleware.mockReturnValue({ valid: true, origin: null, skipped: true, reason: 'no origin' });
+    mockIsOriginValidationBlocking.mockReturnValue(true);
+  });
+
+  it.each([
+    ['mcp', 'Bearer mcp_abc123'],
+    ['session', 'Bearer ps_sess_abc123'],
+    ['oauth', 'Bearer ps_at_abc123'],
+  ])('bypasses the session-cookie check for a %s bearer token on a non-allowlisted API route', async (_kind, authorization) => {
+    // /api/pages, unlike /api/drives, is NOT in the public allowlist — this
+    // isolates the bearer-prefix check itself rather than accidentally passing
+    // via that separate carve-out regardless of the auth header.
+    const request = buildRequest('/api/pages/xyz', { authorization });
+    const response = await middleware(request);
+
+    expect(response.status).not.toBe(401);
+    expect(mockGetSessionFromCookies).not.toHaveBeenCalled();
+  });
+
+  it('still falls through to the session-cookie check (and 401s with none) for an unrecognized bearer prefix', async () => {
+    const request = buildRequest('/api/pages/xyz', { authorization: 'Bearer not_a_real_prefix_xyz' });
+    const response = await middleware(request);
+
+    expect(mockGetSessionFromCookies).toHaveBeenCalled();
+    expect(response.status).toBe(401);
   });
 });

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -12,9 +12,14 @@ import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';
 
 const BEARER_PREFIX = 'Bearer ';
-const MCP_TOKEN_PREFIX = 'mcp_';
-const SESSION_TOKEN_PREFIX = 'ps_sess_';
-const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
+// Exported so middleware.ts's edge-safe bearer-prefix check (which can only test
+// presence, not validity) stays byte-for-byte in sync with the prefixes this
+// module actually authenticates — a second, hand-duplicated copy is exactly how
+// a prefix (ps_at_, added for OAuth CLI login) silently fell out of sync here
+// before, undetected because middleware never executed in production at all.
+export const MCP_TOKEN_PREFIX = 'mcp_';
+export const SESSION_TOKEN_PREFIX = 'ps_sess_';
+export const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
 
 export type TokenType = 'mcp' | 'session' | 'oauth';
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -12,15 +12,22 @@ import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import {
   validateOriginForMiddleware,
   isOriginValidationBlocking,
+  MCP_TOKEN_PREFIX,
+  SESSION_TOKEN_PREFIX,
+  OAUTH_ACCESS_TOKEN_PREFIX,
 } from '@/lib/auth';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 import { WELL_KNOWN_REWRITES } from '@/lib/well-known/rewrites';
 
 // Edge-safe middleware: only checks presence of auth tokens, not validity.
 // Full validation happens in route handlers via verifyAuth()/validateMCPToken().
+// Bearer prefixes are imported from the real auth layer, not hand-duplicated —
+// see the export site for why (a duplicated ps_at_-less copy previously drifted
+// out of sync here, undetected because middleware never ran in production).
 
-const MCP_BEARER_PREFIX = 'Bearer mcp_';
-const SESSION_BEARER_PREFIX = 'Bearer ps_sess_';
+const MCP_BEARER_PREFIX = `Bearer ${MCP_TOKEN_PREFIX}`;
+const SESSION_BEARER_PREFIX = `Bearer ${SESSION_TOKEN_PREFIX}`;
+const OAUTH_BEARER_PREFIX = `Bearer ${OAUTH_ACCESS_TOKEN_PREFIX}`;
 
 const IS_ONPREM = process.env.DEPLOYMENT_MODE === 'onprem';
 const IS_TENANT = process.env.DEPLOYMENT_MODE === 'tenant';
@@ -108,9 +115,13 @@ export async function middleware(req: NextRequest) {
     }
 
     // Bearer token format check (Edge-safe - no database access)
-    // Full validation happens in route handlers via validateMCPToken()/validateSessionToken()
+    // Full validation happens in route handlers via validateMCPToken()/validateSessionToken()/validateOAuthAccessToken()
     const authHeader = req.headers.get('authorization');
-    if (authHeader?.startsWith(MCP_BEARER_PREFIX) || authHeader?.startsWith(SESSION_BEARER_PREFIX)) {
+    if (
+      authHeader?.startsWith(MCP_BEARER_PREFIX) ||
+      authHeader?.startsWith(SESSION_BEARER_PREFIX) ||
+      authHeader?.startsWith(OAUTH_BEARER_PREFIX)
+    ) {
       // API routes get restrictive CSP (no nonce needed)
       const { response } = createSecureResponse(isProduction, req, { isAPIRoute: true });
       return response;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -152,6 +152,16 @@ export async function middleware(req: NextRequest) {
     // (authorize's POST still requires a session; token/revoke/device_authorization never do).
     // Exact matches only — device_authorization's /verify and /decision sub-routes are the
     // browser-side /activate screen and DO require a session, so must not be swept in here.
+    // Third-party webhooks authenticate via their own signature/HMAC check inside route.ts,
+    // never a session cookie or a recognized bearer prefix — each must be listed here or this
+    // middleware (now that it actually runs) blocks them with a 401 before route.ts ever sees
+    // the request.
+    // Signup/verification endpoints run before any session exists by definition (that's what
+    // they're creating), authenticating instead via login-CSRF token, WebAuthn challenge, a
+    // one-time handoff token, or an emailed verification token. `/passkey/register` (and its
+    // `/options` step) support an authenticated-session mode too — that's enforced inside the
+    // route itself, not here; `/passkey/register/handoff` (which mints the handoff token) is
+    // deliberately NOT in this list since it always requires a session.
     if (
       pathname.startsWith('/api/auth/csrf') ||
       pathname.startsWith('/api/auth/login-csrf') ||
@@ -171,6 +181,13 @@ export async function middleware(req: NextRequest) {
       pathname === '/api/memory/cron' ||
       pathname === '/api/pulse/cron' ||
       pathname === '/api/integrations/zoom/webhook' ||
+      pathname === '/api/stripe/webhook' ||
+      pathname === '/api/integrations/google-calendar/webhook' ||
+      pathname === '/api/auth/signup-passkey' ||
+      pathname === '/api/auth/signup-passkey/options' ||
+      pathname === '/api/auth/passkey/register' ||
+      pathname === '/api/auth/passkey/register/options' ||
+      pathname === '/api/auth/verify-email' ||
       pathname === '/api/health' ||
       pathname === '/api/version'
     ) {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -162,15 +162,40 @@ export async function middleware(req: NextRequest) {
     // `/options` step) support an authenticated-session mode too — that's enforced inside the
     // route itself, not here; `/passkey/register/handoff` (which mints the handoff token) is
     // deliberately NOT in this list since it always requires a session.
+    // `/api/auth/apple/` mirrors the existing `/api/auth/google` carve-out above: OAuth
+    // initiation (signin) and the provider callback both run with no session yet.
+    // `/api/auth/step-up/magic-link/verify` is the click-through target of a step-up
+    // confirmation email — like `/api/auth/verify-email`, it authenticates via the emailed
+    // token alone and (per its own doc comment) never creates a session.
+    // `/api/auth/logout` must stay reachable with NO session cookie: per its own comment, it
+    // still needs to revoke a device token by value when the cookie is already missing or
+    // expired — exactly the moment that token is the only credential left to invalidate.
+    // `/api/internal/*` (contact, monitoring/ingest) authenticate via a shared secret in a
+    // custom header or a non-prefixed Bearer value — never a session or a recognized MCP/
+    // session/OAuth bearer prefix — same rationale as the webhooks above.
+    // `/api/notifications/unsubscribe/[token]` is an opaque-token email unsubscribe link,
+    // clicked by (often logged-out) recipients.
+    // `/api/ai/models`, `/api/compiled-css`, `/api/avatar/[userId]/[filename]`, and
+    // `/api/provisioning-status/[slug]` are public-by-design per this codebase's own
+    // apps/web/src/app/api/__tests__/security-audit-coverage.test.ts allowlist (model
+    // catalog, static CSS, public avatar images, tenant-onboarding status polling) and call
+    // no auth function at all — confirmed by reading each route.ts directly.
+    // `/api/contact` is the public marketing contact form (ContactForm.tsx), unauthenticated
+    // by design.
     if (
       pathname.startsWith('/api/auth/csrf') ||
       pathname.startsWith('/api/auth/login-csrf') ||
       pathname.startsWith('/api/auth/magic-link/') ||
       pathname.startsWith('/api/auth/google') ||
+      pathname.startsWith('/api/auth/apple/') ||
       pathname.startsWith('/api/auth/passkey/authenticate') ||
       pathname.startsWith('/api/auth/device/') ||
       pathname.startsWith('/api/auth/mobile/') ||
       pathname.startsWith('/api/auth/desktop/') ||
+      pathname.startsWith('/api/internal/') ||
+      pathname.startsWith('/api/notifications/unsubscribe/') ||
+      pathname.startsWith('/api/avatar/') ||
+      pathname.startsWith('/api/provisioning-status/') ||
       pathname.startsWith('/api/mcp/') ||
       pathname.startsWith('/api/drives') ||
       pathname.startsWith('/api/cron/') ||
@@ -188,6 +213,11 @@ export async function middleware(req: NextRequest) {
       pathname === '/api/auth/passkey/register' ||
       pathname === '/api/auth/passkey/register/options' ||
       pathname === '/api/auth/verify-email' ||
+      pathname === '/api/auth/step-up/magic-link/verify' ||
+      pathname === '/api/auth/logout' ||
+      pathname === '/api/ai/models' ||
+      pathname === '/api/compiled-css' ||
+      pathname === '/api/contact' ||
       pathname === '/api/health' ||
       pathname === '/api/version'
     ) {

--- a/apps/web/src/middleware/__tests__/matcher.test.ts
+++ b/apps/web/src/middleware/__tests__/matcher.test.ts
@@ -16,11 +16,14 @@ vi.mock('@/middleware/security-headers', () => ({
 vi.mock('@/lib/auth', () => ({
   validateOriginForMiddleware: vi.fn(),
   isOriginValidationBlocking: vi.fn(),
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn() }));
 
 // Import the live config so this test fails (RED) until middleware.ts is updated
-const { config } = await import('../../../middleware');
+const { config } = await import('../../middleware');
 const PATTERN = config.matcher[0].source;
 
 describe('middleware matcher', () => {

--- a/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
@@ -21,12 +21,15 @@ vi.mock('@/middleware/security-headers', () => ({
 vi.mock('@/lib/auth', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: exactly the CLI's position — it is a background process
 // with no browser session, calling these endpoints directly over HTTP.
 vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
 
-const { middleware } = await import('../../../middleware');
+const { middleware } = await import('../../middleware');
 
 describe('middleware — OAuth grant endpoints are public by protocol design', () => {
   it.each([

--- a/apps/web/src/middleware/__tests__/pre-session-and-asset-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/pre-session-and-asset-endpoints.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock all runtime dependencies so middleware() can run without a real DB/session.
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/middleware/monitoring', () => ({
+  monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
+}));
+const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: new Headers() } }));
+vi.mock('@/middleware/security-headers', () => ({
+  createSecureResponse,
+  createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isPublicPageRoute: vi.fn(() => false),
+  isPublishedSiteHost: vi.fn(() => false),
+  isSecureRequest: vi.fn(() => true),
+  shouldDisableCOEP: vi.fn(() => false),
+}));
+vi.mock('@/lib/auth', () => ({
+  validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
+  isOriginValidationBlocking: vi.fn(() => false),
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
+}));
+// No session cookie: exactly the position of an anonymous visitor (Apple sign-in,
+// email-link click-throughs, public asset requests) or a caller authenticating
+// via its own out-of-band credential (internal service secret, provisioning poll).
+vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
+
+const { middleware } = await import('../../middleware');
+
+// Regression coverage for a real bug: middleware.ts was relocated so it finally
+// executes in production for the first time (previously it lived outside the
+// src/ directory Next.js actually scans, so it silently never ran). Cross-
+// referencing this codebase's own public-route documentation
+// (apps/web/src/app/api/__tests__/security-audit-coverage.test.ts) against
+// route.ts auth code surfaced several more pre-session/public endpoints that
+// were missing from the allowlist and would now 401 before their own
+// (correct) auth logic ever ran.
+describe('middleware — pre-session auth + public asset/internal endpoints', () => {
+  it.each([
+    ['/api/auth/apple/signin', 'POST'],
+    ['/api/auth/apple/callback', 'POST'],
+    ['/api/auth/step-up/magic-link/verify', 'GET'],
+    ['/api/auth/logout', 'POST'],
+    ['/api/internal/contact', 'POST'],
+    ['/api/internal/monitoring/ingest', 'POST'],
+    ['/api/notifications/unsubscribe/abc123', 'GET'],
+    ['/api/ai/models', 'GET'],
+    ['/api/compiled-css', 'GET'],
+    ['/api/avatar/user123/photo.png', 'GET'],
+    ['/api/provisioning-status/my-tenant', 'GET'],
+    ['/api/contact', 'POST'],
+  ])('lets %s through with no session cookie instead of 401ing before the route runs', async (path, method) => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest(`https://pagespace.ai${path}`, { method });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).toHaveBeenCalled();
+    expect(response.status).not.toBe(401);
+  });
+
+  it.each([
+    ['/api/notifications/read-all', 'control: a similar but non-unsubscribe notifications path still requires a session'],
+    ['/api/account/avatar', 'control: the authenticated account-avatar-upload route (distinct from the public /api/avatar/ asset path) still requires a session'],
+  ])('%s: 401s with no session cookie', async (path) => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest(`https://pagespace.ai${path}`, { method: 'POST' });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/src/middleware/__tests__/signup-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/signup-public-endpoints.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock all runtime dependencies so middleware() can run without a real DB/session.
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/middleware/monitoring', () => ({
+  monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
+}));
+const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: new Headers() } }));
+vi.mock('@/middleware/security-headers', () => ({
+  createSecureResponse,
+  createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isPublicPageRoute: vi.fn(() => false),
+  isPublishedSiteHost: vi.fn(() => false),
+  isSecureRequest: vi.fn(() => true),
+  shouldDisableCOEP: vi.fn(() => false),
+}));
+vi.mock('@/lib/auth', () => ({
+  validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
+  isOriginValidationBlocking: vi.fn(() => false),
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
+}));
+// No session cookie: exactly the position of a brand-new visitor who has no
+// account yet (signup) or is completing email verification from a link
+// opened in a different browser/device than the one that signed up.
+vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
+
+const { middleware } = await import('../../middleware');
+
+// Regression coverage for a real bug: middleware.ts was relocated so it
+// finally executes in production for the first time (previously it lived
+// outside the src/ directory Next.js actually scans, so it silently never
+// ran). Passwordless self-registration (WebAuthn passkey signup) and
+// cross-device email verification both run with no session by definition —
+// that's what they're creating/confirming — authenticating instead via a
+// login-CSRF token, WebAuthn challenge, or an emailed one-time token. None
+// of these were in the public-routes list, so newly-live middleware would
+// 401 every anonymous signup/verification request before route.ts's own
+// (correct) unauthenticated handling ever ran, breaking new-user signup
+// entirely.
+describe('middleware — signup/verification endpoints are public (pre-session by design)', () => {
+  it.each([
+    ['/api/auth/signup-passkey/options', 'POST'],
+    ['/api/auth/signup-passkey', 'POST'],
+    ['/api/auth/passkey/register/options', 'POST'],
+    ['/api/auth/passkey/register', 'POST'],
+    ['/api/auth/verify-email', 'GET'],
+  ])('lets %s through with no session cookie instead of 401ing before the route runs', async (path, method) => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest(`https://pagespace.ai${path}`, { method });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).toHaveBeenCalled();
+    expect(response.status).not.toBe(401);
+  });
+
+  it('control: /passkey/register/handoff always requires a session (401 with none), unlike /register itself', async () => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest('https://pagespace.ai/api/auth/passkey/register/handoff', { method: 'POST' });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/src/middleware/__tests__/webhook-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/webhook-public-endpoints.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock all runtime dependencies so middleware() can run without a real DB/session.
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logSecurityEvent: vi.fn(),
+  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@/middleware/monitoring', () => ({
+  monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
+}));
+const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: new Headers() } }));
+vi.mock('@/middleware/security-headers', () => ({
+  createSecureResponse,
+  createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isPublicPageRoute: vi.fn(() => false),
+  isPublishedSiteHost: vi.fn(() => false),
+  isSecureRequest: vi.fn(() => true),
+  shouldDisableCOEP: vi.fn(() => false),
+}));
+vi.mock('@/lib/auth', () => ({
+  validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
+  isOriginValidationBlocking: vi.fn(() => false),
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
+}));
+// No session cookie: exactly a third-party webhook caller's position — Stripe,
+// Google, and Zoom are background services with no browser session, calling
+// these endpoints directly over HTTP and authenticating via their own
+// signature/HMAC check inside each route's own handler instead.
+vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
+
+const { middleware } = await import('../../middleware');
+
+// Regression coverage for a real bug: middleware.ts was relocated so it
+// finally executes in production for the first time (previously it lived
+// outside the src/ directory Next.js actually scans, so it silently never
+// ran). That means every webhook route's own signature/HMAC verification —
+// previously reached unobstructed — now has to first clear this middleware's
+// session-cookie gate. Only /api/integrations/zoom/webhook was allowlisted;
+// /api/stripe/webhook and /api/integrations/google-calendar/webhook were
+// missing, which would have 401'd Stripe billing events and Google Calendar
+// sync notifications before their own signature checks ever ran.
+describe('middleware — third-party webhooks are public (own signature/HMAC auth, no session)', () => {
+  it.each([
+    '/api/stripe/webhook',
+    '/api/integrations/google-calendar/webhook',
+    '/api/integrations/zoom/webhook',
+  ])('lets POST %s through with no session cookie instead of 401ing before the route runs', async (path) => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest(`https://pagespace.ai${path}`, { method: 'POST' });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).toHaveBeenCalled();
+    expect(response.status).not.toBe(401);
+  });
+
+  it('control: a similar but non-allowlisted integrations path still requires a session (401 with none)', async () => {
+    createSecureResponse.mockClear();
+    const req = new NextRequest('https://pagespace.ai/api/integrations/zoom/settings', { method: 'POST' });
+
+    const response = await middleware(req);
+
+    expect(createSecureResponse).not.toHaveBeenCalled();
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
+++ b/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
@@ -29,12 +29,15 @@ vi.mock('@/middleware/security-headers', () => ({
 vi.mock('@/lib/auth', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
+  MCP_TOKEN_PREFIX: 'mcp_',
+  SESSION_TOKEN_PREFIX: 'ps_sess_',
+  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: this is the exact scenario the CLI login flow hits —
 // discovery is always the first, unauthenticated request.
 vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn(() => null) }));
 
-const { middleware } = await import('../../../middleware');
+const { middleware } = await import('../../middleware');
 
 describe('middleware — RFC 8414 discovery URL', () => {
   it('rewrites /.well-known/oauth-authorization-server to the routable API handler with no session cookie', async () => {

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -3,7 +3,7 @@ import { EXIT_SUCCESS } from '../exit-codes.js';
 import type { CommandHandler } from '../router/router.js';
 
 /** @pagespace/cli npm package version — keep in sync with package.json. */
-export const CLI_VERSION = '0.1.0';
+export const CLI_VERSION = '0.1.2';
 
 export const versionHandler: CommandHandler = async (ctx, intent) => {
   if (intent.flags.json) {

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,7 +1,7 @@
 import type { CompatibilityResult } from './errors.js';
 
 /** @pagespace/sdk npm package version. */
-export const SDK_VERSION = '0.1.0';
+export const SDK_VERSION = '0.1.1';
 
 /**
  * The SDK's compiled-in floor for the server's API_CONTRACT_VERSION (ADR 0001


### PR DESCRIPTION
## Summary

`apps/web/middleware.ts` has lived one directory level outside `src/` since the repo's very first commit (`36a0d18fb`, "Open Beta Init", 2025-08-21) — but `apps/web/src/app/` (the App Router) has used `src/` from that same commit. Next.js only discovers a top-level `middleware.ts` at the project root **or** inside `src/`, not both trees at once. The practical result: **middleware has never executed, in any dev or production build, for this app's entire ~10.5-month history.**

This surfaced as a side effect of testing the (unrelated, already-merged) `@pagespace/cli`/`@pagespace/sdk` publish — every SDK client gets `IncompatibleServerError` against `pagespace.ai` because the version-check header ADR 0001 added is stamped by this same, never-executing middleware.

## Verification (not just theory)

- **Live production**: SSH'd into the running Fly container — `middleware-manifest.json` is completely empty (`{"middleware": {}, "functions": {}, "sortedMiddleware": []}`).
- **Local production build**: a from-scratch, unmodified `next build` reproduces the identical empty manifest — not a Docker/deploy artifact.
- **Dev mode**: with the file at the original path, an unauthenticated `GET /dashboard` (a protected page) returns `200`, not a redirect to `/auth/signin` — dev mode never discovered it either.
- **The fix**: moving the file into `src/` populates the manifest immediately and consistently (`sortedMiddleware: ["/"]`), locally and in a clean rebuild.
- **Why this went unnoticed for 10.5 months**: most of the *other* security headers `applySecurityHeaders` sets are redundantly also set by Caddy at the edge (`X-Frame-Options`, `X-Content-Type-Options`, HSTS, `Permissions-Policy`, COEP/COOP/CORP, etc.) — so their presence in real responses gave false confidence. `Content-Security-Policy` and `X-PageSpace-API-Version` are the only two headers *exclusively* set by this middleware, and both are the ones actually missing live.

## A second real bug found while fixing the first

Middleware hand-duplicated two of the three bearer-token prefixes `@/lib/auth` actually authenticates (`mcp_`, `ps_sess_`), silently missing `ps_at_` (OAuth access tokens from the `pagespace login` flow). Deploying the location fix alone would have swapped the version-header error for a **false 401** on every OAuth-bearer-authenticated request (`whoami`, `keys list`/`revoke`, ...) — middleware would newly start enforcing its session-cookie gate against routes that credential type calls, since it wouldn't recognize the `ps_at_` prefix as already-authenticated. Fixed by exporting the three real prefix constants from `apps/web/src/lib/auth/index.ts` as the single source of truth and importing them into `middleware.ts`, rather than hand-duplicating a subset that had already drifted out of sync once, undetected, because middleware never actually ran to reveal the drift.

## Also included

Two unrelated, stale hardcoded version constants found during CLI dry-run testing ahead of publishing `@pagespace/cli` — cosmetic display only, never read by the actual compatibility check:
- `packages/cli/src/commands/version.ts`: `CLI_VERSION` `0.1.0` → `0.1.2`
- `packages/sdk/src/version.ts`: `SDK_VERSION` `0.1.0` → `0.1.1`

## Test plan

- [x] Full web typecheck clean
- [x] Full cli + sdk typecheck clean
- [x] From-scratch `next build`: zero errors, `middleware-manifest.json` populated (`sortedMiddleware: ["/"]`)
- [x] All 7 middleware test files pass (86 tests), including new regression coverage: all three bearer prefixes (`mcp_`, `ps_sess_`, `ps_at_`) bypass the session-cookie gate; an unrecognized prefix still correctly falls through to it
- [x] Fixed 4 test files that mock `@/lib/auth` (would otherwise silently receive `undefined` for the newly-exported prefix constants)
- [x] sdk test suite (758 tests) and cli version test (2 tests) pass
- [ ] **Not yet done, deliberately flagged**: live manual verification after deploy. This activates real, previously-inert app-wide middleware — CSP in particular — against production traffic for the first time ever. Before considering this done: verify Stripe checkout, Google sign-in, realtime updates, and file/image previews all still work. This is the single biggest remaining unknown; the CSP policy reads as deliberately designed for these integrations but has never been exercised by real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TK2gJfaSxTgMsBByRzgEUp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access handling for API routes so valid bearer tokens are recognized consistently.
  * Expanded public route handling for sign-up, verification, webhook, and other unauthenticated endpoints, reducing unexpected 401 responses.
  * Added regression coverage to prevent session checks from blocking valid bearer-token and public-route requests.

* **Chores**
  * Updated CLI and SDK version numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->