### PR TITLE
perf(encryption): backfill legacy-format PII ciphertext to fast envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       # never sees them. Scoped to backfill-* because the older tenant-* and
       # changelog-* suites in that config are broken independently of CI.
       - name: Run backfill script tests
-        run: cd scripts && bunx vitest run __tests__/backfill-home-drives.test.ts __tests__/backfill-task-verb-tools.test.ts __tests__/backfill-trash-verb-tools.test.ts __tests__/promote-admin.test.ts __tests__/setup-onprem-admin.test.ts
+        run: cd scripts && bunx vitest run __tests__/backfill-home-drives.test.ts __tests__/backfill-task-verb-tools.test.ts __tests__/backfill-trash-verb-tools.test.ts __tests__/backfill-legacy-ciphertext-reencrypt.test.ts __tests__/promote-admin.test.ts __tests__/setup-onprem-admin.test.ts
 
       - name: Coverage report
         if: always()

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -217,6 +217,11 @@
       "import": "./dist/encryption/user-pii-backfill.js",
       "require": "./dist/encryption/user-pii-backfill.js"
     },
+    "./encryption/legacy-ciphertext-reencrypt": {
+      "types": "./dist/encryption/legacy-ciphertext-reencrypt.d.ts",
+      "import": "./dist/encryption/legacy-ciphertext-reencrypt.js",
+      "require": "./dist/encryption/legacy-ciphertext-reencrypt.js"
+    },
     "./auth/device-auth-utils": {
       "types": "./dist/auth/device-auth-utils.d.ts",
       "import": "./dist/auth/device-auth-utils.js",
@@ -1482,6 +1487,9 @@
       ],
       "encryption/user-pii-backfill": [
         "./dist/encryption/user-pii-backfill.d.ts"
+      ],
+      "encryption/legacy-ciphertext-reencrypt": [
+        "./dist/encryption/legacy-ciphertext-reencrypt.d.ts"
       ],
       "auth/device-auth-utils": [
         "./dist/auth/device-auth-utils.d.ts"

--- a/packages/lib/src/encryption/__tests__/legacy-envelope-fixture.ts
+++ b/packages/lib/src/encryption/__tests__/legacy-envelope-fixture.ts
@@ -1,0 +1,27 @@
+/**
+ * Test fixture reproducing the FROZEN pre-#1930 legacy ciphertext envelope
+ * (`salt:iv:authTag:ciphertext`, per-record scrypt-derived key, AES-256-GCM).
+ * Do not "fix" these parameters — they must reproduce exactly what production
+ * wrote before the fast 3-part format existed, or the suites silently start
+ * validating a format that never existed.
+ *
+ * The salt + derived key are computed once per master key and reused:
+ * envelope uniqueness comes from the random IV, and reusing the salt spares
+ * every call the ~50-100ms blocking scrypt.
+ */
+import { scryptSync, randomBytes, createCipheriv } from 'crypto';
+
+const keyByMaster = new Map<string, { salt: Buffer; key: Buffer }>();
+
+export function legacyEncrypt(masterKey: string, plaintext: string): string {
+  let entry = keyByMaster.get(masterKey);
+  if (!entry) {
+    const salt = randomBytes(32);
+    entry = { salt, key: scryptSync(masterKey, salt, 32) };
+    keyByMaster.set(masterKey, entry);
+  }
+  const iv = randomBytes(16);
+  const cipher = createCipheriv('aes-256-gcm', entry.key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return [entry.salt, iv, cipher.getAuthTag(), ciphertext].map((b) => b.toString('hex')).join(':');
+}

--- a/packages/lib/src/encryption/field-crypto.ts
+++ b/packages/lib/src/encryption/field-crypto.ts
@@ -39,12 +39,21 @@ export function looksEncrypted(value: unknown): boolean {
     return isValidCiphertextHex(iv, tag, ct);
   }
 
-  if (parts.length === 4) {
-    const [salt, iv, tag, ct] = parts;
-    return salt.length === SALT_HEX_LEN && isHex(salt) && isValidCiphertextHex(iv, tag, ct);
-  }
+  return looksLegacyEncrypted(value);
+}
 
-  return false;
+/**
+ * True iff `value` matches ONLY the legacy 4-part `salt:iv:authTag:ciphertext`
+ * envelope — the shape whose decrypt still pays a per-record scrypt
+ * (`deriveLegacyKey`). Used by the legacy-ciphertext re-encryption backfill to
+ * pick out rows that need converting to the fast 3-part format.
+ */
+export function looksLegacyEncrypted(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const parts = value.split(':');
+  if (parts.length !== 4) return false;
+  const [salt, iv, tag, ct] = parts;
+  return salt.length === SALT_HEX_LEN && isHex(salt) && isValidCiphertextHex(iv, tag, ct);
 }
 
 /** Encrypt a field value, skipping empty/null and already-encrypted values. */

--- a/packages/lib/src/encryption/legacy-ciphertext-reencrypt.test.ts
+++ b/packages/lib/src/encryption/legacy-ciphertext-reencrypt.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure planner for the legacy-ciphertext re-encryption backfill.
+ *
+ * The 2026-07-06 user-PII backfill wrote every row in the legacy 4-part
+ * `salt:iv:authTag:ciphertext` envelope, which costs a full scrypt per decrypt
+ * (`deriveLegacyKey`). This planner converts those rows to the fast 3-part
+ * `iv:authTag:ciphertext` envelope keyed by the memoized master key. Idempotent:
+ * fast-format and plaintext rows are skipped so re-runs converge to zero work.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { scryptSync, randomBytes, createCipheriv } from 'crypto';
+import { decrypt } from './encryption-utils';
+import { looksEncrypted, looksLegacyEncrypted } from './field-crypto';
+import { planLegacyCiphertextReencrypt } from './legacy-ciphertext-reencrypt';
+
+const MASTER = 'reencrypt-test-master-key-at-least-32-chars!';
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = MASTER;
+});
+
+/**
+ * Produce ciphertext in the legacy 4-part format exactly as the pre-#1930
+ * `encrypt()` did: per-record random salt, scrypt-derived key, AES-256-GCM.
+ */
+function legacyEncrypt(plaintext: string): string {
+  const salt = randomBytes(32);
+  const key = scryptSync(MASTER, salt, 32);
+  const iv = randomBytes(16);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [salt, iv, authTag, ciphertext].map((b) => b.toString('hex')).join(':');
+}
+
+describe('looksLegacyEncrypted', () => {
+  it('is true for the 4-part legacy envelope and false for fast/plaintext', () => {
+    expect(looksLegacyEncrypted(legacyEncrypt('a@b.com'))).toBe(true);
+    expect(looksLegacyEncrypted('a@b.com')).toBe(false);
+    expect(looksLegacyEncrypted(null)).toBe(false);
+  });
+});
+
+describe('planLegacyCiphertextReencrypt', () => {
+  it('given a legacy row, should re-encrypt to fast format with a byte-identical plaintext round-trip', async () => {
+    const email = 'Legacy@Example.com';
+    const name = 'Legacy User';
+    const oldEmail = legacyEncrypt(email);
+    const oldName = legacyEncrypt(name);
+
+    const update = await planLegacyCiphertextReencrypt({ id: 'u1', email: oldEmail, name: oldName });
+
+    expect(update).not.toBeNull();
+    expect(update!.id).toBe('u1');
+    // New envelopes are the fast 3-part format, not the legacy 4-part one.
+    expect(update!.email.split(':')).toHaveLength(3);
+    expect(update!.name.split(':')).toHaveLength(3);
+    expect(looksEncrypted(update!.email)).toBe(true);
+    expect(looksEncrypted(update!.name)).toBe(true);
+    // decrypt(new) === decrypt(old) === original plaintext.
+    expect(await decrypt(update!.email)).toBe(email);
+    expect(await decrypt(update!.name)).toBe(name);
+    expect(await decrypt(oldEmail)).toBe(email);
+    expect(await decrypt(oldName)).toBe(name);
+  });
+
+  it('given a row already in fast format, should skip (idempotent)', async () => {
+    const first = await planLegacyCiphertextReencrypt({
+      id: 'u1',
+      email: legacyEncrypt('a@b.com'),
+      name: legacyEncrypt('A'),
+    });
+    const rerun = await planLegacyCiphertextReencrypt({
+      id: 'u1',
+      email: first!.email,
+      name: first!.name,
+    });
+    expect(rerun).toBeNull();
+  });
+
+  it('given a plaintext row, should skip — encrypting plaintext is the original backfill\'s job', async () => {
+    const update = await planLegacyCiphertextReencrypt({ id: 'u2', email: 'plain@b.com', name: 'Plain' });
+    expect(update).toBeNull();
+  });
+
+  it('given a mixed row (legacy email, fast name), should convert only the legacy field', async () => {
+    const converted = await planLegacyCiphertextReencrypt({
+      id: 'u3',
+      email: legacyEncrypt('mixed@b.com'),
+      name: legacyEncrypt('Mixed'),
+    });
+    const fastName = converted!.name;
+
+    const update = await planLegacyCiphertextReencrypt({
+      id: 'u3',
+      email: legacyEncrypt('mixed@b.com'),
+      name: fastName,
+    });
+    expect(update).not.toBeNull();
+    expect(update!.email.split(':')).toHaveLength(3);
+    expect(await decrypt(update!.email)).toBe('mixed@b.com');
+    // Untouched field is passed through unchanged, not re-encrypted.
+    expect(update!.name).toBe(fastName);
+  });
+
+  it('given tampered legacy ciphertext, should throw (surfaced as an error count by the runner)', async () => {
+    const good = legacyEncrypt('x@y.com');
+    const parts = good.split(':');
+    // Flip the auth tag so GCM authentication fails.
+    parts[2] = parts[2].replace(/^./, parts[2].startsWith('0') ? '1' : '0');
+    const tampered = parts.join(':');
+
+    await expect(
+      planLegacyCiphertextReencrypt({ id: 'u4', email: tampered, name: legacyEncrypt('X') }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/lib/src/encryption/legacy-ciphertext-reencrypt.test.ts
+++ b/packages/lib/src/encryption/legacy-ciphertext-reencrypt.test.ts
@@ -1,37 +1,16 @@
-/**
- * Pure planner for the legacy-ciphertext re-encryption backfill.
- *
- * The 2026-07-06 user-PII backfill wrote every row in the legacy 4-part
- * `salt:iv:authTag:ciphertext` envelope, which costs a full scrypt per decrypt
- * (`deriveLegacyKey`). This planner converts those rows to the fast 3-part
- * `iv:authTag:ciphertext` envelope keyed by the memoized master key. Idempotent:
- * fast-format and plaintext rows are skipped so re-runs converge to zero work.
- */
+/** Tests for planLegacyCiphertextReencrypt and looksLegacyEncrypted. */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { scryptSync, randomBytes, createCipheriv } from 'crypto';
 import { decrypt } from './encryption-utils';
 import { looksEncrypted, looksLegacyEncrypted } from './field-crypto';
 import { planLegacyCiphertextReencrypt } from './legacy-ciphertext-reencrypt';
+import { legacyEncrypt as legacyEncryptWith } from './__tests__/legacy-envelope-fixture';
 
 const MASTER = 'reencrypt-test-master-key-at-least-32-chars!';
+const legacyEncrypt = (plaintext: string): string => legacyEncryptWith(MASTER, plaintext);
 
 beforeAll(() => {
   process.env.ENCRYPTION_KEY = MASTER;
 });
-
-/**
- * Produce ciphertext in the legacy 4-part format exactly as the pre-#1930
- * `encrypt()` did: per-record random salt, scrypt-derived key, AES-256-GCM.
- */
-function legacyEncrypt(plaintext: string): string {
-  const salt = randomBytes(32);
-  const key = scryptSync(MASTER, salt, 32);
-  const iv = randomBytes(16);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
-  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return [salt, iv, authTag, ciphertext].map((b) => b.toString('hex')).join(':');
-}
 
 describe('looksLegacyEncrypted', () => {
   it('is true for the 4-part legacy envelope and false for fast/plaintext', () => {

--- a/packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts
+++ b/packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts
@@ -27,11 +27,12 @@ export interface LegacyCiphertextRow {
   name: string;
 }
 
-export interface LegacyReencryptUpdate {
-  id: string;
-  email: string;
-  name: string;
-}
+/**
+ * Same shape as the input row on purpose: the update rewrites the ciphertext
+ * envelope in place and never adds or removes columns (unlike the original
+ * backfill, whose output gains a non-null emailBidx).
+ */
+export type LegacyReencryptUpdate = LegacyCiphertextRow;
 
 /**
  * Plan the re-encryption update for one row, or `null` to skip.

--- a/packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts
+++ b/packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts
@@ -49,13 +49,20 @@ export async function planLegacyCiphertextReencrypt(
   if (!emailLegacy && !nameLegacy) return null;
 
   const [email, name] = await Promise.all([
-    emailLegacy ? reencrypt(row.email) : row.email,
-    nameLegacy ? reencrypt(row.name) : row.name,
+    emailLegacy ? reencryptLegacyValue(row.email) : row.email,
+    nameLegacy ? reencryptLegacyValue(row.name) : row.name,
   ]);
   return { id: row.id, email, name };
 }
 
-/** Decrypt a legacy envelope and re-encrypt to the fast 3-part format. */
-async function reencrypt(legacyCiphertext: string): Promise<string> {
+/**
+ * Decrypt a legacy envelope and re-encrypt to the fast 3-part format.
+ *
+ * Exported as the column-agnostic core for follow-up backfills — other tables
+ * also hold pre-#1930 legacy ciphertext (integration connection credentials,
+ * OAuth refresh tokens, audit-log IPs) and should convert through this same
+ * tested value-level path rather than reimplementing it.
+ */
+export async function reencryptLegacyValue(legacyCiphertext: string): Promise<string> {
   return encrypt(await decrypt(legacyCiphertext));
 }

--- a/packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts
+++ b/packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure planner for the legacy-ciphertext re-encryption backfill.
+ *
+ * The 2026-07-06 user-PII backfill ran before #1930 introduced the fast 3-part
+ * `iv:authTag:ciphertext` envelope, so every existing row is stuck on the
+ * legacy 4-part `salt:iv:authTag:ciphertext` format whose decrypt pays a full
+ * per-record scrypt (`deriveLegacyKey` in encryption-utils.ts). This planner
+ * decrypts a legacy value and re-encrypts it under the memoized master key in
+ * a single pass, leaving the plaintext byte-identical.
+ *
+ * The imperative runner (scripts/backfill-legacy-ciphertext-reencrypt.ts)
+ * streams rows in batches and applies the update this planner returns. Keeping
+ * the decision pure — no DB access, no I/O — makes idempotency and the
+ * round-trip invariant testable without a database.
+ *
+ * Skips are what make re-runs converge: fast-format values are already done,
+ * and plaintext values are the ORIGINAL backfill's job, never this one's. The
+ * email blind index is untouched — it is derived from the plaintext, which
+ * does not change.
+ */
+import { encrypt, decrypt } from './encryption-utils';
+import { looksLegacyEncrypted } from './field-crypto';
+
+export interface LegacyCiphertextRow {
+  id: string;
+  email: string;
+  name: string;
+}
+
+export interface LegacyReencryptUpdate {
+  id: string;
+  email: string;
+  name: string;
+}
+
+/**
+ * Plan the re-encryption update for one row, or `null` to skip.
+ *
+ * Only fields in the legacy 4-part format are converted; a field already in
+ * the fast format (or plaintext) passes through unchanged. Throws if a legacy
+ * value fails to decrypt (wrong key / tampered ciphertext) — the runner counts
+ * that as a per-row error and continues.
+ */
+export async function planLegacyCiphertextReencrypt(
+  row: LegacyCiphertextRow,
+): Promise<LegacyReencryptUpdate | null> {
+  const emailLegacy = looksLegacyEncrypted(row.email);
+  const nameLegacy = looksLegacyEncrypted(row.name);
+  if (!emailLegacy && !nameLegacy) return null;
+
+  const [email, name] = await Promise.all([
+    emailLegacy ? reencrypt(row.email) : row.email,
+    nameLegacy ? reencrypt(row.name) : row.name,
+  ]);
+  return { id: row.id, email, name };
+}
+
+/** Decrypt a legacy envelope and re-encrypt to the fast 3-part format. */
+async function reencrypt(legacyCiphertext: string): Promise<string> {
+  return encrypt(await decrypt(legacyCiphertext));
+}

--- a/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
+++ b/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
@@ -14,7 +14,7 @@ vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn(), update: vi.fn() } })
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id', email: 'email', name: 'name' },
 }));
-vi.mock('@pagespace/db/operators', () => ({ eq: () => ({}), gt: () => ({}), asc: () => ({}) }));
+vi.mock('@pagespace/db/operators', () => ({ eq: () => ({}), gt: () => ({}), asc: () => ({}), and: () => ({}) }));
 
 import { backfill, resolveReencryptMode } from '../backfill-legacy-ciphertext-reencrypt';
 import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
@@ -48,12 +48,12 @@ function selectReturning(batches: unknown[][]) {
   });
 }
 
-function captureUpdate() {
+function captureUpdate({ rowCount = 1 }: { rowCount?: number } = {}) {
   const sets: Array<Record<string, unknown>> = [];
   const update = vi.fn(() => ({
     set: (v: Record<string, unknown>) => {
       sets.push(v);
-      return { where: () => Promise.resolve() };
+      return { where: () => Promise.resolve({ rowCount }) };
     },
   }));
   return { update, sets };
@@ -123,6 +123,17 @@ describe('backfill-legacy-ciphertext-reencrypt', () => {
 
     expect(result).toEqual({ legacyFound: 0, converted: 0, skipped: 1, errors: 0 });
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('a row modified concurrently between select and write is skipped, not clobbered', async () => {
+    // The compare-and-swap WHERE clause matches 0 rows when the app changed
+    // email/name after the batch select; the runner must not count it as
+    // converted — a re-run picks it up in its then-current state.
+    const select = selectReturning([[{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }], []]);
+    const { update } = captureUpdate({ rowCount: 0 });
+    const result = await backfill(false, { select, update } as never);
+
+    expect(result).toEqual({ legacyFound: 0, converted: 0, skipped: 1, errors: 0 });
   });
 
   it('a row that fails to decrypt is counted as an error without aborting the run', async () => {

--- a/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
+++ b/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
@@ -5,35 +5,55 @@
  * imperative loop: dry-run writes nothing, live mode rewrites only legacy-format
  * rows to the fast envelope, fast-format rows are skipped (idempotent re-runs
  * converge), per-row failures are counted without aborting the run, and
- * cursor-based pagination terminates.
+ * cursor-based pagination advances on the last id of each batch and terminates.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { scryptSync, randomBytes, createCipheriv } from 'crypto';
 
+// Captures the cursor value passed to gt() on each batch select, so the
+// pagination test can assert the cursor actually advances (a stub that only
+// hands out successive batches would pass even with a broken cursor).
+const { gtCursors } = vi.hoisted(() => ({ gtCursors: [] as unknown[] }));
+
 vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn(), update: vi.fn() } }));
 vi.mock('@pagespace/db/schema/auth', () => ({
-  users: { id: 'id', email: 'email', name: 'name' },
+  users: { id: 'id', email: 'email', name: 'name', updatedAt: 'updatedAt' },
 }));
-vi.mock('@pagespace/db/operators', () => ({ eq: () => ({}), gt: () => ({}), asc: () => ({}), and: () => ({}) }));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: () => ({}),
+  gt: (_col: unknown, cursor: unknown) => {
+    gtCursors.push(cursor);
+    return {};
+  },
+  asc: () => ({}),
+  and: () => ({}),
+}));
 
 import { backfill, resolveReencryptMode } from '../backfill-legacy-ciphertext-reencrypt';
 import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
 
 const MASTER = 'reencrypt-runner-test-master-key-32-chars-min!';
 
-beforeEach(() => {
-  process.env.ENCRYPTION_KEY = MASTER;
-});
+// Frozen pre-#1930 legacy envelope, mirroring the shared lib fixture
+// (packages/lib/src/encryption/__tests__/legacy-envelope-fixture.ts) — not
+// importable across the package boundary because lib only exports dist.
+// Salt + key are derived once: uniqueness comes from the random IV, and
+// reusing them spares every call a ~50-100ms blocking scrypt.
+const LEGACY_SALT = randomBytes(32);
+const LEGACY_KEY = scryptSync(MASTER, LEGACY_SALT, 32);
 
 /** Legacy 4-part `salt:iv:authTag:ciphertext` envelope, as pre-#1930 encrypt() wrote it. */
 function legacyEncrypt(plaintext: string): string {
-  const salt = randomBytes(32);
-  const key = scryptSync(MASTER, salt, 32);
   const iv = randomBytes(16);
-  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const cipher = createCipheriv('aes-256-gcm', LEGACY_KEY, iv);
   const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  return [salt, iv, cipher.getAuthTag(), ciphertext].map((b) => b.toString('hex')).join(':');
+  return [LEGACY_SALT, iv, cipher.getAuthTag(), ciphertext].map((b) => b.toString('hex')).join(':');
 }
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = MASTER;
+  gtCursors.length = 0;
+});
 
 /** Chainable select stub terminating on .limit(); returns successive batches. */
 function selectReturning(batches: unknown[][]) {
@@ -76,8 +96,12 @@ describe('resolveReencryptMode (fast-format-readers safety gate)', () => {
 });
 
 describe('backfill-legacy-ciphertext-reencrypt', () => {
-  it('live mode: rewrites a legacy row to the fast 3-part envelope with identical plaintext', async () => {
-    const select = selectReturning([[{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }], []]);
+  it('live mode: rewrites a legacy row to the fast 3-part envelope with identical plaintext, pinning updatedAt', async () => {
+    const priorUpdatedAt = new Date('2026-01-15T12:00:00Z');
+    const select = selectReturning([
+      [{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A'), updatedAt: priorUpdatedAt }],
+      [],
+    ]);
     const { update, sets } = captureUpdate();
     const result = await backfill(false, { select, update } as never);
 
@@ -87,6 +111,10 @@ describe('backfill-legacy-ciphertext-reencrypt', () => {
     expect((sets[0].name as string).split(':')).toHaveLength(3);
     expect(await decrypt(sets[0].email as string)).toBe('a@b.com');
     expect(await decrypt(sets[0].name as string)).toBe('A');
+    // A ciphertext-format rewrite is not a profile update: the write must pin
+    // updatedAt to its prior value or the schema's $onUpdate stamps every
+    // backfilled row with the run time (visible in the GDPR Art-15 export).
+    expect(sets[0].updatedAt).toBe(priorUpdatedAt);
   });
 
   it('dry run: counts legacy rows but writes nothing', async () => {
@@ -157,7 +185,7 @@ describe('backfill-legacy-ciphertext-reencrypt', () => {
     expect(await decrypt(sets[0].email as string)).toBe('ok@b.com');
   });
 
-  it('paginates across batches on the ascending-id cursor and terminates', async () => {
+  it('paginates by advancing the ascending-id cursor to each batch\'s last id and terminates', async () => {
     const select = selectReturning([
       [{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }],
       [{ id: 'u2', email: legacyEncrypt('b@b.com'), name: legacyEncrypt('B') }],
@@ -170,5 +198,8 @@ describe('backfill-legacy-ciphertext-reencrypt', () => {
     expect(sets).toHaveLength(2);
     // Two full batches + one short (empty) terminal batch.
     expect(select).toHaveBeenCalledTimes(3);
+    // The cursor must actually advance to the last id of each prior batch —
+    // otherwise production refetches the same window forever.
+    expect(gtCursors).toEqual(['', 'u1', 'u2']);
   });
 });

--- a/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
+++ b/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the legacy-ciphertext re-encryption backfill runner.
+ *
+ * The pure planner is unit-tested in @pagespace/lib; here we verify the runner's
+ * imperative loop: dry-run writes nothing, live mode rewrites only legacy-format
+ * rows to the fast envelope, fast-format rows are skipped (idempotent re-runs
+ * converge), per-row failures are counted without aborting the run, and
+ * cursor-based pagination terminates.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scryptSync, randomBytes, createCipheriv } from 'crypto';
+
+vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn(), update: vi.fn() } }));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id', email: 'email', name: 'name' },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: () => ({}), gt: () => ({}), asc: () => ({}) }));
+
+import { backfill, resolveReencryptMode } from '../backfill-legacy-ciphertext-reencrypt';
+import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
+
+const MASTER = 'reencrypt-runner-test-master-key-32-chars-min!';
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = MASTER;
+});
+
+/** Legacy 4-part `salt:iv:authTag:ciphertext` envelope, as pre-#1930 encrypt() wrote it. */
+function legacyEncrypt(plaintext: string): string {
+  const salt = randomBytes(32);
+  const key = scryptSync(MASTER, salt, 32);
+  const iv = randomBytes(16);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  return [salt, iv, cipher.getAuthTag(), ciphertext].map((b) => b.toString('hex')).join(':');
+}
+
+/** Chainable select stub terminating on .limit(); returns successive batches. */
+function selectReturning(batches: unknown[][]) {
+  let call = 0;
+  return vi.fn(() => {
+    const rows = batches[call] ?? [];
+    call += 1;
+    const stub: Record<string, unknown> = {};
+    for (const m of ['from', 'where', 'orderBy']) stub[m] = () => stub;
+    stub['limit'] = () => Promise.resolve(rows);
+    return stub;
+  });
+}
+
+function captureUpdate() {
+  const sets: Array<Record<string, unknown>> = [];
+  const update = vi.fn(() => ({
+    set: (v: Record<string, unknown>) => {
+      sets.push(v);
+      return { where: () => Promise.resolve() };
+    },
+  }));
+  return { update, sets };
+}
+
+describe('resolveReencryptMode (fast-format-readers safety gate)', () => {
+  it('defaults to dry-run when --apply is absent', () => {
+    expect(resolveReencryptMode({ apply: false, reencryptConfirmed: false })).toEqual({ ok: true, dryRun: true });
+  });
+
+  it('refuses a live --apply run unless the re-encryption is explicitly confirmed', () => {
+    const mode = resolveReencryptMode({ apply: true, reencryptConfirmed: false });
+    expect(mode.ok).toBe(false);
+    if (!mode.ok) expect(mode.error).toContain('LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED');
+  });
+
+  it('allows a live run only when --apply AND confirmation are both present', () => {
+    expect(resolveReencryptMode({ apply: true, reencryptConfirmed: true })).toEqual({ ok: true, dryRun: false });
+  });
+});
+
+describe('backfill-legacy-ciphertext-reencrypt', () => {
+  it('live mode: rewrites a legacy row to the fast 3-part envelope with identical plaintext', async () => {
+    const select = selectReturning([[{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }], []]);
+    const { update, sets } = captureUpdate();
+    const result = await backfill(false, { select, update } as never);
+
+    expect(result).toEqual({ legacyFound: 1, converted: 1, skipped: 0, errors: 0 });
+    expect(sets).toHaveLength(1);
+    expect((sets[0].email as string).split(':')).toHaveLength(3);
+    expect((sets[0].name as string).split(':')).toHaveLength(3);
+    expect(await decrypt(sets[0].email as string)).toBe('a@b.com');
+    expect(await decrypt(sets[0].name as string)).toBe('A');
+  });
+
+  it('dry run: counts legacy rows but writes nothing', async () => {
+    const select = selectReturning([[{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }], []]);
+    const { update, sets } = captureUpdate();
+    const result = await backfill(true, { select, update } as never);
+
+    expect(result).toEqual({ legacyFound: 1, converted: 1, skipped: 0, errors: 0 });
+    expect(update).not.toHaveBeenCalled();
+    expect(sets).toHaveLength(0);
+  });
+
+  it('idempotent/resumable: a re-run over already-converted rows converges to zero work', async () => {
+    // First pass converts the legacy row.
+    const select1 = selectReturning([[{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }], []]);
+    const cap = captureUpdate();
+    await backfill(false, { select: select1, update: cap.update } as never);
+    const convertedRow = { id: 'u1', email: cap.sets[0].email, name: cap.sets[0].name };
+
+    // Second pass (e.g. resuming after an interruption) skips it.
+    const { update, sets } = captureUpdate();
+    const select2 = selectReturning([[convertedRow], []]);
+    const result = await backfill(false, { select: select2, update } as never);
+
+    expect(result).toEqual({ legacyFound: 0, converted: 0, skipped: 1, errors: 0 });
+    expect(update).not.toHaveBeenCalled();
+    expect(sets).toHaveLength(0);
+  });
+
+  it('plaintext rows are skipped — this backfill never encrypts plaintext', async () => {
+    const select = selectReturning([[{ id: 'u1', email: 'plain@b.com', name: 'Plain' }], []]);
+    const { update } = captureUpdate();
+    const result = await backfill(false, { select, update } as never);
+
+    expect(result).toEqual({ legacyFound: 0, converted: 0, skipped: 1, errors: 0 });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('a row that fails to decrypt is counted as an error without aborting the run', async () => {
+    const good = legacyEncrypt('ok@b.com');
+    const tamperedParts = legacyEncrypt('bad@b.com').split(':');
+    tamperedParts[2] = tamperedParts[2].replace(/^./, tamperedParts[2].startsWith('0') ? '1' : '0');
+    const tampered = tamperedParts.join(':');
+
+    const select = selectReturning([
+      [
+        { id: 'u1', email: tampered, name: legacyEncrypt('Bad') },
+        { id: 'u2', email: good, name: legacyEncrypt('Ok') },
+      ],
+      [],
+    ]);
+    const { update, sets } = captureUpdate();
+    const result = await backfill(false, { select, update } as never);
+
+    expect(result).toEqual({ legacyFound: 2, converted: 1, skipped: 0, errors: 1 });
+    expect(sets).toHaveLength(1);
+    expect(await decrypt(sets[0].email as string)).toBe('ok@b.com');
+  });
+
+  it('paginates across batches on the ascending-id cursor and terminates', async () => {
+    const select = selectReturning([
+      [{ id: 'u1', email: legacyEncrypt('a@b.com'), name: legacyEncrypt('A') }],
+      [{ id: 'u2', email: legacyEncrypt('b@b.com'), name: legacyEncrypt('B') }],
+      [],
+    ]);
+    const { update, sets } = captureUpdate();
+    const result = await backfill(false, { select, update } as never, 1);
+
+    expect(result).toEqual({ legacyFound: 2, converted: 2, skipped: 0, errors: 0 });
+    expect(sets).toHaveLength(2);
+    // Two full batches + one short (empty) terminal batch.
+    expect(select).toHaveBeenCalledTimes(3);
+  });
+});

--- a/scripts/backfill-legacy-ciphertext-reencrypt.ts
+++ b/scripts/backfill-legacy-ciphertext-reencrypt.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env bun
+/**
+ * Backfill Script: re-encrypt legacy-format user PII ciphertext to the fast format.
+ *
+ * The 2026-07-06 user-PII backfill (scripts/backfill-user-pii-encryption.ts)
+ * ran a day BEFORE #1930 memoized the master-key derivation, so every existing
+ * row's `users.email`/`users.name` is stored in the legacy 4-part
+ * `salt:iv:authTag:ciphertext` envelope. Decrypting that format costs a full
+ * per-record scrypt (`deriveLegacyKey`) on every read — the source of the
+ * sustained post-rollout latency on the single-vCPU web machine. This script
+ * decrypts each legacy value and re-encrypts it under the memoized master key
+ * as the fast 3-part `iv:authTag:ciphertext` envelope. Plaintext is unchanged,
+ * so `users.emailBidx` (derived from plaintext) is untouched.
+ *
+ * Idempotent + resumable: the pure planner (planLegacyCiphertextReencrypt)
+ * skips any value already in the fast format (and never touches plaintext), so
+ * re-runs converge to zero work and an interrupted run picks up where it left
+ * off via the ascending-id cursor. Per-row failures are counted and logged
+ * without aborting the run.
+ *
+ * Usage:
+ *   bun scripts/backfill-legacy-ciphertext-reencrypt.ts            # dry-run (default, safe)
+ *   LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true \
+ *     bun scripts/backfill-legacy-ciphertext-reencrypt.ts --apply  # live write
+ *
+ * SAFETY GATE: a live run rewrites ciphertext into the 3-part envelope, which
+ * only app images carrying #1930/#1931 can parse — a pre-#1930 reader throws
+ * "Invalid encrypted text format" on every converted row. The runner therefore
+ * defaults to dry-run and refuses `--apply` unless
+ * `LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true` explicitly confirms every
+ * reader of these columns (web, realtime, processor) is deployed on a
+ * fast-format-aware image.
+ *
+ * Requires ENCRYPTION_KEY in the environment (same key used at runtime).
+ *
+ * ─── Production procedure (Fly) ────────────────────────────────────────────
+ * 1. Verify web, realtime, and processor are all deployed at or after
+ *    #1930 (c6e60f97f) + #1931 (da3514c7f).
+ * 2. Dry-run as a one-off machine with ENCRYPTION_KEY set; sanity-check the
+ *    reported legacy count (~224 users expected).
+ * 3. Re-run with --apply and LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true.
+ *    DO NOT run against production yourself — document only.
+ * ────────────────────────────────────────────────────────────────────────────
+ */
+
+import { db as defaultDb } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { eq, gt, asc } from '@pagespace/db/operators';
+import { planLegacyCiphertextReencrypt } from '@pagespace/lib/encryption/legacy-ciphertext-reencrypt';
+
+const BATCH_SIZE = 500;
+
+export type ReencryptResult = {
+  legacyFound: number;
+  converted: number;
+  skipped: number;
+  errors: number;
+};
+
+export type ReencryptMode =
+  | { ok: true; dryRun: boolean }
+  | { ok: false; error: string };
+
+/**
+ * Resolve the run mode. Dry-run is the default; a live write requires BOTH
+ * `--apply` and explicit confirmation that every reader can parse the fast
+ * 3-part envelope, so the backfill cannot strand ciphertext that a
+ * pre-#1930 app image still in production would fail to decrypt.
+ */
+export function resolveReencryptMode({
+  apply,
+  reencryptConfirmed,
+}: {
+  apply: boolean;
+  reencryptConfirmed: boolean;
+}): ReencryptMode {
+  if (!apply) return { ok: true, dryRun: true };
+  if (!reencryptConfirmed) {
+    return {
+      ok: false,
+      error:
+        'Refusing live legacy-ciphertext re-encryption: set LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true ' +
+        'only AFTER every reader of users.email/users.name (web, realtime, processor) is deployed on an ' +
+        'image carrying #1930/#1931 (fast iv:authTag:ciphertext envelope support). A pre-#1930 reader ' +
+        'cannot parse the converted rows. See docs/security/pii-encryption-design.md.',
+    };
+  }
+  return { ok: true, dryRun: false };
+}
+
+type DbLike = Pick<typeof defaultDb, 'select' | 'update'>;
+
+export async function backfill(
+  dryRun: boolean,
+  dbInstance: DbLike = defaultDb,
+  batchSize: number = BATCH_SIZE,
+): Promise<ReencryptResult> {
+  console.log(`🔐 Re-encrypting legacy-format user PII${dryRun ? ' (dry run)' : ''}...`);
+
+  let converted = 0;
+  let skipped = 0;
+  let errors = 0;
+  let cursor = '';
+
+  for (;;) {
+    const batch = await (dbInstance as typeof defaultDb)
+      .select({ id: users.id, email: users.email, name: users.name })
+      .from(users)
+      .where(gt(users.id, cursor))
+      .orderBy(asc(users.id))
+      .limit(batchSize);
+
+    if (batch.length === 0) break;
+
+    for (const row of batch) {
+      try {
+        const update = await planLegacyCiphertextReencrypt(row);
+        if (!update) {
+          skipped += 1;
+          continue;
+        }
+        if (dryRun) {
+          converted += 1;
+          continue;
+        }
+        await (dbInstance as typeof defaultDb)
+          .update(users)
+          .set({ email: update.email, name: update.name })
+          .where(eq(users.id, update.id));
+        converted += 1;
+      } catch (err) {
+        // The planner only runs crypto (and the runner only writes) for
+        // legacy-format rows, so every failure here is a legacy row.
+        errors += 1;
+        console.error(`  ⚠️ row ${row.id}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    cursor = batch[batch.length - 1].id;
+    if (batch.length < batchSize) break;
+  }
+
+  const legacyFound = converted + errors;
+  console.log(
+    `✅ Re-encryption ${dryRun ? 'dry run ' : ''}complete. legacy found: ${legacyFound}, ${
+      dryRun ? 'would convert' : 'converted'
+    }: ${converted}, already fast/plaintext: ${skipped}, errors: ${errors}`,
+  );
+  return { legacyFound, converted, skipped, errors };
+}
+
+// Only run when invoked directly (not when imported by tests).
+if (import.meta.main) {
+  const mode = resolveReencryptMode({
+    apply: process.argv.includes('--apply'),
+    reencryptConfirmed: process.env.LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED === 'true',
+  });
+  if (!mode.ok) {
+    console.error(`❌ ${mode.error}`);
+    process.exit(1);
+  }
+  backfill(mode.dryRun)
+    .then((result) => process.exit(result.errors > 0 ? 1 : 0))
+    .catch((err) => {
+      console.error('❌ Re-encryption backfill failed:', err);
+      process.exit(1);
+    });
+}

--- a/scripts/backfill-legacy-ciphertext-reencrypt.ts
+++ b/scripts/backfill-legacy-ciphertext-reencrypt.ts
@@ -45,7 +45,7 @@
 
 import { db as defaultDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
-import { eq, gt, asc } from '@pagespace/db/operators';
+import { eq, gt, asc, and } from '@pagespace/db/operators';
 import { planLegacyCiphertextReencrypt } from '@pagespace/lib/encryption/legacy-ciphertext-reencrypt';
 
 const BATCH_SIZE = 500;
@@ -123,10 +123,21 @@ export async function backfill(
           converted += 1;
           continue;
         }
-        await (dbInstance as typeof defaultDb)
+        // Compare-and-swap: the app can rewrite email/name (and emailBidx)
+        // between the batch select and this write. Guarding on the exact
+        // ciphertext read means a concurrently-modified row matches 0 rows
+        // instead of being clobbered back to stale values — which would
+        // desync users.email from the app-written emailBidx and break
+        // blind-index login lookups. A re-run picks the row up as-is.
+        const written = await (dbInstance as typeof defaultDb)
           .update(users)
           .set({ email: update.email, name: update.name })
-          .where(eq(users.id, update.id));
+          .where(and(eq(users.id, update.id), eq(users.email, row.email), eq(users.name, row.name)));
+        if (written.rowCount === 0) {
+          skipped += 1;
+          console.warn(`  ⏭ row ${row.id}: modified concurrently, skipped — a re-run will convert it`);
+          continue;
+        }
         converted += 1;
       } catch (err) {
         // The planner only runs crypto (and the runner only writes) for

--- a/scripts/backfill-legacy-ciphertext-reencrypt.ts
+++ b/scripts/backfill-legacy-ciphertext-reencrypt.ts
@@ -33,6 +33,12 @@
  *
  * Requires ENCRYPTION_KEY in the environment (same key used at runtime).
  *
+ * Exit codes: 0 = run completed with zero row errors; 1 = the safety gate
+ * refused a live run, the run crashed, or one or more rows failed to convert
+ * (deliberate: an undecryptable PII row should be surfaced loudly, not
+ * converged past — the summary line separates converted vs errors so a
+ * human can tell partial progress from a poison row recurring across runs).
+ *
  * ─── Production procedure (Fly) ────────────────────────────────────────────
  * 1. Verify web, realtime, and processor are all deployed at or after
  *    #1930 (c6e60f97f) + #1931 (da3514c7f).
@@ -104,7 +110,7 @@ export async function backfill(
 
   for (;;) {
     const batch = await (dbInstance as typeof defaultDb)
-      .select({ id: users.id, email: users.email, name: users.name })
+      .select({ id: users.id, email: users.email, name: users.name, updatedAt: users.updatedAt })
       .from(users)
       .where(gt(users.id, cursor))
       .orderBy(asc(users.id))
@@ -129,9 +135,13 @@ export async function backfill(
         // instead of being clobbered back to stale values — which would
         // desync users.email from the app-written emailBidx and break
         // blind-index login lookups. A re-run picks the row up as-is.
+        // updatedAt is pinned to its prior value: the schema's $onUpdate would
+        // otherwise stamp every backfilled row with the run time, and a
+        // ciphertext-format rewrite is not a profile update (users.updatedAt
+        // surfaces in the GDPR Art-15 export as "account last updated").
         const written = await (dbInstance as typeof defaultDb)
           .update(users)
-          .set({ email: update.email, name: update.name })
+          .set({ email: update.email, name: update.name, updatedAt: row.updatedAt })
           .where(and(eq(users.id, update.id), eq(users.email, row.email), eq(users.name, row.name)));
         if (written.rowCount === 0) {
           skipped += 1;

--- a/tasks/pii-decrypt-perf-remediation-round2.md
+++ b/tasks/pii-decrypt-perf-remediation-round2.md
@@ -1,64 +1,73 @@
-# PII Decrypt Perf Remediation — Round 2
+# PII Decrypt Perf Remediation — Round 2 Epic
 
-## Context
+**Status**: 📋 PLANNED
+**Goal**: Finish closing the PII-decrypt latency regression that PR #1930/#1931 only partially fixed — every existing user's PII is still on the slow path, and several hot routes were never wired into the dedup fix.
 
-The GDPR PII encryption-at-rest rollout completed 2026-07-06 and `pagespace-web`
-(single 1-vCPU Fly machine) has run elevated HTTP response times since
-(0.3-0.5s baseline → sustained 1-15s, one 37s spike). PR #1930 (c6e60f97f)
-memoized the AES master-key scrypt derivation and PR #1931 (da3514c7f) did the
-same for the blind-index HMAC key, but response times stayed elevated because:
+## Overview
 
-- The one-time backfill (`scripts/backfill-user-pii-encryption.ts`) ran on
-  2026-07-06 — a full day BEFORE #1930 introduced the fast 3-part
-  `iv:authTag:ciphertext` envelope. All 224 existing users' `email`/`name`
-  ciphertext is stuck on the legacy 4-part `salt:iv:authTag:ciphertext` format.
-- `decrypt()` still runs a full unmemoized `scryptSync` per record for the
-  legacy format (`deriveLegacyKey`,
-  `packages/lib/src/encryption/encryption-utils.ts`), so 100% of real user PII
-  reads pay the slow-scrypt cost on every request until the rows are
-  re-encrypted into the fast format.
+Because PR #1930's expand-contract fix only speeds up brand-new writes and only deduped 3 of the routes that decrypt PII in a per-row loop, production response times are still elevated hours after both perf PRs deployed: the one-time backfill (`scripts/backfill-user-pii-encryption.ts`) that encrypted all 224 existing users ran on 2026-07-06, a full day before #1930 introduced the fast ciphertext format, so every existing user's `email`/`name` is permanently stuck on the slow unmemoized-scrypt-per-record legacy decrypt path (`deriveLegacyKey`) until re-encrypted — and grep found `inbox`, `messages/conversations`, `messages/conversations/[conversationId]`, `messages/threads`, `connections`, and `connections/search` routes still doing undeduped per-row `decryptField` calls that PR #1930 never touched. This epic closes both gaps with zero behavior change, full backwards compatibility with mixed-format data mid-migration, and pure-function-core/imperative-shell TDD throughout, following the exact patterns already established in `encryption-utils.ts` (`parseEnvelope`/`buildEnvelope`/`encryptWithKey`/`decryptWithKey`) and `blind-index.ts` (`memoizeSyncByKey`).
 
-## Legacy-ciphertext re-encryption backfill — Done (this PR)
+---
 
-Convert every legacy-4-part-format `users.email`/`users.name` ciphertext row to
-the fast 3-part format so no existing user's PII reads hit the slow legacy
-scrypt path.
+## Legacy-ciphertext re-encryption backfill
 
-Deliverables:
+**Status**: ✅ DONE (PR #1936 — live production run is a separate, explicit,
+human-supervised step; every reader of `users.email`/`users.name` must be on a
+#1930-aware image first, gated by `--apply` +
+`LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true`)
 
-- [x] Pure planner (`packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts`)
-      mirroring `planUserPiiBackfill`: per row, decide legacy (convert) vs
-      fast/plaintext (skip); compute new ciphertext for legacy rows. No DB
-      access or I/O — unit-testable without a database.
-- [x] Runner script (`scripts/backfill-legacy-ciphertext-reencrypt.ts`)
-      mirroring `backfill-user-pii-encryption.ts`: cursor-on-id-ascending
-      batches, dry-run by default, live write requires `--apply` AND
-      `LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true`, reports legacy found /
-      converted / skipped / errors, resumable.
+Idempotent, resumable, dry-run-by-default script that reads every legacy-4-part-format `users.email`/`name` row, decrypts it via the existing dual-format `decrypt()`, and re-encrypts it via `encrypt()` (which always emits the fast 3-part format) — converging every row to the fast format so the legacy scrypt path is no longer on the hot read path for any existing user.
 
-Acceptance criteria:
+**Requirements**:
+- Given a row already in fast-format ciphertext, should skip it (idempotent re-runs converge to zero work, mirroring `scripts/backfill-user-pii-encryption.ts`'s existing-row skip).
+- Given a row in legacy-format ciphertext, should decrypt then re-encrypt it to fast format in a single pass, byte-identical plaintext round-trip proven by test.
+- Given the migration is interrupted mid-run, should be resumable (cursor-based batching, same pattern as the existing backfill) without re-processing already-converted rows or losing progress.
+- Given a dry-run flag (default), should report counts (legacy found / would-convert) without writing, requiring the same explicit `--apply` + confirmed-cutover-deployed gate pattern as the existing backfill before any live write.
+- Given the planner logic (which rows need conversion, what the new value should be), should be a pure function separate from the DB I/O shell, unit-tested without a real database — same split as `planUserPiiBackfill`.
 
-- [x] Fast-format row → skipped (idempotent re-runs converge to zero work).
-- [x] Legacy-format row → decrypt + re-encrypt to fast format in one pass;
-      byte-identical plaintext round-trip proven by test (decrypt(new) ===
-      decrypt(old) === original plaintext; new envelope has 3 colon-separated
-      parts, not 4).
-- [x] Interrupted mid-run → resumable without re-processing converted rows.
-- [x] Dry-run by default; live write gated on `--apply` + confirmation env var.
-- [x] Planner is a pure function separate from the DB I/O shell, unit-tested
-      without a real database.
+---
 
-Rollout note: the live run must only happen AFTER the fast-format-aware app
-(#1930/#1931) is deployed to every reader (web, realtime, processor) — a
-pre-#1930 image cannot parse the 3-part envelope. Running the backfill against
-production is a separate, explicit, human-supervised step.
+## Dedup PII decrypts in inbox route
 
-## Dedup decrypts in routes missed by #1930 — In Progress (parallel workstream)
+Wire the existing `decryptUsersByIdOnce` helper (`packages/lib/src/auth/user-repository.ts`, added by PR #1930) into `apps/web/src/app/api/inbox/route.ts`'s three per-row `decryptField` call sites so a repeated sender/participant within one request's result set decrypts once, not once per row.
 
-A second agent is wiring the request-scoped decrypt dedup into the routes PR
-#1930 missed. Independent files; no coordination with the backfill workstream.
+**Requirements**:
+- Given an inbox response listing multiple conversations from the same sender, should decrypt that sender's name exactly once for the whole request (call-count assertion via the same test pattern PR #1930 used against `decryptUsersByIdOnce`, not a dist-boundary mock on the inner `decryptField`).
+- Given the route's existing response shape and decrypted values, should be byte-identical to before the change (behavior-preserving refactor, not a new feature).
 
-## Follow-ups surfaced by review (not yet scheduled)
+---
+
+## Dedup PII decrypts in messages routes
+
+Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/messages/conversations/route.ts`, `apps/web/src/app/api/messages/conversations/[conversationId]/route.ts`, and `apps/web/src/app/api/messages/threads/route.ts`.
+
+**Requirements**:
+- Given a conversations/threads list with repeated other-party users across rows, should decrypt each unique user once per request.
+- Given the single-conversation detail route, should still correctly decrypt when only one distinct user is present (no regression for the common case).
+
+---
+
+## Dedup PII decrypts in connections routes
+
+Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/connections/route.ts` and `apps/web/src/app/api/connections/search/route.ts`.
+
+**Requirements**:
+- Given a connections list or search result with repeated users, should decrypt each unique user once per request.
+- Given the search route's existing filtering/ranking behavior, should be unaffected by the decrypt-path change.
+
+---
+
+## Verify recovery
+
+After all four tasks land and deploy, confirm the fix actually closes the gap rather than just asserting it should.
+
+**Requirements**:
+- Given the full lib + web test suites and `bun run typecheck`, should be green with zero new failures across all four preceding tasks.
+- Given the fix is deployed to `pagespace-web`, should show HTTP Response Time Avg back down near the pre-regression ~0.3-0.5s baseline on the same Grafana panel used to diagnose this, not just an assumption that the code change helped.
+
+---
+
+## Follow-ups surfaced by PR #1936 review (not yet scheduled)
 
 - Other columns also hold pre-#1930 legacy 4-part ciphertext and pay
   scrypt-per-decrypt on every read: integration connection credentials

--- a/tasks/pii-decrypt-perf-remediation-round2.md
+++ b/tasks/pii-decrypt-perf-remediation-round2.md
@@ -1,0 +1,59 @@
+# PII Decrypt Perf Remediation — Round 2
+
+## Context
+
+The GDPR PII encryption-at-rest rollout completed 2026-07-06 and `pagespace-web`
+(single 1-vCPU Fly machine) has run elevated HTTP response times since
+(0.3-0.5s baseline → sustained 1-15s, one 37s spike). PR #1930 (c6e60f97f)
+memoized the AES master-key scrypt derivation and PR #1931 (da3514c7f) did the
+same for the blind-index HMAC key, but response times stayed elevated because:
+
+- The one-time backfill (`scripts/backfill-user-pii-encryption.ts`) ran on
+  2026-07-06 — a full day BEFORE #1930 introduced the fast 3-part
+  `iv:authTag:ciphertext` envelope. All 224 existing users' `email`/`name`
+  ciphertext is stuck on the legacy 4-part `salt:iv:authTag:ciphertext` format.
+- `decrypt()` still runs a full unmemoized `scryptSync` per record for the
+  legacy format (`deriveLegacyKey`,
+  `packages/lib/src/encryption/encryption-utils.ts`), so 100% of real user PII
+  reads pay the slow-scrypt cost on every request until the rows are
+  re-encrypted into the fast format.
+
+## Legacy-ciphertext re-encryption backfill — Done (this PR)
+
+Convert every legacy-4-part-format `users.email`/`users.name` ciphertext row to
+the fast 3-part format so no existing user's PII reads hit the slow legacy
+scrypt path.
+
+Deliverables:
+
+- [x] Pure planner (`packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts`)
+      mirroring `planUserPiiBackfill`: per row, decide legacy (convert) vs
+      fast/plaintext (skip); compute new ciphertext for legacy rows. No DB
+      access or I/O — unit-testable without a database.
+- [x] Runner script (`scripts/backfill-legacy-ciphertext-reencrypt.ts`)
+      mirroring `backfill-user-pii-encryption.ts`: cursor-on-id-ascending
+      batches, dry-run by default, live write requires `--apply` AND
+      `LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true`, reports legacy found /
+      converted / skipped / errors, resumable.
+
+Acceptance criteria:
+
+- [x] Fast-format row → skipped (idempotent re-runs converge to zero work).
+- [x] Legacy-format row → decrypt + re-encrypt to fast format in one pass;
+      byte-identical plaintext round-trip proven by test (decrypt(new) ===
+      decrypt(old) === original plaintext; new envelope has 3 colon-separated
+      parts, not 4).
+- [x] Interrupted mid-run → resumable without re-processing converted rows.
+- [x] Dry-run by default; live write gated on `--apply` + confirmation env var.
+- [x] Planner is a pure function separate from the DB I/O shell, unit-tested
+      without a real database.
+
+Rollout note: the live run must only happen AFTER the fast-format-aware app
+(#1930/#1931) is deployed to every reader (web, realtime, processor) — a
+pre-#1930 image cannot parse the 3-part envelope. Running the backfill against
+production is a separate, explicit, human-supervised step.
+
+## Dedup decrypts in routes missed by #1930 — In Progress (parallel workstream)
+
+A second agent is wiring the request-scoped decrypt dedup into the routes PR
+#1930 missed. Independent files; no coordination with the backfill workstream.

--- a/tasks/pii-decrypt-perf-remediation-round2.md
+++ b/tasks/pii-decrypt-perf-remediation-round2.md
@@ -57,3 +57,17 @@ production is a separate, explicit, human-supervised step.
 
 A second agent is wiring the request-scoped decrypt dedup into the routes PR
 #1930 missed. Independent files; no coordination with the backfill workstream.
+
+## Follow-ups surfaced by review (not yet scheduled)
+
+- Other columns also hold pre-#1930 legacy 4-part ciphertext and pay
+  scrypt-per-decrypt on every read: integration connection credentials
+  (decrypted per tool execution), Google/Zoom OAuth tokens (token refresh only
+  rewrites the access token, so refresh tokens stay legacy indefinitely), and
+  `security_audit_log.ipAddress` rows written 2026-06-25 → 2026-07-06. Each
+  needs its own backfill reusing `reencryptLegacyValue` from
+  `packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts`.
+- Systemic mitigation to consider: a small LRU keyed by salt in
+  `deriveLegacyKey` (mirroring the masterKeyCache pattern) would collapse
+  repeated decrypts of the same legacy value to one scrypt process-wide,
+  covering all legacy surfaces including the window before each backfill runs.


### PR DESCRIPTION
## Why

The GDPR PII encryption rollout completed 2026-07-06 and `pagespace-web` response times have stayed elevated (1-15s sustained, one 37s spike) even after #1930/#1931 memoized key derivation. Root cause: the one-time user-PII backfill ran a day **before** #1930 introduced the fast 3-part `iv:authTag:ciphertext` envelope, so all 224 existing users' `email`/`name` ciphertext is stuck on the legacy 4-part `salt:iv:authTag:ciphertext` format — and `decrypt()` still pays a full unmemoized scrypt per record for that format (`deriveLegacyKey`). 100% of real user PII reads hit the slow path on a single-vCPU box until the rows are re-encrypted.

## What

Idempotent, resumable, dry-run-by-default backfill converting legacy-format `users.email`/`users.name` to the fast envelope. Plaintext is unchanged, so `users.emailBidx` is untouched.

- **`packages/lib/src/encryption/legacy-ciphertext-reencrypt.ts`** — pure planner (`planLegacyCiphertextReencrypt`) mirroring `planUserPiiBackfill`: converts only legacy-format fields, skips fast-format and plaintext values so re-runs converge to zero work. No DB/I-O; unit-tested with a byte-identical round-trip proof (decrypt(new) === decrypt(old) === original plaintext; 3 parts, not 4). Also exports `reencryptLegacyValue` as the column-agnostic core for follow-up backfills.
- **`scripts/backfill-legacy-ciphertext-reencrypt.ts`** — runner mirroring `backfill-user-pii-encryption.ts`: ascending-id cursor batches, dry-run by default, live write requires `--apply` **and** `LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true` (every reader must be on a #1930-aware image first — a pre-#1930 reader cannot parse the 3-part envelope). Reports legacy found / converted / skipped / errors; per-row failures don't abort the run.
- **Compare-and-swap write**: the UPDATE guards on the exact ciphertext read (id + email + name), so a row the app modifies mid-run matches 0 rows and is skipped instead of clobbered — preventing email/emailBidx desync. A re-run converges it.
- **`looksLegacyEncrypted`** exported from `field-crypto.ts` (existing `looksEncrypted` refactored on top, behavior unchanged).
- New scripts test added to the CI backfill-test list.

## Tests

- `packages/lib` encryption suite: 46 passed (6 new planner tests)
- scripts suite: 16 passed (10 new runner tests incl. mode-gate, idempotency, error-isolation, concurrent-modification, pagination)
- `bun run typecheck`: 16/16 tasks green

## Rollout (human-supervised, NOT part of this PR)

1. Verify web/realtime/processor are all deployed at or after #1930 + #1931.
2. Dry-run as a one-off machine; sanity-check the legacy count (~224).
3. Re-run with `--apply` + `LEGACY_CIPHERTEXT_REENCRYPT_CONFIRMED=true`.

Follow-ups (documented in `tasks/pii-decrypt-perf-remediation-round2.md`): integration credentials, OAuth refresh tokens, and audit-log IPs also hold pre-#1930 legacy ciphertext and need their own backfills via `reencryptLegacyValue`; optionally an LRU on `deriveLegacyKey` as a systemic mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGzF3bCaBBfTL3URJW6vLH

## Review hardening (post-open commits)

- **Compare-and-swap write** (9172d829e): UPDATE guards on the exact ciphertext read; concurrently-modified rows are skipped (0-row match), not clobbered — prevents email/emailBidx desync. Regression-tested.
- **Epic doc rebased onto canonical #1935 structure** (db99b0235) so the add/add resolution against #1935/#1937 is a trivial take-newest.
- **updatedAt pinned** (f700c6267): the schema's `$onUpdate` would stamp every converted row with the run time; a ciphertext-format rewrite is not a profile update (`users.updatedAt` surfaces in the GDPR Art-15 export). Asserted by test.
- **Cursor advancement proven** (f700c6267): the pagination test now asserts the actual cursor sequence passed to `gt()` ('', 'u1', 'u2'), so a broken cursor can no longer pass.
- **Legacy-envelope test fixture deduped** (f700c6267): shared, build-excluded fixture in `packages/lib/src/encryption/__tests__/`; salt+key derived once per master key (saves ~2-4s of scrypt per CI run).
- **Exit-code contract documented**: exit 1 on any row error is deliberate (undecryptable PII surfaces loudly; summary line separates converted vs errors so partial progress is distinguishable from a recurring poison row).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for safely converting older encrypted account data to the newer format.
  * Expanded encryption support so legacy encrypted values are recognized and handled correctly.

* **Bug Fixes**
  * Improved handling of older encrypted records to avoid misidentifying plaintext or already-updated values.
  * Added safeguards so live data updates require explicit confirmation before running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->