### PR TITLE
fix(cli): fix broken 'Set active key' lookup after real-keychain enumeration bug

### DIFF
--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -638,6 +638,50 @@ describe('createKeysHandler — Set active key flow (menu choice "use")', () => 
     expect(stopMessages).toContain('"my-agent" is now the active key');
   });
 
+  it('activates by exact name match even when listCredentialNames is broken (regression: real OS keychains have been observed truncating enumerated account names, making the reverse-lookup fallback unable to find anything)', async () => {
+    selectMock.mockReset().mockResolvedValueOnce('use').mockResolvedValueOnce('tok1').mockResolvedValueOnce('exit');
+    spinnerHandle.stop.mockReset();
+
+    const { createKeysHandler } = await import('../wizard.js');
+    const { createFakeActiveKeyStore } = await import('../../../__tests__/fake-context.js');
+    const base = fakeStore();
+    // The local profile name is IDENTICAL to the server key's name ("CI bot")
+    // — exactly the case create.ts always produces (resolveNewKeyName writes
+    // the name verbatim as the profile, and the same string is embedded as
+    // the mint's name:<...> token). listCredentialNames simulates a real
+    // truncated-keychain enumeration: it can see something is stored, but
+    // never returns "CI bot" as a distinguishable name.
+    const store: CredentialStore = {
+      ...base,
+      listCredentialNames: async () => ['default'],
+    };
+    await store.set(
+      'https://pagespace.ai',
+      { kind: 'static', token: 'mcp_abcdefghijk_full_secret', scopes: ['drive:drv1:member'], createdAt: '2026-07-01T00:00:00.000Z' },
+      'CI bot',
+    );
+
+    const fake = fakeLoopbackServer();
+    const deps = {
+      ...baseMintDeps(store),
+      startServer: async () => fake.server,
+      openBrowser: autoApprove(fake),
+      exchangeCode: async () => ({ kind: 'mcp_activate' as const, tokenId: 'tok1', scope: 'activate_key:tok1' }),
+    };
+    const handler = createKeysHandler(deps);
+
+    const activeKeyStore = createFakeActiveKeyStore();
+    const sdk = fakeSdk({ tokensList: vi.fn(async () => [SERVER_KEY]) });
+    const ctx = createFakeContext({ sdk, activeKeyStore, isTTY: true, env: {} });
+
+    const code = await handler(ctx, commandIntent(['keys']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(activeKeyStore.entries.get('https://pagespace.ai')).toBe('CI bot');
+    const stopMessages = spinnerHandle.stop.mock.calls.flat().map(String).join('\n');
+    expect(stopMessages).toContain('"CI bot" is now the active key');
+  });
+
   it('a key with no locally stored credential cannot be activated from the wizard', async () => {
     selectMock.mockReset().mockResolvedValueOnce('use').mockResolvedValueOnce('tok1').mockResolvedValueOnce('exit');
     logMock.error.mockReset();

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -38,6 +38,7 @@ import { runLoopbackLogin } from '../../auth/loopback-flow.js';
 import type { LoopbackLoginResult } from '../../auth/loopback-flow.js';
 import { resolveConfig } from '../../config/resolve.js';
 import { credentialSecret } from '../../credentials/serialize.js';
+import type { HostCredential } from '../../credentials/serialize.js';
 import { createCredentialStore } from '../../credentials/store.js';
 import type { CredentialStore } from '../../credentials/store.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR, type ExitCode } from '../../exit-codes.js';
@@ -484,6 +485,11 @@ async function runList(keys: readonly KeySummary[]): Promise<FlowOutcome> {
   return null;
 }
 
+/** Whether a locally stored credential is the one a server-side key summary describes. */
+function matchesServerKey(credential: HostCredential, key: KeySummary): boolean {
+  return credential.kind !== 'oauth' && credentialSecret(credential).startsWith(key.tokenPrefix);
+}
+
 /**
  * Set active key — the wizard form of `pagespace keys use <name>`, sharing
  * `runActivateCeremony` (`./use.js`) so the two surfaces cannot drift. The
@@ -508,13 +514,35 @@ async function runUse(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host: 
   const key = keys.find((candidate) => candidate.id === keyId);
   if (!key) return abortSubflow();
 
-  const localNames = (await store.listCredentialNames?.(host)) ?? [];
+  // Try the exact name match FIRST: the local profile a key is stored under
+  // is always the server-side key's own name (create.ts's resolveNewKeyName
+  // writes it verbatim, and the mint embeds that same string as the scope's
+  // name:<...> token), so this is an instant, exact hit in the overwhelmingly
+  // common "create, then immediately activate" case. This isn't just an
+  // optimization — real OS keychain backends (`@napi-rs/keyring`'s
+  // `findCredentialsAsync`, `credentials/keychain.ts`) have been observed
+  // truncating every returned account name at the embedded NUL byte
+  // `keychainAccountKey` uses to separate host/profile, collapsing every
+  // non-default-profile credential to the same bare host string and making
+  // the enumeration below unable to distinguish any of them. `store.get`
+  // takes the account string as an explicit parameter rather than depending
+  // on the native binding to correctly return it, so it's unaffected.
   let localName: string | null = null;
-  for (const name of localNames) {
-    const credential = await store.get(host, name);
-    if (credential !== null && credential.kind !== 'oauth' && credentialSecret(credential).startsWith(key.tokenPrefix)) {
-      localName = name;
-      break;
+  const exactCredential = await store.get(host, key.name);
+  if (exactCredential !== null && matchesServerKey(exactCredential, key)) {
+    localName = key.name;
+  } else {
+    // Fallback for the case an exact name won't catch: the key was renamed
+    // server-side (or the local profile predates a rename) so the stored
+    // credential lives under a different name than the key's current one.
+    // Best-effort only — subject to the same enumeration bug noted above.
+    const localNames = (await store.listCredentialNames?.(host)) ?? [];
+    for (const name of localNames) {
+      const credential = await store.get(host, name);
+      if (credential !== null && matchesServerKey(credential, key)) {
+        localName = name;
+        break;
+      }
     }
   }
   if (localName === null) {

--- a/packages/cli/src/credentials/store.ts
+++ b/packages/cli/src/credentials/store.ts
@@ -100,6 +100,24 @@ export class CompositeCredentialStore implements CredentialStore {
    * problem, not proof the keychain backend itself is unreachable, so it's
    * skipped with a warning rather than throwing (which would lose every
    * other, well-formed entry) or degrading the whole store.
+   *
+   * KNOWN ISSUE (unfixed, tracked here rather than routed around): at least
+   * one real `@napi-rs/keyring` native binding has been observed truncating
+   * every `entry.account` returned by `listSecrets()` at the embedded NUL
+   * byte `keychainAccountKey` uses to separate host/profile (confirmed via a
+   * direct call to `findCredentialsAsync` — every non-default-profile
+   * account round-tripped as the bare host string). `parseKeychainAccountKey`
+   * then reads every one of those as `{ profile: DEFAULT_PROFILE_NAME }`, so
+   * `list(profile)` for any non-default `profile` silently returns nothing
+   * for entries that are genuinely stored, and `list(DEFAULT_PROFILE_NAME)`
+   * over-includes entries whose real profile isn't "default" at all. Unlike
+   * `runUse`'s "Set active key" lookup (wizard.ts), this can't be routed
+   * around with a direct `get()` — the whole point of `list()` is
+   * discovering which HOSTS have a given profile, which requires enumeration.
+   * A real fix needs either a `listSecrets()` that doesn't lose the account
+   * string, or a keychain layout that doesn't require reading it back at
+   * all — out of scope here. Affects `pagespace logout --all --key <name>`
+   * (logout.ts) for any non-default key name.
    */
   async list(profile: string = DEFAULT_PROFILE_NAME): Promise<readonly CredentialSummary[]> {
     if (this.degraded) {


### PR DESCRIPTION
## Summary
- Fixes a live bug: creating a key with the CLI and immediately trying to activate it via the wizard's "Set active key" flow fails with `No locally stored credential matches "<name>"` even though the credential is genuinely stored.
- Root cause: `runUse` (`packages/cli/src/commands/keys/wizard.ts`) reverse-matches a chosen server key to a local credential by enumerating every stored name via `store.listCredentialNames()`, which goes through `@napi-rs/keyring`'s `findCredentialsAsync`. Confirmed via a direct, read-only call against a real macOS keychain that this native binding **truncates every returned account name at the embedded NUL byte** `keychainAccountKey` uses to separate host/profile — collapsing every non-default-profile credential to the same bare host string, indistinguishable from any other.
  - Verified the write path is fine: `security dump-keychain` shows the credential correctly stored under the full `host\0name` account key.
  - Verified the break: `findCredentialsAsync("pagespace-cli")` returns every account as just `"https://pagespace.ai"`.
- Fix: `runUse` now tries `store.get(host, key.name)` directly **first** — the local profile a key is stored under is always the server key's own name, so this is an instant exact hit in the common case and bypasses the broken enumeration entirely (`get()` takes the account string explicitly rather than depending on the native binding to return it). Falls back to the existing enumeration-based reverse search only when the exact name doesn't match (covers a key renamed server-side without updating local storage).
- Flagged (not fixed, no direct-lookup shortcut applies): `CredentialStore.list()` has the identical bug and affects `pagespace logout --all --key <name>` for non-default key names, since that command's job is host *discovery*, which fundamentally requires enumeration. Documented inline in `store.ts` for a future fix.

## Test plan
- [x] Full CLI test suite: 1033 tests passing (was 1032; +1 new regression test)
- [x] New regression test: proves the fix using a store whose `listCredentialNames` returns only `"default"` (simulating the real truncation) while `get(host, exact-name)` still succeeds
- [x] Verified directly against the reporting user's real macOS keychain: `store.get(host, "ALL")` finds the credential instantly, confirming the fix resolves the actual reported failure
- [x] `bun run build` (typecheck) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYhcxUtJ8hxH5Nsv6qKuDd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “use active key” flow to better select the correct saved credential, even when keychain listing is incomplete or misleading.
  * Matching now prefers an exact saved credential name when available, helping the app activate the intended key more reliably.

* **Documentation**
  * Added a note about a known keychain limitation that can affect how some saved keys are listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->