### PR TITLE
fix(ai): reframe ask_user trigger from "blocked" to "enrichment"

### DIFF
--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -71,8 +71,9 @@ Provide a brief summary of what was done. Suggest logical next steps when approp
  * builds its own bespoke system prompt rather than calling buildInlineInstructions)
  * can append the identical wording instead of drifting. */
 export const ASK_USER_SECTION = `ASKING THE USER:
-• Use ask_user only when you are blocked on a decision you cannot resolve yourself — ambiguous requirements, mutually exclusive approaches, or a destructive/irreversible choice
-• Never ask something you could find out by searching or reading first
+• Ask when missing context would materially shape the result — not just because a detail would help a little
+• Skip asking if the user's signaled they want autonomous work (e.g. "just do it," "don't check in with me," running unattended)
+• Never ask something you could find out yourself by searching or reading the drive first
 • 1-4 questions per call, 2-4 concise options each — the UI adds a free-text "Other" option automatically, don't add your own catch-all
 • After calling ask_user, stop — do not call finish or any other tool in the same turn; it resumes when the user answers
 • The result may be {"dismissed": true} — the user replied in chat instead of picking an option; treat their message as the answer`;

--- a/apps/web/src/lib/ai/tools/ask-user-tools.ts
+++ b/apps/web/src/lib/ai/tools/ask-user-tools.ts
@@ -69,13 +69,13 @@ export const askUserTools = {
   ask_user: tool({
     description:
       'Ask the user 1-4 multiple-choice questions and wait for their answers before continuing. ' +
-      'Use this only when you are blocked on a decision you cannot resolve yourself: ambiguous requirements, ' +
-      'mutually exclusive approaches, or destructive/irreversible choices. Never ask something you can look up ' +
-      'with your other tools. Each question offers 2-4 concise options; the UI automatically adds a free-text ' +
-      '"Other" option, so do not include a catch-all option yourself. After calling this tool, STOP — do not call ' +
-      'finish or any other tool; your turn ends and resumes when the user responds. The result may be ' +
-      '{"dismissed": true} if the user replied in chat instead of selecting an option — treat their chat message ' +
-      'as the answer.',
+      'Use this when missing context would materially shape the result — not just because a detail would help ' +
+      'a little. Skip it if the user has signaled they want autonomous work (e.g. "just do it," running unattended). ' +
+      'Never ask something you can look up with your other tools. Each question offers 2-4 concise options; the UI ' +
+      'automatically adds a free-text "Other" option, so do not include a catch-all option yourself. After calling ' +
+      'this tool, STOP — do not call finish or any other tool; your turn ends and resumes when the user responds. ' +
+      'The result may be {"dismissed": true} if the user replied in chat instead of selecting an option — treat ' +
+      'their chat message as the answer.',
     inputSchema: askUserInputSchema,
   }),
 };


### PR DESCRIPTION
## Summary
- Live-tested `ask_user` (shipped in #1954) on a confirmed platform-admin account with an open-ended "help me plan something" prompt — the model did not proactively call it, even though planning tasks often surface genuine forks (approach, scope) the tool is meant to cover. It fired correctly once told explicitly to use it, ruling out a wiring/gating bug.
- Root cause: the instruction wording — "only when blocked on a decision you cannot resolve yourself" — is narrower in effect than intended; in practice the model reads "only when blocked" as "almost never."
- Reworded both the tool's own `description` (`ask-user-tools.ts`) and the mirrored `ASK_USER_SECTION` injected into the default system prompt (`inline-instructions.ts`) around a different framing: ask when missing context would **materially shape the result**, not only when literally blocked. Skip asking when the user has signaled autonomous operation ("just do it," running unattended). Still never ask what's discoverable by searching the drive.
- A cost/risk framing ("ask when a wrong guess is costly") was tried first and dropped after feedback — the intent is context enrichment, not risk, bounded only by "materially" so it doesn't fire on trivial detail.

## Confirmed non-issue (no code change)
Checked whether workflow/triggered executions (cron, task/calendar/webhook triggers, manual `/run`) can reach `ask_user` — they can't. `workflow-executor.ts` builds its tools from `pageSpaceTools`, which never includes `askUserTools`, and never imports `canUseAskUser`/`buildInlineInstructions`/`ASK_USER_SECTION`. Already correctly excluded by the original design (kept out of the shared tool catalog, injected only at the two interactive chat routes) — nothing to fix.

## Test plan
- [x] Wording-only change; no existing test asserts the old strings
- [x] 42 tests pass unchanged: `ask-user-tools`, `inline-instructions`, `ask-user-gating`, `ask-user-resume`, `AskUserQuestionCard`, `agent-finish-classifier`
- [x] `bunx eslint` clean on both changed files
- [x] `bun run typecheck` — clean aside from 2 pre-existing, unrelated errors in `channel-tools.ts`/`agent-mention-responder.ts` that reproduce identically on `origin/master` before this change (confirmed via stash)
- [ ] Manual: as an admin, re-run an open-ended planning prompt and confirm the agent now proactively surfaces a genuine fork via `ask_user` instead of silently picking one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance for when the assistant asks a follow-up question, reducing unnecessary interruptions.
  * The assistant is now more likely to continue working autonomously when enough information is available or when you request unattended help.
  * Questions should be asked only when missing context would meaningfully affect the result, and not when the answer can be found by checking available information first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->