### PR TITLE
fix(messages): close thread-reply attachment race left open by PR #1859

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/manage-keys-scope.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/manage-keys-scope.test.ts
@@ -38,7 +38,6 @@ vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
     insertChannelThreadReply: vi.fn(),
     upsertChannelReadStatus: vi.fn(),
     loadChannelMessageWithRelations: vi.fn(),
-    fileExists: vi.fn(),
     listChannelThreadFollowers: vi.fn(),
   },
 }));

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -41,7 +41,6 @@ const mockInsertChannelMessageWithAttachment = vi.fn();
 const mockInsertChannelThreadReply = vi.fn();
 const mockUpsertChannelReadStatus = vi.fn();
 const mockLoadChannelMessageWithRelations = vi.fn();
-const mockFileExists = vi.fn();
 const mockListChannelThreadFollowers = vi.fn();
 vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
   channelMessageRepository: {
@@ -52,7 +51,6 @@ vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
     insertChannelThreadReply: (...args: unknown[]) => mockInsertChannelThreadReply(...args),
     upsertChannelReadStatus: (...args: unknown[]) => mockUpsertChannelReadStatus(...args),
     loadChannelMessageWithRelations: (...args: unknown[]) => mockLoadChannelMessageWithRelations(...args),
-    fileExists: (...args: unknown[]) => mockFileExists(...args),
     listChannelThreadFollowers: (...args: unknown[]) => mockListChannelThreadFollowers(...args),
   },
 }));
@@ -397,6 +395,19 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     const res = await callPost({ content: 'x', parentId: 'reply-as-parent' });
 
     expect(res.status).toBe(400);
+  });
+
+  // insertChannelThreadReply now validates+locks the fileId inside its own
+  // transaction (issue #1865) instead of a separate pre-check — mirrors the
+  // top-level path's "rejects with not_found" coverage.
+  it('returns 400 when the reply fileId does not exist', async () => {
+    mockInsertChannelThreadReply.mockResolvedValueOnce({ kind: 'not_found' });
+
+    const res = await callPost({ content: 'x', parentId: PARENT_ID, fileId: 'file-1' });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/file not found/i);
   });
 
   it('fans out thread_updated to followers but EXCLUDES the reply author', async () => {

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -295,15 +295,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   // followers in one shot. Mirror copy (alsoSendToParent) writes a second
   // top-level row so the parent stream sees it too.
   if (parentId.length > 0) {
-    // If fileId is provided, verify it exists. insertChannelThreadReply has
-    // its own parent-locking transaction, so this pre-check stays outside it.
-    if (fileId) {
-      const exists = await channelMessageRepository.fileExists(fileId);
-      if (!exists) {
-        return NextResponse.json({ error: 'File not found' }, { status: 400 });
-      }
-    }
-
     const result = await channelMessageRepository.insertChannelThreadReply({
       parentId,
       pageId,
@@ -314,6 +305,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       alsoSendToParent: alsoSendToParent === true,
     });
 
+    if (result.kind === 'not_found') {
+      return NextResponse.json({ error: 'File not found' }, { status: 400 });
+    }
     if (result.kind === 'parent_not_found') {
       return NextResponse.json({ error: 'Parent message not found' }, { status: 404 });
     }

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -26,7 +26,6 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
 
 // --- DM repository seam (the boundary the route must delegate to) --------------
 const mockFindConversationForParticipant = vi.fn();
-const mockValidateAttachmentForDm = vi.fn();
 const mockInsertDmMessageWithAttachment = vi.fn();
 const mockUpdateConversationLastMessage = vi.fn();
 const mockListActiveMessages = vi.fn();
@@ -40,8 +39,6 @@ vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
   dmMessageRepository: {
     findConversationForParticipant: (...args: unknown[]) =>
       mockFindConversationForParticipant(...args),
-    validateAttachmentForDm: (...args: unknown[]) =>
-      mockValidateAttachmentForDm(...args),
     insertDmMessageWithAttachment: (...args: unknown[]) =>
       mockInsertDmMessageWithAttachment(...args),
     updateConversationLastMessage: (...args: unknown[]) =>
@@ -181,7 +178,6 @@ function setupHappyPath() {
   vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
   vi.mocked(isEmailVerified).mockResolvedValue(true);
   mockFindConversationForParticipant.mockResolvedValue(mockConversation());
-  mockValidateAttachmentForDm.mockResolvedValue({ kind: 'ok' });
   mockInsertDmMessageWithAttachment.mockImplementation(async (input) => ({
     kind: 'ok',
     message: mockInsertedRow(input),
@@ -941,6 +937,63 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     const res = await callRoute({ content: 'x', parentId: 'reply-as-parent' });
 
     expect(res.status).toBe(400);
+  });
+
+  // insertDmThreadReply now validates+locks the attachment inside its own
+  // transaction (issue #1865) instead of a separate pre-check — these mirror
+  // the top-level "ownership and conversation linkage" tests.
+  it('returns 404 when the reply fileId does not exist', async () => {
+    mockInsertDmThreadReply.mockResolvedValueOnce({ kind: 'not_found' });
+
+    const res = await callRoute({
+      content: 'x',
+      parentId: PARENT_ID,
+      fileId: FILE_ID,
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/file not found/i);
+  });
+
+  it('returns 403 + authz.access.denied audit when the reply fileId is not owned by the sender', async () => {
+    mockInsertDmThreadReply.mockResolvedValueOnce({ kind: 'wrong_owner' });
+
+    const res = await callRoute({
+      content: 'x',
+      parentId: PARENT_ID,
+      fileId: FILE_ID,
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/do not own this file/i);
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'authz.access.denied',
+        userId: SENDER_ID,
+        resourceType: 'dm_message',
+        resourceId: FILE_ID,
+      })
+    );
+  });
+
+  it('returns 403 + authz.access.denied audit when the reply fileId is not linked to this conversation', async () => {
+    mockInsertDmThreadReply.mockResolvedValueOnce({ kind: 'not_linked' });
+
+    const res = await callRoute({
+      content: 'x',
+      parentId: PARENT_ID,
+      fileId: FILE_ID,
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/not linked to this conversation/i);
   });
 
   it('does NOT emit dm_updated to a mentioned non-participant (sender-controlled IDs cannot leak into other users\' inboxes)', async () => {

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -17,9 +17,9 @@ const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
 /**
  * Shared error mapping for the two attachment-validation call sites (the
- * thread-reply pre-check and the top-level insert's discriminated result) —
- * both surface the same three rejection kinds against the same fileId/
- * conversationId pair, just from different call shapes.
+ * thread-reply and top-level insert discriminated results) — both surface
+ * the same three rejection kinds against the same fileId/conversationId
+ * pair, just from different call shapes.
  */
 function attachmentValidationErrorResponse(
   request: Request,

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -337,22 +337,6 @@ export async function POST(
     // transactional helper that bumps replyCount + lastReplyAt and upserts
     // followers. Mirror copy (alsoSendToParent) writes a second top-level row.
     if (parentId) {
-      if (fileId) {
-        const validation = await dmMessageRepository.validateAttachmentForDm({
-          fileId,
-          conversationId,
-          senderId: userId,
-        });
-
-        if (validation.kind !== 'ok') {
-          return attachmentValidationErrorResponse(request, validation.kind, {
-            userId,
-            fileId,
-            conversationId,
-          });
-        }
-      }
-
       const result = await dmMessageRepository.insertDmThreadReply({
         parentId,
         conversationId,
@@ -363,6 +347,17 @@ export async function POST(
         alsoSendToParent,
       });
 
+      if (
+        result.kind === 'not_found' ||
+        result.kind === 'wrong_owner' ||
+        result.kind === 'not_linked'
+      ) {
+        return attachmentValidationErrorResponse(request, result.kind, {
+          userId,
+          fileId,
+          conversationId,
+        });
+      }
       if (result.kind === 'parent_not_found') {
         return NextResponse.json({ error: 'Parent message not found' }, { status: 404 });
       }

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
@@ -135,15 +135,16 @@ export async function isFileOrphaned(database: DB, fileId: string): Promise<bool
  * The scan that decided `fileIds` (findOrphanedFileRecords) may be long past
  * by the time this runs — reapOrphanedFiles loops per-orphan doing an HTTP
  * call to the processor before batching this call. A message send racing
- * that window (insertDmMessageWithAttachment/insertChannelMessageWithAttachment)
- * takes FOR UPDATE on the same `files` row before referencing it, so we lock
- * the candidate rows first and re-verify referencedness in a *separate*
- * statement afterward — mirroring purgeInactiveMessages's two-statement
- * protocol (dm-message-repository.ts). A single locking DELETE would keep
- * its pre-block snapshot and could still drop a row a just-committed insert
- * now depends on.
+ * that window (insertDmMessageWithAttachment/insertChannelMessageWithAttachment
+ * for top-level sends, insertDmThreadReply/insertChannelThreadReply for thread
+ * replies and their alsoSendToParent mirror) takes FOR UPDATE on the same
+ * `files` row before referencing it, so we lock the candidate rows first and
+ * re-verify referencedness in a *separate* statement afterward — mirroring
+ * purgeInactiveMessages's two-statement protocol (dm-message-repository.ts).
+ * A single locking DELETE would keep its pre-block snapshot and could still
+ * drop a row a just-committed insert now depends on.
  *
- * This closes the race for the two insert paths above, which are the only
+ * This closes the race for the four insert paths above, which are the only
  * writers that take FOR UPDATE on `files` before referencing it. The
  * content-addressed-storage dedup path (a `pages` row pointing at an
  * existing upload's storagePath, apps/web's upload-complete route) does not

--- a/packages/lib/src/services/__tests__/channel-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/channel-message-repository.test.ts
@@ -201,32 +201,6 @@ describe('channelMessageRepository.loadChannelMessageWithRelations', () => {
   });
 });
 
-describe('channelMessageRepository.fileExists', () => {
-  it('returns true when the file row is present', async () => {
-    testDbState.seed('files', [{ id: 'file-1', mimeType: 'image/png' }]);
-
-    const result = await channelMessageRepository.fileExists('file-1');
-
-    assert({
-      given: 'an attachment id that resolves to a file row',
-      should: 'return true so the route accepts the upload',
-      actual: result,
-      expected: true,
-    });
-  });
-
-  it('returns false when the file row is missing', async () => {
-    const result = await channelMessageRepository.fileExists('missing-file');
-
-    assert({
-      given: 'an attachment id with no matching file row',
-      should: 'return false so the route returns a 400 instead of orphaning the message',
-      actual: result,
-      expected: false,
-    });
-  });
-});
-
 describe('channelMessageRepository.insertChannelMessageWithAttachment', () => {
   const baseInput = {
     pageId: 'page-1',
@@ -710,6 +684,86 @@ describe('channelMessageRepository.insertChannelThreadReply', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Attachment locking (issue #1865 — mirrors insertChannelMessageWithAttachment's
+  // top-level lock coverage, which the thread-reply path lacked)
+  // -------------------------------------------------------------------------
+
+  it('locks the file row (FOR UPDATE) once when the reply carries a fileId, inside the same transaction as the parent lock', async () => {
+    seedActiveParent();
+    testDbState.seed('files', [{ id: 'file-1' }]);
+
+    const result = await channelMessageRepository.insertChannelThreadReply({
+      ...baseInput,
+      fileId: 'file-1',
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+    });
+
+    assert({
+      given: 'a thread reply with a fileId that resolves to an existing file',
+      should: 'lock files exactly once, insert successfully, all inside one db.transaction',
+      actual: {
+        kind: result.kind,
+        fileLocks: testDbState.selectsForUpdate('files').length,
+        transactionCalls: testDbState.transactionCalls(),
+      },
+      expected: { kind: 'ok', fileLocks: 1, transactionCalls: 1 },
+    });
+  });
+
+  it('takes only one file lock even when alsoSendToParent writes a second row referencing the same fileId', async () => {
+    seedActiveParent();
+    testDbState.seed('files', [{ id: 'file-1' }]);
+
+    const result = await channelMessageRepository.insertChannelThreadReply({
+      ...baseInput,
+      fileId: 'file-1',
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+      alsoSendToParent: true,
+    });
+
+    const messages = testDbState.rows('channelMessages');
+    assert({
+      given: 'an alsoSendToParent thread reply with a fileId, so the reply AND the mirror both reference file-1',
+      should: 'lock files exactly once — one lock covers both inserts in this transaction',
+      actual: {
+        kind: result.kind,
+        rowCount: messages.length,
+        fileLocks: testDbState.selectsForUpdate('files').length,
+      },
+      expected: { kind: 'ok', rowCount: 3, fileLocks: 1 },
+    });
+  });
+
+  it('inserts without touching files when the reply has no fileId', async () => {
+    seedActiveParent();
+
+    const result = await channelMessageRepository.insertChannelThreadReply(baseInput);
+
+    assert({
+      given: 'a text-only thread reply',
+      should: 'return kind ok and never lock files',
+      actual: { kind: result.kind, fileLocks: testDbState.selectsForUpdate('files').length },
+      expected: { kind: 'ok', fileLocks: 0 },
+    });
+  });
+
+  it('rejects with not_found and inserts no reply when the fileId does not exist', async () => {
+    seedActiveParent();
+
+    const result = await channelMessageRepository.insertChannelThreadReply({
+      ...baseInput,
+      fileId: 'missing-file',
+    });
+
+    assert({
+      given: 'a thread reply whose fileId has no matching file row',
+      should: 'return not_found without inserting a reply — only the seeded parent remains',
+      actual: { kind: result.kind, rowCount: testDbState.count('channelMessages') },
+      expected: { kind: 'not_found', rowCount: 1 },
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Edge cases (PR 6b — added per audit findings)
   // -------------------------------------------------------------------------
 
@@ -1066,7 +1120,6 @@ describe('channelMessageRepository surface', () => {
       expected: [
         'addChannelReaction',
         'addChannelThreadFollower',
-        'fileExists',
         'findChannelMessageInPage',
         'insertChannelMessageWithAttachment',
         'insertChannelThreadReply',

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -447,6 +447,128 @@ describe('dmMessageRepository.insertDmThreadReply', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Attachment locking (issue #1865 — mirrors insertDmMessageWithAttachment's
+  // top-level lock coverage, which the thread-reply path lacked)
+  // -------------------------------------------------------------------------
+
+  it('locks the file and link rows (FOR UPDATE) once each when the reply carries a fileId, inside the same transaction as the parent lock', async () => {
+    seedActiveParent();
+    testDbState.seed('files', [{ id: 'file-1', createdBy: 'user-replier' }]);
+    testDbState.seed('fileConversations', [{ fileId: 'file-1', conversationId: 'conv-1' }]);
+
+    const result = await dmMessageRepository.insertDmThreadReply({
+      ...baseInput,
+      fileId: 'file-1',
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+    });
+
+    assert({
+      given: 'a thread reply with a fileId owned by the replier and linked to the conversation',
+      should: 'lock files and fileConversations exactly once each, insert successfully, all inside one db.transaction',
+      actual: {
+        kind: result.kind,
+        fileLocks: testDbState.selectsForUpdate('files').length,
+        linkLocks: testDbState.selectsForUpdate('fileConversations').length,
+        transactionCalls: testDbState.transactionCalls(),
+      },
+      expected: { kind: 'ok', fileLocks: 1, linkLocks: 1, transactionCalls: 1 },
+    });
+  });
+
+  it('takes only one file/link lock even when alsoSendToParent writes a second row referencing the same fileId', async () => {
+    seedActiveParent();
+    testDbState.seed('files', [{ id: 'file-1', createdBy: 'user-replier' }]);
+    testDbState.seed('fileConversations', [{ fileId: 'file-1', conversationId: 'conv-1' }]);
+
+    const result = await dmMessageRepository.insertDmThreadReply({
+      ...baseInput,
+      fileId: 'file-1',
+      attachmentMeta: { originalName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'A'.repeat(64) },
+      alsoSendToParent: true,
+    });
+
+    const messages = testDbState.rows('directMessages');
+    assert({
+      given: 'an alsoSendToParent thread reply with a fileId, so the reply AND the mirror both reference file-1',
+      should: 'lock files/fileConversations exactly once each — one lock covers both inserts in this transaction',
+      actual: {
+        kind: result.kind,
+        rowCount: messages.length,
+        fileLocks: testDbState.selectsForUpdate('files').length,
+        linkLocks: testDbState.selectsForUpdate('fileConversations').length,
+      },
+      expected: { kind: 'ok', rowCount: 3, fileLocks: 1, linkLocks: 1 },
+    });
+  });
+
+  it('inserts without touching files/fileConversations when the reply has no fileId', async () => {
+    seedActiveParent();
+
+    const result = await dmMessageRepository.insertDmThreadReply(baseInput);
+
+    assert({
+      given: 'a text-only thread reply',
+      should: 'return kind ok and never lock files or fileConversations',
+      actual: {
+        kind: result.kind,
+        fileLocks: testDbState.selectsForUpdate('files').length,
+        linkLocks: testDbState.selectsForUpdate('fileConversations').length,
+      },
+      expected: { kind: 'ok', fileLocks: 0, linkLocks: 0 },
+    });
+  });
+
+  it('rejects with not_found and inserts no reply when the fileId does not exist', async () => {
+    seedActiveParent();
+
+    const result = await dmMessageRepository.insertDmThreadReply({
+      ...baseInput,
+      fileId: 'missing-file',
+    });
+
+    assert({
+      given: 'a thread reply whose fileId has no matching file row',
+      should: 'return not_found without inserting a reply — only the seeded parent remains',
+      actual: { kind: result.kind, rowCount: testDbState.count('directMessages') },
+      expected: { kind: 'not_found', rowCount: 1 },
+    });
+  });
+
+  it('rejects with wrong_owner and inserts no reply when the fileId belongs to another user', async () => {
+    seedActiveParent();
+    testDbState.seed('files', [{ id: 'file-1', createdBy: 'someone-else' }]);
+
+    const result = await dmMessageRepository.insertDmThreadReply({
+      ...baseInput,
+      fileId: 'file-1',
+    });
+
+    assert({
+      given: 'a fileId owned by a different user than the replier',
+      should: 'return wrong_owner without inserting a reply',
+      actual: { kind: result.kind, rowCount: testDbState.count('directMessages') },
+      expected: { kind: 'wrong_owner', rowCount: 1 },
+    });
+  });
+
+  it('rejects with not_linked and inserts no reply when the fileId is not linked to the conversation', async () => {
+    seedActiveParent();
+    testDbState.seed('files', [{ id: 'file-1', createdBy: 'user-replier' }]);
+
+    const result = await dmMessageRepository.insertDmThreadReply({
+      ...baseInput,
+      fileId: 'file-1',
+    });
+
+    assert({
+      given: 'a fileId owned by the replier but not linked to this conversation',
+      should: 'return not_linked without inserting a reply',
+      actual: { kind: result.kind, rowCount: testDbState.count('directMessages') },
+      expected: { kind: 'not_linked', rowCount: 1 },
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Edge cases (PR 6b — added per audit findings)
   // -------------------------------------------------------------------------
 

--- a/packages/lib/src/services/channel-message-repository.ts
+++ b/packages/lib/src/services/channel-message-repository.ts
@@ -149,25 +149,6 @@ async function loadChannelMessageWithRelations(id: string) {
   return row;
 }
 
-/**
- * Standalone pre-check used only by the thread-reply path — `insertChannelThreadReply`
- * has its own parent-locking transaction, so attachment validation stays outside
- * it here. The top-level send path uses `insertChannelMessageWithAttachment`
- * instead, which validates and inserts inside a single transaction.
- *
- * This pre-check takes no lock on `files`, so unlike the top-level path it is
- * NOT race-safe against a concurrent file delete — a delete landing between
- * this check and the reply's (or its mirror's) insert can still turn into a
- * DB error instead of a clean rejection. Accepted, tracked gap: see issue #1865.
- */
-async function fileExists(fileId: string): Promise<boolean> {
-  const row = await db.query.files.findFirst({
-    where: eq(files.id, fileId),
-    columns: { id: true },
-  });
-  return row !== undefined;
-}
-
 export interface InsertChannelMessageInput {
   pageId: string;
   userId: string;
@@ -414,8 +395,19 @@ export type InsertChannelThreadReplyResult =
     }
   | { kind: 'parent_not_found' }
   | { kind: 'parent_wrong_page' }
-  | { kind: 'parent_not_top_level' };
+  | { kind: 'parent_not_top_level' }
+  | { kind: 'not_found' };
 
+/**
+ * Locks the parent row, then (if a fileId is attached) the file row, before
+ * inserting the reply and its optional `alsoSendToParent` mirror — all inside
+ * one transaction. Mirrors `insertDmThreadReply`'s lock ordering (parent ->
+ * files); channels have no `fileConversations`-equivalent link table, so
+ * there's nothing to lock beyond the file itself, matching
+ * `insertChannelMessageWithAttachment`'s lock shape. The lock is taken once
+ * and covers both the reply and the mirror row, since both reference the same
+ * input.fileId inside this same transaction.
+ */
 async function insertChannelThreadReply(
   input: InsertChannelThreadReplyInput
 ): Promise<InsertChannelThreadReplyResult> {
@@ -445,6 +437,18 @@ async function insertChannelThreadReply(
     }
     if (parent.parentId !== null) {
       return { kind: 'parent_not_top_level' };
+    }
+
+    if (input.fileId) {
+      const [file] = await tx
+        .select({ id: files.id })
+        .from(files)
+        .where(eq(files.id, input.fileId))
+        .for('update');
+
+      if (!file) {
+        return { kind: 'not_found' };
+      }
     }
 
     const [reply] = await tx
@@ -591,7 +595,6 @@ export const channelMessageRepository = {
   listChannelMessages,
   findChannelMessageInPage,
   loadChannelMessageWithRelations,
-  fileExists,
   insertChannelMessageWithAttachment,
   upsertChannelReadStatus,
   updateChannelMessageContent,

--- a/packages/lib/src/services/channel-message-repository.ts
+++ b/packages/lib/src/services/channel-message-repository.ts
@@ -162,6 +162,39 @@ export type InsertChannelMessageResult =
   | { kind: 'ok'; message: ChannelMessageRow }
   | { kind: 'not_found' };
 
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+type ChannelAttachmentLockResult = { kind: 'ok' } | { kind: 'not_found' };
+
+/**
+ * Lock the file row with SELECT ... FOR UPDATE. Shared by
+ * insertChannelMessageWithAttachment and insertChannelThreadReply (the
+ * top-level and thread-reply attachment paths) so the two call sites can't
+ * drift out of sync with each other — mirrors the `lockDriveRolesInOrder`
+ * shared-lock-helper pattern in drive-role-service.ts. Channels have no
+ * `fileConversations`-equivalent link table, so this only locks `files`,
+ * unlike the DM side's `lockAndValidateDmAttachment`.
+ *
+ * Callers without a fileId should skip calling this entirely — it always
+ * locks, so it must stay conditional on `input.fileId` at the call site.
+ */
+async function lockAndValidateChannelAttachment(
+  tx: Tx,
+  fileId: string
+): Promise<ChannelAttachmentLockResult> {
+  const [file] = await tx
+    .select({ id: files.id })
+    .from(files)
+    .where(eq(files.id, fileId))
+    .for('update');
+
+  if (!file) {
+    return { kind: 'not_found' };
+  }
+
+  return { kind: 'ok' };
+}
+
 /**
  * Validates the attachment (if any) and inserts the top-level channel
  * message in one transaction. The SELECT ... FOR UPDATE lock on `files`
@@ -173,14 +206,9 @@ async function insertChannelMessageWithAttachment(
 ): Promise<InsertChannelMessageResult> {
   return db.transaction(async (tx) => {
     if (input.fileId) {
-      const [file] = await tx
-        .select({ id: files.id })
-        .from(files)
-        .where(eq(files.id, input.fileId))
-        .for('update');
-
-      if (!file) {
-        return { kind: 'not_found' };
+      const check = await lockAndValidateChannelAttachment(tx, input.fileId);
+      if (check.kind !== 'ok') {
+        return check;
       }
     }
 
@@ -399,14 +427,14 @@ export type InsertChannelThreadReplyResult =
   | { kind: 'not_found' };
 
 /**
- * Locks the parent row, then (if a fileId is attached) the file row, before
- * inserting the reply and its optional `alsoSendToParent` mirror — all inside
- * one transaction. Mirrors `insertDmThreadReply`'s lock ordering (parent ->
- * files); channels have no `fileConversations`-equivalent link table, so
- * there's nothing to lock beyond the file itself, matching
- * `insertChannelMessageWithAttachment`'s lock shape. The lock is taken once
- * and covers both the reply and the mirror row, since both reference the same
- * input.fileId inside this same transaction.
+ * Locks the parent row, then (if a fileId is attached) the file row via
+ * `lockAndValidateChannelAttachment`, before inserting the reply and its
+ * optional `alsoSendToParent` mirror — all inside one transaction. Mirrors
+ * `insertDmThreadReply`'s lock ordering (parent -> files); channels have no
+ * `fileConversations`-equivalent link table, so there's nothing to lock
+ * beyond the file itself. The lock is taken once and covers both the reply
+ * and the mirror row, since both reference the same input.fileId inside this
+ * same transaction.
  */
 async function insertChannelThreadReply(
   input: InsertChannelThreadReplyInput
@@ -440,14 +468,9 @@ async function insertChannelThreadReply(
     }
 
     if (input.fileId) {
-      const [file] = await tx
-        .select({ id: files.id })
-        .from(files)
-        .where(eq(files.id, input.fileId))
-        .for('update');
-
-      if (!file) {
-        return { kind: 'not_found' };
+      const check = await lockAndValidateChannelAttachment(tx, input.fileId);
+      if (check.kind !== 'ok') {
+        return check;
       }
     }
 

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -104,63 +104,6 @@ async function findConversationForParticipant(
   return row ?? null;
 }
 
-export type AttachmentValidation =
-  | { kind: 'ok' }
-  | { kind: 'not_found' }
-  | { kind: 'wrong_owner' }
-  | { kind: 'not_linked' };
-
-export interface ValidateAttachmentForDmInput {
-  fileId: string;
-  conversationId: string;
-  senderId: string;
-}
-
-/**
- * Standalone pre-check used only by the thread-reply path — `insertDmThreadReply`
- * has its own parent-locking transaction, so attachment validation stays outside
- * it here. The top-level send path uses `insertDmMessageWithAttachment` instead,
- * which validates and inserts inside a single transaction.
- *
- * This pre-check takes no lock on `files`/`fileConversations`, so unlike the
- * top-level path it is NOT race-safe against a concurrent `purgeInactiveMessages`
- * cleanup — the reply (or its `alsoSendToParent` mirror) can still commit
- * referencing a link that purge drops in the gap between this check and the
- * reply's insert. Accepted, tracked gap: see issue #1865.
- */
-async function validateAttachmentForDm(
-  input: ValidateAttachmentForDmInput
-): Promise<AttachmentValidation> {
-  const { fileId, conversationId, senderId } = input;
-
-  const file = await db.query.files.findFirst({
-    where: eq(files.id, fileId),
-    columns: { id: true, createdBy: true },
-  });
-
-  if (!file) {
-    return { kind: 'not_found' };
-  }
-
-  if (file.createdBy !== senderId) {
-    return { kind: 'wrong_owner' };
-  }
-
-  const link = await db.query.fileConversations.findFirst({
-    where: and(
-      eq(fileConversations.fileId, fileId),
-      eq(fileConversations.conversationId, conversationId)
-    ),
-    columns: { fileId: true },
-  });
-
-  if (!link) {
-    return { kind: 'not_linked' };
-  }
-
-  return { kind: 'ok' };
-}
-
 export interface InsertDmMessageInput {
   conversationId: string;
   senderId: string;
@@ -572,8 +515,25 @@ export type InsertDmThreadReplyResult =
     }
   | { kind: 'parent_not_found' }
   | { kind: 'parent_wrong_conversation' }
-  | { kind: 'parent_not_top_level' };
+  | { kind: 'parent_not_top_level' }
+  | { kind: 'not_found' }
+  | { kind: 'wrong_owner' }
+  | { kind: 'not_linked' };
 
+/**
+ * Locks the parent row, then (if a fileId is attached) the file + link rows,
+ * before inserting the reply and its optional `alsoSendToParent` mirror — all
+ * inside one transaction. Lock order is parent -> files -> fileConversations,
+ * which never conflicts with `insertDmMessageWithAttachment` (files ->
+ * fileConversations, no parent lock) or `purgeInactiveMessages` (fileConversations
+ * only, never a parent/directMessages row), so this can't introduce a deadlock.
+ *
+ * The file/link lock is taken once and covers both the reply and the mirror
+ * row: both reference the same input.fileId within this same transaction, so
+ * a single FOR UPDATE on each row is sufficient for both inserts. See
+ * `insertDmMessageWithAttachment`'s doc comment for why the lock (rather than
+ * a plain read) is required to close the race with `purgeInactiveMessages`.
+ */
 async function insertDmThreadReply(
   input: InsertDmThreadReplyInput
 ): Promise<InsertDmThreadReplyResult> {
@@ -603,6 +563,36 @@ async function insertDmThreadReply(
     }
     if (parent.parentId !== null) {
       return { kind: 'parent_not_top_level' };
+    }
+
+    if (input.fileId) {
+      const [file] = await tx
+        .select({ id: files.id, createdBy: files.createdBy })
+        .from(files)
+        .where(eq(files.id, input.fileId))
+        .for('update');
+
+      if (!file) {
+        return { kind: 'not_found' };
+      }
+      if (file.createdBy !== input.senderId) {
+        return { kind: 'wrong_owner' };
+      }
+
+      const [link] = await tx
+        .select({ fileId: fileConversations.fileId })
+        .from(fileConversations)
+        .where(
+          and(
+            eq(fileConversations.fileId, input.fileId),
+            eq(fileConversations.conversationId, input.conversationId)
+          )
+        )
+        .for('update');
+
+      if (!link) {
+        return { kind: 'not_linked' };
+      }
     }
 
     const [reply] = await tx
@@ -809,7 +799,6 @@ async function removeDmReaction(input: DmReactionInput): Promise<number> {
 
 export const dmMessageRepository = {
   findConversationForParticipant,
-  validateAttachmentForDm,
   insertDmMessageWithAttachment,
   updateConversationLastMessage,
   findActiveMessage,

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -121,53 +121,87 @@ export type InsertDmMessageResult =
   | { kind: 'wrong_owner' }
   | { kind: 'not_linked' };
 
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+type DmAttachmentLockResult =
+  | { kind: 'ok' }
+  | { kind: 'not_found' }
+  | { kind: 'wrong_owner' }
+  | { kind: 'not_linked' };
+
+/**
+ * Lock the file row, then (if owned) the file-conversation link row, with
+ * SELECT ... FOR UPDATE. Shared by insertDmMessageWithAttachment and
+ * insertDmThreadReply (the top-level and thread-reply attachment paths) so
+ * the two call sites can't drift out of sync with each other — mirrors the
+ * `lockDriveRolesInOrder` shared-lock-helper pattern in drive-role-service.ts.
+ *
+ * The locks are one half of a two-sided protocol with `purgeInactiveMessages`:
+ * purge locks the same link rows (FOR UPDATE) before its orphan-check DELETE,
+ * so whichever side wins the lock, the loser observes the winner's committed
+ * state — a caller that loses sees the link already gone and rejects with
+ * `not_linked`; a purge that loses re-checks with a fresh snapshot and sees
+ * the message the caller committed, keeping the link. The lock alone would
+ * NOT be enough: a single blocked DELETE keeps its pre-block snapshot, which
+ * is why purge re-checks in a separate statement.
+ *
+ * Callers without a fileId should skip calling this entirely — it always
+ * locks, so it must stay conditional on `input.fileId` at the call site.
+ */
+async function lockAndValidateDmAttachment(
+  tx: Tx,
+  input: { fileId: string; senderId: string; conversationId: string }
+): Promise<DmAttachmentLockResult> {
+  const [file] = await tx
+    .select({ id: files.id, createdBy: files.createdBy })
+    .from(files)
+    .where(eq(files.id, input.fileId))
+    .for('update');
+
+  if (!file) {
+    return { kind: 'not_found' };
+  }
+  if (file.createdBy !== input.senderId) {
+    return { kind: 'wrong_owner' };
+  }
+
+  const [link] = await tx
+    .select({ fileId: fileConversations.fileId })
+    .from(fileConversations)
+    .where(
+      and(
+        eq(fileConversations.fileId, input.fileId),
+        eq(fileConversations.conversationId, input.conversationId)
+      )
+    )
+    .for('update');
+
+  if (!link) {
+    return { kind: 'not_linked' };
+  }
+
+  return { kind: 'ok' };
+}
+
 /**
  * Validates the attachment (if any) and inserts the top-level DM in one
  * transaction. Without this, a validate-then-insert-later split lets a
  * concurrent `purgeInactiveMessages` orphan-link cleanup delete the
- * `fileConversations` row between our validation read and the INSERT.
- *
- * The SELECT ... FOR UPDATE locks below are one half of a two-sided
- * protocol with `purgeInactiveMessages`: purge locks the same link rows
- * (FOR UPDATE) before its orphan-check DELETE, so whichever side wins the
- * lock, the loser observes the winner's committed state — a send that
- * loses sees the link already gone and rejects with `not_linked`; a purge
- * that loses re-checks with a fresh snapshot and sees the message we
- * committed, keeping the link. The lock alone would NOT be enough: a
- * single blocked DELETE keeps its pre-block snapshot, which is why purge
- * re-checks in a separate statement.
+ * `fileConversations` row between our validation read and the INSERT. See
+ * `lockAndValidateDmAttachment`'s doc comment for the full lock protocol.
  */
 async function insertDmMessageWithAttachment(
   input: InsertDmMessageInput
 ): Promise<InsertDmMessageResult> {
   return db.transaction(async (tx) => {
     if (input.fileId) {
-      const [file] = await tx
-        .select({ id: files.id, createdBy: files.createdBy })
-        .from(files)
-        .where(eq(files.id, input.fileId))
-        .for('update');
-
-      if (!file) {
-        return { kind: 'not_found' };
-      }
-      if (file.createdBy !== input.senderId) {
-        return { kind: 'wrong_owner' };
-      }
-
-      const [link] = await tx
-        .select({ fileId: fileConversations.fileId })
-        .from(fileConversations)
-        .where(
-          and(
-            eq(fileConversations.fileId, input.fileId),
-            eq(fileConversations.conversationId, input.conversationId)
-          )
-        )
-        .for('update');
-
-      if (!link) {
-        return { kind: 'not_linked' };
+      const check = await lockAndValidateDmAttachment(tx, {
+        fileId: input.fileId,
+        senderId: input.senderId,
+        conversationId: input.conversationId,
+      });
+      if (check.kind !== 'ok') {
+        return check;
       }
     }
 
@@ -521,18 +555,17 @@ export type InsertDmThreadReplyResult =
   | { kind: 'not_linked' };
 
 /**
- * Locks the parent row, then (if a fileId is attached) the file + link rows,
- * before inserting the reply and its optional `alsoSendToParent` mirror — all
- * inside one transaction. Lock order is parent -> files -> fileConversations,
- * which never conflicts with `insertDmMessageWithAttachment` (files ->
- * fileConversations, no parent lock) or `purgeInactiveMessages` (fileConversations
- * only, never a parent/directMessages row), so this can't introduce a deadlock.
+ * Locks the parent row, then (if a fileId is attached) the file + link rows
+ * via `lockAndValidateDmAttachment`, before inserting the reply and its
+ * optional `alsoSendToParent` mirror — all inside one transaction. Lock order
+ * is parent -> files -> fileConversations, which never conflicts with
+ * `insertDmMessageWithAttachment` (files -> fileConversations, no parent
+ * lock) or `purgeInactiveMessages` (fileConversations only, never a
+ * parent/directMessages row), so this can't introduce a deadlock.
  *
  * The file/link lock is taken once and covers both the reply and the mirror
  * row: both reference the same input.fileId within this same transaction, so
- * a single FOR UPDATE on each row is sufficient for both inserts. See
- * `insertDmMessageWithAttachment`'s doc comment for why the lock (rather than
- * a plain read) is required to close the race with `purgeInactiveMessages`.
+ * a single FOR UPDATE on each row is sufficient for both inserts.
  */
 async function insertDmThreadReply(
   input: InsertDmThreadReplyInput
@@ -566,32 +599,13 @@ async function insertDmThreadReply(
     }
 
     if (input.fileId) {
-      const [file] = await tx
-        .select({ id: files.id, createdBy: files.createdBy })
-        .from(files)
-        .where(eq(files.id, input.fileId))
-        .for('update');
-
-      if (!file) {
-        return { kind: 'not_found' };
-      }
-      if (file.createdBy !== input.senderId) {
-        return { kind: 'wrong_owner' };
-      }
-
-      const [link] = await tx
-        .select({ fileId: fileConversations.fileId })
-        .from(fileConversations)
-        .where(
-          and(
-            eq(fileConversations.fileId, input.fileId),
-            eq(fileConversations.conversationId, input.conversationId)
-          )
-        )
-        .for('update');
-
-      if (!link) {
-        return { kind: 'not_linked' };
+      const check = await lockAndValidateDmAttachment(tx, {
+        fileId: input.fileId,
+        senderId: input.senderId,
+        conversationId: input.conversationId,
+      });
+      if (check.kind !== 'ok') {
+        return check;
       }
     }
 


### PR DESCRIPTION
## Summary

- Closes #1865. PR #1859 fixed #1217 for the top-level DM/channel send paths by folding attachment validation + insert into one `db.transaction` with `SELECT ... FOR UPDATE` locks, but explicitly scoped out the thread-reply path (`insertDmThreadReply`/`insertChannelThreadReply`, including the `alsoSendToParent` mirror), which kept a non-transactional pre-check that took no lock — leaving the same race open on that path.
- Folds the same lock-then-check shape into both thread-reply functions: after the existing parent-row lock, lock `files` (+ `fileConversations` for DM) before inserting the reply/mirror. Lock order is parent → files → fileConversations, matching the issue's proposal and introducing no new deadlock risk against `insertDmMessageWithAttachment` or `purgeInactiveMessages`.
- Deletes `validateAttachmentForDm` and `channelMessageRepository.fileExists` (dead code once the routes stop pre-checking); both routes now dispatch on the widened result-kind unions via the existing error-mapping helpers.
- Adds repository-level lock + rejection-kind tests mirroring the top-level path's existing coverage, plus route-level coverage for the new result kinds.

**Follow-up commits (self-review + CodeRabbit):**
- Extracted `lockAndValidateDmAttachment` / `lockAndValidateChannelAttachment` as shared tx-scoped helpers reused by both the top-level and thread-reply insert functions in each file — the lock-check block was duplicated verbatim between them, and a future change applied to only one copy would silently reopen this exact race. Mirrors the existing `lockDriveRolesInOrder` shared-helper pattern in `drive-role-service.ts`. Pure refactor, no behavior change.
- Fixed a stale docblock in `orphan-detector.ts`'s `deleteFileRecords` that named "the two insert paths above" as the only writers taking `FOR UPDATE` on `files` — now four, after this PR.
- Removed a stale `fileExists: vi.fn()` mock stub from `manage-keys-scope.test.ts`'s repository mock factory (a route test file this PR's first pass didn't touch).
- CodeRabbit nitpick: fixed a stale doc comment on `attachmentValidationErrorResponse` still describing one call site as "the thread-reply pre-check" after that pre-check was removed.

## Test plan

- [x] `bun run typecheck` — clean for `@pagespace/lib` and `web`
- [x] `bun run lint` — clean (only pre-existing unrelated warnings)
- [x] `packages/lib/src/services/__tests__/dm-message-repository.test.ts` + `channel-message-repository.test.ts` — 108 tests pass
- [x] `apps/web/.../messages/[conversationId]/__tests__/route.test.ts` + `channels/[pageId]/messages/__tests__/route.test.ts` + `manage-keys-scope.test.ts` — 78 tests pass
- [x] CI: Lint & TypeScript Check, Unit Tests, Security Test Suite, CodeQL, Dependency Audit, Secret Scanning all green on prior commits; re-running on the latest commit
- [x] CodeRabbit review completed — 1 nitpick addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fWZw2Jg39bQJrzQfhtpgp