### PR TITLE
fix(web): CORS for the Bearer-authenticated API surface

### DIFF
--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -10,6 +10,13 @@ vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: (_req: unknown, handler: () => unknown) => handler(),
 }));
 
+const MOCK_API_CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, PUT, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-PageSpace-API-Version',
+  'Access-Control-Expose-Headers': 'X-PageSpace-API-Version, Retry-After',
+};
+
 vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse: () => ({ response: NextResponse.json({ ok: true }, { status: 200 }) }),
   createSecureErrorResponse: (body: unknown, status: number) => NextResponse.json(body, { status }),
@@ -17,6 +24,12 @@ vi.mock('@/middleware/security-headers', () => ({
   isPublishedSiteHost: () => false,
   isSecureRequest: () => true,
   shouldDisableCOEP: () => false,
+  applyApiCorsHeaders: (response: NextResponse) => {
+    for (const [key, value] of Object.entries(MOCK_API_CORS_HEADERS)) {
+      response.headers.set(key, value);
+    }
+    return response;
+  },
 }));
 
 vi.mock('@/lib/logging/edge-logger', () => ({
@@ -47,8 +60,8 @@ vi.mock('@/lib/well-known/rewrites', () => ({
 
 import { middleware } from '../middleware';
 
-const buildRequest = (pathname: string, headers: Record<string, string> = {}) =>
-  new NextRequest(new URL(`http://localhost${pathname}`), { headers });
+const buildRequest = (pathname: string, headers: Record<string, string> = {}, method = 'GET') =>
+  new NextRequest(new URL(`http://localhost${pathname}`), { headers, method });
 
 describe('middleware — /api/public/forms carve-outs', () => {
   beforeEach(() => {
@@ -128,5 +141,68 @@ describe('middleware — bearer-token prefix carve-out (all three token types)',
 
     expect(mockGetSessionFromCookies).toHaveBeenCalled();
     expect(response.status).toBe(401);
+  });
+});
+
+// CORS for the Bearer-authenticated API surface (@pagespace/sdk calling
+// pagespace.ai directly from a browser — see the browser-compat plan). A
+// browser blocks a cross-origin response with no Access-Control-Allow-Origin
+// regardless of whether the server-side auth itself would have succeeded, so
+// these headers must be present on every Bearer-authed response and on the
+// preflight that precedes it.
+describe('middleware — CORS for Bearer-authenticated API routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionFromCookies.mockReturnValue(undefined);
+    mockIsOriginValidationBlocking.mockReturnValue(true);
+  });
+
+  it('attaches CORS headers and skips origin validation for a Bearer-prefixed request to /api/*', async () => {
+    // An origin that origin-validation would normally reject in block mode —
+    // proves this path never even reaches that check.
+    mockValidateOriginForMiddleware.mockReturnValue({
+      valid: false,
+      origin: 'https://some-external-spa.example',
+      skipped: false,
+      reason: 'origin not in allowlist',
+    });
+
+    const request = buildRequest('/api/pages/xyz', {
+      authorization: 'Bearer ps_at_abc123',
+      origin: 'https://some-external-spa.example',
+    });
+    const response = await middleware(request);
+
+    expect(response.status).not.toBe(403);
+    expect(mockValidateOriginForMiddleware).not.toHaveBeenCalled();
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('X-PageSpace-API-Version');
+    expect(response.headers.get('Access-Control-Expose-Headers')).toContain('Retry-After');
+  });
+
+  it('leaves session-cookie traffic to the same path fully subject to origin validation, unaffected', async () => {
+    mockValidateOriginForMiddleware.mockReturnValue({
+      valid: false,
+      origin: 'https://some-external-spa.example',
+      skipped: false,
+      reason: 'origin not in allowlist',
+    });
+
+    const request = buildRequest('/api/pages/xyz', { origin: 'https://some-external-spa.example' });
+    const response = await middleware(request);
+
+    expect(mockValidateOriginForMiddleware).toHaveBeenCalledWith(request);
+    expect(response.status).toBe(403);
+  });
+
+  it('answers a bare OPTIONS preflight to /api/* with a 204 and CORS headers, with no auth check at all', async () => {
+    const request = buildRequest('/api/pages/xyz', {}, 'OPTIONS');
+    const response = await middleware(request);
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    expect(mockValidateOriginForMiddleware).not.toHaveBeenCalled();
+    expect(mockGetSessionFromCookies).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import type { NextFetchEvent } from 'next/server';
 import { monitoringMiddleware } from '@/middleware/monitoring';
 import {
+  applyApiCorsHeaders,
   createSecureResponse,
   createSecureErrorResponse,
   isPublicPageRoute,
@@ -93,7 +94,38 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
       req.headers.get('x-real-ip') ||
       'unknown';
 
-    // Origin validation for API routes (defense-in-depth)
+    // CORS preflight for the Bearer-authenticated API surface (@pagespace/sdk and
+    // any other Bearer-token caller). Browsers never send Authorization (or
+    // cookies) on a preflight OPTIONS request, so the Bearer-prefix detection
+    // below can't tell a preflight apart from an anonymous same-origin OPTIONS —
+    // this short-circuit must be unconditional. It grants no access by itself:
+    // the real GET/POST/etc. that follows still goes through full, normal auth.
+    if (isAPIRoute && req.method === 'OPTIONS') {
+      return applyApiCorsHeaders(new NextResponse(null, { status: 204 }));
+    }
+
+    // Bearer token format check (Edge-safe - no database access), run BEFORE
+    // origin validation below. Bearer-authenticated requests are already
+    // CSRF/Origin-immune at the route layer (`isSessionAuth` gates both checks
+    // in apps/web/src/lib/auth/index.ts — CSRF/Origin only apply to cookie
+    // sessions), so this middleware must skip origin validation for them too,
+    // and must attach CORS response headers so a cross-origin browser caller
+    // (e.g. the SDK) can actually read the response.
+    // Full validation happens in route handlers via validateMCPToken()/validateSessionToken()/validateOAuthAccessToken()
+    const authHeader = req.headers.get('authorization');
+    if (
+      authHeader?.startsWith(MCP_BEARER_PREFIX) ||
+      authHeader?.startsWith(SESSION_BEARER_PREFIX) ||
+      authHeader?.startsWith(OAUTH_BEARER_PREFIX)
+    ) {
+      // API routes get restrictive CSP (no nonce needed)
+      const { response } = createSecureResponse(isProduction, req, { isAPIRoute: true });
+      return applyApiCorsHeaders(response);
+    }
+
+    // Origin validation for API routes (defense-in-depth). Bearer-authenticated
+    // requests never reach here — they returned above — so this only ever
+    // enforces against cookie-session traffic, unchanged from before.
     if (pathname.startsWith('/api')) {
       const originResult = validateOriginForMiddleware(req);
 
@@ -121,19 +153,6 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
           ip,
         });
       }
-    }
-
-    // Bearer token format check (Edge-safe - no database access)
-    // Full validation happens in route handlers via validateMCPToken()/validateSessionToken()/validateOAuthAccessToken()
-    const authHeader = req.headers.get('authorization');
-    if (
-      authHeader?.startsWith(MCP_BEARER_PREFIX) ||
-      authHeader?.startsWith(SESSION_BEARER_PREFIX) ||
-      authHeader?.startsWith(OAUTH_BEARER_PREFIX)
-    ) {
-      // API routes get restrictive CSP (no nonce needed)
-      const { response } = createSecureResponse(isProduction, req, { isAPIRoute: true });
-      return response;
     }
 
     // Well-known discovery routes (e.g. RFC 8414 OAuth metadata) must be

--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -10,6 +10,8 @@ import {
   buildCSPPolicy,
   buildAPICSPPolicy,
   applySecurityHeaders,
+  applyApiCorsHeaders,
+  API_CORS_HEADERS,
   createSecureResponse,
   createSecureErrorResponse,
   isPublicPageRoute,
@@ -515,6 +517,43 @@ describe('Security Headers', () => {
       const csp = r3.headers.get('Content-Security-Policy');
       expect(csp).toContain("default-src 'none'");
       expect(csp).not.toContain('nonce-');
+    });
+  });
+
+  describe('applyApiCorsHeaders', () => {
+    it('sets a wildcard origin, matching the existing Bearer-token CORS precedent (forms/submit route)', () => {
+      const response = NextResponse.next();
+      applyApiCorsHeaders(response);
+
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    });
+
+    it('exposes X-PageSpace-API-Version and Retry-After — required for the SDK to read them cross-origin', () => {
+      // Neither header is in the CORS default-safelisted response-header set, so
+      // without this a cross-origin call succeeds at the network/CORS layer but
+      // the SDK still throws IncompatibleServerError reading a null version header.
+      const response = NextResponse.next();
+      applyApiCorsHeaders(response);
+
+      const exposed = response.headers.get('Access-Control-Expose-Headers');
+      expect(exposed).toContain('X-PageSpace-API-Version');
+      expect(exposed).toContain('Retry-After');
+    });
+
+    it('allows Authorization in preflight — the one header a Bearer-token caller must send', () => {
+      const response = NextResponse.next();
+      applyApiCorsHeaders(response);
+
+      expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+    });
+
+    it('every declared header in API_CORS_HEADERS is actually applied to the response', () => {
+      const response = NextResponse.next();
+      applyApiCorsHeaders(response);
+
+      for (const [key, value] of Object.entries(API_CORS_HEADERS)) {
+        expect(response.headers.get(key)).toBe(value);
+      }
     });
   });
 });

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -172,6 +172,31 @@ export const applySecurityHeaders = (
   return response;
 };
 
+// CORS for the Bearer-authenticated API surface (`@pagespace/sdk` and any other
+// Bearer-token caller — MCP API keys, OAuth access tokens). Wildcard origin
+// mirrors the existing precedent in api/public/forms/[token]/submit/route.ts:
+// Bearer tokens require explicit JS header-setting (unlike cookies), so a
+// wildcard doesn't expose a visitor's own session to a malicious page the way
+// it would for cookie auth. `Access-Control-Expose-Headers` is required, not
+// optional — the SDK reads X-PageSpace-API-Version (version-compat check) and
+// Retry-After (429 backoff) directly off the response, and neither is in the
+// CORS default-safelisted response-header set; omitting this makes every
+// cross-origin call fail with IncompatibleServerError even though CORS itself
+// "succeeded".
+export const API_CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, PUT, OPTIONS',
+  'Access-Control-Allow-Headers': 'Authorization, Content-Type, X-PageSpace-API-Version',
+  'Access-Control-Expose-Headers': 'X-PageSpace-API-Version, Retry-After',
+};
+
+export const applyApiCorsHeaders = (response: NextResponse): NextResponse => {
+  for (const [key, value] of Object.entries(API_CORS_HEADERS)) {
+    response.headers.set(key, value);
+  }
+  return response;
+};
+
 export const isPublicPageRoute = (pathname: string): boolean =>
   pathname === '/auth' ||
   pathname.startsWith('/auth/') ||


### PR DESCRIPTION
## Summary
- `apps/web/src/middleware.ts`: reorder Bearer/MCP/OAuth-prefix detection to run **before** origin validation, so Bearer-authenticated requests skip origin validation and get CORS headers attached — consistent with the route layer, which already treats Bearer auth as CSRF/Origin-immune (`isSessionAuth` gates both checks in `apps/web/src/lib/auth/index.ts`). Session-cookie traffic is untouched.
- Add an unconditional `OPTIONS` short-circuit for `/api/*` (204 + CORS headers, no auth check): browsers never send `Authorization` (or cookies) on a preflight, so Bearer detection alone can't identify one. Grants no access by itself — the real request that follows still goes through full auth.
- `apps/web/src/middleware/security-headers.ts`: new `API_CORS_HEADERS` + `applyApiCorsHeaders()`. Wildcard origin (mirrors the existing precedent in `api/public/forms/[token]/submit/route.ts` — Bearer tokens require explicit header-setting, so a wildcard is safe unlike for cookies). `Access-Control-Expose-Headers` names `X-PageSpace-API-Version`/`Retry-After`, both read directly by the SDK off the response and neither in the CORS default-safelisted set — omitting this would make every cross-origin call succeed at the CORS layer but still throw `IncompatibleServerError` client-side.

This is fix 3 of a 4-part plan to make `@pagespace/sdk` work as a browser-side backend client for a plain cross-origin SPA (no BFF of its own). Fixes 1–2 (SDK-side: `fetch` binding, Web Crypto PKCE) are #1948. **This PR alone is not sufficient** for a cross-origin browser to read the response — `Cross-Origin-Resource-Policy: same-origin`, set at the Caddy proxy layer in the separate `PageSpace-Deploy` repo, independently blocks it (fix 4, companion PR in that repo). Both need to be live before end-to-end cross-origin browser calls work.

Requires an `apps/web` (`pagespace-web`) Fly deploy once merged — separate from the SDK's npm publish.

## Test plan
- [x] `apps/web/src/__tests__/middleware.test.ts` — 3 new cases: Bearer request gets CORS headers + skips origin validation; session-cookie request to the same path unaffected (still enforces origin exactly as before); bare `OPTIONS` preflight gets 204 + CORS headers with no auth check
- [x] `apps/web/src/middleware/__tests__/security-headers.test.ts` — 4 new cases for `applyApiCorsHeaders`/`API_CORS_HEADERS`
- [x] Full `apps/web/src/middleware/__tests__/` suite (126 tests) and `bun run typecheck` — all pass
- [ ] Post-merge + deploy: curl `https://pagespace.ai/api/drives` with an `Origin` header, confirm `Access-Control-Allow-Origin`/`Access-Control-Expose-Headers` present (full pass requires the companion CORP fix too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbwJXkonbbrzXmXcKpEsND