### PR TITLE
fix(web): hide unwired integration adapters from non-admins

### DIFF
--- a/apps/web/src/app/settings/integrations/page.tsx
+++ b/apps/web/src/app/settings/integrations/page.tsx
@@ -14,6 +14,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowLeft, Cable, Calendar, Plug2, Loader2, AlertCircle, Package, Clock, CheckCircle2 } from 'lucide-react';
 import { toast } from 'sonner';
+import { useAuth } from '@/hooks/useAuth';
 import { useProviders, useUserConnections, useAvailableBuiltins, useGoogleCalendarStatus } from '@/hooks/useIntegrations';
 import { IntegrationStatusBadge } from '@/components/integrations/IntegrationStatusBadge';
 import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
@@ -30,6 +31,8 @@ const visibilityLabels: Record<string, string> = {
 export default function IntegrationsSettingsPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const { providers, isLoading: loadingProviders, error: providersError, mutate: mutateProviders } = useProviders();
   const { connections, isLoading: loadingConnections, error: connectionsError, mutate: mutateConnections } = useUserConnections();
 
@@ -59,8 +62,8 @@ export default function IntegrationsSettingsPage() {
     [connections]
   );
   const availableProviders = useMemo(
-    () => providers.filter((p) => !connectedProviderIds.has(p.id)),
-    [providers, connectedProviderIds]
+    () => providers.filter((p) => !connectedProviderIds.has(p.id) && (isAdmin || p.slug === 'github')),
+    [providers, connectedProviderIds, isAdmin]
   );
 
   const handleDisconnect = async () => {
@@ -304,67 +307,69 @@ export default function IntegrationsSettingsPage() {
         </Card>
 
         {/* Built-in Integrations */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Package className="h-5 w-5" />
-              Built-in Integrations
-            </CardTitle>
-            <CardDescription>
-              Install built-in integrations to make them available for connection.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {loadingBuiltins ? (
-              <div className="space-y-3">
-                <Skeleton className="h-16 w-full" />
-              </div>
-            ) : builtinsError ? (
-              <div className="flex items-center gap-2 p-4 text-sm text-destructive bg-destructive/10 rounded-lg">
-                <AlertCircle className="h-4 w-4" />
-                <span>Failed to load available integrations</span>
-              </div>
-            ) : builtins.length === 0 ? (
-              <p className="text-sm text-muted-foreground text-center py-6">
-                All built-in integrations have been installed.
-              </p>
-            ) : (
-              <div className="space-y-3">
-                {builtins.map((builtin) => (
-                  <div
-                    key={builtin.id}
-                    className="flex items-center justify-between p-3 border rounded-lg bg-card"
-                  >
-                    <div className="flex items-center gap-3 min-w-0">
-                      <div className="p-2 rounded-full bg-muted flex-shrink-0">
-                        <Package className="h-4 w-4 text-muted-foreground" />
-                      </div>
-                      <div className="min-w-0">
-                        <span className="font-medium">{builtin.name}</span>
-                        {builtin.description && (
-                          <p className="text-xs text-muted-foreground truncate">
-                            {builtin.description}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={installingBuiltin === builtin.id}
-                      onClick={() => handleInstallBuiltin(builtin.id)}
+        {isAdmin && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Package className="h-5 w-5" />
+                Built-in Integrations
+              </CardTitle>
+              <CardDescription>
+                Install built-in integrations to make them available for connection.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {loadingBuiltins ? (
+                <div className="space-y-3">
+                  <Skeleton className="h-16 w-full" />
+                </div>
+              ) : builtinsError ? (
+                <div className="flex items-center gap-2 p-4 text-sm text-destructive bg-destructive/10 rounded-lg">
+                  <AlertCircle className="h-4 w-4" />
+                  <span>Failed to load available integrations</span>
+                </div>
+              ) : builtins.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center py-6">
+                  All built-in integrations have been installed.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {builtins.map((builtin) => (
+                    <div
+                      key={builtin.id}
+                      className="flex items-center justify-between p-3 border rounded-lg bg-card"
                     >
-                      {installingBuiltin === builtin.id ? (
-                        <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                      ) : null}
-                      Install
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div className="p-2 rounded-full bg-muted flex-shrink-0">
+                          <Package className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                        <div className="min-w-0">
+                          <span className="font-medium">{builtin.name}</span>
+                          {builtin.description && (
+                            <p className="text-xs text-muted-foreground truncate">
+                              {builtin.description}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={installingBuiltin === builtin.id}
+                        onClick={() => handleInstallBuiltin(builtin.id)}
+                      >
+                        {installingBuiltin === builtin.id ? (
+                          <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                        ) : null}
+                        Install
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )}
       </div>
 
       {/* Connect Dialog */}

--- a/apps/web/src/components/settings/DriveIntegrations.tsx
+++ b/apps/web/src/components/settings/DriveIntegrations.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { AlertCircle, Cable, Plug2, Plus, Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
+import { useAuth } from '@/hooks/useAuth';
 import { useDriveConnections, useProviders, useConnectionGrantCount } from '@/hooks/useIntegrations';
 import { IntegrationStatusBadge } from '@/components/integrations/IntegrationStatusBadge';
 import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
@@ -26,6 +27,8 @@ interface DriveIntegrationsProps {
 }
 
 export function DriveIntegrations({ driveId }: DriveIntegrationsProps) {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const { connections, isLoading: loadingConnections, error: connectionsError, mutate: mutateConnections } = useDriveConnections(driveId);
   const { providers, isLoading: loadingProviders, error: providersError, mutate: mutateProviders } = useProviders();
 
@@ -38,8 +41,8 @@ export function DriveIntegrations({ driveId }: DriveIntegrationsProps) {
     [connections]
   );
   const availableProviders = useMemo(
-    () => providers.filter((p) => !connectedProviderIds.has(p.id)),
-    [providers, connectedProviderIds]
+    () => providers.filter((p) => !connectedProviderIds.has(p.id) && (isAdmin || p.slug === 'github')),
+    [providers, connectedProviderIds, isAdmin]
   );
 
   const handleDisconnect = async () => {


### PR DESCRIPTION
## Summary
- Only GitHub is fully wired up for user-facing integration use today; Notion, Slack, and the generic webhook adapter aren't ready yet.
- Regular users now only see GitHub in the "Connect" picker on both the drive-level integrations settings page and the user-level `/settings/integrations` page. Platform admins (`user.role === 'admin'`) still see all four adapters.
- The admin-only "Built-in Integrations" install card (whose install action already required `verifyAdminAuth` server-side) is now hidden from non-admins in the UI too.
- No backend changes — `GET /api/integrations/providers` still returns all providers so already-connected non-GitHub integrations keep rendering correctly for everyone.

## Test plan
- [x] `bun run typecheck` passes clean in `apps/web`
- [ ] Manually verify as a non-admin: only GitHub appears in "Available Providers" on `/settings/integrations` and the drive's Connect picker, and the "Built-in Integrations" card is gone
- [ ] Manually verify as a platform admin: all four adapters still appear in both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017no2eqptaRNyG5VMxjLSkr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Non-admin users now see a more limited set of available integrations, with connected providers still excluded.
  * The built-in integrations section is now hidden for non-admin users, preventing access to admin-only install options.
  * Drive integration options now respect the user’s access level, allowing only the appropriate provider choices for standard users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->