### PR TITLE
fix(billing): stale-period usage window, comped-account refills, terminal heartbeat settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Subscription renewals now set the correct billing period** — a renewal used to stamp your
+  account with the billing cycle that had just *ended* (Stripe reports the old cycle on the invoice
+  itself; the new one is on its line items), so every subscriber's period looked expired the moment
+  they renewed. Renewals and plan changes now record the service period actually paid for.
 - **Usage page no longer freezes on a stale billing period** — if your monthly period lapsed
   without a renewal landing (comped accounts, or a delayed invoice), the usage breakdown silently
   clamped to the old window and showed nothing you'd spent since. It now falls back to the trailing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Usage page no longer freezes on a stale billing period** — if your monthly period lapsed
+  without a renewal landing (comped accounts, or a delayed invoice), the usage breakdown silently
+  clamped to the old window and showed nothing you'd spent since. It now falls back to the trailing
+  30 days so current usage — including Terminal machine time — always shows.
+- **Comped paid accounts get their monthly credit allowance again** — accounts on a paid tier with
+  no live Stripe subscription (founder/comped) never received an `invoice.paid` refill, so their
+  allowance and billing window froze permanently. The credit gate now rolls their window and grants
+  the tier allowance, the same way free-tier accounts refill. Subscription-backed accounts are
+  unchanged (Stripe stays authoritative).
+- **Terminal sessions now bill in 10-minute heartbeats** — interactive machine sessions previously
+  settled their runtime cost only when the session ended, so a server restart mid-session (every
+  deploy) silently dropped the whole session's usage. Heartbeat settling bounds any loss to at most
+  one interval, and a payer who runs out of credits mid-session is disconnected instead of running
+  free.
+
 ### Added
 
 - **Custom 404 pages for published Canvas sites** — pick any Canvas page in a drive's Domains &

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -776,6 +776,31 @@ describe('buildAgentTerminalHandlers', () => {
         expect(retry.activeSeconds).toBeCloseTo((2 * SETTLE_HEARTBEAT_MS) / 1000, 0);
       });
 
+      it('given the session is torn down while a heartbeat settle is FAILING, retries the pre-heartbeat window once instead of dropping it', async () => {
+        let rejectSettle: (e: Error) => void = () => {};
+        const billing = makeBilling({
+          trackUsage: vi.fn()
+            .mockImplementationOnce(() => new Promise((_, rej) => { rejectSettle = rej; })) // heartbeat settle hangs, then fails
+            .mockResolvedValue(undefined),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // heartbeat fires; settle in flight
+        const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+        onExitArg(0); // teardown races the failing settle — its end-settle bills only the ~0s tail
+        rejectSettle(new Error('db blip'));
+        await vi.advanceTimersByTimeAsync(0);
+
+        // The compensating attempt re-bills the full pre-heartbeat window against the original hold.
+        const calls = billing.trackUsage.mock.calls.map((c) => c[0]);
+        const compensating = calls.filter((c) => c.holdId === 'hold-1');
+        expect(compensating.length).toBeGreaterThanOrEqual(2); // the failed attempt + the retry
+        expect(compensating[compensating.length - 1].activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
+        // Total billed across all successful-looking calls still sums to the window (tail ≈ 0).
+        expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo((2 * SETTLE_HEARTBEAT_MS) / 1000, 0);
+      });
+
       it('given a gate infra error at a heartbeat, keeps the session alive (fail-open) rather than killing a live PTY', async () => {
         const billing = makeBilling({
           gate: vi.fn()

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, resolveAgentTerminalCommand } from '../agent-terminal-handler';
+import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand } from '../agent-terminal-handler';
 import { createTerminalSessionMap, DETACHED_IDLE_MS } from '../terminal-session-map';
 import type { AgentTerminalCheckAuthFn, OpenShellFn, SocketLike } from '../agent-terminal-handler';
 import type { PtyShell } from '../sprites-shell';
@@ -394,6 +394,27 @@ describe('buildAgentTerminalHandlers', () => {
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
     });
 
+    it('given re-auth resolves AFTER the session was already torn down, should not double-teardown (no second kill/releaseSlot)', async () => {
+      const auth = makeAuthSuccess();
+      let resolveReauth: (v: unknown) => void = () => {};
+      checkAuth
+        .mockResolvedValueOnce(auth) // connect
+        .mockImplementationOnce(() => new Promise((res) => { resolveReauth = res; })); // re-auth tick hangs
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing: makeBilling() });
+      await onConnect(validPayload);
+
+      await vi.advanceTimersByTimeAsync(60_000); // re-auth fires and is left pending
+      const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+      onExitArg(0); // session ends naturally while the re-auth check is still in flight
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
+
+      resolveReauth({ ok: false, reason: 'permission_revoked' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(shell.kill).not.toHaveBeenCalled(); // natural exit — the stale re-auth must not kill
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1); // slot not double-released
+    });
+
     it('given re-auth fires and checkAuth now fails, should kill shell, remove session, and emit agent-terminal:closed with exitCode -2', async () => {
       const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
       await onConnect(validPayload);
@@ -659,7 +680,7 @@ describe('buildAgentTerminalHandlers', () => {
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
 
-    it('on idle-timeout reap after disconnect, settles the hold to the real active-window seconds', async () => {
+    it('on idle-timeout reap after disconnect, settles the FULL active window across heartbeat slices (revenue conservation)', async () => {
       const billing = makeBilling();
       const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
       await onConnect(validPayload);
@@ -667,13 +688,124 @@ describe('buildAgentTerminalHandlers', () => {
       onDisconnect();
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
 
-      expect(billing.trackUsage).toHaveBeenCalledTimes(1);
-      const call = billing.trackUsage.mock.calls[0][0];
-      expect(call.payerId).toBe('owner-1');
-      expect(call.holdId).toBe('hold-1');
-      expect(call.pageId).toBe('t1');
-      expect(call.activeSeconds).toBeCloseTo(DETACHED_IDLE_MS / 1000, 0);
+      // The 30-min detached window spans heartbeat settles plus the reap's tail —
+      // however it is sliced, the settled seconds must sum to the whole window and
+      // every slice must carry the payer/page attribution.
+      const calls = billing.trackUsage.mock.calls.map((c) => c[0]);
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo(DETACHED_IDLE_MS / 1000, 0);
+      for (const call of calls) {
+        expect(call.payerId).toBe('owner-1');
+        expect(call.pageId).toBe('t1');
+      }
+      expect(calls[0].holdId).toBe('hold-1');
       expect(billing.releaseHold).not.toHaveBeenCalled();
+    });
+
+    describe('heartbeat settle (bounds deploy-time loss to one interval)', () => {
+      it('settles the accrued window at each heartbeat and re-holds, so session end only settles the tail', async () => {
+        let holdN = 0;
+        const billing = makeBilling({
+          gate: vi.fn().mockImplementation(async () => ({ allowed: true, holdId: `hold-${++holdN}` })),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+        const first = billing.trackUsage.mock.calls[0][0];
+        expect(first).toMatchObject({ payerId: 'owner-1', holdId: 'hold-1', pageId: 't1' });
+        expect(first.activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
+        // The session survives the heartbeat with a fresh hold in place.
+        expect(shell.kill).not.toHaveBeenCalled();
+        expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ holdId: 'hold-2' });
+
+        const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+        await vi.advanceTimersByTimeAsync(30_000);
+        onExitArg(0);
+
+        expect(billing.trackUsage).toHaveBeenCalledTimes(2);
+        const tail = billing.trackUsage.mock.calls[1][0];
+        expect(tail.holdId).toBe('hold-2');
+        expect(tail.activeSeconds).toBeCloseTo(30, 0);
+        expect(billing.releaseHold).not.toHaveBeenCalled();
+      });
+
+      it('given the gate denies at a heartbeat, settles the accrued window then tears the session down like a failed re-auth', async () => {
+        const billing = makeBilling({
+          gate: vi.fn()
+            .mockResolvedValueOnce({ allowed: true, holdId: 'hold-1' })
+            .mockResolvedValue({ allowed: false, reason: 'insufficient_balance' }),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+        // The accrued window settles against the original hold; the uniform
+        // teardown then settles the (near-zero) tail — total billed stays the window.
+        const calls = billing.trackUsage.mock.calls.map((c) => c[0]);
+        expect(calls[0].holdId).toBe('hold-1');
+        expect(calls[0].activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
+        expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
+        expect(shell.kill).toHaveBeenCalled();
+        expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
+        expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', expect.objectContaining({ exitCode: -2 }));
+      });
+
+      it('given the settle fails at a heartbeat, restores the window and hold so the next heartbeat retries the FULL window (no slice lost, no hold stacked)', async () => {
+        const billing = makeBilling({
+          trackUsage: vi.fn()
+            .mockRejectedValueOnce(new Error('db blip'))
+            .mockResolvedValue(undefined),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // settle fails
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+        expect(billing.gate).toHaveBeenCalledTimes(1); // connect only — no fresh hold stacked on the failure
+        expect(shell.kill).not.toHaveBeenCalled(); // fail-open: session stays alive
+        expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ holdId: 'hold-1' }); // hold restored
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // next heartbeat retries the whole window
+        expect(billing.trackUsage).toHaveBeenCalledTimes(2);
+        const retry = billing.trackUsage.mock.calls[1][0];
+        expect(retry.holdId).toBe('hold-1');
+        expect(retry.activeSeconds).toBeCloseTo((2 * SETTLE_HEARTBEAT_MS) / 1000, 0);
+      });
+
+      it('given a gate infra error at a heartbeat, keeps the session alive (fail-open) rather than killing a live PTY', async () => {
+        const billing = makeBilling({
+          gate: vi.fn()
+            .mockResolvedValueOnce({ allowed: true, holdId: 'hold-1' })
+            .mockRejectedValue(new Error('db unreachable')),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+        expect(shell.kill).not.toHaveBeenCalled();
+        expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+      });
+
+      it('records usage at session end even when the gate placed no hold (settle keys on payer, hold optional)', async () => {
+        const billing = makeBilling({ gate: vi.fn().mockResolvedValue({ allowed: true }) });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+        await vi.advanceTimersByTimeAsync(5_000);
+        onExitArg(0);
+
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+        const call = billing.trackUsage.mock.calls[0][0];
+        expect(call.holdId).toBeUndefined();
+        expect(call.activeSeconds).toBeCloseTo(5, 0);
+      });
     });
 
     it('given the shell exits naturally WHILE disconnected (idle reap still pending), should cancel the pending reap so it never double-settles', async () => {

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -242,11 +242,20 @@ async function settleAccruedWindow(
     loggers.realtime.error('Agent terminal heartbeat settle failed', error instanceof Error ? error : new Error(String(error)), {
       sessionKey,
     });
-    // Roll the rebase back (if no teardown settled the tail meanwhile) so the
-    // unbilled window is retried later against its original, still-live hold.
     if (sessionMap.getByKey(sessionKey) === session) {
+      // Roll the rebase back so the unbilled window is retried at the next
+      // heartbeat (or session end) against its original, still-live hold.
       session.connectedAt = windowStart;
       session.holdId = holdId;
+    } else {
+      // The session was torn down while this settle was failing: the teardown's
+      // end-settle only billed the post-rebase tail (with no hold), so nothing
+      // will ever retry THIS window. One compensating best-effort attempt —
+      // the same fire-and-forget guarantee the end-settle itself has. If it
+      // also fails, the hold expires via TTL and the window is lost.
+      void billing
+        .trackUsage({ payerId, holdId, activeSeconds, pageId: session.pageId })
+        .catch(() => {});
     }
     return true;
   }

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -102,6 +102,15 @@ function readConnectionId(payload: unknown): string | undefined {
 
 export const MAX_INPUT_BYTES = 4096;
 
+/**
+ * How often a live metered session settles its accrued active window mid-flight.
+ * Sessions live in an in-memory map, so a realtime restart (every deploy) used to
+ * silently lose the WHOLE session's billing; heartbeat settling bounds that loss
+ * to one interval. Kept under the credit hold's TTL (15 min) so the window's
+ * reservation never expires while its session is still accruing.
+ */
+export const SETTLE_HEARTBEAT_MS = 10 * 60 * 1000;
+
 /** Discover the NEWLY created session's id by diffing the Sprite's session list against a snapshot taken before it was launched. Best-effort — an ambiguous or failed lookup just means the next reconnect falls back to a fresh session, exactly like a vanished session already does. */
 async function discoverNewSessionId(sprite: SpriteInstanceLike, before: { id: string }[]): Promise<string | undefined> {
   try {
@@ -137,12 +146,13 @@ export function resolveAgentTerminalCommand({
 }
 
 /**
- * Ends a metered session: settles its hold to the real active-window cost
- * (wall-clock from `connectedAt` to now) BEFORE removing it from the map, so a
- * near-simultaneous reconnect can never observe a stale, already-billed
- * session. Best-effort and fire-and-forget — a billing failure must never
- * block session cleanup. No-op billing fields (unset `billing`, or no
- * `holdId` because the session was never gated) mean nothing to settle.
+ * Ends a metered session: settles the tail of its active window (wall-clock from
+ * `connectedAt` — the connect time, or the last heartbeat rebase — to now)
+ * BEFORE removing it from the map, so a near-simultaneous reconnect can never
+ * observe a stale, already-billed session. Settle keys on the payer + window
+ * start; `holdId` is optional (mirrors tool-runners — a gate that placed no
+ * hold still had a real, billable window). Best-effort and fire-and-forget — a
+ * billing failure must never block session cleanup.
  */
 function endAgentTerminalSession(
   billing: SandboxBillingDeps | undefined,
@@ -151,7 +161,22 @@ function endAgentTerminalSession(
   sessionKey: string,
 ): void {
   sessionMap.deleteByKey(sessionKey);
-  if (billing && session.holdId && session.payerId && session.connectedAt !== undefined) {
+  // This is the one funnel every teardown path goes through, so it owns clearing
+  // ALL of the session's timers — a caller that forgets one can't leak a firing
+  // interval against a dead session.
+  if (session.reAuthInterval !== undefined) {
+    clearInterval(session.reAuthInterval);
+    session.reAuthInterval = undefined;
+  }
+  if (session.settleInterval !== undefined) {
+    clearInterval(session.settleInterval);
+    session.settleInterval = undefined;
+  }
+  if (session.idleTimer !== undefined) {
+    clearTimeout(session.idleTimer);
+    session.idleTimer = undefined;
+  }
+  if (billing && session.payerId && session.connectedAt !== undefined) {
     const activeSeconds = Math.max(0, (Date.now() - session.connectedAt) / 1000);
     void billing
       .trackUsage({ payerId: session.payerId, holdId: session.holdId, activeSeconds, pageId: session.pageId })
@@ -161,6 +186,120 @@ function endAgentTerminalSession(
         });
       });
   }
+}
+
+/**
+ * Forced teardown of a live session (failed re-auth, payer insolvent at a
+ * heartbeat): release the concurrency slot, kill the PTY, settle + remove the
+ * session (endAgentTerminalSession clears all timers), and notify the viewer.
+ */
+function teardownAgentTerminalSession(
+  billing: SandboxBillingDeps | undefined,
+  sessionMap: TerminalSessionMap,
+  session: TerminalSession,
+  sessionKey: string,
+  exitCode: number,
+): void {
+  session.releaseSlot();
+  session.command.kill();
+  endAgentTerminalSession(billing, sessionMap, session, sessionKey);
+  session.closedFn(exitCode);
+}
+
+/**
+ * Heartbeat settle for a live metered session: settles the window accrued since
+ * `connectedAt` against the current hold, rebases the window start to now, and
+ * places a fresh hold for the next interval. The rebase happens SYNCHRONOUSLY
+ * before any await so a teardown racing this settle only ever bills the
+ * (near-zero) tail, never the same window twice. If the settle FAILS, the
+ * rebase is rolled back and the hold kept, so the next heartbeat (or the
+ * end-of-session settle) retries the whole window instead of silently losing
+ * it — and no fresh hold is stacked on top of the still-live one. No fresh
+ * hold is placed if the session ended while the settle was in flight — there
+ * would be nobody left to settle or release it.
+ *
+ * Returns false ONLY on an explicit gate denial after a successful settle
+ * (the payer genuinely can't cover the next window) — the caller tears the
+ * session down. Infra errors keep the session alive (fail-open): killing a
+ * live PTY over a transient billing outage is worse than a delayed settle.
+ */
+async function settleAccruedWindow(
+  billing: SandboxBillingDeps,
+  sessionMap: TerminalSessionMap,
+  session: TerminalSession,
+  sessionKey: string,
+): Promise<boolean> {
+  if (!session.payerId || session.connectedAt === undefined) return true;
+  const payerId = session.payerId;
+  const holdId = session.holdId;
+  const windowStart = session.connectedAt;
+  session.connectedAt = Date.now();
+  session.holdId = undefined;
+  const activeSeconds = Math.max(0, (session.connectedAt - windowStart) / 1000);
+  try {
+    await billing.trackUsage({ payerId, holdId, activeSeconds, pageId: session.pageId });
+  } catch (error) {
+    loggers.realtime.error('Agent terminal heartbeat settle failed', error instanceof Error ? error : new Error(String(error)), {
+      sessionKey,
+    });
+    // Roll the rebase back (if no teardown settled the tail meanwhile) so the
+    // unbilled window is retried later against its original, still-live hold.
+    if (sessionMap.getByKey(sessionKey) === session) {
+      session.connectedAt = windowStart;
+      session.holdId = holdId;
+    }
+    return true;
+  }
+  if (sessionMap.getByKey(sessionKey) !== session) return true;
+  try {
+    const gate = await billing.gate({ payerId });
+    if (!gate.allowed) return false;
+    // Re-check liveness: the session may have ended while the gate ran, and a
+    // hold assigned to a dead session would leak until its TTL expiry.
+    if (sessionMap.getByKey(sessionKey) !== session) {
+      if (gate.holdId) void billing.releaseHold(gate.holdId).catch(() => {});
+      return true;
+    }
+    session.holdId = gate.holdId;
+  } catch (error) {
+    loggers.realtime.error('Agent terminal heartbeat re-hold failed', error instanceof Error ? error : new Error(String(error)), {
+      sessionKey,
+    });
+  }
+  return true;
+}
+
+/**
+ * Arms the heartbeat for a metered session (see SETTLE_HEARTBEAT_MS). A
+ * module-level factory rather than a closure inside onConnect so the
+ * long-lived interval callback captures only what it needs — not the whole
+ * connect scope (auth result, Sprite handle, session-list snapshots).
+ */
+function startSettleHeartbeat(
+  billing: SandboxBillingDeps,
+  sessionMap: TerminalSessionMap,
+  session: TerminalSession,
+  sessionKey: string,
+): ReturnType<typeof setInterval> {
+  let settling = false;
+  const interval = setInterval(async () => {
+    if (sessionMap.getByKey(sessionKey) !== session) { clearInterval(interval); return; }
+    if (settling) return;
+    settling = true;
+    try {
+      const solvent = await settleAccruedWindow(billing, sessionMap, session, sessionKey);
+      if (!solvent && sessionMap.getByKey(sessionKey) === session) {
+        loggers.realtime.info('Agent terminal session ended (payer out of credits at heartbeat)', {
+          sessionKey,
+          sandboxId: session.sandboxId,
+        });
+        teardownAgentTerminalSession(billing, sessionMap, session, sessionKey, -2);
+      }
+    } finally {
+      settling = false;
+    }
+  }, SETTLE_HEARTBEAT_MS);
+  return interval;
 }
 
 export function buildAgentTerminalHandlers({
@@ -190,9 +329,9 @@ export function buildAgentTerminalHandlers({
     session.closedFn = () => {};
     sessionMap.detach(connectionId);
     session.idleTimer = setTimeout(() => {
-      if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
       session.releaseSlot();
       session.command.kill();
+      // Clears all of the session's timers (re-auth, settle heartbeat, idle).
       endAgentTerminalSession(billing, sessionMap, session, sessionKey);
       loggers.realtime.info('Agent terminal session reaped (idle)', { sessionKey, sandboxId: session.sandboxId });
     }, DETACHED_IDLE_MS);
@@ -301,11 +440,10 @@ export function buildAgentTerminalHandlers({
             session.outputFn(data);
           },
           onExit: (exitCode) => {
-            if (session.reAuthInterval !== undefined) clearInterval(session.reAuthInterval);
-            if (session.idleTimer !== undefined) clearTimeout(session.idleTimer);
             session.releaseSlot();
             loggers.realtime.info('Agent terminal session closed', { exitCode, sandboxId, sessionKey });
             session.closedFn(exitCode);
+            // Clears all of the session's timers (re-auth, settle heartbeat, idle).
             endAgentTerminalSession(billing, sessionMap, session, sessionKey);
           },
         });
@@ -332,19 +470,30 @@ export function buildAgentTerminalHandlers({
         });
       }
 
+      // Heartbeat settle (see SETTLE_HEARTBEAT_MS): bill the accrued window and
+      // re-hold on an interval so a realtime restart loses at most one interval
+      // of runtime, not the whole session. A gate DENIAL (payer out of credits)
+      // tears the session down exactly like a failed re-auth below.
+      if (billing) {
+        session.settleInterval = startSettleHeartbeat(billing, sessionMap, session, sessionKey);
+      }
+
       // Periodically re-check authorization while the session is alive.
       // Routes closed notification through closedFn so it reaches the current socket.
       const reAuthInterval = setInterval(async () => {
         const liveSession = sessionMap.getByKey(sessionKey);
         if (!liveSession) { clearInterval(reAuthInterval); return; }
         const result = await checkAuth({ userId, terminalId, projectName, branchName, name });
-        if (!result.ok) {
+        // Re-check liveness after the await: another actor (heartbeat insolvency,
+        // PTY exit, idle reap) may have torn the session down while checkAuth ran —
+        // acting on the stale reference would double releaseSlot/kill/closedFn.
+        if (sessionMap.getByKey(sessionKey) !== liveSession) {
+          if (result.ok) result.releaseSlot();
           clearInterval(reAuthInterval);
-          if (liveSession.idleTimer !== undefined) clearTimeout(liveSession.idleTimer);
-          liveSession.releaseSlot();
-          liveSession.command.kill();
-          endAgentTerminalSession(billing, sessionMap, liveSession, sessionKey);
-          liveSession.closedFn(-2);
+          return;
+        }
+        if (!result.ok) {
+          teardownAgentTerminalSession(billing, sessionMap, liveSession, sessionKey, -2);
         } else {
           result.releaseSlot();
         }

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -10,6 +10,8 @@ export type TerminalSession = {
   /** Detachable exec session id on the Sprite, used to reattach after a WS drop. */
   sessionId?: string;
   reAuthInterval?: ReturnType<typeof setInterval>;
+  /** Heartbeat that settles the accrued active window mid-session (see agent-terminal-handler), bounding what a realtime restart can lose to one interval. */
+  settleInterval?: ReturnType<typeof setInterval>;
   idleTimer?: ReturnType<typeof setTimeout>;
   releaseSlot(): void;
   outputFn: (data: string) => void;
@@ -18,8 +20,10 @@ export type TerminalSession = {
   scrollbackBytes: number;
   /**
    * Terminal Epic 3 metering (optional — set only when a `billing` seam is
-   * wired). `payerId` + `connectedAt` are always set together with `holdId` so
-   * the session's end hook can settle the active-runtime hold to its real cost.
+   * wired). `payerId` + `connectedAt` identify who pays for the window that
+   * started at `connectedAt` (rebased by each heartbeat settle); `holdId` is the
+   * window's reservation when the gate placed one — settle records usage either
+   * way, the hold is just the pre-authorization.
    */
   payerId?: string;
   holdId?: string;

--- a/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
+++ b/apps/web/src/lib/subscription/__tests__/usage-breakdown.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { aggregateUsageBreakdown, type UsageLedgerRow } from '../usage-breakdown';
+import {
+  aggregateUsageBreakdown,
+  resolveUsageWindow,
+  USAGE_FALLBACK_LOOKBACK_MS,
+  type UsageLedgerRow,
+} from '../usage-breakdown';
 
 const PERIOD = { periodStart: '2026-06-01T00:00:00.000Z', periodEnd: '2026-07-01T00:00:00.000Z' };
 
@@ -13,6 +18,42 @@ const row = (over: Partial<UsageLedgerRow>): UsageLedgerRow => ({
   pageTitle: null,
   durationMs: null,
   ...over,
+});
+
+describe('resolveUsageWindow', () => {
+  const NOW = new Date('2026-07-07T12:00:00.000Z');
+
+  it('given a current period (periodEnd in the future), should use the stored window unchanged', () => {
+    const periodStart = new Date('2026-06-13T00:00:00.000Z');
+    const periodEnd = new Date('2026-07-13T00:00:00.000Z');
+    expect(resolveUsageWindow({ periodStart, periodEnd, now: NOW })).toEqual({ periodStart, periodEnd });
+  });
+
+  it('given a stale period (periodEnd in the past), should fall back to the trailing lookback ending now', () => {
+    const r = resolveUsageWindow({
+      periodStart: new Date('2026-05-13T00:00:00.000Z'),
+      periodEnd: new Date('2026-06-13T00:00:00.000Z'),
+      now: NOW,
+    });
+    expect(r.periodEnd).toBeNull();
+    expect(r.periodStart.getTime()).toBe(NOW.getTime() - USAGE_FALLBACK_LOOKBACK_MS);
+  });
+
+  it('given a balance row with a start but no periodEnd, should keep the open-ended stored window', () => {
+    const periodStart = new Date('2026-06-13T00:00:00.000Z');
+    expect(resolveUsageWindow({ periodStart, periodEnd: null, now: NOW })).toEqual({ periodStart, periodEnd: null });
+  });
+
+  it('given no balance row at all, should fall back to the trailing lookback ending now', () => {
+    const r = resolveUsageWindow({ periodStart: null, periodEnd: null, now: NOW });
+    expect(r.periodEnd).toBeNull();
+    expect(r.periodStart.getTime()).toBe(NOW.getTime() - USAGE_FALLBACK_LOOKBACK_MS);
+  });
+
+  it('given a periodEnd exactly at now, should treat the window as still current (boundary is inclusive)', () => {
+    const periodStart = new Date('2026-06-07T12:00:00.000Z');
+    expect(resolveUsageWindow({ periodStart, periodEnd: NOW, now: NOW })).toEqual({ periodStart, periodEnd: NOW });
+  });
 });
 
 describe('aggregateUsageBreakdown', () => {

--- a/apps/web/src/lib/subscription/usage-breakdown-query.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown-query.ts
@@ -10,10 +10,7 @@ import { and, eq, gte, lte } from '@pagespace/db/operators';
 import { creditBalances, creditLedger } from '@pagespace/db/schema/credits';
 import { aiUsageLogs } from '@pagespace/db/schema/monitoring';
 import { pages } from '@pagespace/db/schema/core';
-import { aggregateUsageBreakdown, type UsageBreakdown } from './usage-breakdown';
-
-/** Fallback lookback when the user has no billing-period window yet. */
-const DEFAULT_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+import { aggregateUsageBreakdown, resolveUsageWindow, type UsageBreakdown } from './usage-breakdown';
 
 /**
  * Spend-by-feature, spend-by-model, and (for source:'terminal') spend-by-machine for
@@ -38,8 +35,13 @@ export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakd
     .where(eq(creditBalances.userId, userId))
     .limit(1);
 
-  const periodStart = balance?.periodStart ?? new Date(Date.now() - DEFAULT_LOOKBACK_MS);
-  const periodEnd = balance?.periodEnd ?? null;
+  // A stale window (periodEnd in the past — renewal never landed) falls back to
+  // the trailing lookback so current spend is never hidden; see resolveUsageWindow.
+  const { periodStart, periodEnd } = resolveUsageWindow({
+    periodStart: balance?.periodStart ?? null,
+    periodEnd: balance?.periodEnd ?? null,
+    now: new Date(),
+  });
 
   const rows = await db
     .select({
@@ -65,9 +67,9 @@ export async function getUserUsageBreakdown(userId: string): Promise<UsageBreakd
         eq(creditLedger.userId, userId),
         eq(creditLedger.entryType, 'usage'),
         gte(creditLedger.createdAt, periodStart),
-        // Bound the window to the period end so a stale balance (period rolled but not
-        // yet reset) can't leak the next period's spend into "this period". When
-        // periodEnd is in the future (the normal current period) this excludes nothing.
+        // Upper bound only for a CURRENT period (resolveUsageWindow nulls periodEnd
+        // for stale/missing windows), where it excludes nothing today but keeps the
+        // window honest if the clock/period ever race.
         ...(periodEnd ? [lte(creditLedger.createdAt, periodEnd)] : []),
       ),
     );

--- a/apps/web/src/lib/subscription/usage-breakdown.ts
+++ b/apps/web/src/lib/subscription/usage-breakdown.ts
@@ -35,6 +35,41 @@ export interface UsageBreakdownPeriod {
   periodEnd: string | null;
 }
 
+/** Fallback lookback when the user has no usable billing-period window. */
+export const USAGE_FALLBACK_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the time window the usage breakdown queries over. The stored billing
+ * period is only trusted while it is CURRENT: paid-tier periods roll on Stripe
+ * `invoice.paid`, so an account whose renewal never landed (comped/founder, or a
+ * webhook gap) keeps a stale `monthlyPeriodEnd` forever — and a window clamped to
+ * it would hide ALL usage after that date (the 2026-07-07 audit found a month of
+ * real spend invisible this way). A stale or missing window therefore falls back
+ * to the trailing lookback ending now: honest "recent usage", never a frozen one.
+ *
+ * Deliberate trade-offs:
+ * - A null `periodEnd` WITH a start is kept as an open-ended current window
+ *   (display semantics), even though the credit gate treats that state as
+ *   expired and will stamp a window on the user's next AI call.
+ * - During a brief renewal lag (invoice retrying for a day or two) the fallback
+ *   fires too, so the page briefly shows trailing-30d instead of the lapsed
+ *   period. Showing current spend during the lag beats freezing the page on the
+ *   old period — which is exactly the audit bug this fixes.
+ */
+export function resolveUsageWindow({
+  periodStart,
+  periodEnd,
+  now,
+}: {
+  periodStart: Date | null;
+  periodEnd: Date | null;
+  now: Date;
+}): { periodStart: Date; periodEnd: Date | null } {
+  const stale = periodStart === null || (periodEnd !== null && periodEnd < now);
+  if (stale) return { periodStart: new Date(now.getTime() - USAGE_FALLBACK_LOOKBACK_MS), periodEnd: null };
+  return { periodStart, periodEnd };
+}
+
 export interface UsageFeatureRow {
   source: AIUsageSource;
   label: string;

--- a/packages/lib/src/billing/__tests__/credit-funding.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-funding.test.ts
@@ -190,6 +190,72 @@ describe('applyStripeFunding', () => {
     });
   });
 
+  it('invoice.paid stamps the LINE-ITEM service period, not the invoice-level fields (which describe the just-ended cycle)', async () => {
+    // Stripe renewal invoices: invoice.period_start/end = the cycle that just ENDED;
+    // the NEW service period being paid for lives on the line item. Stamping the
+    // invoice-level fields froze every subscriber's window at "already expired"
+    // (2026-07-07 audit: all 4 live subscribers stale immediately after renewal).
+    const OLD_START = 1_697_000_000; // just-ended cycle
+    const OLD_END = 1_700_000_000;
+    const NEW_START = 1_700_000_000; // service period actually paid for
+    const NEW_END = 1_702_592_000;
+    const renewalEvent = {
+      id: 'evt_renewal',
+      type: 'invoice.paid',
+      data: {
+        object: {
+          id: 'in_renewal',
+          customer: 'cus_1',
+          period_start: OLD_START,
+          period_end: OLD_END,
+          lines: { data: [{ period: { start: NEW_START, end: NEW_END } }] },
+        },
+      },
+    };
+    mockDb.select.mockReturnValue(userSelectReturning(PRO_USER));
+    const cap: Captured = {};
+    mockDb.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+      await cb(refillTx(cap, [{ id: 'led_renewal' }], 0));
+    });
+
+    await applyStripeFunding(renewalEvent);
+
+    expect(cap.balanceSet).toMatchObject({
+      monthlyPeriodStart: new Date(NEW_START * 1000),
+      monthlyPeriodEnd: new Date(NEW_END * 1000),
+    });
+  });
+
+  it('invoice.paid with multiple lines (plan-change proration) stamps the line with the LATEST period end', async () => {
+    const prorationLine = { period: { start: 1_699_000_000, end: 1_700_000_000 } }; // old plan remainder
+    const newPlanLine = { period: { start: 1_700_000_000, end: 1_702_592_000 } }; // new plan's full period
+    const planChangeEvent = {
+      id: 'evt_change',
+      type: 'invoice.paid',
+      data: {
+        object: {
+          id: 'in_change',
+          customer: 'cus_1',
+          period_start: 1_697_000_000,
+          period_end: 1_700_000_000,
+          lines: { data: [prorationLine, newPlanLine] },
+        },
+      },
+    };
+    mockDb.select.mockReturnValue(userSelectReturning(PRO_USER));
+    const cap: Captured = {};
+    mockDb.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+      await cb(refillTx(cap, [{ id: 'led_change' }], 0));
+    });
+
+    await applyStripeFunding(planChangeEvent);
+
+    expect(cap.balanceSet).toMatchObject({
+      monthlyPeriodStart: new Date(1_700_000_000 * 1000),
+      monthlyPeriodEnd: new Date(1_702_592_000 * 1000),
+    });
+  });
+
   it('invoice.paid accumulates: adds allowance on top of carried monthly balance (rollover)', async () => {
     mockDb.select.mockReturnValue(userSelectReturning(PRO_USER));
     const cap: Captured = {};

--- a/packages/lib/src/billing/__tests__/credit-gate.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-gate.test.ts
@@ -125,11 +125,20 @@ function mockLazyInitTransaction(
 function mockResetTransaction(
   sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown>; updateCalled?: boolean } = {},
   lockedRow: Record<string, unknown> | null = null,
+  // Rows the IN-TRANSACTION subscription re-check resolves to (paid tiers only;
+  // `.limit()` chain). Non-empty models a subscription that appeared between the
+  // unlocked pre-check and the grant — the reset must abort.
+  txSubscriptionRows: Record<string, unknown>[] = [],
 ) {
   mockDb.transaction.mockImplementationOnce(async (cb: (tx: unknown) => Promise<unknown>) => {
     const tx = {
       select: vi.fn(() => ({
-        from: () => ({ where: () => ({ for: () => Promise.resolve(lockedRow ? [lockedRow] : []) }) }),
+        from: () => ({
+          where: () => ({
+            for: () => Promise.resolve(lockedRow ? [lockedRow] : []),
+            limit: () => Promise.resolve(txSubscriptionRows),
+          }),
+        }),
       })),
       update: vi.fn(() => {
         sink.updateCalled = true;
@@ -441,13 +450,94 @@ describe('canConsumeAI', () => {
     expect(r.allowed).toBe(true);
   });
 
-  it('does NOT gate-reset a paid user with an expired window — invoice.paid is authoritative', async () => {
-    mockDb.select.mockReturnValue(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+  it('does NOT gate-reset a paid user with an expired window while a renewal-capable subscription exists — invoice.paid is authoritative', async () => {
+    mockDb.select
+      // 1st: balance pre-read (expired window)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      // 2nd: subscription lookup — a live (renewal-capable) subscription row
+      .mockReturnValueOnce(selectReturning([{ id: 'sub_1' }]));
     mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
 
     const r = await canConsumeAI('u1', 'pro');
     expect(mockDb.update).not.toHaveBeenCalled();
     expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' });
+  });
+
+  it('gate-resets a paid user with an expired window and NO renewal-capable subscription (comped account — no invoice will ever roll it)', async () => {
+    mockDb.select
+      // 1st: balance pre-read (expired window)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      // 2nd: subscription lookup — no live subscription rows
+      .mockReturnValueOnce(selectReturning([]))
+      // 3rd: balance re-read after the reset
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 10000, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    const sink: { set?: Record<string, unknown>; ledgerValues?: Record<string, unknown> } = {};
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
+    mockTransaction({ monthlyRemainingCents: 10000, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'business');
+
+    // Business tier allowance (10000¢) granted, window rolled.
+    expect(sink.set).toMatchObject({ monthlyRemainingCents: 10000, monthlyAllowanceCents: 10000 });
+    expect(sink.ledgerValues).toMatchObject({ entryType: 'monthly_grant', amountCents: 10000 });
+    expect(r.allowed).toBe(true);
+    expect(r.reason).toBe('ok');
+  });
+
+  it('treats an "unpaid" subscription as renewal-capable — its open invoices are still collectible, so no gate roll', async () => {
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ id: 'sub_unpaid' }])); // status filter matched an 'unpaid' row
+    mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'pro');
+    expect(mockDb.update).not.toHaveBeenCalled();
+    expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' });
+  });
+
+  it('does NOT gate-reset a tier with no defined allowance (legacy "normal") — the roll would rewrite the account to free-tier values', async () => {
+    mockDb.select.mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+    mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'normal' as unknown as Parameters<typeof canConsumeAI>[1]);
+    // Neither the reset transaction nor the subscription lookup ran — one select (pre-read) only.
+    expect(mockDb.select).toHaveBeenCalledTimes(1);
+    expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' });
+  });
+
+  it('aborts the paid gate-reset when a renewal-capable subscription appears between the pre-check and the grant (in-tx re-check)', async () => {
+    mockDb.select
+      // 1st: balance pre-read (expired window)
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      // 2nd: unlocked subscription lookup — nothing yet (checkout still in flight)
+      .mockReturnValueOnce(selectReturning([]))
+      // 3rd: balance re-read after the (aborted) reset — unchanged
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]));
+    const sink: { updateCalled?: boolean; ledgerValues?: Record<string, unknown> } = {};
+    // In-tx re-check now sees the freshly committed subscription row → abort.
+    mockResetTransaction(sink, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST }, [{ id: 'sub_new' }]);
+    mockTransaction({ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'business');
+
+    expect(sink.updateCalled).toBeUndefined(); // no grant written
+    expect(sink.ledgerValues).toBeUndefined();
+    expect(r).toMatchObject({ allowed: false, reason: 'out_of_credits' }); // invoice.paid owns the refill now
+  });
+
+  it('does NOT look up subscriptions for a free user with an expired window (free reset path unchanged)', async () => {
+    mockDb.select
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 0, topupRemainingCents: 0, monthlyPeriodEnd: PAST }]))
+      .mockReturnValueOnce(selectReturning([{ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }]));
+    mockResetTransaction({}, { monthlyRemainingCents: 0, debtCents: 0, monthlyPeriodEnd: PAST });
+    mockTransaction({ monthlyRemainingCents: 500, topupRemainingCents: 0, monthlyPeriodEnd: FUTURE }, { reserved: 0, inFlight: 0 });
+
+    const r = await canConsumeAI('u1', 'free');
+
+    // Exactly two unlocked selects: the pre-read and the post-reset re-read — no
+    // subscription lookup in between.
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
+    expect(r.allowed).toBe(true);
   });
 
   it('counts a paid user\'s carried monthly balance as spendable even after the window expires (rollover)', async () => {

--- a/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
+++ b/packages/lib/src/billing/__tests__/credits-flow.integration.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // ── A column reference the fake operators/select can resolve against a row ────────
 type Col = { __col: true; table: TableKey; name: string };
-type TableKey = 'creditBalances' | 'creditLedger' | 'creditHolds' | 'users' | 'aiUsageLogs';
+type TableKey = 'creditBalances' | 'creditLedger' | 'creditHolds' | 'users' | 'aiUsageLogs' | 'subscriptions';
 
 interface Row { [k: string]: unknown }
 type Store = Record<TableKey, Row[]>;
@@ -39,7 +39,7 @@ type Pred =
 
 // ── Hoisted shared state: one store + one fake db, shared by all four real shells ─
 const H = vi.hoisted(() => {
-  const store: Store = { creditBalances: [], creditLedger: [], creditHolds: [], users: [], aiUsageLogs: [] };
+  const store: Store = { creditBalances: [], creditLedger: [], creditHolds: [], users: [], aiUsageLogs: [], subscriptions: [] };
 
   const col = (table: TableKey, name: string): Col => ({ __col: true, table, name });
   const cols = (table: TableKey, names: string[]): Record<string, Col> & { __table: TableKey } => {
@@ -59,6 +59,7 @@ const H = vi.hoisted(() => {
   ]);
   const creditHolds = cols('creditHolds', ['id', 'userId', 'estCents', 'aiUsageLogId', 'createdAt', 'expiresAt']);
   const users = cols('users', ['id', 'stripeCustomerId', 'subscriptionTier']);
+  const subscriptions = cols('subscriptions', ['id', 'userId', 'status']);
   const aiUsageLogs = cols('aiUsageLogs', [
     'id', 'userId', 'cost', 'timestamp', 'success', 'provider',
     'metadata', 'reconcileStatus', 'reconcileAttempts', 'reconciledAt',
@@ -392,7 +393,7 @@ const H = vi.hoisted(() => {
 
   return {
     store, db, isBillingEnabled, logger,
-    schema: { creditBalances, creditLedger, creditHolds, users, aiUsageLogs },
+    schema: { creditBalances, creditLedger, creditHolds, users, aiUsageLogs, subscriptions },
     ops: { eq, lt, gt, gte, inArray, notInArray, isNull, and, or, sql: sqlTag },
   };
 });
@@ -400,6 +401,7 @@ const H = vi.hoisted(() => {
 vi.mock('@pagespace/db/db', () => ({ db: H.db }));
 vi.mock('@pagespace/db/schema/credits', () => ({ creditBalances: H.schema.creditBalances, creditLedger: H.schema.creditLedger, creditHolds: H.schema.creditHolds }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: H.schema.users }));
+vi.mock('@pagespace/db/schema/subscriptions', () => ({ subscriptions: H.schema.subscriptions }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({ aiUsageLogs: H.schema.aiUsageLogs }));
 vi.mock('@pagespace/db/operators', () => H.ops);
 vi.mock('../../deployment-mode', () => ({ isBillingEnabled: H.isBillingEnabled }));
@@ -429,10 +431,16 @@ function reset() {
   store.creditHolds.length = 0;
   store.users.length = 0;
   store.aiUsageLogs.length = 0;
+  store.subscriptions.length = 0;
 }
 
 function seedUser(id: string, customer: string, tier: string) {
   store.users.push({ id, stripeCustomerId: customer, subscriptionTier: tier });
+}
+
+/** A Stripe-backed subscription in a renewal-capable status — makes invoice.paid (not the gate) authoritative for this user's period roll. */
+function seedLiveSubscription(userId: string, status = 'active') {
+  store.subscriptions.push({ id: `sub_${userId}`, userId, status });
 }
 
 function balanceOf(userId: string) {
@@ -736,7 +744,7 @@ describe('credits flow — crash recovery (backfill reconcile)', () => {
 
 describe('credits flow — monthly reset', () => {
   it('gate resets an expired period to the tier allowance for a FREE user and rolls the window forward', async () => {
-    seedUser('u1', 'cus_1', 'free'); // gate-driven reset is free-only; paid users refill via invoice.paid
+    seedUser('u1', 'cus_1', 'free'); // free users always refill via the gate; subscription-backed paid users via invoice.paid
     // Drained balance whose period already ended yesterday.
     store.creditBalances.push({
       userId: 'u1', monthlyRemainingCents: 0, monthlyAllowanceCents: 500,
@@ -752,8 +760,9 @@ describe('credits flow — monthly reset', () => {
     expect(balanceOf('u1')!.monthlyPeriodEnd!.getTime()).toBeGreaterThan(Date.now()); // window advanced
   });
 
-  it('paid user with expired window and ZERO carry is blocked (no credits, not because of expiry)', async () => {
+  it('paid user with expired window, a live subscription, and ZERO carry is blocked (no credits — invoice.paid owns the refill)', async () => {
     seedUser('u3', 'cus_3', 'pro');
+    seedLiveSubscription('u3');
     store.creditBalances.push({
       userId: 'u3', monthlyRemainingCents: 0, monthlyAllowanceCents: 1500,
       topupRemainingCents: 0, pendingMillicents: 0,
@@ -767,8 +776,29 @@ describe('credits flow — monthly reset', () => {
     expect(balanceOf('u3')!.monthlyRemainingCents).toBe(0); // gate does NOT refill; invoice.paid does
   });
 
-  it('paid user with expired window and carry credits CAN spend (rollover — carry is always spendable)', async () => {
+  it('paid user with expired window and NO live subscription (comped account) gets the gate-driven roll — no invoice will ever arrive', async () => {
+    seedUser('u5', 'cus_5', 'business');
+    // A dead subscription must not block the roll — it can never deliver an invoice.
+    store.subscriptions.push({ id: 'sub_u5_old', userId: 'u5', status: 'incomplete_expired' });
+    store.creditBalances.push({
+      userId: 'u5', monthlyRemainingCents: 0, monthlyAllowanceCents: 10000,
+      topupRemainingCents: 0, pendingMillicents: 0,
+      monthlyPeriodStart: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
+      monthlyPeriodEnd: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      updatedAt: new Date(),
+    });
+
+    const gate = await canConsumeAI('u5', 'business');
+    expect(gate).toMatchObject({ allowed: true, reason: 'ok' });
+    expect(balanceOf('u5')!.monthlyRemainingCents).toBe(TIER_MONTHLY_ALLOWANCE_CENTS.business); // refilled at the paid tier's allowance
+    expect(balanceOf('u5')!.monthlyPeriodEnd!.getTime()).toBeGreaterThan(Date.now()); // window advanced
+    // The grant is ledgered under the gate-reset ref, distinguishable from free resets.
+    expect(ledgerOf('u5').some((r) => r.entryType === 'monthly_grant' && String(r.stripeRef).startsWith('gate-reset-'))).toBe(true);
+  });
+
+  it('paid user with expired window, a live subscription, and carry credits CAN spend (rollover — carry is always spendable)', async () => {
     seedUser('u4', 'cus_4', 'pro');
+    seedLiveSubscription('u4');
     store.creditBalances.push({
       userId: 'u4', monthlyRemainingCents: 400, monthlyAllowanceCents: 1500,
       topupRemainingCents: 0, pendingMillicents: 0,

--- a/packages/lib/src/billing/credit-funding.ts
+++ b/packages/lib/src/billing/credit-funding.ts
@@ -77,19 +77,30 @@ function toDate(ts?: number | null): Date | null {
 }
 
 /**
- * The renewal invoice is the period boundary: take period_start/period_end from
- * the invoice, falling back to the first line item's period. Either may be absent
- * (the schema allows NULL period dates).
+ * The renewal invoice is the period boundary. The SERVICE period being paid for
+ * lives on the invoice's line items — Stripe's invoice-level period_start/end
+ * describe the cycle that just ENDED (for a first invoice, both equal the
+ * creation instant), so stamping those froze every subscriber's window at
+ * "already expired" the moment their renewal landed (2026-07-07 audit). Prefer
+ * the line with the LATEST period end (a plan-change invoice carries proration
+ * lines for the old plan alongside the new plan's full period); fall back to
+ * the invoice-level fields only when no line carries a period.
  */
 function invoicePeriod(obj: FundingEventObject): { start: Date | null; end: Date | null } {
-  let start = toDate(obj.period_start);
-  let end = toDate(obj.period_end);
-  if (!start || !end) {
-    const linePeriod = obj.lines?.data?.[0]?.period;
-    start = start ?? toDate(linePeriod?.start);
-    end = end ?? toDate(linePeriod?.end);
+  let start: Date | null = null;
+  let end: Date | null = null;
+  for (const line of obj.lines?.data ?? []) {
+    const lineStart = toDate(line?.period?.start);
+    const lineEnd = toDate(line?.period?.end);
+    if (lineStart && lineEnd && (!end || lineEnd > end)) {
+      start = lineStart;
+      end = lineEnd;
+    }
   }
-  return { start, end };
+  return {
+    start: start ?? toDate(obj.period_start),
+    end: end ?? toDate(obj.period_end),
+  };
 }
 
 async function resolveUser(

--- a/packages/lib/src/billing/credit-gate.ts
+++ b/packages/lib/src/billing/credit-gate.ts
@@ -16,6 +16,7 @@
 
 import { db } from '@pagespace/db/db';
 import { creditBalances, creditHolds, creditLedger } from '@pagespace/db/schema/credits';
+import { subscriptions } from '@pagespace/db/schema/subscriptions';
 import { and, eq, gt, gte, inArray, sql } from '@pagespace/db/operators';
 import { isBillingEnabled } from '../deployment-mode';
 import {
@@ -78,6 +79,37 @@ interface BalanceRow {
   monthlyPeriodEnd: Date | null;
 }
 
+/**
+ * Subscription statuses whose renewal invoice may still arrive: `invoice.paid`
+ * stays authoritative for these (a gate roll would double-grant when the invoice
+ * lands or replays). `unpaid` is included — Stripe keeps its open invoices
+ * collectible, so a later payment still fires invoice.paid. Everything else —
+ * canceled, incomplete, incomplete_expired, or no subscription row at all
+ * (comped/founder accounts) — will never produce an invoice, so the gate is the
+ * only thing that can roll them. Exported so other surfaces that need a "live
+ * subscription" filter converge on one definition instead of drifting copies.
+ */
+export const RENEWAL_CAPABLE_STATUSES = ['active', 'trialing', 'past_due', 'unpaid'];
+
+/**
+ * Whether ANY of the user's subscriptions could still deliver an invoice-driven
+ * refill. Takes the executor so the reset transaction can RE-CHECK on `tx`
+ * right before granting — a subscription created between the unlocked pre-check
+ * and the grant (checkout completing concurrently with an AI request) would
+ * otherwise double-grant when its first invoice.paid lands.
+ */
+async function hasRenewalCapableSubscription(
+  executor: Pick<typeof db, 'select'>,
+  userId: string,
+): Promise<boolean> {
+  const rows = await executor
+    .select({ id: subscriptions.id })
+    .from(subscriptions)
+    .where(and(eq(subscriptions.userId, userId), inArray(subscriptions.status, RENEWAL_CAPABLE_STATUSES)))
+    .limit(1);
+  return rows.length > 0;
+}
+
 export interface GateOptions {
   /**
    * Override the per-call reservation (in whole cents) for this gate check. The
@@ -127,16 +159,19 @@ export async function canConsumeAI(
 
   let row = await readBalance();
 
-  // Gate-driven monthly reset, restricted to FREE / non-subscription users. Free
-  // users have no invoice.paid to drive a refill, so the gate rolls their window
-  // when it has expired (monthlyPeriodEnd < now) or was never stamped
+  // Gate-driven monthly reset for users whose refill can never come from Stripe.
+  // Free users have no invoice.paid to drive a refill, so the gate rolls their
+  // window when it has expired (monthlyPeriodEnd < now) or was never stamped
   // (monthlyPeriodEnd IS NULL — e.g. a top-up funding row created bare before the
-  // user's first AI request). Paid tiers are deliberately excluded: their refill is
-  // authoritative via invoice.paid (keyed to the invoice stripeRef). Resetting a
-  // subscription-backed balance here would over-grant if a renewal invoice is late
-  // or retried after the period end — the gate would refill, the user could spend,
-  // then the webhook would refill again. A paid user with an expired window is
-  // therefore (correctly) blocked until their renewal lands.
+  // user's first AI request). Paid tiers get the same roll ONLY when no
+  // renewal-capable subscription exists (comped/founder accounts — see
+  // hasRenewalCapableSubscription): with a live subscription, invoice.paid stays
+  // authoritative (keyed to the invoice stripeRef), because resetting here would
+  // over-grant if a renewal invoice is late or retried after the period end — the
+  // gate would refill, the user could spend, then the webhook would refill again.
+  // A paid user with a live subscription and an expired window is therefore
+  // (correctly) blocked until their renewal lands. The subscription lookup only
+  // runs on the rare expired-window path, never on the hot path.
   //
   // The unlocked `row` read above is only a cheap pre-check: it decides whether a
   // reset is even worth attempting (don't open a transaction when the window is
@@ -148,7 +183,16 @@ export async function canConsumeAI(
   // drawn-down balance with stale_remaining + allowance), and a concurrent
   // debt-clearing top-up would have its debt collected twice (the reset re-nets the
   // already-paid debt). Reading the row under the lock closes both interleavings.
-  if (tier === 'free' && row && (row.monthlyPeriodEnd === null || row.monthlyPeriodEnd < now)) {
+  const windowExpired = row !== null && (row.monthlyPeriodEnd === null || row.monthlyPeriodEnd < now);
+  // Only tiers with a defined allowance may roll: callers pass users.subscriptionTier
+  // through unchecked casts, and a legacy/unknown value (e.g. 'normal') reaching
+  // computeMonthlyRefill would silently rewrite the account to the free allowance.
+  const tierHasAllowance = tier in TIER_MONTHLY_ALLOWANCE_CENTS;
+  if (
+    windowExpired &&
+    tierHasAllowance &&
+    (tier === 'free' || !(await hasRenewalCapableSubscription(db, userId)))
+  ) {
     const newEnd = addOneMonth(now);
     await db.transaction(async (tx) => {
       // Lock the balance row and RE-READ the current monthly/debt values inside the
@@ -170,6 +214,16 @@ export async function canConsumeAI(
       // unlocked pre-check and acquiring the lock; if the window is no longer expired,
       // that other request already granted this period — skip to avoid a double grant.
       if (!locked || !(locked.monthlyPeriodEnd === null || locked.monthlyPeriodEnd < now)) {
+        return;
+      }
+
+      // Paid tiers: RE-CHECK the subscription state on the transaction right before
+      // granting. The unlocked pre-check races a concurrent checkout — if the
+      // customer.subscription.* webhook committed a renewal-capable row since,
+      // invoice.paid now owns this user's refill and granting here would double it.
+      // (Not fully serialized against the webhook's own transaction, but it shrinks
+      // the race from "any time since the pre-check" to the instant before commit.)
+      if (tier !== 'free' && (await hasRenewalCapableSubscription(tx, userId))) {
         return;
       }
 
@@ -206,7 +260,10 @@ export async function canConsumeAI(
           entryType: 'monthly_grant',
           bucket: 'monthly',
           amountCents: refill.monthlyAllowanceCents,
-          stripeRef: `free-reset-${userId}-${now.toISOString()}`,
+          // 'free-reset' kept verbatim for the free tier (pre-existing ledger rows use
+          // it); paid no-subscription rolls get their own prefix so they're
+          // distinguishable in the ledger.
+          stripeRef: `${tier === 'free' ? 'free' : 'gate'}-reset-${userId}-${now.toISOString()}`,
           consumeStatus: 'applied',
         })
         .onConflictDoNothing(STRIPE_REF_ARBITER);

--- a/tasks/metering-remediation.md
+++ b/tasks/metering-remediation.md
@@ -1,0 +1,79 @@
+# Metered Sandbox Remediation
+
+Follow-ups from the 2026-07-07 terminal/sandbox metering audit (branch
+`pu/audit-metered-sandboxes`). Prod findings: 2,390 usage rows ($74.41 of billed
+spend) invisible on the usage page behind a stale billing-period window; PTY
+sessions settle only at session end from an in-memory map, so any realtime
+deploy/crash mid-session silently loses the whole session's billing.
+
+## Requirements
+
+### 1. Usage breakdown window (stale billing period)
+
+- Given a user whose `credit_balances.monthlyPeriodEnd` is in the past, the
+  usage breakdown should fall back to the trailing 30 days ending now, so
+  current usage is never hidden behind a stale period window.
+- Given a user whose `monthlyPeriodEnd` is in the future (a normal current
+  period), the breakdown should keep using `[monthlyPeriodStart, monthlyPeriodEnd]`.
+- Given a user with a balance row but no `monthlyPeriodEnd`, the breakdown
+  should keep using `[monthlyPeriodStart, now)` (open-ended), unchanged.
+- Given a user with no balance row at all, the breakdown should keep the
+  existing trailing-30-day fallback, unchanged.
+
+### 2. Gate-driven period roll for accounts without live Stripe renewals
+
+- Given a paid-tier user whose monthly window has expired and who has NO
+  subscription in a renewal-capable status (`active`, `trialing`, `past_due`),
+  the credit gate should roll their window and refill their tier allowance —
+  the same reset free users get (no invoice will ever arrive to do it).
+- Given a paid-tier user whose window has expired but who HAS a subscription in
+  a renewal-capable status, the gate should NOT roll — `invoice.paid` remains
+  authoritative (rolling would double-grant when the invoice lands or replays).
+- Given a free-tier user, the existing gate-driven reset should be unchanged
+  (no subscription lookup added to that path).
+
+### 3. Agent-terminal heartbeat settle (deploy-time revenue loss)
+
+- Given a metered agent-terminal session that stays open longer than the settle
+  heartbeat interval, the handler should settle the accrued active window at
+  each heartbeat (usage recorded, hold consumed) and place a fresh hold with the
+  window start rebased — so a realtime restart loses at most one heartbeat
+  interval of billing, not the whole session.
+- Given the fresh-hold gate is denied at a heartbeat (payer out of credits),
+  the session should be torn down the same way a failed re-auth tears it down,
+  after the accrued window has been settled.
+- Given a metered session whose gate placed no hold (billing pipeline in a
+  no-hold mode), session end should still record its usage — settle keys on
+  payer + window start, with the hold optional (matches tool-runners).
+
+## Out of scope
+
+- Why `invoice.paid` refills stopped landing for subscriptions that Stripe
+  still reports `active` with a long-stale `currentPeriodEnd` (webhook/payment
+  delivery issue — needs its own investigation).
+- Backfilling June's unmetered machine runtime/storage (predates metering).
+
+## Review follow-ups (accepted, not in this change)
+
+- **Deploy tail loss**: the heartbeat bounds a realtime restart's loss to one
+  interval, but the final partial interval of every live session is still lost
+  on deploy (plus its fresh hold lingers to TTL). Deeper fix: persist per-session
+  `billedThrough` and reconcile on boot, or a SIGTERM settle sweep.
+- **Comped as inferred state**: `hasRenewalCapableSubscription` infers "comped"
+  from the absence of a live subscriptions row (webhook-maintained). A missed
+  webhook makes a real subscriber look comped (double-grant window); a
+  first-class comped/billing-mode flag on the account would key on declared
+  intent. The in-tx re-check narrows but does not eliminate this.
+- **Gifted subscriptions**: a `gifted=true` subscription with status `active`
+  counts as renewal-capable; if gift flows don't deliver `invoice.paid` to the
+  recipient, those accounts still never refill. Verify the gift funding path
+  and exclude gifted rows if so.
+- **Predicate drift**: window-expiry staleness is now computed in three places
+  (credit-gate, credit-balance display, usage-breakdown) with intentionally
+  different null semantics; converge on shared helpers in packages/lib/billing.
+  Same for `RENEWAL_CAPABLE_STATUSES` (now exported) vs the six apps/web routes
+  that inline `['active','trialing','past_due']`.
+- **Stuck past-due hot path**: a paid user whose window is expired but whose
+  subscription is still renewal-capable pays one extra subscriptions SELECT per
+  gate call until the renewal lands. Fold into the balance read if it shows up
+  in metrics.

--- a/tasks/metering-remediation.md
+++ b/tasks/metering-remediation.md
@@ -32,6 +32,19 @@ deploy/crash mid-session silently loses the whole session's billing.
 - Given a free-tier user, the existing gate-driven reset should be unchanged
   (no subscription lookup added to that path).
 
+### 4. Renewal invoices must stamp the NEW service period (root cause of #1/#2's stale windows for subscribers)
+
+- Given a renewal `invoice.paid` whose invoice-level `period_start`/`period_end`
+  describe the just-ended cycle (Stripe semantics), the refill should stamp the
+  balance window from the LINE ITEM's service period — the cycle actually paid
+  for — so a subscriber's window is current, not expired-on-arrival. (Prod
+  evidence: all 4 live subscribers had windows stamped to the ended cycle; one
+  first-invoice user had start == end.)
+- Given a plan-change invoice with multiple lines (prorations + new plan), the
+  refill should stamp the line with the latest period end.
+- Given an invoice with no line periods at all, the refill should keep the
+  invoice-level fallback.
+
 ### 3. Agent-terminal heartbeat settle (deploy-time revenue loss)
 
 - Given a metered agent-terminal session that stays open longer than the settle
@@ -48,9 +61,13 @@ deploy/crash mid-session silently loses the whole session's billing.
 
 ## Out of scope
 
-- Why `invoice.paid` refills stopped landing for subscriptions that Stripe
-  still reports `active` with a long-stale `currentPeriodEnd` (webhook/payment
-  delivery issue — needs its own investigation).
+- ~~Why `invoice.paid` refills stopped landing~~ RESOLVED: they never stopped —
+  the June 13 refill landed; requirement #4's invoice-period stamping bug made
+  the window expired-on-arrival. Remaining oddity: `subscriptions.currentPeriodEnd`
+  is stale (Jun 13) for 2 of 4 live subscribers, so `customer.subscription.updated`
+  after renewal appears not to be processed for some accounts — investigate
+  separately. Existing stale balance windows self-heal at each account's next
+  renewal now that stamping is fixed; the usage-page fallback covers the gap.
 - Backfilling June's unmetered machine runtime/storage (predates metering).
 
 ## Review follow-ups (accepted, not in this change)

--- a/tasks/metering-remediation.md
+++ b/tasks/metering-remediation.md
@@ -81,10 +81,14 @@ deploy/crash mid-session silently loses the whole session's billing.
   webhook makes a real subscriber look comped (double-grant window); a
   first-class comped/billing-mode flag on the account would key on declared
   intent. The in-tx re-check narrows but does not eliminate this.
-- **Gifted subscriptions**: a `gifted=true` subscription with status `active`
-  counts as renewal-capable; if gift flows don't deliver `invoice.paid` to the
-  recipient, those accounts still never refill. Verify the gift funding path
-  and exclude gifted rows if so.
+- **Gifted subscriptions**: RESOLVED by prod evidence (2026-07-07). No prod
+  subscription has `gifted=true` (the flag needs `metadata.type =
+  'gift_subscription'`, which nothing sets — the in-app gift flow is unused).
+  Actual gift accounts are dashboard-created Stripe subscriptions (3 of the 4
+  `active` subs; 1 real payer) and Stripe fires `invoice.paid` on their $0
+  renewal invoices — all 4 have invoice-keyed `monthly_grant` rows — so they
+  refill like paying accounts and are correctly renewal-capable. No exclusion
+  needed.
 - **Predicate drift**: window-expiry staleness is now computed in three places
   (credit-gate, credit-balance display, usage-breakdown) with intentionally
   different null semantics; converge on shared helpers in packages/lib/billing.


### PR DESCRIPTION
## Context

Remediation from the 2026-07-07 terminal/sandbox metering audit, which found (verified against prod):

- **2,390 usage rows ($74.41 of billed spend) invisible** on `/settings/usage` — the breakdown query clamps to `credit_balances.monthlyPeriodEnd`, and every live subscriber's window was stale (11 users affected).
- **Root cause (found during review): renewal invoices stamped the wrong period.** Stripe's invoice-level `period_start/end` describe the just-*ended* cycle (first invoices: `start == end == created`); the new service period lives on the line items. All 4 live subscribers in prod had windows stamped to the ended cycle — expired the moment their renewal landed. Refills themselves were landing fine.
- **Comped/founder paid accounts never refill** — no invoice ever arrives, so their allowance froze permanently.
- **PTY terminal sessions settle billing only at session end from an in-memory map** — every realtime deploy silently dropped the entire billing of any live session.

## Changes

**1. Renewal window stamping** (`packages/lib/src/billing/credit-funding.ts`)
`invoicePeriod` now prefers the line item with the latest period end (plan-change invoices carry old-plan proration lines) and falls back to invoice-level fields only when no line carries a period. Existing stale windows self-heal at each account's next renewal.

**2. Usage breakdown — stale window fallback** (`apps/web/src/lib/subscription/`)
`resolveUsageWindow` (new pure fn): a `monthlyPeriodEnd` in the past falls back to the trailing 30 days ending now, so current spend always shows (covers the gap until windows self-heal, plus permanently-stale comped accounts). Current periods, open-ended windows, and the no-balance fallback are unchanged.

**3. Credit gate — roll for accounts Stripe can never refill** (`packages/lib/src/billing/credit-gate.ts`)
The gate-driven monthly reset (previously free-only) now also covers paid tiers with **no renewal-capable subscription** (`active`/`trialing`/`past_due`/`unpaid` — exported as `RENEWAL_CAPABLE_STATUSES`). Guards: subscription state re-checked **inside** the reset transaction (narrows the concurrent-checkout double-grant race); tiers without a defined allowance (legacy `normal`) never roll; grants ledgered under a distinguishable `gate-reset-*` ref.

**4. Agent terminals — heartbeat settle** (`apps/realtime/src/terminal/`)
Metered sessions settle their accrued window every 10 min (`SETTLE_HEARTBEAT_MS`, under the 15-min hold TTL) and place a fresh hold, bounding deploy-time loss to one interval. A failed settle rolls the rebase back and retries next tick; if a teardown races a *failing* settle, a compensating best-effort settle re-bills the pre-heartbeat window instead of dropping it. A gate denial after a successful settle tears the session down like a failed re-auth. `endAgentTerminalSession` owns clearing all session timers; the re-auth teardown re-checks liveness after its await so concurrent teardown actors can't double-release a slot; settle no longer requires a `holdId` (parity with tool-runners).

## Review

Multi-angle review + external (Codex) review ran over the diff; confirmed findings fixed here: renewal-period stamping (the actual root cause), settle-failure revenue loss + hold leak, settle/teardown race dropping the pre-heartbeat window, re-auth double-teardown race, `unpaid`-status double-grant, legacy-tier allowance overwrite, checkout TOCTOU (narrowed), missing changelog. Accepted follow-ups documented in `tasks/metering-remediation.md`.

## Tests

- `packages/lib`: 6755 passed (new: line-period stamping + plan-change lines; gate comped roll / live-sub block / unpaid block / legacy-tier skip / in-tx re-check abort / free-path unchanged)
- `apps/realtime`: 164 terminal-suite passed (new: heartbeat settle/re-hold, settle-failure retry, settle-teardown race compensation, insolvency teardown, gate-infra fail-open, no-hold settle, revenue conservation, stale re-auth no-double-teardown)
- `apps/web` subscription suite: 115 passed (new: 5 `resolveUsageWindow` cases)
- Typecheck + lint clean

## Out of scope (flagged for follow-up)

- `subscriptions.currentPeriodEnd` is stale for 2 of 4 live subscribers — `customer.subscription.updated` after renewal appears unprocessed for some accounts; investigate separately
- Interactive PTY spawn path has **zero** `machine_agent_terminals` rows in prod — needs a live smoke test
- June's pre-metering machine runtime/storage (not backfillable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V4Xx74B9G8T7jwYxvuq5J9