### PR TITLE
docs(tasks): add PII decrypt perf remediation round 2 epic

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -2,6 +2,7 @@
 
 ## Active Epics
 
+- [PII Decrypt Perf Remediation — Round 2](tasks/pii-decrypt-perf-remediation-round2.md) — finish closing the PII-decrypt latency regression PR #1930/#1931 only partially fixed: re-encrypt the 224 existing users stuck on the slow legacy ciphertext format, and dedup PII decrypts in the inbox/messages/connections routes PR #1930 never wired up.
 - [Prepaid AI Credits Billing Bridge](tasks/prepaid-credits-billing.md) — prepaid usage-based AI billing on our own Stripe account (decoupled from the stalled Parallel Drive/Polar move); monthly credit allowance that resets + never-expiring top-up packs, consumed at real cost ×1.5, hard-gated so we never front unpaid AI; Stripe collects money only, local two-bucket ledger is source of truth; strict TDD + pure `credit-core.ts` decision layer.
 - [Fly.io Upload Infrastructure](tasks/fly-upload-infra.md) — migrate from local VPS filesystem to Tigris S3, presigned URL delivery, remove memory monitor, raise limits for video support, batch upload in channels/DMs.
 - [Agent Conversation Privacy](tasks/agent-conversation-privacy.md) — User-scoped conversation history for AI Chat pages; private by default, opt-in multiplayer sharing.

--- a/tasks/pii-decrypt-perf-remediation-round2.md
+++ b/tasks/pii-decrypt-perf-remediation-round2.md
@@ -1,0 +1,61 @@
+# PII Decrypt Perf Remediation — Round 2 Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Finish closing the PII-decrypt latency regression that PR #1930/#1931 only partially fixed — every existing user's PII is still on the slow path, and several hot routes were never wired into the dedup fix.
+
+## Overview
+
+Because PR #1930's expand-contract fix only speeds up brand-new writes and only deduped 3 of the routes that decrypt PII in a per-row loop, production response times are still elevated hours after both perf PRs deployed: the one-time backfill (`scripts/backfill-user-pii-encryption.ts`) that encrypted all 224 existing users ran on 2026-07-06, a full day before #1930 introduced the fast ciphertext format, so every existing user's `email`/`name` is permanently stuck on the slow unmemoized-scrypt-per-record legacy decrypt path (`deriveLegacyKey`) until re-encrypted — and grep found `inbox`, `messages/conversations`, `messages/conversations/[conversationId]`, `messages/threads`, `connections`, and `connections/search` routes still doing undeduped per-row `decryptField` calls that PR #1930 never touched. This epic closes both gaps with zero behavior change, full backwards compatibility with mixed-format data mid-migration, and pure-function-core/imperative-shell TDD throughout, following the exact patterns already established in `encryption-utils.ts` (`parseEnvelope`/`buildEnvelope`/`encryptWithKey`/`decryptWithKey`) and `blind-index.ts` (`memoizeSyncByKey`).
+
+---
+
+## Legacy-ciphertext re-encryption backfill
+
+Idempotent, resumable, dry-run-by-default script that reads every legacy-4-part-format `users.email`/`name` row, decrypts it via the existing dual-format `decrypt()`, and re-encrypts it via `encrypt()` (which always emits the fast 3-part format) — converging every row to the fast format so the legacy scrypt path is no longer on the hot read path for any existing user.
+
+**Requirements**:
+- Given a row already in fast-format ciphertext, should skip it (idempotent re-runs converge to zero work, mirroring `scripts/backfill-user-pii-encryption.ts`'s existing-row skip).
+- Given a row in legacy-format ciphertext, should decrypt then re-encrypt it to fast format in a single pass, byte-identical plaintext round-trip proven by test.
+- Given the migration is interrupted mid-run, should be resumable (cursor-based batching, same pattern as the existing backfill) without re-processing already-converted rows or losing progress.
+- Given a dry-run flag (default), should report counts (legacy found / would-convert) without writing, requiring the same explicit `--apply` + confirmed-cutover-deployed gate pattern as the existing backfill before any live write.
+- Given the planner logic (which rows need conversion, what the new value should be), should be a pure function separate from the DB I/O shell, unit-tested without a real database — same split as `planUserPiiBackfill`.
+
+---
+
+## Dedup PII decrypts in inbox route
+
+Wire the existing `decryptUsersByIdOnce` helper (`packages/lib/src/auth/user-repository.ts`, added by PR #1930) into `apps/web/src/app/api/inbox/route.ts`'s three per-row `decryptField` call sites so a repeated sender/participant within one request's result set decrypts once, not once per row.
+
+**Requirements**:
+- Given an inbox response listing multiple conversations from the same sender, should decrypt that sender's name exactly once for the whole request (call-count assertion via the same test pattern PR #1930 used against `decryptUsersByIdOnce`, not a dist-boundary mock on the inner `decryptField`).
+- Given the route's existing response shape and decrypted values, should be byte-identical to before the change (behavior-preserving refactor, not a new feature).
+
+---
+
+## Dedup PII decrypts in messages routes
+
+Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/messages/conversations/route.ts`, `apps/web/src/app/api/messages/conversations/[conversationId]/route.ts`, and `apps/web/src/app/api/messages/threads/route.ts`.
+
+**Requirements**:
+- Given a conversations/threads list with repeated other-party users across rows, should decrypt each unique user once per request.
+- Given the single-conversation detail route, should still correctly decrypt when only one distinct user is present (no regression for the common case).
+
+---
+
+## Dedup PII decrypts in connections routes
+
+Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/connections/route.ts` and `apps/web/src/app/api/connections/search/route.ts`.
+
+**Requirements**:
+- Given a connections list or search result with repeated users, should decrypt each unique user once per request.
+- Given the search route's existing filtering/ranking behavior, should be unaffected by the decrypt-path change.
+
+---
+
+## Verify recovery
+
+After all four tasks land and deploy, confirm the fix actually closes the gap rather than just asserting it should.
+
+**Requirements**:
+- Given the full lib + web test suites and `bun run typecheck`, should be green with zero new failures across all four preceding tasks.
+- Given the fix is deployed to `pagespace-web`, should show HTTP Response Time Avg back down near the pre-regression ~0.3-0.5s baseline on the same Grafana panel used to diagnose this, not just an assumption that the code change helped.


### PR DESCRIPTION
## Summary
- Adds `tasks/pii-decrypt-perf-remediation-round2.md`, tracking the follow-up work needed after #1930/#1931: (1) a re-encryption backfill to move the 224 existing users off the slow legacy ciphertext format, (2) dedup PII decrypts in inbox/messages/connections routes that #1930 didn't touch.
- Links it from `plan.md`'s Active Epics.
- Docs-only, no code changes. Two PU agents are already executing against this epic in parallel worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xaj1xB4PDHs8Z9P1gpWCVT