### PR TITLE
fix(admin): decrypt PII in users, audit-logs, and monitoring routes

### DIFF
--- a/apps/admin/src/app/api/admin/audit-logs/export/__tests__/pii-decrypt.test.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/export/__tests__/pii-decrypt.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * PII decryption coverage for the audit-logs CSV export stream.
+ *
+ * activityLogs.actorEmail/actorDisplayName are denormalized actor snapshots,
+ * distinct from the joined users.name/users.email columns. A ~4-hour
+ * production gap (before the actor-info decrypt-before-write fix landed)
+ * could have written raw ciphertext into these two columns for
+ * `code_execution` rows, and there is no backfill for `activityLogs`. The
+ * export route must decrypt actorEmail/actorDisplayName the same
+ * plaintext-safe way it already decrypts the joined userName/userEmail
+ * columns, so any surviving ciphertext never reaches the CSV.
+ */
+
+const { mockVerifyAdminAuth } = vi.hoisted(() => ({
+  mockVerifyAdminAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  verifyAdminAuth: mockVerifyAdminAuth,
+  isAdminAuthError: (result: unknown) => result instanceof Response,
+  withAdminAuth: <T>(handler: (user: unknown, request: Request, context: T) => Promise<Response>) => {
+    return async (request: Request, context: T): Promise<Response> => {
+      const resolved = await mockVerifyAdminAuth(request);
+      if (resolved instanceof Response) return resolved;
+      return handler(resolved, request, context);
+    };
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    security: { warn: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+// Wrap (not replace) the real decryptFieldValuesOnce so batching can be
+// asserted at the route's call boundary, matching the pattern used for the
+// sibling non-export audit-logs route's PII-decrypt coverage.
+vi.mock('@pagespace/lib/encryption/field-crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@pagespace/lib/encryption/field-crypto')>();
+  return { ...actual, decryptFieldValuesOnce: vi.fn(actual.decryptFieldValuesOnce) };
+});
+
+const { fixtureRows } = vi.hoisted(() => ({
+  fixtureRows: [] as Record<string, unknown>[],
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => ({
+            orderBy: () => ({
+              limit: () => ({
+                offset: (n: number) => Promise.resolve(n === 0 ? fixtureRows : []),
+              }),
+            }),
+          }),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ type: 'eq', col, val })),
+  and: vi.fn((...conditions: unknown[]) => ({ type: 'and', conditions })),
+  desc: vi.fn((col: unknown) => ({ type: 'desc', col })),
+  gte: vi.fn((col: unknown, val: unknown) => ({ type: 'gte', col, val })),
+  lte: vi.fn((col: unknown, val: unknown) => ({ type: 'lte', col, val })),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({ type: 'sql', strings, values }),
+    {},
+  ),
+}));
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id', name: 'name', email: 'email' },
+}));
+
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  activityLogs: {
+    id: 'id',
+    timestamp: 'timestamp',
+    userId: 'userId',
+    actorEmail: 'actorEmail',
+    actorDisplayName: 'actorDisplayName',
+    isAiGenerated: 'isAiGenerated',
+    aiProvider: 'aiProvider',
+    aiModel: 'aiModel',
+    aiConversationId: 'aiConversationId',
+    operation: { enumValues: ['create', 'update', 'delete', 'code_execution'] },
+    resourceType: { enumValues: ['page', 'drive', 'user'] },
+    resourceId: 'resourceId',
+    resourceTitle: 'resourceTitle',
+    driveId: 'driveId',
+    pageId: 'pageId',
+    updatedFields: 'updatedFields',
+    previousValues: 'previousValues',
+    newValues: 'newValues',
+    metadata: 'metadata',
+    isArchived: 'isArchived',
+    previousLogHash: 'previousLogHash',
+    logHash: 'logHash',
+    chainSeed: 'chainSeed',
+  },
+}));
+
+import { GET } from '../route';
+import { decryptFieldValuesOnce, encryptField } from '@pagespace/lib/encryption/field-crypto';
+
+const mockAdminUser = {
+  id: 'admin-user-id',
+  role: 'admin' as const,
+  tokenVersion: 1,
+  adminRoleVersion: 1,
+};
+
+async function readAllText(response: Response): Promise<string> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let text = '';
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  return text;
+}
+
+describe('GET /api/admin/audit-logs/export — actor snapshot PII decryption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyAdminAuth.mockResolvedValue(mockAdminUser);
+    fixtureRows.length = 0;
+  });
+
+  it('decrypts a ciphertext actorEmail/actorDisplayName snapshot before writing the CSV row', async () => {
+    // Simulates a `code_execution` row written during the historical gap
+    // where the realtime writer stored the raw actor snapshot pre-encrypt.
+    const encryptedEmail = await encryptField('actor@example.com');
+    const encryptedName = await encryptField('Real Actor');
+
+    fixtureRows.push({
+      id: 'log-1',
+      timestamp: new Date('2024-01-10T00:00:00.000Z'),
+      userId: 'user-1',
+      actorEmail: encryptedEmail,
+      actorDisplayName: encryptedName,
+      isAiGenerated: false,
+      aiProvider: null,
+      aiModel: null,
+      aiConversationId: null,
+      operation: 'code_execution',
+      resourceType: 'page',
+      resourceId: 'res-1',
+      resourceTitle: 'Some Page',
+      driveId: 'drive-1',
+      pageId: 'page-1',
+      updatedFields: null,
+      previousValues: null,
+      newValues: null,
+      metadata: null,
+      isArchived: false,
+      previousLogHash: null,
+      logHash: 'hash-1',
+      chainSeed: null,
+      userName: null,
+      userEmail: null,
+    });
+
+    const request = new Request('http://localhost/api/admin/audit-logs/export', { method: 'GET' });
+    const response = await GET(request);
+    const csv = await readAllText(response);
+
+    const [headerLine, dataLine] = csv.trim().split('\n');
+    const headers = headerLine.split(',');
+    const cells = dataLine.split(',');
+    const actorEmailIdx = headers.indexOf('actorEmail');
+    const actorDisplayNameIdx = headers.indexOf('actorDisplayName');
+
+    // The raw ciphertext must never reach the exported CSV row.
+    expect(cells[actorEmailIdx]).toBe('actor@example.com');
+    expect(cells[actorDisplayNameIdx]).toBe('Real Actor');
+    expect(cells[actorEmailIdx]).not.toBe(encryptedEmail);
+    expect(cells[actorDisplayNameIdx]).not.toBe(encryptedName);
+  });
+
+  it('batches actorEmail/actorDisplayName decryption together with userEmail/userName per page', async () => {
+    const encryptedEmail = await encryptField('shared-actor@example.com');
+    const encryptedName = await encryptField('Shared Actor');
+
+    fixtureRows.push(
+      {
+        id: 'log-1',
+        timestamp: new Date('2024-01-10T00:00:00.000Z'),
+        userId: 'user-1',
+        actorEmail: encryptedEmail,
+        actorDisplayName: encryptedName,
+        isAiGenerated: false,
+        aiProvider: null,
+        aiModel: null,
+        aiConversationId: null,
+        operation: 'code_execution',
+        resourceType: 'page',
+        resourceId: 'res-1',
+        resourceTitle: 'Some Page',
+        driveId: 'drive-1',
+        pageId: 'page-1',
+        updatedFields: null,
+        previousValues: null,
+        newValues: null,
+        metadata: null,
+        isArchived: false,
+        previousLogHash: null,
+        logHash: 'hash-1',
+        chainSeed: null,
+        userName: encryptedName,
+        userEmail: encryptedEmail,
+      },
+    );
+
+    const request = new Request('http://localhost/api/admin/audit-logs/export', { method: 'GET' });
+    const response = await GET(request);
+    await readAllText(response);
+
+    // Same repeated ciphertext across the joined and snapshot columns should
+    // be included in the same batched decrypt call (dedup handles repeats),
+    // not one decryptField call per row/column.
+    const emailBatch = vi
+      .mocked(decryptFieldValuesOnce)
+      .mock.calls.filter(([values]) => values.includes(encryptedEmail));
+    const nameBatch = vi
+      .mocked(decryptFieldValuesOnce)
+      .mock.calls.filter(([values]) => values.includes(encryptedName));
+
+    expect(emailBatch).toHaveLength(1);
+    expect(emailBatch[0][0].filter((v) => v === encryptedEmail)).toHaveLength(2);
+    expect(nameBatch).toHaveLength(1);
+    expect(nameBatch[0][0].filter((v) => v === encryptedName)).toHaveLength(2);
+  });
+});

--- a/apps/admin/src/app/api/admin/audit-logs/export/route.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/export/route.ts
@@ -3,6 +3,7 @@ import { eq, and, desc, gte, lte, sql } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { activityLogs } from '@pagespace/db/schema/monitoring';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { decryptFieldValuesOnce } from '@pagespace/lib/encryption/field-crypto';
 import { withAdminAuth } from '@/lib/auth';
 import { format } from 'date-fns';
 
@@ -211,9 +212,17 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
               .limit(BATCH_SIZE)
               .offset(offset);
 
+            // users.name/email are encrypted at rest; decrypt the joined columns before writing.
+            const decryptUserName = await decryptFieldValuesOnce(logs.map((log) => log.userName));
+            const decryptUserEmail = await decryptFieldValuesOnce(logs.map((log) => log.userEmail));
+
             // Write each log as a CSV row
             for (const log of logs) {
-              const row = logToCSVRow(log as Record<string, unknown>);
+              const row = logToCSVRow({
+                ...log,
+                userName: decryptUserName(log.userName),
+                userEmail: decryptUserEmail(log.userEmail),
+              } as Record<string, unknown>);
               controller.enqueue(encoder.encode(row + '\n'));
             }
 

--- a/apps/admin/src/app/api/admin/audit-logs/export/route.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/export/route.ts
@@ -212,16 +212,28 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
               .limit(BATCH_SIZE)
               .offset(offset);
 
-            // users.name/email are encrypted at rest; decrypt the joined columns before writing.
-            const decryptUserName = await decryptFieldValuesOnce(logs.map((log) => log.userName));
-            const decryptUserEmail = await decryptFieldValuesOnce(logs.map((log) => log.userEmail));
+            // users.name/email are encrypted at rest, and activityLogs.actorEmail/actorDisplayName
+            // are denormalized snapshots that may also hold ciphertext from historical write paths
+            // that predate the actor-info decrypt-before-write fix. Decrypt all four for export,
+            // batching the joined and snapshot columns of the same shape together so a repeated
+            // actor across many rows only decrypts once per unique value.
+            const decryptName = await decryptFieldValuesOnce([
+              ...logs.map((log) => log.userName),
+              ...logs.map((log) => log.actorDisplayName),
+            ]);
+            const decryptEmail = await decryptFieldValuesOnce([
+              ...logs.map((log) => log.userEmail),
+              ...logs.map((log) => log.actorEmail),
+            ]);
 
             // Write each log as a CSV row
             for (const log of logs) {
               const row = logToCSVRow({
                 ...log,
-                userName: decryptUserName(log.userName),
-                userEmail: decryptUserEmail(log.userEmail),
+                userName: decryptName(log.userName),
+                userEmail: decryptEmail(log.userEmail),
+                actorDisplayName: decryptName(log.actorDisplayName),
+                actorEmail: decryptEmail(log.actorEmail),
               } as Record<string, unknown>);
               controller.enqueue(encoder.encode(row + '\n'));
             }

--- a/apps/admin/src/app/api/admin/audit-logs/route.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/route.ts
@@ -4,6 +4,7 @@ import { users } from '@pagespace/db/schema/auth'
 import { activityLogs } from '@pagespace/db/schema/monitoring';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { decryptFieldValuesOnce } from '@pagespace/lib/encryption/field-crypto';
 import { withAdminAuth } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
@@ -141,6 +142,15 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
       .limit(limit)
       .offset(offset);
 
+    // users.name/email are encrypted at rest; decrypt the joined columns for display.
+    const decryptUserName = await decryptFieldValuesOnce(logs.map((log) => log.userName));
+    const decryptUserEmail = await decryptFieldValuesOnce(logs.map((log) => log.userEmail));
+    const decryptedLogs = logs.map((log) => ({
+      ...log,
+      userName: decryptUserName(log.userName),
+      userEmail: decryptUserEmail(log.userEmail),
+    }));
+
     auditRequest(request, { eventType: 'data.read', userId: _adminUser.id, resourceType: 'audit_log', resourceId: '*', details: {
       source: 'admin',
       resultCount: logs.length,
@@ -148,7 +158,7 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
     } });
 
     return Response.json({
-      logs,
+      logs: decryptedLogs,
       pagination: {
         page,
         limit,

--- a/apps/admin/src/app/api/admin/audit-logs/route.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/route.ts
@@ -142,13 +142,25 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
       .limit(limit)
       .offset(offset);
 
-    // users.name/email are encrypted at rest; decrypt the joined columns for display.
-    const decryptUserName = await decryptFieldValuesOnce(logs.map((log) => log.userName));
-    const decryptUserEmail = await decryptFieldValuesOnce(logs.map((log) => log.userEmail));
+    // users.name/email are encrypted at rest, and activityLogs.actorEmail/actorDisplayName
+    // are denormalized snapshots that may also hold ciphertext from historical write paths
+    // that predate the actor-info decrypt-before-write fix. Decrypt all four for display,
+    // batching the joined and snapshot columns of the same shape together so a repeated
+    // actor across many rows only decrypts once per unique value.
+    const decryptName = await decryptFieldValuesOnce([
+      ...logs.map((log) => log.userName),
+      ...logs.map((log) => log.actorDisplayName),
+    ]);
+    const decryptEmail = await decryptFieldValuesOnce([
+      ...logs.map((log) => log.userEmail),
+      ...logs.map((log) => log.actorEmail),
+    ]);
     const decryptedLogs = logs.map((log) => ({
       ...log,
-      userName: decryptUserName(log.userName),
-      userEmail: decryptUserEmail(log.userEmail),
+      userName: decryptName(log.userName),
+      userEmail: decryptEmail(log.userEmail),
+      actorDisplayName: decryptName(log.actorDisplayName),
+      actorEmail: decryptEmail(log.actorEmail),
     }));
 
     auditRequest(request, { eventType: 'data.read', userId: _adminUser.id, resourceType: 'audit_log', resourceId: '*', details: {

--- a/apps/admin/src/app/api/admin/users/route.ts
+++ b/apps/admin/src/app/api/admin/users/route.ts
@@ -9,12 +9,13 @@ import { stripe } from '@/lib/stripe';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { decryptUserRows } from '@pagespace/lib/auth/user-repository';
 import { withAdminAuth } from '@/lib/auth';
 
 export const GET = withAdminAuth(async (_adminUser, _request) => {
   try {
     // Get all users
-    const allUsers = await db
+    const rawUsers = await db
       .select({
         id: users.id,
         name: users.name,
@@ -27,8 +28,12 @@ export const GET = withAdminAuth(async (_adminUser, _request) => {
         subscriptionTier: users.subscriptionTier,
         stripeCustomerId: users.stripeCustomerId,
       })
-      .from(users)
-      .orderBy(users.name);
+      .from(users);
+
+    // name/email are encrypted at rest; decrypt before any sorting/display.
+    const allUsers = (await decryptUserRows(rawUsers)).sort((a, b) =>
+      (a.name ?? '').localeCompare(b.name ?? '')
+    );
 
     if (allUsers.length === 0) {
       return Response.json({ users: [] });

--- a/apps/admin/src/lib/monitoring-queries.ts
+++ b/apps/admin/src/lib/monitoring-queries.ts
@@ -14,6 +14,18 @@ import { computeBalanceDrift, isNegativeMargin } from '@pagespace/lib/billing/cr
 import { BALANCE_DRIFT_TOLERANCE_CENTS, NEGATIVE_MARGIN_FLOOR_BPS } from '@pagespace/lib/billing/credit-pricing';
 import { getTierFromPrice } from './stripe/price-config';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+
+/** users.name/email are encrypted at rest; decrypt the joined columns for display. */
+async function decryptUserNameEmail<T extends { userName?: string | null; userEmail?: string | null }>(
+  rows: T[],
+): Promise<T[]> {
+  return Promise.all(rows.map(async (r) => ({
+    ...r,
+    userName: typeof r.userName === 'string' ? await decryptField(r.userName) : r.userName,
+    userEmail: typeof r.userEmail === 'string' ? await decryptField(r.userEmail) : r.userEmail,
+  })));
+}
 
 /**
  * Get system health overview
@@ -199,7 +211,7 @@ export async function getUserActivity(startDate?: Date, endDate?: Date) {
 
   return {
     heatmapData,
-    mostActiveUsers,
+    mostActiveUsers: await decryptUserNameEmail(mostActiveUsers),
     featureUsage,
   };
 }
@@ -292,7 +304,7 @@ export async function getAiUsageMetrics(startDate?: Date, endDate?: Date) {
     tokenUsageOverTime,
     modelPopularity,
     successRate,
-    topSpenders,
+    topSpenders: await decryptUserNameEmail(topSpenders),
   };
 }
 
@@ -679,7 +691,7 @@ export async function getTopSpendersByMargin(
     .orderBy(desc(chargedSum))
     .limit(limit);
 
-  return rows.map((r) => ({
+  return (await decryptUserNameEmail(rows)).map((r) => ({
     ...r,
     marginCents: r.chargedCents - r.realCostCents,
     marginPct: computeMarginPct(r.realCostCents, r.chargedCents),
@@ -740,7 +752,7 @@ export async function getOutstandingDebtByUser(limit = 10): Promise<DebtByUserRo
     .orderBy(desc(creditBalances.debtCents))
     .limit(limit);
 
-  return rows.map((r) => ({
+  return (await decryptUserNameEmail(rows)).map((r) => ({
     userId: r.userId,
     userName: r.userName,
     userEmail: r.userEmail,
@@ -785,7 +797,7 @@ export async function getBalanceDriftAlerts(
       creditBalances.debtCents,
     );
 
-  return rows
+  return (await decryptUserNameEmail(rows))
     .map((r): BalanceDriftRow | null => {
       const drift = computeBalanceDrift(
         {
@@ -849,7 +861,7 @@ export async function getNegativeMarginAccounts(
     .orderBy(asc(sql`${chargedSum} - ${realCostSum}`))
     .limit(limit);
 
-  return rows
+  return (await decryptUserNameEmail(rows))
     .filter((r) => isNegativeMargin(r.realCostCents, r.chargedCents, floorBps))
     .map((r) => ({
       ...r,
@@ -1015,7 +1027,7 @@ export async function getTokenUsageByUser(
   endDate?: Date,
   limit = 10,
 ): Promise<TokenUsageByUserRow[]> {
-  return db
+  const rows = await db
     .select({
       userId: aiUsageLogs.userId,
       userName: users.name,
@@ -1031,6 +1043,8 @@ export async function getTokenUsageByUser(
     .groupBy(aiUsageLogs.userId, users.name, users.email)
     .orderBy(desc(totalTokenSum))
     .limit(limit);
+
+  return decryptUserNameEmail(rows);
 }
 
 export async function getProviderCostRollup(

--- a/apps/admin/src/lib/monitoring-queries.ts
+++ b/apps/admin/src/lib/monitoring-queries.ts
@@ -14,18 +14,7 @@ import { computeBalanceDrift, isNegativeMargin } from '@pagespace/lib/billing/cr
 import { BALANCE_DRIFT_TOLERANCE_CENTS, NEGATIVE_MARGIN_FLOOR_BPS } from '@pagespace/lib/billing/credit-pricing';
 import { getTierFromPrice } from './stripe/price-config';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
-
-/** users.name/email are encrypted at rest; decrypt the joined columns for display. */
-async function decryptUserNameEmail<T extends { userName?: string | null; userEmail?: string | null }>(
-  rows: T[],
-): Promise<T[]> {
-  return Promise.all(rows.map(async (r) => ({
-    ...r,
-    userName: typeof r.userName === 'string' ? await decryptField(r.userName) : r.userName,
-    userEmail: typeof r.userEmail === 'string' ? await decryptField(r.userEmail) : r.userEmail,
-  })));
-}
+import { decryptUserDisplayFields } from '@pagespace/lib/auth/user-repository';
 
 /**
  * Get system health overview
@@ -211,7 +200,7 @@ export async function getUserActivity(startDate?: Date, endDate?: Date) {
 
   return {
     heatmapData,
-    mostActiveUsers: await decryptUserNameEmail(mostActiveUsers),
+    mostActiveUsers: await decryptUserDisplayFields(mostActiveUsers),
     featureUsage,
   };
 }
@@ -304,7 +293,7 @@ export async function getAiUsageMetrics(startDate?: Date, endDate?: Date) {
     tokenUsageOverTime,
     modelPopularity,
     successRate,
-    topSpenders: await decryptUserNameEmail(topSpenders),
+    topSpenders: await decryptUserDisplayFields(topSpenders),
   };
 }
 
@@ -691,7 +680,7 @@ export async function getTopSpendersByMargin(
     .orderBy(desc(chargedSum))
     .limit(limit);
 
-  return (await decryptUserNameEmail(rows)).map((r) => ({
+  return (await decryptUserDisplayFields(rows)).map((r) => ({
     ...r,
     marginCents: r.chargedCents - r.realCostCents,
     marginPct: computeMarginPct(r.realCostCents, r.chargedCents),
@@ -752,7 +741,7 @@ export async function getOutstandingDebtByUser(limit = 10): Promise<DebtByUserRo
     .orderBy(desc(creditBalances.debtCents))
     .limit(limit);
 
-  return (await decryptUserNameEmail(rows)).map((r) => ({
+  return (await decryptUserDisplayFields(rows)).map((r) => ({
     userId: r.userId,
     userName: r.userName,
     userEmail: r.userEmail,
@@ -797,7 +786,7 @@ export async function getBalanceDriftAlerts(
       creditBalances.debtCents,
     );
 
-  return (await decryptUserNameEmail(rows))
+  return (await decryptUserDisplayFields(rows))
     .map((r): BalanceDriftRow | null => {
       const drift = computeBalanceDrift(
         {
@@ -861,7 +850,7 @@ export async function getNegativeMarginAccounts(
     .orderBy(asc(sql`${chargedSum} - ${realCostSum}`))
     .limit(limit);
 
-  return (await decryptUserNameEmail(rows))
+  return (await decryptUserDisplayFields(rows))
     .filter((r) => isNegativeMargin(r.realCostCents, r.chargedCents, floorBps))
     .map((r) => ({
       ...r,
@@ -1044,7 +1033,7 @@ export async function getTokenUsageByUser(
     .orderBy(desc(totalTokenSum))
     .limit(limit);
 
-  return decryptUserNameEmail(rows);
+  return decryptUserDisplayFields(rows);
 }
 
 export async function getProviderCostRollup(

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -10,29 +10,11 @@ import { apiMetrics, userActivities, aiUsageLogs, systemLogs, errorLogs } from '
 import { creditLedger, creditBalances, creditHolds } from '@pagespace/db/schema/credits';
 import { subscriptions } from '@pagespace/db/schema/subscriptions';
 import type { SQL } from '@pagespace/db/operators';
-import { decryptField } from '@pagespace/lib/encryption/field-crypto';
+import { decryptUserDisplayFields } from '@pagespace/lib/auth/user-repository';
 import { computeBalanceDrift, isNegativeMargin } from '@pagespace/lib/billing/credit-core';
 import { BALANCE_DRIFT_TOLERANCE_CENTS, NEGATIVE_MARGIN_FLOOR_BPS } from '@pagespace/lib/billing/credit-pricing';
 import { getTierFromPrice } from '@/lib/stripe/price-config';
 import type { SubscriptionTier } from '@/lib/subscription/plans';
-
-/**
- * Decrypt the displayed `userName`/`userEmail` columns on admin-panel rows (GDPR
- * #965). The SQL groupBy/orderBy on the ciphertext columns is fine (ciphertext is
- * opaque but stable per user); only the DISPLAYED value must be decrypted. Legacy
- * plaintext passes through unchanged.
- */
-async function decryptUserDisplayFields<
-  T extends { userName?: string | null; userEmail?: string | null },
->(rows: T[]): Promise<T[]> {
-  return Promise.all(
-    rows.map(async (r) => ({
-      ...r,
-      ...(r.userName !== undefined ? { userName: await decryptField(r.userName) } : {}),
-      ...(r.userEmail !== undefined ? { userEmail: await decryptField(r.userEmail) } : {}),
-    })),
-  );
-}
 
 /**
  * Get system health overview

--- a/packages/lib/src/auth/user-repository.ts
+++ b/packages/lib/src/auth/user-repository.ts
@@ -223,6 +223,26 @@ export async function decryptUsersByIdOnce<T extends DecryptableUserRow & { id: 
   return new Map(decrypted);
 }
 
+/**
+ * Decrypt the displayed `userName`/`userEmail` columns on admin-panel/monitoring
+ * rows (GDPR #965). The SQL groupBy/orderBy on the ciphertext columns is fine
+ * (ciphertext is opaque but stable per user); only the DISPLAYED value must be
+ * decrypted. Legacy plaintext passes through unchanged. Distinct from
+ * `decryptUserRows` because monitoring queries alias the joined columns to
+ * `userName`/`userEmail` rather than `name`/`email`.
+ */
+export async function decryptUserDisplayFields<
+  T extends { userName?: string | null; userEmail?: string | null },
+>(rows: T[]): Promise<T[]> {
+  return Promise.all(
+    rows.map(async (r) => ({
+      ...r,
+      ...(r.userName !== undefined ? { userName: await decryptField(r.userName) } : {}),
+      ...(r.userEmail !== undefined ? { userEmail: await decryptField(r.userEmail) } : {}),
+    })),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Convenience full-row lookup
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The GDPR encryption-at-rest rollout encrypted `users.name`/`email` at rest and updated every read path in `apps/web`/`apps/realtime` to decrypt before display — `apps/admin` was missed, so the admin UI showed raw AES-256-GCM ciphertext instead of names/emails, breaking card/table layout.
- Fixed `apps/admin/src/app/api/admin/users/route.ts` (decrypt via `decryptUserRows`, sort by name in JS instead of ordering ciphertext at the DB level), `apps/admin/src/app/api/admin/audit-logs/route.ts` + `audit-logs/export/route.ts` (decrypt joined `userName`/`userEmail` via `decryptFieldValuesOnce`, batched per page).
- While fixing `apps/admin/src/lib/monitoring-queries.ts`, found that `apps/web/src/lib/monitoring/monitoring-queries.ts` already solved this exact problem with a private `decryptUserDisplayFields` helper — rather than add a third duplicate copy, promoted it to `packages/lib/src/auth/user-repository.ts` (alongside `decryptUserRows`/`decryptUsersByIdOnce`) and switched both apps to import the shared implementation.
- Review follow-up (automated review): the admin audit-logs UI actually renders the denormalized `activityLogs.actorEmail`/`actorDisplayName` snapshot columns, not the joined `userName`/`userEmail` fields — these could hold ciphertext from a ~4-hour historical write gap in `apps/realtime` (fixed upstream, but no backfill exists for `activityLogs`). Extended both audit-log routes to decrypt all four columns, batching same-shape pairs together for dedup, with new regression tests in `audit-logs/export/__tests__/pii-decrypt.test.ts`.
- No UI changes needed — `UsersTable.tsx` already renders plain strings; it just needed the API to stop sending ciphertext.

## Test plan
- [x] `bun run typecheck` — clean, 0 errors across the monorepo
- [x] `bunx vitest run` on `apps/admin/src/app/api/admin/audit-logs` — 9/9 tests pass, including new PII-decrypt regression coverage
- [x] Standalone script round-tripping real `encryptField`→decrypt through `decryptUserRows`, `decryptFieldValuesOnce`, and the shared `decryptUserDisplayFields` (including the undefined-key passthrough edge case); confirmed legacy-plaintext rows still pass through untouched
- [ ] Manual check in a running admin instance: `/users` shows real names/emails with normal card layout, `/audit-logs` (+ CSV export) shows plaintext actor/user names and emails, and the growth/unit-economics/ai-billing/monitoring dashboards show real names in "most active users"/"top spenders"/"outstanding debt" tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsQmpqnPrUdmaqshKzkbPV