### PR TITLE
fix(sdk): pages.read broken for every plain page — 1.5.1

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.5.1] — 2026-07-08
+
+### Fixed
+
+- **`pages.read` (`read_page`) was broken for every plain page — DOCUMENT, FOLDER, CANVAS, CODE,
+  and completed FILE pages — the single most common case.** `genericReadResultSchema` declared
+  `pageType: z.undefined()` to assert that branch's responses never carry a `pageType` field. But
+  JSON cannot encode "key present with value `undefined`" (`JSON.stringify` always drops such
+  keys), so every real server response for this branch has `pageType` genuinely *absent*, not
+  present-as-undefined — and a bare (non-optional) `z.undefined()` field requires the key to
+  actually exist. Confirmed live against production and via a comprehensive full-endpoint sweep:
+  every `pages.read` call on a non-TASK_LIST/CHANNEL/FILE page failed with
+  `RESPONSE_VALIDATION_ERROR`, including through `pagespace mcp`'s `read_page` tool (same SDK
+  invoke pipeline underneath). Fixed via `pageType: z.undefined().optional()`, which still
+  correctly rejects a real `pageType` string (so TASK_LIST/CHANNEL/FILE responses can't silently
+  parse against this branch instead of their own) while accepting the real-world missing-key case.
+  Not a regression from 1.5.0 — `documents.ts` was untouched by that release; this bug predates it
+  (present since at least 0.1.1) and was only now caught by exhaustive live-production testing.
+- **Root cause note (informational, not fixed here):** the specific failure was version-dependent
+  on *zod itself* — `z.undefined()`'s treatment of a missing key changed between zod 4.3.6 (accepts
+  it) and 4.4.3 (rejects it, requiring the key to exist). This repo's own test suite runs against
+  whatever zod its lockfile has pinned (4.3.6 at the time of the 1.5.0 release) and never caught
+  this, while a fresh `npm install` today resolves 4.4.3+ under the SDK's `"zod": "^4.1.8"` range.
+  The `.optional()` fix is verified stable across both zod versions, but the underlying dependency-
+  range fragility (CI can pass while every real consumer's resolved zod silently behaves
+  differently) is a broader hardening item worth a follow-up, not addressed in this patch.
+
 ## [1.5.0] — 2026-07-07
 
 ### Removed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Typed TypeScript/JavaScript client SDK for the PageSpace API — drives, pages, tasks, roles, search, agents, and more.",
   "keywords": [
     "pagespace",

--- a/packages/sdk/src/operations/__tests__/documents.test.ts
+++ b/packages/sdk/src/operations/__tests__/documents.test.ts
@@ -47,6 +47,33 @@ describe('pages.read (documents) — response contract: generic text page', () =
     expect(result).toEqual(genericFixture);
   });
 
+  /**
+   * Regression test for a real production outage: `genericReadResultSchema`
+   * previously declared `pageType: z.undefined()` (bare, non-optional).
+   * JSON has no way to encode "key present with value undefined" —
+   * `JSON.stringify` always drops such keys — so every real server response
+   * for this branch has `pageType` genuinely ABSENT, never present-as-
+   * undefined. Confirmed live against production: zod 4.3.6 (this repo's
+   * lockfile-pinned version) treats a missing key as satisfying a bare
+   * `z.undefined()` field, but zod 4.4.3 (what `npm install` resolves fresh
+   * today under the SDK's `^4.1.8` range) does not — it requires the key to
+   * literally exist. That silent behavior drift between zod patch versions
+   * meant this repo's own test suite never caught the bug (it runs against
+   * the older pinned zod), while every real `pages.read`/`read_page` call
+   * against a plain page failed for anyone installing the package fresh.
+   * Fixed via `.optional()`, verified stable across both zod versions.
+   * `JSON.parse(JSON.stringify(...))` here (not a bare object literal) is
+   * deliberate — it's the only way to reproduce "key genuinely absent" as
+   * opposed to "key present with an `undefined` value", which behave
+   * differently under strict zod versions.
+   */
+  it('parses a real JSON-round-tripped response (pageType key genuinely absent, not undefined-valued)', () => {
+    const roundTripped = JSON.parse(JSON.stringify(genericFixture));
+    expect(Object.prototype.hasOwnProperty.call(roundTripped, 'pageType')).toBe(false);
+    const result = parseResponse(readDocument, 200, new Headers(), JSON.stringify(roundTripped));
+    expect(result).toEqual(genericFixture);
+  });
+
   it('parses a FILE page with fileMetadata attached', () => {
     const withFile = {
       ...genericFixture,

--- a/packages/sdk/src/operations/documents.ts
+++ b/packages/sdk/src/operations/documents.ts
@@ -61,15 +61,22 @@ const taskItemSchema = z.object({
 
 /**
  * Non-TASK_LIST, non-CHANNEL, non-in-progress-FILE pages (the generic text
- * path, `route.ts:521-559`). `pageType` is required-absent (`z.undefined()`)
- * so a TASK_LIST/CHANNEL/FILE-status response — which all set a literal
- * `pageType` string — can never silently parse (and strip its extra fields)
- * against this branch instead of its own.
+ * path, `route.ts:521-559`) — the most common branch (plain DOCUMENT/FOLDER/
+ * CANVAS/CODE pages). `pageType` is `z.undefined().optional()`, not bare
+ * `z.undefined()`: JSON has no way to encode "key present with value
+ * undefined" (`JSON.stringify` always drops such keys), so every real server
+ * response for this branch has `pageType` entirely ABSENT, not
+ * present-as-undefined. A bare `z.undefined()` requires the key to actually
+ * exist and rejects a genuinely missing key, so it failed 100% of real
+ * responses here — `.optional()` accepts the missing-key case while still
+ * rejecting a literal `pageType` string, so a TASK_LIST/CHANNEL/FILE-status
+ * response still can't silently parse against this branch instead of its
+ * own.
  */
 const genericReadResultSchema = z.object({
   pageId: z.string(),
   pageTitle: z.string().nullable(),
-  pageType: z.undefined(),
+  pageType: z.undefined().optional(),
   totalLines: z.number(),
   numberedLines: z.array(z.string()),
   content: z.string(),

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -5,7 +5,7 @@ import type { CompatibilityResult } from './errors.js';
  * guarded by `__tests__/version.test.ts`, which reads package.json directly,
  * so bumping one without the other fails the suite.
  */
-export const SDK_VERSION = '1.5.0';
+export const SDK_VERSION = '1.5.1';
 
 /**
  * The SDK's compiled-in floor for the server's API_CONTRACT_VERSION (ADR 0001


### PR DESCRIPTION
## Summary

`client.pages.read()` (the SDK equivalent of `read_page`/`pagespace mcp`'s tool) currently throws `RESPONSE_VALIDATION_ERROR` for **every** plain page — DOCUMENT, FOLDER, CANVAS, CODE, and completed FILE pages — i.e. the single most common case. Only CHANNEL and TASK_LIST reads (which carry a real `pageType` discriminator) currently work.

**Confirmed live against production**, three ways:
1. Raw `fetch` to `/api/mcp/documents` — real server response never includes a `pageType` key for this branch.
2. `client.pages.read()` via the SDK directly — fails.
3. The actual `pagespace mcp` `read_page` tool call, live, through this exact Claude Code session's MCP connection — fails with the same error, while `read_page` on a CHANNEL/TASK_LIST page in the same drive succeeds.

## Root cause

`genericReadResultSchema` declares `pageType: z.undefined()` to assert "this branch's responses never carry `pageType`." But JSON has no way to encode "key present with value `undefined`" — `JSON.stringify` always drops such keys — so every real server response for this branch has `pageType` genuinely **absent**, not present-as-undefined. A bare (non-optional) `z.undefined()` field requires the key to actually exist, so it rejects every real response.

It's also **zod-version-dependent**, which is why it slipped through CI: `z.undefined()`'s handling of a missing key changed between zod `4.3.6` (accepts a missing key) and `4.4.3` (rejects it, requires the key to exist). This repo's own test suite runs against whatever zod its lockfile pins (`4.3.6`), so it never caught this — but a fresh `npm install` today resolves `4.4.3+` under the SDK's `"zod": "^4.1.8"` range, which is exactly what every real consumer gets. Verified this divergence directly by pinning both exact zod versions in isolated test dirs and running the identical schema check against each.

**Not a regression from #1942/1.5.0** — `documents.ts` was untouched by that release. This bug predates it (present since at least 0.1.1) and was only caught now via an exhaustive full-endpoint sweep against live production.

## Fix

- `pageType: z.undefined()` → `pageType: z.undefined().optional()`. Verified this still correctly rejects a real `pageType: "TASK_LIST"` string (so CHANNEL/TASK_LIST/FILE-status responses still can't silently parse against this branch instead of their own), across both zod 4.3.6 and 4.4.3.
- New regression test in `documents.test.ts` using `JSON.parse(JSON.stringify(...))` rather than a bare object literal — that round-trip is what reproduces "key genuinely absent" as opposed to "key present with an `undefined` value," which is the exact distinction that let this slip through the existing (correctly-intentioned but insufficient-in-isolation) test.
- `SDK_VERSION` / `package.json` → `1.5.1`, CHANGELOG entry documenting both the fix and the zod-version-drift root cause as a noted-but-not-addressed hardening item.

## Verification

- `packages/sdk`: `bun run test` → 38 files, **761/761** (was 760; +1 regression test)
- `bun run typecheck` → clean
- Fix confirmed against live production via the freshly built local `dist/`, both as a direct SDK call and through the live `pagespace mcp` `read_page` tool call in this session

## Not addressed here (follow-up)

The `"zod": "^4.1.8"` dependency range is loose enough that a routine zod patch bump can silently change real behavior without this repo's CI ever noticing, because CI tests against a stale lockfile-pinned version while real consumers get whatever's current on npm. Worth a follow-up (tighter range, or a CI job that also runs against zod's latest) — out of scope for this urgent patch to keep the diff minimal and fast to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QtY16bnAP9aaujUrB5YsT