### PR TITLE
fix(cli,web): keys wizard drives-auth + readable list

### DIFF
--- a/apps/web/src/app/api/drives/__tests__/oauth-scope.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/oauth-scope.test.ts
@@ -1,0 +1,169 @@
+/**
+ * GET /api/drives under OAuth credentials (Phase 9 keys wizard fix).
+ *
+ * The `pagespace keys` wizard lists drives with the ambient manage_keys-scoped
+ * OAuth credential minted by `pagespace login` — that credential must see the
+ * owner's full drive list (it belongs to the real user; manage_keys only
+ * self-limits *content* access, not seeing which drives exist to scope a new
+ * key to). A genuine drive-scoped OAuth grant, however, must stay restricted
+ * to exactly its scoped drives — never the empty-allowedDriveIds-means-full-
+ * access default (the Phase 9 Task 1 bug class).
+ *
+ * Uses the REAL isScopedMCPAuth/isScopedOAuthAuth/getScopedDriveMembership
+ * implementations (not mocked) so these fail if the scope dispatch regresses.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '../route';
+import { manageKeysScopedAuthResult, driveScopedOAuthAuthResult } from '@/lib/auth/__tests__/manage-keys-fixture';
+
+vi.mock('@pagespace/lib/services/drive-service', () => ({
+  listAccessibleDrives: vi.fn(),
+  createDrive: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackDriveOperation: vi.fn(),
+}));
+vi.mock('@pagespace/lib/utils/api-utils', () => ({
+  jsonResponse: vi.fn((data, options = {}) => Response.json(data, { status: options.status || 200 })),
+}));
+vi.mock('@/lib/websocket', () => ({
+  broadcastDriveEvent: vi.fn().mockResolvedValue(undefined),
+  createDriveEventPayload: vi.fn((driveId, event, data) => ({ driveId, event, data })),
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: { query: { drives: { findMany: vi.fn() } } },
+}));
+
+// Only stub authentication — isScopedMCPAuth/isScopedOAuthAuth and
+// getScopedDriveMembership run for real.
+vi.mock('@/lib/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/auth')>();
+  return {
+    ...actual,
+    authenticateRequestWithOptions: vi.fn(),
+  };
+});
+
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { listAccessibleDrives } from '@pagespace/lib/services/drive-service';
+import { db } from '@pagespace/db/db';
+import type { DriveWithAccess } from '@pagespace/lib/services/drive-service';
+
+const driveFixture = (overrides: { id: string; name: string; ownerId?: string }) => ({
+  id: overrides.id,
+  name: overrides.name,
+  slug: overrides.name.toLowerCase().replace(/\s+/g, '-'),
+  ownerId: overrides.ownerId ?? 'test-user-id',
+  kind: 'STANDARD' as const,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  isTrashed: false,
+  trashedAt: null,
+  drivePrompt: null,
+  homePageId: null,
+  publishSubdomain: null,
+  publishDefaultOgImageUrl: null,
+  notFoundPageId: null,
+  publishFaviconUrl: null,
+});
+
+describe('GET /api/drives — OAuth credentials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('permits OAuth in the read auth options', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+    vi.mocked(listAccessibleDrives).mockResolvedValue([]);
+
+    const request = new Request('https://example.com/api/drives');
+    await GET(request);
+
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(request, {
+      allow: ['session', 'mcp', 'oauth'],
+      requireCSRF: false,
+    });
+  });
+
+  it('gives a manage_keys-scoped credential the full listAccessibleDrives result', async () => {
+    const drives = [
+      driveFixture({ id: 'drive-a', name: 'Drive A', ownerId: 'user-manage-keys' }),
+      driveFixture({ id: 'drive-b', name: 'Drive B', ownerId: 'someone-else' }),
+    ].map((drive) => ({ ...drive, isOwned: true, role: 'OWNER' as const, lastAccessedAt: null })) satisfies DriveWithAccess[];
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(manageKeysScopedAuthResult());
+    vi.mocked(listAccessibleDrives).mockResolvedValue(drives);
+
+    const request = new Request('https://example.com/api/drives?tokenScopable=true');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listAccessibleDrives).toHaveBeenCalledWith('user-manage-keys', { includeTrash: false, tokenScopable: true });
+    expect(body.map((drive: { id: string }) => drive.id)).toEqual(['drive-a', 'drive-b']);
+    expect(db.query.drives.findMany).not.toHaveBeenCalled();
+  });
+
+  it('gives an account-scoped OAuth credential the full listAccessibleDrives result', async () => {
+    const drives = [
+      driveFixture({ id: 'drive-account', name: 'Account Drive', ownerId: 'user-account' }),
+    ].map((drive) => ({ ...drive, isOwned: true, role: 'OWNER' as const, lastAccessedAt: null })) satisfies DriveWithAccess[];
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(
+      manageKeysScopedAuthResult({
+        userId: 'user-account',
+        tokenId: 'oauth-token-account',
+        scopes: { account: true, offlineAccess: false, drives: new Map(), manageKeys: false },
+      }),
+    );
+    vi.mocked(listAccessibleDrives).mockResolvedValue(drives);
+
+    const request = new Request('https://example.com/api/drives');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listAccessibleDrives).toHaveBeenCalledWith('user-account', { includeTrash: false, tokenScopable: false });
+    expect(body.map((drive: { id: string }) => drive.id)).toEqual(['drive-account']);
+    expect(db.query.drives.findMany).not.toHaveBeenCalled();
+  });
+
+  it('restricts a drive-scoped OAuth credential to exactly its scoped drives — never the full list', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(driveScopedOAuthAuthResult());
+    vi.mocked(db.query.drives.findMany).mockResolvedValue([driveFixture({ id: 'drive-1', name: 'Scoped Drive' })]);
+
+    const request = new Request('https://example.com/api/drives');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(listAccessibleDrives).not.toHaveBeenCalled();
+    expect(db.query.drives.findMany).toHaveBeenCalledTimes(1);
+    expect(body.map((drive: { id: string }) => drive.id)).toEqual(['drive-1']);
+    // Inherit-role scope row owned by the requesting user resolves as OWNER.
+    expect(body[0]).toMatchObject({ id: 'drive-1', role: 'OWNER', isOwned: true });
+  });
+
+  it('presents the scope row explicit role, not the owner relationship, when the grant is downgraded', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(
+      driveScopedOAuthAuthResult({
+        driveScopes: [{ driveId: 'drive-1', role: 'MEMBER', customRoleId: null }],
+      }),
+    );
+    vi.mocked(db.query.drives.findMany).mockResolvedValue([driveFixture({ id: 'drive-1', name: 'Scoped Drive' })]);
+
+    const request = new Request('https://example.com/api/drives');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(body[0]).toMatchObject({ id: 'drive-1', role: 'MEMBER', isOwned: false });
+  });
+});

--- a/apps/web/src/app/api/drives/__tests__/oauth-scope.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/oauth-scope.test.ts
@@ -10,7 +10,8 @@
  * access default (the Phase 9 Task 1 bug class).
  *
  * Uses the REAL isScopedMCPAuth/isScopedOAuthAuth/getScopedDriveMembership
- * implementations (not mocked) so these fail if the scope dispatch regresses.
+ * implementations so these fail if scope dispatch regresses. Only the active
+ * inherited-drive membership check is stubbed at the route boundary.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GET } from '../route';
@@ -43,6 +44,14 @@ vi.mock('@/lib/websocket', () => ({
 vi.mock('@pagespace/db/db', () => ({
   db: { query: { drives: { findMany: vi.fn() } } },
 }));
+vi.mock('@pagespace/lib/permissions/app-permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/permissions/app-permissions')>();
+  return {
+    ...actual,
+    hasAppDriveMembership: vi.fn(),
+    hasScopedDriveMembership: vi.fn(),
+  };
+});
 
 // Only stub authentication — isScopedMCPAuth/isScopedOAuthAuth and
 // getScopedDriveMembership run for real.
@@ -57,6 +66,7 @@ vi.mock('@/lib/auth', async (importOriginal) => {
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { listAccessibleDrives } from '@pagespace/lib/services/drive-service';
 import { db } from '@pagespace/db/db';
+import { hasScopedDriveMembership } from '@pagespace/lib/permissions/app-permissions';
 import type { DriveWithAccess } from '@pagespace/lib/services/drive-service';
 
 const driveFixture = (overrides: { id: string; name: string; ownerId?: string }) => ({
@@ -80,6 +90,7 @@ const driveFixture = (overrides: { id: string; name: string; ownerId?: string })
 describe('GET /api/drives — OAuth credentials', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(hasScopedDriveMembership).mockResolvedValue(true);
   });
 
   it('permits OAuth in the read auth options', async () => {
@@ -150,6 +161,47 @@ describe('GET /api/drives — OAuth credentials', () => {
     expect(body.map((drive: { id: string }) => drive.id)).toEqual(['drive-1']);
     // Inherit-role scope row owned by the requesting user resolves as OWNER.
     expect(body[0]).toMatchObject({ id: 'drive-1', role: 'OWNER', isOwned: true });
+  });
+
+  it('returns no drives for an empty drive-scoped OAuth credential instead of falling back to the full list', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(
+      driveScopedOAuthAuthResult({
+        scopes: { account: false, offlineAccess: false, manageKeys: false, drives: new Map() },
+        driveScopes: [],
+        allowedDriveIds: [],
+      }),
+    );
+    vi.mocked(listAccessibleDrives).mockResolvedValue([
+      { ...driveFixture({ id: 'drive-leak', name: 'Should Not Leak' }), isOwned: true, role: 'OWNER' as const, lastAccessedAt: null },
+    ]);
+
+    const request = new Request('https://example.com/api/drives');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual([]);
+    expect(listAccessibleDrives).not.toHaveBeenCalled();
+    expect(db.query.drives.findMany).not.toHaveBeenCalled();
+  });
+
+  it('filters inherited OAuth drive scopes when the granting user no longer belongs to the drive', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(driveScopedOAuthAuthResult());
+    vi.mocked(db.query.drives.findMany).mockResolvedValue([driveFixture({ id: 'drive-1', name: 'Former Drive', ownerId: 'someone-else' })]);
+    vi.mocked(hasScopedDriveMembership).mockResolvedValue(false);
+
+    const request = new Request('https://example.com/api/drives');
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual([]);
+    expect(listAccessibleDrives).not.toHaveBeenCalled();
+    expect(hasScopedDriveMembership).toHaveBeenCalledWith(
+      [{ driveId: 'drive-1', role: null, customRoleId: null }],
+      'test-user-id',
+      'drive-1',
+    );
   });
 
   it('presents the scope row explicit role, not the owner relationship, when the grant is downgraded', async () => {

--- a/apps/web/src/app/api/drives/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/route.test.ts
@@ -53,11 +53,13 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
   isScopedMCPAuth: vi.fn(() => false), // Session/unscoped fixtures by default
+  isScopedOAuthAuth: vi.fn(() => false),
   checkMCPCreateScope: vi.fn(() => null), // Allow all creates by default
 }));
 
 vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
   getAppDriveMembership: vi.fn(),
+  getScopedDriveMembership: vi.fn(),
 }));
 
 import { listAccessibleDrives, createDrive } from '@pagespace/lib/services/drive-service'
@@ -133,7 +135,7 @@ describe('GET /api/drives', () => {
 
       expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
         request,
-        { allow: ['session', 'mcp'], requireCSRF: false }
+        { allow: ['session', 'mcp', 'oauth'], requireCSRF: false }
       );
     });
   });

--- a/apps/web/src/app/api/drives/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/route.test.ts
@@ -54,12 +54,15 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
   isScopedMCPAuth: vi.fn(() => false), // Session/unscoped fixtures by default
   isScopedOAuthAuth: vi.fn(() => false),
+  isManageKeysOnly: vi.fn(() => false),
   checkMCPCreateScope: vi.fn(() => null), // Allow all creates by default
 }));
 
 vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
   getAppDriveMembership: vi.fn(),
   getScopedDriveMembership: vi.fn(),
+  hasAppDriveMembership: vi.fn(),
+  hasScopedDriveMembership: vi.fn(),
 }));
 
 import { listAccessibleDrives, createDrive } from '@pagespace/lib/services/drive-service'

--- a/apps/web/src/app/api/drives/route.ts
+++ b/apps/web/src/app/api/drives/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { listAccessibleDrives, createDrive, type DriveWithAccess } from '@pagespace/lib/services/drive-service';
 import { isReservedDriveName } from '@pagespace/lib/services/drive-guards';
-import { getAppDriveMembership } from '@pagespace/lib/permissions/app-permissions';
+import { getAppDriveMembership, getScopedDriveMembership } from '@pagespace/lib/permissions/app-permissions';
 import { db } from '@pagespace/db/db';
 import { and, eq, inArray } from '@pagespace/db/operators';
 import { drives as drivesTable } from '@pagespace/db/schema/core';
@@ -10,12 +10,12 @@ import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackDriveOperation } from '@pagespace/lib/monitoring/activity-tracker';
-import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isScopedMCPAuth } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isScopedMCPAuth, isScopedOAuthAuth } from '@/lib/auth';
 import { jsonResponse } from '@pagespace/lib/utils/api-utils';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { safeParseBody } from '@/lib/validation/parse-body';
 
-const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_READ = { allow: ['session', 'mcp', 'oauth'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
 const createDriveSchema = z.object({
@@ -62,6 +62,23 @@ export async function GET(req: Request) {
           };
         })
       );
+    } else if (isScopedOAuthAuth(auth) && auth.allowedDriveIds.length > 0) {
+      const rows = await db.query.drives.findMany({
+        where: includeTrash
+          ? inArray(drivesTable.id, auth.allowedDriveIds)
+          : and(inArray(drivesTable.id, auth.allowedDriveIds), eq(drivesTable.isTrashed, false)),
+      });
+      drives = rows.map((drive) => {
+        const membership = getScopedDriveMembership(auth.driveScopes, drive.id);
+        const role = membership?.role
+          ?? (drive.ownerId === userId ? ('OWNER' as const) : ('MEMBER' as const));
+        return {
+          ...drive,
+          isOwned: membership?.role === null && drive.ownerId === userId,
+          role,
+          lastAccessedAt: null,
+        };
+      });
     } else {
       drives = await listAccessibleDrives(userId, { includeTrash, tokenScopable });
     }

--- a/apps/web/src/app/api/drives/route.ts
+++ b/apps/web/src/app/api/drives/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { listAccessibleDrives, createDrive, type DriveWithAccess } from '@pagespace/lib/services/drive-service';
 import { isReservedDriveName } from '@pagespace/lib/services/drive-guards';
-import { getAppDriveMembership, getScopedDriveMembership } from '@pagespace/lib/permissions/app-permissions';
+import { getAppDriveMembership, getScopedDriveMembership, hasAppDriveMembership, hasScopedDriveMembership } from '@pagespace/lib/permissions/app-permissions';
 import { db } from '@pagespace/db/db';
 import { and, eq, inArray } from '@pagespace/db/operators';
 import { drives as drivesTable } from '@pagespace/db/schema/core';
@@ -10,7 +10,7 @@ import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackDriveOperation } from '@pagespace/lib/monitoring/activity-tracker';
-import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isScopedMCPAuth, isScopedOAuthAuth } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope, isScopedMCPAuth, isScopedOAuthAuth, isManageKeysOnly } from '@/lib/auth';
 import { jsonResponse } from '@pagespace/lib/utils/api-utils';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { safeParseBody } from '@/lib/validation/parse-body';
@@ -18,12 +18,52 @@ import { safeParseBody } from '@/lib/validation/parse-body';
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp', 'oauth'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
+type ScopedDriveMembership = {
+  role: 'OWNER' | 'ADMIN' | 'MEMBER' | null;
+  customRoleId: string | null;
+} | null;
+
 const createDriveSchema = z.object({
   name: z.preprocess(
     (v) => (typeof v === 'string' ? v : ''),
     z.string().min(1, 'Missing name')
   ),
 });
+
+async function listScopedDrivesWithMembership({
+  allowedDriveIds,
+  includeTrash,
+  userId,
+  getMembership,
+}: {
+  allowedDriveIds: string[];
+  includeTrash: boolean;
+  userId: string;
+  getMembership: (driveId: string) => ScopedDriveMembership | Promise<ScopedDriveMembership>;
+}): Promise<DriveWithAccess[]> {
+  const rows = await db.query.drives.findMany({
+    where: includeTrash
+      ? inArray(drivesTable.id, allowedDriveIds)
+      : and(inArray(drivesTable.id, allowedDriveIds), eq(drivesTable.isTrashed, false)),
+  });
+
+  const drives = await Promise.all(
+    rows.map(async (drive): Promise<DriveWithAccess | null> => {
+      const membership = await getMembership(drive.id);
+      if (!membership) return null;
+      const role = membership.role
+        ?? (drive.ownerId === userId ? ('OWNER' as const) : ('MEMBER' as const));
+      return {
+        ...drive,
+        isOwned: membership.role === null && drive.ownerId === userId,
+        role,
+        lastAccessedAt: null,
+      };
+    }),
+  );
+
+  return drives.filter((drive): drive is DriveWithAccess => drive !== null);
+}
 
 export async function GET(req: Request) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS_READ);
@@ -43,42 +83,33 @@ export async function GET(req: Request) {
     if (isScopedMCPAuth(auth)) {
       // A scoped MCP token is its own drive member: list exactly its member
       // drives (with the TOKEN's role), not the owning user's drive universe.
-      const rows = await db.query.drives.findMany({
-        where: includeTrash
-          ? inArray(drivesTable.id, auth.allowedDriveIds)
-          : and(inArray(drivesTable.id, auth.allowedDriveIds), eq(drivesTable.isTrashed, false)),
+      drives = await listScopedDrivesWithMembership({
+        allowedDriveIds: auth.allowedDriveIds,
+        includeTrash,
+        userId,
+        getMembership: async (driveId) => {
+          const membership = await getAppDriveMembership(auth.tokenId, driveId);
+          if (!membership || membership.role !== null) return membership;
+          return (await hasAppDriveMembership(auth.tokenId, driveId)) ? membership : null;
+        },
       });
-      drives = await Promise.all(
-        rows.map(async (drive) => {
-          const membership = await getAppDriveMembership(auth.tokenId, drive.id);
-          // Inherit rows present the owner's own relationship to the drive.
-          const role = membership?.role
-            ?? (drive.ownerId === userId ? ('OWNER' as const) : ('MEMBER' as const));
-          return {
-            ...drive,
-            isOwned: membership?.role === null && drive.ownerId === userId,
-            role,
-            lastAccessedAt: null,
-          };
-        })
-      );
-    } else if (isScopedOAuthAuth(auth) && auth.allowedDriveIds.length > 0) {
-      const rows = await db.query.drives.findMany({
-        where: includeTrash
-          ? inArray(drivesTable.id, auth.allowedDriveIds)
-          : and(inArray(drivesTable.id, auth.allowedDriveIds), eq(drivesTable.isTrashed, false)),
-      });
-      drives = rows.map((drive) => {
-        const membership = getScopedDriveMembership(auth.driveScopes, drive.id);
-        const role = membership?.role
-          ?? (drive.ownerId === userId ? ('OWNER' as const) : ('MEMBER' as const));
-        return {
-          ...drive,
-          isOwned: membership?.role === null && drive.ownerId === userId,
-          role,
-          lastAccessedAt: null,
-        };
-      });
+    } else if (isScopedOAuthAuth(auth)) {
+      if (isManageKeysOnly(auth)) {
+        drives = await listAccessibleDrives(userId, { includeTrash, tokenScopable });
+      } else if (auth.allowedDriveIds.length > 0) {
+        drives = await listScopedDrivesWithMembership({
+          allowedDriveIds: auth.allowedDriveIds,
+          includeTrash,
+          userId,
+          getMembership: async (driveId) => {
+            const membership = getScopedDriveMembership(auth.driveScopes, driveId);
+            if (!membership || membership.role !== null) return membership;
+            return (await hasScopedDriveMembership(auth.driveScopes, auth.userId, driveId)) ? membership : null;
+          },
+        });
+      } else {
+        drives = [];
+      }
     } else {
       drives = await listAccessibleDrives(userId, { includeTrash, tokenScopable });
     }

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -274,6 +274,15 @@ const latestMcpConversationId = (): string | null => {
   return last ? last[0].conversationId : null;
 };
 
+// "The init fetch was called" is NOT enough before firing onStreamComplete:
+// identity only becomes the page-scoped placeholder after the resolve chain
+// flushes (fetch → json → dispatch RESOLVED → re-render). If the callback
+// fires inside that window, isPlaceholderConversationId() is false, the
+// late-joiner branch is skipped, and the sync fetch never starts — under CI
+// load this window is wide enough to hit. Wait for the resolved identity.
+const waitForPlaceholderIdentity = (pageId: string) =>
+  waitFor(() => expect(latestMcpConversationId()).toBe(`${pageId}-default`));
+
 const PAGE_ID = 'page-123';
 const CONV_ID = 'conv-existing-abc';
 const CONVERSATIONS_URL = `/api/ai/page-agents/${PAGE_ID}/conversations`;
@@ -854,6 +863,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
@@ -896,6 +906,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     // The page-scoped placeholder id must not trigger a refresh (nothing persisted yet).
     assert({
@@ -946,6 +957,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
@@ -989,6 +1001,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
@@ -1030,6 +1043,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
@@ -1072,6 +1086,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
@@ -1144,6 +1159,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI from page A' }], conversationId: REAL_CONV_ID }]]),
@@ -1193,6 +1209,7 @@ describe('AiChatView late-joiner conversation sync', () => {
         expected: true,
       });
     });
+    await waitForPlaceholderIdentity(PAGE_ID);
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
       streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),

--- a/packages/cli/src/commands/keys/__tests__/logic.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/logic.test.ts
@@ -130,14 +130,38 @@ const SAMPLE_KEYS: readonly KeySummary[] = [
 ];
 
 describe('renderKeysTable', () => {
-  it('renders one readable line per key, including drive names and last-used', () => {
-    const lines = renderKeysTable(SAMPLE_KEYS);
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toContain('CI bot');
-    expect(lines[0]).toContain('mcp_abcdefghijk');
-    expect(lines[0]).toContain('Engineering');
-    expect(lines[1]).toContain('(unscoped)');
-    expect(lines[1]).toContain('last used 2026-06-15T00:00:00.000Z');
+  it('renders each key as a short vertical block with date-only timestamps, blank-line separated', () => {
+    expect(renderKeysTable(SAMPLE_KEYS)).toEqual([
+      'CI bot  mcp_abcdefghijk',
+      '  scopes: Engineering',
+      '  created 2026-07-01 · last used never',
+      '',
+      'Unscoped key  mcp_zzzzzzzzzzz',
+      '  scopes: (unscoped)',
+      '  created 2026-06-01 · last used 2026-06-15',
+    ]);
+  });
+
+  it('summarizes long drive-scope lists instead of letting them wrap across lines', () => {
+    const manyScopes: KeySummary = {
+      id: 'tok3',
+      name: 'Everything key',
+      tokenPrefix: 'mcp_qqqqqqqqqqq',
+      driveScopes: [
+        { id: 'drv1', name: 'AIDD Agents' },
+        { id: 'drv2', name: 'PageSpace' },
+        { id: 'drv3', name: 'AI Agent Hub' },
+        { id: 'drv4', name: 'Marketing' },
+        { id: 'drv5', name: 'Engineering' },
+      ],
+      createdAt: '2026-04-30T16:15:07.553Z',
+      lastUsed: '2026-07-06T09:00:00.000Z',
+    };
+    expect(renderKeysTable([manyScopes])).toEqual([
+      'Everything key  mcp_qqqqqqqqqqq',
+      '  scopes: AIDD Agents, PageSpace, AI Agent Hub +2 more',
+      '  created 2026-04-30 · last used 2026-07-06',
+    ]);
   });
 
   it('renders a friendly single line when there are no keys', () => {

--- a/packages/cli/src/commands/keys/logic.ts
+++ b/packages/cli/src/commands/keys/logic.ts
@@ -113,16 +113,26 @@ export interface KeySummary {
   readonly lastUsed: string | null;
 }
 
-function formatDriveScopeNames(driveScopes: readonly KeyDriveScope[]): string {
-  return driveScopes.length > 0 ? driveScopes.map((drive) => drive.name).join(', ') : '(unscoped)';
+function formatDateOnly(value: string | null): string {
+  return value?.slice(0, 10) ?? 'never';
 }
 
-/** One readable line per key for the List step's plain terminal output — no table primitive in `@clack/prompts` fits tabular data. */
+function formatDriveScopeNames(driveScopes: readonly KeyDriveScope[]): string {
+  if (driveScopes.length === 0) return '(unscoped)';
+  const visibleNames = driveScopes.slice(0, 3).map((drive) => drive.name);
+  const remaining = driveScopes.length - visibleNames.length;
+  return remaining > 0 ? `${visibleNames.join(', ')} +${remaining} more` : visibleNames.join(', ');
+}
+
+/** Compact vertical blocks fit inside clack.note's bordered width better than one long row per key. */
 export function renderKeysTable(keys: readonly KeySummary[]): readonly string[] {
   if (keys.length === 0) return ['No keys found.'];
-  return keys.map(
-    (key) => `${key.name}  ${key.tokenPrefix}  ${formatDriveScopeNames(key.driveScopes)}  created ${key.createdAt}  last used ${key.lastUsed ?? 'never'}`,
-  );
+  return keys.flatMap((key, index) => [
+    ...(index === 0 ? [] : ['']),
+    `${key.name}  ${key.tokenPrefix}`,
+    `  scopes: ${formatDriveScopeNames(key.driveScopes)}`,
+    `  created ${formatDateOnly(key.createdAt)} · last used ${formatDateOnly(key.lastUsed)}`,
+  ]);
 }
 
 /** Key select options for the Edit/Revoke flows, hinting each key's current drive scopes. */


### PR DESCRIPTION
## Summary
- Allow OAuth credentials on GET /api/drives so pagespace keys Create/Edit can load drives after pagespace login.
- Keep drive-scoped OAuth restricted to auth.allowedDriveIds; manage_keys and account-scoped OAuth use the full user-accessible drive list.
- Render wizard List keys as compact per-key blocks with date-only timestamps and summarized drive scopes.

## Tests
- bun vitest run src/app/api/drives/__tests__/route.test.ts src/app/api/drives/__tests__/oauth-scope.test.ts (apps/web): 33 passed
- bun vitest run src/commands/keys/__tests__/logic.test.ts src/commands/keys/__tests__/wizard.test.ts src/commands/keys/__tests__/list.test.ts (packages/cli): 30 passed
- bun run typecheck (apps/web): passed
- bun run typecheck (packages/cli): passed
- bun run test (packages/cli): 56 files / 891 tests passed
- bun run test (apps/web): failed on pre-existing/local-environment issues outside this change: Postgres role "test" missing in DB-backed auth/activity suites, plus src/lib/messages/__tests__/grouping.test.ts midnight grouping assertion. The touched drives suites passed in the full run.

## Review
- Independent read-only review pass reported no blocking findings for the OAuth drive-scope auth change or CLI rendering change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `GET /api/drives` now supports OAuth-scoped access, returning only the drives a token is allowed to see.
  * Drive results now show more accurate role and ownership details for scoped access.

* **Bug Fixes**
  * OAuth-authenticated drive requests now follow the correct access path instead of falling back to broader results.
  * CLI key listings are now easier to read, with shorter dates and condensed drive scope summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->