### PR TITLE
fix(security): trust-boundary-aware getClientIP() + oauth origin hardening

### DIFF
--- a/apps/marketing/src/app/api/contact/route.ts
+++ b/apps/marketing/src/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { Resend } from "resend";
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
+import { getClientIP } from '@pagespace/lib/security/client-ip';
 
 // Bounded-quantifier RFC 5322 regex — O(N), no ReDoS risk
 const EMAIL_PATTERN = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
@@ -21,10 +22,7 @@ function getResend() {
 }
 
 export async function POST(request: Request) {
-  const clientIP =
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    request.headers.get("x-real-ip") ||
-    "unknown";
+  const clientIP = getClientIP(request);
 
   try {
     const rateLimitResult = await checkDistributedRateLimit(

--- a/apps/processor/src/middleware/__tests__/rate-limit.test.ts
+++ b/apps/processor/src/middleware/__tests__/rate-limit.test.ts
@@ -13,13 +13,15 @@ afterEach(() => {
 function createMockReq(overrides: {
   userId?: string;
   forwardedFor?: string;
+  flyClientIp?: string;
   ip?: string;
 } = {}): Request {
+  const headers: Record<string, string> = {};
+  if (overrides.forwardedFor) headers['x-forwarded-for'] = overrides.forwardedFor;
+  if (overrides.flyClientIp) headers['fly-client-ip'] = overrides.flyClientIp;
   return {
     auth: overrides.userId ? { userId: overrides.userId } : undefined,
-    headers: overrides.forwardedFor
-      ? { 'x-forwarded-for': overrides.forwardedFor }
-      : {},
+    headers,
     ip: overrides.ip || '127.0.0.1',
   } as unknown as Request;
 }
@@ -316,5 +318,98 @@ describe('rateLimitRead (createRateLimiter)', () => {
     expect(next2).toHaveBeenCalledTimes(1);
 
     vi.useRealTimers();
+  });
+});
+
+// getClientIP (this file's internal helper, not exported) is only observable
+// through the rate-limit bucket key it feeds into getBucketKey — these tests
+// exercise it that way: two requests that land in the SAME bucket collide
+// (second is blocked at limit=1); two requests that land in DIFFERENT
+// buckets don't. See packages/lib/src/security/__tests__/client-ip.test.ts
+// for the same trust-gate logic tested directly against the shared helper.
+describe('Fly-Client-IP trust gate (FLY_APP_NAME)', () => {
+  const ORIGINAL_FLY_APP_NAME = process.env.FLY_APP_NAME;
+
+  afterEach(() => {
+    if (ORIGINAL_FLY_APP_NAME === undefined) {
+      delete process.env.FLY_APP_NAME;
+    } else {
+      process.env.FLY_APP_NAME = ORIGINAL_FLY_APP_NAME;
+    }
+  });
+
+  it('when running on Fly, distinct fly-client-ip values get distinct buckets even with the same x-forwarded-for', async () => {
+    process.env.FLY_APP_NAME = 'pagespace-processor';
+    process.env.PROCESSOR_READ_RATE_LIMIT = '1';
+    process.env.PROCESSOR_READ_RATE_WINDOW = '3600';
+    const { rateLimitRead } = await import('../rate-limit');
+
+    const req1 = createMockReq({ flyClientIp: '9.9.9.9', forwardedFor: '1.2.3.4' });
+    const { res: res1 } = createMockRes();
+    rateLimitRead(req1, res1, createMockNext());
+
+    // Different fly-client-ip, same x-forwarded-for — must be a separate bucket
+    // (not blocked), proving fly-client-ip is the key, not x-forwarded-for.
+    const req2 = createMockReq({ flyClientIp: '8.8.8.8', forwardedFor: '1.2.3.4' });
+    const { res: res2 } = createMockRes();
+    const next2 = createMockNext();
+    rateLimitRead(req2, res2, next2);
+    expect(next2).toHaveBeenCalledTimes(1);
+  });
+
+  it('when running on Fly, the same fly-client-ip collides into one bucket regardless of x-forwarded-for', async () => {
+    process.env.FLY_APP_NAME = 'pagespace-processor';
+    process.env.PROCESSOR_READ_RATE_LIMIT = '1';
+    process.env.PROCESSOR_READ_RATE_WINDOW = '3600';
+    const { rateLimitRead } = await import('../rate-limit');
+
+    const req1 = createMockReq({ flyClientIp: '9.9.9.9', forwardedFor: '1.2.3.4' });
+    const { res: res1 } = createMockRes();
+    rateLimitRead(req1, res1, createMockNext());
+
+    const req2 = createMockReq({ flyClientIp: '9.9.9.9', forwardedFor: '5.6.7.8' });
+    const { res: res2, status: status2 } = createMockRes();
+    const next2 = createMockNext();
+    rateLimitRead(req2, res2, next2);
+    expect(next2).not.toHaveBeenCalled();
+    expect(status2).toHaveBeenCalledWith(429);
+  });
+
+  it('when NOT running on Fly, a forged fly-client-ip is ignored — distinct requests sharing x-forwarded-for collide into one bucket', async () => {
+    delete process.env.FLY_APP_NAME;
+    process.env.PROCESSOR_READ_RATE_LIMIT = '1';
+    process.env.PROCESSOR_READ_RATE_WINDOW = '3600';
+    const { rateLimitRead } = await import('../rate-limit');
+
+    const req1 = createMockReq({ flyClientIp: '9.9.9.9', forwardedFor: '1.2.3.4' });
+    const { res: res1 } = createMockRes();
+    rateLimitRead(req1, res1, createMockNext());
+
+    // Different (forged) fly-client-ip but the SAME x-forwarded-for — must
+    // collide into the same bucket as req1, proving fly-client-ip is fully
+    // ignored off-Fly and cannot be used to evade the rate limit.
+    const req2 = createMockReq({ flyClientIp: '8.8.8.8', forwardedFor: '1.2.3.4' });
+    const { res: res2, status: status2 } = createMockRes();
+    const next2 = createMockNext();
+    rateLimitRead(req2, res2, next2);
+    expect(next2).not.toHaveBeenCalled();
+    expect(status2).toHaveBeenCalledWith(429);
+  });
+
+  it('when NOT running on Fly, distinct x-forwarded-for values still get distinct buckets', async () => {
+    delete process.env.FLY_APP_NAME;
+    process.env.PROCESSOR_READ_RATE_LIMIT = '1';
+    process.env.PROCESSOR_READ_RATE_WINDOW = '3600';
+    const { rateLimitRead } = await import('../rate-limit');
+
+    const req1 = createMockReq({ forwardedFor: '1.2.3.4' });
+    const { res: res1 } = createMockRes();
+    rateLimitRead(req1, res1, createMockNext());
+
+    const req2 = createMockReq({ forwardedFor: '5.6.7.8' });
+    const { res: res2 } = createMockRes();
+    const next2 = createMockNext();
+    rateLimitRead(req2, res2, next2);
+    expect(next2).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/processor/src/middleware/rate-limit.ts
+++ b/apps/processor/src/middleware/rate-limit.ts
@@ -9,6 +9,23 @@ const buckets = new Map<string, RateLimitBucket>();
 const DEFAULT_LIMIT = parseInt(process.env.PROCESSOR_UPLOAD_RATE_LIMIT ?? '100', 10);
 const WINDOW_SECONDS = parseInt(process.env.PROCESSOR_UPLOAD_RATE_WINDOW ?? '3600', 10);
 
+// Express's req.headers is a plain object, not a Fetch Headers instance, so
+// it can't use @pagespace/lib/security/client-ip directly — same trust
+// priority (Fly-Client-IP first, unspoofable), adapted to Express's shape.
+function getClientIP(req: Request): string {
+  const flyClientIP = req.headers['fly-client-ip'];
+  if (typeof flyClientIP === 'string' && flyClientIP.length > 0) {
+    return flyClientIP.trim();
+  }
+
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+
+  return req.ip ?? 'unknown';
+}
+
 function getBucketKey(req: Request): string {
   const auth = req.auth;
   // Use userId for rate limiting - this ensures rate limits accumulate per-user
@@ -17,12 +34,7 @@ function getBucketKey(req: Request): string {
   }
 
   // Fallback to IP-based limiting for unauthenticated requests
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string' && forwarded.length > 0) {
-    return `ip:${forwarded.split(',')[0]}`;
-  }
-
-  return `ip:${req.ip}`;
+  return `ip:${getClientIP(req)}`;
 }
 
 function createRateLimiter(

--- a/apps/processor/src/middleware/rate-limit.ts
+++ b/apps/processor/src/middleware/rate-limit.ts
@@ -11,9 +11,12 @@ const WINDOW_SECONDS = parseInt(process.env.PROCESSOR_UPLOAD_RATE_WINDOW ?? '360
 
 // Express's req.headers is a plain object, not a Fetch Headers instance, so
 // it can't use @pagespace/lib/security/client-ip directly — same trust
-// priority (Fly-Client-IP first, unspoofable), adapted to Express's shape.
+// priority (Fly-Client-IP first, unspoofable — but ONLY when actually running
+// on Fly; this repo also ships a non-Fly `tenant` deployment mode where
+// Fly-Client-IP is just another ordinary client-settable header, see the
+// packages/lib copy's doc for the full reasoning), adapted to Express's shape.
 function getClientIP(req: Request): string {
-  const flyClientIP = req.headers['fly-client-ip'];
+  const flyClientIP = process.env.FLY_APP_NAME ? req.headers['fly-client-ip'] : undefined;
   if (typeof flyClientIP === 'string' && flyClientIP.length > 0) {
     return flyClientIP.trim();
   }

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -132,6 +132,7 @@ const eslintConfig = [
       "src/lib/request-id/request-id.ts",
       "src/lib/monitoring/ingest-sanitizer.ts",
       "src/lib/well-known/rewrites.ts",
+      "src/lib/security/edge-client-ip.ts",
     ],
     rules: {
       "no-restricted-imports": [

--- a/apps/web/src/app/api/account/devices/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/__tests__/route.test.ts
@@ -416,7 +416,7 @@ describe('DELETE /api/account/devices', () => {
       expect(createArgs[4]).toEqual({
         deviceName: 'My MacBook',
         userAgent: undefined,
-        ipAddress: undefined,
+        ipAddress: 'unknown',
       });
     });
 
@@ -570,7 +570,7 @@ describe('DELETE /api/account/devices', () => {
       expect(createArgs[4]).toEqual({
         deviceName: undefined,
         userAgent: undefined,
-        ipAddress: undefined,
+        ipAddress: 'unknown',
       });
     });
   });

--- a/apps/web/src/app/api/account/devices/route.ts
+++ b/apps/web/src/app/api/account/devices/route.ts
@@ -8,6 +8,7 @@ import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getUserDeviceTokens, revokeAllUserDeviceTokens, createDeviceTokenRecord, revokeExpiredDeviceTokens } from '@pagespace/lib/auth/device-auth-utils';
 import { isValidTokenFormat, getTokenType } from '@pagespace/lib/auth/opaque-tokens';
+import { getClientIP } from '@pagespace/lib/security/client-ip';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -160,7 +161,7 @@ export async function DELETE(req: Request) {
         {
           deviceName: currentDeviceInfo.deviceName || undefined,
           userAgent: req.headers.get('user-agent') ?? undefined,
-          ipAddress: req.headers.get('x-forwarded-for')?.split(',')[0] || req.headers.get('x-real-ip') || undefined,
+          ipAddress: getClientIP(req),
         }
       );
 

--- a/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/authorize/__tests__/route.test.ts
@@ -5,7 +5,7 @@
  * never redirect), error-redirect-after-validated-uri, session gate, CSRF on
  * the consent POST, single-use code hashed at rest, state echoed verbatim.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/auth', () => ({
@@ -91,6 +91,14 @@ beforeEach(() => {
   vi.clearAllMocks();
   checkDistributedRateLimit.mockResolvedValue(ALLOWED);
   vi.mocked(consumeStepUpGrant).mockResolvedValue({ ok: true });
+  // appOrigin() (issue #1908 hardening) only trusts this configured value —
+  // never x-forwarded-host/x-forwarded-proto. Matches the real deployment,
+  // where NEXT_PUBLIC_APP_URL is baked into the build image.
+  process.env.WEB_APP_URL = 'https://pagespace.ai';
+});
+
+afterEach(() => {
+  delete process.env.WEB_APP_URL;
 });
 
 describe('GET /api/oauth/authorize — per-IP rate limiting', () => {
@@ -193,7 +201,7 @@ describe('GET /api/oauth/authorize — session gate', () => {
     expect(decodeURIComponent(next)).toContain('state=xyz123');
   });
 
-  it('uses forwarded public origin for signin redirects instead of internal standalone bind host', async () => {
+  it('uses the configured app origin for signin redirects, ignoring x-forwarded-host/bind host (issue #1908)', async () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
       error: new Response(null, { status: 401 }),
     } as never);
@@ -201,7 +209,7 @@ describe('GET /api/oauth/authorize — session gate', () => {
     const res = await GET(new NextRequest(authorizeUrl(), {
       headers: {
         host: '[::]:3000',
-        'x-forwarded-host': 'pagespace.ai',
+        'x-forwarded-host': 'evil.example.com',
         'x-forwarded-proto': 'https',
       },
     }));
@@ -211,6 +219,7 @@ describe('GET /api/oauth/authorize — session gate', () => {
     expect(location.origin).toBe('https://pagespace.ai');
     expect(location.pathname).toBe('/auth/signin');
     expect(location.href).not.toContain('[::]');
+    expect(location.href).not.toContain('evil.example.com');
   });
 
   it('redirects to the consent screen, preserving the full authorize request, when authenticated', async () => {
@@ -231,7 +240,7 @@ describe('GET /api/oauth/authorize — session gate', () => {
     expect(location.searchParams.get('state')).toBe('xyz123');
   });
 
-  it('uses forwarded public origin for consent redirects instead of internal standalone bind host', async () => {
+  it('uses the configured app origin for consent redirects, ignoring x-forwarded-host/bind host (issue #1908)', async () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
       tokenType: 'session',
       userId: 'user-1',
@@ -244,7 +253,7 @@ describe('GET /api/oauth/authorize — session gate', () => {
     const res = await GET(new NextRequest(authorizeUrl(), {
       headers: {
         host: '[::]:3000',
-        'x-forwarded-host': 'pagespace.ai',
+        'x-forwarded-host': 'evil.example.com',
         'x-forwarded-proto': 'https',
       },
     }));
@@ -254,6 +263,21 @@ describe('GET /api/oauth/authorize — session gate', () => {
     expect(location.origin).toBe('https://pagespace.ai');
     expect(location.pathname).toBe('/oauth/consent');
     expect(location.href).not.toContain('[::]');
+    expect(location.href).not.toContain('evil.example.com');
+  });
+
+  it('fails closed (never redirects) when the app origin is not configured, even with a forged x-forwarded-host', async () => {
+    delete process.env.WEB_APP_URL;
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(null, { status: 401 }),
+    } as never);
+
+    const res = await GET(new NextRequest(authorizeUrl(), {
+      headers: { 'x-forwarded-host': 'evil.example.com', 'x-forwarded-proto': 'https' },
+    }));
+
+    expect(res.status).not.toBe(302);
+    expect(res.headers.get('location')).toBeNull();
   });
 });
 

--- a/apps/web/src/app/api/oauth/authorize/route.ts
+++ b/apps/web/src/app/api/oauth/authorize/route.ts
@@ -65,11 +65,12 @@ function buildRedirectWithParams(redirectUri: string, params: Record<string, str
   return url.toString();
 }
 
-function firstForwardedValue(value: string | null): string | undefined {
-  return value?.split(',')[0]?.trim() || undefined;
-}
-
-function configuredAppOrigin(): string | null {
+// Deliberately does NOT fall back to x-forwarded-host/x-forwarded-proto or
+// req.url — those are client-influenceable, and this origin feeds a redirect
+// target on an unauthenticated OAuth endpoint. WEB_APP_URL/NEXT_PUBLIC_APP_URL
+// is baked into every real deployment's build image, so this should never be
+// unset outside of misconfiguration; fail closed rather than trust a header.
+function appOrigin(): string | null {
   const configuredUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
   if (!configuredUrl) return null;
 
@@ -83,24 +84,6 @@ function configuredAppOrigin(): string | null {
   }
 
   return null;
-}
-
-function forwardedAppOrigin(req: NextRequest): string | null {
-  const host = firstForwardedValue(req.headers.get('x-forwarded-host')) ?? req.headers.get('host');
-  const proto =
-    firstForwardedValue(req.headers.get('x-forwarded-proto')) ??
-    (new URL(req.url).protocol === 'https:' ? 'https' : 'http');
-  if (!host || (proto !== 'http' && proto !== 'https')) return null;
-
-  try {
-    return new URL(`${proto}://${host}`).origin;
-  } catch {
-    return null;
-  }
-}
-
-function appOrigin(req: NextRequest): string {
-  return configuredAppOrigin() ?? forwardedAppOrigin(req) ?? new URL(req.url).origin;
 }
 
 export async function GET(req: NextRequest) {
@@ -131,17 +114,22 @@ export async function GET(req: NextRequest) {
     );
   }
 
+  const origin = appOrigin();
+  if (!origin) {
+    return renderErrorPage('Server misconfiguration.');
+  }
+
   const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: false });
   const consentTarget = `/oauth/consent${search}`;
 
   if (isAuthError(auth)) {
     return NextResponse.redirect(
-      new URL(`/auth/signin?next=${encodeURIComponent(consentTarget)}`, appOrigin(req)),
+      new URL(`/auth/signin?next=${encodeURIComponent(consentTarget)}`, origin),
       302,
     );
   }
 
-  return NextResponse.redirect(new URL(consentTarget, appOrigin(req)), 302);
+  return NextResponse.redirect(new URL(consentTarget, origin), 302);
 }
 
 const approvalSchema = z.object({

--- a/apps/web/src/lib/auth/auth-helpers.ts
+++ b/apps/web/src/lib/auth/auth-helpers.ts
@@ -6,22 +6,7 @@ import {
 } from './index';
 
 export { isSafeReturnUrl, isSafeNextPath, SIGNIN_NEXT_ALLOWED_PREFIXES } from './url-utils';
-
-/**
- * Extract client IP address from request headers.
- * Checks x-forwarded-for (proxy), x-real-ip (nginx), falls back to 'unknown'.
- *
- * @example
- * const clientIP = getClientIP(request);
- * const rateLimit = await checkDistributedRateLimit(`login:ip:${clientIP}`, config);
- */
-export function getClientIP(request: Request | NextRequest): string {
-  return (
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-    request.headers.get('x-real-ip') ||
-    'unknown'
-  );
-}
+export { getClientIP } from '@pagespace/lib/security/client-ip';
 
 export interface AuthUser {
   userId: string;

--- a/apps/web/src/lib/security/__tests__/edge-client-ip.test.ts
+++ b/apps/web/src/lib/security/__tests__/edge-client-ip.test.ts
@@ -1,7 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getClientIP } from '../edge-client-ip';
 
 describe('getClientIP (edge)', () => {
+  const ORIGINAL_FLY_APP_NAME = process.env.FLY_APP_NAME;
+
+  beforeEach(() => {
+    process.env.FLY_APP_NAME = 'pagespace-web';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_FLY_APP_NAME === undefined) {
+      delete process.env.FLY_APP_NAME;
+    } else {
+      process.env.FLY_APP_NAME = ORIGINAL_FLY_APP_NAME;
+    }
+  });
+
   it('prefers fly-client-ip over x-forwarded-for', () => {
     const request = new Request('http://localhost', {
       headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
@@ -54,6 +68,29 @@ describe('getClientIP (edge)', () => {
         headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4' },
       });
       expect(getClientIP(request)).toBe('9.9.9.9');
+    });
+  });
+
+  // Regression coverage: on a non-Fly host (e.g. this repo's `tenant`
+  // deployment mode — Docker/Traefik), fly-client-ip is just another
+  // ordinary, client-settable header with no trust guarantee at all.
+  describe('not running on Fly (FLY_APP_NAME unset — e.g. tenant/self-hosted)', () => {
+    beforeEach(() => {
+      delete process.env.FLY_APP_NAME;
+    });
+
+    it('ignores a forged fly-client-ip entirely and falls back to x-forwarded-for', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4' },
+      });
+      expect(getClientIP(request)).toBe('1.2.3.4');
+    });
+
+    it('returns unknown when only a forged fly-client-ip is present, never trusting it', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9' },
+      });
+      expect(getClientIP(request)).toBe('unknown');
     });
   });
 });

--- a/apps/web/src/lib/security/__tests__/edge-client-ip.test.ts
+++ b/apps/web/src/lib/security/__tests__/edge-client-ip.test.ts
@@ -27,4 +27,33 @@ describe('getClientIP (edge)', () => {
     const request = new Request('http://localhost');
     expect(getClientIP(request)).toBe('unknown');
   });
+
+  // Regression coverage — see packages/lib/src/security/__tests__/client-ip.test.ts
+  // for the full reasoning: fly-client-ip is set fresh per Fly Proxy hop, and
+  // pagespace.ai traffic reaches this app through Caddy's internal flycast
+  // relay, whose own second hop overwrites fly-client-ip with Caddy's own
+  // machine address (always Fly's private 6PN range, fdaa::/16) rather than
+  // the real visitor's.
+  describe('fly-client-ip in Fly 6PN range (arrived via the internal Caddy relay hop)', () => {
+    it('prefers x-forwarded-for over a 6PN fly-client-ip', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': 'fdaa:0:2ed2:a7b:19c:d9d2:5484:2', 'x-forwarded-for': '203.0.113.7' },
+      });
+      expect(getClientIP(request)).toBe('203.0.113.7');
+    });
+
+    it('falls back to the 6PN fly-client-ip itself as a last resort — still better than "unknown"', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': 'fdaa:0:2ed2:a7b:19c:d9d2:5484:2' },
+      });
+      expect(getClientIP(request)).toBe('fdaa:0:2ed2:a7b:19c:d9d2:5484:2');
+    });
+
+    it('still prefers a non-6PN fly-client-ip over x-forwarded-for (direct-hit path, #1908)', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4' },
+      });
+      expect(getClientIP(request)).toBe('9.9.9.9');
+    });
+  });
 });

--- a/apps/web/src/lib/security/__tests__/edge-client-ip.test.ts
+++ b/apps/web/src/lib/security/__tests__/edge-client-ip.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getClientIP } from '../edge-client-ip';
+
+describe('getClientIP (edge)', () => {
+  it('prefers fly-client-ip over x-forwarded-for', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+    });
+    expect(getClientIP(request)).toBe('9.9.9.9');
+  });
+
+  it('falls back to the first x-forwarded-for entry when fly-client-ip is absent', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+    });
+    expect(getClientIP(request)).toBe('1.2.3.4');
+  });
+
+  it('falls back to x-real-ip when fly-client-ip and x-forwarded-for are absent', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'x-real-ip': '10.0.0.1' },
+    });
+    expect(getClientIP(request)).toBe('10.0.0.1');
+  });
+
+  it('returns unknown when no IP headers are present', () => {
+    const request = new Request('http://localhost');
+    expect(getClientIP(request)).toBe('unknown');
+  });
+});

--- a/apps/web/src/lib/security/edge-client-ip.ts
+++ b/apps/web/src/lib/security/edge-client-ip.ts
@@ -11,14 +11,28 @@
  * actual TCP peer it accepted the connection from, so it cannot be spoofed
  * by a client-supplied header (GitHub issue #1908). Falls back to
  * `x-forwarded-for`/`x-real-ip` for local dev/CI, where there's no Fly edge.
+ *
+ * EXCEPT: `Fly-Client-IP` is set fresh per Fly Proxy hop, not chained.
+ * `pagespace.ai` traffic reaches this app via `pagespace-proxy` (Caddy) over
+ * the internal `flycast` network — a second hop whose own edge overwrites
+ * `Fly-Client-IP` with Caddy's own machine address, not the visitor's. Fly's
+ * private 6PN network exclusively uses IPv6 ULA addresses in `fdaa::/16`,
+ * which a real internet client's direct connection can never present — so an
+ * `fdaa:`-prefixed value unambiguously means this arrived over that internal
+ * hop, and Caddy has already relayed the real visitor IP as
+ * `X-Forwarded-For` instead (an unconditional replace, not an append — see
+ * PageSpace-Deploy's `fly/Caddyfile.fly` — so it isn't attacker-appendable).
+ * Trust that instead in this one case; see the `packages/lib` copy's doc for
+ * the full reasoning.
  */
 export function getClientIP(request: Request): string {
-  const flyClientIP = request.headers.get('fly-client-ip');
-  if (flyClientIP) return flyClientIP.trim();
+  const flyClientIP = request.headers.get('fly-client-ip')?.trim();
+  if (flyClientIP && !flyClientIP.toLowerCase().startsWith('fdaa:')) return flyClientIP;
 
   return (
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     request.headers.get('x-real-ip')?.trim() ||
+    flyClientIP ||
     'unknown'
   );
 }

--- a/apps/web/src/lib/security/edge-client-ip.ts
+++ b/apps/web/src/lib/security/edge-client-ip.ts
@@ -1,0 +1,24 @@
+/**
+ * Client IP extraction for the Edge-runtime middleware graph — a deliberate
+ * duplicate of @pagespace/lib/security/client-ip's logic. Edge-runtime files
+ * (src/middleware.ts, src/middleware/monitoring.ts) cannot import
+ * @pagespace/lib at all (see eslint.config.mjs's edge-runtime import-graph
+ * rule), so this stays a standalone leaf with zero imports rather than a
+ * re-export. Keep this in sync with the packages/lib version by hand if the
+ * trust logic ever changes.
+ *
+ * Prefers Fly's own `Fly-Client-IP` header — set by Fly's edge from the
+ * actual TCP peer it accepted the connection from, so it cannot be spoofed
+ * by a client-supplied header (GitHub issue #1908). Falls back to
+ * `x-forwarded-for`/`x-real-ip` for local dev/CI, where there's no Fly edge.
+ */
+export function getClientIP(request: Request): string {
+  const flyClientIP = request.headers.get('fly-client-ip');
+  if (flyClientIP) return flyClientIP.trim();
+
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip')?.trim() ||
+    'unknown'
+  );
+}

--- a/apps/web/src/lib/security/edge-client-ip.ts
+++ b/apps/web/src/lib/security/edge-client-ip.ts
@@ -24,9 +24,17 @@
  * PageSpace-Deploy's `fly/Caddyfile.fly` — so it isn't attacker-appendable).
  * Trust that instead in this one case; see the `packages/lib` copy's doc for
  * the full reasoning.
+ *
+ * GATED ON ACTUALLY RUNNING ON FLY: this repo also ships a non-Fly `tenant`
+ * deployment mode (Docker/Traefik), where `Fly-Client-IP` is just another
+ * ordinary, client-settable header with no trust guarantee at all — trusting
+ * it unconditionally there would let any caller forge it to bypass IP-keyed
+ * rate limits. `FLY_APP_NAME` is a runtime env var Fly injects into every Fly
+ * Machine automatically (never client-settable); use its presence to gate
+ * trust, not `DEPLOYMENT_MODE` — see the `packages/lib` copy's doc for why.
  */
 export function getClientIP(request: Request): string {
-  const flyClientIP = request.headers.get('fly-client-ip')?.trim();
+  const flyClientIP = process.env.FLY_APP_NAME ? request.headers.get('fly-client-ip')?.trim() : undefined;
   if (flyClientIP && !flyClientIP.toLowerCase().startsWith('fdaa:')) return flyClientIP;
 
   return (

--- a/apps/web/src/lib/websocket/ws-security.ts
+++ b/apps/web/src/lib/websocket/ws-security.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from 'next/server';
 import { createHash } from 'crypto';
+import { getClientIP } from '@pagespace/lib/security/client-ip';
 
 /**
  * WebSocket Security Utilities
@@ -25,10 +26,7 @@ import { createHash } from 'crypto';
  */
 export function getConnectionFingerprint(request: NextRequest): string {
   // Extract IP address (handle proxies)
-  const ip =
-    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
-    request.headers.get('x-real-ip') ||
-    'unknown';
+  const ip = getClientIP(request);
 
   // Extract User-Agent
   const userAgent = request.headers.get('user-agent') || 'unknown';

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/auth/token-prefixes';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 import { WELL_KNOWN_REWRITES } from '@/lib/well-known/rewrites';
+import { getClientIP } from '@/lib/security/edge-client-ip';
 
 // Edge-safe middleware: only checks presence of auth tokens, not validity.
 // Full validation happens in route handlers via verifyAuth()/validateMCPToken().
@@ -88,10 +89,7 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
       return response;
     }
 
-    const ip =
-      req.headers.get('x-forwarded-for')?.split(',')[0] ||
-      req.headers.get('x-real-ip') ||
-      'unknown';
+    const ip = getClientIP(req);
 
     // Origin validation for API routes (defense-in-depth)
     if (pathname.startsWith('/api')) {

--- a/apps/web/src/middleware/monitoring.ts
+++ b/apps/web/src/middleware/monitoring.ts
@@ -23,6 +23,7 @@ import {
   REQUEST_ID_HEADER,
 } from '@/lib/request-id/request-id';
 import { sanitizeEndpoint } from '@/lib/monitoring/ingest-sanitizer';
+import { getClientIP } from '@/lib/security/edge-client-ip';
 
 const systemLogger = createEdgeLogger('system');
 const performanceLogger = createEdgeLogger('performance');
@@ -44,10 +45,7 @@ function extractRequestContext(request: NextRequest): RequestContext {
   return {
     endpoint: request.nextUrl.pathname,
     method: request.method,
-    ip:
-      request.headers.get('x-forwarded-for')?.split(',')[0] ||
-      request.headers.get('x-real-ip') ||
-      'unknown',
+    ip: getClientIP(request),
     userAgent: request.headers.get('user-agent') || undefined,
   };
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1032,6 +1032,11 @@
       "import": "./dist/security/distributed-rate-limit.js",
       "require": "./dist/security/distributed-rate-limit.js"
     },
+    "./security/client-ip": {
+      "types": "./dist/security/client-ip.d.ts",
+      "import": "./dist/security/client-ip.js",
+      "require": "./dist/security/client-ip.js"
+    },
     "./security/auth-handoff-sweep": {
       "types": "./dist/security/auth-handoff-sweep.d.ts",
       "import": "./dist/security/auth-handoff-sweep.js",

--- a/packages/lib/src/audit/audit-log.ts
+++ b/packages/lib/src/audit/audit-log.ts
@@ -9,6 +9,7 @@
 import { securityAudit, type AuditEvent } from './security-audit';
 import { loggers } from '../logging/logger-config';
 import { sanitizeAuditDetails } from './sanitize-audit-details';
+import { getClientIP } from '../security/client-ip';
 
 /**
  * Dual-write an audit event to the structured logger and audit DB.
@@ -42,15 +43,9 @@ export function audit(event: AuditEvent): void {
  * already provided on the event.
  */
 export function auditRequest(request: Request, event: AuditEvent): void {
-  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
-  const realIp = request.headers.get('x-real-ip')?.trim();
   const headerUserAgent = request.headers.get('user-agent')?.trim();
 
-  const ipAddress =
-    event.ipAddress ??
-    (forwardedFor || undefined) ??
-    (realIp || undefined) ??
-    'unknown';
+  const ipAddress = event.ipAddress ?? getClientIP(request);
 
   const userAgent =
     event.userAgent ??

--- a/packages/lib/src/auth/device-fingerprint-utils.ts
+++ b/packages/lib/src/auth/device-fingerprint-utils.ts
@@ -1,9 +1,12 @@
 import { createHash } from 'crypto';
+import { getClientIP } from '../security/client-ip';
 
 /**
  * Server-side device fingerprinting utilities for detecting token theft
  * and generating stable device identifiers
  */
+
+export { getClientIP };
 
 /**
  * Parse User-Agent to extract browser family and OS
@@ -50,28 +53,6 @@ export interface DeviceFingerprint {
   ipAddress: string;
   platform: 'web' | 'desktop' | 'ios' | 'android';
   location?: string;
-}
-
-/**
- * Extract client IP address from request
- * Handles X-Forwarded-For, X-Real-IP, and direct connection
- */
-export function getClientIP(request: Request): string {
-  // Check X-Forwarded-For (set by proxies/load balancers)
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    // Take the first IP in the chain
-    return forwardedFor.split(',')[0].trim();
-  }
-
-  // Check X-Real-IP (set by some proxies)
-  const realIP = request.headers.get('x-real-ip');
-  if (realIP) {
-    return realIP.trim();
-  }
-
-  // Fallback to unknown (Next.js doesn't expose socket in edge runtime)
-  return 'unknown';
 }
 
 /**

--- a/packages/lib/src/logging/logger-config.ts
+++ b/packages/lib/src/logging/logger-config.ts
@@ -4,6 +4,7 @@
 
 import { logger, LogContext } from './logger';
 import type { LogInput, HttpMethod } from './logger-types';
+import { getClientIP } from '../security/client-ip';
 
 interface NextLikeRequest {
   nextUrl: { pathname: string; searchParams: URLSearchParams };
@@ -47,9 +48,7 @@ export function extractRequestContext(req: LoggableRequest): LogContext {
   if ('nextUrl' in req) {
     context.endpoint = req.nextUrl.pathname;
     context.method = req.method;
-    context.ip = req.headers.get('x-forwarded-for')?.split(',')[0] || 
-                  req.headers.get('x-real-ip') || 
-                  'unknown';
+    context.ip = getClientIP(req);
     context.userAgent = req.headers.get('user-agent') || undefined;
     
     // Extract query params

--- a/packages/lib/src/security/__tests__/client-ip.test.ts
+++ b/packages/lib/src/security/__tests__/client-ip.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { getClientIP } from '../client-ip';
+
+describe('getClientIP', () => {
+  it('prefers fly-client-ip over x-forwarded-for', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+    });
+    expect(getClientIP(request)).toBe('9.9.9.9');
+  });
+
+  it('prefers fly-client-ip over x-real-ip', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'fly-client-ip': '9.9.9.9', 'x-real-ip': '10.0.0.1' },
+    });
+    expect(getClientIP(request)).toBe('9.9.9.9');
+  });
+
+  it('trims whitespace from fly-client-ip', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'fly-client-ip': '  9.9.9.9  ' },
+    });
+    expect(getClientIP(request)).toBe('9.9.9.9');
+  });
+
+  it('falls back to the first x-forwarded-for entry when fly-client-ip is absent', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+    });
+    expect(getClientIP(request)).toBe('1.2.3.4');
+  });
+
+  it('falls back to x-real-ip when fly-client-ip and x-forwarded-for are absent', () => {
+    const request = new Request('http://localhost', {
+      headers: { 'x-real-ip': '10.0.0.1' },
+    });
+    expect(getClientIP(request)).toBe('10.0.0.1');
+  });
+
+  it('returns unknown when no IP headers are present', () => {
+    const request = new Request('http://localhost');
+    expect(getClientIP(request)).toBe('unknown');
+  });
+});

--- a/packages/lib/src/security/__tests__/client-ip.test.ts
+++ b/packages/lib/src/security/__tests__/client-ip.test.ts
@@ -1,7 +1,26 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getClientIP } from '../client-ip';
 
 describe('getClientIP', () => {
+  // Fly-Client-IP is only trustworthy when the request genuinely traversed
+  // Fly's own edge, which FLY_APP_NAME (Fly's own runtime-injected env var)
+  // is used to detect. Most of this suite simulates "running on Fly" since
+  // that's the deployed-cloud case; the dedicated describe block below covers
+  // the non-Fly (tenant/self-hosted) case where the header must be ignored.
+  const ORIGINAL_FLY_APP_NAME = process.env.FLY_APP_NAME;
+
+  beforeEach(() => {
+    process.env.FLY_APP_NAME = 'pagespace-web';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_FLY_APP_NAME === undefined) {
+      delete process.env.FLY_APP_NAME;
+    } else {
+      process.env.FLY_APP_NAME = ORIGINAL_FLY_APP_NAME;
+    }
+  });
+
   it('prefers fly-client-ip over x-forwarded-for', () => {
     const request = new Request('http://localhost', {
       headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
@@ -84,6 +103,39 @@ describe('getClientIP', () => {
         headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4' },
       });
       expect(getClientIP(request)).toBe('9.9.9.9');
+    });
+  });
+
+  // Regression coverage: this repo also ships a non-Fly `tenant` deployment
+  // mode (infrastructure/docker-compose.tenant.yml, Traefik). On a host that
+  // isn't actually Fly, fly-client-ip is just another ordinary,
+  // client-settable header with zero trust guarantee — a caller could forge
+  // it directly to bypass IP-keyed rate limits and poison audit/
+  // device-fingerprint data, the exact class of attack #1908 exists to close.
+  describe('not running on Fly (FLY_APP_NAME unset — e.g. tenant/self-hosted)', () => {
+    beforeEach(() => {
+      delete process.env.FLY_APP_NAME;
+    });
+
+    it('ignores a forged fly-client-ip entirely and falls back to x-forwarded-for', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4' },
+      });
+      expect(getClientIP(request)).toBe('1.2.3.4');
+    });
+
+    it('ignores a forged fly-client-ip and falls back to x-real-ip when x-forwarded-for is absent', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9', 'x-real-ip': '10.0.0.1' },
+      });
+      expect(getClientIP(request)).toBe('10.0.0.1');
+    });
+
+    it('returns unknown when only a forged fly-client-ip is present, never trusting it', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9' },
+      });
+      expect(getClientIP(request)).toBe('unknown');
     });
   });
 });

--- a/packages/lib/src/security/__tests__/client-ip.test.ts
+++ b/packages/lib/src/security/__tests__/client-ip.test.ts
@@ -41,4 +41,49 @@ describe('getClientIP', () => {
     const request = new Request('http://localhost');
     expect(getClientIP(request)).toBe('unknown');
   });
+
+  // Regression coverage: fly-client-ip is set fresh per Fly Proxy hop, not
+  // chained. Traffic via pagespace.ai reaches this app through Caddy's
+  // internal flycast relay — a second hop whose own edge overwrites
+  // fly-client-ip with CADDY's own machine address (always in Fly's private
+  // 6PN range, fdaa::/16), not the real visitor's. Preferring it unconditionally
+  // (the pre-fix behavior) collapsed every pagespace.ai visitor into one
+  // shared rate-limit bucket instead of trusting the visitor IP Caddy already
+  // relayed as x-forwarded-for.
+  describe('fly-client-ip in Fly 6PN range (arrived via the internal Caddy relay hop)', () => {
+    it('prefers x-forwarded-for over a 6PN fly-client-ip', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': 'fdaa:0:2ed2:a7b:19c:d9d2:5484:2', 'x-forwarded-for': '203.0.113.7' },
+      });
+      expect(getClientIP(request)).toBe('203.0.113.7');
+    });
+
+    it('is case-insensitive when detecting the 6PN prefix', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': 'FDAA:0:2ed2:a7b:19c:d9d2:5484:2', 'x-forwarded-for': '203.0.113.7' },
+      });
+      expect(getClientIP(request)).toBe('203.0.113.7');
+    });
+
+    it('falls back to x-real-ip over a 6PN fly-client-ip when x-forwarded-for is absent', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': 'fdaa:0:2ed2:a7b:19c:d9d2:5484:2', 'x-real-ip': '203.0.113.7' },
+      });
+      expect(getClientIP(request)).toBe('203.0.113.7');
+    });
+
+    it('falls back to the 6PN fly-client-ip itself as a last resort — still better than "unknown"', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': 'fdaa:0:2ed2:a7b:19c:d9d2:5484:2' },
+      });
+      expect(getClientIP(request)).toBe('fdaa:0:2ed2:a7b:19c:d9d2:5484:2');
+    });
+
+    it('still prefers a non-6PN fly-client-ip over x-forwarded-for (direct-hit path, #1908)', () => {
+      const request = new Request('http://localhost', {
+        headers: { 'fly-client-ip': '9.9.9.9', 'x-forwarded-for': '1.2.3.4' },
+      });
+      expect(getClientIP(request)).toBe('9.9.9.9');
+    });
+  });
 });

--- a/packages/lib/src/security/client-ip.ts
+++ b/packages/lib/src/security/client-ip.ts
@@ -13,6 +13,25 @@
  * `x-forwarded-for` first reintroduces the spoofing hole this file exists to
  * close.
  *
+ * EXCEPT: `Fly-Client-IP` is set fresh per Fly Proxy hop, not chained like
+ * `X-Forwarded-For`. `pagespace.ai` traffic terminates at the `pagespace-proxy`
+ * (Caddy) app, which then relays to this app over the internal `flycast`
+ * network — a SECOND Fly Proxy hop, whose own edge overwrites `Fly-Client-IP`
+ * with Caddy's own machine address, not the original visitor's. Fly's private
+ * 6PN network exclusively uses IPv6 ULA addresses in the `fdaa::/16` block,
+ * which a real internet client can never present (that's what the TCP peer
+ * of a direct, public connection to Fly's true edge would have to spoof, and
+ * it can't — Fly's edge sets `Fly-Client-IP` from what it actually observed,
+ * not from anything the client sent). So an `fdaa:`-prefixed `Fly-Client-IP`
+ * unambiguously means this request arrived over that internal hop, and
+ * Caddy has already relayed the real visitor IP as `X-Forwarded-For` instead
+ * (an unconditional `header_up` replace, not append — see
+ * PageSpace-Deploy's `fly/Caddyfile.fly` — so it isn't attacker-appendable
+ * either). Trust that instead in this one case. A direct hit that bypasses
+ * Caddy entirely (the attack #1908 exists to close) always carries a real,
+ * non-6PN `Fly-Client-IP` here, since that IS the true edge for that
+ * connection.
+ *
  * Zero Node-only imports: this module must stay importable from the Next.js
  * Edge runtime (apps/web/src/middleware.ts).
  */
@@ -21,13 +40,19 @@ interface HasHeaders {
   headers: { get(name: string): string | null };
 }
 
+/** Fly's private 6PN network — inter-app traffic only, never a real visitor's address. */
+function isFly6pnAddress(ip: string): boolean {
+  return ip.toLowerCase().startsWith('fdaa:');
+}
+
 export function getClientIP(request: HasHeaders): string {
-  const flyClientIP = request.headers.get('fly-client-ip');
-  if (flyClientIP) return flyClientIP.trim();
+  const flyClientIP = request.headers.get('fly-client-ip')?.trim();
+  if (flyClientIP && !isFly6pnAddress(flyClientIP)) return flyClientIP;
 
   return (
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     request.headers.get('x-real-ip')?.trim() ||
+    flyClientIP ||
     'unknown'
   );
 }

--- a/packages/lib/src/security/client-ip.ts
+++ b/packages/lib/src/security/client-ip.ts
@@ -13,19 +13,37 @@
  * `x-forwarded-for` first reintroduces the spoofing hole this file exists to
  * close.
  *
- * EXCEPT: `Fly-Client-IP` is set fresh per Fly Proxy hop, not chained like
- * `X-Forwarded-For`. `pagespace.ai` traffic terminates at the `pagespace-proxy`
- * (Caddy) app, which then relays to this app over the internal `flycast`
- * network — a SECOND Fly Proxy hop, whose own edge overwrites `Fly-Client-IP`
- * with Caddy's own machine address, not the original visitor's. Fly's private
- * 6PN network exclusively uses IPv6 ULA addresses in the `fdaa::/16` block,
- * which a real internet client can never present (that's what the TCP peer
- * of a direct, public connection to Fly's true edge would have to spoof, and
- * it can't — Fly's edge sets `Fly-Client-IP` from what it actually observed,
- * not from anything the client sent). So an `fdaa:`-prefixed `Fly-Client-IP`
- * unambiguously means this request arrived over that internal hop, and
- * Caddy has already relayed the real visitor IP as `X-Forwarded-For` instead
- * (an unconditional `header_up` replace, not append — see
+ * GATED ON ACTUALLY RUNNING ON FLY: `Fly-Client-IP` is trustworthy ONLY
+ * because Fly's own edge sets it, unspoofably, from the real TCP peer. That
+ * guarantee holds only when a request genuinely traversed Fly's infrastructure
+ * — this repo also ships a `tenant` deployment mode (`infrastructure/
+ * docker-compose.tenant.yml`, Traefik) that runs on non-Fly hosts, where
+ * `Fly-Client-IP` is just another ordinary, unmanaged, client-settable header.
+ * Trusting it unconditionally there would let any caller forge it directly to
+ * bypass IP-keyed rate limits and poison audit/device-fingerprint data — the
+ * exact class of attack #1908 exists to close, just via a different header
+ * name. `FLY_APP_NAME` is a runtime environment variable Fly injects into
+ * every Fly Machine automatically (never something a caller can set via an
+ * HTTP header, and never present on a non-Fly host unless an operator
+ * deliberately fakes it — not a realistic threat model change from today).
+ * Use its presence to gate trust, not `DEPLOYMENT_MODE`: `cloud` and `tenant`
+ * are a product/billing axis, not an infrastructure-topology one, and a
+ * `tenant` deployment could in principle also run on Fly — what actually
+ * determines whether `Fly-Client-IP` is trustworthy is the real, current host,
+ * not which mode the app believes it's in.
+ *
+ * EXCEPT: even when confirmed to be on Fly, `Fly-Client-IP` is set fresh per
+ * Fly Proxy hop, not chained like `X-Forwarded-For`. `pagespace.ai` traffic
+ * terminates at the `pagespace-proxy` (Caddy) app, which then relays to this
+ * app over the internal `flycast` network — a SECOND Fly Proxy hop, whose own
+ * edge overwrites `Fly-Client-IP` with Caddy's own machine address, not the
+ * original visitor's. Fly's private 6PN network exclusively uses IPv6 ULA
+ * addresses in the `fdaa::/16` block, which a real internet client can never
+ * present (that's what the TCP peer of a direct, public connection to Fly's
+ * true edge would have to spoof, and it can't). So an `fdaa:`-prefixed
+ * `Fly-Client-IP` unambiguously means this request arrived over that internal
+ * hop, and Caddy has already relayed the real visitor IP as `X-Forwarded-For`
+ * instead (an unconditional `header_up` replace, not append — see
  * PageSpace-Deploy's `fly/Caddyfile.fly` — so it isn't attacker-appendable
  * either). Trust that instead in this one case. A direct hit that bypasses
  * Caddy entirely (the attack #1908 exists to close) always carries a real,
@@ -45,8 +63,17 @@ function isFly6pnAddress(ip: string): boolean {
   return ip.toLowerCase().startsWith('fdaa:');
 }
 
+/**
+ * `FLY_APP_NAME` is auto-injected by Fly's runtime into every Fly Machine —
+ * never client-settable, never present on a non-Fly host by default. Read
+ * per-call (not cached at module load) so tests can toggle it deterministically.
+ */
+function isRunningOnFly(): boolean {
+  return Boolean(process.env.FLY_APP_NAME);
+}
+
 export function getClientIP(request: HasHeaders): string {
-  const flyClientIP = request.headers.get('fly-client-ip')?.trim();
+  const flyClientIP = isRunningOnFly() ? request.headers.get('fly-client-ip')?.trim() : undefined;
   if (flyClientIP && !isFly6pnAddress(flyClientIP)) return flyClientIP;
 
   return (

--- a/packages/lib/src/security/client-ip.ts
+++ b/packages/lib/src/security/client-ip.ts
@@ -1,0 +1,33 @@
+/**
+ * Client IP extraction — trusted-proxy aware (GitHub issue #1908).
+ *
+ * `X-Forwarded-For`/`X-Real-IP` are client-settable headers: any caller that
+ * can reach an app directly (bypassing the edge proxy) can set them to
+ * whatever it wants, which defeats IP-keyed rate limiting. On Fly.io, every
+ * request that terminates at Fly's own edge carries `Fly-Client-IP` — Fly's
+ * proxy sets this itself from the actual TCP peer it accepted the connection
+ * from, so it cannot be spoofed by a client-supplied header. Prefer it.
+ *
+ * `X-Forwarded-For`/`X-Real-IP` remain the fallback for local dev/CI, where
+ * there's no Fly edge and no real exposure. Do not reorder this — reading
+ * `x-forwarded-for` first reintroduces the spoofing hole this file exists to
+ * close.
+ *
+ * Zero Node-only imports: this module must stay importable from the Next.js
+ * Edge runtime (apps/web/src/middleware.ts).
+ */
+
+interface HasHeaders {
+  headers: { get(name: string): string | null };
+}
+
+export function getClientIP(request: HasHeaders): string {
+  const flyClientIP = request.headers.get('fly-client-ip');
+  if (flyClientIP) return flyClientIP.trim();
+
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip')?.trim() ||
+    'unknown'
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1908. `getClientIP()` trusted `x-forwarded-for`/`x-real-ip` with no validation that the request passed through a trusted proxy. Live investigation via `flyctl` confirmed the concrete exploit path: `pagespace-web`, `pagespace-admin`, `pagespace-marketing`, and `pagespace-realtime` are all independently public Fly apps with their own IPs — a caller can hit any of them directly on `*.fly.dev`, bypassing the Caddy front door entirely, and set any `X-Forwarded-For` value with zero resistance. That value is the rate-limit key on 30+ routes (all OAuth flows, passkey/magic-link/Google/Apple auth, contact, tracking, form submissions), plus it feeds device-fingerprint anomaly scoring and audit logs.

This is **Part A + Part C** of a 4-part fix (full plan and research trail: local plan file `vivid-seeking-dewdrop.md`, epic tracked in PageSpace under Security & Compliance → "Trusted-Proxy IP Validation for Public Rate-Limited Routes"). Part B (Caddy relay for rate-limit precision on the `pagespace.ai` path) and Part D (closing the direct-bypass path by releasing the four apps' public IPs, gated on Part B being deployed and live-verified) land as a separate PR in `PageSpace-Deploy`.

- **New shared `packages/lib/src/security/client-ip.ts`**: prefers Fly's own `Fly-Client-IP` header — set by Fly's edge from the actual TCP peer it accepted the connection from, so it can't be spoofed by a client-supplied header — over `x-forwarded-for`/`x-real-ip`, which remain the fallback for local dev/CI where there's no Fly edge.
- **Consolidated** the two independent `getClientIP()` implementations (`apps/web/src/lib/auth/auth-helpers.ts`, `packages/lib`'s `device-fingerprint-utils.ts`, the latter also used directly by `apps/admin`) to both re-export the shared one.
- **Swept 8 call sites** that read `x-forwarded-for`/`x-real-ip` directly instead of going through `getClientIP()`: `audit-log.ts`, `logger-config.ts`, `middleware.ts`, `middleware/monitoring.ts`, `ws-security.ts`, `account/devices/route.ts`, the marketing app's contact route, and the processor app's Express rate-limit middleware (its own small adapter, since Express's `req.headers` isn't a Fetch `Headers` instance).
- **Added `apps/web/src/lib/security/edge-client-ip.ts`**: a standalone edge-safe duplicate for `middleware.ts`/`middleware/monitoring.ts`, which cannot import `@pagespace/lib` at all per the edge-runtime import-graph ESLint rule added in the 2026-07-07 outage remediation — added to that rule's tracked file list.
- **Hardened `oauth/authorize/route.ts`'s `appOrigin()`**: dropped the `x-forwarded-host`/`x-forwarded-proto` and `req.url` fallbacks (same trust-boundary risk, feeding a redirect target on an unauthenticated OAuth endpoint) — now fails closed on the configured `WEB_APP_URL`/`NEXT_PUBLIC_APP_URL` alone, which every real deployment already bakes into its build image.

## Test plan

- [x] `tsc --noEmit` clean on every touched package (`@pagespace/lib`, `apps/web`, `apps/marketing`, `apps/processor`, `apps/admin`) — verified directly, bypassing a turbo/`.next` caching quirk unrelated to this diff
- [x] `next build` for `apps/web` succeeds with no edge-runtime import-graph lint errors
- [x] New unit tests for `client-ip.ts` and `edge-client-ip.ts` (precedence, fallback, `unknown` sentinel)
- [x] Updated `oauth/authorize` and `account/devices` route tests: two tests that asserted the old forwarded-header-trusting behavior now assert the hardened behavior (forwarded host ignored, fails closed without a configured origin); two tests updated for the `'unknown'` vs `undefined` IP sentinel change
- [x] Full `bun run test:unit` green except one pre-existing, unrelated failure (`activity-tools.test.ts`, missing local DB role `"test"`) — confirmed pre-existing by reproducing identically with this diff fully stashed out
- [ ] Manual: curl a route directly against a `*.fly.dev` hostname with a forged `X-Forwarded-For` post-deploy to confirm the rate-limit key now derives from `Fly-Client-IP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsxBCTzxQ3mz2FieR1GJ76

---

**Update (0e33e7236):** a review comment caught that `getClientIP()` still preferred `Fly-Client-IP` unconditionally, which meant Part B's Caddy relay (PageSpace-Deploy#16) was being silently ignored on real `pagespace.ai` traffic — `Fly-Client-IP` is set fresh per Fly Proxy hop, not chained, so on the Caddy→flycast hop it reflects Caddy's own machine address, not the visitor's, collapsing every real visitor into one rate-limit bucket (not spoofable, but still wrong). Fixed by detecting Fly's private 6PN range (`fdaa::/16`, exclusively inter-app traffic, never a real client's address) and deferring to the `X-Forwarded-For` Caddy already relays in that case — the original direct-bypass protection (`#1908`) is unchanged, since a direct hit that skips Caddy always carries a real, non-6PN `Fly-Client-IP`. Applied to both `client-ip.ts` and its edge-runtime twin; new tests cover the 6PN-deferral behavior and confirm the original protection still holds.


---

**Update (c2609ae64):** a second review comment correctly flagged that `Fly-Client-IP` was trusted unconditionally whenever present, but this repo also ships a non-Fly `tenant` deployment mode (`infrastructure/docker-compose.tenant.yml`, Traefik) where the header has zero trust guarantee — any caller could forge it directly to bypass IP-keyed rate limits and poison audit/device-fingerprint data, the exact class of attack #1908 exists to close, just via a different header name. Fixed by gating the `Fly-Client-IP` branch on `FLY_APP_NAME`, a runtime env var Fly auto-injects into every Fly Machine (never client-settable, never present on a non-Fly host by default). Deliberately **not** gated on `DEPLOYMENT_MODE`: `cloud`/`tenant` is a product/billing axis, not an infrastructure-topology one — a `tenant` deployment could in principle also run on Fly, so `DEPLOYMENT_MODE` doesn't actually answer "did this request traverse Fly's real edge." Applied to all three duplicated copies (`packages/lib`, the edge-runtime twin, and `apps/processor`'s own Express adapter), with new tests confirming a forged `fly-client-ip` is fully ignored when `FLY_APP_NAME` is unset. Full local suites re-verified after both fixes: `packages/lib` client-ip (14/14), `apps/web` edge-client-ip (9/9) + auth-helpers (86/86, unaffected), `apps/processor` rate-limit (16/16); typecheck clean across all three packages.
