### PR TITLE
fix(domains): let platform admins register pagespace.ai from the UI

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/__tests__/route.test.ts
@@ -75,7 +75,8 @@ vi.mock('@/lib/canvas/reconcile-cert', () => ({
 
 const DRIVE_ID = 'drive-1';
 const USER_ID = 'user-1';
-const mockAuth = { userId: USER_ID };
+const mockAuth = { userId: USER_ID, role: 'user' };
+const mockPlatformAdminAuth = { userId: USER_ID, role: 'admin' };
 const makeReq = (body?: unknown): Request =>
   ({
     json: () => Promise.resolve(body ?? {}),
@@ -83,25 +84,16 @@ const makeReq = (body?: unknown): Request =>
 const ctx = (driveId = DRIVE_ID) => ({ params: Promise.resolve({ driveId }) });
 
 /**
- * Mock for POST (non-platform-domain path): four sequential dbSelect calls.
- *  1. Platform-admin role lookup: SELECT role FROM users WHERE id
- *  2. Tier lookup (outside transaction): drives JOIN users → [{tier}]
- *  3. Drive row lock (inside transaction): SELECT drives.id FOR UPDATE
- *  4. Count query (inside transaction): SELECT count() FROM customDomains
+ * Mock for POST (non-platform-domain path): three sequential dbSelect calls.
+ *  1. Tier lookup (outside transaction): drives JOIN users -> [{tier}]
+ *  2. Drive row lock (inside transaction): SELECT drives.id FOR UPDATE
+ *  3. Count query (inside transaction): SELECT count() FROM customDomains
  */
-function mockPostSelects({ ownerTier = 'pro', domainCount = 0, role = 'user' } = {}) {
+function mockPostSelects({ ownerTier = 'pro', domainCount = 0 } = {}) {
   let callIndex = 0;
   dbSelect.mockImplementation(() => {
     callIndex++;
     if (callIndex === 1) {
-      // Platform-admin role lookup
-      return {
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockResolvedValue([{ role }]),
-      };
-    }
-    if (callIndex === 2) {
       // Tier lookup
       return {
         from: vi.fn().mockReturnThis(),
@@ -110,7 +102,7 @@ function mockPostSelects({ ownerTier = 'pro', domainCount = 0, role = 'user' } =
         limit: vi.fn().mockResolvedValue([{ tier: ownerTier }]),
       };
     }
-    if (callIndex === 3) {
+    if (callIndex === 2) {
       // Drive row lock: tx.select({id}).from(drives).where().for('update')
       return {
         from: vi.fn().mockReturnThis(),
@@ -126,13 +118,8 @@ function mockPostSelects({ ownerTier = 'pro', domainCount = 0, role = 'user' } =
   });
 }
 
-/** Mock for the platform-owned-domain POST path: a single role-lookup dbSelect call. */
-function mockPlatformAdminSelect() {
-  dbSelect.mockImplementation(() => ({
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockResolvedValue([{ role: 'admin' }]),
-  }));
+function mockPlatformAdmin() {
+  authenticateRequestWithOptions.mockResolvedValue(mockPlatformAdminAuth);
 }
 
 beforeEach(() => {
@@ -140,12 +127,12 @@ beforeEach(() => {
   authenticateRequestWithOptions.mockResolvedValue(mockAuth);
   checkMCPDriveScope.mockReturnValue(null);
   isPrincipalDriveOwnerOrAdmin.mockResolvedValue(true);
-  // Default role lookup: non-admin, so existing behavior is unaffected unless a
-  // test explicitly opts into the platform-admin path.
+  // Default tier lookup.
   dbSelect.mockImplementation(() => ({
     from: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockResolvedValue([{ role: 'user' }]),
+    limit: vi.fn().mockResolvedValue([{ tier: 'pro' }]),
   }));
   mirrorDriveToCustomHost.mockResolvedValue(undefined);
   // Default reconcile: no-op echoing the input status (overridden per-test).
@@ -400,7 +387,7 @@ describe('POST /api/drives/[driveId]/domains', () => {
   });
 
   it('allows a platform admin to register pagespace.ai for a drive they do not own, skipping the tier cap', async () => {
-    mockPlatformAdminSelect();
+    mockPlatformAdmin();
     isPrincipalDriveOwnerOrAdmin.mockResolvedValue(false); // not a drive member — must not matter
     const inserted = { id: 'dom-1', driveId: DRIVE_ID, hostname: 'pagespace.ai', status: 'active', platformOwned: true, createdAt: new Date() };
     const valuesMock = vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([inserted]) });
@@ -419,13 +406,13 @@ describe('POST /api/drives/[driveId]/domains', () => {
   });
 
   it('does not let a platform admin bypass the blocklist for an unrelated pagespace.* host', async () => {
-    mockPlatformAdminSelect();
+    mockPlatformAdmin();
     const res = await POST(makeReq({ hostname: 'evil.pagespace.xyz' }), ctx());
     expect(res.status).toBe(400);
   });
 
   it('audits the platform-owned registration with platformOwned: true', async () => {
-    mockPlatformAdminSelect();
+    mockPlatformAdmin();
     const inserted = { id: 'dom-1', driveId: DRIVE_ID, hostname: 'pagespace.ai', status: 'active', platformOwned: true, createdAt: new Date() };
     dbInsert.mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([inserted]) }) });
 
@@ -449,7 +436,7 @@ describe('POST /api/drives/[driveId]/domains', () => {
   });
 
   it('returns 409 when pagespace.ai is already registered', async () => {
-    mockPlatformAdminSelect();
+    mockPlatformAdmin();
     const uniqueErr = Object.assign(new Error('duplicate key value violates unique constraint'), { code: '23505' });
     dbInsert.mockReturnValue({ values: vi.fn().mockReturnValue({ returning: vi.fn().mockRejectedValue(uniqueErr) }) });
 

--- a/apps/web/src/app/api/drives/[driveId]/domains/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/domains/route.ts
@@ -42,12 +42,6 @@ async function getMaxCustomDomainsForDrive(driveId: string): Promise<number> {
   return getPlan(tier).limits.maxCustomDomains;
 }
 
-/** Platform admin = `users.role === 'admin'` — distinct from drive-level owner/admin membership. */
-async function isPlatformAdmin(userId: string): Promise<boolean> {
-  const [row] = await db.select({ role: users.role }).from(users).where(eq(users.id, userId)).limit(1);
-  return row?.role === 'admin';
-}
-
 export async function GET(
   request: Request,
   context: { params: Promise<{ driveId: string }> },
@@ -113,7 +107,8 @@ export async function POST(
     const scopeError = checkMCPDriveScope(auth, driveId);
     if (scopeError) return scopeError;
 
-    const isAdmin = await isPlatformAdmin(auth.userId);
+    // Platform admin = `users.role === 'admin'` — distinct from drive-level owner/admin membership.
+    const isAdmin = auth.role === 'admin';
     if (!isAdmin && !(await isPrincipalDriveOwnerOrAdmin(auth, driveId))) {
       return NextResponse.json({ error: 'Only drive owners and admins can add custom domains' }, { status: 403 });
     }

--- a/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ChevronLeft, Shield, Globe, Trash2, Plus, RefreshCw, CheckCircle2, XCircle, Lock, Loader2, Star, Image as ImageIcon, FileWarning } from 'lucide-react';
 import Link from 'next/link';
 import { useDriveStore, type Drive } from '@/hooks/useDrive';
+import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 import { fetchWithAuth, del, patch } from '@/lib/auth/auth-fetch';
 import useSWR from 'swr';
@@ -69,6 +70,11 @@ export default function DomainsSettingsPage() {
 
   const drive = drives.find((d) => d.id === driveId);
   const canManage = drive?.isOwned || drive?.role === 'ADMIN';
+  const { user } = useAuth();
+  // Platform admin (users.role === 'admin') — distinct from drive-level admin.
+  // Gates the platform-owned-domain bypass (e.g. registering pagespace.ai),
+  // mirroring the backend's wantsPlatformDomain path.
+  const isPlatformAdmin = user?.role === 'admin';
 
   useEffect(() => {
     if (drive) setNotFoundPageId(drive.notFoundPageId ?? null);
@@ -150,7 +156,7 @@ export default function DomainsSettingsPage() {
 
   const handleAddDomain = async () => {
     const hostname = normalizeHostname(newDomain.trim());
-    const validation = validateCustomDomain(hostname);
+    const validation = validateCustomDomain(hostname, { allowPlatformDomain: isPlatformAdmin });
     if (!validation.valid) {
       toast.error(validation.reason);
       return;
@@ -349,6 +355,7 @@ export default function DomainsSettingsPage() {
         refreshingCertId={refreshingCertId}
         settingPrimaryId={settingPrimaryId}
         verifyReasons={verifyReasons}
+        isPlatformAdmin={isPlatformAdmin}
       />
 
       <UploadableImageSettingCard
@@ -675,15 +682,19 @@ interface CustomDomainsCardProps {
   refreshingCertId: string | null;
   settingPrimaryId: string | null;
   verifyReasons: Record<string, string | undefined>;
+  isPlatformAdmin: boolean;
 }
 
 const EDGE_IPV4 = process.env.NEXT_PUBLIC_PUBLISH_EDGE_IPV4 ?? '';
 const EDGE_IPV6 = process.env.NEXT_PUBLIC_PUBLISH_EDGE_IPV6 ?? '';
 const CNAME_TARGET = process.env.NEXT_PUBLIC_PUBLISH_EDGE_CNAME_TARGET ?? '';
 
-function CustomDomainsCard({ domains, limit, newDomain, onNewDomainChange, onAdd, onRemove, onVerify, onRefreshCert, onSetPrimary, isAdding, removingId, verifyingId, refreshingCertId, settingPrimaryId, verifyReasons }: CustomDomainsCardProps) {
-  const atCap = limit !== null && limit > 0 && domains.length >= limit;
-  const notAvailable = limit === 0;
+function CustomDomainsCard({ domains, limit, newDomain, onNewDomainChange, onAdd, onRemove, onVerify, onRefreshCert, onSetPrimary, isAdding, removingId, verifyingId, refreshingCertId, settingPrimaryId, verifyReasons, isPlatformAdmin }: CustomDomainsCardProps) {
+  // A platform admin keeps the input usable regardless of the drive's plan tier
+  // — the backend's platform-domain path skips the subscription cap, and a
+  // non-platform hostname over cap still gets the server's 403 + toast.
+  const atCap = limit !== null && limit > 0 && domains.length >= limit && !isPlatformAdmin;
+  const notAvailable = limit === 0 && !isPlatformAdmin;
   const addDisabled = isAdding || !newDomain.trim() || atCap || notAvailable;
   // "Make primary" only matters once there's a choice to make between domains.
   const showPrimaryControls = domains.length > 1;


### PR DESCRIPTION
## Problem

PR #1923 added backend support for a platform admin (`users.role === 'admin'`) to register the platform-owned hostname `pagespace.ai` as a custom domain on a drive — aliasing that drive's published Canvas pages onto the app's own domain (e.g. a page published at path `prism` becomes reachable at `pagespace.ai/prism`, the literal example documented at `Caddyfile.fly:267-284` in PageSpace-Deploy). In practice a platform admin still couldn't do it, because the Add Domain UI never let the request reach the backend:

1. **Client-side validator rejected it before any POST fired.** `handleAddDomain` called `validateCustomDomain(hostname)` with no options, so typing `pagespace.ai` produced a local toast error no matter what the backend allows.
2. **The Add-Domain UI disabled itself based on the drive plan's subscription cap**, even though the backend's platform-domain branch (`wantsPlatformDomain`) explicitly skips the tier-cap check. On a free-tier or at-cap drive, `CustomDomainsCard` replaced the input with a "not available" message — there was no way to even type the hostname.
3. **Backend redundancy (cleanup):** the POST handler's `isPlatformAdmin(userId)` helper ran its own DB query for `users.role`, even though `auth.role` is already populated on the `AuthResult` passed into every route handler.

## Changes

**`apps/web/src/app/dashboard/[driveId]/settings/domains/page.tsx`**
- Read `user.role` via the established `useAuth()` hook; `isPlatformAdmin = user?.role === 'admin'` (same pattern the general settings page uses to gate the admin console link).
- `handleAddDomain` now calls `validateCustomDomain(hostname, { allowPlatformDomain: isPlatformAdmin })`.
- `CustomDomainsCard` takes an `isPlatformAdmin` prop and relaxes `atCap`/`notAvailable` only for platform admins, mirroring the backend's cap bypass on the platform-domain path. Non-admin behavior is byte-for-byte unchanged, and a platform admin submitting a *non*-platform hostname on an at-cap/free drive still gets the existing server-side 403 + toast — no enforcement is loosened server-side.

**`apps/web/src/app/api/drives/[driveId]/domains/route.ts`**
- Removed the local `isPlatformAdmin(userId)` helper and its DB query; `POST` reads `auth.role === 'admin'` directly. No other handler logic changes.

Explicitly untouched (out of scope): `isPrincipalDriveOwnerOrAdmin`, `getDriveWithAccess`, `/api/drives`, `/api/drives/[driveId]` — this is scoped to the custom-domains Add Domain flow only, not a general drive-permission change.

## Verification

- `bun run --filter web typecheck` passes.
- `eslint` clean on both changed files.
- Manual check (staged/deployed env with Caddy in front): as a platform admin, add `pagespace.ai` on an owned drive → no client-side rejection, POST returns 201, row appears immediately as Active (platform-owned path skips DNS/cert), and a Canvas page published at `prism` serves at `pagespace.ai/prism`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014twvUQeeKirGEX8utZvPo8