### PR TITLE
fix(perf): dedup PII decrypts in inbox, messages, and connections routes

### DIFF
--- a/apps/web/src/app/api/connections/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/__tests__/route.test.ts
@@ -57,9 +57,23 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   isEmailVerified: vi.fn().mockResolvedValue(true),
 }));
 
+// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
+// asserted at the route's call boundary — proves the route batches decryption
+// once per request instead of once per row. A bare `vi.spyOn` doesn't work
+// here because `@pagespace/lib` resolves to its built CJS dist output, and the
+// per-row-dedup internals (decryptUserRow -> decryptField) are a *nested*
+// require inside that compiled module, invisible to any mock at this level.
+vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
+  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+});
+
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { db } from '@pagespace/db/db';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
 
 const mockUserId = 'user_123';
 
@@ -87,6 +101,71 @@ describe('GET /api/connections audit', () => {
       expect.any(Request),
       expect.objectContaining({ eventType: 'data.read', userId: mockUserId, resourceType: 'connections', resourceId: 'self' })
     );
+  });
+});
+
+describe('GET /api/connections PII decryption dedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  // Queue results in route order: (1) connections list (…orderBy), then
+  // (2) connected-user details (…leftJoin…where).
+  const setupSelect = (connectionRows: unknown[], userRows: unknown[]) => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(connectionRows),
+          }),
+        }),
+      } as never)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(userRows),
+          }),
+        }),
+      } as never);
+  };
+
+  const connectionRow = (id: string, otherUserId: string) => ({
+    id,
+    status: 'ACCEPTED',
+    requestedAt: '2026-05-01T00:00:00.000Z',
+    acceptedAt: '2026-05-02T00:00:00.000Z',
+    requestMessage: null,
+    user1Id: mockUserId,
+    user2Id: otherUserId,
+    requestedBy: mockUserId,
+  });
+
+  it('decrypts every connected user in one batched call per request (dedup)', async () => {
+    const encryptedNameA = await encryptField('User A');
+    const encryptedEmailA = await encryptField('a@example.com');
+    setupSelect(
+      [connectionRow('conn_1', 'user_a'), connectionRow('conn_2', 'user_b')],
+      [
+        { id: 'user_a', name: encryptedNameA, email: encryptedEmailA, image: null, username: 'a', displayName: null, bio: null, avatarUrl: null },
+        { id: 'user_b', name: 'Plain B', email: 'b@example.com', image: null, username: 'b', displayName: null, bio: null, avatarUrl: null },
+      ]
+    );
+
+    const res = await GET(new Request('http://localhost/api/connections'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.connections).toHaveLength(2);
+    const byId = new Map(body.connections.map((c: { user: { id: string } }) => [c.user.id, c]));
+    expect((byId.get('user_a') as { user: { name: string; email: string } }).user.name).toBe('User A');
+    expect((byId.get('user_a') as { user: { name: string; email: string } }).user.email).toBe('a@example.com');
+    // Legacy plaintext passes through unchanged.
+    expect((byId.get('user_b') as { user: { name: string; email: string } }).user.name).toBe('Plain B');
+    // Decryption is batched once per request (dedup happens inside), not
+    // once per connected-user row.
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decryptUsersByIdOnce).mock.calls[0][0]).toHaveLength(2);
   });
 });
 

--- a/apps/web/src/app/api/connections/route.ts
+++ b/apps/web/src/app/api/connections/route.ts
@@ -4,7 +4,7 @@ import { eq, and, or, desc, inArray } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { userProfiles } from '@pagespace/db/schema/members'
 import { connections } from '@pagespace/db/schema/social';
-import { decryptUserRows } from '@pagespace/lib/auth/user-repository';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import { decryptField } from '@pagespace/lib/encryption/field-crypto';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -57,7 +57,7 @@ export async function GET(request: Request) {
       .map(conn => conn.user1Id === userId ? conn.user2Id : conn.user1Id);
 
     const otherUsers = otherUserIds.length > 0
-      ? await decryptUserRows(await db
+      ? await db
           .select({
             id: users.id,
             name: users.name,
@@ -70,10 +70,12 @@ export async function GET(request: Request) {
           })
           .from(users)
           .leftJoin(userProfiles, eq(users.id, userProfiles.userId))
-          .where(inArray(users.id, otherUserIds)))
+          .where(inArray(users.id, otherUserIds))
       : [];
 
-    const userMap = new Map(otherUsers.map(u => [u.id, u]));
+    // Decrypt each unique connected user's PII once for the whole request —
+    // the returned id-keyed map is exactly the lookup the rows re-attach by.
+    const userMap = await decryptUsersByIdOnce(otherUsers);
 
     const validConnections = userConnections
       .filter(conn => conn.user1Id && conn.user2Id)

--- a/apps/web/src/app/api/connections/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/search/__tests__/route.test.ts
@@ -102,7 +102,7 @@ describe('GET /api/connections/search', () => {
       { id: mockUserId, email: currentEmail } as unknown as Awaited<ReturnType<typeof verifyAuth>>,
     );
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
-    setupSelect([[{ id: mockUserId, email: currentEmail }]]);
+    setupSelect([]);
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -134,7 +134,7 @@ describe('GET /api/connections/search', () => {
   });
 
   it('returns the actionable user when one can be invited (exists, not self, no connection)', async () => {
-    setupSelect([[{ id: mockUserId, email: currentEmail }], [targetRow], []]);
+    setupSelect([[targetRow], []]);
     const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
     const body = await response.json();
     expect(response.status).toBe(200);
@@ -151,16 +151,29 @@ describe('GET /api/connections/search', () => {
   });
 
   it('collapses self-search into a generic { user: null } with no error', async () => {
-    // email === current user's email
-    setupSelect([[{ id: mockUserId, email: currentEmail }], [{ ...targetRow, email: currentEmail }], []]);
+    // Searching your own email: the dual lookup resolves to the caller's own
+    // row (same id), so isSelf collapses the response.
+    setupSelect([[{ ...targetRow, id: mockUserId, email: currentEmail }], []]);
     const response = await GET(new Request(`http://localhost/api/connections/search?email=${currentEmail}`));
     const body = await response.json();
     expect(body).toEqual({ user: null });
     expect(body).not.toHaveProperty('error');
   });
 
+  it('collapses a case-variant self-search into { user: null } (no self-profile enumeration)', async () => {
+    // The blind index normalizes case, so "CURRENT@TEST.COM" resolves to the
+    // caller's own row. db is chain-mocked here, so this proves the id-based
+    // isSelf decision, not the blind-index SQL itself: a target row carrying
+    // the caller's id must collapse regardless of the searched string's case.
+    setupSelect([[{ ...targetRow, id: mockUserId, email: currentEmail }], []]);
+    const response = await GET(new Request('http://localhost/api/connections/search?email=CURRENT@TEST.COM'));
+    const body = await response.json();
+    expect(body).toEqual({ user: null });
+    expect(body).not.toHaveProperty('error');
+  });
+
   it('collapses "no account" into a generic { user: null } with no error', async () => {
-    setupSelect([[{ id: mockUserId, email: currentEmail }], [], []]);
+    setupSelect([[], []]);
     const response = await GET(new Request('http://localhost/api/connections/search?email=ghost@test.com'));
     const body = await response.json();
     expect(body).toEqual({ user: null });
@@ -169,7 +182,7 @@ describe('GET /api/connections/search', () => {
 
   it('collapses every existing-relationship state into the SAME generic response', async () => {
     for (const status of ['PENDING', 'ACCEPTED', 'BLOCKED'] as const) {
-      setupSelect([[{ id: mockUserId, email: currentEmail }], [targetRow], [{ status }]]);
+      setupSelect([[targetRow], [{ status }]]);
       const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
       const body = await response.json();
       expect(body, `status=${status}`).toEqual({ user: null });
@@ -177,12 +190,10 @@ describe('GET /api/connections/search', () => {
     }
   });
 
-  it('decrypts the caller and the target in one batched call per request (dedup)', async () => {
-    const encryptedCurrentEmail = await encryptField(currentEmail);
+  it('decrypts the target in one batched call per request', async () => {
     const encryptedTargetName = await encryptField('Target');
     const encryptedTargetEmail = await encryptField('other@test.com');
     setupSelect([
-      [{ id: mockUserId, email: encryptedCurrentEmail }],
       [{ ...targetRow, name: encryptedTargetName, email: encryptedTargetEmail, displayName: null }],
       [],
     ]);
@@ -206,10 +217,9 @@ describe('GET /api/connections/search', () => {
     expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
   });
 
-  it('self-search decrypts the shared user once and still collapses to { user: null }', async () => {
+  it('self-search with ciphertext email still collapses to { user: null } with one decrypt call', async () => {
     const encryptedCurrentEmail = await encryptField(currentEmail);
     setupSelect([
-      [{ id: mockUserId, email: encryptedCurrentEmail }],
       [{ ...targetRow, id: mockUserId, email: encryptedCurrentEmail }],
       [],
     ]);
@@ -217,8 +227,8 @@ describe('GET /api/connections/search', () => {
     const response = await GET(new Request(`http://localhost/api/connections/search?email=${currentEmail}`));
     const body = await response.json();
 
-    // The caller row and the target row are the same user: one dedup'd batch,
-    // and the enumeration-safe self-collapse is unaffected.
+    // isSelf is decided by id (no caller-email decrypt at all); the target's
+    // PII decrypts in the single batched call.
     expect(body).toEqual({ user: null });
     expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/app/api/connections/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/search/__tests__/route.test.ts
@@ -46,11 +46,24 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
 
+// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
+// asserted at the route's call boundary — proves the route batches decryption
+// once per request. A bare `vi.spyOn` doesn't work here because
+// `@pagespace/lib` resolves to its built CJS dist output, and the
+// per-row-dedup internals (decryptUserRow -> decryptField) are a *nested*
+// require inside that compiled module, invisible to any mock at this level.
+vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
+  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+});
+
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { db } from '@pagespace/db/db';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
 
 const mockUserId = 'user_123';
 const currentEmail = 'current@test.com';
@@ -89,7 +102,7 @@ describe('GET /api/connections/search', () => {
       { id: mockUserId, email: currentEmail } as unknown as Awaited<ReturnType<typeof verifyAuth>>,
     );
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
-    setupSelect([[{ email: currentEmail }]]);
+    setupSelect([[{ id: mockUserId, email: currentEmail }]]);
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -121,7 +134,7 @@ describe('GET /api/connections/search', () => {
   });
 
   it('returns the actionable user when one can be invited (exists, not self, no connection)', async () => {
-    setupSelect([[{ email: currentEmail }], [targetRow], []]);
+    setupSelect([[{ id: mockUserId, email: currentEmail }], [targetRow], []]);
     const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
     const body = await response.json();
     expect(response.status).toBe(200);
@@ -139,7 +152,7 @@ describe('GET /api/connections/search', () => {
 
   it('collapses self-search into a generic { user: null } with no error', async () => {
     // email === current user's email
-    setupSelect([[{ email: currentEmail }], [{ ...targetRow, email: currentEmail }], []]);
+    setupSelect([[{ id: mockUserId, email: currentEmail }], [{ ...targetRow, email: currentEmail }], []]);
     const response = await GET(new Request(`http://localhost/api/connections/search?email=${currentEmail}`));
     const body = await response.json();
     expect(body).toEqual({ user: null });
@@ -147,7 +160,7 @@ describe('GET /api/connections/search', () => {
   });
 
   it('collapses "no account" into a generic { user: null } with no error', async () => {
-    setupSelect([[{ email: currentEmail }], [], []]);
+    setupSelect([[{ id: mockUserId, email: currentEmail }], [], []]);
     const response = await GET(new Request('http://localhost/api/connections/search?email=ghost@test.com'));
     const body = await response.json();
     expect(body).toEqual({ user: null });
@@ -156,11 +169,57 @@ describe('GET /api/connections/search', () => {
 
   it('collapses every existing-relationship state into the SAME generic response', async () => {
     for (const status of ['PENDING', 'ACCEPTED', 'BLOCKED'] as const) {
-      setupSelect([[{ email: currentEmail }], [targetRow], [{ status }]]);
+      setupSelect([[{ id: mockUserId, email: currentEmail }], [targetRow], [{ status }]]);
       const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
       const body = await response.json();
       expect(body, `status=${status}`).toEqual({ user: null });
       expect(body).not.toHaveProperty('error');
     }
+  });
+
+  it('decrypts the caller and the target in one batched call per request (dedup)', async () => {
+    const encryptedCurrentEmail = await encryptField(currentEmail);
+    const encryptedTargetName = await encryptField('Target');
+    const encryptedTargetEmail = await encryptField('other@test.com');
+    setupSelect([
+      [{ id: mockUserId, email: encryptedCurrentEmail }],
+      [{ ...targetRow, name: encryptedTargetName, email: encryptedTargetEmail, displayName: null }],
+      [],
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/connections/search?email=other@test.com'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    // Name/email decrypted at the edge; displayName falls back to the
+    // decrypted name exactly as before the dedup change.
+    expect(body).toEqual({
+      user: {
+        id: 'user_target',
+        name: 'Target',
+        email: 'other@test.com',
+        displayName: 'Target',
+        bio: 'bio',
+        avatarUrl: 'https://cdn/a.png',
+      },
+    });
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+  });
+
+  it('self-search decrypts the shared user once and still collapses to { user: null }', async () => {
+    const encryptedCurrentEmail = await encryptField(currentEmail);
+    setupSelect([
+      [{ id: mockUserId, email: encryptedCurrentEmail }],
+      [{ ...targetRow, id: mockUserId, email: encryptedCurrentEmail }],
+      [],
+    ]);
+
+    const response = await GET(new Request(`http://localhost/api/connections/search?email=${currentEmail}`));
+    const body = await response.json();
+
+    // The caller row and the target row are the same user: one dedup'd batch,
+    // and the enumeration-safe self-collapse is unaffected.
+    expect(body).toEqual({ user: null });
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/api/connections/search/route.ts
+++ b/apps/web/src/app/api/connections/search/route.ts
@@ -47,13 +47,6 @@ export async function GET(request: Request) {
       return NextResponse.json({ user: null });
     }
 
-    // Get current user's email to check for self-connection
-    const [currentUser] = await db
-      .select({ id: users.id, email: users.email })
-      .from(users)
-      .where(eq(users.id, user.id))
-      .limit(1);
-
     // Find user by exact email match (dual blind-index/raw-email lookup)
     const [targetRow] = await db
       .select({
@@ -69,30 +62,17 @@ export async function GET(request: Request) {
       .where(userEmailMatch(email))
       .limit(1);
 
-    // Decrypt PII at the edge so the search result shows plaintext name/email —
-    // one batched decrypt for the caller + target, once per unique user. The
-    // target row goes FIRST: on a self-search both rows share an id and
-    // decryptUsersByIdOnce keeps the first row per id, so the full profile row
-    // must win over the email-only caller row.
-    type SearchUserRow = {
-      id: string;
-      name: string | null;
-      email: string;
-      displayName?: string | null;
-      bio?: string | null;
-      avatarUrl?: string | null;
-    };
-    const decryptedUsersById = await decryptUsersByIdOnce<SearchUserRow>([
-      targetRow ?? null,
-      currentUser ? { id: currentUser.id, name: null, email: currentUser.email } : null,
-    ]);
+    // Self-search detection by id: the dual lookup above already resolves the
+    // caller's own email — in any letter case, via the normalized blind index —
+    // to the caller's row, so no separate fetch-and-decrypt of the caller's
+    // stored email is needed. (The old plaintext string compare also missed
+    // case-variant self-searches, leaking the caller's own profile as
+    // actionable; the id compare closes that.)
+    const isSelf = targetRow?.id === user.id;
 
-    // Decrypted stored email for the self-connection comparison.
-    const currentUserEmail = currentUser
-      ? decryptedUsersById.get(currentUser.id)?.email ?? null
-      : null;
-    const isSelf = !!currentUserEmail && email === currentUserEmail;
-
+    // Decrypt PII at the edge so the search result shows plaintext name/email
+    // (at most one user here; the batch helper is the shared decrypt path).
+    const decryptedUsersById = await decryptUsersByIdOnce([targetRow ?? null]);
     const targetUser = targetRow ? decryptedUsersById.get(targetRow.id) : undefined;
 
     let existingStatus: ConnectionStatus | null = null;
@@ -104,8 +84,8 @@ export async function GET(request: Request) {
         name: targetUser.name,
         email: targetUser.email,
         displayName: targetUser.displayName || targetUser.name,
-        bio: targetUser.bio ?? null,
-        avatarUrl: targetUser.avatarUrl ?? null,
+        bio: targetUser.bio,
+        avatarUrl: targetUser.avatarUrl,
       };
 
       // Check if a connection already exists - select ALL fields (status enum)

--- a/apps/web/src/app/api/connections/search/route.ts
+++ b/apps/web/src/app/api/connections/search/route.ts
@@ -7,8 +7,7 @@ import { connections } from '@pagespace/db/schema/social';
 import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { userEmailMatch, decryptUserRow } from '@pagespace/lib/auth/user-repository';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+import { userEmailMatch, decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
@@ -50,14 +49,10 @@ export async function GET(request: Request) {
 
     // Get current user's email to check for self-connection
     const [currentUser] = await db
-      .select({ email: users.email })
+      .select({ id: users.id, email: users.email })
       .from(users)
       .where(eq(users.id, user.id))
       .limit(1);
-
-    // Decrypt the stored email before the self-connection comparison.
-    const currentUserEmail = currentUser ? await decryptField(currentUser.email) : null;
-    const isSelf = !!currentUserEmail && email === currentUserEmail;
 
     // Find user by exact email match (dual blind-index/raw-email lookup)
     const [targetRow] = await db
@@ -74,8 +69,31 @@ export async function GET(request: Request) {
       .where(userEmailMatch(email))
       .limit(1);
 
-    // Decrypt PII at the edge so the search result shows plaintext name/email.
-    const targetUser = targetRow ? await decryptUserRow(targetRow) : undefined;
+    // Decrypt PII at the edge so the search result shows plaintext name/email —
+    // one batched decrypt for the caller + target, once per unique user. The
+    // target row goes FIRST: on a self-search both rows share an id and
+    // decryptUsersByIdOnce keeps the first row per id, so the full profile row
+    // must win over the email-only caller row.
+    type SearchUserRow = {
+      id: string;
+      name: string | null;
+      email: string;
+      displayName?: string | null;
+      bio?: string | null;
+      avatarUrl?: string | null;
+    };
+    const decryptedUsersById = await decryptUsersByIdOnce<SearchUserRow>([
+      targetRow ?? null,
+      currentUser ? { id: currentUser.id, name: null, email: currentUser.email } : null,
+    ]);
+
+    // Decrypted stored email for the self-connection comparison.
+    const currentUserEmail = currentUser
+      ? decryptedUsersById.get(currentUser.id)?.email ?? null
+      : null;
+    const isSelf = !!currentUserEmail && email === currentUserEmail;
+
+    const targetUser = targetRow ? decryptedUsersById.get(targetRow.id) : undefined;
 
     let existingStatus: ConnectionStatus | null = null;
     let target: ConnectionSearchProfile | null = null;
@@ -86,8 +104,8 @@ export async function GET(request: Request) {
         name: targetUser.name,
         email: targetUser.email,
         displayName: targetUser.displayName || targetUser.name,
-        bio: targetUser.bio,
-        avatarUrl: targetUser.avatarUrl,
+        bio: targetUser.bio ?? null,
+        avatarUrl: targetUser.avatarUrl ?? null,
       };
 
       // Check if a connection already exists - select ALL fields (status enum)

--- a/apps/web/src/app/api/inbox/__tests__/route.test.ts
+++ b/apps/web/src/app/api/inbox/__tests__/route.test.ts
@@ -36,10 +36,24 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getBatchPagePermissions: vi.fn(),
 }));
 
+// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
+// asserted at the route's call boundary — proves the route batches decryption
+// once per request instead of once per row (the actual regression this test
+// guards). A bare `vi.spyOn` doesn't work here because `@pagespace/lib`
+// resolves to its built CJS dist output, and the per-row-dedup internals
+// (decryptUserRow -> decryptField) are a *nested* require inside that
+// compiled module, invisible to any mock declared at this level.
+vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
+  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+});
+
 import { GET } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
 
 const mockUserId = 'user_123';
 
@@ -155,5 +169,121 @@ describe('GET /api/inbox ?type filter', () => {
     const body = await res.json();
     const types = body.items.map((i: { type: string }) => i.type).sort();
     expect(types).toEqual(['channel', 'dm']);
+  });
+});
+
+describe('GET /api/inbox PII decryption dedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  const allowChannels = (ids: string[]) => {
+    (getBatchPagePermissions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Map(ids.map((id) => [id, { canView: true, canEdit: false, canShare: false, canDelete: false }]))
+    );
+  };
+
+  const mockExecute = (dmRows: unknown[], channelRows: unknown[]) => {
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockImplementation(async (arg: unknown) => {
+      if (isDmQuery(arg)) return { rows: dmRows };
+      if (isChannelQuery(arg)) return { rows: channelRows };
+      return { rows: [] };
+    });
+  };
+
+  it('decrypts one encrypted sender shared across many channel rows only once (dedup)', async () => {
+    const encryptedSender = await encryptField('Real Sender');
+    const channelRows = Array.from({ length: 5 }, (_, i) => ({
+      ...channelRow,
+      id: `ch_${i}`,
+      sender_name: encryptedSender,
+    }));
+    mockExecute([], channelRows);
+    allowChannels(channelRows.map((row) => row.id as string));
+
+    const res = await GET(new Request('http://localhost/api/inbox?type=channel&limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toHaveLength(5);
+    for (const item of body.items) {
+      expect(item.lastMessageSender).toBe('Real Sender');
+    }
+    // Decryption is batched once per request (dedup happens inside), not
+    // once per of the 5 channel rows.
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+  });
+
+  it('decrypts DM sender names and channel sender names in ONE batch for a type=all request', async () => {
+    const encryptedDmName = await encryptField('Dm Counterpart');
+    const encryptedSender = await encryptField('Channel Sender');
+    mockExecute(
+      [{ ...dmRow, other_user_display_name: null, other_user_name: encryptedDmName }],
+      [{ ...channelRow, sender_name: encryptedSender }]
+    );
+    allowChannels(['ch_1']);
+
+    const res = await GET(new Request('http://localhost/api/inbox?limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    const dm = body.items.find((i: { type: string }) => i.type === 'dm');
+    const channel = body.items.find((i: { type: string }) => i.type === 'channel');
+    expect(dm.name).toBe('Dm Counterpart');
+    expect(channel.lastMessageSender).toBe('Channel Sender');
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+  });
+
+  it('decrypts a repeated encrypted sender once in the drive-scoped inbox', async () => {
+    const encryptedSender = await encryptField('Drive Sender');
+    const channelRows = Array.from({ length: 3 }, (_, i) => ({
+      ...channelRow,
+      id: `ch_${i}`,
+      sender_name: encryptedSender,
+    }));
+    mockExecute([], channelRows);
+    allowChannels(channelRows.map((row) => row.id as string));
+
+    const res = await GET(new Request('http://localhost/api/inbox?driveId=drv_1&limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toHaveLength(3);
+    for (const item of body.items) {
+      expect(item.lastMessageSender).toBe('Drive Sender');
+    }
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through plaintext AI sender names and profile display names unchanged', async () => {
+    const encryptedDmName = await encryptField('Hidden Name');
+    mockExecute(
+      // displayName present: users.name must not be needed (nor surfaced).
+      [{ ...dmRow, other_user_display_name: 'Profile Display', other_user_name: encryptedDmName }],
+      // COALESCE'd AI senderName is plaintext and must pass through unchanged.
+      [{ ...channelRow, sender_name: 'AI Agent' }]
+    );
+    allowChannels(['ch_1']);
+
+    const res = await GET(new Request('http://localhost/api/inbox?limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    const dm = body.items.find((i: { type: string }) => i.type === 'dm');
+    const channel = body.items.find((i: { type: string }) => i.type === 'channel');
+    expect(dm.name).toBe('Profile Display');
+    expect(channel.lastMessageSender).toBe('AI Agent');
+  });
+
+  it('keeps a null last-message sender null (channel with no messages)', async () => {
+    mockExecute([], [{ ...channelRow, sender_name: null, last_message: null, last_message_at: null }]);
+    allowChannels(['ch_1']);
+
+    const res = await GET(new Request('http://localhost/api/inbox?type=channel&limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items[0].lastMessageSender).toBeNull();
   });
 });

--- a/apps/web/src/app/api/inbox/__tests__/route.test.ts
+++ b/apps/web/src/app/api/inbox/__tests__/route.test.ts
@@ -36,24 +36,24 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getBatchPagePermissions: vi.fn(),
 }));
 
-// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
-// asserted at the route's call boundary — proves the route batches decryption
-// once per request instead of once per row (the actual regression this test
-// guards). A bare `vi.spyOn` doesn't work here because `@pagespace/lib`
-// resolves to its built CJS dist output, and the per-row-dedup internals
-// (decryptUserRow -> decryptField) are a *nested* require inside that
-// compiled module, invisible to any mock declared at this level.
-vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
-  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+// Wrap (not replace) the real decryptFieldValuesOnce so call counts and batch
+// contents can be asserted at the route's call boundary — proves the route
+// batches decryption once per request instead of once per row (the actual
+// regression this test guards). A bare `vi.spyOn` doesn't work here because
+// `@pagespace/lib` resolves to its built CJS dist output, and the inner
+// per-value decrypt (decryptField) is a *nested* require inside that compiled
+// module, invisible to any mock declared at this level. encryptField stays
+// real via the spread.
+vi.mock('@pagespace/lib/encryption/field-crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/encryption/field-crypto')>();
+  return { ...actual, decryptFieldValuesOnce: vi.fn(actual.decryptFieldValuesOnce) };
 });
 
 import { GET } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
-import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
-import { encryptField } from '@pagespace/lib/encryption/field-crypto';
+import { decryptFieldValuesOnce, encryptField } from '@pagespace/lib/encryption/field-crypto';
 
 const mockUserId = 'user_123';
 
@@ -212,7 +212,7 @@ describe('GET /api/inbox PII decryption dedup', () => {
     }
     // Decryption is batched once per request (dedup happens inside), not
     // once per of the 5 channel rows.
-    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decryptFieldValuesOnce)).toHaveBeenCalledTimes(1);
   });
 
   it('decrypts DM sender names and channel sender names in ONE batch for a type=all request', async () => {
@@ -232,7 +232,7 @@ describe('GET /api/inbox PII decryption dedup', () => {
     const channel = body.items.find((i: { type: string }) => i.type === 'channel');
     expect(dm.name).toBe('Dm Counterpart');
     expect(channel.lastMessageSender).toBe('Channel Sender');
-    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decryptFieldValuesOnce)).toHaveBeenCalledTimes(1);
   });
 
   it('decrypts a repeated encrypted sender once in the drive-scoped inbox', async () => {
@@ -253,7 +253,7 @@ describe('GET /api/inbox PII decryption dedup', () => {
     for (const item of body.items) {
       expect(item.lastMessageSender).toBe('Drive Sender');
     }
-    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decryptFieldValuesOnce)).toHaveBeenCalledTimes(1);
   });
 
   it('passes through plaintext AI sender names and profile display names unchanged', async () => {
@@ -315,7 +315,7 @@ describe('GET /api/inbox PII decryption dedup', () => {
     expect(res.status).toBe(200);
     expect(body.items).toHaveLength(1);
     expect(body.items[0].lastMessageSender).toBe('Visible Sender');
-    const batched = vi.mocked(decryptUsersByIdOnce).mock.calls[0][0];
+    const batched = vi.mocked(decryptFieldValuesOnce).mock.calls[0][0];
     expect(batched).toHaveLength(1);
   });
 
@@ -330,7 +330,33 @@ describe('GET /api/inbox PII decryption dedup', () => {
     expect(res.status).toBe(200);
     expect(body.items).toHaveLength(1);
     expect(body.items[0].lastMessageSender).toBe('Visible Sender');
-    const batched = vi.mocked(decryptUsersByIdOnce).mock.calls[0][0];
+    const batched = vi.mocked(decryptFieldValuesOnce).mock.calls[0][0];
     expect(batched).toHaveLength(1);
+  });
+
+  it('never decrypts sender names of rows the page limit discards (decrypt after slice)', async () => {
+    const survivingSender = await encryptField('Surviving Sender');
+    const slicedSender = await encryptField('Sliced Sender');
+    // Distinct timestamps make the survivor deterministic: the newer row wins
+    // the lastMessageAt sort, the older row is sliced off by limit=1.
+    const channelRows = [
+      { ...channelRow, id: 'ch_new', sender_name: survivingSender, last_message_at: '2026-05-02T00:00:00.000Z' },
+      { ...channelRow, id: 'ch_old', sender_name: slicedSender, last_message_at: '2026-05-01T00:00:00.000Z' },
+    ];
+    mockExecute([], channelRows);
+    allowChannels(['ch_new', 'ch_old']);
+
+    const res = await GET(new Request('http://localhost/api/inbox?type=channel&limit=1'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].lastMessageSender).toBe('Surviving Sender');
+    expect(body.pagination.hasMore).toBe(true);
+    // Only the surviving row's value enters the batch — the sliced row's
+    // ciphertext is never decrypted.
+    expect(vi.mocked(decryptFieldValuesOnce)).toHaveBeenCalledTimes(1);
+    const batched = vi.mocked(decryptFieldValuesOnce).mock.calls[0][0];
+    expect(batched).toEqual([survivingSender]);
   });
 });

--- a/apps/web/src/app/api/inbox/__tests__/route.test.ts
+++ b/apps/web/src/app/api/inbox/__tests__/route.test.ts
@@ -286,4 +286,51 @@ describe('GET /api/inbox PII decryption dedup', () => {
     expect(res.status).toBe(200);
     expect(body.items[0].lastMessageSender).toBeNull();
   });
+
+  // The permission filter must run BEFORE the decrypt batch is built: a
+  // non-viewable channel's sender_name never entered the old per-row decrypt
+  // path, and an undecryptable value on such a row must not be able to fail
+  // (or even reach) the batch for the rest of the inbox.
+  const mixedVisibilityChannels = (visibleSender: string, hiddenSender: string) => {
+    (getBatchPagePermissions as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Map([
+        ['ch_visible', { canView: true, canEdit: false, canShare: false, canDelete: false }],
+        ['ch_hidden', { canView: false, canEdit: false, canShare: false, canDelete: false }],
+      ])
+    );
+    return [
+      { ...channelRow, id: 'ch_visible', sender_name: visibleSender },
+      { ...channelRow, id: 'ch_hidden', sender_name: hiddenSender },
+    ];
+  };
+
+  it('never decrypts sender names of channels the requester cannot view (drive inbox)', async () => {
+    const visibleSender = await encryptField('Visible Sender');
+    const hiddenSender = await encryptField('Hidden Sender');
+    mockExecute([], mixedVisibilityChannels(visibleSender, hiddenSender));
+
+    const res = await GET(new Request('http://localhost/api/inbox?driveId=drv_1&limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].lastMessageSender).toBe('Visible Sender');
+    const batched = vi.mocked(decryptUsersByIdOnce).mock.calls[0][0];
+    expect(batched).toHaveLength(1);
+  });
+
+  it('never decrypts sender names of channels the requester cannot view (dashboard inbox)', async () => {
+    const visibleSender = await encryptField('Visible Sender');
+    const hiddenSender = await encryptField('Hidden Sender');
+    mockExecute([], mixedVisibilityChannels(visibleSender, hiddenSender));
+
+    const res = await GET(new Request('http://localhost/api/inbox?type=channel&limit=20'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0].lastMessageSender).toBe('Visible Sender');
+    const batched = vi.mocked(decryptUsersByIdOnce).mock.calls[0][0];
+    expect(batched).toHaveLength(1);
+  });
 });

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -5,32 +5,13 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { decryptFieldValuesOnce } from '@pagespace/lib/encryption/field-crypto';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
 import type { ChannelRow, DMRow } from '@/types/messaging';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
-
-/**
- * Dedup-decrypt this request's PII display values in one batch via
- * decryptUsersByIdOnce, instead of one decryptField call per row.
- *
- * The inbox SQL rows don't expose user ids — and a value may not even belong
- * to a user (`sender_name` COALESCEs a plaintext AI senderName with the
- * ciphertext users.name) — so dedup is keyed by the stored value itself: the
- * same user repeated across rows repeats the same stored ciphertext, which is
- * exactly one decrypt. Returns a decryptField-equivalent lookup (null/empty
- * and legacy plaintext pass through unchanged).
- */
-async function decryptValuesOnce(values: ReadonlyArray<string | null | undefined>) {
-  const decryptedByValue = await decryptUsersByIdOnce(
-    values.map((value) => (typeof value === 'string' ? { id: value, name: value } : null))
-  );
-  return <T extends string | null | undefined>(value: T): T =>
-    typeof value === 'string' ? ((decryptedByValue.get(value)?.name ?? value) as T) : value;
-}
 
 // GET /api/inbox - Get unified inbox (DMs + channels)
 export async function GET(request: Request) {
@@ -140,14 +121,20 @@ export async function GET(request: Request) {
         (row) => channelPermissions.get(row.id)?.canView
       );
 
+      // Paginate BEFORE decrypting so rows the page limit discards never
+      // enter the decrypt batch (the fetch reads limit + 1 rows).
+      const hasMore = visibleChannelRows.length > limit;
+      const pageRows = visibleChannelRows.slice(0, limit);
+
       // Decrypt PII at the edge (GDPR #965): sender_name COALESCEs an AI senderName
-      // (plaintext) with users.name (ciphertext); the lookup handles both. One
-      // batched decrypt per request, not one per row.
-      const decryptSenderName = await decryptValuesOnce(
-        visibleChannelRows.map((row) => row.sender_name)
+      // (plaintext) with users.name (ciphertext). The rows carry no user ids, so
+      // dedup is keyed by the stored value itself — the same user repeated across
+      // rows repeats the same stored ciphertext, which is exactly one decrypt.
+      const lookupSenderName = await decryptFieldValuesOnce(
+        pageRows.map((row) => row.sender_name)
       );
 
-      for (const row of visibleChannelRows) {
+      for (const row of pageRows) {
         items.push({
           id: row.id,
           type: 'channel',
@@ -155,17 +142,14 @@ export async function GET(request: Request) {
           avatarUrl: null,
           lastMessageAt: toISOTimestamp(row.last_message_at),
           lastMessagePreview: row.last_message ? row.last_message.substring(0, 100) : null,
-          lastMessageSender: decryptSenderName(row.sender_name),
+          lastMessageSender: lookupSenderName(row.sender_name),
           unreadCount: parseInt(row.unread_count) || 0,
           driveId: row.drive_id,
           driveName: row.drive_name,
         });
       }
 
-      // Determine pagination for drive-specific query
-      const hasMore = items.length > limit;
-      const paginatedItems = items.slice(0, limit);
-      const lastItem = paginatedItems[paginatedItems.length - 1];
+      const lastItem = items[items.length - 1];
       const nextCursor = lastItem
         ? lastItem.lastMessageAt || `id:${lastItem.id}`
         : null;
@@ -173,7 +157,7 @@ export async function GET(request: Request) {
       auditRequest(request, { eventType: 'data.read', userId, resourceType: 'inbox', resourceId: 'self' });
 
       return NextResponse.json({
-        items: paginatedItems,
+        items,
         pagination: {
           hasMore,
           nextCursor,
@@ -310,72 +294,95 @@ export async function GET(request: Request) {
         );
       }
 
-      // Decrypt PII at the edge (GDPR #965): profile displayName and AI
-      // senderName stay plaintext; users.name is ciphertext (the lookup handles
-      // both). One batched decrypt for the whole request — DM names whose
-      // profile displayName already wins are excluded, matching the previous
-      // short-circuit.
-      const decryptName = await decryptValuesOnce([
-        ...dmRows.map((row) => (row.other_user_display_name ? null : row.other_user_name)),
-        ...visibleChannelRows.map((row) => row.sender_name),
-      ]);
-
-      for (const row of dmRows) {
-        items.push({
-          id: row.id,
-          type: 'dm',
-          name: row.other_user_display_name || decryptName(row.other_user_name),
-          avatarUrl: row.other_user_image || row.other_user_avatar_url,
+      // Combine both feeds and sort/paginate BEFORE decrypting, so rows the
+      // page limit discards never enter the decrypt batch. DMs are appended
+      // first so equal/null-timestamp ordering (stable sort) matches the
+      // previous item insertion order byte for byte.
+      type PendingInboxRow =
+        | { kind: 'dm'; row: DMRow; lastMessageAt: string | null }
+        | { kind: 'channel'; row: ChannelRow; lastMessageAt: string | null };
+      const pendingRows: PendingInboxRow[] = [
+        ...dmRows.map((row) => ({
+          kind: 'dm' as const,
+          row,
           lastMessageAt: toISOTimestamp(row.last_message_at),
-          lastMessagePreview: row.last_message,
-          lastMessageSender: null,
-          unreadCount: parseInt(row.unread_count) || 0,
-        });
-      }
-
-      for (const row of visibleChannelRows) {
-        items.push({
-          id: row.id,
-          type: 'channel',
-          name: row.name,
-          avatarUrl: null,
+        })),
+        ...visibleChannelRows.map((row) => ({
+          kind: 'channel' as const,
+          row,
           lastMessageAt: toISOTimestamp(row.last_message_at),
-          lastMessagePreview: row.last_message ? row.last_message.substring(0, 100) : null,
-          lastMessageSender: decryptName(row.sender_name),
-          unreadCount: parseInt(row.unread_count) || 0,
-          driveId: row.drive_id,
-          driveName: row.drive_name,
-        });
-      }
+        })),
+      ];
 
       // Sort combined results by lastMessageAt
-      items.sort((a, b) => {
+      pendingRows.sort((a, b) => {
         if (!a.lastMessageAt && !b.lastMessageAt) return 0;
         if (!a.lastMessageAt) return 1;
         if (!b.lastMessageAt) return -1;
         return new Date(b.lastMessageAt).getTime() - new Date(a.lastMessageAt).getTime();
       });
+
+      const hasMore = pendingRows.length > limit;
+      const pageRows = pendingRows.slice(0, limit);
+
+      // Decrypt PII at the edge (GDPR #965): one batched decrypt for the rows
+      // that survive pagination. Profile displayName and AI senderName stay
+      // plaintext; users.name is ciphertext (the value-keyed lookup handles
+      // both). DM names whose profile displayName already wins are excluded,
+      // matching the previous short-circuit.
+      const lookupName = await decryptFieldValuesOnce(
+        pageRows.map((pending) =>
+          pending.kind === 'dm'
+            ? (pending.row.other_user_display_name ? null : pending.row.other_user_name)
+            : pending.row.sender_name
+        )
+      );
+
+      for (const pending of pageRows) {
+        if (pending.kind === 'dm') {
+          const { row } = pending;
+          items.push({
+            id: row.id,
+            type: 'dm',
+            name: (row.other_user_display_name || lookupName(row.other_user_name)) ?? '',
+            avatarUrl: row.other_user_image || row.other_user_avatar_url,
+            lastMessageAt: pending.lastMessageAt,
+            lastMessagePreview: row.last_message,
+            lastMessageSender: null,
+            unreadCount: parseInt(row.unread_count) || 0,
+          });
+        } else {
+          const { row } = pending;
+          items.push({
+            id: row.id,
+            type: 'channel',
+            name: row.name,
+            avatarUrl: null,
+            lastMessageAt: pending.lastMessageAt,
+            lastMessagePreview: row.last_message ? row.last_message.substring(0, 100) : null,
+            lastMessageSender: lookupName(row.sender_name),
+            unreadCount: parseInt(row.unread_count) || 0,
+            driveId: row.drive_id,
+            driveName: row.drive_name,
+          });
+        }
+      }
+
+      const lastItem = items[items.length - 1];
+      const nextCursor = lastItem
+        ? lastItem.lastMessageAt || `id:${lastItem.id}`
+        : null;
+
+      auditRequest(request, { eventType: 'data.read', userId, resourceType: 'inbox', resourceId: 'self' });
+
+      return NextResponse.json({
+        items,
+        pagination: {
+          hasMore,
+          nextCursor,
+        },
+      } satisfies InboxResponse);
     }
-
-    // Apply limit - cursor filtering is already done in SQL queries
-    const paginatedItems = items.slice(0, limit);
-
-    // Determine pagination info
-    const hasMore = items.length > limit;
-    const lastItem = paginatedItems[paginatedItems.length - 1];
-    const nextCursor = lastItem
-      ? lastItem.lastMessageAt || `id:${lastItem.id}`
-      : null;
-
-    auditRequest(request, { eventType: 'data.read', userId, resourceType: 'inbox', resourceId: 'self' });
-
-    return NextResponse.json({
-      items: paginatedItems,
-      pagination: {
-        hasMore,
-        nextCursor,
-      },
-    } satisfies InboxResponse);
   } catch (error) {
     loggers.api.error('Error fetching inbox:', error as Error);
     return NextResponse.json(

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -133,18 +133,21 @@ export async function GET(request: Request) {
         userId,
         channelResults.rows.map((row) => row.id)
       );
+      // Permission-filter BEFORE decrypting: a non-viewable channel's sender
+      // PII must never enter the decrypt batch (an undecryptable value there
+      // would otherwise fail the whole request, where it used to be skipped).
+      const visibleChannelRows = channelResults.rows.filter(
+        (row) => channelPermissions.get(row.id)?.canView
+      );
 
       // Decrypt PII at the edge (GDPR #965): sender_name COALESCEs an AI senderName
       // (plaintext) with users.name (ciphertext); the lookup handles both. One
       // batched decrypt per request, not one per row.
       const decryptSenderName = await decryptValuesOnce(
-        channelResults.rows.map((row) => row.sender_name)
+        visibleChannelRows.map((row) => row.sender_name)
       );
 
-      for (const row of channelResults.rows) {
-        const permissions = channelPermissions.get(row.id);
-        if (!permissions?.canView) continue;
-
+      for (const row of visibleChannelRows) {
         items.push({
           id: row.id,
           type: 'channel',
@@ -236,8 +239,7 @@ export async function GET(request: Request) {
       }
 
       // Fetch channels from all drives user is member of or owns (skipped when filter excludes channels)
-      let channelRows: ChannelRow[] = [];
-      let channelPermissions: Awaited<ReturnType<typeof getBatchPagePermissions>> = new Map();
+      let visibleChannelRows: ChannelRow[] = [];
       if (type !== 'dm') {
         const channelResults = await db.execute<ChannelRow>(sql`
           WITH user_channels AS (
@@ -296,11 +298,15 @@ export async function GET(request: Request) {
           ORDER BY clm.last_message_at DESC NULLS LAST
           LIMIT ${fetchLimit}
         `);
-        channelRows = channelResults.rows;
-
-        channelPermissions = await getBatchPagePermissions(
+        const channelPermissions = await getBatchPagePermissions(
           userId,
-          channelRows.map((row) => row.id)
+          channelResults.rows.map((row) => row.id)
+        );
+        // Permission-filter BEFORE decrypting: a non-viewable channel's sender
+        // PII must never enter the decrypt batch (an undecryptable value there
+        // would otherwise fail the whole request, where it used to be skipped).
+        visibleChannelRows = channelResults.rows.filter(
+          (row) => channelPermissions.get(row.id)?.canView
         );
       }
 
@@ -311,7 +317,7 @@ export async function GET(request: Request) {
       // short-circuit.
       const decryptName = await decryptValuesOnce([
         ...dmRows.map((row) => (row.other_user_display_name ? null : row.other_user_name)),
-        ...channelRows.map((row) => row.sender_name),
+        ...visibleChannelRows.map((row) => row.sender_name),
       ]);
 
       for (const row of dmRows) {
@@ -327,10 +333,7 @@ export async function GET(request: Request) {
         });
       }
 
-      for (const row of channelRows) {
-        const permissions = channelPermissions.get(row.id);
-        if (!permissions?.canView) continue;
-
+      for (const row of visibleChannelRows) {
         items.push({
           id: row.id,
           type: 'channel',

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -5,13 +5,32 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
 import type { ChannelRow, DMRow } from '@/types/messaging';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+/**
+ * Dedup-decrypt this request's PII display values in one batch via
+ * decryptUsersByIdOnce, instead of one decryptField call per row.
+ *
+ * The inbox SQL rows don't expose user ids — and a value may not even belong
+ * to a user (`sender_name` COALESCEs a plaintext AI senderName with the
+ * ciphertext users.name) — so dedup is keyed by the stored value itself: the
+ * same user repeated across rows repeats the same stored ciphertext, which is
+ * exactly one decrypt. Returns a decryptField-equivalent lookup (null/empty
+ * and legacy plaintext pass through unchanged).
+ */
+async function decryptValuesOnce(values: ReadonlyArray<string | null | undefined>) {
+  const decryptedByValue = await decryptUsersByIdOnce(
+    values.map((value) => (typeof value === 'string' ? { id: value, name: value } : null))
+  );
+  return <T extends string | null | undefined>(value: T): T =>
+    typeof value === 'string' ? ((decryptedByValue.get(value)?.name ?? value) as T) : value;
+}
 
 // GET /api/inbox - Get unified inbox (DMs + channels)
 export async function GET(request: Request) {
@@ -115,6 +134,13 @@ export async function GET(request: Request) {
         channelResults.rows.map((row) => row.id)
       );
 
+      // Decrypt PII at the edge (GDPR #965): sender_name COALESCEs an AI senderName
+      // (plaintext) with users.name (ciphertext); the lookup handles both. One
+      // batched decrypt per request, not one per row.
+      const decryptSenderName = await decryptValuesOnce(
+        channelResults.rows.map((row) => row.sender_name)
+      );
+
       for (const row of channelResults.rows) {
         const permissions = channelPermissions.get(row.id);
         if (!permissions?.canView) continue;
@@ -126,9 +152,7 @@ export async function GET(request: Request) {
           avatarUrl: null,
           lastMessageAt: toISOTimestamp(row.last_message_at),
           lastMessagePreview: row.last_message ? row.last_message.substring(0, 100) : null,
-          // Decrypt PII at the edge (GDPR #965): sender_name COALESCEs an AI senderName
-          // (plaintext) with users.name (ciphertext); decryptField handles both.
-          lastMessageSender: await decryptField(row.sender_name),
+          lastMessageSender: decryptSenderName(row.sender_name),
           unreadCount: parseInt(row.unread_count) || 0,
           driveId: row.drive_id,
           driveName: row.drive_name,
@@ -161,6 +185,7 @@ export async function GET(request: Request) {
       const cursorTimestamp = !isIdCursor && cursor ? cursor : null;
 
       // Fetch DM conversations with cursor filtering (skipped when filter excludes DMs)
+      let dmRows: DMRow[] = [];
       if (type !== 'channel') {
         const dmResults = await db.execute<DMRow>(sql`
           WITH dm_data AS (
@@ -207,24 +232,12 @@ export async function GET(request: Request) {
           ORDER BY dd."lastMessageAt" DESC NULLS LAST
           LIMIT ${fetchLimit}
         `);
-
-        for (const row of dmResults.rows) {
-          items.push({
-            id: row.id,
-            type: 'dm',
-            // Decrypt PII at the edge (GDPR #965): profile displayName stays
-            // plaintext; users.name fallback is ciphertext (decryptField handles both).
-            name: row.other_user_display_name || (await decryptField(row.other_user_name)),
-            avatarUrl: row.other_user_image || row.other_user_avatar_url,
-            lastMessageAt: toISOTimestamp(row.last_message_at),
-            lastMessagePreview: row.last_message,
-            lastMessageSender: null,
-            unreadCount: parseInt(row.unread_count) || 0,
-          });
-        }
+        dmRows = dmResults.rows;
       }
 
       // Fetch channels from all drives user is member of or owns (skipped when filter excludes channels)
+      let channelRows: ChannelRow[] = [];
+      let channelPermissions: Awaited<ReturnType<typeof getBatchPagePermissions>> = new Map();
       if (type !== 'dm') {
         const channelResults = await db.execute<ChannelRow>(sql`
           WITH user_channels AS (
@@ -283,31 +296,53 @@ export async function GET(request: Request) {
           ORDER BY clm.last_message_at DESC NULLS LAST
           LIMIT ${fetchLimit}
         `);
+        channelRows = channelResults.rows;
 
-        const channelPermissions = await getBatchPagePermissions(
+        channelPermissions = await getBatchPagePermissions(
           userId,
-          channelResults.rows.map((row) => row.id)
+          channelRows.map((row) => row.id)
         );
+      }
 
-        for (const row of channelResults.rows) {
-          const permissions = channelPermissions.get(row.id);
-          if (!permissions?.canView) continue;
+      // Decrypt PII at the edge (GDPR #965): profile displayName and AI
+      // senderName stay plaintext; users.name is ciphertext (the lookup handles
+      // both). One batched decrypt for the whole request — DM names whose
+      // profile displayName already wins are excluded, matching the previous
+      // short-circuit.
+      const decryptName = await decryptValuesOnce([
+        ...dmRows.map((row) => (row.other_user_display_name ? null : row.other_user_name)),
+        ...channelRows.map((row) => row.sender_name),
+      ]);
 
-          items.push({
-            id: row.id,
-            type: 'channel',
-            name: row.name,
-            avatarUrl: null,
-            lastMessageAt: toISOTimestamp(row.last_message_at),
-            lastMessagePreview: row.last_message ? row.last_message.substring(0, 100) : null,
-            // Decrypt PII at the edge (GDPR #965): sender_name COALESCEs an AI senderName
-            // (plaintext) with users.name (ciphertext); decryptField handles both.
-            lastMessageSender: await decryptField(row.sender_name),
-            unreadCount: parseInt(row.unread_count) || 0,
-            driveId: row.drive_id,
-            driveName: row.drive_name,
-          });
-        }
+      for (const row of dmRows) {
+        items.push({
+          id: row.id,
+          type: 'dm',
+          name: row.other_user_display_name || decryptName(row.other_user_name),
+          avatarUrl: row.other_user_image || row.other_user_avatar_url,
+          lastMessageAt: toISOTimestamp(row.last_message_at),
+          lastMessagePreview: row.last_message,
+          lastMessageSender: null,
+          unreadCount: parseInt(row.unread_count) || 0,
+        });
+      }
+
+      for (const row of channelRows) {
+        const permissions = channelPermissions.get(row.id);
+        if (!permissions?.canView) continue;
+
+        items.push({
+          id: row.id,
+          type: 'channel',
+          name: row.name,
+          avatarUrl: null,
+          lastMessageAt: toISOTimestamp(row.last_message_at),
+          lastMessagePreview: row.last_message ? row.last_message.substring(0, 100) : null,
+          lastMessageSender: decryptName(row.sender_name),
+          unreadCount: parseInt(row.unread_count) || 0,
+          driveId: row.drive_id,
+          driveName: row.drive_name,
+        });
       }
 
       // Sort combined results by lastMessageAt

--- a/apps/web/src/app/api/messages/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/conversations/[conversationId]/__tests__/route.test.ts
@@ -1,0 +1,140 @@
+/**
+ * PII decryption tests for GET /api/messages/conversations/[conversationId].
+ * The single-conversation detail must decrypt the counterpart's name/email
+ * through the same request-batched decryptUsersByIdOnce path as the list
+ * routes (GDPR #965 perf remediation round 2).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { execute: vi.fn() },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: Object.assign(vi.fn(), { raw: vi.fn() }),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
+// asserted at the route's call boundary — proves the route batches decryption
+// once per request. A bare `vi.spyOn` doesn't work here because
+// `@pagespace/lib` resolves to its built CJS dist output, and the
+// per-row-dedup internals (decryptUserRow -> decryptField) are a *nested*
+// require inside that compiled module, invisible to any mock at this level.
+vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
+  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+});
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
+
+const mockUserId = 'user_123';
+const otherUserId = 'user_other';
+
+const mockAuth = () => {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+    userId: mockUserId,
+    tokenVersion: 0,
+    tokenType: 'session' as const,
+    sessionId: 'test-session',
+    role: 'user' as const,
+    adminRoleVersion: 0,
+  });
+};
+
+const detailRow = (overrides: Record<string, unknown>) => ({
+  id: 'conv_1',
+  participant1Id: mockUserId,
+  participant2Id: otherUserId,
+  lastMessageAt: '2026-05-03T00:00:00.000Z',
+  lastMessagePreview: 'hi',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  other_user_id: otherUserId,
+  user_id: otherUserId,
+  user_name: 'Other',
+  user_email: 'other@example.com',
+  user_image: null,
+  user_username: 'other',
+  user_display_name: null,
+  user_avatar_url: null,
+  ...overrides,
+});
+
+const makeRequest = () =>
+  GET(new Request('http://localhost/api/messages/conversations/conv_1'), {
+    params: Promise.resolve({ conversationId: 'conv_1' }),
+  });
+
+describe('GET /api/messages/conversations/[conversationId] PII decryption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  it('decrypts the single counterpart name/email in one batched call', async () => {
+    const encryptedName = await encryptField('Real Name');
+    const encryptedEmail = await encryptField('real@example.com');
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [detailRow({ user_name: encryptedName, user_email: encryptedEmail })],
+    });
+
+    const response = await makeRequest();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversation.otherUser.name).toBe('Real Name');
+    expect(body.conversation.otherUser.email).toBe('real@example.com');
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through legacy plaintext name/email unchanged', async () => {
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [detailRow({})],
+    });
+
+    const response = await makeRequest();
+    const body = await response.json();
+
+    expect(body.conversation.otherUser.name).toBe('Other');
+    expect(body.conversation.otherUser.email).toBe('other@example.com');
+  });
+
+  it('does not crash when the counterpart user row is gone (deleted user)', async () => {
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [detailRow({ user_id: null, user_name: null, user_email: null })],
+    });
+
+    const response = await makeRequest();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversation.otherUser.name).toBeNull();
+    expect(body.conversation.otherUser.email).toBeNull();
+  });
+
+  it('returns 404 when the conversation does not exist for this user', async () => {
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows: [] });
+
+    const response = await makeRequest();
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/messages/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/conversations/[conversationId]/route.ts
@@ -78,8 +78,10 @@ export async function GET(
       createdAt: row.createdAt,
       otherUser: {
         id: row.user_id,
-        name: decryptedUser?.name ?? row.user_name,
-        email: decryptedUser?.email ?? row.user_email,
+        // Fail closed: on a missing join row emit null, never the raw
+        // (potentially ciphertext) column value.
+        name: decryptedUser?.name ?? null,
+        email: decryptedUser?.email ?? null,
         image: row.user_image,
         username: row.user_username,
         displayName: row.user_display_name,

--- a/apps/web/src/app/api/messages/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/conversations/[conversationId]/route.ts
@@ -4,7 +4,7 @@ import { sql } from '@pagespace/db/operators';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import type { ConversationDetailRow } from '@/types/messaging';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -61,6 +61,14 @@ export async function GET(
 
     const row = result.rows[0];
 
+    // Decrypt PII at the edge so the conversation header shows plaintext
+    // name/email. At most one distinct user here, but batching through the
+    // same request-scoped dedup as the list routes keeps one decrypt path.
+    const decryptedUsersById = await decryptUsersByIdOnce(
+      row.user_id ? [{ id: row.user_id, name: row.user_name, email: row.user_email }] : []
+    );
+    const decryptedUser = row.user_id ? decryptedUsersById.get(row.user_id) : undefined;
+
     const conversation = {
       id: row.id,
       participant1Id: row.participant1Id,
@@ -70,9 +78,8 @@ export async function GET(
       createdAt: row.createdAt,
       otherUser: {
         id: row.user_id,
-        // Decrypt PII at the edge so the conversation header shows plaintext name/email.
-        name: await decryptField(row.user_name),
-        email: await decryptField(row.user_email),
+        name: decryptedUser?.name ?? row.user_name,
+        email: decryptedUser?.email ?? row.user_email,
         image: row.user_image,
         username: row.user_username,
         displayName: row.user_display_name,

--- a/apps/web/src/app/api/messages/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/conversations/__tests__/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@pagespace/db/db', () => ({
   db: {
     select: vi.fn(),
     insert: vi.fn(),
+    execute: vi.fn(),
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
@@ -51,7 +52,20 @@ vi.mock('@/lib/utils/timestamp', () => ({
   toISOTimestamp: vi.fn((v: unknown) => (v instanceof Date ? v.toISOString() : v)),
 }));
 
-import { POST } from '../route';
+// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
+// asserted at the route's call boundary — proves the route batches decryption
+// once per request instead of once per row. A bare `vi.spyOn` doesn't work
+// here because `@pagespace/lib` resolves to its built CJS dist output, and the
+// per-row-dedup internals (decryptUserRow -> decryptField) are a *nested*
+// require inside that compiled module, invisible to any mock at this level.
+vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
+  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+});
+
+import { GET, POST } from '../route';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { usersShareDrive } from '@pagespace/lib/permissions/permissions';
@@ -171,5 +185,81 @@ describe('POST /api/messages/conversations DM eligibility', () => {
     const body = await response.json();
     expect(body.conversation.id).toBe('existing_conv');
     expect(db.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/messages/conversations PII decryption dedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  const conversationRow = (overrides: Record<string, unknown>) => ({
+    id: 'conv_1',
+    participant1Id: userId,
+    participant2Id: recipientId,
+    lastMessageAt: '2026-05-03T00:00:00.000Z',
+    lastMessagePreview: 'hi',
+    participant1LastRead: null,
+    participant2LastRead: null,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    last_read: null,
+    other_user_id: recipientId,
+    other_user_name: 'Other',
+    other_user_email: 'other@example.com',
+    other_user_image: null,
+    other_user_username: 'other',
+    other_user_display_name: null,
+    other_user_avatar_url: null,
+    unread_count: '0',
+    ...overrides,
+  });
+
+  it('decrypts one counterpart repeated across conversation rows only once (dedup)', async () => {
+    const encryptedName = await encryptField('Real Name');
+    const encryptedEmail = await encryptField('real@example.com');
+    const rows = Array.from({ length: 4 }, (_, i) =>
+      conversationRow({ id: `conv_${i}`, other_user_name: encryptedName, other_user_email: encryptedEmail })
+    );
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({ rows });
+
+    const response = await GET(new Request('http://localhost/api/messages/conversations'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversations).toHaveLength(4);
+    for (const conversation of body.conversations) {
+      expect(conversation.otherUser.name).toBe('Real Name');
+      expect(conversation.otherUser.email).toBe('real@example.com');
+    }
+    // Decryption is batched once per request (dedup happens inside), not
+    // once per of the 4 conversation rows.
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decryptUsersByIdOnce).mock.calls[0][0]).toHaveLength(4);
+  });
+
+  it('passes through legacy plaintext name/email unchanged', async () => {
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [conversationRow({})],
+    });
+
+    const response = await GET(new Request('http://localhost/api/messages/conversations'));
+    const body = await response.json();
+
+    expect(body.conversations[0].otherUser.name).toBe('Other');
+    expect(body.conversations[0].otherUser.email).toBe('other@example.com');
+  });
+
+  it('does not crash when the counterpart user row is gone (deleted user)', async () => {
+    (db.execute as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rows: [conversationRow({ other_user_id: null, other_user_name: null, other_user_email: null })],
+    });
+
+    const response = await GET(new Request('http://localhost/api/messages/conversations'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.conversations[0].otherUser.name).toBeNull();
+    expect(body.conversations[0].otherUser.email).toBeNull();
   });
 });

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -122,8 +122,10 @@ export async function GET(request: Request) {
         lastRead: toISOTimestamp(row.last_read),
         otherUser: {
           id: row.other_user_id,
-          name: decryptedOtherUser?.name ?? row.other_user_name,
-          email: decryptedOtherUser?.email ?? row.other_user_email,
+          // Fail closed: on a missing join row emit null, never the raw
+          // (potentially ciphertext) column value.
+          name: decryptedOtherUser?.name ?? null,
+          email: decryptedOtherUser?.email ?? null,
           image: row.other_user_image,
           username: row.other_user_username,
           displayName: row.other_user_display_name,

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -6,7 +6,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import { usersShareDrive } from '@pagespace/lib/permissions/permissions';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
@@ -96,7 +96,20 @@ export async function GET(request: Request) {
       ORDER BY cd."lastMessageAt" DESC NULLS LAST
     `);
 
-    const conversations = await Promise.all(conversationDetails.rows.map(async (row) => {
+    // Decrypt PII at the edge so the DM list shows plaintext name/email —
+    // batched once per request per unique counterpart, not once per row.
+    const decryptedOtherUsersById = await decryptUsersByIdOnce(
+      conversationDetails.rows.map((row) =>
+        row.other_user_id
+          ? { id: row.other_user_id, name: row.other_user_name, email: row.other_user_email }
+          : null
+      )
+    );
+
+    const conversations = conversationDetails.rows.map((row) => {
+      const decryptedOtherUser = row.other_user_id
+        ? decryptedOtherUsersById.get(row.other_user_id)
+        : undefined;
       return {
         id: row.id,
         participant1Id: row.participant1Id,
@@ -109,9 +122,8 @@ export async function GET(request: Request) {
         lastRead: toISOTimestamp(row.last_read),
         otherUser: {
           id: row.other_user_id,
-          // Decrypt PII at the edge so the DM list shows plaintext name/email.
-          name: await decryptField(row.other_user_name),
-          email: await decryptField(row.other_user_email),
+          name: decryptedOtherUser?.name ?? row.other_user_name,
+          email: decryptedOtherUser?.email ?? row.other_user_email,
           image: row.other_user_image,
           username: row.other_user_username,
           displayName: row.other_user_display_name,
@@ -119,7 +131,7 @@ export async function GET(request: Request) {
         },
         unreadCount: parseInt(row.unread_count) || 0,
       };
-    }));
+    });
 
     // Determine if there are more conversations (for pagination)
     const hasMore = conversations.length === limit;

--- a/apps/web/src/app/api/messages/threads/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/threads/__tests__/route.test.ts
@@ -1,0 +1,160 @@
+/**
+ * PII decryption tests for GET /api/messages/threads.
+ * The DM thread list must decrypt each unique counterpart's name/email once
+ * per request via decryptUsersByIdOnce, not once per conversation row
+ * (GDPR #965 perf remediation round 2).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { execute: vi.fn() },
+}));
+
+vi.mock('@pagespace/db/operators', () => {
+  // Capture the literal text chunks so tests can identify which CTE ran.
+  const sql = (strings: TemplateStringsArray, ..._values: unknown[]) => ({
+    __sqlText: strings.join('?'),
+  });
+  return { sql };
+});
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+// Wrap (not replace) the real decryptUsersByIdOnce so call counts can be
+// asserted at the route's call boundary — proves the route batches decryption
+// once per request instead of once per row. A bare `vi.spyOn` doesn't work
+// here because `@pagespace/lib` resolves to its built CJS dist output, and the
+// per-row-dedup internals (decryptUserRow -> decryptField) are a *nested*
+// require inside that compiled module, invisible to any mock at this level.
+vi.mock('@pagespace/lib/auth/user-repository', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/auth/user-repository')>();
+  return { ...actual, decryptUsersByIdOnce: vi.fn(actual.decryptUsersByIdOnce) };
+});
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
+
+const mockUserId = 'user_123';
+const otherUserId = 'user_other';
+
+const mockAuth = () => {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+    userId: mockUserId,
+    tokenVersion: 0,
+    tokenType: 'session' as const,
+    sessionId: 'test-session',
+    role: 'user' as const,
+    adminRoleVersion: 0,
+  });
+};
+
+const dmRow = (overrides: Record<string, unknown>) => ({
+  id: 'conv_1',
+  participant1Id: mockUserId,
+  participant2Id: otherUserId,
+  lastMessageAt: '2026-05-03T00:00:00.000Z',
+  lastMessagePreview: 'hi',
+  participant1LastRead: null,
+  participant2LastRead: null,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  last_read: null,
+  other_user_id: otherUserId,
+  other_user_name: 'Other',
+  other_user_email: 'other@example.com',
+  other_user_image: null,
+  other_user_username: 'other',
+  other_user_display_name: null,
+  other_user_avatar_url: null,
+  unread_count: '0',
+  ...overrides,
+});
+
+const channelRow = {
+  id: 'ch_1',
+  title: 'general',
+  driveId: 'drv_1',
+  drive_name: 'Workspace',
+  updatedAt: '2026-05-02T00:00:00.000Z',
+  last_message: 'hello',
+  last_message_at: '2026-05-02T00:00:00.000Z',
+};
+
+const isDmQuery = (arg: unknown) =>
+  typeof arg === 'object' && arg !== null && '__sqlText' in arg &&
+  String((arg as { __sqlText: string }).__sqlText).includes('dm_conversations');
+
+const mockExecute = (dmRows: unknown[], channelRows: unknown[]) => {
+  (db.execute as unknown as ReturnType<typeof vi.fn>).mockImplementation(async (arg: unknown) => {
+    if (isDmQuery(arg)) return { rows: dmRows };
+    return { rows: channelRows };
+  });
+};
+
+describe('GET /api/messages/threads PII decryption dedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  it('decrypts one counterpart repeated across DM rows only once (dedup)', async () => {
+    const encryptedName = await encryptField('Real Name');
+    const encryptedEmail = await encryptField('real@example.com');
+    const dmRows = Array.from({ length: 4 }, (_, i) =>
+      dmRow({ id: `conv_${i}`, other_user_name: encryptedName, other_user_email: encryptedEmail })
+    );
+    mockExecute(dmRows, [channelRow]);
+
+    const response = await GET(new Request('http://localhost/api/messages/threads'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.dms).toHaveLength(4);
+    for (const dm of body.dms) {
+      expect(dm.otherUser.name).toBe('Real Name');
+      expect(dm.otherUser.email).toBe('real@example.com');
+    }
+    // Channels carry no PII columns; the request makes exactly one batched
+    // decrypt call for the DM rows, not one per of the 4 rows.
+    expect(vi.mocked(decryptUsersByIdOnce)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(decryptUsersByIdOnce).mock.calls[0][0]).toHaveLength(4);
+    expect(body.channels).toHaveLength(1);
+    expect(body.channels[0].title).toBe('general');
+  });
+
+  it('passes through legacy plaintext name/email unchanged', async () => {
+    mockExecute([dmRow({})], []);
+
+    const response = await GET(new Request('http://localhost/api/messages/threads'));
+    const body = await response.json();
+
+    expect(body.dms[0].otherUser.name).toBe('Other');
+    expect(body.dms[0].otherUser.email).toBe('other@example.com');
+  });
+
+  it('does not crash when a counterpart user row is gone (deleted user)', async () => {
+    mockExecute([dmRow({ other_user_id: null, other_user_name: null, other_user_email: null })], []);
+
+    const response = await GET(new Request('http://localhost/api/messages/threads'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.dms[0].otherUser.name).toBeNull();
+    expect(body.dms[0].otherUser.email).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/messages/threads/route.ts
+++ b/apps/web/src/app/api/messages/threads/route.ts
@@ -4,7 +4,7 @@ import { sql } from '@pagespace/db/operators';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
 import type { ConversationRow, ChannelThreadRow } from '@/types/messaging';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -104,7 +104,20 @@ async function fetchDMConversations(userId: string) {
     ORDER BY cd."lastMessageAt" DESC NULLS LAST
   `);
 
-  return Promise.all(conversationDetails.rows.map(async (row) => {
+  // Decrypt PII at the edge so the DM list shows plaintext name/email —
+  // batched once per request per unique counterpart, not once per row.
+  const decryptedOtherUsersById = await decryptUsersByIdOnce(
+    conversationDetails.rows.map((row) =>
+      row.other_user_id
+        ? { id: row.other_user_id, name: row.other_user_name, email: row.other_user_email }
+        : null
+    )
+  );
+
+  return conversationDetails.rows.map((row) => {
+    const decryptedOtherUser = row.other_user_id
+      ? decryptedOtherUsersById.get(row.other_user_id)
+      : undefined;
     return {
       id: row.id,
       participant1Id: row.participant1Id,
@@ -118,9 +131,8 @@ async function fetchDMConversations(userId: string) {
       lastRead: row.last_read ? new Date(row.last_read).toISOString() : null,
       otherUser: {
         id: row.other_user_id,
-        // Decrypt PII at the edge so the DM list shows plaintext name/email.
-        name: await decryptField(row.other_user_name),
-        email: await decryptField(row.other_user_email),
+        name: decryptedOtherUser?.name ?? row.other_user_name,
+        email: decryptedOtherUser?.email ?? row.other_user_email,
         image: row.other_user_image,
         username: row.other_user_username,
         displayName: row.other_user_display_name,
@@ -128,7 +140,7 @@ async function fetchDMConversations(userId: string) {
       },
       unreadCount: parseInt(row.unread_count) || 0,
     };
-  }));
+  });
 }
 
 // Fetch channels user has access to with their last message

--- a/apps/web/src/app/api/messages/threads/route.ts
+++ b/apps/web/src/app/api/messages/threads/route.ts
@@ -131,8 +131,10 @@ async function fetchDMConversations(userId: string) {
       lastRead: row.last_read ? new Date(row.last_read).toISOString() : null,
       otherUser: {
         id: row.other_user_id,
-        name: decryptedOtherUser?.name ?? row.other_user_name,
-        email: decryptedOtherUser?.email ?? row.other_user_email,
+        // Fail closed: on a missing join row emit null, never the raw
+        // (potentially ciphertext) column value.
+        name: decryptedOtherUser?.name ?? null,
+        email: decryptedOtherUser?.email ?? null,
         image: row.other_user_image,
         username: row.other_user_username,
         displayName: row.other_user_display_name,

--- a/apps/web/src/app/api/pulse/cron/__tests__/pii-decrypt-dedup.test.ts
+++ b/apps/web/src/app/api/pulse/cron/__tests__/pii-decrypt-dedup.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ============================================================================
+// POST /api/pulse/cron — PII decryption dedup (GDPR #965 perf remediation
+// round 2). The per-user summary build decrypts sender/member PII through
+// decryptFieldValuesOnce, batched once per section per unique stored value,
+// instead of one decryptField call per row. This exercises the unread-DMs
+// section end to end: one sender repeated across many unread messages must
+// decrypt once and surface plaintext in the persisted contextData.
+//
+// Uses the same fixture-based fake DB as ../../__tests__/task-fixture-db.
+// ============================================================================
+
+const h = vi.hoisted(() => ({
+  tableRows: new Map<unknown, Record<string, unknown>[]>(),
+  accessiblePageIds: [] as string[],
+  insertValuesMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/auth/cron-auth', () => ({
+  validateSignedCronRequest: vi.fn(() => null),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() } },
+}));
+
+vi.mock('@pagespace/lib/billing/automation-preferences', () => ({
+  filterPulseEligible: vi.fn((ids: string[]) => ids),
+}));
+
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn(() => ''),
+  getUserTimeOfDay: vi.fn(() => ({ timeOfDay: 'morning' })),
+  getStartOfTodayInTimezone: vi.fn(() => new Date('2024-01-10T00:00:00.000Z')),
+  normalizeTimezone: vi.fn(() => 'UTC'),
+  formatDateInTimezone: vi.fn(() => 'today'),
+}));
+
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  BACKGROUND_LIGHT_MODEL: 'anthropic/claude-test',
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {}, provider: 'anthropic', modelName: 'anthropic/claude-test' }),
+  isProviderError: vi.fn(() => false),
+}));
+
+vi.mock('ai', () => ({
+  generateText: vi.fn().mockResolvedValue({
+    text: 'Good morning! Everything looks fine.',
+    usage: { inputTokens: 10, outputTokens: 10 },
+    steps: [],
+  }),
+}));
+
+vi.mock('../../calendar-context', () => ({
+  fetchCalendarContext: vi.fn().mockResolvedValue({
+    happeningNow: [], upcomingToday: [], tomorrow: [], pendingInvites: [], allEvents: [],
+  }),
+}));
+
+vi.mock('@pagespace/lib/permissions/accessible-page-ids', () => ({
+  accessiblePageIds: vi.fn(() => Promise.resolve(h.accessiblePageIds)),
+}));
+
+vi.mock('@pagespace/lib/content/activity-diff-utils', () => ({
+  groupActivitiesForDiff: vi.fn(() => []),
+}));
+vi.mock('@pagespace/lib/content/version-resolver', () => ({
+  resolveStackedVersionContent: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock('@pagespace/lib/content/diff-generator', () => ({
+  generateDiffsWithinBudget: vi.fn(() => []),
+  calculateDiffBudget: vi.fn(() => 1000),
+}));
+vi.mock('@pagespace/lib/services/page-content-store', () => ({
+  readPageContent: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn() },
+  extractOpenRouterCostDollars: vi.fn(() => 0),
+  extractOpenRouterGenerationIds: vi.fn(() => []),
+}));
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, holdId: 'hold-1' }),
+}));
+vi.mock('@pagespace/lib/billing/credit-consume', () => ({ releaseHold: vi.fn().mockResolvedValue(undefined) }));
+
+// Wrap (not replace) the real decryptFieldValuesOnce so call counts and batch
+// contents can be asserted at the route's call boundary — proves the route
+// batches decryption per section instead of one decryptField call per row.
+// A bare `vi.spyOn` doesn't work here because `@pagespace/lib` resolves to
+// its built CJS dist output, and the inner per-value decrypt (decryptField)
+// is a *nested* require inside that compiled module, invisible to any mock
+// declared at this level. encryptField/decryptField stay real via the spread.
+vi.mock('@pagespace/lib/encryption/field-crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/encryption/field-crypto')>();
+  return { ...actual, decryptFieldValuesOnce: vi.fn(actual.decryptFieldValuesOnce) };
+});
+
+vi.mock('@pagespace/db/db', async () => {
+  const { createFixtureSelect } = await import('../../__tests__/task-fixture-db');
+  return {
+    db: {
+      select: createFixtureSelect(h.tableRows),
+      insert: vi.fn(() => ({ values: h.insertValuesMock })),
+    },
+  };
+});
+
+vi.mock('@pagespace/db/operators', async () => {
+  const { fixtureOperators } = await import('../../__tests__/task-fixture-db');
+  return fixtureOperators;
+});
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id', timezone: 'timezone', name: 'name', email: 'email', subscriptionTier: 'subscriptionTier' },
+}));
+vi.mock('@pagespace/db/schema/sessions', () => ({
+  sessions: { userId: 'userId', type: 'type', revokedAt: 'revokedAt', lastUsedAt: 'lastUsedAt' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId', isTrashed: 'isTrashed', title: 'title', content: 'content' },
+  drives: { id: 'id', name: 'name', drivePrompt: 'drivePrompt', isTrashed: 'isTrashed', ownerId: 'ownerId' },
+  userMentions: { targetUserId: 'targetUserId', createdAt: 'createdAt', mentionedByUserId: 'mentionedByUserId', sourcePageId: 'sourcePageId' },
+  chatMessages: { pageId: 'pageId', role: 'role', isActive: 'isActive', createdAt: 'createdAt', userId: 'userId', content: 'content' },
+}));
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  activityLogs: {
+    id: 'id', userId: 'userId', actorDisplayName: 'actorDisplayName', actorEmail: 'actorEmail',
+    operation: 'operation', resourceType: 'resourceType', resourceId: 'resourceId', pageId: 'pageId',
+    resourceTitle: 'resourceTitle', driveId: 'driveId', timestamp: 'timestamp', changeGroupId: 'changeGroupId',
+    aiConversationId: 'aiConversationId', isAiGenerated: 'isAiGenerated', contentRef: 'contentRef', contentSnapshot: 'contentSnapshot',
+  },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: { driveId: 'driveId', userId: 'userId', acceptedAt: 'acceptedAt' },
+  pagePermissions: { userId: 'userId', pageId: 'pageId', grantedBy: 'grantedBy', grantedAt: 'grantedAt' },
+}));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: {
+    pageId: 'pageId', assigneeId: 'assigneeId', userId: 'userId', status: 'status',
+    dueDate: 'dueDate', completedAt: 'completedAt', priority: 'priority',
+  },
+}));
+vi.mock('@pagespace/db/schema/social', () => ({
+  directMessages: {
+    conversationId: 'conversationId', senderId: 'senderId', isRead: 'isRead', isActive: 'isActive',
+    parentId: 'parentId', content: 'content', createdAt: 'createdAt',
+  },
+  dmConversations: { id: 'id', participant1Id: 'participant1Id', participant2Id: 'participant2Id' },
+}));
+vi.mock('@pagespace/db/schema/dashboard', () => ({
+  pulseSummaries: { userId: 'userId', generatedAt: 'generatedAt', summary: 'summary' },
+}));
+vi.mock('@pagespace/db/schema/automation-preferences', () => ({
+  userAutomationPreferences: { userId: 'userId', pulseEnabled: 'pulseEnabled' },
+}));
+
+import { POST } from '../route';
+import { users } from '@pagespace/db/schema/auth';
+import { sessions } from '@pagespace/db/schema/sessions';
+import { directMessages, dmConversations } from '@pagespace/db/schema/social';
+import { decryptFieldValuesOnce, encryptField } from '@pagespace/lib/encryption/field-crypto';
+
+const USER_ID = 'user-1';
+const OTHER_ID = 'user-other';
+
+function setupTables(dmRows: Record<string, unknown>[]) {
+  h.tableRows.clear();
+  h.accessiblePageIds = [];
+  h.tableRows.set(users, [{ id: USER_ID, timezone: 'UTC', name: 'Tester', email: 'tester@example.com', subscriptionTier: 'pro' }]);
+  h.tableRows.set(sessions, [{ userId: USER_ID, type: 'user', revokedAt: null, lastUsedAt: new Date() }]);
+  h.tableRows.set(dmConversations, [{ id: 'conv-1', participant1Id: USER_ID, participant2Id: OTHER_ID }]);
+  h.tableRows.set(directMessages, dmRows);
+}
+
+// Joined users.name/email are flattened into the message fixture rows
+// (the fixture DB resolves select fields by column name).
+const unreadDmRow = (senderName: string, content: string) => ({
+  conversationId: 'conv-1',
+  senderId: OTHER_ID,
+  isRead: false,
+  isActive: true,
+  parentId: null,
+  name: senderName,
+  email: 'other@example.com',
+  content,
+  createdAt: new Date('2024-01-10T08:00:00.000Z'),
+});
+
+const makeRequest = () => new Request('https://example.com/api/pulse/cron', { method: 'POST' });
+
+describe('POST /api/pulse/cron — PII decryption dedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.insertValuesMock.mockClear();
+    h.insertValuesMock.mockResolvedValue(undefined);
+  });
+
+  it('decrypts one encrypted sender repeated across unread DMs once and persists plaintext', async () => {
+    const encryptedSender = await encryptField('Real Sender');
+    setupTables([
+      unreadDmRow(encryptedSender, 'first'),
+      unreadDmRow(encryptedSender, 'second'),
+      unreadDmRow(encryptedSender, 'third'),
+    ]);
+
+    const response = await POST(makeRequest());
+    const body = await response.json();
+    expect(body.errors).toBeUndefined();
+    expect(body.generated).toBe(1);
+
+    expect(h.insertValuesMock).toHaveBeenCalledTimes(1);
+    const row = h.insertValuesMock.mock.calls[0][0] as {
+      contextData: { messages: { unreadCount: number; recentSenders: string[] } };
+    };
+    // The repeated sender surfaces as ONE plaintext name in the summary.
+    expect(row.contextData.messages.unreadCount).toBe(3);
+    expect(row.contextData.messages.recentSenders).toEqual(['Real Sender']);
+
+    // The unread-DMs section made exactly one batched decrypt call carrying
+    // the repeated ciphertext (dedup happens inside the helper) — not one
+    // decryptField call per row. Emails stay out of the batch because every
+    // row has a sender name (the old || short-circuit, preserved).
+    const dmBatch = vi
+      .mocked(decryptFieldValuesOnce)
+      .mock.calls.filter(([values]) => values.includes(encryptedSender));
+    expect(dmBatch).toHaveLength(1);
+    expect(dmBatch[0][0].filter((v) => v === encryptedSender)).toHaveLength(3);
+    expect(dmBatch[0][0]).not.toContain('other@example.com');
+  });
+
+  it('falls back to the decrypted email local-part when a sender has no name', async () => {
+    const encryptedEmail = await encryptField('fallback@example.com');
+    setupTables([
+      { ...unreadDmRow('', 'no name on this one'), name: null, email: encryptedEmail },
+    ]);
+
+    const response = await POST(makeRequest());
+    const body = await response.json();
+    expect(body.errors).toBeUndefined();
+    expect(body.generated).toBe(1);
+
+    const row = h.insertValuesMock.mock.calls[0][0] as {
+      contextData: { messages: { recentSenders: string[] } };
+    };
+    expect(row.contextData.messages.recentSenders).toEqual(['fallback']);
+  });
+});

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -6,7 +6,7 @@ import { BACKGROUND_LIGHT_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { db } from '@pagespace/db/db'
 import { eq, and, or, lt, gte, ne, desc, inArray, isNull, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
-import { decryptField } from '@pagespace/lib/encryption/field-crypto'
+import { decryptField, decryptFieldValuesOnce } from '@pagespace/lib/encryption/field-crypto'
 import { sessions } from '@pagespace/db/schema/sessions'
 import { pages, drives, userMentions, chatMessages } from '@pagespace/db/schema/core'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
@@ -267,12 +267,17 @@ async function buildAndPersistPulse(
       ne(driveMembers.userId, userId),
       isNotNull(driveMembers.acceptedAt)
     )) : [];
-  // Decrypt PII at the edge so the team roster in the prompt is plaintext.
-  const teamMembers = await Promise.all(teamMembersRaw.map(async (m) => ({
+  // Decrypt PII at the edge so the team roster in the prompt is plaintext —
+  // batched once per unique stored value (the same user repeats across
+  // drives with the same ciphertext), not once per row.
+  const lookupTeamPii = await decryptFieldValuesOnce(
+    teamMembersRaw.flatMap((m) => [m.userName, m.userEmail])
+  );
+  const teamMembers = teamMembersRaw.map((m) => ({
     ...m,
-    userName: await decryptField(m.userName),
-    userEmail: await decryptField(m.userEmail),
-  })));
+    userName: lookupTeamPii(m.userName),
+    userEmail: lookupTeamPii(m.userEmail),
+  }));
 
   const teamByDrive = teamMembers.reduce((acc, m) => {
     if (!acc[m.driveId]) acc[m.driveId] = [];
@@ -537,12 +542,18 @@ async function buildAndPersistPulse(
       .orderBy(desc(directMessages.createdAt))
       .limit(10);
 
-    // Decrypt PII at the edge so DM sender names in the prompt are plaintext.
-    unreadDMs = await Promise.all(unreadMessagesList.map(async m => ({
-      from: (await decryptField(m.senderName)) || (await decryptField(m.senderEmail))?.split('@')[0] || 'Someone',
+    // Decrypt PII at the edge so DM sender names in the prompt are plaintext
+    // — batched once per unique stored value. Emails only enter the batch
+    // for rows with no sender name, mirroring the old `||` short-circuit
+    // (no stored value decrypts to '', so raw-falsy ⇔ decrypted-falsy).
+    const lookupDmPii = await decryptFieldValuesOnce(
+      unreadMessagesList.flatMap((m) => [m.senderName, m.senderName ? null : m.senderEmail])
+    );
+    unreadDMs = unreadMessagesList.map((m) => ({
+      from: lookupDmPii(m.senderName) || lookupDmPii(m.senderEmail)?.split('@')[0] || 'Someone',
       content: m.content || '',
       sentAt: m.createdAt,
-    })));
+    }));
   }
 
   // ========================================
@@ -572,12 +583,16 @@ async function buildAndPersistPulse(
     )
     .orderBy(desc(chatMessages.createdAt))
     .limit(15) : [];
-  // Decrypt PII at the edge so page-chat sender names in the prompt are plaintext.
-  const recentPageChats = await Promise.all(recentPageChatsRaw.map(async (c) => ({
+  // Decrypt PII at the edge so page-chat sender names in the prompt are
+  // plaintext — batched once per unique stored value, not once per row.
+  const lookupChatPii = await decryptFieldValuesOnce(
+    recentPageChatsRaw.flatMap((c) => [c.senderName, c.senderEmail])
+  );
+  const recentPageChats = recentPageChatsRaw.map((c) => ({
     ...c,
-    senderName: await decryptField(c.senderName),
-    senderEmail: await decryptField(c.senderEmail),
-  })));
+    senderName: lookupChatPii(c.senderName),
+    senderEmail: lookupChatPii(c.senderEmail),
+  }));
 
   const chatsByPage = recentPageChats
     .filter(chat => chat.pageId && accessiblePages.has(chat.pageId))
@@ -617,11 +632,15 @@ async function buildAndPersistPulse(
     )
     .orderBy(desc(userMentions.createdAt))
     .limit(5);
-  // Decrypt PII at the edge so mention author names in the prompt are plaintext.
-  const recentMentions = await Promise.all(recentMentionsRaw.map(async (m) => ({
+  // Decrypt PII at the edge so mention author names in the prompt are
+  // plaintext — batched once per unique stored value, not once per row.
+  const lookupMentionPii = await decryptFieldValuesOnce(
+    recentMentionsRaw.map((m) => m.mentionedByName)
+  );
+  const recentMentions = recentMentionsRaw.map((m) => ({
     ...m,
-    mentionedByName: await decryptField(m.mentionedByName),
-  })));
+    mentionedByName: lookupMentionPii(m.mentionedByName),
+  }));
 
   const recentSharesRaw = await db
     .select({
@@ -641,11 +660,15 @@ async function buildAndPersistPulse(
     )
     .orderBy(desc(pagePermissions.grantedAt))
     .limit(5);
-  // Decrypt PII at the edge so share author names in the prompt are plaintext.
-  const recentShares = await Promise.all(recentSharesRaw.map(async (s) => ({
+  // Decrypt PII at the edge so share author names in the prompt are
+  // plaintext — batched once per unique stored value, not once per row.
+  const lookupSharePii = await decryptFieldValuesOnce(
+    recentSharesRaw.map((s) => s.sharedByName)
+  );
+  const recentShares = recentSharesRaw.map((s) => ({
     ...s,
-    sharedByName: await decryptField(s.sharedByName),
-  })));
+    sharedByName: lookupSharePii(s.sharedByName),
+  }));
 
   // ========================================
   // 8. PREVIOUS PULSES (for deduplication)

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -7,7 +7,7 @@ import { BACKGROUND_LIGHT_MODEL } from '@/lib/ai/core/ai-providers-config';
 import { db } from '@pagespace/db/db'
 import { eq, and, or, lt, gte, ne, desc, inArray, isNotNull, isNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
-import { decryptField } from '@pagespace/lib/encryption/field-crypto'
+import { decryptField, decryptFieldValuesOnce } from '@pagespace/lib/encryption/field-crypto'
 import { pages, drives, userMentions, chatMessages } from '@pagespace/db/schema/core'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members'
@@ -168,12 +168,17 @@ export async function POST(req: Request) {
         ne(driveMembers.userId, userId),
         isNotNull(driveMembers.acceptedAt)
       )) : [];
-    // Decrypt PII at the edge so the team roster in the prompt is plaintext.
-    const teamMembers = await Promise.all(teamMembersRaw.map(async (m) => ({
+    // Decrypt PII at the edge so the team roster in the prompt is plaintext —
+    // batched once per unique stored value (the same user repeats across
+    // drives with the same ciphertext), not once per row.
+    const lookupTeamPii = await decryptFieldValuesOnce(
+      teamMembersRaw.flatMap((m) => [m.userName, m.userEmail])
+    );
+    const teamMembers = teamMembersRaw.map((m) => ({
       ...m,
-      userName: await decryptField(m.userName),
-      userEmail: await decryptField(m.userEmail),
-    })));
+      userName: lookupTeamPii(m.userName),
+      userEmail: lookupTeamPii(m.userEmail),
+    }));
 
     const teamByDrive = teamMembers.reduce((acc, m) => {
       if (!acc[m.driveId]) acc[m.driveId] = [];
@@ -408,12 +413,18 @@ export async function POST(req: Request) {
         .orderBy(desc(directMessages.createdAt))
         .limit(10);
 
-      // Decrypt PII at the edge so DM sender names in the prompt are plaintext.
-      unreadDMs = await Promise.all(unreadMessagesList.map(async m => ({
-        from: (await decryptField(m.senderName)) || (await decryptField(m.senderEmail))?.split('@')[0] || 'Someone',
+      // Decrypt PII at the edge so DM sender names in the prompt are plaintext
+      // — batched once per unique stored value. Emails only enter the batch
+      // for rows with no sender name, mirroring the old `||` short-circuit
+      // (no stored value decrypts to '', so raw-falsy ⇔ decrypted-falsy).
+      const lookupDmPii = await decryptFieldValuesOnce(
+        unreadMessagesList.flatMap((m) => [m.senderName, m.senderName ? null : m.senderEmail])
+      );
+      unreadDMs = unreadMessagesList.map((m) => ({
+        from: lookupDmPii(m.senderName) || lookupDmPii(m.senderEmail)?.split('@')[0] || 'Someone',
         content: m.content || '',
         sentAt: m.createdAt,
-      })));
+      }));
     }
 
     // ========================================
@@ -442,12 +453,16 @@ export async function POST(req: Request) {
       )
       .orderBy(desc(chatMessages.createdAt))
       .limit(15) : [];
-    // Decrypt PII at the edge so page-chat sender names in the prompt are plaintext.
-    const recentPageChats = await Promise.all(recentPageChatsRaw.map(async (c) => ({
+    // Decrypt PII at the edge so page-chat sender names in the prompt are
+    // plaintext — batched once per unique stored value, not once per row.
+    const lookupChatPii = await decryptFieldValuesOnce(
+      recentPageChatsRaw.flatMap((c) => [c.senderName, c.senderEmail])
+    );
+    const recentPageChats = recentPageChatsRaw.map((c) => ({
       ...c,
-      senderName: await decryptField(c.senderName),
-      senderEmail: await decryptField(c.senderEmail),
-    })));
+      senderName: lookupChatPii(c.senderName),
+      senderEmail: lookupChatPii(c.senderEmail),
+    }));
 
     const chatsByPage = recentPageChats
       .filter(chat => chat.pageId && accessiblePages.has(chat.pageId))
@@ -487,11 +502,15 @@ export async function POST(req: Request) {
       )
       .orderBy(desc(userMentions.createdAt))
       .limit(5);
-    // Decrypt PII at the edge so mention author names in the prompt are plaintext.
-    const recentMentions = await Promise.all(recentMentionsRaw.map(async (m) => ({
+    // Decrypt PII at the edge so mention author names in the prompt are
+    // plaintext — batched once per unique stored value, not once per row.
+    const lookupMentionPii = await decryptFieldValuesOnce(
+      recentMentionsRaw.map((m) => m.mentionedByName)
+    );
+    const recentMentions = recentMentionsRaw.map((m) => ({
       ...m,
-      mentionedByName: await decryptField(m.mentionedByName),
-    })));
+      mentionedByName: lookupMentionPii(m.mentionedByName),
+    }));
 
     const recentSharesRaw = await db
       .select({
@@ -510,11 +529,15 @@ export async function POST(req: Request) {
       )
       .orderBy(desc(pagePermissions.grantedAt))
       .limit(5);
-    // Decrypt PII at the edge so share author names in the prompt are plaintext.
-    const recentShares = await Promise.all(recentSharesRaw.map(async (s) => ({
+    // Decrypt PII at the edge so share author names in the prompt are
+    // plaintext — batched once per unique stored value, not once per row.
+    const lookupSharePii = await decryptFieldValuesOnce(
+      recentSharesRaw.map((s) => s.sharedByName)
+    );
+    const recentShares = recentSharesRaw.map((s) => ({
       ...s,
-      sharedByName: await decryptField(s.sharedByName),
-    })));
+      sharedByName: lookupSharePii(s.sharedByName),
+    }));
 
     // ========================================
     // 8. PREVIOUS PULSES (for deduplication)

--- a/apps/web/src/types/messaging.ts
+++ b/apps/web/src/types/messaging.ts
@@ -17,9 +17,10 @@ export interface ConversationRow extends Record<string, unknown> {
   participant2LastRead: string | null;
   createdAt: string;
   last_read: string | null;
-  other_user_id: string;
-  other_user_name: string;
-  other_user_email: string;
+  // LEFT JOIN users — nullable so consumers must handle a missing join row.
+  other_user_id: string | null;
+  other_user_name: string | null;
+  other_user_email: string | null;
   other_user_image: string | null;
   other_user_username: string | null;
   other_user_display_name: string | null;
@@ -55,7 +56,8 @@ export interface DMRow extends Record<string, unknown> {
   id: string;
   last_message_at: string | null;
   last_message: string | null;
-  other_user_name: string;
+  // LEFT JOIN users — nullable so consumers must handle a missing join row.
+  other_user_name: string | null;
   other_user_display_name: string | null;
   other_user_image: string | null;
   other_user_avatar_url: string | null;
@@ -71,9 +73,10 @@ export interface ConversationDetailRow extends Record<string, unknown> {
   lastMessagePreview: string | null;
   createdAt: string;
   other_user_id: string;
-  user_id: string;
-  user_name: string;
-  user_email: string;
+  // LEFT JOIN users — nullable so consumers must handle a missing join row.
+  user_id: string | null;
+  user_name: string | null;
+  user_email: string | null;
   user_image: string | null;
   user_username: string | null;
   user_display_name: string | null;

--- a/packages/lib/src/encryption/field-crypto.test.ts
+++ b/packages/lib/src/encryption/field-crypto.test.ts
@@ -7,7 +7,7 @@
  * never encrypted.
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { encryptField, decryptField, looksEncrypted } from './field-crypto';
+import { encryptField, decryptField, decryptFieldValuesOnce, looksEncrypted } from './field-crypto';
 
 beforeAll(() => {
   process.env.ENCRYPTION_KEY = 'test-encryption-key-at-least-32-characters!!';
@@ -64,5 +64,46 @@ describe('encryptField / decryptField round-trip', () => {
     expect(await encryptField(null)).toBe(null);
     expect(await encryptField(undefined)).toBe(undefined);
     expect(await decryptField(null)).toBe(null);
+  });
+});
+
+describe('decryptFieldValuesOnce', () => {
+  it('given ciphertext values, should return a lookup that decrypts them', async () => {
+    const ctName = await encryptField('Alice');
+    const ctEmail = await encryptField('alice@example.com');
+    const lookup = await decryptFieldValuesOnce([ctName, ctEmail]);
+    expect(lookup(ctName)).toBe('Alice');
+    expect(lookup(ctEmail)).toBe('alice@example.com');
+  });
+
+  it('given the same ciphertext repeated across many rows, should decrypt it once (dedup by value)', async () => {
+    const ct = await encryptField('Repeated Sender');
+    const lookup = await decryptFieldValuesOnce([ct, ct, ct, ct]);
+    expect(lookup(ct)).toBe('Repeated Sender');
+  });
+
+  it('given legacy plaintext values, should pass them through unchanged', async () => {
+    const lookup = await decryptFieldValuesOnce(['Legacy Name', 'legacy@plaintext.com']);
+    expect(lookup('Legacy Name')).toBe('Legacy Name');
+    expect(lookup('legacy@plaintext.com')).toBe('legacy@plaintext.com');
+  });
+
+  it('given null/undefined lookups, should return null', async () => {
+    const lookup = await decryptFieldValuesOnce([null, undefined, 'x']);
+    expect(lookup(null)).toBeNull();
+    expect(lookup(undefined)).toBeNull();
+  });
+
+  it('given an empty string, should pass it through unchanged', async () => {
+    const lookup = await decryptFieldValuesOnce(['']);
+    expect(lookup('')).toBe('');
+  });
+
+  it('given a value that was never batched, should fail closed to null (never emit raw ciphertext)', async () => {
+    const batched = await encryptField('In Batch');
+    const unbatched = await encryptField('Not In Batch');
+    const lookup = await decryptFieldValuesOnce([batched]);
+    expect(lookup(batched)).toBe('In Batch');
+    expect(lookup(unbatched)).toBeNull();
   });
 });

--- a/packages/lib/src/encryption/field-crypto.ts
+++ b/packages/lib/src/encryption/field-crypto.ts
@@ -60,3 +60,25 @@ export async function decryptField<T extends string | null | undefined>(value: T
   if (!looksEncrypted(value)) return value;
   return (await decrypt(value)) as T;
 }
+
+/**
+ * Batch-decrypt a request's field values exactly once per distinct value.
+ *
+ * For rows that carry no user id (raw-SQL projections, COALESCEd columns), the
+ * stored value itself is the dedup key: the same user repeated across rows
+ * repeats the same stored ciphertext, so each unique value decrypts once
+ * instead of once per row. Plaintext values pass through via `decryptField`.
+ *
+ * Returns a lookup with fail-closed semantics: `null`/`undefined` map to
+ * `null`, and a value that was never batched returns `null` rather than the
+ * raw (potentially ciphertext) input — a drift between batch construction and
+ * lookup sites must never leak ciphertext to a client.
+ */
+export async function decryptFieldValuesOnce(
+  values: ReadonlyArray<string | null | undefined>,
+): Promise<(value: string | null | undefined) => string | null> {
+  const unique = [...new Set(values.filter((value): value is string => typeof value === 'string'))];
+  const decrypted = await Promise.all(unique.map(async (value) => [value, await decryptField(value)] as const));
+  const byValue = new Map<string, string>(decrypted);
+  return (value) => (typeof value === 'string' ? byValue.get(value) ?? null : null);
+}

--- a/tasks/pii-decrypt-perf-remediation-round2.md
+++ b/tasks/pii-decrypt-perf-remediation-round2.md
@@ -58,6 +58,19 @@ Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/connection
 
 ---
 
+## Review follow-ups (round 2)
+
+**Status**: ✅ DONE
+
+The dedup PR's multi-agent self-review surfaced four verified follow-ups; all landed on the same branch:
+
+- `decryptFieldValuesOnce` promoted to `packages/lib/src/encryption/field-crypto.ts` as the first-class value-keyed batch-decrypt helper (fail-closed lookup: a value missing from the batch returns `null`, never raw ciphertext). Inbox rewired onto it; the pulse `generate` + `cron` routes (same id-less per-row decrypt shape, 5 sections each) wired too.
+- `/api/connections/search` derives `isSelf` from `targetRow?.id === user.id` — drops one query + one decrypt per search and **closes a case-variant self-search enumeration corner** (was: keyed case-variant self-search returned the caller's own profile as actionable; now `{user:null}`). The one intentional behavior change in the PR.
+- Inbox decrypts only pagination survivors: permission-filter → sort → slice → one batched decrypt (rows the page limit discards are never decrypted).
+- Type honesty + fail-closed: LEFT-JOINed user columns in `apps/web/src/types/messaging.ts` are `| null`; the messages routes' `?? raw` fallbacks are now `?? null` so no future drift can emit ciphertext.
+
+---
+
 ## Verify recovery
 
 After all four tasks land and deploy, confirm the fix actually closes the gap rather than just asserting it should.

--- a/tasks/pii-decrypt-perf-remediation-round2.md
+++ b/tasks/pii-decrypt-perf-remediation-round2.md
@@ -1,0 +1,67 @@
+# PII Decrypt Perf Remediation — Round 2 Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Finish closing the PII-decrypt latency regression that PR #1930/#1931 only partially fixed — every existing user's PII is still on the slow path, and several hot routes were never wired into the dedup fix.
+
+## Overview
+
+Because PR #1930's expand-contract fix only speeds up brand-new writes and only deduped 3 of the routes that decrypt PII in a per-row loop, production response times are still elevated hours after both perf PRs deployed: the one-time backfill (`scripts/backfill-user-pii-encryption.ts`) that encrypted all 224 existing users ran on 2026-07-06, a full day before #1930 introduced the fast ciphertext format, so every existing user's `email`/`name` is permanently stuck on the slow unmemoized-scrypt-per-record legacy decrypt path (`deriveLegacyKey`) until re-encrypted — and grep found `inbox`, `messages/conversations`, `messages/conversations/[conversationId]`, `messages/threads`, `connections`, and `connections/search` routes still doing undeduped per-row `decryptField` calls that PR #1930 never touched. This epic closes both gaps with zero behavior change, full backwards compatibility with mixed-format data mid-migration, and pure-function-core/imperative-shell TDD throughout, following the exact patterns already established in `encryption-utils.ts` (`parseEnvelope`/`buildEnvelope`/`encryptWithKey`/`decryptWithKey`) and `blind-index.ts` (`memoizeSyncByKey`).
+
+---
+
+## Legacy-ciphertext re-encryption backfill
+
+Idempotent, resumable, dry-run-by-default script that reads every legacy-4-part-format `users.email`/`name` row, decrypts it via the existing dual-format `decrypt()`, and re-encrypts it via `encrypt()` (which always emits the fast 3-part format) — converging every row to the fast format so the legacy scrypt path is no longer on the hot read path for any existing user.
+
+**Requirements**:
+- Given a row already in fast-format ciphertext, should skip it (idempotent re-runs converge to zero work, mirroring `scripts/backfill-user-pii-encryption.ts`'s existing-row skip).
+- Given a row in legacy-format ciphertext, should decrypt then re-encrypt it to fast format in a single pass, byte-identical plaintext round-trip proven by test.
+- Given the migration is interrupted mid-run, should be resumable (cursor-based batching, same pattern as the existing backfill) without re-processing already-converted rows or losing progress.
+- Given a dry-run flag (default), should report counts (legacy found / would-convert) without writing, requiring the same explicit `--apply` + confirmed-cutover-deployed gate pattern as the existing backfill before any live write.
+- Given the planner logic (which rows need conversion, what the new value should be), should be a pure function separate from the DB I/O shell, unit-tested without a real database — same split as `planUserPiiBackfill`.
+
+---
+
+## Dedup PII decrypts in inbox route
+
+**Status**: ✅ DONE
+
+Wire the existing `decryptUsersByIdOnce` helper (`packages/lib/src/auth/user-repository.ts`, added by PR #1930) into `apps/web/src/app/api/inbox/route.ts`'s three per-row `decryptField` call sites so a repeated sender/participant within one request's result set decrypts once, not once per row.
+
+**Requirements**:
+- Given an inbox response listing multiple conversations from the same sender, should decrypt that sender's name exactly once for the whole request (call-count assertion via the same test pattern PR #1930 used against `decryptUsersByIdOnce`, not a dist-boundary mock on the inner `decryptField`).
+- Given the route's existing response shape and decrypted values, should be byte-identical to before the change (behavior-preserving refactor, not a new feature).
+
+---
+
+## Dedup PII decrypts in messages routes
+
+**Status**: ✅ DONE
+
+Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/messages/conversations/route.ts`, `apps/web/src/app/api/messages/conversations/[conversationId]/route.ts`, and `apps/web/src/app/api/messages/threads/route.ts`.
+
+**Requirements**:
+- Given a conversations/threads list with repeated other-party users across rows, should decrypt each unique user once per request.
+- Given the single-conversation detail route, should still correctly decrypt when only one distinct user is present (no regression for the common case).
+
+---
+
+## Dedup PII decrypts in connections routes
+
+**Status**: ✅ DONE
+
+Apply the same `decryptUsersByIdOnce` wiring to `apps/web/src/app/api/connections/route.ts` and `apps/web/src/app/api/connections/search/route.ts`.
+
+**Requirements**:
+- Given a connections list or search result with repeated users, should decrypt each unique user once per request.
+- Given the search route's existing filtering/ranking behavior, should be unaffected by the decrypt-path change.
+
+---
+
+## Verify recovery
+
+After all four tasks land and deploy, confirm the fix actually closes the gap rather than just asserting it should.
+
+**Requirements**:
+- Given the full lib + web test suites and `bun run typecheck`, should be green with zero new failures across all four preceding tasks.
+- Given the fix is deployed to `pagespace-web`, should show HTTP Response Time Avg back down near the pre-regression ~0.3-0.5s baseline on the same Grafana panel used to diagnose this, not just an assumption that the code change helped.


### PR DESCRIPTION
## Summary

Round 2 of the PII-decrypt latency remediation (follow-up to #1930, which wired `decryptUsersByIdOnce` into only 3 routes). Six more hot, frequently-polled routes were still calling `decryptField` once per row, so a repeated user across a result set paid a serialized scrypt-derived decrypt per row. This PR wires request-batched decryption into all of them — then closes every follow-up its own multi-agent self-review surfaced, so the decrypt path is done: fast and fail-closed.

### Route dedup (behavior-preserving)

- **`/api/inbox`** (3 call sites) — rows carry no user ids and `sender_name` COALESCEs a plaintext AI `senderName` with ciphertext `users.name`, so dedup keys on the stored value itself (same user ⇒ same stored ciphertext). DM names short-circuited by a profile `displayName` are excluded, matching the old `||` skip.
- **`/api/messages/conversations`**, **`/api/messages/conversations/[conversationId]`**, **`/api/messages/threads`** — keyed by the joined user id; null-join rows skipped exactly as before.
- **`/api/connections`** — `decryptUserRows` + hand-built id map replaced by `decryptUsersByIdOnce` (which returns exactly that map).

### Review findings, all resolved in this PR

1. **Permission-order fix** (`e9b1007e8`): the inbox batches were originally built before the `canView` filter — hidden channels' sender PII was decrypted, and one undecryptable value on a hidden channel could 500 the whole inbox. Rows are now permission-filtered first (regression-tested).
2. **First-class lib helper** (`62acca3fe`): `decryptFieldValuesOnce` in `packages/lib/encryption/field-crypto` — value-keyed batch decrypt with a fail-closed lookup (never emits raw ciphertext on a miss). Replaces inbox's fake-`{id: ciphertext}` indirection through `decryptUsersByIdOnce`.
3. **Decrypt-after-slice** (`e1f5490d5`): inbox fetches `limit+1` rows per source but returns `limit` items; both branches now permission-filter → sort → slice → decrypt only the survivors (up to ~half the batch trimmed on a default dashboard load; push order and cursors byte-identical).
4. **⚠️ One intentional behavior change** (`64585ba13`): `/api/connections/search` derives `isSelf` from `targetRow?.id === user.id` instead of fetching + decrypting the caller's email for an exact-string compare. Deletes a query + a decrypt per search — and closes a real enumeration corner: a keyed case-variant self-search (`Me@X.com` vs stored `me@x.com`) previously returned the caller's own profile as actionable; it now collapses to `{ user: null }` like every other non-actionable outcome (L2).
5. **Type honesty + fail-closed** (`64c2bd56c`): LEFT-JOINed user columns in `types/messaging.ts` are now `| null`, and the messages routes' `?? raw` fallbacks are `?? null` — a future query edit can never silently emit ciphertext.
6. **Pulse routes wired** (`3a2817cc1`): `pulse/generate` (per-request) and `pulse/cron` (fans out over every active user per tick) each had five per-row decrypt loops over id-less rows — now one batched call per section, with the unread-DMs `senderName || senderEmail` short-circuit decrypt-set preserved exactly.

## Testing

- TDD throughout: call-count + batch-content tests at the `decryptUsersByIdOnce`/`decryptFieldValuesOnce` boundary (wrapping the real export per the #1930 approach — the built CJS dist makes inner `decryptField` mocks invisible), plus ciphertext round-trips, legacy-plaintext passthrough, deleted-user null-joins, AI-plaintext passthrough, displayName short-circuit, hidden-channel exclusion, slice exclusion, self-search + case-variant enumeration collapse, and a pulse cron fixture-DB dedup test.
- `apps/web` affected suites: 172 tests pass (inbox 14, messages, connections, pulse 20, activities/commands regression).
- `packages/lib`: 766 encryption+auth tests pass (incl. 6 new helper tests).
- `bun run typecheck`: 16/16 tasks green. Zero `any` in the diff.

Epic: `tasks/pii-decrypt-perf-remediation-round2.md` (three dedup sections + round-2 follow-ups ✅ DONE; the re-encryption backfill is the parallel workstream, PR #1936; post-deploy Grafana verification is the remaining human step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eBsZcnAZrRYT4ud7j78Am