### PR TITLE
fix(sdk): browser compat — fetch binding + Web Crypto PKCE — 2.0.0 (breaking: async PKCE)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -535,7 +535,7 @@
     },
     "packages/sdk": {
       "name": "@pagespace/sdk",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "dependencies": {
         "zod": "^4.1.8",
       },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.5.1] — 2026-07-08
+
+### Changed
+
+- **Requires `@pagespace/sdk` `^2.0.0`** (was `^1.5.0`). The SDK's `deriveCodeChallenge` — used
+  internally by `pagespace login`'s loopback flow — became `async` in the SDK's `2.0.0` release
+  (browser-compat fix; see `@pagespace/sdk`'s changelog), so `loopback-flow.ts` now `await`s it.
+  No user-facing behavior change.
+
 ## [1.5.0] — 2026-07-07
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "pagespace — the official CLI for PageSpace: browser-based login, drive/page/task management, and a `pagespace mcp` stdio server for coding agents.",
   "license": "MIT",
   "repository": {
@@ -41,7 +41,7 @@
     "@clack/prompts": "^1.7.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
-    "@pagespace/sdk": "^1.5.0",
+    "@pagespace/sdk": "^2.0.0",
     "zod": "^4.1.8"
   },
   "devDependencies": {

--- a/packages/cli/src/auth/loopback-flow.ts
+++ b/packages/cli/src/auth/loopback-flow.ts
@@ -311,7 +311,7 @@ export async function runLoopbackLogin(deps: LoopbackLoginDeps): Promise<Loopbac
 
   try {
     const verifier = generateCodeVerifier(deps.randomBytes(32));
-    const challenge = deriveCodeChallenge(verifier);
+    const challenge = await deriveCodeChallenge(verifier);
     const state = toBase64Url(deps.randomBytes(16));
     const redirectUri = `http://127.0.0.1:${server.port}${CALLBACK_PATH}`;
     const authorizeUrl = buildAuthorizeUrl({

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -7,7 +7,7 @@ import type { CommandHandler } from '../router/router.js';
  * guarded by `commands/__tests__/version.test.ts`, which reads package.json
  * directly, so bumping one without the other fails the suite.
  */
-export const CLI_VERSION = '1.5.0';
+export const CLI_VERSION = '1.5.1';
 
 export const versionHandler: CommandHandler = async (ctx, intent) => {
   if (intent.flags.json) {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.5.2] — 2026-07-08
+## [2.0.0] — 2026-07-08
+
+### Breaking Changes
+
+- **`deriveCodeChallenge` is now `async`, returning `Promise<string>` instead of `string`.**
+  Required to make the PKCE helpers work in a browser bundle (see below) — there is no synchronous
+  SHA-256 primitive available in a browser, so this could not ship as a patch/minor release without
+  silently breaking any caller that used the return value synchronously. Confirmed via automated
+  review before merge: the already-published `@pagespace/cli@1.5.0` depends on
+  `@pagespace/sdk: ^1.5.0` and its published build calls this synchronously (unawaited) — publishing
+  this fix as a `1.x` patch would have meant every *existing* CLI install silently picked up the
+  new async SDK on its next `npm install` and started sending `[object Promise]` as the OAuth
+  `code_challenge`, breaking `pagespace login` with no code change on the CLI's side at all. Shipping
+  as `2.0.0` means npm's `^1.5.0` range on the already-published CLI does not resolve to it — only a
+  consumer that explicitly opts into `^2.0.0` (this repo's own `packages/cli`, bumped in the same
+  change) is affected.
+  **Migration:** `await deriveCodeChallenge(verifier)` instead of `deriveCodeChallenge(verifier)`.
+  `generateCodeVerifier` is unaffected (still synchronous).
 
 ### Fixed
 
@@ -20,11 +37,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `node:crypto` and `Buffer` directly and could not run in a browser bundle at all.** Needed by any
   browser app implementing its own `pagespace login`-equivalent OAuth flow (not needed for simple
   `StaticTokenProvider` API usage). Rewrote `packages/sdk/src/auth/pkce.ts` on the Web Crypto API
-  (`crypto.subtle.digest`, `btoa`), which both Node 20+ and every real browser provide.
-  `deriveCodeChallenge` is now `async` (`subtle.digest` is Promise-based) — a signature change;
-  updated its one caller, `packages/cli/src/auth/loopback-flow.ts`, to `await` it. Output is
+  (`crypto.subtle.digest`, `btoa`), which both Node 20+ and every real browser provide. Output is
   byte-for-byte identical to the old `Buffer`-based encoding for the same inputs, verified by the
-  existing drift-guard test against `@pagespace/lib`'s canonical (Node-only, server-side) copy.
+  existing drift-guard test against `@pagespace/lib`'s canonical (Node-only, server-side) copy. Its
+  one in-repo caller, `packages/cli/src/auth/loopback-flow.ts`, now `await`s it — see the breaking
+  change entry above for why this could not ship as a patch/minor version.
 
 ## [1.5.1] — 2026-07-08
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.5.2] — 2026-07-08
+
+### Fixed
+
+- **Every API call from a real browser threw `TypeError: Failed to execute 'fetch' on 'Window':
+  Illegal invocation`, before the request ever reached the network.** `client.ts` captured a
+  detached reference to the global `fetch` (`options.fetch ?? fetch`) and later invoked it in
+  method-call position through an options object (`options.fetch(url, ...)`). Browsers require
+  `fetch`'s receiver to be the real `Window` object; Node's `fetch` (undici) has no such check, so
+  this was invisible to the entirely-Node vitest suite and only surfaced building a real
+  browser-based demo app. Fixed by binding to `globalThis` at construction time
+  (`fetch.bind(globalThis)`), which satisfies the receiver check in both environments. The
+  existing `options.fetch` injection point (used throughout the test suite's `vi.fn()` mocks) is
+  unaffected — this only changes the default when no `fetch` override is supplied.
+- **`generateCodeVerifier`/`deriveCodeChallenge` (PKCE math, public SDK surface) used
+  `node:crypto` and `Buffer` directly and could not run in a browser bundle at all.** Needed by any
+  browser app implementing its own `pagespace login`-equivalent OAuth flow (not needed for simple
+  `StaticTokenProvider` API usage). Rewrote `packages/sdk/src/auth/pkce.ts` on the Web Crypto API
+  (`crypto.subtle.digest`, `btoa`), which both Node 20+ and every real browser provide.
+  `deriveCodeChallenge` is now `async` (`subtle.digest` is Promise-based) — a signature change;
+  updated its one caller, `packages/cli/src/auth/loopback-flow.ts`, to `await` it. Output is
+  byte-for-byte identical to the old `Buffer`-based encoding for the same inputs, verified by the
+  existing drift-guard test against `@pagespace/lib`'s canonical (Node-only, server-side) copy.
+
 ## [1.5.1] — 2026-07-08
 
 ### Fixed

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Typed TypeScript/JavaScript client SDK for the PageSpace API — drives, pages, tasks, roles, search, agents, and more.",
   "keywords": [
     "pagespace",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagespace/sdk",
-  "version": "1.5.2",
+  "version": "2.0.0",
   "description": "Typed TypeScript/JavaScript client SDK for the PageSpace API — drives, pages, tasks, roles, search, agents, and more.",
   "keywords": [
     "pagespace",

--- a/packages/sdk/src/auth/__tests__/pkce-drift-guard.test.ts
+++ b/packages/sdk/src/auth/__tests__/pkce-drift-guard.test.ts
@@ -27,7 +27,7 @@ import {
 import { deriveCodeChallenge, generateCodeVerifier } from '../pkce.js';
 
 describe('deriveCodeChallenge — drift guard vs @pagespace/lib canonical implementation', () => {
-  it('produces byte-for-byte identical output for a range of verifier strings', () => {
+  it('produces byte-for-byte identical output for a range of verifier strings', async () => {
     const verifiers = [
       'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
       'a',
@@ -35,7 +35,7 @@ describe('deriveCodeChallenge — drift guard vs @pagespace/lib canonical implem
       'mixed-Case_and-Digits012789',
     ];
     for (const verifier of verifiers) {
-      expect(deriveCodeChallenge(verifier)).toBe(libDeriveCodeChallenge(verifier));
+      expect(await deriveCodeChallenge(verifier)).toBe(libDeriveCodeChallenge(verifier));
     }
   });
 });

--- a/packages/sdk/src/auth/__tests__/pkce.test.ts
+++ b/packages/sdk/src/auth/__tests__/pkce.test.ts
@@ -43,19 +43,19 @@ describe('generateCodeVerifier', () => {
 });
 
 describe('deriveCodeChallenge', () => {
-  it('derives BASE64URL(SHA256(ASCII(verifier)))', () => {
+  it('derives BASE64URL(SHA256(ASCII(verifier)))', async () => {
     // Known RFC 7636 Appendix B test vector.
     const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
-    expect(deriveCodeChallenge(verifier)).toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+    await expect(deriveCodeChallenge(verifier)).resolves.toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
   });
 
-  it('is pure — same verifier in, same challenge out, every time', () => {
+  it('is pure — same verifier in, same challenge out, every time', async () => {
     const verifier = 'a-fixed-verifier-string-for-determinism-check';
-    expect(deriveCodeChallenge(verifier)).toBe(deriveCodeChallenge(verifier));
+    expect(await deriveCodeChallenge(verifier)).toBe(await deriveCodeChallenge(verifier));
   });
 
-  it('produces a challenge with no padding characters', () => {
-    const challenge = deriveCodeChallenge('some-arbitrary-verifier-value-1234567890');
+  it('produces a challenge with no padding characters', async () => {
+    const challenge = await deriveCodeChallenge('some-arbitrary-verifier-value-1234567890');
     expect(challenge).not.toContain('=');
   });
 });

--- a/packages/sdk/src/auth/pkce.ts
+++ b/packages/sdk/src/auth/pkce.ts
@@ -2,24 +2,39 @@
  * Client-side PKCE (RFC 7636) math for the OAuth 2.1 authorization-code +
  * PKCE flow (`pagespace login`, `packages/cli/src/auth/loopback-flow.ts`).
  *
- * Pure: no I/O, no clock, no ambient randomness — every decision is a
- * function of its arguments only. Deliberately copied (not imported) from
- * the provider-side implementation (`packages/lib/src/auth/oauth/pkce.ts`,
- * which also verifies challenges server-side and pulls in
- * `packages/lib`'s `secureCompare`): the published SDK must never
- * runtime-import `@pagespace/lib` (see `operations/roles.ts`'s equivalent
- * inlining of `PagePerm`, for the same reason) — the derivation itself is
- * the same SHA256/base64url math regardless of which side of the exchange
- * calls it.
+ * Pure: no clock, no ambient randomness — every decision is a function of
+ * its arguments only. Uses the Web Crypto API (`crypto.subtle`, `btoa`)
+ * rather than `node:crypto`/`Buffer` so this module runs unmodified in a
+ * browser bundle — this file is reachable from the SDK's public entry point,
+ * so a plain browser app implementing its own login flow needs it to work
+ * without Node polyfills. Deliberately copied (not imported) from the
+ * provider-side implementation (`packages/lib/src/auth/oauth/pkce.ts`, which
+ * also verifies challenges server-side and pulls in `packages/lib`'s
+ * `secureCompare`): the published SDK must never runtime-import
+ * `@pagespace/lib` (see `operations/roles.ts`'s equivalent inlining of
+ * `PagePerm`, for the same reason) — the derivation itself is the same
+ * SHA256/base64url math regardless of which side of the exchange calls it.
  *
  * @see https://datatracker.ietf.org/doc/html/rfc7636
  */
-import { createHash } from 'node:crypto';
 
 /** Base64url-encodes to exactly a 43-char code_verifier — RFC 7636 §4.1's floor. */
 const MIN_VERIFIER_BYTES = 32;
 /** Base64url-encodes to exactly a 128-char code_verifier — RFC 7636 §4.1's ceiling. */
 const MAX_VERIFIER_BYTES = 96;
+
+/**
+ * Base64url-encodes bytes with no padding (RFC 4648 §5), byte-for-byte
+ * identical to Node's `Buffer.from(bytes).toString('base64url')` — but built
+ * from `btoa`, which (unlike `Buffer`) exists in both Node and browsers.
+ */
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
 
 /**
  * Derive a code_verifier from injected randomness (RFC 7636 §4.1 recommends
@@ -42,13 +57,16 @@ export function generateCodeVerifier(randomBytes: Uint8Array): string {
       `generateCodeVerifier requires ${MIN_VERIFIER_BYTES}-${MAX_VERIFIER_BYTES} random bytes (encodes to a 43-128 char code_verifier per RFC 7636 §4.1); got ${randomBytes.length}.`,
     );
   }
-  return Buffer.from(randomBytes).toString('base64url');
+  return toBase64Url(randomBytes);
 }
 
 /**
  * Derive the S256 code_challenge for a code_verifier:
- * BASE64URL(SHA256(ASCII(verifier))).
+ * BASE64URL(SHA256(ASCII(verifier))). Async because Web Crypto's
+ * `subtle.digest` is Promise-based (unlike `node:crypto`'s synchronous
+ * `createHash`) — the one API both Node and browsers actually share.
  */
-export function deriveCodeChallenge(verifier: string): string {
-  return createHash('sha256').update(verifier, 'ascii').digest('base64url');
+export async function deriveCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return toBase64Url(new Uint8Array(digest));
 }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -324,7 +324,7 @@ export class PageSpaceClient {
   constructor(options: PageSpaceClientOptions) {
     this.#config = { baseUrl: trimTrailingSlashes(options.baseUrl), apiVersion: options.apiVersion };
     this.#auth = options.auth;
-    this.#fetch = options.fetch ?? fetch;
+    this.#fetch = options.fetch ?? fetch.bind(globalThis);
     this.#timeoutMs = options.timeoutMs ?? 30_000;
     this.#retryPolicy = { ...DEFAULT_RETRY_POLICY, ...options.retryPolicy };
     this.#skipVersionCheck = options.skipVersionCheck ?? false;

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -5,7 +5,7 @@ import type { CompatibilityResult } from './errors.js';
  * guarded by `__tests__/version.test.ts`, which reads package.json directly,
  * so bumping one without the other fails the suite.
  */
-export const SDK_VERSION = '1.5.1';
+export const SDK_VERSION = '1.5.2';
 
 /**
  * The SDK's compiled-in floor for the server's API_CONTRACT_VERSION (ADR 0001

--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -5,7 +5,7 @@ import type { CompatibilityResult } from './errors.js';
  * guarded by `__tests__/version.test.ts`, which reads package.json directly,
  * so bumping one without the other fails the suite.
  */
-export const SDK_VERSION = '1.5.2';
+export const SDK_VERSION = '2.0.0';
 
 /**
  * The SDK's compiled-in floor for the server's API_CONTRACT_VERSION (ADR 0001


### PR DESCRIPTION
## Summary
- `packages/sdk/src/client.ts`: bind `fetch` to `globalThis` at construction time. The previous `options.fetch ?? fetch` captured a detached reference, later invoked in method position (`options.fetch(url, ...)`) — Chromium/real-browser `fetch` requires its receiver to be the real `Window` object and throws `TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation` otherwise. Node's undici `fetch` has no such receiver check, so this was invisible to the all-Node vitest suite and only surfaced building a real browser demo.
- `packages/sdk/src/auth/pkce.ts`: replace `node:crypto`'s `createHash`/`Buffer` with the Web Crypto API (`crypto.subtle.digest`, `btoa`) so the SDK's public PKCE helpers (`generateCodeVerifier`/`deriveCodeChallenge`) work in a browser bundle, not just Node. `deriveCodeChallenge` is now `async`; updated its one in-repo caller, `packages/cli/src/auth/loopback-flow.ts`, to `await` it. Output is byte-for-byte identical to the previous `Buffer`-based encoding — verified by the existing drift-guard test against `@pagespace/lib`'s canonical (Node-only) copy.

**Update after review:** Codex correctly flagged (P1) that the async signature change is a breaking change to public SDK surface, and the already-published `@pagespace/cli@1.5.0` on npm depends on `@pagespace/sdk: ^1.5.0` with a pre-fix `loopback-flow.ts` that calls this synchronously — publishing as a `1.5.2` patch would have meant every existing CLI install silently broke `pagespace login` (`code_challenge` becomes `"[object Promise]"`) on its next reinstall, with zero code change on the user's end. Fixed by shipping this as **`2.0.0`** instead (npm's `^1.5.0` on the published CLI does not resolve to `2.x`) and bumping this repo's own `packages/cli` to depend on `^2.0.0` + its own version to `1.5.1`. See both packages' `CHANGELOG.md` for the full breaking-change/migration notes.

This is fix 1 and 2 of a 4-part browser-compat plan (root-caused via a real Playwright-driven npm-installed demo app). Fixes 3 and 4 (CORS + CORP, needed for the *cross-origin* case) are separate PRs — #1950 in this repo and a companion PR in `PageSpace-Deploy` — since they touch different packages/repos and need their own deploys (Fly / npm publish are independent release processes).

## Test plan
- [x] `packages/sdk`: `bun run typecheck`, `bun run build`, `bun run test` — 761/761 pass
- [x] `packages/cli`: `bun run typecheck`, `bun run build`, `bun run test` — 999/999 pass (including the loopback-flow PKCE integration test, now awaiting the async `deriveCodeChallenge`)
- [x] Re-verified both suites after the 2.0.0/1.5.1 version bump — still 761/761 and 999/999, both typecheck clean
- [ ] Post-merge: `npm publish` `@pagespace/sdk@2.0.0` and `@pagespace/cli@1.5.1` together, rerun the Playwright-driven browser demo against a freshly-built local SDK to confirm same-origin calls now dispatch real network requests instead of throwing before reaching the network layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbwJXkonbbrzXmXcKpEsND