### PR TITLE
feat(ai): interactive ask_user tool for agent chat (admin-only)

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -446,6 +446,10 @@ export async function POST(request: Request) {
 
     // Save user's message immediately to database (database-first approach)
     const userMessage = messages[messages.length - 1]; // Last message is the new user message
+    // Set below (fire-early/await-late — see the ask_user branches ~30 lines down)
+    // and joined right before the history load, so its DB round trip overlaps
+    // with the independent setup in between instead of blocking it.
+    let askUserSyncPromise: Promise<unknown> | undefined;
     if (userMessage && userMessage.role === 'user') {
       try {
         const messageId = userMessage.id || createId();
@@ -530,8 +534,12 @@ export async function POST(request: Request) {
       }
 
       // A typed message was sent instead of answering a pending ask_user
-      // question — dismiss it so the model doesn't re-ask.
-      await dismissPendingAskUserForPageConversation({
+      // question — dismiss it so the model doesn't re-ask. Kicked off here
+      // (not awaited) and joined via askUserSyncPromise just before the
+      // history load below, so its DB round trip overlaps with the
+      // independent setup in between instead of blocking it — same pattern
+      // as userProfilePromise a few lines down.
+      askUserSyncPromise = dismissPendingAskUserForPageConversation({
         pageId: chatId as string,
         conversationId,
       }).catch((error) => {
@@ -540,10 +548,11 @@ export async function POST(request: Request) {
     } else if (userMessage?.role === 'assistant') {
       // Resume request: the client answered a pending ask_user question via
       // addToolResult (no new user message). Merge the answer into the
-      // persisted assistant row so history load below picks it up.
+      // persisted assistant row so history load below picks it up. Same
+      // fire-early/await-late pattern as the dismissal branch above.
       const clientResults = extractClientAskUserResults(userMessage);
       if (clientResults.length > 0) {
-        await applyAskUserResultsToPageMessage({
+        askUserSyncPromise = applyAskUserResultsToPageMessage({
           messageId: userMessage.id,
           pageId: chatId as string,
           conversationId,
@@ -986,6 +995,11 @@ export async function POST(request: Request) {
       pageId: chatId
     });
 
+    // Join the ask_user resume/dismiss write (if any) before loading history,
+    // so this turn's model context reflects it — fired early above to
+    // overlap with the independent setup between there and here.
+    if (askUserSyncPromise) await askUserSyncPromise;
+
     const pageId = chatId as string;
     const dbMessages = await db
       .select()
@@ -1071,6 +1085,14 @@ export async function POST(request: Request) {
           triggeredBy: { userId: userId!, displayName, browserSessionId },
         }).catch(() => {});
       }
+    } else if (userMessage?.role === 'assistant') {
+      // ask_user resume turn: no new user message to broadcast, but
+      // isConversationShared still gates the mention-notify call below for
+      // the agent's reply — must still be computed here, or it silently
+      // stays at its initial `false` and mention notifications are dropped
+      // for every turn that follows an answered ask_user question.
+      const convRow = await conversationRepository.getConversation(conversationId!).catch(() => null);
+      isConversationShared = convRow?.isShared === true;
     }
 
     lifecycle = await createStreamLifecycle({

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -14,6 +14,13 @@ import { ALL_PROVIDER_NAMES } from '@/lib/ai/core/ai-utils';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
+import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { canUseAskUser } from '@/lib/ai/core/ask-user-gating';
+import {
+  extractClientAskUserResults,
+  applyAskUserResultsToPageMessage,
+  dismissPendingAskUserForPageConversation,
+} from '@/lib/ai/core/ask-user-resume';
 import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
 import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
@@ -521,8 +528,32 @@ export async function POST(request: Request) {
           userMessage: userMessage // Preserve user input for retry
         }, { status: 500 });
       }
+
+      // A typed message was sent instead of answering a pending ask_user
+      // question — dismiss it so the model doesn't re-ask.
+      await dismissPendingAskUserForPageConversation({
+        pageId: chatId as string,
+        conversationId,
+      }).catch((error) => {
+        loggers.ai.error('AI Chat API: Failed to dismiss pending ask_user question', error as Error);
+      });
+    } else if (userMessage?.role === 'assistant') {
+      // Resume request: the client answered a pending ask_user question via
+      // addToolResult (no new user message). Merge the answer into the
+      // persisted assistant row so history load below picks it up.
+      const clientResults = extractClientAskUserResults(userMessage);
+      if (clientResults.length > 0) {
+        await applyAskUserResultsToPageMessage({
+          messageId: userMessage.id,
+          pageId: chatId as string,
+          conversationId,
+          results: clientResults,
+        }).catch((error) => {
+          loggers.ai.error('AI Chat API: Failed to merge ask_user answer', error as Error);
+        });
+      }
     }
-    
+
     // Get user's current AI provider settings (user was loaded above for the gate)
     const currentProvider = selectedProvider || user?.currentAiProvider || DEFAULT_PROVIDER;
     const currentModel = selectedModel || user?.currentAiModel || DEFAULT_MODEL;
@@ -831,6 +862,16 @@ export async function POST(request: Request) {
     // Always inject the finish tool so the model can signal task completion
     filteredTools = { ...filteredTools, ...finishTool } as ToolSet;
 
+    // Interactive ask_user tool (execute-less, pauses the turn for user input).
+    // Injected after allowlist/exposure transforms, like finish, so it is always
+    // directly callable and never routed through tool_search/execute_tool.
+    // allowedToolNames was captured pre-exposure; push so the inline-instructions
+    // ASK_USER section is emitted.
+    if (canUseAskUser(user)) {
+      filteredTools = { ...filteredTools, ...askUserTools } as ToolSet;
+      allowedToolNames.push(ASK_USER_TOOL_NAME);
+    }
+
     // Guard against a stale read_page tool-result (image bytes delivered on an
     // earlier turn when the model had vision) being re-embedded as an image when
     // convertToModelMessages re-converts history for a model that no longer has
@@ -1071,6 +1112,7 @@ export async function POST(request: Request) {
             abortSignal,
             baseMessages: modelMessages,
             finishToolName: FINISH_TOOL_NAME,
+            pauseToolNames: [ASK_USER_TOOL_NAME],
             maxSteps: AGENT_MAX_STEPS,
             startTimeMs: startTime,
             logger: loggers.ai,
@@ -1098,7 +1140,9 @@ export async function POST(request: Request) {
               system: systemPrompt + pageTreePrompt + agentMemoryPrompt + toolDiscoveryPrompt,
               messages: cachedMessages,
               tools: filteredTools,
-              stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(AGENT_MAX_STEPS)],
+              // hasToolCall(ASK_USER_TOOL_NAME) is documentation: ask_user has no
+              // execute, so v6 halts the loop on it anyway (finishReason 'tool-calls').
+              stopWhen: [hasToolCall(FINISH_TOOL_NAME), hasToolCall(ASK_USER_TOOL_NAME), stepCountIs(AGENT_MAX_STEPS)],
               // abortSignal from the abort registry — only fires on explicit user stop, never on client disconnect
               // creditAbortController fires when mid-stream credit check determines balance is exhausted
               abortSignal: creditAbortController

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -401,6 +401,10 @@ export async function POST(
 
     // Save user's message immediately to database
     const userMessage = requestMessages[requestMessages.length - 1];
+    // Set below (fire-early/await-late — see the ask_user branches ~90 lines
+    // down) and joined right before the history load, so its DB round trip
+    // overlaps with the independent setup in between instead of blocking it.
+    let askUserSyncPromise: Promise<unknown> | undefined;
     if (userMessage && userMessage.role === 'user') {
       try {
         const messageId = userMessage.id || createId();
@@ -487,17 +491,21 @@ export async function POST(
       }
 
       // A typed message was sent instead of answering a pending ask_user
-      // question — dismiss it so the model doesn't re-ask.
-      await dismissPendingAskUserForGlobalConversation({ conversationId }).catch((error) => {
+      // question — dismiss it so the model doesn't re-ask. Kicked off here
+      // (not awaited) and joined via askUserSyncPromise just before the
+      // history load below, so its DB round trip overlaps with the
+      // independent setup in between instead of blocking it.
+      askUserSyncPromise = dismissPendingAskUserForGlobalConversation({ conversationId }).catch((error) => {
         loggers.api.error('Global Assistant Chat API: Failed to dismiss pending ask_user question', error as Error);
       });
     } else if (userMessage?.role === 'assistant') {
       // Resume request: the client answered a pending ask_user question via
       // addToolResult (no new user message). Merge the answer into the
-      // persisted assistant row so history load below picks it up.
+      // persisted assistant row so history load below picks it up. Same
+      // fire-early/await-late pattern as the dismissal branch above.
       const clientResults = extractClientAskUserResults(userMessage);
       if (clientResults.length > 0) {
-        await applyAskUserResultsToGlobalMessage({
+        askUserSyncPromise = applyAskUserResultsToGlobalMessage({
           messageId: userMessage.id,
           conversationId,
           results: clientResults,
@@ -548,6 +556,11 @@ export async function POST(
     loggers.api.debug('Global Assistant Chat API: Loading conversation history from database', {
       conversationId
     });
+
+    // Join the ask_user resume/dismiss write (if any) before loading history,
+    // so this turn's model context reflects it — fired early above to
+    // overlap with the independent setup between there and here.
+    if (askUserSyncPromise) await askUserSyncPromise;
 
     // Read ALL active messages from database (source of truth)
     const dbMessages = await db

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -2,6 +2,14 @@ import { NextResponse } from 'next/server';
 import { streamText, stepCountIs, hasToolCall, UIMessage, createUIMessageStream, createUIMessageStreamResponse, type ToolSet } from 'ai';
 import type { convertToModelMessages } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
+import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+import { canUseAskUser } from '@/lib/ai/core/ask-user-gating';
+import { ASK_USER_SECTION } from '@/lib/ai/core/inline-instructions';
+import {
+  extractClientAskUserResults,
+  applyAskUserResultsToGlobalMessage,
+  dismissPendingAskUserForGlobalConversation,
+} from '@/lib/ai/core/ask-user-resume';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { requiresProSubscription, createSubscriptionRequiredResponse, createAdminRestrictedResponse } from '@/lib/subscription/rate-limit-middleware';
 import { ADMIN_ONLY_PROVIDERS, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
@@ -477,8 +485,28 @@ export async function POST(
           userMessage: userMessage // Preserve user input for retry
         }, { status: 500 });
       }
+
+      // A typed message was sent instead of answering a pending ask_user
+      // question — dismiss it so the model doesn't re-ask.
+      await dismissPendingAskUserForGlobalConversation({ conversationId }).catch((error) => {
+        loggers.api.error('Global Assistant Chat API: Failed to dismiss pending ask_user question', error as Error);
+      });
+    } else if (userMessage?.role === 'assistant') {
+      // Resume request: the client answered a pending ask_user question via
+      // addToolResult (no new user message). Merge the answer into the
+      // persisted assistant row so history load below picks it up.
+      const clientResults = extractClientAskUserResults(userMessage);
+      if (clientResults.length > 0) {
+        await applyAskUserResultsToGlobalMessage({
+          messageId: userMessage.id,
+          conversationId,
+          results: clientResults,
+        }).catch((error) => {
+          loggers.api.error('Global Assistant Chat API: Failed to merge ask_user answer', error as Error);
+        });
+      }
     }
-    
+
     // Create AI provider using factory service
     const providerRequest: ProviderRequest = {
       selectedProvider,
@@ -720,7 +748,9 @@ MENTION PROCESSING:
 • When users @mention documents using @[Label](id:type) format, you MUST read those documents first
 • Use the read_page tool for each mentioned document before providing your main response
 • Let mentioned document content inform and enrich your response
-• Don't explicitly mention that you're reading @mentioned docs unless relevant to the conversation` + drivePromptSection;
+• Don't explicitly mention that you're reading @mentioned docs unless relevant to the conversation` +
+      (canUseAskUser({ role: auth.role }) ? `\n\n${ASK_USER_SECTION}` : '') +
+      drivePromptSection;
 
     // Build agent awareness prompt - lists visible AI agents for consultation
     const agentAwarenessPrompt = await buildAgentAwarenessPrompt(userId);
@@ -901,6 +931,15 @@ MENTION PROCESSING:
     // Always inject the finish tool so the model can signal task completion
     finalTools = { ...finalTools, ...finishTool } as ToolSet;
 
+    // Interactive ask_user tool (execute-less, pauses the turn for user input).
+    // Injected here like finish — deliberately NOT in filteredAllTools/nonCoreTools,
+    // so it never enters the tool_search catalog or the execute_tool dispatch map
+    // (execute_tool would crash on an execute-less tool, and the catalog is
+    // visible to non-admins).
+    if (canUseAskUser({ role: auth.role })) {
+      finalTools = { ...finalTools, ...askUserTools } as ToolSet;
+    }
+
     // Sanitize, compact, and elide via the unified seam.
     // finalSystemPrompt + finalTools are now known — pass for accurate token budgeting.
     // IIFE keeps the outputs const (each is assigned exactly once).
@@ -1056,6 +1095,7 @@ MENTION PROCESSING:
           abortSignal,
           baseMessages: modelMessages,
           finishToolName: FINISH_TOOL_NAME,
+          pauseToolNames: [ASK_USER_TOOL_NAME],
           maxSteps: AGENT_MAX_STEPS,
           startTimeMs: startTime,
           logger: loggers.api,
@@ -1078,7 +1118,9 @@ MENTION PROCESSING:
             system: finalSystemPrompt,
             messages: cachedMessages,
             tools: finalTools,
-            stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(AGENT_MAX_STEPS)],
+            // hasToolCall(ASK_USER_TOOL_NAME) is documentation: ask_user has no
+            // execute, so v6 halts the loop on it anyway (finishReason 'tool-calls').
+            stopWhen: [hasToolCall(FINISH_TOOL_NAME), hasToolCall(ASK_USER_TOOL_NAME), stepCountIs(AGENT_MAX_STEPS)],
             // abortSignal from the abort registry — only fires on explicit user stop, never on client disconnect
             abortSignal,
             experimental_context: {

--- a/apps/web/src/components/ai/shared/chat/__tests__/AskUserQuestionCard.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/AskUserQuestionCard.test.tsx
@@ -60,11 +60,11 @@ describe('AskUserQuestionCard', () => {
   it('enables Submit only after selecting an option, and submits the correct answer', () => {
     let submitted: unknown = null;
     const part = answerablePart(QUESTIONS_INPUT);
-    const { getByText } = renderAnswerable(part, (_toolCallId, output) => {
+    const { getByRole, getByText } = renderAnswerable(part, (_toolCallId, output) => {
       submitted = output;
     });
 
-    fireEvent.click(getByText('OAuth'));
+    fireEvent.click(getByRole('button', { name: /OAuth/ }));
     const submitButton = getByText('Submit') as HTMLButtonElement;
     expect(submitButton.disabled).toBe(false);
 
@@ -86,7 +86,7 @@ describe('AskUserQuestionCard', () => {
     };
     const finalPart = answerablePart(QUESTIONS_INPUT);
 
-    const { rerender, getByText, queryByText } = renderAnswerable(streamingPart as never);
+    const { rerender, getByRole, getByText, queryByText } = renderAnswerable(streamingPart as never);
     expect(queryByText('Submit')).toBeNull();
 
     rerender(
@@ -102,7 +102,7 @@ describe('AskUserQuestionCard', () => {
 
     // ...and clicking an option + Submit works without throwing.
     expect(() => {
-      fireEvent.click(getByText('OAuth'));
+      fireEvent.click(getByRole('button', { name: /OAuth/ }));
       fireEvent.click(getByText('Submit'));
     }).not.toThrow();
   });
@@ -130,18 +130,77 @@ describe('AskUserQuestionCard', () => {
         ],
       },
     };
-    const { getAllByText } = renderAnswerable(part as never);
+    // With >1 question, only the active tab's question is in the DOM at a
+    // time — the first tab (backend/REST-GraphQL) is active by default.
+    const { getByRole, getAllByRole } = renderAnswerable(part as never);
 
-    // The chosen option renders a Check icon (svg child) inside its button;
-    // an unchosen option does not. Each question's OWN answer must mark its
-    // own option, not the other (same-header) question's.
-    const isChosen = (label: string) =>
-      (getAllByText(label)[0].closest('button') as HTMLButtonElement).querySelector('svg') !== null;
+    const isChosen = (name: RegExp) =>
+      (getByRole('button', { name }) as HTMLButtonElement).querySelector('svg') !== null;
 
-    expect(isChosen('REST')).toBe(true);
-    expect(isChosen('GraphQL')).toBe(false);
-    expect(isChosen('CSR')).toBe(true);
-    expect(isChosen('SSR')).toBe(false);
+    expect(isChosen(/REST/)).toBe(true);
+    expect(isChosen(/GraphQL/)).toBe(false);
+
+    // Switch to the second tab ("2. Approach") — its OWN answer (CSR) must
+    // show as chosen, not the first question's (this is exactly the bug the
+    // positional-matching fix guards against: keying by header would have
+    // shown REST's checkmark here too, since both tabs share the header).
+    fireEvent.click(getAllByRole('tab')[1]);
+    expect(isChosen(/CSR/)).toBe(true);
+    expect(isChosen(/SSR/)).toBe(false);
+  });
+
+  it('renders a tab per question only when there is more than one question', () => {
+    const { queryAllByRole } = renderAnswerable(answerablePart(QUESTIONS_INPUT));
+    expect(queryAllByRole('tab')).toHaveLength(0);
+  });
+
+  it('arrow-key navigation between tabs moves the active question', () => {
+    const twoQuestions = {
+      questions: [
+        { header: 'Q1', question: 'First?', options: [{ label: 'A' }, { label: 'B' }] },
+        { header: 'Q2', question: 'Second?', options: [{ label: 'C' }, { label: 'D' }] },
+      ],
+    };
+    const { getAllByRole, getByText } = renderAnswerable(answerablePart(twoQuestions));
+    const tabs = getAllByRole('tab');
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(tabs[0], { key: 'ArrowRight' });
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    expect(getByText('Second?')).toBeTruthy();
+
+    fireEvent.keyDown(tabs[1], { key: 'ArrowLeft' });
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(getByText('First?')).toBeTruthy();
+  });
+
+  it('number-key shortcut selects the Nth option of the active question without a click', () => {
+    let submitted: unknown = null;
+    const part = answerablePart(QUESTIONS_INPUT);
+    const { getByRole, getByText, container } = renderAnswerable(part, (_toolCallId, output) => {
+      submitted = output;
+    });
+
+    fireEvent.keyDown(container.firstChild as HTMLElement, { key: '2' });
+    expect(getByRole('button', { name: /API key/ }).querySelector('svg')).not.toBeNull();
+
+    fireEvent.click(getByText('Submit'));
+    expect(submitted).toEqual({
+      answers: [{ header: 'Auth method', question: 'Which auth method should we use?', selectedLabel: 'API key' }],
+    });
+  });
+
+  it('does not treat digits typed into the Other… textarea as the number-key shortcut', () => {
+    const part = answerablePart(QUESTIONS_INPUT);
+    const { getByRole, getByPlaceholderText } = renderAnswerable(part);
+
+    fireEvent.click(getByRole('button', { name: /Other…/ }));
+    const textarea = getByPlaceholderText('Type your answer…');
+    fireEvent.keyDown(textarea, { key: '1' });
+
+    // OAuth (option 1) must NOT become selected just because '1' was
+    // pressed while focus was in the free-text field.
+    expect(getByRole('button', { name: /OAuth/ }).querySelector('svg')).toBeNull();
   });
 
   it('renders read-only (no interactive buttons disabled-state crash) when not answerable', () => {

--- a/apps/web/src/components/ai/shared/chat/__tests__/AskUserQuestionCard.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/AskUserQuestionCard.test.tsx
@@ -107,6 +107,43 @@ describe('AskUserQuestionCard', () => {
     }).not.toThrow();
   });
 
+  it('matches answers to questions by position, not by header — duplicate headers do not collide', () => {
+    // Two questions sharing the identical header ("Approach") — headers have
+    // no uniqueness constraint. handleSubmit builds `answers` positionally
+    // (input.questions.map((q, i) => ...)), so rendering must read answers
+    // back the same way, or one question would display the other's answer.
+    const duplicateHeaderInput = {
+      questions: [
+        { header: 'Approach', question: 'Which approach for the backend?', options: [{ label: 'REST' }, { label: 'GraphQL' }] },
+        { header: 'Approach', question: 'Which approach for the frontend?', options: [{ label: 'SSR' }, { label: 'CSR' }] },
+      ],
+    };
+    const part = {
+      type: 'tool-ask_user',
+      toolCallId: 'q1',
+      state: 'output-available' as const,
+      input: duplicateHeaderInput,
+      output: {
+        answers: [
+          { header: 'Approach', question: 'Which approach for the backend?', selectedLabel: 'REST' },
+          { header: 'Approach', question: 'Which approach for the frontend?', selectedLabel: 'CSR' },
+        ],
+      },
+    };
+    const { getAllByText } = renderAnswerable(part as never);
+
+    // The chosen option renders a Check icon (svg child) inside its button;
+    // an unchosen option does not. Each question's OWN answer must mark its
+    // own option, not the other (same-header) question's.
+    const isChosen = (label: string) =>
+      (getAllByText(label)[0].closest('button') as HTMLButtonElement).querySelector('svg') !== null;
+
+    expect(isChosen('REST')).toBe(true);
+    expect(isChosen('GraphQL')).toBe(false);
+    expect(isChosen('CSR')).toBe(true);
+    expect(isChosen('SSR')).toBe(false);
+  });
+
   it('renders read-only (no interactive buttons disabled-state crash) when not answerable', () => {
     const part = answerablePart(QUESTIONS_INPUT);
     const { getByText } = render(

--- a/apps/web/src/components/ai/shared/chat/__tests__/AskUserQuestionCard.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/AskUserQuestionCard.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * AskUserQuestionCard tests.
+ *
+ * Regression coverage for a real bug caught in review: `drafts` was seeded
+ * ONCE via a lazy useState initializer keyed off `part.input` at mount time.
+ * Since a tool part streams in incrementally (input-streaming with partial/
+ * unparsable JSON, THEN input-available with the final questions array),
+ * a card that first mounted before input finished parsing permanently held
+ * an empty `drafts` array. `drafts.every(...)` on that empty array is
+ * vacuously true, so Submit could enable with nothing selected, and
+ * `handleSubmit` would then crash dereferencing `drafts[i]` (undefined).
+ */
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { AskUserQuestionCard } from '../ask-user/AskUserQuestionCard';
+import { AskUserAnswerProvider } from '../ask-user/AskUserAnswerContext';
+
+const QUESTIONS_INPUT = {
+  questions: [
+    {
+      header: 'Auth method',
+      question: 'Which auth method should we use?',
+      options: [{ label: 'OAuth' }, { label: 'API key' }],
+    },
+  ],
+};
+
+const answerablePart = (input: unknown, toolCallId = 'q1') => ({
+  type: 'tool-ask_user',
+  toolCallId,
+  state: 'input-available' as const,
+  input,
+});
+
+function renderAnswerable(
+  part: ReturnType<typeof answerablePart>,
+  submitAnswers: (toolCallId: string, output: unknown) => void = () => {}
+) {
+  return render(
+    <AskUserAnswerProvider value={{ answerableToolCallIds: new Set([part.toolCallId]), submitAnswers }}>
+      <AskUserQuestionCard part={part} />
+    </AskUserAnswerProvider>
+  );
+}
+
+describe('AskUserQuestionCard', () => {
+  it('renders nothing while input is streaming and not yet parsable JSON', () => {
+    const part = { type: 'tool-ask_user', toolCallId: 'q1', state: 'input-streaming' as const, input: '{"quest' };
+    const { container } = renderAnswerable(part as never);
+    expect(container.textContent).toBe('');
+  });
+
+  it('does NOT enable Submit before any option is selected (no vacuous empty-drafts bypass)', () => {
+    const part = answerablePart(QUESTIONS_INPUT);
+    const { getByText } = renderAnswerable(part);
+    const submitButton = getByText('Submit') as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('enables Submit only after selecting an option, and submits the correct answer', () => {
+    let submitted: unknown = null;
+    const part = answerablePart(QUESTIONS_INPUT);
+    const { getByText } = renderAnswerable(part, (_toolCallId, output) => {
+      submitted = output;
+    });
+
+    fireEvent.click(getByText('OAuth'));
+    const submitButton = getByText('Submit') as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(false);
+
+    fireEvent.click(submitButton);
+    expect(submitted).toEqual({
+      answers: [{ header: 'Auth method', question: 'Which auth method should we use?', selectedLabel: 'OAuth' }],
+    });
+  });
+
+  it('resyncs drafts (and does not crash on submit) when a card mounts before input finishes streaming', () => {
+    // Mount with unparsable/streaming input (drafts seeds to []), THEN
+    // transition to the finalized questions array on a re-render — mirrors
+    // the real tool-part lifecycle (input-streaming -> input-available).
+    const streamingPart = {
+      type: 'tool-ask_user',
+      toolCallId: 'q1',
+      state: 'input-streaming' as const,
+      input: '{"quest',
+    };
+    const finalPart = answerablePart(QUESTIONS_INPUT);
+
+    const { rerender, getByText, queryByText } = renderAnswerable(streamingPart as never);
+    expect(queryByText('Submit')).toBeNull();
+
+    rerender(
+      <AskUserAnswerProvider value={{ answerableToolCallIds: new Set(['q1']), submitAnswers: () => {} }}>
+        <AskUserQuestionCard part={finalPart} />
+      </AskUserAnswerProvider>
+    );
+
+    // Drafts must have resynced to length 1 (not stuck at the initial []) —
+    // Submit starts disabled (no vacuous empty-array bypass)...
+    const submitButton = getByText('Submit') as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+
+    // ...and clicking an option + Submit works without throwing.
+    expect(() => {
+      fireEvent.click(getByText('OAuth'));
+      fireEvent.click(getByText('Submit'));
+    }).not.toThrow();
+  });
+
+  it('renders read-only (no interactive buttons disabled-state crash) when not answerable', () => {
+    const part = answerablePart(QUESTIONS_INPUT);
+    const { getByText } = render(
+      <AskUserAnswerProvider value={{ answerableToolCallIds: new Set(), submitAnswers: () => {} }}>
+        <AskUserQuestionCard part={part} />
+      </AskUserAnswerProvider>
+    );
+    const submitButton = getByText('Waiting for a response…') as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserAnswerContext.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserAnswerContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react';
+import type { AskUserOutput } from '@/lib/ai/tools/ask-user-tools';
+
+export interface AskUserAnswerContextValue {
+  /** toolCallIds currently answerable in THIS chat instance (last message, chat idle). */
+  answerableToolCallIds: ReadonlySet<string>;
+  submitAnswers: (toolCallId: string, output: AskUserOutput) => void;
+}
+
+/**
+ * Carries answer plumbing from a chat surface (AiChatView, GlobalAssistantView,
+ * SidebarChatTab) down to AskUserQuestionCard without prop-drilling through
+ * ToolCallRenderer/CompactToolCallRenderer, which receive only the part.
+ *
+ * Absent (null) for any renderer outside a live chat surface — historical
+ * fetches, other viewers, channel mentions — so those render read-only by
+ * construction.
+ */
+const AskUserAnswerContext = createContext<AskUserAnswerContextValue | null>(null);
+
+export const AskUserAnswerProvider = AskUserAnswerContext.Provider;
+
+export function useAskUserAnswerContext(): AskUserAnswerContextValue | null {
+  return useContext(AskUserAnswerContext);
+}

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { HelpCircle, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -62,6 +62,11 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
   const [drafts, setDrafts] = useState<DraftAnswer[]>(() =>
     (input?.questions ?? []).map(() => ({ showOther: false }))
   );
+  // Multiple questions render as tabs (mirrors Claude Code's AskUserQuestion),
+  // one question visible at a time, so a keyboard/mouse-free user navigates
+  // with arrow keys instead of tabbing through every option of every question.
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   // `input` streams in incrementally (input-streaming state, or a partial/
   // unparsable JSON string) and only becomes the final questions array once
@@ -75,6 +80,7 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
     setDrafts((prev) =>
       prev.length === questionCount ? prev : Array.from({ length: questionCount }, () => ({ showOther: false }))
     );
+    setActiveIndex((prev) => (prev < questionCount ? prev : 0));
   }, [questionCount]);
 
   if (!input) return null;
@@ -127,75 +133,150 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
     ctx.submitAnswers(part.toolCallId, { answers });
   };
 
+  const isQuestionAnswered = (i: number) => {
+    if (answeredList?.[i]) return true;
+    const d = drafts[i];
+    return Boolean(d && (d.showOther ? d.otherText?.trim() : d.selectedLabel));
+  };
+
+  const focusTab = (index: number) => {
+    setActiveIndex(index);
+    tabRefs.current[index]?.focus();
+  };
+
+  const onTabKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      focusTab((index + 1) % questionCount);
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      focusTab((index - 1 + questionCount) % questionCount);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      focusTab(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      focusTab(questionCount - 1);
+    }
+  };
+
+  // Number-key shortcut: jump straight to option N of the active question
+  // without tabbing/clicking into it. Ignored while typing free text (a
+  // digit is valid Other… content) and once the question is no longer
+  // answerable — mirrors `isAnswerable` disabling the option buttons below.
+  const onCardKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!isAnswerable) return;
+    if ((e.target as HTMLElement).tagName === 'TEXTAREA') return;
+    const digit = Number(e.key);
+    if (!Number.isInteger(digit) || digit < 1) return;
+    const q = input.questions[activeIndex];
+    if (!q || answeredList?.[activeIndex]) return;
+    if (digit <= q.options.length) {
+      setDraft(activeIndex, { selectedLabel: q.options[digit - 1].label, showOther: false });
+    } else if (digit === q.options.length + 1) {
+      setDraft(activeIndex, { showOther: true });
+    }
+  };
+
+  const activeQuestion = input.questions[activeIndex];
+  const answered = answeredList?.[activeIndex];
+  const draft = drafts[activeIndex];
+
   return (
-    <div className="my-2 rounded-lg border bg-card p-4 space-y-4">
+    <div className="my-2 rounded-lg border bg-card p-4 space-y-4" onKeyDown={onCardKeyDown}>
       <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
         <HelpCircle className="h-4 w-4" />
-        Question{input.questions.length > 1 ? 's' : ''}
+        Question{questionCount > 1 ? 's' : ''}
       </div>
 
-      {input.questions.map((q, i) => {
-        const answered = answeredList?.[i];
-        const draft = drafts[i];
+      {questionCount > 1 && (
+        <div role="tablist" aria-label="Questions" className="flex flex-wrap gap-1.5">
+          {input.questions.map((q, i) => (
+            <button
+              key={i}
+              ref={(el) => {
+                tabRefs.current[i] = el;
+              }}
+              role="tab"
+              type="button"
+              aria-selected={i === activeIndex}
+              tabIndex={i === activeIndex ? 0 : -1}
+              onClick={() => setActiveIndex(i)}
+              onKeyDown={(e) => onTabKeyDown(e, i)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors',
+                i === activeIndex
+                  ? 'border-transparent bg-primary text-primary-foreground'
+                  : 'border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+              )}
+            >
+              {isQuestionAnswered(i) && <Check className="h-3 w-3" />}
+              {i + 1}. {q.header}
+            </button>
+          ))}
+        </div>
+      )}
 
-        return (
-          <div key={i} className="space-y-2">
-            <Badge variant="secondary" className="font-normal">
-              {q.header}
-            </Badge>
-            <p className="text-sm">{q.question}</p>
+      {activeQuestion && (
+        <div role="tabpanel" className="space-y-2">
+          <Badge variant="secondary" className="font-normal">
+            {activeQuestion.header}
+          </Badge>
+          <p className="text-sm">{activeQuestion.question}</p>
 
-            <div className="flex flex-wrap gap-2">
-              {q.options.map((opt) => {
-                const isChosen = answered
-                  ? answered.selectedLabel === opt.label
-                  : draft?.selectedLabel === opt.label && !draft.showOther;
-                return (
-                  <Button
-                    key={opt.label}
-                    type="button"
-                    variant={isChosen ? 'default' : 'outline'}
-                    size="sm"
-                    disabled={!isAnswerable}
-                    onClick={() => setDraft(i, { selectedLabel: opt.label, showOther: false })}
-                    className="flex items-center gap-1.5"
-                    title={opt.description}
-                  >
-                    {isChosen && <Check className="h-3.5 w-3.5" />}
-                    {opt.label}
-                  </Button>
-                );
-              })}
-              {!answered && (
+          <div className="flex flex-wrap gap-2">
+            {activeQuestion.options.map((opt, optIndex) => {
+              const isChosen = answered
+                ? answered.selectedLabel === opt.label
+                : draft?.selectedLabel === opt.label && !draft.showOther;
+              return (
                 <Button
+                  key={opt.label}
                   type="button"
-                  variant={draft?.showOther ? 'default' : 'outline'}
+                  variant={isChosen ? 'default' : 'outline'}
                   size="sm"
                   disabled={!isAnswerable}
-                  onClick={() => setDraft(i, { showOther: true })}
+                  onClick={() => setDraft(activeIndex, { selectedLabel: opt.label, showOther: false })}
+                  className="flex items-center gap-1.5"
+                  title={opt.description}
                 >
-                  Other…
+                  {isChosen && <Check className="h-3.5 w-3.5" />}
+                  <span className="tabular-nums opacity-60">{optIndex + 1}</span>
+                  {opt.label}
                 </Button>
-              )}
-            </div>
-
-            {answered?.otherText && (
-              <p className="text-sm italic text-muted-foreground">&quot;{answered.otherText}&quot;</p>
-            )}
-
-            {!answered && draft?.showOther && (
-              <Textarea
-                value={draft.otherText ?? ''}
-                onChange={(e) => setDraft(i, { otherText: e.target.value })}
-                placeholder="Type your answer…"
+              );
+            })}
+            {!answered && (
+              <Button
+                type="button"
+                variant={draft?.showOther ? 'default' : 'outline'}
+                size="sm"
                 disabled={!isAnswerable}
-                className="text-sm"
-                rows={2}
-              />
+                onClick={() => setDraft(activeIndex, { showOther: true })}
+                className="flex items-center gap-1.5"
+              >
+                <span className="tabular-nums opacity-60">{activeQuestion.options.length + 1}</span>
+                Other…
+              </Button>
             )}
           </div>
-        );
-      })}
+
+          {answered?.otherText && (
+            <p className="text-sm italic text-muted-foreground">&quot;{answered.otherText}&quot;</p>
+          )}
+
+          {!answered && draft?.showOther && (
+            <Textarea
+              value={draft.otherText ?? ''}
+              onChange={(e) => setDraft(activeIndex, { otherText: e.target.value })}
+              placeholder="Type your answer…"
+              disabled={!isAnswerable}
+              className="text-sm"
+              rows={2}
+            />
+          )}
+        </div>
+      )}
 
       {!output && (
         <Button

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
@@ -1,0 +1,190 @@
+import React, { useMemo, useState } from 'react';
+import { HelpCircle, Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+import { useAskUserAnswerContext } from './AskUserAnswerContext';
+import type { AskUserInput, AskUserAnswer } from '@/lib/ai/tools/ask-user-tools';
+
+interface ToolPart {
+  type: string;
+  toolCallId?: string;
+  state?: 'input-streaming' | 'input-available' | 'output-available' | 'output-error' | 'done' | 'streaming';
+  input?: unknown;
+  output?: unknown;
+}
+
+interface AskUserQuestionCardProps {
+  part: ToolPart;
+}
+
+const safeParseInput = (value: unknown): AskUserInput | null => {
+  const parsed = typeof value === 'string' ? tryJson(value) : value;
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray((parsed as AskUserInput).questions)) return null;
+  return parsed as AskUserInput;
+};
+
+const tryJson = (value: string): unknown => {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+};
+
+type AskUserOutputShape =
+  | { answers: AskUserAnswer[] }
+  | { dismissed: true; reason: string };
+
+const safeParseOutput = (value: unknown): AskUserOutputShape | null => {
+  const parsed = typeof value === 'string' ? tryJson(value) : value;
+  if (!parsed || typeof parsed !== 'object') return null;
+  return parsed as AskUserOutputShape;
+};
+
+/** Local per-question selection state before the user submits. */
+interface DraftAnswer {
+  selectedLabel?: string;
+  otherText?: string;
+  showOther: boolean;
+}
+
+export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }) => {
+  const ctx = useAskUserAnswerContext();
+  const input = useMemo(() => safeParseInput(part.input), [part.input]);
+  const output = useMemo(() => safeParseOutput(part.output), [part.output]);
+
+  const isAnswerable = Boolean(
+    ctx && part.toolCallId && part.state === 'input-available' && ctx.answerableToolCallIds.has(part.toolCallId)
+  );
+
+  const [drafts, setDrafts] = useState<DraftAnswer[]>(() =>
+    (input?.questions ?? []).map(() => ({ showOther: false }))
+  );
+
+  if (!input) return null;
+
+  if (part.state === 'input-streaming') {
+    return (
+      <div className="my-2 rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+        Preparing a question…
+      </div>
+    );
+  }
+
+  if (output && 'dismissed' in output) {
+    return (
+      <div className="my-2 rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+        Answered in chat instead.
+      </div>
+    );
+  }
+
+  const answeredByHeader = new Map(
+    output && 'answers' in output ? output.answers.map((a) => [a.header, a]) : []
+  );
+
+  const setDraft = (index: number, patch: Partial<DraftAnswer>) => {
+    setDrafts((prev) => prev.map((d, i) => (i === index ? { ...d, ...patch } : d)));
+  };
+
+  const canSubmit =
+    isAnswerable &&
+    drafts.every((d) => (d.showOther ? d.otherText?.trim() : d.selectedLabel));
+
+  const handleSubmit = () => {
+    if (!ctx || !part.toolCallId || !canSubmit || !input) return;
+    const answers: AskUserAnswer[] = input.questions.map((q, i) => {
+      const draft = drafts[i];
+      return draft.showOther
+        ? { header: q.header, question: q.question, otherText: draft.otherText }
+        : { header: q.header, question: q.question, selectedLabel: draft.selectedLabel };
+    });
+    ctx.submitAnswers(part.toolCallId, { answers });
+  };
+
+  return (
+    <div className="my-2 rounded-lg border bg-card p-4 space-y-4">
+      <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        <HelpCircle className="h-4 w-4" />
+        Question{input.questions.length > 1 ? 's' : ''}
+      </div>
+
+      {input.questions.map((q, i) => {
+        const answered = answeredByHeader.get(q.header);
+        const draft = drafts[i];
+
+        return (
+          <div key={i} className="space-y-2">
+            <Badge variant="secondary" className="font-normal">
+              {q.header}
+            </Badge>
+            <p className="text-sm">{q.question}</p>
+
+            <div className="flex flex-wrap gap-2">
+              {q.options.map((opt) => {
+                const isChosen = answered
+                  ? answered.selectedLabel === opt.label
+                  : draft?.selectedLabel === opt.label && !draft.showOther;
+                return (
+                  <Button
+                    key={opt.label}
+                    type="button"
+                    variant={isChosen ? 'default' : 'outline'}
+                    size="sm"
+                    disabled={!isAnswerable}
+                    onClick={() => setDraft(i, { selectedLabel: opt.label, showOther: false })}
+                    className="flex items-center gap-1.5"
+                    title={opt.description}
+                  >
+                    {isChosen && <Check className="h-3.5 w-3.5" />}
+                    {opt.label}
+                  </Button>
+                );
+              })}
+              {!answered && (
+                <Button
+                  type="button"
+                  variant={draft?.showOther ? 'default' : 'outline'}
+                  size="sm"
+                  disabled={!isAnswerable}
+                  onClick={() => setDraft(i, { showOther: true })}
+                >
+                  Other…
+                </Button>
+              )}
+            </div>
+
+            {answered?.otherText && (
+              <p className="text-sm italic text-muted-foreground">"{answered.otherText}"</p>
+            )}
+
+            {!answered && draft?.showOther && (
+              <Textarea
+                value={draft.otherText ?? ''}
+                onChange={(e) => setDraft(i, { otherText: e.target.value })}
+                placeholder="Type your answer…"
+                disabled={!isAnswerable}
+                className="text-sm"
+                rows={2}
+              />
+            )}
+          </div>
+        );
+      })}
+
+      {!output && (
+        <Button
+          type="button"
+          size="sm"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+          className={cn(!isAnswerable && 'opacity-50')}
+        >
+          {isAnswerable ? 'Submit' : 'Waiting for a response…'}
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { HelpCircle, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -63,6 +63,20 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
     (input?.questions ?? []).map(() => ({ showOther: false }))
   );
 
+  // `input` streams in incrementally (input-streaming state, or a partial/
+  // unparsable JSON string) and only becomes the final questions array once
+  // streaming completes — well after this component first mounted and ran
+  // the lazy useState initializer above. Resync drafts whenever the question
+  // count changes so a card that mounted with 0 questions (still streaming)
+  // grows real per-question draft slots once input finalizes, instead of
+  // permanently holding an empty drafts array.
+  const questionCount = input?.questions.length ?? 0;
+  useEffect(() => {
+    setDrafts((prev) =>
+      prev.length === questionCount ? prev : Array.from({ length: questionCount }, () => ({ showOther: false }))
+    );
+  }, [questionCount]);
+
   if (!input) return null;
 
   if (part.state === 'input-streaming') {
@@ -91,6 +105,10 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
 
   const canSubmit =
     isAnswerable &&
+    // Defends against a stale drafts array (e.g. mid-resync effect): `.every`
+    // on an empty/mismatched array is vacuously true, so the length check
+    // must hold before trusting it.
+    drafts.length === questionCount &&
     drafts.every((d) => (d.showOther ? d.otherText?.trim() : d.selectedLabel));
 
   const handleSubmit = () => {
@@ -157,7 +175,7 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
             </div>
 
             {answered?.otherText && (
-              <p className="text-sm italic text-muted-foreground">"{answered.otherText}"</p>
+              <p className="text-sm italic text-muted-foreground">&quot;{answered.otherText}&quot;</p>
             )}
 
             {!answered && draft?.showOther && (

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
@@ -95,9 +95,14 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
     );
   }
 
-  const answeredByHeader = new Map(
-    output && 'answers' in output ? output.answers.map((a) => [a.header, a]) : []
-  );
+  // Answers correspond to questions by POSITION, not by header — headers are
+  // free-form model-authored text with no uniqueness constraint, so two
+  // questions in the same call can legitimately share a header (e.g. both
+  // titled "Approach"). handleSubmit below builds `answers` via
+  // `input.questions.map((q, i) => ...)`, so `answers[i]` always answers
+  // `input.questions[i]`; keying by header here would silently swap answers
+  // whenever two headers collide.
+  const answeredList = output && 'answers' in output ? output.answers : undefined;
 
   const setDraft = (index: number, patch: Partial<DraftAnswer>) => {
     setDrafts((prev) => prev.map((d, i) => (i === index ? { ...d, ...patch } : d)));
@@ -130,7 +135,7 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
       </div>
 
       {input.questions.map((q, i) => {
-        const answered = answeredByHeader.get(q.header);
+        const answered = answeredList?.[i];
         const draft = drafts[i];
 
         return (

--- a/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
+++ b/apps/web/src/components/ai/shared/chat/ask-user/AskUserQuestionCard.tsx
@@ -50,6 +50,54 @@ interface DraftAnswer {
   showOther: boolean;
 }
 
+interface OptionRowProps {
+  index: number;
+  label: string;
+  description?: string;
+  chosen: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+/**
+ * A single option as a full-width stacked row (number/check badge, label,
+ * optional description) rather than a flex-wrap pill — long labels and
+ * descriptions wrap cleanly instead of forcing a pill to stretch or break
+ * mid-word, and the description is now visible instead of a hover-only
+ * `title` tooltip. The chosen state is a soft `bg-primary/8` tint + colored
+ * border, not an opaque `bg-primary` fill, to match how restrained every
+ * other surface in the app is (badges, tabs, chips are all desaturated) —
+ * a full-saturation block read as a generic form-library "selected" state.
+ */
+const OptionRow: React.FC<OptionRowProps> = ({ index, label, description, chosen, disabled, onClick }) => (
+  <button
+    type="button"
+    disabled={disabled}
+    onClick={onClick}
+    className={cn(
+      'flex w-full items-start gap-3 rounded-md px-3.5 py-2.5 text-left text-sm transition-[background-color,border-color,box-shadow,transform] active:scale-[0.997] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none',
+      chosen
+        ? 'border border-primary bg-primary/8 shadow-[var(--shadow-elevated)] hover:bg-primary/14'
+        : 'border border-border bg-card shadow-[var(--shadow-ambient)] hover:border-primary/35 hover:shadow-[var(--shadow-elevated)]'
+    )}
+  >
+    <span
+      className={cn(
+        'mt-px flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[11px] tabular-nums',
+        chosen ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+      )}
+    >
+      {chosen ? <Check className="h-3.5 w-3.5" /> : index}
+    </span>
+    <span className="flex min-w-0 flex-col gap-0.5 pt-px">
+      <span className="font-medium">{label}</span>
+      {description && (
+        <span className="text-[12.5px] font-normal leading-[1.45] text-muted-foreground">{description}</span>
+      )}
+    </span>
+  </button>
+);
+
 export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }) => {
   const ctx = useAskUserAnswerContext();
   const input = useMemo(() => safeParseInput(part.input), [part.input]);
@@ -224,40 +272,31 @@ export const AskUserQuestionCard: React.FC<AskUserQuestionCardProps> = ({ part }
           </Badge>
           <p className="text-sm">{activeQuestion.question}</p>
 
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-col gap-2">
             {activeQuestion.options.map((opt, optIndex) => {
               const isChosen = answered
                 ? answered.selectedLabel === opt.label
                 : draft?.selectedLabel === opt.label && !draft.showOther;
               return (
-                <Button
+                <OptionRow
                   key={opt.label}
-                  type="button"
-                  variant={isChosen ? 'default' : 'outline'}
-                  size="sm"
+                  index={optIndex + 1}
+                  label={opt.label}
+                  description={opt.description}
+                  chosen={isChosen}
                   disabled={!isAnswerable}
                   onClick={() => setDraft(activeIndex, { selectedLabel: opt.label, showOther: false })}
-                  className="flex items-center gap-1.5"
-                  title={opt.description}
-                >
-                  {isChosen && <Check className="h-3.5 w-3.5" />}
-                  <span className="tabular-nums opacity-60">{optIndex + 1}</span>
-                  {opt.label}
-                </Button>
+                />
               );
             })}
             {!answered && (
-              <Button
-                type="button"
-                variant={draft?.showOther ? 'default' : 'outline'}
-                size="sm"
+              <OptionRow
+                index={activeQuestion.options.length + 1}
+                label="Other…"
+                chosen={Boolean(draft?.showOther)}
                 disabled={!isAnswerable}
                 onClick={() => setDraft(activeIndex, { showOther: true })}
-                className="flex items-center gap-1.5"
-              >
-                <span className="tabular-nums opacity-60">{activeQuestion.options.length + 1}</span>
-                Other…
-              </Button>
+              />
             )}
           </div>
 

--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -25,6 +25,7 @@ import { type TreeItem } from './PageTreeRenderer';
 import { TaskRenderer } from './TaskRenderer';
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
 import { PageAgentConversationRenderer } from '@/components/ai/page-agents';
+import { AskUserQuestionCard } from '../ask-user/AskUserQuestionCard';
 import { renderToolContent } from './registry';
 import { dispatchToolCall, resolveIntegrationToolLabel } from './tool-call-dispatch';
 
@@ -87,6 +88,7 @@ const getSendChannelMessagePreview = (
 // Tool name mapping (moved outside component to avoid recreation)
 export const TOOL_NAME_MAP: Record<string, string> = {
   'ask_agent': 'Ask Agent',
+  'ask_user': 'Question',
   'list_drives': 'List Drives',
   'list_pages': 'List Pages',
   'read_page': 'Read',
@@ -377,6 +379,8 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = m
       return <TaskRenderer part={dispatch.part} />;
     case 'agent':
       return <PageAgentConversationRenderer part={dispatch.part} />;
+    case 'question':
+      return <AskUserQuestionCard part={dispatch.part} />;
     case 'generic':
       return (
         <CompactToolCallRendererInternal

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -6,6 +6,7 @@ import {
   ToolHeader,
 } from '@/components/ai/ui/tool';
 import { PageAgentConversationRenderer } from '@/components/ai/page-agents';
+import { AskUserQuestionCard } from '../ask-user/AskUserQuestionCard';
 import { TaskRenderer } from './TaskRenderer';
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
 import { renderToolContent } from './registry';
@@ -97,6 +98,7 @@ export const TOOL_NAME_MAP: Record<string, string> = {
   'list_agents': 'Agents',
   'multi_drive_list_agents': 'All Agents',
   'ask_agent': 'Ask Agent',
+  'ask_user': 'Question',
   // Web
   'web_search': 'Web Search',
   'web_fetch': 'Fetch Page',
@@ -264,6 +266,8 @@ export const ToolCallRenderer: React.FC<ToolCallRendererProps> = memo(function T
       return <TaskRenderer part={dispatch.part} />;
     case 'agent':
       return <PageAgentConversationRenderer part={dispatch.part} />;
+    case 'question':
+      return <AskUserQuestionCard part={dispatch.part} />;
     case 'generic':
       return <ToolCallRendererInternal part={dispatch.part} toolName={dispatch.toolName} open={open} onOpenChange={onOpenChange} />;
   }

--- a/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/registry.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { TASK_TOOL_NAMES } from '../useAggregatedTasks';
+import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
 import { RichContentRenderer } from './RichContentRenderer';
 import { RichDiffRenderer } from './RichDiffRenderer';
 import { PageTreeRenderer, type TreeItem } from './PageTreeRenderer';
@@ -214,6 +215,7 @@ const parsePathsToTree = (paths: string[]): TreeItem[] => {
 export const SPECIAL_HANDLED_TOOLS: Set<string> = new Set<string>([
   ...TASK_TOOL_NAMES,
   'ask_agent',
+  ASK_USER_TOOL_NAME,
 ]);
 
 // pi uses lowercase tool names — these must match exactly what the pi coding agent sends.

--- a/apps/web/src/components/ai/shared/chat/tool-calls/tool-call-dispatch.ts
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/tool-call-dispatch.ts
@@ -8,6 +8,7 @@
 import { isHiddenTool } from './tool-significance';
 import { isIntegrationTool, parseIntegrationToolName } from '@pagespace/lib/integrations/converter/ai-sdk';
 import { getBuiltinProvider } from '@pagespace/lib/integrations/providers/builtin-providers';
+import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
 
 export interface DispatchToolPart {
   type: string;
@@ -23,6 +24,7 @@ export type ToolCallDispatchResult<TPart extends DispatchToolPart> =
   | { kind: 'hidden' }
   | { kind: 'task'; part: TPart }
   | { kind: 'agent'; part: TPart }
+  | { kind: 'question'; part: TPart }
   | { kind: 'generic'; part: TPart; toolName: string };
 
 const safeJsonParse = (value: unknown): Record<string, unknown> | null => {
@@ -68,6 +70,7 @@ export function dispatchToolCall<TPart extends DispatchToolPart>(
 
   if (taskToolNames.has(toolName)) return { kind: 'task', part: resolvedPart };
   if (toolName === 'ask_agent') return { kind: 'agent', part: resolvedPart };
+  if (toolName === ASK_USER_TOOL_NAME) return { kind: 'question', part: resolvedPart };
   return { kind: 'generic', part: resolvedPart, toolName };
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -60,12 +60,14 @@ import {
   useChatTransport,
   useStreamingRegistration,
   useSendHandoff,
+  useAskUserAnswering,
   buildChatConfig,
   AgentConfig,
 } from '@/lib/ai/shared';
 import {
   ProviderSetupCard,
 } from '@/components/ai/shared/chat';
+import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { AiUsageMonitor, TasksDropdown } from '@/components/ai/shared';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import {
@@ -175,7 +177,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     [page.id, transport, handleChatError]
   );
 
-  const { messages, sendMessage, status, error, regenerate, setMessages, stop: chatStop } =
+  const { messages, sendMessage, status, error, regenerate, setMessages, stop: chatStop, addToolResult } =
     useChat(chatConfig || {});
 
   const isStreaming = status === 'submitted' || status === 'streaming';
@@ -765,6 +767,37 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     });
   }, [cache, drives, driveId, page.id, page.title, page.type]);
 
+  const buildAskUserAnswerBody = useCallback(async () => {
+    const pageContext = await buildFreshPageContext();
+    return {
+      chatId: page.id,
+      conversationId: currentConversationId,
+      selectedProvider,
+      selectedModel,
+      isReadOnly,
+      webSearchEnabled,
+      mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
+      pageContext,
+    };
+  }, [
+    buildFreshPageContext,
+    page.id,
+    currentConversationId,
+    selectedProvider,
+    selectedModel,
+    isReadOnly,
+    webSearchEnabled,
+    mcpToolSchemas,
+  ]);
+
+  const askUserAnswering = useAskUserAnswering({
+    messages,
+    status,
+    addToolResult,
+    wrapSend,
+    buildBody: buildAskUserAnswerBody,
+  });
+
   const handleSendMessage = useCallback(() => {
     if (isReadOnly) {
       toast.error('You do not have permission to send messages in this AI chat');
@@ -947,6 +980,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   }
 
   return (
+    <AskUserAnswerProvider value={askUserAnswering}>
     <div className="flex flex-col h-full">
       <Tabs value={activeTab} onValueChange={setActiveTab} className="flex flex-col h-full">
         <div className="p-4 border-b border-[var(--separator)] space-y-3">
@@ -1183,6 +1217,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       </Tabs>
 
     </div>
+    </AskUserAnswerProvider>
   );
 };
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -65,11 +65,13 @@ import {
   useChatStop,
   useSendHandoff,
   useStreamRecovery,
+  useAskUserAnswering,
   buildChatConfig,
   AGENT_CHAT_ID,
   LocationContext,
   buildGlobalChatRequestBody,
 } from '@/lib/ai/shared';
+import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { useEditingStore } from '@/stores/useEditingStore';
@@ -308,6 +310,7 @@ const GlobalAssistantView: React.FC = () => {
     regenerate: globalRegenerate,
     setMessages: setGlobalLocalMessages,
     stop: globalStop,
+    addToolResult: globalAddToolResult,
   } = useChat(globalChatConfig || {});
 
   // Agent mode chat
@@ -320,6 +323,7 @@ const GlobalAssistantView: React.FC = () => {
     regenerate: agentRegenerate,
     setMessages: setAgentMessages,
     stop: agentStop,
+    addToolResult: agentAddToolResult,
   } = useChat(agentChatConfig || {});
 
   // ============================================
@@ -332,6 +336,7 @@ const GlobalAssistantView: React.FC = () => {
   const clearError = selectedAgent ? agentClearError : globalClearError;
   const regenerate = selectedAgent ? agentRegenerate : globalRegenerate;
   const rawStop = selectedAgent ? agentStop : globalStop;
+  const addToolResult = selectedAgent ? agentAddToolResult : globalAddToolResult;
   const isStreaming = status === 'submitted' || status === 'streaming';
   const { wrapSend } = useSendHandoff(currentConversationId, status);
 
@@ -872,6 +877,49 @@ const GlobalAssistantView: React.FC = () => {
     wrapSend,
   ]);
 
+  const buildAskUserAnswerBody = useCallback(() => {
+    return selectedAgent
+      ? {
+          chatId: selectedAgent.id,
+          conversationId: currentConversationId,
+          selectedProvider: agentSelectedProvider,
+          selectedModel: agentSelectedModel,
+          isReadOnly,
+          webSearchEnabled,
+          mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
+        }
+      : buildGlobalChatRequestBody({
+          conversationId: currentConversationId,
+          isReadOnly,
+          webSearchEnabled,
+          showPageTree,
+          locationContext,
+          selectedProvider: currentProvider,
+          selectedModel: currentModel,
+          mcpTools: mcpToolSchemas,
+        });
+  }, [
+    currentConversationId,
+    selectedAgent,
+    agentSelectedProvider,
+    agentSelectedModel,
+    isReadOnly,
+    webSearchEnabled,
+    showPageTree,
+    locationContext,
+    currentProvider,
+    currentModel,
+    mcpToolSchemas,
+  ]);
+
+  const askUserAnswering = useAskUserAnswering({
+    messages,
+    status,
+    addToolResult,
+    wrapSend,
+    buildBody: buildAskUserAnswerBody,
+  });
+
   // Track last AI response for voice mode TTS.
   // voiceBaselineRef captures the last message ID when voice mode activates so pre-existing
   // messages are never spoken — only genuinely new responses trigger TTS.
@@ -951,6 +999,7 @@ const GlobalAssistantView: React.FC = () => {
   }
 
   return (
+    <AskUserAnswerProvider value={askUserAnswering}>
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-[var(--separator)]">
@@ -1101,6 +1150,7 @@ const GlobalAssistantView: React.FC = () => {
       />
 
     </div>
+    </AskUserAnswerProvider>
   );
 };
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -35,7 +35,8 @@ import { LocationContext } from '@/lib/ai/shared';
 import { parseTabPath, getStaticTabMeta } from '@/lib/tabs/tab-title';
 import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId } from '@/lib/ai/core/client';
 import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
-import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery, buildChatConfig, SIDEBAR_AGENT_CHAT_ID, buildGlobalChatRequestBody } from '@/lib/ai/shared';
+import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageActions, useStreamRecovery, useAskUserAnswering, buildChatConfig, SIDEBAR_AGENT_CHAT_ID, buildGlobalChatRequestBody } from '@/lib/ai/shared';
+import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
@@ -251,6 +252,7 @@ const SidebarChatTab: React.FC = () => {
     stop,
     isStreaming,
     setGlobalMessages,
+    addToolResult,
   } = usePageAgentSidebarChat({
     selectedAgent,
     globalChatConfig,
@@ -848,6 +850,49 @@ const SidebarChatTab: React.FC = () => {
     wrapSend,
   ]);
 
+  const buildAskUserAnswerBody = useCallback(() => {
+    const isReadOnly = !writeMode;
+    return selectedAgent
+      ? {
+          chatId: selectedAgent.id,
+          conversationId: agentConversationId,
+          isReadOnly,
+          webSearchEnabled,
+          provider: selectedAgent.aiProvider,
+          model: selectedAgent.aiModel,
+          systemPrompt: selectedAgent.systemPrompt,
+          locationContext: locationContext || undefined,
+          enabledTools: selectedAgent.enabledTools,
+        }
+      : buildGlobalChatRequestBody({
+          conversationId: currentConversationId,
+          isReadOnly,
+          webSearchEnabled,
+          showPageTree,
+          locationContext,
+          selectedProvider: currentProvider,
+          selectedModel: currentModel,
+        });
+  }, [
+    selectedAgent,
+    agentConversationId,
+    writeMode,
+    webSearchEnabled,
+    showPageTree,
+    locationContext,
+    currentProvider,
+    currentModel,
+    currentConversationId,
+  ]);
+
+  const askUserAnswering = useAskUserAnswering({
+    messages,
+    status,
+    addToolResult,
+    wrapSend,
+    buildBody: buildAskUserAnswerBody,
+  });
+
   // Voice mode toggle handler
   const handleVoiceModeToggle = useCallback(() => {
     if (isVoiceModeActive) {
@@ -1048,6 +1093,7 @@ const SidebarChatTab: React.FC = () => {
   }
 
   return (
+    <AskUserAnswerProvider value={askUserAnswering}>
     <div className="flex flex-col h-full">
       {/* Header */}
       <div className="flex flex-col border-b border-gray-200 dark:border-[var(--separator)] bg-card">
@@ -1189,6 +1235,7 @@ const SidebarChatTab: React.FC = () => {
         onSuccess={handleUndoSuccess}
       />
     </div>
+    </AskUserAnswerProvider>
   );
 };
 

--- a/apps/web/src/hooks/page-agents/usePageAgentSidebarChat.ts
+++ b/apps/web/src/hooks/page-agents/usePageAgentSidebarChat.ts
@@ -33,6 +33,13 @@ export interface UseSidebarChatReturn {
   globalMessages: UIMessage[];
   /** Set global messages */
   setGlobalMessages: (messages: UIMessage[] | ((prev: UIMessage[]) => UIMessage[])) => void;
+  /** Add a client-side tool result (mode-selected) — used by ask_user answers */
+  addToolResult: (args: {
+    tool: string;
+    toolCallId: string;
+    output: unknown;
+    options?: { body?: object };
+  }) => void | PromiseLike<void>;
 }
 
 interface UseSidebarChatOptions {
@@ -72,6 +79,7 @@ export function usePageAgentSidebarChat({
     regenerate: globalRegenerate,
     setMessages: setGlobalMessages,
     stop: globalStop,
+    addToolResult: globalAddToolResult,
   } = useChat(globalChatConfig || {});
 
   // ============================================
@@ -86,6 +94,7 @@ export function usePageAgentSidebarChat({
     regenerate: agentRegenerate,
     setMessages: setAgentMessages,
     stop: agentStop,
+    addToolResult: agentAddToolResult,
   } = useChat(agentChatConfig || {});
 
   // ============================================
@@ -133,6 +142,7 @@ export function usePageAgentSidebarChat({
   const clearError = selectedAgent ? agentClearError : globalClearError;
   const setMessages = selectedAgent ? setAgentMessages : setGlobalMessages;
   const stop = selectedAgent ? agentStop : globalStop;
+  const addToolResult = selectedAgent ? agentAddToolResult : globalAddToolResult;
   const isStreaming = status === 'submitted' || status === 'streaming';
 
   // Wrap sendMessage to use correct function
@@ -170,6 +180,7 @@ export function usePageAgentSidebarChat({
     setMessages,
     stop,
     isStreaming,
+    addToolResult,
     // Expose global mode specifics for syncing to GlobalChatContext
     globalStatus,
     globalStop,
@@ -185,6 +196,7 @@ export function usePageAgentSidebarChat({
     setMessages,
     stop,
     isStreaming,
+    addToolResult,
     globalStatus,
     globalStop,
     globalMessages,

--- a/apps/web/src/lib/ai/core/__tests__/agent-finish-classifier.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/agent-finish-classifier.test.ts
@@ -190,4 +190,57 @@ describe('classifyAttempt', () => {
       expected: { kind: 'terminal', reason: 'ambiguous' },
     });
   });
+
+  it('tool-calls ending with a pause tool (ask_user) is terminal:awaiting-user-input', () => {
+    assert({
+      given: 'a tool-calls finish where an execute-less pause tool was called, no finish tool',
+      should: 'be terminal:awaiting-user-input (a deliberate pause, never retried)',
+      actual: classifyAttempt(
+        base({
+          finishReason: 'tool-calls',
+          responseMessages: [assistantToolCall('ask_user')],
+          pauseToolNames: ['ask_user'],
+        }),
+      ),
+      expected: { kind: 'terminal', reason: 'awaiting-user-input' },
+    });
+  });
+
+  it('finish tool wins over a pause tool called in the same turn', () => {
+    assert({
+      given: 'a tool-calls finish where both the finish tool and a pause tool were called',
+      should: 'be clean (finish is checked first)',
+      actual: classifyAttempt(
+        base({
+          finishReason: 'tool-calls',
+          responseMessages: [
+            {
+              role: 'assistant',
+              content: [
+                { type: 'tool-call', toolCallId: 'a', toolName: 'ask_user', input: {} },
+                { type: 'tool-call', toolCallId: 'b', toolName: FINISH, input: {} },
+              ],
+            },
+          ],
+          pauseToolNames: ['ask_user'],
+        }),
+      ),
+      expected: { kind: 'clean' },
+    });
+  });
+
+  it('a pause tool call is only recognized when its name is in pauseToolNames', () => {
+    assert({
+      given: 'a tool-calls finish calling ask_user, but pauseToolNames not configured',
+      should: 'fall through to terminal:tool-calls-no-finish',
+      actual: classifyAttempt(
+        base({
+          finishReason: 'tool-calls',
+          responseMessages: [assistantToolCall('ask_user')],
+          stepCount: 5,
+        }),
+      ),
+      expected: { kind: 'terminal', reason: 'tool-calls-no-finish' },
+    });
+  });
 });

--- a/apps/web/src/lib/ai/core/__tests__/ask-user-gating.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ask-user-gating.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { canUseAskUser } from '../ask-user-gating';
+
+describe('canUseAskUser', () => {
+  it('grants app admins only', () => {
+    expect(canUseAskUser({ role: 'admin' })).toBe(true);
+  });
+
+  it('denies non-admin roles', () => {
+    expect(canUseAskUser({ role: 'user' })).toBe(false);
+    expect(canUseAskUser({ role: 'member' })).toBe(false);
+  });
+
+  it('denies missing/null role or user', () => {
+    expect(canUseAskUser({ role: null })).toBe(false);
+    expect(canUseAskUser({})).toBe(false);
+    expect(canUseAskUser(null)).toBe(false);
+    expect(canUseAskUser(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/ask-user-resume.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ask-user-resume.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UIMessage } from 'ai';
+
+// --- DB mock -----------------------------------------------------------
+// A minimal chainable select() that supports both .where().limit() (targeted
+// lookup by messageId) and .where().orderBy().limit() (dismissal's "last
+// assistant message" scan). Each test seeds the row(s) it wants returned.
+let selectRows: unknown[] = [];
+function makeSelectChain() {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(() => Promise.resolve(selectRows)),
+  };
+  return chain;
+}
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(() => makeSelectChain()),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  desc: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ chatMessages: {} }));
+vi.mock('@pagespace/db/schema/conversations', () => ({ messages: {} }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), info: vi.fn() } },
+}));
+
+// --- message-utils mock -------------------------------------------------
+// convertDbMessageToUIMessage / convertGlobalAssistantMessageToUIMessage are
+// stubbed to hand back the exact UIMessage the test seeded on the row (via
+// `__uiMessage`), so these tests exercise the MERGE logic in ask-user-resume.ts
+// against a known-shape message rather than the unrelated structured-content
+// reconstruction pipeline (covered separately by message-utils' own tests).
+// extractMessageContent/extractToolCalls/extractToolResults run for REAL so the
+// persistence payload built from the merged message is genuinely exercised.
+// vi.hoisted: vi.mock factories are hoisted above all other top-level code, so
+// these mocks must be created through vi.hoisted to be visible inside them.
+const { saveMessageToDatabase, saveGlobalAssistantMessageToDatabase } = vi.hoisted(() => ({
+  saveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+  saveGlobalAssistantMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Keyed by row.id — set per-test via `uiMessagesById` below — rather than
+// piggy-backing extra fields onto the DatabaseMessage-shaped object the real
+// code constructs (which only carries fields convertDbMessageToUIMessage's
+// real signature declares). vi.hoisted: must exist before the vi.mock
+// factory below runs (imports, and therefore mock factories, execute before
+// ordinary top-level `const`s in this file).
+const uiMessagesById = vi.hoisted(() => new Map<string, UIMessage>());
+
+vi.mock('@/lib/ai/core/message-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../message-utils')>();
+  return {
+    ...actual,
+    convertDbMessageToUIMessage: vi.fn(async (row: { id: string }) => uiMessagesById.get(row.id)),
+    convertGlobalAssistantMessageToUIMessage: vi.fn(async (row: { id: string }) => uiMessagesById.get(row.id)),
+    saveMessageToDatabase,
+    saveGlobalAssistantMessageToDatabase,
+  };
+});
+
+import {
+  extractClientAskUserResults,
+  applyAskUserResultsToPageMessage,
+  dismissPendingAskUserForPageConversation,
+} from '../ask-user-resume';
+
+const pendingPart = (toolCallId: string): UIMessage['parts'][number] => ({
+  type: 'tool-ask_user',
+  toolCallId,
+  state: 'input-available',
+  input: { questions: [{ header: 'Auth', question: 'Which?', options: [{ label: 'OAuth' }, { label: 'API key' }] }] },
+} as UIMessage['parts'][number]);
+
+const answeredPart = (toolCallId: string): UIMessage['parts'][number] => ({
+  type: 'tool-ask_user',
+  toolCallId,
+  state: 'output-available',
+  input: { questions: [{ header: 'Auth', question: 'Which?', options: [{ label: 'OAuth' }, { label: 'API key' }] }] },
+  output: { answers: [{ header: 'Auth', question: 'Which?', selectedLabel: 'OAuth' }] },
+} as UIMessage['parts'][number]);
+
+const dbRow = (parts: UIMessage['parts'], overrides: Record<string, unknown> = {}) => {
+  const id = (overrides.id as string) ?? 'msg-1';
+  const role = (overrides.role as string) ?? 'assistant';
+  uiMessagesById.set(id, { id, role: role as UIMessage['role'], parts });
+  return {
+    id,
+    pageId: 'page-1',
+    conversationId: 'conv-1',
+    userId: null,
+    role,
+    content: '',
+    toolCalls: null,
+    toolResults: null,
+    createdAt: new Date('2026-01-01'),
+    isActive: true,
+    editedAt: null,
+    messageType: 'standard' as const,
+    ...overrides,
+  };
+};
+
+beforeEach(() => {
+  selectRows = [];
+  uiMessagesById.clear();
+  saveMessageToDatabase.mockClear();
+  saveGlobalAssistantMessageToDatabase.mockClear();
+});
+
+describe('extractClientAskUserResults', () => {
+  it('extracts output-available ask_user parts from a trailing assistant message', () => {
+    const results = extractClientAskUserResults({
+      id: 'm1',
+      role: 'assistant',
+      parts: [answeredPart('q1')],
+    } as UIMessage);
+    expect(results).toEqual([{ toolCallId: 'q1', output: { answers: [{ header: 'Auth', question: 'Which?', selectedLabel: 'OAuth' }] } }]);
+  });
+
+  it('returns empty for a non-assistant message', () => {
+    expect(extractClientAskUserResults({ id: 'm1', role: 'user', parts: [] } as UIMessage)).toEqual([]);
+  });
+
+  it('returns empty when the ask_user part has no output yet', () => {
+    const results = extractClientAskUserResults({
+      id: 'm1',
+      role: 'assistant',
+      parts: [pendingPart('q1')],
+    } as UIMessage);
+    expect(results).toEqual([]);
+  });
+});
+
+describe('applyAskUserResultsToPageMessage', () => {
+  it('merges a valid answer into the pending part and persists an update', async () => {
+    selectRows = [dbRow([pendingPart('q1')])];
+
+    const result = await applyAskUserResultsToPageMessage({
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      results: [{ toolCallId: 'q1', output: { answers: [{ header: 'Auth', question: 'Which?', selectedLabel: 'OAuth' }] } }],
+    });
+
+    expect(result).toEqual({ merged: true });
+    expect(saveMessageToDatabase).toHaveBeenCalledTimes(1);
+    const call = saveMessageToDatabase.mock.calls[0][0];
+    expect(call.messageId).toBe('msg-1');
+    expect(call.role).toBe('assistant');
+    const savedPart = call.uiMessage.parts.find((p: { toolCallId: string }) => p.toolCallId === 'q1');
+    expect(savedPart.state).toBe('output-available');
+    expect(savedPart.output).toEqual({ answers: [{ header: 'Auth', question: 'Which?', selectedLabel: 'OAuth' }] });
+  });
+
+  it('is idempotent: skips a toolCallId that is already answered', async () => {
+    selectRows = [dbRow([answeredPart('q1')])];
+
+    const result = await applyAskUserResultsToPageMessage({
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      results: [{ toolCallId: 'q1', output: { answers: [{ header: 'Auth', question: 'Which?', selectedLabel: 'API key' }] } }],
+    });
+
+    expect(result).toEqual({ merged: false });
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown toolCallId — no matching part to merge into', async () => {
+    selectRows = [dbRow([pendingPart('q1')])];
+
+    const result = await applyAskUserResultsToPageMessage({
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      results: [{ toolCallId: 'does-not-exist', output: { answers: [] } }],
+    });
+
+    expect(result).toEqual({ merged: false });
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+
+  it('rejects output that fails schema validation and does not persist it', async () => {
+    selectRows = [dbRow([pendingPart('q1')])];
+
+    const result = await applyAskUserResultsToPageMessage({
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      results: [{ toolCallId: 'q1', output: { junk: 'not a valid answer shape' } }],
+    });
+
+    expect(result).toEqual({ merged: false });
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the row is not an assistant message', async () => {
+    selectRows = [dbRow([pendingPart('q1')], { role: 'user' })];
+
+    const result = await applyAskUserResultsToPageMessage({
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      results: [{ toolCallId: 'q1', output: { answers: [] } }],
+    });
+
+    expect(result).toEqual({ merged: false });
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when no row is found', async () => {
+    selectRows = [];
+
+    const result = await applyAskUserResultsToPageMessage({
+      messageId: 'missing',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      results: [{ toolCallId: 'q1', output: { answers: [] } }],
+    });
+
+    expect(result).toEqual({ merged: false });
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+});
+
+describe('dismissPendingAskUserForPageConversation', () => {
+  it('synthesizes a dismissed result onto a still-pending ask_user call', async () => {
+    selectRows = [dbRow([pendingPart('q1')])];
+
+    await dismissPendingAskUserForPageConversation({ pageId: 'page-1', conversationId: 'conv-1' });
+
+    expect(saveMessageToDatabase).toHaveBeenCalledTimes(1);
+    const call = saveMessageToDatabase.mock.calls[0][0];
+    const savedPart = call.uiMessage.parts.find((p: { toolCallId: string }) => p.toolCallId === 'q1');
+    expect(savedPart.state).toBe('output-available');
+    expect(savedPart.output).toEqual({ dismissed: true, reason: 'User replied in chat instead of selecting an option.' });
+  });
+
+  it('does nothing when there is no pending ask_user call', async () => {
+    selectRows = [dbRow([answeredPart('q1')])];
+
+    await dismissPendingAskUserForPageConversation({ pageId: 'page-1', conversationId: 'conv-1' });
+
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no assistant message exists yet', async () => {
+    selectRows = [];
+
+    await dismissPendingAskUserForPageConversation({ pageId: 'page-1', conversationId: 'conv-1' });
+
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/core/agent-finish-classifier.ts
+++ b/apps/web/src/lib/ai/core/agent-finish-classifier.ts
@@ -17,6 +17,7 @@ export type TerminalReason =
   | 'content-filter'
   | 'step-budget'
   | 'tool-calls-no-finish'
+  | 'awaiting-user-input'
   | 'aborted'
   | 'provider-error'
   | 'ambiguous';
@@ -41,6 +42,12 @@ export interface ClassifyAttemptArgs {
   finishToolName: string;
   /** Whether the user explicitly aborted (abortSignal fired). Never retry an abort. */
   aborted: boolean;
+  /**
+   * Client-side (execute-less) tools that deliberately pause the turn awaiting
+   * user input (e.g. ask_user). A `tool-calls` finish that called one of these
+   * is a clean pause, never a retry — a retry would re-ask the question.
+   */
+  pauseToolNames?: string[];
   /**
    * Whether this attempt already streamed visible content (text/tool/reasoning parts) to
    * the client. The UI message stream is append-only: a from-scratch retry would duplicate
@@ -102,6 +109,13 @@ export function classifyAttempt(args: ClassifyAttemptArgs): AttemptOutcome {
     case 'tool-calls': {
       if (calledFinishTool(args.responseMessages, args.finishToolName)) {
         return { kind: 'clean' };
+      }
+      // A pause tool (execute-less, awaiting user input) halts the loop with a
+      // 'tool-calls' finish by design. Terminal so nothing retries and re-asks;
+      // the distinct reason keeps observability from conflating it with a
+      // broken tool-calls-no-finish turn.
+      if (args.pauseToolNames?.some((name) => calledFinishTool(args.responseMessages, name))) {
+        return { kind: 'terminal', reason: 'awaiting-user-input' };
       }
       // A multi-step loop with stopWhen [hasToolCall(finish), stepCountIs(N)] only
       // surfaces a top-level 'tool-calls' finish when stopWhen matched — i.e. the finish

--- a/apps/web/src/lib/ai/core/ask-user-gating.ts
+++ b/apps/web/src/lib/ai/core/ask-user-gating.ts
@@ -1,0 +1,11 @@
+/**
+ * Exposure gating for the interactive ask_user tool.
+ *
+ * Admin-only rollout: the platform-level app admin role (users.role), NOT a
+ * drive membership role. Widen here when the feature graduates.
+ */
+export function canUseAskUser(
+  user: { role?: string | null } | null | undefined
+): boolean {
+  return user?.role === 'admin';
+}

--- a/apps/web/src/lib/ai/core/ask-user-resume.ts
+++ b/apps/web/src/lib/ai/core/ask-user-resume.ts
@@ -1,0 +1,343 @@
+import type { UIMessage } from 'ai';
+import { eq, and, desc } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { chatMessages } from '@pagespace/db/schema/core';
+import { messages as globalMessages } from '@pagespace/db/schema/conversations';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  convertDbMessageToUIMessage,
+  convertGlobalAssistantMessageToUIMessage,
+  saveMessageToDatabase,
+  saveGlobalAssistantMessageToDatabase,
+  extractMessageContent,
+  extractToolCalls,
+  extractToolResults,
+} from '@/lib/ai/core/message-utils';
+import { ASK_USER_TOOL_NAME, askUserOutputSchema } from '@/lib/ai/tools/ask-user-tools';
+
+const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+const DISMISSED_REASON = 'User replied in chat instead of selecting an option.';
+
+type AskUserToolPart = { type: string; toolCallId: string; state?: string; output?: unknown };
+
+function isAskUserPart(part: { type: string }): part is AskUserToolPart {
+  return part.type === ASK_USER_PART_TYPE;
+}
+
+export interface ClientAskUserResult {
+  toolCallId: string;
+  output: unknown;
+}
+
+/**
+ * Pull `tool-ask_user` output-available parts off a trailing ASSISTANT request
+ * message (produced client-side by `addToolResult`). Everything except
+ * toolCallId/output is untrusted and discarded — the merge re-derives the
+ * rest from the persisted assistant row.
+ */
+export function extractClientAskUserResults(
+  message: UIMessage | undefined
+): ClientAskUserResult[] {
+  if (!message || message.role !== 'assistant' || !message.parts) return [];
+  const results: ClientAskUserResult[] = [];
+  for (const part of message.parts) {
+    if (!isAskUserPart(part)) continue;
+    if (part.state === 'output-available' && part.output !== undefined) {
+      results.push({ toolCallId: part.toolCallId, output: part.output });
+    }
+  }
+  return results;
+}
+
+/**
+ * Merge validated results into a reconstructed message's ask_user parts.
+ * Only flips parts that are still pending (input-available) — already
+ * answered parts are left untouched (idempotent under double-submit races),
+ * and invalid client output is rejected and logged rather than persisted.
+ */
+function mergeResultsIntoParts(
+  parts: UIMessage['parts'],
+  results: ClientAskUserResult[]
+): { parts: UIMessage['parts']; changed: boolean } {
+  const byId = new Map(results.map((r) => [r.toolCallId, r]));
+  let changed = false;
+
+  const nextParts = parts.map((part) => {
+    if (!isAskUserPart(part)) return part;
+    const result = byId.get(part.toolCallId);
+    if (!result) return part;
+    if (part.state !== 'input-available') return part;
+
+    const parsed = askUserOutputSchema.safeParse(result.output);
+    if (!parsed.success) {
+      loggers.ai.warn('ask_user resume: rejected invalid client output', {
+        toolCallId: part.toolCallId,
+        issues: parsed.error.issues,
+      });
+      return part;
+    }
+
+    changed = true;
+    return { ...part, state: 'output-available', output: parsed.data };
+  });
+
+  return { parts: nextParts as UIMessage['parts'], changed };
+}
+
+function pendingAskUserToolCallIds(parts: UIMessage['parts']): string[] {
+  const ids: string[] = [];
+  for (const part of parts) {
+    if (isAskUserPart(part) && part.state === 'input-available') ids.push(part.toolCallId);
+  }
+  return ids;
+}
+
+// --- Page (page-agent) conversations -------------------------------------
+
+export async function applyAskUserResultsToPageMessage(args: {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  results: ClientAskUserResult[];
+}): Promise<{ merged: boolean }> {
+  if (args.results.length === 0) return { merged: false };
+
+  const [row] = await db
+    .select()
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.id, args.messageId),
+        eq(chatMessages.pageId, args.pageId),
+        eq(chatMessages.conversationId, args.conversationId),
+        eq(chatMessages.isActive, true)
+      )
+    )
+    .limit(1);
+
+  if (!row || row.role !== 'assistant') return { merged: false };
+
+  const uiMessage = await convertDbMessageToUIMessage({
+    id: row.id,
+    pageId: row.pageId,
+    userId: row.userId,
+    role: row.role,
+    content: row.content,
+    toolCalls: row.toolCalls,
+    toolResults: row.toolResults,
+    createdAt: row.createdAt,
+    isActive: row.isActive,
+    editedAt: row.editedAt,
+    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
+  });
+
+  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, args.results);
+  if (!changed) return { merged: false };
+
+  const merged: UIMessage = { ...uiMessage, parts };
+  const content = extractMessageContent(merged);
+  const toolCalls = extractToolCalls(merged);
+  const toolResults = extractToolResults(merged);
+
+  await saveMessageToDatabase({
+    messageId: args.messageId,
+    pageId: args.pageId,
+    conversationId: args.conversationId,
+    userId: null,
+    role: 'assistant',
+    content,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    toolResults: toolResults.length > 0 ? toolResults : undefined,
+    uiMessage: merged,
+  });
+
+  return { merged: true };
+}
+
+/**
+ * A new user message arrived instead of an answer. Synthesize a
+ * `{dismissed: true}` result onto any still-pending ask_user calls on the
+ * conversation's last assistant message so the model sees its questions were
+ * answered free-form in chat and does not re-ask.
+ */
+export async function dismissPendingAskUserForPageConversation(args: {
+  pageId: string;
+  conversationId: string;
+}): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.pageId, args.pageId),
+        eq(chatMessages.conversationId, args.conversationId),
+        eq(chatMessages.isActive, true),
+        eq(chatMessages.role, 'assistant')
+      )
+    )
+    .orderBy(desc(chatMessages.createdAt))
+    .limit(1);
+
+  if (!row) return;
+
+  const uiMessage = await convertDbMessageToUIMessage({
+    id: row.id,
+    pageId: row.pageId,
+    userId: row.userId,
+    role: row.role,
+    content: row.content,
+    toolCalls: row.toolCalls,
+    toolResults: row.toolResults,
+    createdAt: row.createdAt,
+    isActive: row.isActive,
+    editedAt: row.editedAt,
+    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
+  });
+
+  const pendingIds = pendingAskUserToolCallIds(uiMessage.parts);
+  if (pendingIds.length === 0) return;
+
+  const results: ClientAskUserResult[] = pendingIds.map((toolCallId) => ({
+    toolCallId,
+    output: { dismissed: true, reason: DISMISSED_REASON },
+  }));
+
+  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, results);
+  if (!changed) return;
+
+  const merged: UIMessage = { ...uiMessage, parts };
+  const content = extractMessageContent(merged);
+  const toolCalls = extractToolCalls(merged);
+  const toolResults = extractToolResults(merged);
+
+  await saveMessageToDatabase({
+    messageId: row.id,
+    pageId: args.pageId,
+    conversationId: args.conversationId,
+    userId: null,
+    role: 'assistant',
+    content,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    toolResults: toolResults.length > 0 ? toolResults : undefined,
+    uiMessage: merged,
+  });
+}
+
+// --- Global Assistant conversations --------------------------------------
+
+export async function applyAskUserResultsToGlobalMessage(args: {
+  messageId: string;
+  conversationId: string;
+  results: ClientAskUserResult[];
+}): Promise<{ merged: boolean }> {
+  if (args.results.length === 0) return { merged: false };
+
+  const [row] = await db
+    .select()
+    .from(globalMessages)
+    .where(
+      and(
+        eq(globalMessages.id, args.messageId),
+        eq(globalMessages.conversationId, args.conversationId),
+        eq(globalMessages.isActive, true)
+      )
+    )
+    .limit(1);
+
+  if (!row || row.role !== 'assistant') return { merged: false };
+
+  const uiMessage = await convertGlobalAssistantMessageToUIMessage({
+    id: row.id,
+    conversationId: row.conversationId,
+    userId: row.userId,
+    role: row.role,
+    content: row.content,
+    toolCalls: row.toolCalls,
+    toolResults: row.toolResults,
+    createdAt: row.createdAt,
+    isActive: row.isActive,
+    editedAt: row.editedAt,
+    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
+  });
+
+  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, args.results);
+  if (!changed) return { merged: false };
+
+  const merged: UIMessage = { ...uiMessage, parts };
+  const content = extractMessageContent(merged);
+  const toolCalls = extractToolCalls(merged);
+  const toolResults = extractToolResults(merged);
+
+  await saveGlobalAssistantMessageToDatabase({
+    messageId: args.messageId,
+    conversationId: args.conversationId,
+    userId: row.userId,
+    role: 'assistant',
+    content,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    toolResults: toolResults.length > 0 ? toolResults : undefined,
+    uiMessage: merged,
+  });
+
+  return { merged: true };
+}
+
+export async function dismissPendingAskUserForGlobalConversation(args: {
+  conversationId: string;
+}): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(globalMessages)
+    .where(
+      and(
+        eq(globalMessages.conversationId, args.conversationId),
+        eq(globalMessages.isActive, true),
+        eq(globalMessages.role, 'assistant')
+      )
+    )
+    .orderBy(desc(globalMessages.createdAt))
+    .limit(1);
+
+  if (!row) return;
+
+  const uiMessage = await convertGlobalAssistantMessageToUIMessage({
+    id: row.id,
+    conversationId: row.conversationId,
+    userId: row.userId,
+    role: row.role,
+    content: row.content,
+    toolCalls: row.toolCalls,
+    toolResults: row.toolResults,
+    createdAt: row.createdAt,
+    isActive: row.isActive,
+    editedAt: row.editedAt,
+    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
+  });
+
+  const pendingIds = pendingAskUserToolCallIds(uiMessage.parts);
+  if (pendingIds.length === 0) return;
+
+  const results: ClientAskUserResult[] = pendingIds.map((toolCallId) => ({
+    toolCallId,
+    output: { dismissed: true, reason: DISMISSED_REASON },
+  }));
+
+  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, results);
+  if (!changed) return;
+
+  const merged: UIMessage = { ...uiMessage, parts };
+  const content = extractMessageContent(merged);
+  const toolCalls = extractToolCalls(merged);
+  const toolResults = extractToolResults(merged);
+
+  await saveGlobalAssistantMessageToDatabase({
+    messageId: row.id,
+    conversationId: args.conversationId,
+    userId: row.userId,
+    role: 'assistant',
+    content,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    toolResults: toolResults.length > 0 ? toolResults : undefined,
+    uiMessage: merged,
+  });
+}

--- a/apps/web/src/lib/ai/core/ask-user-resume.ts
+++ b/apps/web/src/lib/ai/core/ask-user-resume.ts
@@ -9,10 +9,11 @@ import {
   convertGlobalAssistantMessageToUIMessage,
   saveMessageToDatabase,
   saveGlobalAssistantMessageToDatabase,
-  extractMessageContent,
-  extractToolCalls,
-  extractToolResults,
 } from '@/lib/ai/core/message-utils';
+import {
+  buildAssistantPersistencePayload,
+  type AssistantPersistencePayload,
+} from '@/lib/ai/core/persistAssistantParts';
 import { ASK_USER_TOOL_NAME, askUserOutputSchema } from '@/lib/ai/tools/ask-user-tools';
 
 const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
@@ -92,65 +93,44 @@ function pendingAskUserToolCallIds(parts: UIMessage['parts']): string[] {
   return ids;
 }
 
-// --- Page (page-agent) conversations -------------------------------------
+/**
+ * A fetched assistant row, reconstructed into a UIMessage, paired with a
+ * `persist` closure already bound to that specific row (id, and for the
+ * global backend, its non-null userId) — so the shared orchestration below
+ * never needs to know the row's shape or carry state between fetch and save.
+ */
+interface FetchedAssistantMessage {
+  message: UIMessage;
+  persist(payload: AssistantPersistencePayload): Promise<void>;
+}
 
-export async function applyAskUserResultsToPageMessage(args: {
-  messageId: string;
-  pageId: string;
-  conversationId: string;
-  results: ClientAskUserResult[];
-}): Promise<{ merged: boolean }> {
-  if (args.results.length === 0) return { merged: false };
+/**
+ * Row-agnostic backend for the merge/dismiss orchestration below, so that
+ * logic is written once and shared by both the page-agent (chatMessages) and
+ * Global Assistant (messages) persistence tables, which differ only in
+ * table/where-clause shape and save-call field requirements.
+ */
+interface AssistantMessageAdapter {
+  /** Fetch + reconstruct the specific assistant message this resume answers, or null if not found/not assistant. */
+  fetchById(messageId: string): Promise<FetchedAssistantMessage | null>;
+  /** Fetch + reconstruct the conversation's most recent assistant message, or null if none exists. */
+  fetchLastAssistant(): Promise<FetchedAssistantMessage | null>;
+}
 
-  const [row] = await db
-    .select()
-    .from(chatMessages)
-    .where(
-      and(
-        eq(chatMessages.id, args.messageId),
-        eq(chatMessages.pageId, args.pageId),
-        eq(chatMessages.conversationId, args.conversationId),
-        eq(chatMessages.isActive, true)
-      )
-    )
-    .limit(1);
+async function applyAskUserResults(
+  adapter: AssistantMessageAdapter,
+  messageId: string,
+  results: ClientAskUserResult[]
+): Promise<{ merged: boolean }> {
+  if (results.length === 0) return { merged: false };
 
-  if (!row || row.role !== 'assistant') return { merged: false };
+  const fetched = await adapter.fetchById(messageId);
+  if (!fetched) return { merged: false };
 
-  const uiMessage = await convertDbMessageToUIMessage({
-    id: row.id,
-    pageId: row.pageId,
-    userId: row.userId,
-    role: row.role,
-    content: row.content,
-    toolCalls: row.toolCalls,
-    toolResults: row.toolResults,
-    createdAt: row.createdAt,
-    isActive: row.isActive,
-    editedAt: row.editedAt,
-    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
-  });
-
-  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, args.results);
+  const { parts, changed } = mergeResultsIntoParts(fetched.message.parts, results);
   if (!changed) return { merged: false };
 
-  const merged: UIMessage = { ...uiMessage, parts };
-  const content = extractMessageContent(merged);
-  const toolCalls = extractToolCalls(merged);
-  const toolResults = extractToolResults(merged);
-
-  await saveMessageToDatabase({
-    messageId: args.messageId,
-    pageId: args.pageId,
-    conversationId: args.conversationId,
-    userId: null,
-    role: 'assistant',
-    content,
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    toolResults: toolResults.length > 0 ? toolResults : undefined,
-    uiMessage: merged,
-  });
-
+  await fetched.persist(buildAssistantPersistencePayload(messageId, parts));
   return { merged: true };
 }
 
@@ -160,41 +140,11 @@ export async function applyAskUserResultsToPageMessage(args: {
  * conversation's last assistant message so the model sees its questions were
  * answered free-form in chat and does not re-ask.
  */
-export async function dismissPendingAskUserForPageConversation(args: {
-  pageId: string;
-  conversationId: string;
-}): Promise<void> {
-  const [row] = await db
-    .select()
-    .from(chatMessages)
-    .where(
-      and(
-        eq(chatMessages.pageId, args.pageId),
-        eq(chatMessages.conversationId, args.conversationId),
-        eq(chatMessages.isActive, true),
-        eq(chatMessages.role, 'assistant')
-      )
-    )
-    .orderBy(desc(chatMessages.createdAt))
-    .limit(1);
+async function dismissPendingAskUser(adapter: AssistantMessageAdapter): Promise<void> {
+  const fetched = await adapter.fetchLastAssistant();
+  if (!fetched) return;
 
-  if (!row) return;
-
-  const uiMessage = await convertDbMessageToUIMessage({
-    id: row.id,
-    pageId: row.pageId,
-    userId: row.userId,
-    role: row.role,
-    content: row.content,
-    toolCalls: row.toolCalls,
-    toolResults: row.toolResults,
-    createdAt: row.createdAt,
-    isActive: row.isActive,
-    editedAt: row.editedAt,
-    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
-  });
-
-  const pendingIds = pendingAskUserToolCallIds(uiMessage.parts);
+  const pendingIds = pendingAskUserToolCallIds(fetched.message.parts);
   if (pendingIds.length === 0) return;
 
   const results: ClientAskUserResult[] = pendingIds.map((toolCallId) => ({
@@ -202,142 +152,189 @@ export async function dismissPendingAskUserForPageConversation(args: {
     output: { dismissed: true, reason: DISMISSED_REASON },
   }));
 
-  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, results);
+  const { parts, changed } = mergeResultsIntoParts(fetched.message.parts, results);
   if (!changed) return;
 
-  const merged: UIMessage = { ...uiMessage, parts };
-  const content = extractMessageContent(merged);
-  const toolCalls = extractToolCalls(merged);
-  const toolResults = extractToolResults(merged);
+  await fetched.persist(buildAssistantPersistencePayload(fetched.message.id, parts));
+}
 
-  await saveMessageToDatabase({
-    messageId: row.id,
-    pageId: args.pageId,
-    conversationId: args.conversationId,
-    userId: null,
-    role: 'assistant',
-    content,
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    toolResults: toolResults.length > 0 ? toolResults : undefined,
-    uiMessage: merged,
-  });
+// --- Page (page-agent) conversations -------------------------------------
+
+function pageAdapter(args: { pageId: string; conversationId: string }): AssistantMessageAdapter {
+  const toUIMessage = (row: {
+    id: string;
+    pageId: string;
+    userId: string | null;
+    role: string;
+    content: string;
+    toolCalls: unknown;
+    toolResults: unknown;
+    createdAt: Date;
+    isActive: boolean;
+    editedAt: Date | null;
+    messageType: string | null;
+  }) =>
+    convertDbMessageToUIMessage({
+      id: row.id,
+      pageId: row.pageId,
+      userId: row.userId,
+      role: row.role,
+      content: row.content,
+      toolCalls: row.toolCalls,
+      toolResults: row.toolResults,
+      createdAt: row.createdAt,
+      isActive: row.isActive,
+      editedAt: row.editedAt,
+      messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
+    });
+
+  const persistFor = (messageId: string) => (payload: AssistantPersistencePayload) =>
+    saveMessageToDatabase({
+      messageId,
+      pageId: args.pageId,
+      conversationId: args.conversationId,
+      userId: null,
+      role: 'assistant',
+      ...payload,
+    });
+
+  return {
+    async fetchById(messageId) {
+      const [row] = await db
+        .select()
+        .from(chatMessages)
+        .where(
+          and(
+            eq(chatMessages.id, messageId),
+            eq(chatMessages.pageId, args.pageId),
+            eq(chatMessages.conversationId, args.conversationId),
+            eq(chatMessages.isActive, true)
+          )
+        )
+        .limit(1);
+      if (!row || row.role !== 'assistant') return null;
+      return { message: await toUIMessage(row), persist: persistFor(row.id) };
+    },
+    async fetchLastAssistant() {
+      const [row] = await db
+        .select()
+        .from(chatMessages)
+        .where(
+          and(
+            eq(chatMessages.pageId, args.pageId),
+            eq(chatMessages.conversationId, args.conversationId),
+            eq(chatMessages.isActive, true),
+            eq(chatMessages.role, 'assistant')
+          )
+        )
+        .orderBy(desc(chatMessages.createdAt))
+        .limit(1);
+      if (!row) return null;
+      return { message: await toUIMessage(row), persist: persistFor(row.id) };
+    },
+  };
+}
+
+export function applyAskUserResultsToPageMessage(args: {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  results: ClientAskUserResult[];
+}): Promise<{ merged: boolean }> {
+  return applyAskUserResults(pageAdapter(args), args.messageId, args.results);
+}
+
+export function dismissPendingAskUserForPageConversation(args: {
+  pageId: string;
+  conversationId: string;
+}): Promise<void> {
+  return dismissPendingAskUser(pageAdapter(args));
 }
 
 // --- Global Assistant conversations --------------------------------------
 
-export async function applyAskUserResultsToGlobalMessage(args: {
+function globalAdapter(args: { conversationId: string }): AssistantMessageAdapter {
+  const toUIMessage = (row: {
+    id: string;
+    conversationId: string;
+    userId: string;
+    role: string;
+    content: string;
+    toolCalls: unknown;
+    toolResults: unknown;
+    createdAt: Date;
+    isActive: boolean;
+    editedAt: Date | null;
+    messageType: string | null;
+  }) =>
+    convertGlobalAssistantMessageToUIMessage({
+      id: row.id,
+      conversationId: row.conversationId,
+      userId: row.userId,
+      role: row.role,
+      content: row.content,
+      toolCalls: row.toolCalls,
+      toolResults: row.toolResults,
+      createdAt: row.createdAt,
+      isActive: row.isActive,
+      editedAt: row.editedAt,
+      messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
+    });
+
+  const persistFor = (messageId: string, userId: string) => (payload: AssistantPersistencePayload) =>
+    saveGlobalAssistantMessageToDatabase({
+      messageId,
+      conversationId: args.conversationId,
+      userId,
+      role: 'assistant',
+      ...payload,
+    });
+
+  return {
+    async fetchById(messageId) {
+      const [row] = await db
+        .select()
+        .from(globalMessages)
+        .where(
+          and(
+            eq(globalMessages.id, messageId),
+            eq(globalMessages.conversationId, args.conversationId),
+            eq(globalMessages.isActive, true)
+          )
+        )
+        .limit(1);
+      if (!row || row.role !== 'assistant') return null;
+      return { message: await toUIMessage(row), persist: persistFor(row.id, row.userId) };
+    },
+    async fetchLastAssistant() {
+      const [row] = await db
+        .select()
+        .from(globalMessages)
+        .where(
+          and(
+            eq(globalMessages.conversationId, args.conversationId),
+            eq(globalMessages.isActive, true),
+            eq(globalMessages.role, 'assistant')
+          )
+        )
+        .orderBy(desc(globalMessages.createdAt))
+        .limit(1);
+      if (!row) return null;
+      return { message: await toUIMessage(row), persist: persistFor(row.id, row.userId) };
+    },
+  };
+}
+
+export function applyAskUserResultsToGlobalMessage(args: {
   messageId: string;
   conversationId: string;
   results: ClientAskUserResult[];
 }): Promise<{ merged: boolean }> {
-  if (args.results.length === 0) return { merged: false };
-
-  const [row] = await db
-    .select()
-    .from(globalMessages)
-    .where(
-      and(
-        eq(globalMessages.id, args.messageId),
-        eq(globalMessages.conversationId, args.conversationId),
-        eq(globalMessages.isActive, true)
-      )
-    )
-    .limit(1);
-
-  if (!row || row.role !== 'assistant') return { merged: false };
-
-  const uiMessage = await convertGlobalAssistantMessageToUIMessage({
-    id: row.id,
-    conversationId: row.conversationId,
-    userId: row.userId,
-    role: row.role,
-    content: row.content,
-    toolCalls: row.toolCalls,
-    toolResults: row.toolResults,
-    createdAt: row.createdAt,
-    isActive: row.isActive,
-    editedAt: row.editedAt,
-    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
-  });
-
-  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, args.results);
-  if (!changed) return { merged: false };
-
-  const merged: UIMessage = { ...uiMessage, parts };
-  const content = extractMessageContent(merged);
-  const toolCalls = extractToolCalls(merged);
-  const toolResults = extractToolResults(merged);
-
-  await saveGlobalAssistantMessageToDatabase({
-    messageId: args.messageId,
-    conversationId: args.conversationId,
-    userId: row.userId,
-    role: 'assistant',
-    content,
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    toolResults: toolResults.length > 0 ? toolResults : undefined,
-    uiMessage: merged,
-  });
-
-  return { merged: true };
+  return applyAskUserResults(globalAdapter(args), args.messageId, args.results);
 }
 
-export async function dismissPendingAskUserForGlobalConversation(args: {
+export function dismissPendingAskUserForGlobalConversation(args: {
   conversationId: string;
 }): Promise<void> {
-  const [row] = await db
-    .select()
-    .from(globalMessages)
-    .where(
-      and(
-        eq(globalMessages.conversationId, args.conversationId),
-        eq(globalMessages.isActive, true),
-        eq(globalMessages.role, 'assistant')
-      )
-    )
-    .orderBy(desc(globalMessages.createdAt))
-    .limit(1);
-
-  if (!row) return;
-
-  const uiMessage = await convertGlobalAssistantMessageToUIMessage({
-    id: row.id,
-    conversationId: row.conversationId,
-    userId: row.userId,
-    role: row.role,
-    content: row.content,
-    toolCalls: row.toolCalls,
-    toolResults: row.toolResults,
-    createdAt: row.createdAt,
-    isActive: row.isActive,
-    editedAt: row.editedAt,
-    messageType: row.messageType === 'todo_list' ? 'todo_list' : 'standard',
-  });
-
-  const pendingIds = pendingAskUserToolCallIds(uiMessage.parts);
-  if (pendingIds.length === 0) return;
-
-  const results: ClientAskUserResult[] = pendingIds.map((toolCallId) => ({
-    toolCallId,
-    output: { dismissed: true, reason: DISMISSED_REASON },
-  }));
-
-  const { parts, changed } = mergeResultsIntoParts(uiMessage.parts, results);
-  if (!changed) return;
-
-  const merged: UIMessage = { ...uiMessage, parts };
-  const content = extractMessageContent(merged);
-  const toolCalls = extractToolCalls(merged);
-  const toolResults = extractToolResults(merged);
-
-  await saveGlobalAssistantMessageToDatabase({
-    messageId: row.id,
-    conversationId: args.conversationId,
-    userId: row.userId,
-    role: 'assistant',
-    content,
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    toolResults: toolResults.length > 0 ? toolResults : undefined,
-    uiMessage: merged,
-  });
+  return dismissPendingAskUser(globalAdapter(args));
 }

--- a/apps/web/src/lib/ai/core/ask-user-resume.ts
+++ b/apps/web/src/lib/ai/core/ask-user-resume.ts
@@ -98,6 +98,17 @@ function pendingAskUserToolCallIds(parts: UIMessage['parts']): string[] {
  * `persist` closure already bound to that specific row (id, and for the
  * global backend, its non-null userId) — so the shared orchestration below
  * never needs to know the row's shape or carry state between fetch and save.
+ *
+ * KNOWN LIMITATION: fetch → merge → persist is an unlocked read-modify-write,
+ * not a transaction. Two requests racing on the SAME pending toolCallId (a
+ * double-submit, or answering in one tab while a dismiss-triggering message
+ * arrives from another) can interleave and the later write wins, silently
+ * dropping the earlier one. Not fixed here: doing so correctly requires
+ * threading a transaction/row-lock through `saveMessageToDatabase` /
+ * `saveGlobalAssistantMessageToDatabase` in message-utils.ts, which are
+ * shared by many unrelated AI features — broader blast radius than this
+ * narrow, low-probability, self-healing race (the user can just answer
+ * again) justifies in isolation.
  */
 interface FetchedAssistantMessage {
   message: UIMessage;

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -67,6 +67,16 @@ const SEARCH = `SEARCH:
 const AFTER_TOOLS = `AFTER TOOLS:
 Provide a brief summary of what was done. Suggest logical next steps when appropriate.`;
 
+/** Guidance for the ask_user tool. Exported so the Global Assistant route (which
+ * builds its own bespoke system prompt rather than calling buildInlineInstructions)
+ * can append the identical wording instead of drifting. */
+export const ASK_USER_SECTION = `ASKING THE USER:
+• Use ask_user only when you are blocked on a decision you cannot resolve yourself — ambiguous requirements, mutually exclusive approaches, or a destructive/irreversible choice
+• Never ask something you could find out by searching or reading first
+• 1-4 questions per call, 2-4 concise options each — the UI adds a free-text "Other" option automatically, don't add your own catch-all
+• After calling ask_user, stop — do not call finish or any other tool in the same turn; it resumes when the user answers
+• The result may be {"dismissed": true} — the user replied in chat instead of picking an option; treat their message as the answer`;
+
 /**
  * MENTIONS section — the @[everyone] bullet is conditional on whether a driveId
  * is available in context. Without one, instructing the model to use "DriveId from
@@ -122,6 +132,7 @@ export function buildInlineInstructions(
   const includeAgents = hasAny(availableTools, ['ask_agent', 'list_agents', 'multi_drive_list_agents', 'update_agent_config', 'list_models']);
   const includeAutomation = hasAny(availableTools, ['set_task_trigger', 'delete_task_trigger', 'set_calendar_trigger', 'delete_calendar_trigger', 'create_workflow', 'list_workflows']);
   const includeSearch = hasAny(availableTools, ['glob_search', 'regex_search', 'multi_drive_search', 'web_search', 'web_fetch']);
+  const includeAskUser = hasAny(availableTools, ['ask_user']);
 
   const sections = [
     WORKSPACE_RULES,
@@ -136,6 +147,7 @@ export function buildInlineInstructions(
     includeAgents ? AGENTS : null,
     includeAutomation ? AUTOMATION : null,
     includeSearch ? SEARCH : null,
+    includeAskUser ? ASK_USER_SECTION : null,
     AFTER_TOOLS,
     buildMentions(true),
   ].filter(Boolean);

--- a/apps/web/src/lib/ai/core/run-agent-with-retry.ts
+++ b/apps/web/src/lib/ai/core/run-agent-with-retry.ts
@@ -45,6 +45,8 @@ export interface RunAgentWithRetryParams {
   buildStreamText: (messages: ModelMessage[]) => AgentStreamResult;
   /** The finish-tool name (FINISH_TOOL_NAME). */
   finishToolName: string;
+  /** Execute-less tools that pause the turn awaiting user input (e.g. ask_user). */
+  pauseToolNames?: string[];
   /** The `stepCountIs(...)` cap configured on the loop (must match the route). */
   maxSteps: number;
   /** Max transparent retries after the first attempt. Default 2 (conservative). */
@@ -126,6 +128,7 @@ export async function runAgentWithRetry(
     baseMessages,
     buildStreamText,
     finishToolName,
+    pauseToolNames,
     maxSteps,
     maxRetries = 2,
     startTimeMs,
@@ -203,6 +206,7 @@ export async function runAgentWithRetry(
       stepCount: steps.length,
       maxSteps,
       finishToolName,
+      pauseToolNames,
       aborted: abortSignal.aborted,
       emittedContent,
     });

--- a/apps/web/src/lib/ai/shared/__tests__/ask-user-client.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/ask-user-client.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for askUserAnswersComplete — the sendAutomaticallyWhen predicate that
+ * auto-resumes an agent turn once a pending ask_user question is answered.
+ *
+ * The critical invariant: this must NEVER be true for a turn that ended with
+ * the executed `finish` tool (which always has output-available), or every
+ * normal agent turn would auto-resubmit forever. See ask-user-client.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { askUserAnswersComplete } from '../ask-user-client';
+
+// `parts` is loosely typed here (test fixtures build minimal tool-part shapes,
+// not the full discriminated UIMessagePart union) and cast at the boundary.
+const msg = (role: UIMessage['role'], parts: unknown[]): UIMessage =>
+  ({ id: 'm1', role, parts } as UIMessage);
+
+describe('askUserAnswersComplete', () => {
+  it('is false for a turn ending with the executed finish tool (no ask_user present)', () => {
+    expect(
+      askUserAnswersComplete({
+        messages: [
+          msg('assistant', [
+            { type: 'tool-finish', toolCallId: 'f1', state: 'output-available', output: { done: true } },
+          ]),
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('is false while an ask_user question is still pending (input-available)', () => {
+    expect(
+      askUserAnswersComplete({
+        messages: [
+          msg('assistant', [
+            { type: 'tool-ask_user', toolCallId: 'q1', state: 'input-available', input: { questions: [] } },
+          ]),
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('is true once every ask_user part on the last message is answered', () => {
+    expect(
+      askUserAnswersComplete({
+        messages: [
+          msg('assistant', [
+            { type: 'tool-ask_user', toolCallId: 'q1', state: 'output-available', output: { answers: [] } },
+          ]),
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it('is false if only SOME of multiple ask_user parts are answered', () => {
+    expect(
+      askUserAnswersComplete({
+        messages: [
+          msg('assistant', [
+            { type: 'tool-ask_user', toolCallId: 'q1', state: 'output-available', output: { answers: [] } },
+            { type: 'tool-ask_user', toolCallId: 'q2', state: 'input-available', input: { questions: [] } },
+          ]),
+        ],
+      })
+    ).toBe(false);
+  });
+
+  it('is true for an errored ask_user tool part (output-error also unblocks the loop)', () => {
+    expect(
+      askUserAnswersComplete({
+        messages: [
+          msg('assistant', [
+            { type: 'tool-ask_user', toolCallId: 'q1', state: 'output-error', errorText: 'boom' },
+          ]),
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it('is false when the last message is not from the assistant', () => {
+    expect(
+      askUserAnswersComplete({
+        messages: [msg('user', [{ type: 'text', text: 'hi' }])],
+      })
+    ).toBe(false);
+  });
+
+  it('is false for an empty message list', () => {
+    expect(askUserAnswersComplete({ messages: [] })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
+++ b/apps/web/src/lib/ai/shared/__tests__/chat-config.test.ts
@@ -63,5 +63,23 @@ describe('chat-config pure functions', () => {
       expect(a.transport).toBe(b.transport);
       expect(a.experimental_throttle).toBe(b.experimental_throttle);
     });
+
+    it('given no explicit predicate, should wire sendAutomaticallyWhen to askUserAnswersComplete', () => {
+      const config = buildChatConfig({ id: GLOBAL_CHAT_ID, transport: mockTransport });
+      expect(typeof config.sendAutomaticallyWhen).toBe('function');
+      // A normal turn ending in the executed `finish` tool must NEVER auto-resubmit —
+      // this is the guard against the infinite-loop failure mode the stock SDK helper has.
+      expect(
+        config.sendAutomaticallyWhen({
+          messages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [{ type: 'tool-finish', toolCallId: 'x', state: 'output-available', output: { done: true } }],
+            } as unknown as UIMessage,
+          ],
+        })
+      ).toBe(false);
+    });
   });
 });

--- a/apps/web/src/lib/ai/shared/ask-user-client.ts
+++ b/apps/web/src/lib/ai/shared/ask-user-client.ts
@@ -1,0 +1,27 @@
+import type { UIMessage } from 'ai';
+import { ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
+
+const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+
+/**
+ * sendAutomaticallyWhen predicate: auto-resubmit ONLY once every ask_user
+ * question on the last assistant message has been answered.
+ *
+ * Deliberately NOT the stock `lastAssistantMessageIsCompleteWithToolCalls` —
+ * every PageSpace turn ends with the executed `finish` tool (which has an
+ * `execute` and so is always "complete"), so that helper would auto-resubmit
+ * after every normal turn and loop forever. Scoping the check to ask_user
+ * parts specifically avoids that.
+ */
+export function askUserAnswersComplete({ messages }: { messages: UIMessage[] }): boolean {
+  const last = messages[messages.length - 1];
+  if (!last || last.role !== 'assistant' || !last.parts) return false;
+
+  const askParts = last.parts.filter((part) => part.type === ASK_USER_PART_TYPE);
+  if (askParts.length === 0) return false;
+
+  return askParts.every((part) => {
+    const state = (part as { state?: string }).state;
+    return state === 'output-available' || state === 'output-error';
+  });
+}

--- a/apps/web/src/lib/ai/shared/chat-config.ts
+++ b/apps/web/src/lib/ai/shared/chat-config.ts
@@ -14,6 +14,7 @@
  */
 
 import type { DefaultChatTransport, UIMessage } from 'ai';
+import { askUserAnswersComplete } from '@/lib/ai/shared/ask-user-client';
 
 /**
  * Stable chat IDs per surface. These never change across conversation switches
@@ -52,12 +53,16 @@ export function buildChatConfig(params: ChatConfigParams): {
   transport: DefaultChatTransport<UIMessage>;
   experimental_throttle: number;
   onError: (error: Error) => void;
+  sendAutomaticallyWhen: (options: { messages: UIMessage[] }) => boolean;
 } {
   return {
     id: params.id,
     transport: params.transport,
     experimental_throttle: params.throttleMs ?? 100,
     onError: params.onError ?? defaultOnError,
+    // Auto-resume the agent once a pending ask_user question is answered.
+    // See ask-user-client.ts for why this can't be the SDK's stock helper.
+    sendAutomaticallyWhen: askUserAnswersComplete,
   };
 }
 

--- a/apps/web/src/lib/ai/shared/hooks/index.ts
+++ b/apps/web/src/lib/ai/shared/hooks/index.ts
@@ -12,6 +12,7 @@ export { useStreamingRegistration } from './useStreamingRegistration';
 export { useChatStop } from './useChatStop';
 export { useSendHandoff } from './useSendHandoff';
 export { useStreamRecovery } from './useStreamRecovery';
+export { useAskUserAnswering } from './useAskUserAnswering';
 
 // Pure functions (no hooks, no side effects)
 export {

--- a/apps/web/src/lib/ai/shared/hooks/useAskUserAnswering.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useAskUserAnswering.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo } from 'react';
+import type { UIMessage } from 'ai';
+import { ASK_USER_TOOL_NAME, type AskUserOutput } from '@/lib/ai/tools/ask-user-tools';
+
+const ASK_USER_PART_TYPE = `tool-${ASK_USER_TOOL_NAME}`;
+
+type AddToolResultFn = (args: {
+  tool: string;
+  toolCallId: string;
+  output: unknown;
+  options?: { body?: object };
+}) => void | PromiseLike<void>;
+
+export interface UseAskUserAnsweringParams {
+  messages: UIMessage[];
+  status: 'ready' | 'submitted' | 'streaming' | 'error';
+  addToolResult: AddToolResultFn;
+  wrapSend: <T>(sendFn: () => T) => T | undefined;
+  /** Builds the per-request body (chatId/conversationId/provider/etc) for this surface. */
+  buildBody: () => object | Promise<object>;
+}
+
+export interface AskUserAnsweringApi {
+  /** toolCallIds of ask_user parts on the LAST message that are currently answerable. */
+  answerableToolCallIds: ReadonlySet<string>;
+  submitAnswers: (toolCallId: string, output: AskUserOutput) => void;
+}
+
+/**
+ * Shared answer plumbing for the ask_user interactive question tool.
+ *
+ * A question is only answerable when its part sits on the conversation's
+ * LAST message (addToolOutput only patches the last message) and the chat is
+ * idle — otherwise it renders read-only (historical, mid-stream, or a later
+ * message already exists).
+ */
+export function useAskUserAnswering(params: UseAskUserAnsweringParams): AskUserAnsweringApi {
+  const { messages, status, addToolResult, wrapSend, buildBody } = params;
+
+  const answerableToolCallIds = useMemo(() => {
+    const ids = new Set<string>();
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant' || status !== 'ready' || !last.parts) return ids;
+
+    for (const part of last.parts) {
+      if (part.type !== ASK_USER_PART_TYPE) continue;
+      const p = part as { toolCallId: string; state?: string };
+      if (p.state === 'input-available') ids.add(p.toolCallId);
+    }
+    return ids;
+  }, [messages, status]);
+
+  const submitAnswers = useCallback(
+    (toolCallId: string, output: AskUserOutput) => {
+      wrapSend(async () => {
+        const body = await buildBody();
+        await addToolResult({
+          tool: ASK_USER_TOOL_NAME,
+          toolCallId,
+          output,
+          options: { body },
+        });
+      });
+    },
+    [addToolResult, buildBody, wrapSend]
+  );
+
+  return { answerableToolCallIds, submitAnswers };
+}

--- a/apps/web/src/lib/ai/tools/__tests__/ask-user-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/ask-user-tools.test.ts
@@ -1,0 +1,133 @@
+import { describe, it } from 'vitest';
+import { assert } from './riteway';
+import {
+  askUserTools,
+  askUserInputSchema,
+  askUserOutputSchema,
+  ASK_USER_TOOL_NAME,
+} from '../ask-user-tools';
+
+const question = (overrides: Partial<{ header: string; question: string; options: Array<{ label: string; description?: string }> }> = {}) => ({
+  header: 'Auth method',
+  question: 'Which auth method should we use?',
+  options: [{ label: 'OAuth' }, { label: 'API key' }],
+  ...overrides,
+});
+
+describe('ask_user tool definition', () => {
+  it('has no execute — it is a client-side tool that pauses the turn', () => {
+    assert({
+      given: 'the ask_user tool definition',
+      should: 'not have an execute function',
+      actual: 'execute' in askUserTools[ASK_USER_TOOL_NAME],
+      expected: false,
+    });
+  });
+});
+
+describe('askUserInputSchema', () => {
+  it('accepts 1-4 questions with 2-4 options each', () => {
+    assert({
+      given: 'a single well-formed question with two options',
+      should: 'parse successfully',
+      actual: askUserInputSchema.safeParse({ questions: [question()] }).success,
+      expected: true,
+    });
+  });
+
+  it('rejects zero questions', () => {
+    assert({
+      given: 'an empty questions array',
+      should: 'fail validation',
+      actual: askUserInputSchema.safeParse({ questions: [] }).success,
+      expected: false,
+    });
+  });
+
+  it('rejects more than 4 questions', () => {
+    assert({
+      given: 'five questions',
+      should: 'fail validation',
+      actual: askUserInputSchema.safeParse({ questions: Array.from({ length: 5 }, () => question()) }).success,
+      expected: false,
+    });
+  });
+
+  it('rejects a question with only one option', () => {
+    assert({
+      given: 'a question with a single option',
+      should: 'fail validation',
+      actual: askUserInputSchema.safeParse({
+        questions: [question({ options: [{ label: 'Only one' }] })],
+      }).success,
+      expected: false,
+    });
+  });
+
+  it('rejects a question with more than 4 options', () => {
+    assert({
+      given: 'a question with five options',
+      should: 'fail validation',
+      actual: askUserInputSchema.safeParse({
+        questions: [question({ options: Array.from({ length: 5 }, (_, i) => ({ label: `Option ${i}` })) })],
+      }).success,
+      expected: false,
+    });
+  });
+});
+
+describe('askUserOutputSchema', () => {
+  it('accepts a single answered question with a selected label', () => {
+    assert({
+      given: 'answers with a selectedLabel',
+      should: 'parse successfully',
+      actual: askUserOutputSchema.safeParse({
+        answers: [{ header: 'Auth method', question: 'Which?', selectedLabel: 'OAuth' }],
+      }).success,
+      expected: true,
+    });
+  });
+
+  it('accepts an answer with free-text otherText instead of a selection', () => {
+    assert({
+      given: 'answers with otherText only',
+      should: 'parse successfully',
+      actual: askUserOutputSchema.safeParse({
+        answers: [{ header: 'Auth method', question: 'Which?', otherText: 'Something else' }],
+      }).success,
+      expected: true,
+    });
+  });
+
+  it('rejects an answer with neither selectedLabel nor otherText', () => {
+    assert({
+      given: 'an answer missing both selectedLabel and otherText',
+      should: 'fail validation',
+      actual: askUserOutputSchema.safeParse({
+        answers: [{ header: 'Auth method', question: 'Which?' }],
+      }).success,
+      expected: false,
+    });
+  });
+
+  it('accepts a dismissed output', () => {
+    assert({
+      given: 'a dismissed result (user answered in chat instead)',
+      should: 'parse successfully',
+      actual: askUserOutputSchema.safeParse({
+        dismissed: true,
+        reason: 'User replied in chat instead of selecting an option.',
+      }).success,
+      expected: true,
+    });
+  });
+
+  it('rejects a bare object with neither answers nor dismissed', () => {
+    assert({
+      given: 'junk output matching neither union member',
+      should: 'fail validation',
+      actual: askUserOutputSchema.safeParse({ foo: 'bar' }).success,
+      expected: false,
+    });
+  });
+});

--- a/apps/web/src/lib/ai/tools/ask-user-tools.ts
+++ b/apps/web/src/lib/ai/tools/ask-user-tools.ts
@@ -1,0 +1,81 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+export const ASK_USER_TOOL_NAME = 'ask_user';
+
+const askUserOptionSchema = z.object({
+  label: z.string().min(1).max(60).describe('Short button label (1-5 words)'),
+  description: z
+    .string()
+    .max(300)
+    .optional()
+    .describe('One-line explanation of what choosing this option means'),
+});
+
+const askUserQuestionSchema = z.object({
+  header: z
+    .string()
+    .min(1)
+    .max(24)
+    .describe('Very short chip/tag shown on the card, e.g. "Auth method"'),
+  question: z.string().min(1).max(500).describe('The complete question to ask the user'),
+  options: z
+    .array(askUserOptionSchema)
+    .min(2)
+    .max(4)
+    .describe('Distinct, mutually exclusive choices. Do not add a catch-all option; the UI provides a free-text "Other" automatically.'),
+});
+
+export const askUserInputSchema = z.object({
+  questions: z.array(askUserQuestionSchema).min(1).max(4),
+});
+
+export type AskUserInput = z.infer<typeof askUserInputSchema>;
+
+/**
+ * Output shape produced by the CLIENT (the tool has no execute). The server
+ * validates any client-supplied output against this schema before merging it
+ * into the persisted assistant message; the length caps bound what an
+ * answering client can inject into model context.
+ */
+const askUserAnswerSchema = z
+  .object({
+    header: z.string().max(24),
+    question: z.string().max(500),
+    selectedLabel: z.string().max(60).optional(),
+    otherText: z.string().max(2000).optional(),
+  })
+  .refine((answer) => answer.selectedLabel !== undefined || answer.otherText !== undefined, {
+    message: 'Each answer needs a selected option or free-text input',
+  });
+
+export const askUserOutputSchema = z.union([
+  z.object({ answers: z.array(askUserAnswerSchema).min(1).max(4) }),
+  z.object({ dismissed: z.literal(true), reason: z.string().max(500) }),
+]);
+
+export type AskUserOutput = z.infer<typeof askUserOutputSchema>;
+export type AskUserAnswer = z.infer<typeof askUserAnswerSchema>;
+
+/**
+ * Client-side tool: no execute. Calling it ends the agent turn with the tool
+ * call left open (state input-available); the turn resumes when the user
+ * answers in the chat UI and the answer is merged in as the tool result.
+ * Injected at route level for app admins only (see ask-user-gating.ts) —
+ * intentionally NOT part of baseTools/pageSpaceTools so it never enters the
+ * tool_search catalog or the execute_tool dispatch map.
+ */
+export const askUserTools = {
+  ask_user: tool({
+    description:
+      'Ask the user 1-4 multiple-choice questions and wait for their answers before continuing. ' +
+      'Use this only when you are blocked on a decision you cannot resolve yourself: ambiguous requirements, ' +
+      'mutually exclusive approaches, or destructive/irreversible choices. Never ask something you can look up ' +
+      'with your other tools. Each question offers 2-4 concise options; the UI automatically adds a free-text ' +
+      '"Other" option, so do not include a catch-all option yourself. After calling this tool, STOP — do not call ' +
+      'finish or any other tool; your turn ends and resumes when the user responds. The result may be ' +
+      '{"dismissed": true} if the user replied in chat instead of selecting an option — treat their chat message ' +
+      'as the answer.',
+    inputSchema: askUserInputSchema,
+  }),
+};


### PR DESCRIPTION
## Summary
- Adds an `ask_user` tool (Claude-Code-style AskUserQuestion) letting agents pause a turn to ask 1-4 multiple-choice questions and resume when the user answers, rolled out to app admins only (`users.role`, not drive-level roles)
- Client-side (execute-less) AI SDK v6 tool; the turn ends cleanly on the pause (new `awaiting-user-input` classifier reason, never retried) and the answer is merged server-side into the persisted assistant message so the resumed request's history carries the resolved result
- Custom `sendAutomaticallyWhen` scoped to `tool-ask_user` parts only — the SDK's stock `lastAssistantMessageIsCompleteWithToolCalls` would auto-resubmit after every ordinary turn, since the `finish` tool always has `output-available`
- Typing a reply instead of answering synthesizes `{dismissed: true}` on the pending question so the model treats the chat message as the answer instead of re-asking
- Wired into all three chat surfaces (AiChatView, GlobalAssistantView, SidebarChatTab) via a shared `useAskUserAnswering` hook + `AskUserAnswerContext`, rendered by a new `AskUserQuestionCard` registered in both tool-call registries
- Multiple questions render as a tablist (one visible at a time) instead of a simultaneous stack, matching how Claude Code's own `AskUserQuestion` handles stacked questions — arrow keys move between tabs, and every option is numbered and selectable by its digit, so answering never requires a mouse

## Review convergence
Fixed in response to CI + two rounds of automated review (Codex, CodeRabbit) plus an independent 8-angle self-review of the full diff:
- **CI**: unescaped `"` in `AskUserQuestionCard.tsx` breaking `next build`'s lint step (fixed all 3 failing checks)
- **Correctness**: `drafts` state didn't resync when a tool part's input finished streaming after mount — could enable Submit with nothing selected and crash on submit (regression test added)
- **Correctness**: submitted answers were matched back to questions by `header` string, which has no uniqueness constraint — two same-header questions could display each other's answer; now matched positionally, matching how `handleSubmit` builds them (regression test added)
- **Correctness**: `isConversationShared` was only recomputed on the pre-existing `role === 'user'` branch; the new ask_user resume branch (`role === 'assistant'`) skipped it, silently dropping @mention notifications in shared conversations on any turn following an answered question
- **Simplification**: consolidated `ask-user-resume.ts`'s 4 near-duplicate functions into 2 shared orchestration functions + a small per-backend adapter, reusing `buildAssistantPersistencePayload` instead of re-deriving it 4 times
- **Efficiency**: the resume/dismiss DB round trip now fires early and is joined right before the history load, instead of blocking ~400 lines of independent request setup (mirrors the existing `userProfilePromise` pattern)
- **Documented, not fixed**: a narrow, unlocked read-modify-write race in the resume/dismiss merge (two requests racing on the same pending question) — a correct fix needs a transaction/row-lock threaded through shared, widely-used persistence helpers; the race is low-probability and self-healing (a lost answer, not data corruption), so left as a documented known limitation rather than a heavier shared-infrastructure change

## Accessibility follow-up: tab UI + keyboard shortcuts
Raised in manual pre-ship review: the original flat stacked-questions layout meant a mouse-free user had to Tab through every option of every question with no way to jump directly to one. Fixed by:
- Multi-question calls now render as a `role="tablist"`/`role="tab"` pair per question (only when there's more than one), with roving `tabIndex` and Arrow/Home/End key navigation — matches the ARIA authoring practices tab pattern and Claude Code's own multi-question UX
- Every option (and "Other…") gets a visible number badge; pressing that digit selects it directly, scoped to the active tab and ignored while typing in the free-text box (a digit there is valid content, not a shortcut)
- Answered tabs pick up a check mark so a keyboard user can see what's left without revisiting each one

## Visual polish: stacked option rows
Raised in the same pre-ship review: pill-shaped option buttons in a wrapped row read poorly once a label or its description ran long, and `description` had nowhere to render except a hover-only `title` tooltip (invisible on touch and to keyboard users). Replaced with a vertical stack of full-width rows (number/check badge, label, visible description) via a new local `OptionRow` component. The chosen state went through one more iteration after visual review: an initial `color-mix(in oklch, primary, card)` tint was skewing violet because it interpolates toward an achromatic (chroma-0) endpoint whose hue is undefined — browsers resolve that inconsistently. Switched to Tailwind's built-in `bg-primary/8`/`border-primary/35` opacity modifiers instead (alpha compositing, not color interpolation — no hue ambiguity), landing on a soft tint + colored border + the app's own `--shadow-elevated` token rather than an opaque `bg-primary` fill, matching how desaturated every other surface (badges, tabs, chips) in the app already is.

## Test plan
- [x] `bun run typecheck` — clean across the monorepo
- [x] 85 unit tests covering the feature (tool schema bounds, admin gating, resume-merge idempotency/tamper-resistance, classifier pause handling, auto-resume infinite-loop guard, draft-resync crash regression, positional-answer-matching regression, tab navigation, number-key shortcut, digit-vs-textarea disambiguation) — all passing
- [x] Full `apps/web` unit suite: 2218/2219 passing (1 pre-existing, unrelated DB-role failure in `activity-tools.test.ts`)
- [x] `bun run build` — clean
- [ ] Manual: as an admin, prompt an agent to ask a clarifying question in each of the three chat surfaces, verify the card renders, click an option, confirm the agent resumes with the answer
- [ ] Manual: verify a non-admin never sees the tool offered, and can view (read-only) an admin's answered question card in a shared conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAnEAWcuLjGbcQFExZFYob



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive “ask user” flow in AI chat so assistants can pause and ask questions, then resume once answers are submitted.
  * Users can answer multi-question prompts with options, “Other…” text, keyboard navigation, and tabbed question switching.
  * The AI interface now shows these prompts consistently across page, global assistant, and sidebar chat experiences.

* **Bug Fixes**
  * Improved prompt handling so pending questions can be dismissed or updated correctly when chat messages change.
  * Added better auto-resume behavior after all asked questions are answered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
