### PR TITLE
fix(web): make middleware edge-safe — pure leaf imports, edge logger, ingest-route metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,14 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Fixed
 
+- **Request middleware is now edge-safe and actually deployable** — registering the previously
+  dormant middleware took production down because its import graph reached Node-only code (the
+  database client and server logger) that the Edge runtime cannot execute. Middleware now uses
+  pure leaf modules (token prefixes, an edge-safe structured logger) and forwards API metrics to
+  the internal ingest route instead of writing to the database in-process; the build now fails
+  fast if a Node-only import ever reaches the middleware bundle again. Admin monitoring
+  dashboards begin receiving API request metrics once this deploys — the previous in-middleware
+  metrics writer had never actually run.
 - **GDPR data exports now include system logs, API metrics, and error logs** — the account data
   export (`Settings > Privacy > Download my data`) previously omitted these three monitoring
   tables even though they can carry your user ID until account deletion. They're now included in

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -114,6 +114,63 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    // Edge-runtime import graph: middleware.ts and every module it
+    // (transitively) imports compiles for the Edge runtime, where db access
+    // and @pagespace/lib's Node-only logger crash at request time — the
+    // 2026-07-07 prod outage. The next.config.ts edge build guard is the
+    // backstop; this rule surfaces the mistake in the editor/lint instead of
+    // at build. Keep this file list in sync with middleware.ts's imports.
+    files: [
+      "src/middleware.ts",
+      "src/middleware/monitoring.ts",
+      "src/middleware/security-headers.ts",
+      "src/lib/auth/origin-validation.ts",
+      "src/lib/auth/cookie-config.ts",
+      "src/lib/auth/token-prefixes.ts",
+      "src/lib/logging/edge-logger.ts",
+      "src/lib/request-id/request-id.ts",
+      "src/lib/monitoring/ingest-sanitizer.ts",
+      "src/lib/well-known/rewrites.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          // `paths` entries match the exact specifier only — required for the
+          // @/lib/auth barrel ban, since a gitignore-style `group` pattern
+          // would also match the allowed leaf modules under @/lib/auth/*.
+          paths: [
+            {
+              name: "@/lib/auth",
+              message:
+                "Edge-runtime middleware graph: the @/lib/auth barrel drags in db + sessions + permissions. Import the specific leaf (e.g. @/lib/auth/token-prefixes, @/lib/auth/origin-validation).",
+            },
+            {
+              name: "@/lib/auth/index",
+              message:
+                "Edge-runtime middleware graph: the @/lib/auth barrel drags in db + sessions + permissions. Import the specific leaf (e.g. @/lib/auth/token-prefixes, @/lib/auth/origin-validation).",
+            },
+          ],
+          patterns: [
+            {
+              group: ["@pagespace/db", "@pagespace/db/*"],
+              message:
+                "Edge-runtime middleware graph: no database access. Persist via the /api/internal/monitoring/ingest route (Node runtime) instead.",
+            },
+            {
+              // Everything under @pagespace/lib except api-contract-version
+              // (a pure constant that security-headers.ts legitimately
+              // bundles into the edge build).
+              regex: "^@pagespace/lib(?!/api-contract-version$)(/.*)?$",
+              message:
+                "Edge-runtime middleware graph: @pagespace/lib is Node-only (logger uses os/process.on; many leaves import the db). Use edge-safe leaf modules under apps/web/src, e.g. @/lib/logging/edge-logger.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -32,8 +32,14 @@ export const nextConfig: NextConfig = {
   // Next.js emit require() at runtime, which fails for ESM-only packages. Instead
   // it is a direct dependency of apps/web so webpack bundles it as a server chunk.
   serverExternalPackages: ["pg"],
-  webpack: (config, { isServer }) => {
-    if (isServer) {
+  webpack: (config, { isServer, nextRuntime }) => {
+    // Externalization emits `require()` calls, which only the Node.js runtime
+    // can execute. The edge compile (middleware) has no require(): it must
+    // bundle everything from source so Next's edge static analysis fails the
+    // BUILD on Node-only imports instead of 500ing every request at runtime —
+    // exactly what took prod down when middleware first registered (PR #1932:
+    // "Native module not found: @pagespace/lib/logging/logger-config").
+    if (isServer && nextRuntime === 'nodejs') {
       // Externalize pg unconditionally (bun cache path bypasses Next's heuristic).
       // When workspaceDistReady, also externalize @pagespace/db and @pagespace/lib
       // so Next emits require('@pagespace/...') calls resolved to their dist/.
@@ -60,6 +66,50 @@ export const nextConfig: NextConfig = {
         config.externals = [config.externals as NonNullable<typeof config.externals>, bunWorkspaceExternals];
       } else {
         config.externals = [bunWorkspaceExternals];
+      }
+    }
+
+    if (isServer && nextRuntime === 'edge') {
+      // Fail the BUILD when the edge bundle (middleware) reaches a Node-only
+      // module. Next.js itself only WARNS ("A Node.js API is used (…) which is
+      // not supported in the Edge Runtime") and defers the crash to request
+      // time — verified empirically; a probe import of the Node-only logger
+      // built green and then would 500 every request, which is exactly how
+      // prod went down the day middleware first registered. This hook turns
+      // those imports into hard build errors instead. Node built-ins the Edge
+      // runtime DOES provide (buffer, events, util, assert, async_hooks) are
+      // deliberately not listed.
+      const nodeOnlyModules = new Set([
+        'os', 'fs', 'fs/promises', 'path', 'net', 'tls', 'dns', 'dgram',
+        'child_process', 'cluster', 'http', 'https', 'http2', 'module',
+        'perf_hooks', 'readline', 'repl', 'tty', 'v8', 'vm', 'worker_threads',
+        'zlib', 'stream', 'stream/promises', 'string_decoder', 'inspector',
+        'pg', 'pg-pool', 'pg-protocol', 'pg-native', 'pg-connection-string',
+        'dotenv',
+      ]);
+      const edgeNodeOnlyGuard = (
+        { request, contextInfo }: { context: string; request: string; contextInfo?: { issuer?: string } },
+        callback: (err?: Error | null, result?: string) => void
+      ) => {
+        const bare = request.startsWith('node:') ? request.slice('node:'.length) : request;
+        if (nodeOnlyModules.has(bare) || request.startsWith('@pagespace/db')) {
+          return callback(new Error(
+            `Edge bundle imports Node-only module '${request}'` +
+            (contextInfo?.issuer ? ` (via ${contextInfo.issuer})` : '') +
+            `. The Edge runtime cannot execute it at request time — middleware and ` +
+            `everything it imports must stay on edge-safe leaf modules ` +
+            `(see apps/web/src/middleware.ts header comment).`
+          ));
+        }
+        callback();
+      };
+
+      if (Array.isArray(config.externals)) {
+        config.externals.push(edgeNodeOnlyGuard);
+      } else if (config.externals) {
+        config.externals = [config.externals as NonNullable<typeof config.externals>, edgeNodeOnlyGuard];
+      } else {
+        config.externals = [edgeNodeOnlyGuard];
       }
     }
     if (!isServer) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import path from "path";
 import fs from "fs";
+import { builtinModules } from "module";
 import CopyPlugin from "copy-webpack-plugin";
 import { withSentryConfig } from "@sentry/nextjs";
 import { WELL_KNOWN_REWRITES } from "./src/lib/well-known/rewrites";
@@ -14,6 +15,64 @@ const dbDistExists = fs.existsSync(path.resolve(__dirname, "../../packages/db/di
 const libDistExists = fs.existsSync(path.resolve(__dirname, "../../packages/lib/dist"));
 const workspaceDistReady =
   process.env.NODE_ENV === "production" && dbDistExists && libDistExists;
+
+type ExternalsFn = (
+  data: { context: string; request: string; contextInfo?: { issuer?: string } },
+  callback: (err?: Error | null, result?: string) => void
+) => void;
+
+// webpack's `externals` can be an array, a single entry, or unset; normalize
+// to an array and append. Shared by the nodejs externalization and the edge
+// guard below so a fix to the merge logic can't apply to one runtime only.
+type WebpackConfig = { externals?: unknown };
+function pushExternal(config: WebpackConfig, external: ExternalsFn): void {
+  if (Array.isArray(config.externals)) {
+    config.externals.push(external);
+  } else if (config.externals) {
+    config.externals = [config.externals, external];
+  } else {
+    config.externals = [external];
+  }
+}
+
+// Node built-ins the Edge runtime actually provides (per Next.js edge-runtime
+// docs). Everything else in `module`'s builtinModules is Node-only.
+const EDGE_SUPPORTED_BUILTINS = new Set(["buffer", "events", "util", "assert", "async_hooks"]);
+const nodeOnlyBuiltins = new Set(
+  builtinModules.filter((m) => !m.startsWith("_") && !EDGE_SUPPORTED_BUILTINS.has(m))
+);
+// Node-only npm packages that don't necessarily import a built-in at their
+// entry point (native bindings, lazy requires) — deny them by name.
+const NODE_ONLY_PACKAGES = new Set([
+  "pg", "pg-pool", "pg-protocol", "pg-native", "pg-connection-string", "dotenv",
+]);
+
+// Fail the BUILD when an edge bundle (middleware) reaches a Node-only module.
+// Next.js itself only WARNS ("A Node.js API is used (…) which is not supported
+// in the Edge Runtime") and defers the crash to request time — verified
+// empirically: a probe import of the Node-only logger built green and then
+// 500'd every request, which is exactly how prod went down the day middleware
+// first registered. Built-ins are an allowlist inversion (everything Node
+// ships minus what edge provides) so new Node-only imports — crypto, vm,
+// worker_threads, whatever ships next — are denied by default rather than
+// waiting for someone to extend a hand-maintained list.
+const edgeNodeOnlyGuard: ExternalsFn = ({ request, contextInfo }, callback) => {
+  const bare = request.startsWith("node:") ? request.slice("node:".length) : request;
+  if (
+    nodeOnlyBuiltins.has(bare) ||
+    NODE_ONLY_PACKAGES.has(bare) ||
+    request.startsWith("@pagespace/db")
+  ) {
+    return callback(new Error(
+      `Edge bundle imports Node-only module '${request}'` +
+      (contextInfo?.issuer ? ` (via ${contextInfo.issuer})` : "") +
+      `. The Edge runtime cannot execute it at request time — middleware and ` +
+      `everything it imports must stay on edge-safe leaf modules ` +
+      `(see apps/web/src/middleware.ts header comment).`
+    ));
+  }
+  callback();
+};
 
 // Named export so tests can assert on rewrites()/redirects() without going
 // through withSentryConfig's wrapping.
@@ -60,57 +119,11 @@ export const nextConfig: NextConfig = {
         callback();
       };
 
-      if (Array.isArray(config.externals)) {
-        config.externals.push(bunWorkspaceExternals);
-      } else if (config.externals) {
-        config.externals = [config.externals as NonNullable<typeof config.externals>, bunWorkspaceExternals];
-      } else {
-        config.externals = [bunWorkspaceExternals];
-      }
+      pushExternal(config, bunWorkspaceExternals);
     }
 
     if (isServer && nextRuntime === 'edge') {
-      // Fail the BUILD when the edge bundle (middleware) reaches a Node-only
-      // module. Next.js itself only WARNS ("A Node.js API is used (…) which is
-      // not supported in the Edge Runtime") and defers the crash to request
-      // time — verified empirically; a probe import of the Node-only logger
-      // built green and then would 500 every request, which is exactly how
-      // prod went down the day middleware first registered. This hook turns
-      // those imports into hard build errors instead. Node built-ins the Edge
-      // runtime DOES provide (buffer, events, util, assert, async_hooks) are
-      // deliberately not listed.
-      const nodeOnlyModules = new Set([
-        'os', 'fs', 'fs/promises', 'path', 'net', 'tls', 'dns', 'dgram',
-        'child_process', 'cluster', 'http', 'https', 'http2', 'module',
-        'perf_hooks', 'readline', 'repl', 'tty', 'v8', 'vm', 'worker_threads',
-        'zlib', 'stream', 'stream/promises', 'string_decoder', 'inspector',
-        'pg', 'pg-pool', 'pg-protocol', 'pg-native', 'pg-connection-string',
-        'dotenv',
-      ]);
-      const edgeNodeOnlyGuard = (
-        { request, contextInfo }: { context: string; request: string; contextInfo?: { issuer?: string } },
-        callback: (err?: Error | null, result?: string) => void
-      ) => {
-        const bare = request.startsWith('node:') ? request.slice('node:'.length) : request;
-        if (nodeOnlyModules.has(bare) || request.startsWith('@pagespace/db')) {
-          return callback(new Error(
-            `Edge bundle imports Node-only module '${request}'` +
-            (contextInfo?.issuer ? ` (via ${contextInfo.issuer})` : '') +
-            `. The Edge runtime cannot execute it at request time — middleware and ` +
-            `everything it imports must stay on edge-safe leaf modules ` +
-            `(see apps/web/src/middleware.ts header comment).`
-          ));
-        }
-        callback();
-      };
-
-      if (Array.isArray(config.externals)) {
-        config.externals.push(edgeNodeOnlyGuard);
-      } else if (config.externals) {
-        config.externals = [config.externals as NonNullable<typeof config.externals>, edgeNodeOnlyGuard];
-      } else {
-        config.externals = [edgeNodeOnlyGuard];
-      }
+      pushExternal(config, edgeNodeOnlyGuard);
     }
     if (!isServer) {
       config.resolve.fallback = {

--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -19,21 +19,22 @@ vi.mock('@/middleware/security-headers', () => ({
   shouldDisableCOEP: () => false,
 }));
 
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: mockLogSecurityEvent,
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes are NOT mocked: middleware.ts builds its prefix checks from the
+// real '@/lib/auth/token-prefixes' leaf at module-load time (`Bearer
+// ${MCP_TOKEN_PREFIX}` etc.) — it's pure and edge-safe, and a mocked-away
+// value would silently break every prefix check this file's tests exercise
+// below, the same way a hand-duplicated copy already drifted out of sync once
+// (see middleware.ts's import site comment).
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: mockValidateOriginForMiddleware,
   isOriginValidationBlocking: mockIsOriginValidationBlocking,
-  // Real string values, not mocks — middleware.ts builds its bearer-prefix
-  // checks from these at module-load time (`Bearer ${MCP_TOKEN_PREFIX}` etc.),
-  // so a mocked-away value here would silently break every prefix check this
-  // file's tests exercise below, the same way a hand-duplicated copy already
-  // drifted out of sync once (see middleware.ts's import site comment).
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({

--- a/apps/web/src/app/api/internal/monitoring/ingest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/monitoring/ingest/__tests__/route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Monitoring ingest route tests.
+ *
+ * This route is the Node-runtime persistence layer for the edge middleware's
+ * fire-and-forget monitoring POSTs: it is the ONLY writer of apiMetrics rows
+ * (the admin dashboard's monitoring-queries.ts reads that table), plus a
+ * systemLogs row per request and an errorLogs row for failures. The
+ * apiMetrics-insertion assertions here are the persistence-parity acceptance
+ * criterion for the edge-safe middleware work: middleware itself never touches
+ * @pagespace/db, so the dashboard only gets data if this route writes it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockWriteApiMetrics = vi.hoisted(() => vi.fn());
+const mockWriteError = vi.hoisted(() => vi.fn());
+const mockSystemLogsValues = vi.hoisted(() => vi.fn());
+const mockDbInsert = vi.hoisted(() => vi.fn());
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { insert: mockDbInsert },
+}));
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  systemLogs: { __table: 'system_logs' },
+}));
+vi.mock('@pagespace/lib/logging/logger-database', () => ({
+  writeApiMetrics: mockWriteApiMetrics,
+  writeError: mockWriteError,
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    system: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+    api: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  },
+}));
+vi.mock('@pagespace/lib/auth/secure-compare', () => ({
+  secureCompare: (a: string, b: string) => a === b,
+}));
+
+import { POST } from '../route';
+
+const INGEST_KEY = 'test-ingest-key';
+
+const buildRequest = (
+  body: unknown,
+  { key = INGEST_KEY }: { key?: string | null } = {}
+): Request =>
+  new Request('http://localhost/api/internal/monitoring/ingest', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(key ? { 'x-monitoring-ingest-key': key } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+
+const apiRequestPayload = {
+  type: 'api-request' as const,
+  requestId: 'req-cuid-1',
+  timestamp: '2026-07-07T12:00:00.000Z',
+  method: 'post',
+  endpoint: '/api/pages/xyz',
+  statusCode: 201,
+  duration: 42,
+  requestSize: 128,
+  responseSize: 256,
+  userId: 'user-1',
+  sessionId: 'sess-1',
+  ip: '10.0.0.1',
+  userAgent: 'test-agent',
+};
+
+describe('POST /api/internal/monitoring/ingest', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.MONITORING_INGEST_KEY = INGEST_KEY;
+    delete process.env.MONITORING_INGEST_DISABLED;
+    mockWriteApiMetrics.mockResolvedValue(undefined);
+    mockWriteError.mockResolvedValue(undefined);
+    mockSystemLogsValues.mockResolvedValue(undefined);
+    mockDbInsert.mockReturnValue({ values: mockSystemLogsValues });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('rejects a request without the ingest key', async () => {
+    const response = await POST(buildRequest(apiRequestPayload, { key: null }));
+    expect(response.status).toBe(401);
+    expect(mockWriteApiMetrics).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with a wrong ingest key', async () => {
+    const response = await POST(buildRequest(apiRequestPayload, { key: 'wrong' }));
+    expect(response.status).toBe(401);
+    expect(mockWriteApiMetrics).not.toHaveBeenCalled();
+  });
+
+  it('inserts an apiMetrics row for an api-request payload (dashboard persistence parity)', async () => {
+    const response = await POST(buildRequest(apiRequestPayload));
+
+    expect(response.status).toBe(200);
+    expect(mockWriteApiMetrics).toHaveBeenCalledTimes(1);
+    expect(mockWriteApiMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: '/api/pages/xyz',
+        method: 'POST',
+        statusCode: 201,
+        duration: 42,
+        requestSize: 128,
+        responseSize: 256,
+        userId: 'user-1',
+        sessionId: 'sess-1',
+        ip: '10.0.0.1',
+        userAgent: 'test-agent',
+        requestId: 'req-cuid-1',
+        timestamp: new Date('2026-07-07T12:00:00.000Z'),
+      })
+    );
+  });
+
+  it('also writes a systemLogs row for the same payload', async () => {
+    await POST(buildRequest(apiRequestPayload));
+
+    expect(mockDbInsert).toHaveBeenCalledTimes(1);
+    expect(mockSystemLogsValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'info',
+        category: 'api',
+        endpoint: '/api/pages/xyz',
+        method: 'POST',
+        requestId: 'req-cuid-1',
+      })
+    );
+  });
+
+  it('writes an errorLogs row when the payload carries an error', async () => {
+    const response = await POST(
+      buildRequest({
+        ...apiRequestPayload,
+        statusCode: 500,
+        error: 'HTTP 500',
+        errorName: 'HttpError',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockWriteError).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'HttpError', message: 'HTTP 500' })
+    );
+    expect(mockWriteApiMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 500, error: 'HTTP 500' })
+    );
+  });
+
+  it('rejects non api-request payload types', async () => {
+    const response = await POST(buildRequest({ ...apiRequestPayload, type: 'page-view' }));
+    expect(response.status).toBe(400);
+    expect(mockWriteApiMetrics).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes the endpoint before persisting (query strings never reach the table)', async () => {
+    await POST(
+      buildRequest({ ...apiRequestPayload, endpoint: '/api/search?q=secret%20term' })
+    );
+    expect(mockWriteApiMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({ endpoint: '/api/search' })
+    );
+  });
+
+  it('returns 503 when the ingest key is not configured', async () => {
+    delete process.env.MONITORING_INGEST_KEY;
+    const response = await POST(buildRequest(apiRequestPayload));
+    expect(response.status).toBe(503);
+  });
+
+  it('returns 404 when ingest is explicitly disabled', async () => {
+    process.env.MONITORING_INGEST_DISABLED = 'true';
+    const response = await POST(buildRequest(apiRequestPayload));
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/origin-validation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/origin-validation.test.ts
@@ -28,18 +28,18 @@ import {
  *   - Origin normalization handles various URL formats
  */
 
-// Mock dependencies at system boundary
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-    auth: {
-      warn: vi.fn(),
-      debug: vi.fn(),
-      error: vi.fn(),
-    },
-  },
+// Mock dependencies at system boundary. origin-validation runs in the Edge
+// runtime, so it logs through the edge logger (created once at module load —
+// the mock returns a stable singleton so assertions can reference it).
+const mockAuthLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
 }));
-
-import { loggers } from '@pagespace/lib/logging/logger-config';
+vi.mock('@/lib/logging/edge-logger', () => ({
+  createEdgeLogger: vi.fn(() => mockAuthLogger),
+}));
 
 describe('origin-validation', () => {
   // Store original env values
@@ -109,7 +109,7 @@ describe('origin-validation', () => {
         const result = validateOrigin(request);
 
         expect(result).toBeNull();
-        expect(loggers.auth.debug).toHaveBeenCalledWith(
+        expect(mockAuthLogger.debug).toHaveBeenCalledWith(
           'Origin validation: no Origin header present (allowed)',
           expect.objectContaining({
             method: 'POST',
@@ -147,7 +147,7 @@ describe('origin-validation', () => {
         const result = validateOrigin(request);
 
         expect(result).toBeNull();
-        expect(loggers.auth.debug).toHaveBeenCalledWith(
+        expect(mockAuthLogger.debug).toHaveBeenCalledWith(
           'Origin validation successful',
           expect.objectContaining({
             origin: 'https://app.example.com',
@@ -219,7 +219,7 @@ describe('origin-validation', () => {
 
         validateOrigin(request);
 
-        expect(loggers.auth.warn).toHaveBeenCalledWith(
+        expect(mockAuthLogger.warn).toHaveBeenCalledWith(
           'Origin validation failed: unexpected origin',
           expect.objectContaining({
             origin: 'https://malicious.example.com',
@@ -363,7 +363,7 @@ describe('origin-validation', () => {
         const result = validateOrigin(request);
 
         expect(result).toBeNull();
-        expect(loggers.auth.warn).toHaveBeenCalledWith(
+        expect(mockAuthLogger.warn).toHaveBeenCalledWith(
           'Origin validation: WEB_APP_URL not configured, skipping validation',
           expect.objectContaining({
             origin: 'https://any-origin.example.com',
@@ -462,7 +462,7 @@ describe('origin-validation', () => {
           skipped: true,
           reason: 'No Origin header present',
         });
-        expect(loggers.auth.debug).toHaveBeenCalledWith(
+        expect(mockAuthLogger.debug).toHaveBeenCalledWith(
           'Middleware origin validation: no Origin header (skipped)',
           expect.objectContaining({
             method: 'POST',
@@ -511,7 +511,7 @@ describe('origin-validation', () => {
           skipped: false,
           reason: 'Origin not in allowed list (block mode - request rejected)',
         });
-        expect(loggers.auth.warn).toHaveBeenCalledWith(
+        expect(mockAuthLogger.warn).toHaveBeenCalledWith(
           'Middleware origin validation: unexpected origin (block mode)',
           expect.objectContaining({
             origin: 'https://evil.example.com',
@@ -560,7 +560,7 @@ describe('origin-validation', () => {
           skipped: false,
           reason: 'Origin not in allowed list (warn mode - request allowed)',
         });
-        expect(loggers.auth.warn).toHaveBeenCalledWith(
+        expect(mockAuthLogger.warn).toHaveBeenCalledWith(
           'Middleware origin validation: unexpected origin (warn mode)',
           expect.objectContaining({
             origin: 'https://evil.example.com',
@@ -588,7 +588,7 @@ describe('origin-validation', () => {
           skipped: true,
           reason: 'WEB_APP_URL not configured',
         });
-        expect(loggers.auth.warn).toHaveBeenCalledWith(
+        expect(mockAuthLogger.warn).toHaveBeenCalledWith(
           'Middleware origin validation: WEB_APP_URL not configured',
           expect.objectContaining({
             origin: 'https://any-origin.example.com',

--- a/apps/web/src/lib/auth/__tests__/token-prefixes.test.ts
+++ b/apps/web/src/lib/auth/__tests__/token-prefixes.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Token-prefix single-source-of-truth tests.
+ *
+ * middleware.ts (Edge runtime) imports the bearer prefixes from the
+ * token-prefixes leaf; the '@/lib/auth' barrel re-exports the same values for
+ * Node-side consumers. These tests pin both halves of that contract:
+ * 1. the leaf exports the exact prefixes the auth layer authenticates,
+ * 2. the barrel's re-exports are identical (no second copy can drift),
+ * 3. middleware.ts never imports the Node-only barrel (the import graph that
+ *    500'd every request when middleware first shipped to production).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// --- Mocks so the real barrel (Node-only import graph) can load in a unit test.
+vi.mock('next/server', () => ({
+  NextResponse: { json: vi.fn(), redirect: vi.fn(), rewrite: vi.fn(), next: vi.fn() },
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: { query: {}, insert: vi.fn(), update: vi.fn() },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), and: vi.fn(), isNull: vi.fn() }));
+vi.mock('@pagespace/db/schema/auth', () => ({ mcpTokens: {} }));
+vi.mock('@pagespace/db/schema/oauth', () => ({ oauthAccessTokens: {} }));
+vi.mock('@pagespace/lib/auth/token-utils', () => ({ hashToken: vi.fn() }));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: { validateSession: vi.fn() },
+}));
+vi.mock('@pagespace/lib/auth/token-lookup', () => ({ findOAuthAccessTokenByValue: vi.fn() }));
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+  EnforcedAuthContext: { fromSession: vi.fn() },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({ logSecurityEvent: vi.fn() }));
+vi.mock('../cookie-config', () => ({
+  getSessionFromCookies: vi.fn(),
+  COOKIE_CONFIG: {},
+  createSessionCookie: vi.fn(),
+  createClearSessionCookie: vi.fn(),
+  createLoggedInIndicatorCookie: vi.fn(),
+  createClearLoggedInIndicatorCookie: vi.fn(),
+  appendSessionCookie: vi.fn(),
+  appendClearCookies: vi.fn(),
+}));
+
+import * as leaf from '../token-prefixes';
+import * as barrel from '../index';
+
+describe('token-prefixes leaf', () => {
+  it('exports the exact prefixes the auth layer authenticates', () => {
+    expect(leaf.MCP_TOKEN_PREFIX).toBe('mcp_');
+    expect(leaf.SESSION_TOKEN_PREFIX).toBe('ps_sess_');
+    expect(leaf.OAUTH_ACCESS_TOKEN_PREFIX).toBe('ps_at_');
+  });
+
+  it('has no imports at all — it must stay an edge-safe leaf', () => {
+    // Strip comments first — the doc header talks about imports.
+    const source = fs
+      .readFileSync(path.resolve(__dirname, '../token-prefixes.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    expect(source).not.toMatch(/\bimport\b/);
+    expect(source).not.toMatch(/\brequire\s*\(/);
+  });
+});
+
+describe('@/lib/auth barrel re-export integrity', () => {
+  it('re-exports the identical leaf values (single source of truth, no drift possible)', () => {
+    expect(barrel.MCP_TOKEN_PREFIX).toBe(leaf.MCP_TOKEN_PREFIX);
+    expect(barrel.SESSION_TOKEN_PREFIX).toBe(leaf.SESSION_TOKEN_PREFIX);
+    expect(barrel.OAUTH_ACCESS_TOKEN_PREFIX).toBe(leaf.OAUTH_ACCESS_TOKEN_PREFIX);
+  });
+
+  it('defines no prefix literals of its own in index.ts', () => {
+    const source = fs.readFileSync(path.resolve(__dirname, '../index.ts'), 'utf8');
+    expect(source).not.toMatch(/=\s*'mcp_'/);
+    expect(source).not.toMatch(/=\s*'ps_sess_'/);
+    expect(source).not.toMatch(/=\s*'ps_at_'/);
+  });
+});
+
+describe('middleware.ts edge-safety (acceptance criterion)', () => {
+  it('has zero imports from the @/lib/auth barrel — leaf modules only', () => {
+    const source = fs.readFileSync(path.resolve(__dirname, '../../../middleware.ts'), 'utf8');
+    // Barrel forms: '@/lib/auth' exactly, or '@/lib/auth/index'
+    expect(source).not.toMatch(/from\s+['"]@\/lib\/auth['"]/);
+    expect(source).not.toMatch(/from\s+['"]@\/lib\/auth\/index['"]/);
+    // And no @pagespace/lib logger (the exact import that 500'd prod)
+    expect(source).not.toMatch(/@pagespace\/lib\/logging/);
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/token-prefixes.test.ts
+++ b/apps/web/src/lib/auth/__tests__/token-prefixes.test.ts
@@ -80,6 +80,22 @@ describe('@/lib/auth barrel re-export integrity', () => {
   });
 });
 
+describe('packages/lib token-lookup drift guard', () => {
+  // packages/lib/src/auth/token-lookup.ts keeps its own private copies of the
+  // mcp_/ps_at_ prefixes (packages/lib cannot import from apps/web). Nothing
+  // at the type level couples them to the leaf, so pin them here: if either
+  // side changes a prefix, this fails instead of tokens silently failing to
+  // authenticate.
+  it('token-lookup.ts private prefix literals match the leaf', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../../../../../packages/lib/src/auth/token-lookup.ts'),
+      'utf8'
+    );
+    expect(source).toContain(`const MCP_TOKEN_PREFIX = '${leaf.MCP_TOKEN_PREFIX}'`);
+    expect(source).toContain(`const OAUTH_ACCESS_TOKEN_PREFIX = '${leaf.OAUTH_ACCESS_TOKEN_PREFIX}'`);
+  });
+});
+
 describe('middleware.ts edge-safety (acceptance criterion)', () => {
   it('has zero imports from the @/lib/auth barrel — leaf modules only', () => {
     const source = fs.readFileSync(path.resolve(__dirname, '../../../middleware.ts'), 'utf8');

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateSessionRequest, isAuthError } from './index';
+import { SESSION_TOKEN_PREFIX } from './token-prefixes';
 import { validateAdminAccess, type AdminValidationResult } from './admin-role';
 import { validateCSRF } from './csrf-validation';
 import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
@@ -25,7 +26,7 @@ export async function verifyAuth(request: Request): Promise<VerifiedUser | null>
   }
 
   const authHeader = request.headers.get('authorization');
-  const hasSessionBearerToken = authHeader?.startsWith('Bearer ps_sess_') ?? false;
+  const hasSessionBearerToken = authHeader?.startsWith(`Bearer ${SESSION_TOKEN_PREFIX}`) ?? false;
 
   return {
     id: result.userId,

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -12,14 +12,17 @@ import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';
 
 const BEARER_PREFIX = 'Bearer ';
-// Exported so middleware.ts's edge-safe bearer-prefix check (which can only test
-// presence, not validity) stays byte-for-byte in sync with the prefixes this
-// module actually authenticates — a second, hand-duplicated copy is exactly how
-// a prefix (ps_at_, added for OAuth CLI login) silently fell out of sync here
-// before, undetected because middleware never executed in production at all.
-export const MCP_TOKEN_PREFIX = 'mcp_';
-export const SESSION_TOKEN_PREFIX = 'ps_sess_';
-export const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
+// Single source of truth is ./token-prefixes, an edge-safe leaf: middleware.ts
+// (Edge runtime) imports the prefixes from there directly — never from this
+// barrel, whose import graph is Node-only — while this module re-exports them
+// so its bearer-prefix checks and every Node-side consumer stay byte-for-byte
+// in sync. Do not redefine these values anywhere else.
+import {
+  MCP_TOKEN_PREFIX,
+  SESSION_TOKEN_PREFIX,
+  OAUTH_ACCESS_TOKEN_PREFIX,
+} from './token-prefixes';
+export { MCP_TOKEN_PREFIX, SESSION_TOKEN_PREFIX, OAUTH_ACCESS_TOKEN_PREFIX };
 
 export type TokenType = 'mcp' | 'session' | 'oauth';
 

--- a/apps/web/src/lib/auth/origin-validation.ts
+++ b/apps/web/src/lib/auth/origin-validation.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
-import { loggers } from '@pagespace/lib/logging/logger-config';
+import { createEdgeLogger } from '@/lib/logging/edge-logger';
+
+// This module runs in the Edge runtime (imported by middleware.ts), so it
+// must log through the edge-safe logger — @pagespace/lib's logger is Node-only.
+const authLogger = createEdgeLogger('auth');
 
 /**
  * Origin Header Validation for API Routes (Defense-in-Depth)
@@ -118,7 +122,7 @@ export function validateOrigin(request: Request): NextResponse | null {
   // Allow requests without Origin header
   // This handles same-origin requests, non-browser clients (curl, MCP), and older browsers
   if (!origin) {
-    loggers.auth.debug('Origin validation: no Origin header present (allowed)', {
+    authLogger.debug('Origin validation: no Origin header present (allowed)', {
       method: request.method,
       url: request.url,
     });
@@ -129,7 +133,7 @@ export function validateOrigin(request: Request): NextResponse | null {
 
   // If no allowed origins configured, log warning but allow request
   if (allowedOrigins.length === 0) {
-    loggers.auth.warn('Origin validation: WEB_APP_URL not configured, skipping validation', {
+    authLogger.warn('Origin validation: WEB_APP_URL not configured, skipping validation', {
       method: request.method,
       url: request.url,
       origin,
@@ -139,7 +143,7 @@ export function validateOrigin(request: Request): NextResponse | null {
 
   // Validate origin against allowed list
   if (isOriginAllowed(origin, allowedOrigins)) {
-    loggers.auth.debug('Origin validation successful', {
+    authLogger.debug('Origin validation successful', {
       method: request.method,
       url: request.url,
       origin,
@@ -148,7 +152,7 @@ export function validateOrigin(request: Request): NextResponse | null {
   }
 
   // Origin not in allowed list - reject with 403
-  loggers.auth.warn('Origin validation failed: unexpected origin', {
+  authLogger.warn('Origin validation failed: unexpected origin', {
     method: request.method,
     url: request.url,
     origin,
@@ -246,7 +250,7 @@ export function validateOriginForMiddleware(request: Request): MiddlewareOriginV
   // Skip validation if no Origin header
   // Non-browser clients (curl, MCP, mobile apps) may not send Origin
   if (!origin) {
-    loggers.auth.debug('Middleware origin validation: no Origin header (skipped)', {
+    authLogger.debug('Middleware origin validation: no Origin header (skipped)', {
       method,
       url,
     });
@@ -262,7 +266,7 @@ export function validateOriginForMiddleware(request: Request): MiddlewareOriginV
 
   // If no allowed origins configured, skip validation but log warning
   if (allowedOrigins.length === 0) {
-    loggers.auth.warn('Middleware origin validation: WEB_APP_URL not configured', {
+    authLogger.warn('Middleware origin validation: WEB_APP_URL not configured', {
       method,
       url,
       origin,
@@ -277,7 +281,7 @@ export function validateOriginForMiddleware(request: Request): MiddlewareOriginV
 
   // Check if origin is allowed
   if (isOriginAllowed(origin, allowedOrigins)) {
-    loggers.auth.debug('Middleware origin validation: valid origin', {
+    authLogger.debug('Middleware origin validation: valid origin', {
       method,
       url,
       origin,
@@ -301,7 +305,7 @@ export function validateOriginForMiddleware(request: Request): MiddlewareOriginV
   };
 
   if (mode === 'warn') {
-    loggers.auth.warn('Middleware origin validation: unexpected origin (warn mode)', logContext);
+    authLogger.warn('Middleware origin validation: unexpected origin (warn mode)', logContext);
     return {
       valid: false,
       origin,
@@ -309,7 +313,7 @@ export function validateOriginForMiddleware(request: Request): MiddlewareOriginV
       reason: 'Origin not in allowed list (warn mode - request allowed)',
     };
   } else {
-    loggers.auth.warn('Middleware origin validation: unexpected origin (block mode)', logContext);
+    authLogger.warn('Middleware origin validation: unexpected origin (block mode)', logContext);
     return {
       valid: false,
       origin,

--- a/apps/web/src/lib/auth/token-prefixes.ts
+++ b/apps/web/src/lib/auth/token-prefixes.ts
@@ -1,0 +1,17 @@
+/**
+ * Bearer token prefixes — the single source of truth for the prefixes the
+ * auth layer mints and authenticates.
+ *
+ * This is a dependency-free leaf module so the Edge-runtime middleware can
+ * import the prefixes without dragging in the '@/lib/auth' barrel, whose
+ * import graph (db client, session service, permissions) only exists in the
+ * Node.js runtime. The barrel re-exports from here; nothing else may define
+ * these values. A hand-duplicated copy is exactly how a prefix (ps_at_, added
+ * for OAuth CLI login) silently fell out of sync in middleware.ts before,
+ * undetected because middleware never executed in production at all.
+ *
+ * MUST stay edge-safe: no imports, no Node built-ins, no side effects.
+ */
+export const MCP_TOKEN_PREFIX = 'mcp_';
+export const SESSION_TOKEN_PREFIX = 'ps_sess_';
+export const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';

--- a/apps/web/src/lib/logging/__tests__/edge-logger.test.ts
+++ b/apps/web/src/lib/logging/__tests__/edge-logger.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Edge-logger tests: output shape (parseable JSON matching the Node logger's
+ * field names), level routing, LOG_LEVEL filtering, error serialization, and
+ * the module-purity acceptance criterion (imports only from itself/types).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createEdgeLogger, logSecurityEvent, type EdgeLogEntry } from '../edge-logger';
+
+const parseOnlyCall = (spy: ReturnType<typeof vi.fn>): EdgeLogEntry => {
+  expect(spy).toHaveBeenCalledTimes(1);
+  const line = spy.mock.calls[0][0] as string;
+  return JSON.parse(line) as EdgeLogEntry;
+};
+
+describe('edge-logger', () => {
+  const originalEnv = process.env;
+  let logSpy: ReturnType<typeof vi.fn>;
+  let warnSpy: ReturnType<typeof vi.fn>;
+  let errorSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.LOG_LEVEL;
+    logSpy = vi.fn();
+    warnSpy = vi.fn();
+    errorSpy = vi.fn();
+    vi.spyOn(console, 'log').mockImplementation(logSpy);
+    vi.spyOn(console, 'warn').mockImplementation(warnSpy);
+    vi.spyOn(console, 'error').mockImplementation(errorSpy);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe('output shape', () => {
+    it('emits single-line JSON with timestamp, level, category, message, metadata', () => {
+      const log = createEdgeLogger('api');
+      log.info('GET /api/health 200 12ms', { requestId: 'req-1', statusCode: 200 });
+
+      const entry = parseOnlyCall(logSpy);
+      expect(entry).toEqual({
+        timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+        level: 'INFO',
+        category: 'api',
+        message: 'GET /api/health 200 12ms',
+        metadata: { requestId: 'req-1', statusCode: 200 },
+      });
+    });
+
+    it('omits the metadata key entirely when no metadata is given', () => {
+      createEdgeLogger('system').info('startup');
+      const entry = parseOnlyCall(logSpy);
+      expect('metadata' in entry).toBe(false);
+    });
+
+    it('routes warn to console.warn and error to console.error (matching the Node logger)', () => {
+      const log = createEdgeLogger('api');
+      log.warn('slow request');
+      log.error('request failed');
+
+      expect(parseOnlyCall(warnSpy).level).toBe('WARN');
+      expect(parseOnlyCall(errorSpy).level).toBe('ERROR');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('serializes an Error into metadata.error (Errors otherwise stringify to {})', () => {
+      const boom = new Error('kaboom');
+      createEdgeLogger('api').error('Request failed', boom, { requestId: 'req-9' });
+
+      const entry = parseOnlyCall(errorSpy);
+      expect(entry.metadata).toMatchObject({
+        requestId: 'req-9',
+        error: { name: 'Error', message: 'kaboom', stack: expect.stringContaining('kaboom') },
+      });
+    });
+  });
+
+  describe('LOG_LEVEL filtering', () => {
+    it('suppresses debug by default (info threshold)', () => {
+      createEdgeLogger('auth').debug('noisy');
+      expect(logSpy).not.toHaveBeenCalled();
+    });
+
+    it('emits debug when LOG_LEVEL=debug', () => {
+      process.env.LOG_LEVEL = 'debug';
+      createEdgeLogger('auth').debug('now visible');
+      expect(parseOnlyCall(logSpy).level).toBe('DEBUG');
+    });
+
+    it('suppresses info when LOG_LEVEL=error but still emits error', () => {
+      process.env.LOG_LEVEL = 'error';
+      const log = createEdgeLogger('api');
+      log.info('hidden');
+      log.error('shown');
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses everything when LOG_LEVEL=silent', () => {
+      process.env.LOG_LEVEL = 'silent';
+      const log = createEdgeLogger('api');
+      log.error('even errors');
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logSecurityEvent', () => {
+    it('warns with category security and the same message format as the Node logger', () => {
+      logSecurityEvent('unauthorized', { pathname: '/dashboard', reason: 'No session token', ip: '1.2.3.4' });
+
+      const entry = parseOnlyCall(warnSpy);
+      expect(entry.level).toBe('WARN');
+      expect(entry.category).toBe('security');
+      expect(entry.message).toBe('Security event: unauthorized');
+      expect(entry.metadata).toEqual({ pathname: '/dashboard', reason: 'No session token', ip: '1.2.3.4' });
+    });
+  });
+
+  describe('module purity (acceptance criterion)', () => {
+    it('imports nothing — no Node built-ins, no @pagespace/*, no db, no dynamic imports, no process.on', () => {
+      // Strip comments first — the doc header legitimately names the modules
+      // this file must NOT import.
+      const source = fs
+        .readFileSync(path.resolve(__dirname, '../edge-logger.ts'), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/\/\/.*$/gm, '');
+      expect(source).not.toMatch(/^import\s/m); // zero import statements
+      expect(source).not.toMatch(/\brequire\s*\(/);
+      expect(source).not.toMatch(/\bimport\s*\(/); // dynamic import
+      expect(source).not.toMatch(/@pagespace\//);
+      expect(source).not.toMatch(/from\s+['"]os['"]/);
+      expect(source).not.toMatch(/process\.on\b/);
+      expect(source).not.toMatch(/setInterval|setTimeout/);
+    });
+  });
+});

--- a/apps/web/src/lib/logging/__tests__/edge-logger.test.ts
+++ b/apps/web/src/lib/logging/__tests__/edge-logger.test.ts
@@ -48,6 +48,9 @@ describe('edge-logger', () => {
         level: 'INFO',
         category: 'api',
         message: 'GET /api/health 200 12ms',
+        // context.category mirrors the Node logger's nesting so log-drain
+        // queries keyed on either shape match both runtimes.
+        context: { category: 'api' },
         metadata: { requestId: 'req-1', statusCode: 200 },
       });
     });
@@ -109,6 +112,54 @@ describe('edge-logger', () => {
     });
   });
 
+  describe('sensitive-key redaction (parity with the Node logger sanitizer)', () => {
+    it('redacts substring-sensitive keys (token, authorization, …) and exact PII keys (email, name)', () => {
+      createEdgeLogger('auth').warn('probe', {
+        accessToken: 'ps_at_secret_value',
+        authorization: 'Bearer abc',
+        email: 'user@example.com',
+        name: 'Ada',
+        pathname: '/dashboard',
+      });
+
+      const entry = parseOnlyCall(warnSpy);
+      expect(entry.metadata).toEqual({
+        accessToken: '[REDACTED]',
+        authorization: '[REDACTED]',
+        email: '[REDACTED]',
+        name: '[REDACTED]',
+        pathname: '/dashboard',
+      });
+    });
+
+    it('redacts nested sensitive keys', () => {
+      createEdgeLogger('auth').warn('probe', { headers: { cookie: 'sid=1', host: 'x' } });
+      const entry = parseOnlyCall(warnSpy);
+      expect(entry.metadata).toEqual({ headers: { cookie: '[REDACTED]', host: 'x' } });
+    });
+
+    it('survives circular metadata instead of throwing into the caller', () => {
+      const loop: Record<string, unknown> = { pathname: '/x' };
+      loop.self = loop;
+      expect(() => createEdgeLogger('api').warn('circular', loop)).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(() => JSON.parse(warnSpy.mock.calls[0][0] as string)).not.toThrow();
+    });
+
+    it('falls back to a metadata-free line when metadata cannot be serialized (BigInt)', () => {
+      expect(() => createEdgeLogger('api').warn('bigint', { big: BigInt(1) })).not.toThrow();
+      const entry = parseOnlyCall(warnSpy);
+      expect(entry.message).toBe('bigint');
+      expect(entry.metadata).toEqual({ serialization: 'failed' });
+    });
+
+    it('does not redact the constructed error object fields (error.name is safe)', () => {
+      createEdgeLogger('api').error('failed', new TypeError('boom'));
+      const entry = parseOnlyCall(errorSpy);
+      expect(entry.metadata).toMatchObject({ error: { name: 'TypeError', message: 'boom' } });
+    });
+  });
+
   describe('logSecurityEvent', () => {
     it('warns with category security and the same message format as the Node logger', () => {
       logSecurityEvent('unauthorized', { pathname: '/dashboard', reason: 'No session token', ip: '1.2.3.4' });
@@ -118,6 +169,36 @@ describe('edge-logger', () => {
       expect(entry.category).toBe('security');
       expect(entry.message).toBe('Security event: unauthorized');
       expect(entry.metadata).toEqual({ pathname: '/dashboard', reason: 'No session token', ip: '1.2.3.4' });
+    });
+  });
+
+  describe('SecurityEventName drift guard', () => {
+    // The union is duplicated (edge-logger must not import from
+    // @pagespace/lib, and the Node union is an anonymous parameter type), so
+    // nothing at the type level couples them. This test parses both unions
+    // from source and fails when they diverge.
+    const extractUnionMembers = (source: string, anchor: RegExp): Set<string> => {
+      const anchorMatch = source.match(anchor);
+      expect(anchorMatch, `anchor ${anchor} not found`).toBeTruthy();
+      const fromAnchor = source.slice(anchorMatch!.index!);
+      // Union members are single-quoted names; the union ends at the first
+      // line that is not part of the quoted-union block.
+      const unionBlock = fromAnchor.match(/(?:\s*\|?\s*'[a-z0-9_]+')+/i);
+      expect(unionBlock, 'quoted union block not found after anchor').toBeTruthy();
+      return new Set([...unionBlock![0].matchAll(/'([a-z0-9_]+)'/gi)].map((m) => m[1]));
+    };
+
+    it('matches the union in packages/lib logger-config logSecurityEvent exactly', () => {
+      const edgeSource = fs.readFileSync(path.resolve(__dirname, '../edge-logger.ts'), 'utf8');
+      const nodeSource = fs.readFileSync(
+        path.resolve(__dirname, '../../../../../../packages/lib/src/logging/logger-config.ts'),
+        'utf8'
+      );
+
+      const edgeEvents = extractUnionMembers(edgeSource, /export type SecurityEventName =/);
+      const nodeEvents = extractUnionMembers(nodeSource, /export function logSecurityEvent\(\s*event:/);
+
+      expect([...edgeEvents].sort()).toEqual([...nodeEvents].sort());
     });
   });
 

--- a/apps/web/src/lib/logging/edge-logger.ts
+++ b/apps/web/src/lib/logging/edge-logger.ts
@@ -1,0 +1,139 @@
+/**
+ * Edge-safe structured logger.
+ *
+ * The Edge runtime middleware (and any module in its import graph) cannot use
+ * @pagespace/lib's logger: that logger reads os.hostname(), registers
+ * process.on() exit handlers, runs a setInterval flush loop, and dynamically
+ * imports the database writer — all Node-only. This module is the middleware's
+ * logging surface instead: synchronous structured JSON to the console, which
+ * Fly log drains ingest the same way they ingest the Node logger's output.
+ *
+ * Output shape mirrors the existing logger's JSON so downstream parsing keeps
+ * working: { timestamp, level, category, message, metadata? }. Level is
+ * uppercase to match packages/lib/src/logging/logger.ts.
+ *
+ * MUST stay edge-safe: imports nothing (types only), no Node built-ins, no
+ * process.on, no timers, no dynamic imports, no @pagespace/* imports.
+ * `process.env` reads are supported in the Edge runtime and are the only
+ * ambient state touched.
+ */
+
+/**
+ * Security event names — keep in sync with logSecurityEvent's union in
+ * packages/lib/src/logging/logger-config.ts. Duplicated (not imported) because
+ * importing anything from @pagespace/lib would pull the Node-only logger into
+ * the edge bundle; the token-prefixes re-export test pattern doesn't apply to
+ * a pure type, and a drift here fails loudly at typecheck the moment a caller
+ * uses a new event name.
+ */
+export type SecurityEventName =
+  | 'rate_limit' | 'invalid_token' | 'unauthorized' | 'suspicious_activity'
+  | 'login_csrf_missing' | 'login_csrf_mismatch' | 'login_csrf_invalid'
+  | 'signup_csrf_missing' | 'signup_csrf_mismatch' | 'signup_csrf_invalid'
+  | 'origin_validation_failed' | 'origin_validation_warning'
+  | 'account_locked_login_attempt' | 'admin_role_version_mismatch'
+  | 'magic_link_csrf_missing' | 'magic_link_csrf_mismatch' | 'magic_link_csrf_invalid'
+  | 'magic_link_rate_limit_ip' | 'magic_link_rate_limit_email' | 'magic_link_suspended_user'
+  | 'passkey_csrf_invalid' | 'passkey_rate_limit_auth' | 'passkey_rate_limit_options' | 'passkey_rate_limit_register'
+  | 'passkey_rate_limit_signup_ip' | 'passkey_rate_limit_signup_email'
+  | 'signup_blocked_onprem';
+
+export type EdgeLogMetadata = Record<string, unknown>;
+
+export type EdgeLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface EdgeLogEntry {
+  timestamp: string;
+  level: string;
+  category: string;
+  message: string;
+  metadata?: EdgeLogMetadata;
+}
+
+const LEVEL_ORDER: Record<EdgeLogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+/**
+ * Minimum level to emit, from LOG_LEVEL (same env var the Node logger reads).
+ * The Node logger's extra levels map onto this module's four: trace → debug,
+ * fatal → error, silent → suppress everything. Unknown values → info.
+ * Read per-call, not at module load, so tests (and runtime reconfiguration)
+ * see current env.
+ */
+function minimumLevel(): number {
+  const raw = (process.env.LOG_LEVEL || 'info').trim().toLowerCase();
+  if (raw === 'silent') return Number.POSITIVE_INFINITY;
+  if (raw === 'trace') return LEVEL_ORDER.debug;
+  if (raw === 'fatal') return LEVEL_ORDER.error;
+  return raw in LEVEL_ORDER ? LEVEL_ORDER[raw as EdgeLogLevel] : LEVEL_ORDER.info;
+}
+
+function emit(
+  level: EdgeLogLevel,
+  category: string,
+  message: string,
+  metadata?: EdgeLogMetadata
+): void {
+  if (LEVEL_ORDER[level] < minimumLevel()) return;
+
+  const entry: EdgeLogEntry = {
+    timestamp: new Date().toISOString(),
+    level: level.toUpperCase(),
+    category,
+    message,
+  };
+  if (metadata && Object.keys(metadata).length > 0) {
+    entry.metadata = metadata;
+  }
+
+  const line = JSON.stringify(entry);
+  if (level === 'error') {
+    console.error(line);
+  } else if (level === 'warn') {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+/** Serialize an Error into plain metadata (Errors JSON.stringify to {}). */
+function errorMetadata(error: Error | undefined, metadata?: EdgeLogMetadata): EdgeLogMetadata | undefined {
+  if (!error) return metadata;
+  return {
+    ...metadata,
+    error: { name: error.name, message: error.message, stack: error.stack },
+  };
+}
+
+export interface EdgeLogger {
+  debug(message: string, metadata?: EdgeLogMetadata): void;
+  info(message: string, metadata?: EdgeLogMetadata): void;
+  warn(message: string, metadata?: EdgeLogMetadata): void;
+  error(message: string, error?: Error, metadata?: EdgeLogMetadata): void;
+}
+
+/**
+ * Category-scoped logger, mirroring `loggers.<category>` from
+ * packages/lib logger-config (auth, api, system, performance, security, …).
+ */
+export function createEdgeLogger(category: string): EdgeLogger {
+  return {
+    debug: (message, metadata) => emit('debug', category, message, metadata),
+    info: (message, metadata) => emit('info', category, message, metadata),
+    warn: (message, metadata) => emit('warn', category, message, metadata),
+    error: (message, error, metadata) => emit('error', category, message, errorMetadata(error, metadata)),
+  };
+}
+
+/**
+ * Edge counterpart of packages/lib logSecurityEvent: same event-name union,
+ * same message format and warn level, so security-event queries over the log
+ * stream match rows from either runtime.
+ */
+export function logSecurityEvent(event: SecurityEventName, details: EdgeLogMetadata): void {
+  emit('warn', 'security', `Security event: ${event}`, details);
+}

--- a/apps/web/src/lib/logging/edge-logger.ts
+++ b/apps/web/src/lib/logging/edge-logger.ts
@@ -8,23 +8,31 @@
  * logging surface instead: synchronous structured JSON to the console, which
  * Fly log drains ingest the same way they ingest the Node logger's output.
  *
- * Output shape mirrors the existing logger's JSON so downstream parsing keeps
- * working: { timestamp, level, category, message, metadata? }. Level is
- * uppercase to match packages/lib/src/logging/logger.ts.
+ * Output shape: { timestamp, level, category, message, context, metadata? }.
+ * Level is uppercase and `context.category` is set to match the Node logger's
+ * console JSON (packages/lib/src/logging/logger.ts nests category there), so
+ * drain queries keyed on either `category` or `context.category` match lines
+ * from both runtimes. Known, accepted divergences from the Node logger: no
+ * hostname/pid (no `os` on edge), no SIEM error-hook fan-out (middleware
+ * errors reach the Node layer via the monitoring ingest POST instead), and
+ * response-log fields sit flat under `metadata` rather than
+ * `metadata.context`.
  *
- * MUST stay edge-safe: imports nothing (types only), no Node built-ins, no
- * process.on, no timers, no dynamic imports, no @pagespace/* imports.
- * `process.env` reads are supported in the Edge runtime and are the only
- * ambient state touched.
+ * Sensitive-key redaction mirrors the Node logger's sanitizer (same
+ * substring/exact lists) so a metadata field like `token` or `email` never
+ * reaches the log stream verbatim from either runtime.
+ *
+ * MUST stay edge-safe: imports nothing, no Node built-ins, no process.on, no
+ * timers, no dynamic imports, no @pagespace/* imports. `process.env` reads
+ * are supported in the Edge runtime and are the only ambient state touched.
  */
 
 /**
- * Security event names — keep in sync with logSecurityEvent's union in
- * packages/lib/src/logging/logger-config.ts. Duplicated (not imported) because
- * importing anything from @pagespace/lib would pull the Node-only logger into
- * the edge bundle; the token-prefixes re-export test pattern doesn't apply to
- * a pure type, and a drift here fails loudly at typecheck the moment a caller
- * uses a new event name.
+ * Security event names — keep in sync with logSecurityEvent's parameter union
+ * in packages/lib/src/logging/logger-config.ts. Duplicated (not imported)
+ * because this module must not import from @pagespace/lib, and the Node-side
+ * union is an anonymous parameter type. Drift is caught by the sync test in
+ * __tests__/edge-logger.test.ts, which parses both unions from source.
  */
 export type SecurityEventName =
   | 'rate_limit' | 'invalid_token' | 'unauthorized' | 'suspicious_activity'
@@ -40,13 +48,15 @@ export type SecurityEventName =
 
 export type EdgeLogMetadata = Record<string, unknown>;
 
-export type EdgeLogLevel = 'debug' | 'info' | 'warn' | 'error';
+type EdgeLogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface EdgeLogEntry {
   timestamp: string;
   level: string;
   category: string;
   message: string;
+  /** Mirrors the Node logger's `context.category` nesting for drain parity. */
+  context: { category: string };
   metadata?: EdgeLogMetadata;
 }
 
@@ -60,23 +70,69 @@ const LEVEL_ORDER: Record<EdgeLogLevel, number> = {
 /**
  * Minimum level to emit, from LOG_LEVEL (same env var the Node logger reads).
  * The Node logger's extra levels map onto this module's four: trace → debug,
- * fatal → error, silent → suppress everything. Unknown values → info.
- * Read per-call, not at module load, so tests (and runtime reconfiguration)
- * see current env.
+ * fatal → error, silent → suppress everything. Unknown values → info (the
+ * Node logger's default too). Read per-call, not at module load, so tests
+ * (and runtime reconfiguration) see current env.
  */
 function minimumLevel(): number {
   const raw = (process.env.LOG_LEVEL || 'info').trim().toLowerCase();
   if (raw === 'silent') return Number.POSITIVE_INFINITY;
   if (raw === 'trace') return LEVEL_ORDER.debug;
   if (raw === 'fatal') return LEVEL_ORDER.error;
-  return raw in LEVEL_ORDER ? LEVEL_ORDER[raw as EdgeLogLevel] : LEVEL_ORDER.info;
+  return Object.hasOwn(LEVEL_ORDER, raw) ? LEVEL_ORDER[raw as EdgeLogLevel] : LEVEL_ORDER.info;
+}
+
+// Sensitive-key redaction — same two-tier matching as the Node logger's
+// sanitizeData (packages/lib/src/logging/logger.ts): substrings that always
+// mean credentials, exact names that mean PII. Keep the lists aligned.
+const SUBSTRING_SENSITIVE = [
+  'password', 'token', 'secret', 'api_key', 'apikey',
+  'authorization', 'cookie', 'credit_card', 'jwt',
+];
+const EXACT_SENSITIVE = new Set([
+  'ssn',
+  'email', 'emailaddress',
+  'phone', 'phonenumber', 'mobilenumber',
+  'address', 'streetaddress', 'homeaddress', 'mailingaddress',
+  'dob', 'dateofbirth', 'birthdate',
+  'name', 'firstname', 'lastname', 'fullname', 'displayname',
+  'username', 'filename', 'originalname',
+]);
+
+const MAX_SANITIZE_DEPTH = 6;
+
+/**
+ * Redact sensitive keys, depth-limited. The depth cap doubles as circular-
+ * reference protection: a cycle bottoms out as '[depth_limited]' instead of
+ * recursing forever (and instead of JSON.stringify throwing later).
+ */
+function sanitizeMetadata(value: unknown, depth = 0): unknown {
+  if (depth > MAX_SANITIZE_DEPTH) return '[depth_limited]';
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeMetadata(item, depth + 1));
+  }
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const sanitized: Record<string, unknown> = {};
+    for (const key of Object.keys(source)) {
+      const lower = key.toLowerCase();
+      if (SUBSTRING_SENSITIVE.some((s) => lower.includes(s)) || EXACT_SENSITIVE.has(lower)) {
+        sanitized[key] = '[REDACTED]';
+      } else {
+        sanitized[key] = sanitizeMetadata(source[key], depth + 1);
+      }
+    }
+    return sanitized;
+  }
+  return value;
 }
 
 function emit(
   level: EdgeLogLevel,
   category: string,
   message: string,
-  metadata?: EdgeLogMetadata
+  metadata?: EdgeLogMetadata,
+  error?: Error
 ): void {
   if (LEVEL_ORDER[level] < minimumLevel()) return;
 
@@ -85,12 +141,29 @@ function emit(
     level: level.toUpperCase(),
     category,
     message,
+    context: { category },
   };
   if (metadata && Object.keys(metadata).length > 0) {
-    entry.metadata = metadata;
+    entry.metadata = sanitizeMetadata(metadata) as EdgeLogMetadata;
+  }
+  if (error) {
+    // Attached after sanitization on purpose: `name` is on the exact-match
+    // redaction list, but error.name here is a constructed, safe field.
+    entry.metadata = {
+      ...entry.metadata,
+      error: { name: error.name, message: error.message, stack: error.stack },
+    };
   }
 
-  const line = JSON.stringify(entry);
+  // A logger must never throw into its caller: metadata can still contain
+  // non-serializable values (BigInt), so fall back to a metadata-free line.
+  let line: string;
+  try {
+    line = JSON.stringify(entry);
+  } catch {
+    line = JSON.stringify({ ...entry, metadata: { serialization: 'failed' } });
+  }
+
   if (level === 'error') {
     console.error(line);
   } else if (level === 'warn') {
@@ -98,15 +171,6 @@ function emit(
   } else {
     console.log(line);
   }
-}
-
-/** Serialize an Error into plain metadata (Errors JSON.stringify to {}). */
-function errorMetadata(error: Error | undefined, metadata?: EdgeLogMetadata): EdgeLogMetadata | undefined {
-  if (!error) return metadata;
-  return {
-    ...metadata,
-    error: { name: error.name, message: error.message, stack: error.stack },
-  };
 }
 
 export interface EdgeLogger {
@@ -125,7 +189,7 @@ export function createEdgeLogger(category: string): EdgeLogger {
     debug: (message, metadata) => emit('debug', category, message, metadata),
     info: (message, metadata) => emit('info', category, message, metadata),
     warn: (message, metadata) => emit('warn', category, message, metadata),
-    error: (message, error, metadata) => emit('error', category, message, errorMetadata(error, metadata)),
+    error: (message, error, metadata) => emit('error', category, message, metadata, error),
   };
 }
 

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -5,6 +5,7 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
+import { OAUTH_ACCESS_TOKEN_PREFIX } from '@/lib/auth/token-prefixes';
 import { db } from '@pagespace/db/db';
 import { eq, and, isNull } from '@pagespace/db/operators';
 import { oauthClients, oauthAuthorizationCodes, oauthRefreshTokens, oauthAccessTokens, oauthDeviceCodes } from '@pagespace/db/schema/oauth';
@@ -285,7 +286,6 @@ export interface RevokeOAuthTokenInput {
 }
 
 const OAUTH_REFRESH_TOKEN_PREFIX = 'ps_rt_';
-const OAUTH_ACCESS_TOKEN_PREFIX = 'ps_at_';
 
 /**
  * RFC 7009 revocation (task qyqgrjbvntpsdh578k0yiwgr). A refresh token

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,22 +8,27 @@ import {
   isSecureRequest,
   shouldDisableCOEP,
 } from '@/middleware/security-headers';
-import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
+import { logSecurityEvent } from '@/lib/logging/edge-logger';
 import {
   validateOriginForMiddleware,
   isOriginValidationBlocking,
+} from '@/lib/auth/origin-validation';
+import {
   MCP_TOKEN_PREFIX,
   SESSION_TOKEN_PREFIX,
   OAUTH_ACCESS_TOKEN_PREFIX,
-} from '@/lib/auth';
+} from '@/lib/auth/token-prefixes';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 import { WELL_KNOWN_REWRITES } from '@/lib/well-known/rewrites';
 
 // Edge-safe middleware: only checks presence of auth tokens, not validity.
 // Full validation happens in route handlers via verifyAuth()/validateMCPToken().
-// Bearer prefixes are imported from the real auth layer, not hand-duplicated —
-// see the export site for why (a duplicated ps_at_-less copy previously drifted
-// out of sync here, undetected because middleware never ran in production).
+// Every import above must stay edge-safe — leaf modules only, NEVER the
+// '@/lib/auth' barrel (Node-only graph: db, sessions, permissions) and never
+// @pagespace/lib's logger. Bearer prefixes come from the token-prefixes leaf
+// the auth layer itself re-exports, not a hand-duplicated copy — a duplicated
+// ps_at_-less copy previously drifted out of sync here, undetected because
+// middleware never ran in production.
 
 const MCP_BEARER_PREFIX = `Bearer ${MCP_TOKEN_PREFIX}`;
 const SESSION_BEARER_PREFIX = `Bearer ${SESSION_TOKEN_PREFIX}`;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import type { NextFetchEvent } from 'next/server';
 import { monitoringMiddleware } from '@/middleware/monitoring';
 import {
   createSecureResponse,
@@ -51,7 +52,10 @@ const CLOUD_ONLY_ROUTE_PREFIXES = [
   '/api/auth/mobile/signup',
 ];
 
-export async function middleware(req: NextRequest) {
+export async function middleware(req: NextRequest, event?: NextFetchEvent) {
+  // `event` lets the monitoring layer register its ingest POST with
+  // waitUntil(), so the Edge runtime can't cancel it when the response
+  // returns — it is the only persistence path for API metrics.
   return monitoringMiddleware(req, async () => {
     const { pathname } = req.nextUrl;
     const isProduction = process.env.NODE_ENV === 'production';
@@ -260,7 +264,7 @@ export async function middleware(req: NextRequest) {
     const { response } = createSecureResponse(isProduction, req, { isAPIRoute, disableCOEP: shouldDisableCOEP(pathname) });
 
     return response;
-  });
+  }, event);
 }
 
 export const config = {

--- a/apps/web/src/middleware/__tests__/matcher.test.ts
+++ b/apps/web/src/middleware/__tests__/matcher.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // Mock all runtime dependencies so the static `config` export can be imported
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: vi.fn(),
-  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 vi.mock('@/middleware/monitoring', () => ({ monitoringMiddleware: vi.fn() }));
 vi.mock('@/middleware/security-headers', () => ({
@@ -13,12 +13,13 @@ vi.mock('@/middleware/security-headers', () => ({
   isPublishedSiteHost: vi.fn(),
   shouldDisableCOEP: vi.fn(),
 }));
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes load from the real '@/lib/auth/token-prefixes' leaf: it's pure and
+// edge-safe, and mocking it would just recreate the drift it exists to prevent.
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: vi.fn(),
   isOriginValidationBlocking: vi.fn(),
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 vi.mock('@/lib/auth/cookie-config', () => ({ getSessionFromCookies: vi.fn() }));
 

--- a/apps/web/src/middleware/__tests__/monitoring.test.ts
+++ b/apps/web/src/middleware/__tests__/monitoring.test.ts
@@ -190,6 +190,34 @@ describe('monitoringMiddleware', () => {
     });
   });
 
+  it('registers the ingest POST with event.waitUntil so the Edge runtime cannot cancel it', async () => {
+    const waitUntil = vi.fn();
+    const event = { waitUntil } as unknown as import('next/server').NextFetchEvent;
+
+    await monitoringMiddleware(
+      buildRequest('/api/pages/xyz'),
+      async () => NextResponse.json({ ok: true }),
+      event
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    expect(waitUntil.mock.calls[0][0]).toBeInstanceOf(Promise);
+  });
+
+  it('registers the error-path ingest POST with event.waitUntil too', async () => {
+    const waitUntil = vi.fn();
+    const event = { waitUntil } as unknown as import('next/server').NextFetchEvent;
+
+    await expect(
+      monitoringMiddleware(buildRequest('/api/pages/xyz'), async () => {
+        throw new Error('boom');
+      }, event)
+    ).rejects.toThrow('boom');
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
   it('survives an ingest fetch rejection without failing the request', async () => {
     fetchMock.mockRejectedValue(new Error('network down'));
 

--- a/apps/web/src/middleware/__tests__/monitoring.test.ts
+++ b/apps/web/src/middleware/__tests__/monitoring.test.ts
@@ -1,73 +1,27 @@
 /**
- * Tests for monitoring middleware
+ * Tests for the edge-safe monitoring middleware.
+ *
+ * The middleware must never touch the database (the old MetricsCollector was
+ * deleted for exactly that reason) — its only persistence path is the
+ * fire-and-forget fetch POST to /api/internal/monitoring/ingest. These tests
+ * pin that contract: ingest forwarding for /api requests, response headers,
+ * the error-path re-throw, and the module's edge purity.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { db } from '@pagespace/db/db'
-import { apiMetrics } from '@pagespace/db/schema/monitoring';
-import { getMonitoringIngestStatus } from '../monitoring';
+import fs from 'node:fs';
+import path from 'node:path';
+import { NextRequest, NextResponse } from 'next/server';
 
-// Mock the database
-vi.mock('@pagespace/db/db', () => ({
-  db: {
-    insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined)
-    })
-  },
-}));
-vi.mock('@pagespace/db/schema/monitoring', () => ({
-  apiMetrics: {},
-}));
-
-// Mock loggers
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    logger: {
-    child: vi.fn(() => ({
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn()
-    }))
-  },
-    loggers: {
-    performance: {
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn()
-    },
-    api: {
-      info: vi.fn(),
-      error: vi.fn()
-    },
-    auth: {
-      debug: vi.fn()
-    },
-    database: {
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn()
-    },
-    ai: {
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn()
-    },
-    system: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }
-  },
-    extractRequestContext: vi.fn(() => ({
-    method: 'GET',
-    endpoint: '/api/test',
-    ip: '127.0.0.1',
-    userAgent: 'test-agent',
-    sessionId: 'test-session',
-    query: {}
+// Mock the edge logger to keep test output clean; behavior under test is the
+// middleware's, not the logger's (which has its own test file).
+vi.mock('@/lib/logging/edge-logger', () => ({
+  createEdgeLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
   })),
-    logResponse: vi.fn(),
 }));
 
 // Mock request-id (has transitive dep on @paralleldrive/cuid2)
@@ -75,6 +29,8 @@ vi.mock('@/lib/request-id/request-id', () => ({
   getOrCreateRequestId: vi.fn(() => 'test-request-id'),
   REQUEST_ID_HEADER: 'X-Request-Id',
 }));
+
+import { getMonitoringIngestStatus, monitoringMiddleware } from '../monitoring';
 
 describe('getMonitoringIngestStatus', () => {
   const originalEnv = process.env;
@@ -115,39 +71,147 @@ describe('getMonitoringIngestStatus', () => {
   });
 });
 
-describe('Monitoring Middleware - Database Persistence', () => {
+describe('monitoringMiddleware', () => {
+  const originalEnv = process.env;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  const buildRequest = (pathname: string, headers: Record<string, string> = {}) =>
+    new NextRequest(new URL(`http://localhost${pathname}`), { headers });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.MONITORING_INGEST_KEY = 'test-key';
+    delete process.env.MONITORING_INGEST_DISABLED;
+    delete process.env.MONITORING_INGEST_PATH;
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
   });
 
-  it('should write metrics to database on flush', async () => {
-    // This test verifies that the flush() method writes to the database
-    // We're testing the implementation indirectly through the mock
-
-    const mockInsert = vi.fn().mockReturnValue({
-      values: vi.fn().mockResolvedValue(undefined)
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db.insert as any) = mockInsert;
-
-    // The actual implementation will be tested in integration tests
-    // This is a placeholder to ensure the types are correct
-    expect(db.insert).toBeDefined();
-    expect(apiMetrics).toBeDefined();
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
   });
 
-  it('should handle database write errors gracefully', async () => {
-    // This test verifies that errors are caught and logged
-    const mockInsert = vi.fn().mockReturnValue({
-      values: vi.fn().mockRejectedValue(new Error('Database error'))
+  it('forwards an api-request payload to the ingest route for /api requests', async () => {
+    const request = buildRequest('/api/pages/xyz', {
+      'x-user-id': 'user-1',
+      'user-agent': 'test-agent',
+      'x-forwarded-for': '10.0.0.1',
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (db.insert as any) = mockInsert;
+    const response = await monitoringMiddleware(request, async () =>
+      NextResponse.json({ ok: true }, { status: 200 })
+    );
 
-    // The implementation should catch errors and fall back to logging
-    // This will be verified in integration tests
-    expect(true).toBe(true);
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://localhost/api/internal/monitoring/ingest');
+    expect(init.method).toBe('POST');
+    expect(init.headers['x-monitoring-ingest-key']).toBe('test-key');
+    const payload = JSON.parse(init.body);
+    expect(payload).toMatchObject({
+      type: 'api-request',
+      requestId: 'test-request-id',
+      method: 'GET',
+      endpoint: '/api/pages/xyz',
+      statusCode: 200,
+      userId: 'user-1',
+      ip: '10.0.0.1',
+      userAgent: 'test-agent',
+    });
+    expect(typeof payload.duration).toBe('number');
+  });
+
+  it('does not POST to ingest for non-API page requests', async () => {
+    const response = await monitoringMiddleware(buildRequest('/dashboard'), async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    expect(response).toBeDefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not POST to ingest when the key is missing (misconfigured)', async () => {
+    delete process.env.MONITORING_INGEST_KEY;
+
+    await monitoringMiddleware(buildRequest('/api/pages/xyz'), async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips monitoring entirely for static assets and the ingest route itself', async () => {
+    for (const pathname of ['/_next/static/chunk.js', '/favicon.ico', '/api/internal/monitoring/ingest']) {
+      const next = vi.fn(async () => NextResponse.json({ ok: true }));
+      const response = await monitoringMiddleware(buildRequest(pathname), next);
+      expect(next).toHaveBeenCalledTimes(1);
+      // No monitoring headers on skipped paths
+      expect(response.headers.get('X-Response-Time')).toBeNull();
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sets request-id and X-Response-Time headers on monitored responses', async () => {
+    const response = await monitoringMiddleware(buildRequest('/api/health'), async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    expect(response.headers.get('X-Request-Id')).toBe('test-request-id');
+    expect(response.headers.get('X-Response-Time')).toMatch(/^\d+ms$/);
+  });
+
+  it('strips query strings from the ingested endpoint', async () => {
+    await monitoringMiddleware(buildRequest('/api/search?q=secret'), async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.endpoint).toBe('/api/search');
+  });
+
+  it('re-throws handler errors after forwarding a statusCode-500 payload', async () => {
+    const boom = new Error('handler exploded');
+
+    await expect(
+      monitoringMiddleware(buildRequest('/api/pages/xyz'), async () => {
+        throw boom;
+      })
+    ).rejects.toThrow('handler exploded');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload).toMatchObject({
+      statusCode: 500,
+      error: 'handler exploded',
+      errorName: 'Error',
+    });
+  });
+
+  it('survives an ingest fetch rejection without failing the request', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const response = await monitoringMiddleware(buildRequest('/api/health'), async () =>
+      NextResponse.json({ ok: true })
+    );
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe('module edge purity (acceptance criterion)', () => {
+  it('never imports @pagespace/db, @pagespace/lib, or Node built-ins', () => {
+    // Strip comments first — the doc header legitimately names the modules
+    // this file must NOT import.
+    const source = fs
+      .readFileSync(path.resolve(__dirname, '../monitoring.ts'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    expect(source).not.toMatch(/@pagespace\//);
+    expect(source).not.toMatch(/from\s+['"](os|fs|net|tls|crypto)['"]/);
+    expect(source).not.toMatch(/setInterval/);
+    expect(source).not.toMatch(/\bMetricsCollector\b/);
   });
 });

--- a/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // Mock all runtime dependencies so middleware() can run without a real DB/session.
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: vi.fn(),
-  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
@@ -18,12 +18,13 @@ vi.mock('@/middleware/security-headers', () => ({
   isSecureRequest: vi.fn(() => true),
   shouldDisableCOEP: vi.fn(() => false),
 }));
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes load from the real '@/lib/auth/token-prefixes' leaf: it's pure and
+// edge-safe, and mocking it would just recreate the drift it exists to prevent.
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: exactly the CLI's position — it is a background process
 // with no browser session, calling these endpoints directly over HTTP.

--- a/apps/web/src/middleware/__tests__/pre-session-and-asset-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/pre-session-and-asset-endpoints.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // Mock all runtime dependencies so middleware() can run without a real DB/session.
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: vi.fn(),
-  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
@@ -18,12 +18,13 @@ vi.mock('@/middleware/security-headers', () => ({
   isSecureRequest: vi.fn(() => true),
   shouldDisableCOEP: vi.fn(() => false),
 }));
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes load from the real '@/lib/auth/token-prefixes' leaf: it's pure and
+// edge-safe, and mocking it would just recreate the drift it exists to prevent.
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: exactly the position of an anonymous visitor (Apple sign-in,
 // email-link click-throughs, public asset requests) or a caller authenticating

--- a/apps/web/src/middleware/__tests__/signup-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/signup-public-endpoints.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // Mock all runtime dependencies so middleware() can run without a real DB/session.
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: vi.fn(),
-  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
@@ -18,12 +18,13 @@ vi.mock('@/middleware/security-headers', () => ({
   isSecureRequest: vi.fn(() => true),
   shouldDisableCOEP: vi.fn(() => false),
 }));
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes load from the real '@/lib/auth/token-prefixes' leaf: it's pure and
+// edge-safe, and mocking it would just recreate the drift it exists to prevent.
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: exactly the position of a brand-new visitor who has no
 // account yet (signup) or is completing email verification from a link

--- a/apps/web/src/middleware/__tests__/webhook-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/webhook-public-endpoints.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 
 // Mock all runtime dependencies so middleware() can run without a real DB/session.
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: vi.fn(),
-  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
@@ -18,12 +18,13 @@ vi.mock('@/middleware/security-headers', () => ({
   isSecureRequest: vi.fn(() => true),
   shouldDisableCOEP: vi.fn(() => false),
 }));
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes load from the real '@/lib/auth/token-prefixes' leaf: it's pure and
+// edge-safe, and mocking it would just recreate the drift it exists to prevent.
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: exactly a third-party webhook caller's position — Stripe,
 // Google, and Zoom are background services with no browser session, calling

--- a/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
+++ b/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
@@ -11,9 +11,9 @@ if (typeof (NextResponse as { rewrite?: unknown }).rewrite !== 'function') {
 }
 
 // Mock all runtime dependencies so middleware() can run without a real DB/session.
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@/lib/logging/edge-logger', () => ({
   logSecurityEvent: vi.fn(),
-  logger: { child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })) },
+  createEdgeLogger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
 }));
 vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: vi.fn((_req, handler: () => unknown) => handler()),
@@ -26,12 +26,13 @@ vi.mock('@/middleware/security-headers', () => ({
   isPublishedSiteHost: vi.fn(() => false),
   shouldDisableCOEP: vi.fn(() => false),
 }));
-vi.mock('@/lib/auth', () => ({
+// middleware.ts imports origin validation from its leaf module (never the
+// Node-only '@/lib/auth' barrel), so that's what gets mocked. The bearer
+// prefixes load from the real '@/lib/auth/token-prefixes' leaf: it's pure and
+// edge-safe, and mocking it would just recreate the drift it exists to prevent.
+vi.mock('@/lib/auth/origin-validation', () => ({
   validateOriginForMiddleware: vi.fn(() => ({ valid: true, skipped: true })),
   isOriginValidationBlocking: vi.fn(() => false),
-  MCP_TOKEN_PREFIX: 'mcp_',
-  SESSION_TOKEN_PREFIX: 'ps_sess_',
-  OAUTH_ACCESS_TOKEN_PREFIX: 'ps_at_',
 }));
 // No session cookie: this is the exact scenario the CLI login flow hits —
 // discovery is always the first, unauthenticated request.

--- a/apps/web/src/middleware/monitoring.ts
+++ b/apps/web/src/middleware/monitoring.ts
@@ -16,6 +16,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import type { NextFetchEvent } from 'next/server';
 import { createEdgeLogger } from '@/lib/logging/edge-logger';
 import {
   getOrCreateRequestId,
@@ -73,6 +74,10 @@ function logResponse(
   }
 }
 
+// Fields this middleware actually sends. The ingest route's IngestPayload
+// (@/lib/monitoring/ingest-sanitizer) accepts a wider optional set
+// (sessionId, cacheHit, driveId, …) for other producers; middleware has no
+// values for those, so they are deliberately absent here.
 interface MonitoringIngestPayload {
   type: 'api-request';
   requestId: string;
@@ -84,17 +89,11 @@ interface MonitoringIngestPayload {
   requestSize?: number;
   responseSize?: number;
   userId?: string;
-  sessionId?: string;
   ip?: string;
   userAgent?: string;
   error?: string;
   errorName?: string;
   errorStack?: string;
-  cacheHit?: boolean;
-  cacheKey?: string;
-  driveId?: string;
-  pageId?: string;
-  metadata?: Record<string, unknown>;
 }
 
 const DEFAULT_INGEST_PATH = '/api/internal/monitoring/ingest';
@@ -134,7 +133,11 @@ function logMonitoringStatus(): void {
   }
 }
 
-function queueMonitoringIngest(request: NextRequest, payload: MonitoringIngestPayload): void {
+function queueMonitoringIngest(
+  request: NextRequest,
+  payload: MonitoringIngestPayload,
+  event?: NextFetchEvent
+): void {
   const status = getMonitoringIngestStatus();
 
   if (status !== 'active') {
@@ -154,7 +157,7 @@ function queueMonitoringIngest(request: NextRequest, payload: MonitoringIngestPa
     const ingestPath = process.env.MONITORING_INGEST_PATH || DEFAULT_INGEST_PATH;
     const url = new URL(ingestPath, request.nextUrl.origin);
 
-    fetch(url.toString(), {
+    const forward = fetch(url.toString(), {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -169,6 +172,12 @@ function queueMonitoringIngest(request: NextRequest, payload: MonitoringIngestPa
         endpoint: payload.endpoint,
       });
     });
+
+    // Fire-and-forget is not enough on Edge: the runtime may cancel in-flight
+    // work as soon as the response is returned. waitUntil() keeps this POST —
+    // the ONLY persistence path for API metrics — alive until it settles.
+    // (`forward` already has a .catch, so it never rejects inside waitUntil.)
+    event?.waitUntil(forward);
   } catch (error) {
     performanceLogger.debug('Unable to construct monitoring ingest request', {
       error: (error as Error).message,
@@ -204,42 +213,47 @@ function getResponseSize(response: NextResponse): number {
   if (contentLength) {
     return parseInt(contentLength, 10);
   }
-  // Estimate size from response body if available
   return 0;
 }
+
+// Static assets and Next.js internals to skip (module-level: this check runs
+// first thing on every request).
+const SKIP_PATHS = [
+  '/_next',
+  '/favicon.ico',
+  '/robots.txt',
+  '/sitemap.xml',
+  '/api/internal/monitoring/ingest',
+  '.js',
+  '.css',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.ico',
+  '.woff',
+  '.woff2'
+];
 
 /**
  * Check if path should be monitored
  */
 function shouldMonitor(pathname: string): boolean {
-  // Skip static assets and Next.js internals
-  const skipPaths = [
-    '/_next',
-    '/favicon.ico',
-    '/robots.txt',
-    '/sitemap.xml',
-    '/api/internal/monitoring/ingest',
-    '.js',
-    '.css',
-    '.png',
-    '.jpg',
-    '.jpeg',
-    '.gif',
-    '.svg',
-    '.ico',
-    '.woff',
-    '.woff2'
-  ];
-
-  return !skipPaths.some(path => pathname.includes(path));
+  return !SKIP_PATHS.some(path => pathname.includes(path));
 }
 
 /**
- * Main monitoring middleware
+ * Main monitoring middleware.
+ *
+ * `event` is the NextFetchEvent Next passes to middleware; when provided, the
+ * ingest POST is registered via event.waitUntil() so the Edge runtime keeps it
+ * alive after the response returns (otherwise it may be cancelled in flight).
  */
 export async function monitoringMiddleware(
   request: NextRequest,
-  next: () => Promise<NextResponse>
+  next: () => Promise<NextResponse>,
+  event?: NextFetchEvent
 ): Promise<NextResponse> {
   // Log monitoring configuration status once on first request
   logMonitoringStatus();
@@ -253,7 +267,6 @@ export async function monitoringMiddleware(
 
   // Get or generate request ID (preserves incoming ID for distributed tracing)
   const requestId = getOrCreateRequestId(request);
-  const startedAt = new Date();
   const startTime = Date.now();
 
   // Extract context
@@ -269,6 +282,20 @@ export async function monitoringMiddleware(
     ...context,
   });
 
+  // Fields common to the success- and error-path ingest payloads, so a new
+  // field can't be added to one path and silently missed on the other.
+  const basePayload = {
+    type: 'api-request' as const,
+    requestId,
+    timestamp: new Date(startTime).toISOString(),
+    method: request.method.toUpperCase(),
+    endpoint: cleanEndpoint,
+    requestSize,
+    userId,
+    ip: context.ip,
+    userAgent: context.userAgent,
+  };
+
   try {
     // Execute the request
     const response = await next();
@@ -281,21 +308,13 @@ export async function monitoringMiddleware(
     if (pathname.startsWith('/api')) {
       const isServerError = statusCode >= 500;
       queueMonitoringIngest(request, {
-        type: 'api-request',
-        requestId,
-        timestamp: startedAt.toISOString(),
-        method: request.method.toUpperCase(),
-        endpoint: cleanEndpoint,
+        ...basePayload,
         statusCode,
         duration,
-        requestSize,
         responseSize,
-        userId,
-        ip: context.ip,
-        userAgent: context.userAgent,
         error: isServerError ? `HTTP ${statusCode}` : undefined,
         errorName: isServerError ? 'HttpError' : undefined,
-      });
+      }, event);
     }
 
     // Log response
@@ -330,22 +349,14 @@ export async function monitoringMiddleware(
 
     if (pathname.startsWith('/api')) {
       queueMonitoringIngest(request, {
-        type: 'api-request',
-        requestId,
-        timestamp: startedAt.toISOString(),
-        method: request.method.toUpperCase(),
-        endpoint: cleanEndpoint,
+        ...basePayload,
         statusCode: 500,
         duration,
-        requestSize,
         responseSize: 0,
-        userId,
-        ip: context.ip,
-        userAgent: context.userAgent,
         error: errorMessage,
         errorName,
         errorStack,
-      });
+      }, event);
     }
 
     // Log error

--- a/apps/web/src/middleware/monitoring.ts
+++ b/apps/web/src/middleware/monitoring.ts
@@ -1,164 +1,77 @@
 /**
- * Monitoring Middleware for PageSpace
- * Tracks API requests, performance, and user interactions
+ * Monitoring Middleware for PageSpace — edge-safe.
+ *
+ * Runs inside the Edge runtime (imported by src/middleware.ts), so this module
+ * must never touch the database, Node built-ins, or @pagespace/lib's Node-only
+ * logger. Persistence happens at the Node layer instead: every /api request is
+ * forwarded as a fire-and-forget POST to /api/internal/monitoring/ingest
+ * (authenticated via x-monitoring-ingest-key), whose route handler writes the
+ * apiMetrics and systemLogs rows the admin dashboard reads. The old in-process
+ * MetricsCollector (setInterval + direct db.insert from middleware) was
+ * deleted: it was Node-only, never once ran in production, and wrote from the
+ * wrong layer.
+ *
+ * Non-API page requests are logged to the console stream only, by design —
+ * they were previously tracked only by the deleted collector.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { logger, loggers, extractRequestContext, logResponse } from '@pagespace/lib/logging/logger-config';
+import { createEdgeLogger } from '@/lib/logging/edge-logger';
 import {
   getOrCreateRequestId,
   REQUEST_ID_HEADER,
 } from '@/lib/request-id/request-id';
-import { db } from '@pagespace/db/db'
-import { apiMetrics } from '@pagespace/db/schema/monitoring';
 import { sanitizeEndpoint } from '@/lib/monitoring/ingest-sanitizer';
 
-// In-memory buffer for metrics (flushed to database every 30s or when buffer is full)
-interface RequestMetrics {
+const systemLogger = createEdgeLogger('system');
+const performanceLogger = createEdgeLogger('performance');
+const apiLogger = createEdgeLogger('api');
+
+interface RequestContext {
   endpoint: string;
   method: string;
-  statusCode: number;
-  duration: number;
-  timestamp: Date;
-  userId?: string;
-  sessionId?: string;
-  requestId?: string;
-  ip?: string;
+  ip: string;
   userAgent?: string;
-  requestSize?: number;
-  responseSize?: number;
-  error?: string;
 }
 
-interface EndpointMetrics {
-  count: number;
-  avgDuration: number;
-  errors: number;
+/**
+ * Extract logging context from the request. Local, pure equivalent of
+ * @pagespace/lib logger-config's extractRequestContext (which lives in the
+ * Node-only logger graph).
+ */
+function extractRequestContext(request: NextRequest): RequestContext {
+  return {
+    endpoint: request.nextUrl.pathname,
+    method: request.method,
+    ip:
+      request.headers.get('x-forwarded-for')?.split(',')[0] ||
+      request.headers.get('x-real-ip') ||
+      'unknown',
+    userAgent: request.headers.get('user-agent') || undefined,
+  };
 }
 
-interface MetricsSummary {
-  total: number;
-  errors: number;
-  errorRate: number;
-  avgDuration: number;
-  endpoints: number;
-  topEndpoints: Array<[string, EndpointMetrics]>;
-}
+/**
+ * Log the response line (same message format as @pagespace/lib logResponse:
+ * "METHOD /endpoint STATUS DURATIONms", warn at 4xx, error at 5xx).
+ */
+function logResponse(
+  context: RequestContext,
+  statusCode: number,
+  duration: number,
+  metadata: Record<string, unknown>
+): void {
+  const message = `${context.method} ${context.endpoint} ${statusCode} ${duration}ms`;
+  const fullMetadata = { ...metadata, ...context, statusCode, duration };
 
-class MetricsCollector {
-  private static instance: MetricsCollector;
-  private metrics: RequestMetrics[] = [];
-  private readonly maxBufferSize = 1000;
-  private readonly flushInterval = 30000; // 30 seconds
-  private flushTimer: NodeJS.Timeout | null = null;
-
-  private constructor() {
-    this.startFlushTimer();
-  }
-
-  static getInstance(): MetricsCollector {
-    if (!MetricsCollector.instance) {
-      MetricsCollector.instance = new MetricsCollector();
-    }
-    return MetricsCollector.instance;
-  }
-
-  private startFlushTimer(): void {
-    if (this.flushTimer) {
-      clearInterval(this.flushTimer);
-    }
-
-    this.flushTimer = setInterval(() => {
-      this.flush();
-    }, this.flushInterval);
-  }
-
-  track(metric: RequestMetrics): void {
-    this.metrics.push(metric);
-
-    if (this.metrics.length >= this.maxBufferSize) {
-      this.flush().catch(() => {});
-    }
-  }
-
-  async flush(): Promise<void> {
-    if (this.metrics.length === 0) return;
-
-    const metricsToFlush = [...this.metrics];
-    this.metrics = [];
-
-    try {
-      // Write metrics to database
-      await db.insert(apiMetrics).values(
-        metricsToFlush.map(metric => ({
-          endpoint: metric.endpoint,
-          method: metric.method as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS',
-          statusCode: metric.statusCode,
-          duration: metric.duration,
-          timestamp: metric.timestamp,
-          userId: metric.userId,
-          sessionId: metric.sessionId,
-          requestId: metric.requestId,
-          ip: metric.ip,
-          userAgent: metric.userAgent,
-          requestSize: metric.requestSize,
-          responseSize: metric.responseSize,
-          error: metric.error,
-        }))
-      );
-
-      // Also log summary for real-time monitoring
-      const summary = this.summarizeMetrics(metricsToFlush);
-      loggers.performance.info('Metrics flushed to database', {
-        ...summary,
-        flushedCount: metricsToFlush.length
-      });
-    } catch (error) {
-      // If database write fails, fall back to logging only
-      loggers.performance.error('Failed to write metrics to database', error as Error);
-      const summary = this.summarizeMetrics(metricsToFlush);
-      loggers.performance.info('Metrics flush (fallback to logs only)', { ...summary });
-    }
-  }
-
-  private summarizeMetrics(metrics: RequestMetrics[]): MetricsSummary {
-    const total = metrics.length;
-    const errors = metrics.filter(m => m.statusCode >= 400).length;
-    const avgDuration = metrics.reduce((sum, m) => sum + m.duration, 0) / total;
-    
-    const byEndpoint = metrics.reduce((acc, m) => {
-      const key = `${m.method} ${m.endpoint}`;
-      if (!acc[key]) acc[key] = { count: 0, avgDuration: 0, errors: 0 };
-      acc[key].count++;
-      acc[key].avgDuration += m.duration;
-      if (m.statusCode >= 400) acc[key].errors++;
-      return acc;
-    }, {} as Record<string, EndpointMetrics>);
-
-    // Calculate averages
-    Object.keys(byEndpoint).forEach(key => {
-      byEndpoint[key].avgDuration /= byEndpoint[key].count;
-    });
-
-    return {
-      total,
-      errors,
-      errorRate: (errors / total) * 100,
-      avgDuration: Math.round(avgDuration),
-      endpoints: Object.keys(byEndpoint).length,
-      topEndpoints: Object.entries(byEndpoint)
-        .sort((a, b) => b[1].count - a[1].count)
-        .slice(0, 5) as Array<[string, EndpointMetrics]>
-    };
-  }
-
-  getMetrics(): RequestMetrics[] {
-    return [...this.metrics];
+  if (statusCode >= 500) {
+    apiLogger.error(message, undefined, fullMetadata);
+  } else if (statusCode >= 400) {
+    apiLogger.warn(message, fullMetadata);
+  } else {
+    apiLogger.info(message, fullMetadata);
   }
 }
-
-// Initialize metrics collector
-const metricsCollector = MetricsCollector.getInstance();
 
 interface MonitoringIngestPayload {
   type: 'api-request';
@@ -211,13 +124,13 @@ function logMonitoringStatus(): void {
   if (status === 'misconfigured') {
     const isProduction = process.env.NODE_ENV === 'production';
     const prefix = isProduction ? '[PRODUCTION WARNING]' : '[WARNING]';
-    loggers.system.warn(
+    systemLogger.warn(
       `${prefix} MONITORING_INGEST_KEY is not configured and MONITORING_INGEST_DISABLED is not set. ` +
       'Monitoring ingest is silently degraded. Set MONITORING_INGEST_KEY to enable monitoring, ' +
       'or set MONITORING_INGEST_DISABLED=true to explicitly opt out.'
     );
   } else if (status === 'disabled') {
-    loggers.system.info('Monitoring ingest explicitly disabled via MONITORING_INGEST_DISABLED=true');
+    systemLogger.info('Monitoring ingest explicitly disabled via MONITORING_INGEST_DISABLED=true');
   }
 }
 
@@ -227,7 +140,7 @@ function queueMonitoringIngest(request: NextRequest, payload: MonitoringIngestPa
   if (status !== 'active') {
     if (status === 'misconfigured' && !hasWarnedMissingIngestKey) {
       hasWarnedMissingIngestKey = true;
-      loggers.system.warn(
+      systemLogger.warn(
         'MONITORING_INGEST_KEY is not configured; monitoring ingest is disabled. ' +
         'Set MONITORING_INGEST_KEY to enable monitoring or MONITORING_INGEST_DISABLED=true to silence this warning.'
       );
@@ -251,13 +164,13 @@ function queueMonitoringIngest(request: NextRequest, payload: MonitoringIngestPa
       cache: 'no-store',
       keepalive: true,
     }).catch((error) => {
-      loggers.performance.debug('Failed to forward monitoring payload', {
+      performanceLogger.debug('Failed to forward monitoring payload', {
         error: (error as Error).message,
         endpoint: payload.endpoint,
       });
     });
   } catch (error) {
-    loggers.performance.debug('Unable to construct monitoring ingest request', {
+    performanceLogger.debug('Unable to construct monitoring ingest request', {
       error: (error as Error).message,
       endpoint: payload.endpoint,
     });
@@ -267,7 +180,7 @@ function queueMonitoringIngest(request: NextRequest, payload: MonitoringIngestPa
 /**
  * Extract user ID from request headers (set by main middleware)
  */
-async function extractUserId(request: NextRequest): Promise<string | undefined> {
+function extractUserId(request: NextRequest): string | undefined {
   const userIdHeader = request.headers.get('x-user-id');
   return userIdHeader ?? undefined;
 }
@@ -345,19 +258,16 @@ export async function monitoringMiddleware(
 
   // Extract context
   const context = extractRequestContext(request);
-  const userId = await extractUserId(request);
+  const userId = extractUserId(request);
   const cleanEndpoint = sanitizeEndpoint(pathname);
   const requestSize = getRequestSize(request);
 
-  // Create request-scoped logger
-  const requestLogger = logger.child({
+  // Log request start
+  apiLogger.info(`Request started: ${context.method} ${context.endpoint}`, {
     requestId,
     userId,
-    ...context
+    ...context,
   });
-
-  // Log request start
-  requestLogger.info(`Request started: ${context.method} ${context.endpoint}`);
 
   try {
     // Execute the request
@@ -367,22 +277,6 @@ export async function monitoringMiddleware(
     const duration = Date.now() - startTime;
     const responseSize = getResponseSize(response);
     const statusCode = response.status;
-
-    // Track metrics
-    metricsCollector.track({
-      endpoint: cleanEndpoint,
-      method: request.method,
-      statusCode,
-      duration,
-      timestamp: startedAt,
-      userId,
-      sessionId: context.sessionId,
-      requestId,
-      ip: context.ip,
-      userAgent: context.userAgent,
-      requestSize,
-      responseSize
-    });
 
     if (pathname.startsWith('/api')) {
       const isServerError = statusCode >= 500;
@@ -397,7 +291,6 @@ export async function monitoringMiddleware(
         requestSize,
         responseSize,
         userId,
-        sessionId: context.sessionId,
         ip: context.ip,
         userAgent: context.userAgent,
         error: isServerError ? `HTTP ${statusCode}` : undefined,
@@ -406,7 +299,7 @@ export async function monitoringMiddleware(
     }
 
     // Log response
-    logResponse(request, statusCode, startTime, {
+    logResponse(context, statusCode, duration, {
       requestId,
       userId,
       requestSize,
@@ -415,9 +308,12 @@ export async function monitoringMiddleware(
 
     // Log slow requests
     if (duration > 1000) {
-      requestLogger.warn(`Slow request detected: ${duration}ms`, {
+      performanceLogger.warn(`Slow request detected: ${duration}ms`, {
         threshold: 1000,
-        actual: duration
+        actual: duration,
+        requestId,
+        userId,
+        ...context,
       });
     }
 
@@ -432,21 +328,6 @@ export async function monitoringMiddleware(
     const errorName = error instanceof Error ? error.name : 'Error';
     const errorStack = error instanceof Error ? error.stack : undefined;
 
-    // Track error metrics
-    metricsCollector.track({
-      endpoint: cleanEndpoint,
-      method: request.method,
-      statusCode: 500,
-      duration,
-      timestamp: startedAt,
-      userId,
-      sessionId: context.sessionId,
-      requestId,
-      ip: context.ip,
-      userAgent: context.userAgent,
-      error: errorMessage
-    });
-
     if (pathname.startsWith('/api')) {
       queueMonitoringIngest(request, {
         type: 'api-request',
@@ -459,7 +340,6 @@ export async function monitoringMiddleware(
         requestSize,
         responseSize: 0,
         userId,
-        sessionId: context.sessionId,
         ip: context.ip,
         userAgent: context.userAgent,
         error: errorMessage,
@@ -469,66 +349,13 @@ export async function monitoringMiddleware(
     }
 
     // Log error
-    requestLogger.error(`Request failed: ${context.method} ${context.endpoint}`, error as Error, {
-      duration,
-      requestId
-    });
+    apiLogger.error(
+      `Request failed: ${context.method} ${context.endpoint}`,
+      error instanceof Error ? error : undefined,
+      { duration, requestId, userId, ...context }
+    );
 
     // Re-throw the error
     throw error;
   }
 }
-
-/**
- * Export metrics for dashboard
- */
-export function getMetricsSummary(): MetricsSummary | { message: string } {
-  const metrics = metricsCollector.getMetrics();
-  
-  if (metrics.length === 0) {
-    return { message: 'No metrics collected yet' };
-  }
-
-  const now = Date.now();
-  const recentMetrics = metrics.filter(m => 
-    now - m.timestamp.getTime() < 300000 // Last 5 minutes
-  );
-
-  const total = recentMetrics.length;
-  
-  if (total === 0) {
-    return { message: 'No recent metrics in the last 5 minutes' };
-  }
-  
-  const errors = recentMetrics.filter(m => m.statusCode >= 400).length;
-  const avgDuration = recentMetrics.reduce((sum, m) => sum + m.duration, 0) / total;
-
-  // Build byEndpoint for topEndpoints
-  const byEndpoint = recentMetrics.reduce((acc, m) => {
-    const key = `${m.method} ${m.endpoint}`;
-    if (!acc[key]) acc[key] = { count: 0, avgDuration: 0, errors: 0 };
-    acc[key].count++;
-    acc[key].avgDuration += m.duration;
-    if (m.statusCode >= 400) acc[key].errors++;
-    return acc;
-  }, {} as Record<string, EndpointMetrics>);
-
-  // Calculate averages
-  Object.keys(byEndpoint).forEach(key => {
-    byEndpoint[key].avgDuration /= byEndpoint[key].count;
-  });
-
-  return {
-    total,
-    errors,
-    errorRate: (errors / total) * 100,
-    avgDuration: Math.round(avgDuration),
-    endpoints: Object.keys(byEndpoint).length,
-    topEndpoints: Object.entries(byEndpoint)
-      .sort((a, b) => b[1].count - a[1].count)
-      .slice(0, 5) as Array<[string, EndpointMetrics]>
-  };
-}
-
-// Export everything
-export { metricsCollector };


### PR DESCRIPTION
## Root cause (prod outage 2026-07-07, rolled back to `sha-da3514c`)

PR #1932 registered `apps/web/src/middleware.ts` for the first time ever, and every request 500'd with `TypeError: Native module not found: @pagespace/lib/logging/logger-config`. Two compounding causes:

1. **Edge externals**: the webpack hook in `next.config.ts` externalized `@pagespace/lib/*` / `@pagespace/db/*` as `commonjs` for *every* `isServer` compile — including the edge-server compile, which has no `require()`. The build passed (externals are never analyzed) and the crash landed at request time.
2. **Node-only import graph**: even bundled, middleware couldn't run on Edge — `monitoring.ts` instantiated a pg-backed `MetricsCollector`, the `@/lib/auth` barrel dragged in db + sessions + permissions to supply three string constants, and the shared logger uses `os.hostname()` + `process.on` + dynamic db imports.

## What moved where

| Concern | Before | After |
|---|---|---|
| Workspace externals | every `isServer` compile | `nextRuntime === 'nodejs'` only (`apps/web/next.config.ts`) |
| Edge Node-import safety | Next only *warns*, crash deferred to runtime | new edge-compile guard fails the **build** on node builtins / pg / `@pagespace/db` |
| Token prefixes | defined in the Node-only `@/lib/auth` barrel | `apps/web/src/lib/auth/token-prefixes.ts` (pure leaf); barrel re-exports it; middleware imports the leaf — **zero barrel imports** |
| Middleware logging | `@pagespace/lib` logger (os/process.on/db) | `apps/web/src/lib/logging/edge-logger.ts` — structured JSON to console, same field names (`timestamp, level, category, message, metadata`) and `logSecurityEvent` event union, so Fly log drains keep parsing |
| API metrics persistence | `MetricsCollector` (setInterval + `db.insert` **from middleware**; never once ran in prod) — **deleted** | fire-and-forget POST to `/api/internal/monitoring/ingest` (kept); that Node route already writes `apiMetrics` + `systemLogs` + `errorLogs` via `writeApiMetrics`/`writeError`, so `monitoring-queries.ts` dashboards get data the moment middleware ships |
| `origin-validation.ts` | imported `@pagespace/lib/logging/logger-config` | edge logger; rest of its graph is `next/server` only |

Preserved byte-for-byte: middleware route allowlists + audit comments (PR #1932), request-id + `X-Response-Time` headers, slow-request warning, error-path re-throw. Non-API page requests are no longer persisted anywhere (they were only ever tracked by the deleted, never-running collector) — accepted per remediation scope.

Note: the ingest route already wrote `apiMetrics` via `writeApiMetrics` (the remediation brief believed it was systemLogs-only); this PR pins that behavior with tests rather than duplicating the insert.

## Verification

**Build proof** (`NODE_ENV=production bun run --filter 'web' build`, dist dirs present → `workspaceDistReady=true`, same as Docker):
- Build green; `ƒ Middleware 109 kB` in output.
- `middleware-manifest.json` → non-empty: `{"/": {name: "src/middleware", files: [...], matchers: 1}}`.
- `grep -c '@pagespace' .next/server/src/middleware.js` → **0**. Only `require()` calls in the bundle are Next's own `node:async_hooks` / `node:buffer` shims (both Edge-supported).

**Negative probe** (done once, then reverted): added `import { logSecurityEvent } from '@pagespace/lib/logging/logger-config'` to middleware.ts →
- *Without* the new guard: Next builds **green** (only warnings; middleware grew to 202 kB) — i.e. the stock toolchain would have shipped this outage again.
- *With* the guard: build **fails**: `Module not found: Edge bundle imports Node-only module '@pagespace/db/db' (via packages/lib/src/logging/logger-database.ts)…` → exit 1.

**Runtime proof** (standalone output: `node apps/web/.next/standalone/apps/web/server.js`):

```
$ curl -si http://127.0.0.1:3111/api/health | head -4
HTTP/1.1 200 OK
content-security-policy: default-src 'none'; frame-ancestors 'none'
permissions-policy: geolocation=(), microphone=(self), camera=(), payment=(self "https://js.stripe.com")
referrer-policy: strict-origin-when-cross-origin
# x-request-id: roib5gjzt61n86l25ohol1is / x-response-time: 1ms — monitoring middleware ran
# body: {"status":"degraded",...,"checks":{"database":"disconnected",...}} (no local DB; expected)

$ curl -si http://127.0.0.1:3111/dashboard   # no cookie
HTTP/1.1 307 Temporary Redirect
location: /auth/signin
# 307 is NextResponse.redirect()'s default status — pre-existing audited behavior, not changed

$ curl -s http://127.0.0.1:3111/api/drives   # allowlisted → passes through to the route
{"error":"Authentication required"}          # the ROUTE's own JSON 401 (middleware let it through)

$ curl -s http://127.0.0.1:3111/api/pages/xyz  # NOT allowlisted → middleware's own 401
Authentication required
```

Edge logger output observed in the server stream:
```
{"timestamp":"2026-07-07T16:13:07.874Z","level":"WARN","category":"security","message":"Security event: unauthorized","metadata":{"pathname":"/dashboard","reason":"No session token","ip":"127.0.0.1"}}
```
and the middleware's monitoring POST **reached the ingest route** (its `apiMetrics` write failed locally only on `ENOTFOUND postgres` — no DB in the test env), proving the middleware → ingest → db chain end-to-end.

**Suites**: `bun run typecheck` ✅ · `bun run lint` ✅ (pre-existing warnings only) · `bun run test:unit`: all middleware/auth/logging/ingest tests green (205 tests across the 15 affected files). Remaining failures are pre-existing/environmental in files this PR doesn't touch: `activity-tools` + `admin-role-version` (`error: role "test" does not exist` — no local PG test role) and `grouping.test.ts` (midnight/timezone-sensitive).

## Review round (commit `ceaa0453a`)

Codex flagged (P2) that the fire-and-forget ingest `fetch` — the only persistence path for API metrics — can be cancelled by the Edge runtime once the response returns. Fixed by threading `NextFetchEvent` through `middleware.ts` → `monitoringMiddleware` → `queueMonitoringIngest` and registering the POST with `event.waitUntil()` on both success and error paths (unit-tested for each).

The same round applied self-review findings from an 8-angle multi-agent pass over the diff:

- **Edge guard hardened to an allowlist inversion** — the hand-listed builtins deny-list missed `crypto` (and anything Node ships next). Now every module in `module.builtinModules` is denied in edge compiles except the five the Edge runtime provides (`buffer`, `events`, `util`, `assert`, `async_hooks`); pg family / `dotenv` / `@pagespace/db` stay denied by name. Clean build re-verified green with the stricter guard (`ƒ Middleware 110 kB`, manifest registered, 0 `@pagespace` refs in the bundle). Re-probed the exact gap: a deliberate `import { createHash } from 'node:crypto'` in middleware.ts now fails the build (`Module not found: Edge bundle imports Node-only module 'node:crypto' (via …/middleware.ts)`), where the deny-list version would have shipped it.
- **Editor-time enforcement** — files-scoped `no-restricted-imports` over the middleware import graph (bans `@pagespace/db`, `@pagespace/lib` except the pure `api-contract-version`, and the `@/lib/auth` barrel), in front of the build-time guard.
- **Edge logger** — re-established the Node logger's sensitive-key redaction (same substring/exact lists), depth-limited walk (doubles as circular-ref protection), stringify try/catch so the logger can never throw a 500 into a request, `context.category` emitted alongside top-level `category` for drain-query parity, `Object.hasOwn` guard on LOG_LEVEL.
- **Drift guards** — a test parses the `SecurityEventName` unions out of both `logger-config.ts` and `edge-logger.ts` sources and fails on divergence (they're duplicated because edge code must not import `@pagespace/lib` and the Node union is an anonymous parameter type); another pins `token-lookup.ts`'s private prefix copies to the leaf. Two more hand-duplicated prefix literals in `auth.ts` / `oauth-repository.ts` now import the `token-prefixes` leaf.
- **Monitoring payload** — success/error ingest payloads share a base object; dropped fields the middleware never populated (`sessionId` etc. were always `undefined`, on master too); static skip-list hoisted off the per-request path.

Reviewed-and-declined (with rationale): sharing `SecurityEventName` via a packages/lib type module (constraint: everything new lives in apps/web; drift test covers it instead); SIEM error-hook fan-out from the edge logger (Node-only mechanism — middleware 5xx errors reach `errorLogs` via the ingest route instead); `metadata.context.*` nesting parity for response logs (middleware never ran in prod, so no existing queries depend on that shape).

## Deploy note — this re-activates middleware for the first time

Merging + deploying turns middleware ON in production for the first time in 10.5 months. Recommend a staged rollout: deploy one machine first, watch `/api/health`, OAuth/CLI login, webhooks (Stripe/Zoom/Google Calendar), and published-site 404 behavior, then roll the rest. **Rollback image: `sha-da3514c`** (the currently-pinned stable image, middleware unregistered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NVwgNC2Phsew2ugpJTKLR
