### PR TITLE
fix(canvas): valid published-page HTML, code-authored meta wins

### DIFF
--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -562,6 +562,53 @@ describe('extractAndStripOgMeta', () => {
     expect(meta).toEqual({});
     expect(html).toBe('');
   });
+
+  it('extracts a plain <title> and removes the tag from html', () => {
+    const { meta, html } = extractAndStripOgMeta('<title>Author Title</title><p>hi</p>');
+    expect(meta.title).toBe('Author Title');
+    expect(html).not.toContain('<title>');
+    expect(html).toContain('<p>hi</p>');
+  });
+
+  it('extracts a plain <meta name="description"> and removes the tag from html', () => {
+    const { meta, html } = extractAndStripOgMeta('<meta name="description" content="Author description"><p>hi</p>');
+    expect(meta.description).toBe('Author description');
+    expect(html).not.toContain('name="description"');
+    expect(html).toContain('<p>hi</p>');
+  });
+
+  it('extracts a <meta name="description"> when content comes before name', () => {
+    const { meta } = extractAndStripOgMeta('<meta content="Author description" name="description">');
+    expect(meta.description).toBe('Author description');
+  });
+
+  it('extracts title/description from a full standalone document (author wrote a complete HTML page)', () => {
+    const fullDoc =
+      '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">' +
+      '<title>Full Doc Title</title>' +
+      '<meta name="description" content="Full doc description">' +
+      '<meta property="og:site_name" content="Acme">' +
+      '</head><body><nav>hi</nav></body></html>';
+    const { meta, html } = extractAndStripOgMeta(fullDoc);
+    expect(meta.title).toBe('Full Doc Title');
+    expect(meta.description).toBe('Full doc description');
+    expect(html).not.toContain('<title>');
+    expect(html).not.toContain('name="description"');
+    // Structural wrapper tags themselves are untouched here — unwrapping to a
+    // single document happens later, in renderCanvasDocument.
+    expect(html).toContain('<nav>hi</nav>');
+  });
+
+  it('prefers og:title/og:description over a plain <title>/<meta name=description> when both are present', () => {
+    const { meta } = extractAndStripOgMeta(
+      '<title>Plain Title</title><meta name="description" content="Plain description">' +
+        '<meta property="og:title" content="OG Title"><meta property="og:description" content="OG description">'
+    );
+    expect(meta.title).toBe('Plain Title');
+    expect(meta.ogTitle).toBe('OG Title');
+    expect(meta.description).toBe('Plain description');
+    expect(meta.ogDescription).toBe('OG description');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/asset-pipeline.test.ts
@@ -609,6 +609,22 @@ describe('extractAndStripOgMeta', () => {
     expect(meta.description).toBe('Plain description');
     expect(meta.ogDescription).toBe('OG description');
   });
+
+  it('given an inline <svg><title>…</title></svg> icon label, should preserve it verbatim and NOT extract it as the page title', () => {
+    const html = '<p>hi</p><svg role="img"><title>Search icon</title><path d="M1 1"/></svg>';
+    const { meta, html: result } = extractAndStripOgMeta(html);
+    expect(meta.title).toBeUndefined();
+    expect(result).toBe(html);
+  });
+
+  it('given a real top-level <title> alongside an inline SVG with its own <title>, should extract only the page title and leave the SVG untouched', () => {
+    const svg = '<svg role="img"><title>Search icon</title><path d="M1 1"/></svg>';
+    const html = `<title>Page Title</title><p>hi</p>${svg}`;
+    const { meta, html: result } = extractAndStripOgMeta(html);
+    expect(meta.title).toBe('Page Title');
+    expect(result).not.toContain('<title>Page Title</title>');
+    expect(result).toContain(svg);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -490,7 +490,7 @@ describe('publishCanvasPage — SEO overrides', () => {
     expect(renderInput?.title).toBe('Author OG Title');
   });
 
-  it('prefers an explicit title override over the canvas-authored og:title', async () => {
+  it('prefers the canvas-authored og:title over an explicit title override — code wins', async () => {
     setupPage();
     vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
     vi.mocked(extractAndStripOgMeta).mockReturnValueOnce({
@@ -503,7 +503,7 @@ describe('publishCanvasPage — SEO overrides', () => {
     });
 
     const renderInput = vi.mocked(renderPublishedPage).mock.lastCall?.[0];
-    expect(renderInput?.title).toBe('Custom Title');
+    expect(renderInput?.title).toBe('Author OG Title');
   });
 
   it('falls back to the drive default OG image when neither override nor canvas set one', async () => {

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -101,11 +101,26 @@ function stripMetaName(html: string, name: string, assign: (content: string) => 
     });
 }
 
-/** Strip a `<title>…</title>` tag (only valid in `<head>`, so any occurrence is stray content), invoking `assign` with its text. */
+/**
+ * Strip a document-level `<title>…</title>` tag, invoking `assign` with its
+ * text. A `<title>` nested inside an inline `<svg>…</svg>` is valid
+ * accessibility markup (the SVG's accessible name), not page metadata, so it
+ * must be left untouched — both the tag itself and any title text inside it.
+ *
+ * Mirrors the alternation pattern in `extractAndSanitizeStyles`
+ * (packages/lib/src/canvas/render-document.ts): a single regex alternates
+ * between whole `<svg>...</svg>` blocks (consumed first, returned verbatim)
+ * and the `<title>` pattern, acting only on the capture group that matched.
+ */
 function stripTitle(html: string, assign: (content: string) => void): string {
-  return html.replace(/<title(?=[\s/>])[^>]*>([\s\S]*?)<\/title(?=[\s/>])[^>]*>/gi, (_, content: string) => {
-    assign(content);
-    return '';
+  const svgOrTitle =
+    /<svg(?=[\s/>])[^>]*>[\s\S]*?<\/svg(?=[\s/>])[^>]*>|<title(?=[\s/>])[^>]*>([\s\S]*?)<\/title(?=[\s/>])[^>]*>/gi;
+  return html.replace(svgOrTitle, (match, content: string | undefined) => {
+    if (content !== undefined) {
+      assign(content);
+      return '';
+    }
+    return match; // <svg> block — leave verbatim, including any nested <title>
   });
 }
 

--- a/apps/web/src/lib/canvas/asset-pipeline.ts
+++ b/apps/web/src/lib/canvas/asset-pipeline.ts
@@ -38,17 +38,28 @@ export interface OgMeta {
   ogImageUrl?: string;
   ogDescription?: string;
   faviconHref?: string;
+  /** Plain `<title>` the author wrote — a lower-priority fallback behind `ogTitle`. */
+  title?: string;
+  /** Plain `<meta name="description">` the author wrote — a lower-priority fallback behind `ogDescription`. */
+  description?: string;
 }
 
 /**
- * Extract OG/favicon meta from already-rewritten canvas HTML and strip those
- * tags from the body so they can be hoisted into <head> by renderCanvasDocument.
+ * Extract SEO/OG/favicon meta from already-rewritten canvas HTML and strip
+ * those tags from the body so they can be hoisted into <head> by
+ * renderCanvasDocument. This is how code wins: whatever the author wrote
+ * directly in their canvas — whether a small fragment with an inline
+ * `<meta property="og:*">`, or a complete standalone document with its own
+ * `<title>`/`<meta name="description">` — is read here and later takes
+ * precedence over UI-only fallbacks (see `resolvePublishedMeta`).
  *
  * Reads standard HTML semantics the author placed directly in the canvas:
  *   <meta property="og:title"       content="…">  → ogTitle
  *   <meta property="og:image"       content="…">  → ogImageUrl
  *   <meta property="og:description" content="…">  → ogDescription
  *   <link rel="icon" href="…">                    → faviconHref
+ *   <title>…</title>                              → title (fallback behind ogTitle)
+ *   <meta name="description" content="…">         → description (fallback behind ogDescription)
  *
  * After rewriteCanvasAssets has run, any file URLs in those attributes are
  * already public CDN URLs, so no further rewriting is needed here.
@@ -75,6 +86,29 @@ function stripMetaProperty(html: string, property: string, assign: (content: str
     });
 }
 
+/** Same as `stripMetaProperty`, but for `<meta name="{name}" content="…">`. */
+function stripMetaName(html: string, name: string, assign: (content: string) => void): string {
+  const nameFirst = new RegExp(`<meta\\b[^>]+name="${name}"[^>]+content="([^"]*)"[^>]*/?>`, 'gi');
+  const contentFirst = new RegExp(`<meta\\b[^>]+content="([^"]*)"[^>]+name="${name}"[^>]*/?>`, 'gi');
+  return html
+    .replace(nameFirst, (_, content: string) => {
+      assign(content);
+      return '';
+    })
+    .replace(contentFirst, (_, content: string) => {
+      assign(content);
+      return '';
+    });
+}
+
+/** Strip a `<title>…</title>` tag (only valid in `<head>`, so any occurrence is stray content), invoking `assign` with its text. */
+function stripTitle(html: string, assign: (content: string) => void): string {
+  return html.replace(/<title(?=[\s/>])[^>]*>([\s\S]*?)<\/title(?=[\s/>])[^>]*>/gi, (_, content: string) => {
+    assign(content);
+    return '';
+  });
+}
+
 export function extractAndStripOgMeta(html: string): { meta: OgMeta; html: string } {
   const meta: OgMeta = {};
 
@@ -86,6 +120,12 @@ export function extractAndStripOgMeta(html: string): { meta: OgMeta; html: strin
   });
   result = stripMetaProperty(result, 'og:description', (content) => {
     meta.ogDescription ??= content || undefined;
+  });
+  result = stripMetaName(result, 'description', (content) => {
+    meta.description ??= content || undefined;
+  });
+  result = stripTitle(result, (content) => {
+    meta.title ??= content || undefined;
   });
   result = result
     .replace(/<link\b[^>]+rel="icon"[^>]+href="([^"]*)"[^>]*\/?>/gi, (_, href: string) => {

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -252,12 +252,18 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   // to text derived from the page content; robots defaults to indexable.
   const canonicalUrl = isHomePage ? rootUrl : publishedUrl;
   // Resolve the effective metadata through the pure precedence resolver:
-  // per-page override → canvas <meta> → drive default (image) / derived (text).
+  // canvas code → per-page override → drive default (image) / derived (text).
   const resolvedMeta = resolvePublishedMeta({
     override: { title: effectiveTitle, description: effectiveDescription, ogImageUrl: effectiveOgImageUrl },
     noindex: effectiveNoindex,
     pageTitle: page.title,
-    canvasMeta: { ogTitle: meta.ogTitle, ogImageUrl: meta.ogImageUrl, ogDescription: meta.ogDescription },
+    canvasMeta: {
+      ogTitle: meta.ogTitle,
+      ogImageUrl: meta.ogImageUrl,
+      ogDescription: meta.ogDescription,
+      title: meta.title,
+      description: meta.description,
+    },
     driveDefaultOgImageUrl: drive.publishDefaultOgImageUrl,
     body: bodyHtml,
   });
@@ -589,13 +595,13 @@ async function renderNotFoundPageHtml(params: {
     return renderPublishedPage({
       html: bodyHtml,
       // Same precedence as a normal publish (resolvePublishedMeta): the
-      // page's own og:title wins over its internal page title.
-      title: meta.ogTitle || page.title || 'Page not found',
+      // page's own code-authored meta wins over its internal page title.
+      title: meta.ogTitle || meta.title || page.title || 'Page not found',
       assetBaseUrl: getPublishAssetBaseUrl(),
       faviconHref: favicon.faviconHref,
       faviconBaseUrl: favicon.faviconBaseUrl,
       ogImageUrl: meta.ogImageUrl ?? publishDefaultOgImageUrl ?? undefined,
-      description: meta.ogDescription,
+      description: meta.ogDescription || meta.description,
       robots: 'noindex',
       formActionOrigin,
     });

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -709,5 +709,23 @@ describe('renderCanvasDocument — Twitter Card', () => {
       expect(out.match(/<html(?=[\s>])/gi) ?? []).toHaveLength(1);
       expect(out).toContain('<div>fragment</div>');
     });
+
+    it('given a <style> block inside the <head>, should hoist it into the generated <head> (not drop it)', () => {
+      const out = renderCanvasDocument({
+        html:
+          '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="UTF-8">\n<title>Author Title</title>\n' +
+          '<style>body { color: red; }</style>\n</head>\n<body>\n<nav>hi</nav>\n</body>\n</html>',
+      });
+      // Still a single, non-nested document.
+      expect(out.match(/<!doctype html>/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<html(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<head(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<body(?=[\s>])/gi) ?? []).toHaveLength(1);
+      // The author's head <style> rule survives, hoisted into the generated
+      // <head> (same treatment as a body-level <style>) — not silently dropped.
+      const headEnd = out.indexOf('</head>');
+      expect(out.slice(0, headEnd)).toContain('body { color: red; }');
+      expect(out).toContain('<nav>hi</nav>');
+    });
   });
 });

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -674,4 +674,40 @@ describe('renderCanvasDocument — Twitter Card', () => {
     expect(head).toContain('.y');
     expect(out).not.toContain('<style>.y{color:blue}</style>');
   });
+
+  describe('given author html that is already a full standalone document', () => {
+    it('should unwrap it to a single, non-nested document (not double-wrap it)', () => {
+      const out = renderCanvasDocument({
+        html:
+          '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="UTF-8">\n<title>Author Title</title>\n' +
+          '<meta name="description" content="Author description">\n</head>\n<body>\n<nav>hi</nav>\n</body>\n</html>',
+      });
+      // Exactly one doctype/html/head/body — no stray structural tags nested
+      // inside the generated <body>.
+      expect(out.match(/<!doctype html>/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<html(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<head(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<body(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<meta charset/gi) ?? []).toHaveLength(1);
+      // The author's <head> (title/description) is discarded here — it is a
+      // higher-level concern (SEO meta extraction) — but the body content survives.
+      expect(out).toContain('<nav>hi</nav>');
+      expect(out).not.toContain('Author Title');
+    });
+
+    it('given a full document with no explicit <body> tag, should still strip the wrapper', () => {
+      const out = renderCanvasDocument({
+        html: '<!DOCTYPE html><html><head><title>x</title></head><p>orphan</p></html>',
+      });
+      expect(out.match(/<!doctype html>/gi) ?? []).toHaveLength(1);
+      expect(out.match(/<html(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out).toContain('<p>orphan</p>');
+    });
+
+    it('given a bare fragment (the common case), should pass through unchanged', () => {
+      const out = renderCanvasDocument({ html: '<div>fragment</div>' });
+      expect(out.match(/<html(?=[\s>])/gi) ?? []).toHaveLength(1);
+      expect(out).toContain('<div>fragment</div>');
+    });
+  });
 });

--- a/packages/lib/src/canvas/__tests__/resolve-published-meta.test.ts
+++ b/packages/lib/src/canvas/__tests__/resolve-published-meta.test.ts
@@ -38,10 +38,38 @@ describe('resolvePublishedMeta — title', () => {
     expect(meta.title).toBe('Canvas Title');
   });
 
-  it('prefers the override title over the canvas og:title', () => {
+  it('prefers the canvas og:title over the override title — code wins', () => {
     const meta = resolvePublishedMeta({
       override: { title: 'Override' },
       canvasMeta: { ogTitle: 'Canvas Title' },
+      pageTitle: 'Page',
+      body: BODY,
+    });
+    expect(meta.title).toBe('Canvas Title');
+  });
+
+  it('prefers the canvas plain <title> over the override title — code wins', () => {
+    const meta = resolvePublishedMeta({
+      override: { title: 'Override' },
+      canvasMeta: { title: 'Canvas <title>' },
+      pageTitle: 'Page',
+      body: BODY,
+    });
+    expect(meta.title).toBe('Canvas <title>');
+  });
+
+  it('prefers the canvas og:title over the canvas plain <title> when both are set', () => {
+    const meta = resolvePublishedMeta({
+      canvasMeta: { ogTitle: 'OG Title', title: 'Plain Title' },
+      pageTitle: 'Page',
+      body: BODY,
+    });
+    expect(meta.title).toBe('OG Title');
+  });
+
+  it('falls back to the override title when the canvas has no title meta at all', () => {
+    const meta = resolvePublishedMeta({
+      override: { title: 'Override' },
       pageTitle: 'Page',
       body: BODY,
     });
@@ -59,18 +87,9 @@ describe('resolvePublishedMeta — title', () => {
 });
 
 describe('resolvePublishedMeta — ogImageUrl', () => {
-  it('prefers the override image over canvas + drive default', () => {
+  it('prefers the canvas image over the override — code wins', () => {
     const meta = resolvePublishedMeta({
       override: { ogImageUrl: 'https://o.example/o.png' },
-      canvasMeta: { ogImageUrl: 'https://c.example/c.png' },
-      driveDefaultOgImageUrl: 'https://d.example/d.png',
-      body: BODY,
-    });
-    expect(meta.ogImageUrl).toBe('https://o.example/o.png');
-  });
-
-  it('falls back to the canvas image when no override', () => {
-    const meta = resolvePublishedMeta({
       canvasMeta: { ogImageUrl: 'https://c.example/c.png' },
       driveDefaultOgImageUrl: 'https://d.example/d.png',
       body: BODY,
@@ -78,7 +97,16 @@ describe('resolvePublishedMeta — ogImageUrl', () => {
     expect(meta.ogImageUrl).toBe('https://c.example/c.png');
   });
 
-  it('falls back to the drive default when neither override nor canvas set one', () => {
+  it('falls back to the override image when the canvas sets none', () => {
+    const meta = resolvePublishedMeta({
+      override: { ogImageUrl: 'https://o.example/o.png' },
+      driveDefaultOgImageUrl: 'https://d.example/d.png',
+      body: BODY,
+    });
+    expect(meta.ogImageUrl).toBe('https://o.example/o.png');
+  });
+
+  it('falls back to the drive default when neither canvas nor override set one', () => {
     const meta = resolvePublishedMeta({
       driveDefaultOgImageUrl: 'https://d.example/d.png',
       body: BODY,
@@ -102,21 +130,38 @@ describe('resolvePublishedMeta — ogImageUrl', () => {
 });
 
 describe('resolvePublishedMeta — description', () => {
-  it('prefers the override description over canvas + derived', () => {
+  it('prefers the canvas og:description over the override — code wins', () => {
     const meta = resolvePublishedMeta({
       override: { description: 'Author blurb' },
       canvasMeta: { ogDescription: 'Canvas blurb' },
       body: BODY,
     });
-    expect(meta.description).toBe('Author blurb');
+    expect(meta.description).toBe('Canvas blurb');
   });
 
-  it('falls back to the canvas og:description when no override', () => {
+  it('prefers the canvas plain meta description over the override — code wins', () => {
     const meta = resolvePublishedMeta({
-      canvasMeta: { ogDescription: 'Canvas blurb' },
+      override: { description: 'Author blurb' },
+      canvasMeta: { description: 'Canvas plain description' },
       body: BODY,
     });
-    expect(meta.description).toBe('Canvas blurb');
+    expect(meta.description).toBe('Canvas plain description');
+  });
+
+  it('prefers the canvas og:description over the canvas plain description when both are set', () => {
+    const meta = resolvePublishedMeta({
+      canvasMeta: { ogDescription: 'OG blurb', description: 'Plain blurb' },
+      body: BODY,
+    });
+    expect(meta.description).toBe('OG blurb');
+  });
+
+  it('falls back to the override description when the canvas sets none', () => {
+    const meta = resolvePublishedMeta({
+      override: { description: 'Author blurb' },
+      body: BODY,
+    });
+    expect(meta.description).toBe('Author blurb');
   });
 
   it('falls back to a description derived from the body when nothing else is set', () => {

--- a/packages/lib/src/canvas/__tests__/sanitize-css.test.ts
+++ b/packages/lib/src/canvas/__tests__/sanitize-css.test.ts
@@ -95,6 +95,18 @@ describe('sanitizeCSS', () => {
       expect(result.toLowerCase()).not.toContain('behavior:')
       expect(result).toContain('/* behavior blocked */')
     })
+
+    it('given scroll-behavior: smooth, should NOT corrupt it as a blocked behavior', () => {
+      const result = sanitizeCSS('html { scroll-behavior: smooth; }')
+      expect(result).toContain('scroll-behavior: smooth')
+      expect(result).not.toContain('/* behavior blocked */')
+    })
+
+    it('given overscroll-behavior: contain, should NOT corrupt it as a blocked behavior', () => {
+      const result = sanitizeCSS('.x { overscroll-behavior: contain; }')
+      expect(result).toContain('overscroll-behavior: contain')
+      expect(result).not.toContain('/* behavior blocked */')
+    })
   })
 
   describe('blocks external resource loading', () => {

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -159,19 +159,28 @@ export { escapeHtml };
  * to the pipeline overall — SEO/social meta from within it is extracted at a
  * higher level (see `extractAndStripOgMeta` in the publish pipeline) before
  * this function ever runs; this pure renderer only cares about structure.
+ * Any `<style>` blocks in that discarded `<head>` ARE preserved, though —
+ * they're the normal place authors put page CSS, and dropping them would
+ * silently blank out the page's styling. They're prepended to the returned
+ * markup so they flow into `extractAndSanitizeStyles` below exactly like a
+ * body-level `<style>` tag: sanitized and hoisted into the generated `<head>`.
  */
 function unwrapFullDocument(html: string): string {
   if (!/<html(?=[\s/>])/i.test(html)) return html;
 
+  const headMatch = html.match(/<head(?=[\s/>])[^>]*>([\s\S]*?)<\/head(?=[\s/>])[^>]*>/i);
+  const headStyles = headMatch ? (headMatch[1].match(/<style(?=[\s/>])[^>]*>[\s\S]*?<\/style(?=[\s/>])[^>]*>/gi) ?? []).join('\n') : '';
+
   const bodyMatch = html.match(/<body(?=[\s/>])[^>]*>([\s\S]*)<\/body(?=[\s/>])[^>]*>/i);
-  if (bodyMatch) return bodyMatch[1];
+  if (bodyMatch) return headStyles + bodyMatch[1];
 
   // No explicit <body> tag (malformed/partial document) — best-effort: strip
   // the doctype/html/head wrapper and keep whatever's left.
-  return html
+  const stripped = html
     .replace(/<!doctype[^>]*>/gi, '')
     .replace(/<\/?html(?=[\s/>])[^>]*>/gi, '')
     .replace(/<head(?=[\s/>])[^>]*>[\s\S]*?<\/head(?=[\s/>])[^>]*>/gi, '');
+  return headStyles + stripped;
 }
 
 function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[]): { css: string; body: string } {

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -145,6 +145,35 @@ export { escapeHtml };
  * source (e.g. a web-component template literal) is never mistaken for a real
  * stylesheet — the script is preserved verbatim.
  */
+/**
+ * If `html` is already a complete standalone document (its own `<html>`
+ * wrapper — e.g. author code that wrote a full page, or content pasted from
+ * elsewhere) unwrap it to just the `<body>` element's inner markup. Without
+ * this, the caller's own generated `<head>`/`<body>` shell (built below) gets
+ * assembled AROUND an existing one, doubling every structural tag (doctype,
+ * html, head, body) and failing HTML validation. Bare fragments — the common
+ * case — pass through unchanged, detected by the absence of an `<html>` tag.
+ *
+ * Regex-based so it runs identically in Node and the browser, matching the
+ * rest of this module. The discarded `<head>` (title/meta/etc.) is not lost
+ * to the pipeline overall — SEO/social meta from within it is extracted at a
+ * higher level (see `extractAndStripOgMeta` in the publish pipeline) before
+ * this function ever runs; this pure renderer only cares about structure.
+ */
+function unwrapFullDocument(html: string): string {
+  if (!/<html(?=[\s/>])/i.test(html)) return html;
+
+  const bodyMatch = html.match(/<body(?=[\s/>])[^>]*>([\s\S]*)<\/body(?=[\s/>])[^>]*>/i);
+  if (bodyMatch) return bodyMatch[1];
+
+  // No explicit <body> tag (malformed/partial document) — best-effort: strip
+  // the doctype/html/head wrapper and keep whatever's left.
+  return html
+    .replace(/<!doctype[^>]*>/gi, '')
+    .replace(/<\/?html(?=[\s/>])[^>]*>/gi, '')
+    .replace(/<head(?=[\s/>])[^>]*>[\s\S]*?<\/head(?=[\s/>])[^>]*>/gi, '');
+}
+
 function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[]): { css: string; body: string } {
   // Tag names require a genuine delimiter — whitespace, `/`, or `>` — immediately
   // after the name (the `(?=[\s/>])` lookahead), mirroring the HTML tokenizer.
@@ -174,7 +203,7 @@ export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
   const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin } = input;
   const csp = buildBaselineCsp(formActionOrigin);
 
-  const { css, body } = extractAndSanitizeStyles(html ?? '', allowedAssetHosts);
+  const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts);
   const rawTitle = title && title.trim() ? title : 'Untitled';
   const safeTitle = escapeHtml(rawTitle);
   const safeLang = escapeHtml(lang && lang.trim() ? lang : 'en');

--- a/packages/lib/src/canvas/resolve-published-meta.ts
+++ b/packages/lib/src/canvas/resolve-published-meta.ts
@@ -1,23 +1,26 @@
 import { deriveDescription } from './render-document';
 
 /**
- * Author-supplied per-page SEO overrides for a published canvas page. Each field
- * is optional and may be null/empty (treated as "no override"). These map to the
- * persisted `published_pages.publish_*` columns and the publish dialog's inputs.
+ * Author-supplied per-page SEO overrides for a published canvas page, set via
+ * the publish dialog. Each field is optional and may be null/empty (treated as
+ * "no override"). These map to the persisted `published_pages.publish_*`
+ * columns. They only take effect when the canvas code itself doesn't already
+ * set the equivalent meta — code wins (see {@link resolvePublishedMeta}).
  */
 export interface PublishedMetaOverride {
-  /** Overrides the document `<title>` / `og:title`. Blank → fall back to page title. */
+  /** Used when the canvas code sets no `<title>`/`og:title`. Blank → fall back to page title. */
   title?: string | null;
-  /** Overrides the meta + social description. Blank → fall back to canvas/derived. */
+  /** Used when the canvas code sets no description meta. Blank → fall back to derived text. */
   description?: string | null;
-  /** Overrides the social preview image URL. Blank → fall back to canvas/drive default. */
+  /** Used when the canvas code sets no `og:image`. Blank → fall back to the drive default. */
   ogImageUrl?: string | null;
 }
 
 /**
- * Inputs to {@link resolvePublishedMeta}. The override is the highest-priority
- * source; the canvas-extracted meta and the drive default are progressively
- * lower fallbacks; `body` is the last resort for the description.
+ * Inputs to {@link resolvePublishedMeta}. `canvasMeta` (what the author wrote
+ * in code) is the highest-priority source; `override` (the publish dialog) and
+ * the drive default are progressively lower fallbacks; `body` is the last
+ * resort for the description.
  */
 export interface ResolvePublishedMetaInput {
   /** Author overrides (per-page). Highest priority. */
@@ -26,8 +29,19 @@ export interface ResolvePublishedMetaInput {
   noindex?: boolean;
   /** The live page title, used when no title override is set. */
   pageTitle?: string | null;
-  /** OG meta the author embedded in the canvas (`<meta property="og:*">`). */
-  canvasMeta?: { ogTitle?: string | null; ogImageUrl?: string | null; ogDescription?: string | null } | null;
+  /**
+   * Meta the author embedded directly in the canvas code — either `og:*`
+   * properties or plain `<title>`/`<meta name="description">`. This is
+   * authoritative: code wins over the publish dialog's UI override fields
+   * (see the precedence note on {@link resolvePublishedMeta}).
+   */
+  canvasMeta?: {
+    ogTitle?: string | null;
+    ogImageUrl?: string | null;
+    ogDescription?: string | null;
+    title?: string | null;
+    description?: string | null;
+  } | null;
   /** Drive-level default share image, used when neither override nor canvas set one. */
   driveDefaultOgImageUrl?: string | null;
   /** Rendered page body, used to derive a description when nothing else supplies one. */
@@ -55,11 +69,14 @@ function clean(value: string | null | undefined): string | undefined {
 
 /**
  * Resolve the effective SEO metadata for a published canvas page from the layered
- * sources, applying a fixed precedence:
+ * sources, applying a fixed precedence. Meta the author wrote directly in the
+ * canvas code is authoritative — the publish dialog's UI override fields are a
+ * fallback for when the author hasn't set something in code, not a forced
+ * override:
  *
- *   title       = override.title          → canvasMeta.ogTitle       → pageTitle
- *   ogImageUrl  = override.ogImageUrl      → canvasMeta.ogImageUrl    → driveDefaultOgImageUrl
- *   description = override.description      → canvasMeta.ogDescription → deriveDescription(body)
+ *   title       = canvasMeta.ogTitle       → canvasMeta.title       → override.title       → pageTitle
+ *   ogImageUrl  = canvasMeta.ogImageUrl    → override.ogImageUrl    → driveDefaultOgImageUrl
+ *   description = canvasMeta.ogDescription → canvasMeta.description → override.description → deriveDescription(body)
  *   robots      = noindex ? 'noindex' : 'index, follow'
  *
  * Pure: no I/O, no env reads. The publish service is a thin shell over this.
@@ -67,16 +84,18 @@ function clean(value: string | null | undefined): string | undefined {
 export function resolvePublishedMeta(input: ResolvePublishedMetaInput): ResolvedPublishedMeta {
   const { override, noindex, pageTitle, canvasMeta, driveDefaultOgImageUrl, body } = input;
 
-  const title = clean(override?.title) ?? clean(canvasMeta?.ogTitle) ?? clean(pageTitle);
+  const title =
+    clean(canvasMeta?.ogTitle) ?? clean(canvasMeta?.title) ?? clean(override?.title) ?? clean(pageTitle);
 
   const ogImageUrl =
-    clean(override?.ogImageUrl) ??
     clean(canvasMeta?.ogImageUrl) ??
+    clean(override?.ogImageUrl) ??
     clean(driveDefaultOgImageUrl);
 
   const description =
-    clean(override?.description) ??
     clean(canvasMeta?.ogDescription) ??
+    clean(canvasMeta?.description) ??
+    clean(override?.description) ??
     deriveDescription(body);
 
   return {

--- a/packages/lib/src/canvas/sanitize-css.ts
+++ b/packages/lib/src/canvas/sanitize-css.ts
@@ -35,7 +35,7 @@ export function sanitizeCSS(css: string, opts?: { allowedHttpsHosts?: string[] }
     .replace(/javascript\s*:/gi, '/* javascript blocked */')
     .replace(/vbscript\s*:/gi, '/* vbscript blocked */')
     .replace(/data\s*:\s*text\/html/gi, '/* data:text/html blocked */')
-    .replace(/behavior\s*:/gi, '/* behavior blocked */');
+    .replace(/(?<![a-zA-Z-])behavior\s*:/gi, '/* behavior blocked */');
 
   // Block external @import statements (prevent external stylesheet loading)
   sanitized = sanitized


### PR DESCRIPTION
## Summary

Fixes PageSpace issue `x2gc9xa07li1hfsocs8eyobb` — published Canvas pages (e.g. paralleldrive.com) fail W3C Nu HTML validation, breaking OG/social unfurls and SEO. Reported URGENT by Eric Elliott.

Two independent, confirmed root causes:

- **CSS sanitizer bug**: `sanitizeCSS`'s `behavior:` blocklist regex (`packages/lib/src/canvas/sanitize-css.ts`) wasn't word-bounded, so it also matched inside `scroll-behavior:`/`overscroll-behavior:`, corrupting valid CSS into a parse error (`scroll-/* behavior blocked */smooth`).
- **Full HTML documents weren't handled as first-class Canvas input**: a Canvas page authored as a complete standalone document (its own doctype/html/head/body) got double-wrapped by `renderCanvasDocument`, which always assumed a body-only fragment. Result: stray doctype/html/head/body tags, duplicate charset/description meta, a `<title>` illegally nested inside `<body>` — accounting for nearly every validator error.

A secondary problem: even when the author *did* embed meta in their code, the pipeline discarded or under-prioritized it — only `og:*` tags were extracted (never a plain `<title>`/`<meta name="description">`), and the publish dialog's UI override fields ranked above code-authored meta rather than below it.

## Changes

- Word-bound the `behavior:` regex in `sanitize-css.ts`.
- Added a structural unwrap step in `renderCanvasDocument` (`packages/lib/src/canvas/render-document.ts`) so a full-document input is flattened to its `<body>` content before the single generated shell is built — shared by both the publish path and the in-app iframe preview.
- Extended `extractAndStripOgMeta` (`apps/web/src/lib/canvas/asset-pipeline.ts`) to also extract a plain `<title>`/`<meta name="description">`, not just `og:*` tags.
- Flipped `resolvePublishedMeta`'s precedence (`packages/lib/src/canvas/resolve-published-meta.ts`) so code-authored meta wins over the publish dialog's UI override for title, description, and image — the UI fields are now a fallback for when the author hasn't set something in code, not a forced override.

## Test plan

- [x] `bun test`/`vitest` across the touched suites (sanitize-css, render-document, asset-pipeline, resolve-published-meta, publish-page) — 351 tests passing, including new regression coverage for both bugs.
- [x] `bun run typecheck` clean on `packages/lib` and `apps/web`.
- [x] Re-ran the actual captured paralleldrive.com HTML through the fixed pipeline and re-submitted to the W3C Nu validator API directly: **0 errors**, down from ~24.
- [ ] After merge/deploy: republish paralleldrive.com (and spot-check other full-HTML-document Canvas pages) — the live artifact is pre-rendered in CDN storage and won't self-heal from this code change alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MqTjB39zjkrFNLtgUJDhX