### PR TITLE
fix(csp): allow Google Fonts in outer CSP for in-app canvas pages

### DIFF
--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -155,6 +155,13 @@ describe('Security Headers', () => {
       expect(csp).toContain('https://accounts.google.com');
     });
 
+    it('allows Google Fonts for canvas author stylesheets', () => {
+      const csp = buildCSPPolicy('test-nonce');
+
+      expect(csp).toContain('https://fonts.googleapis.com');
+      expect(csp).toContain('https://fonts.gstatic.com');
+    });
+
     it('does not allow jsDelivr CDN sources', () => {
       const csp = buildCSPPolicy('test-nonce');
 

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -141,7 +141,11 @@ export const buildCSPPolicy = (nonce: string): string => {
     "'strict-dynamic'",
     "'unsafe-inline'", // Fallback for older browsers (ignored when strict-dynamic present)
   ];
-  const styleSrc = ["'self'", "'unsafe-inline'"];
+  // fonts.googleapis.com: in-app canvas pages render via an iframe srcDoc, which
+  // inherits this outer CSP in addition to their own baked-in <meta> CSP
+  // (packages/lib/src/canvas/csp.ts) — so author-linked Google Fonts stylesheets
+  // need to be allowed here too, not just in the canvas baseline policy.
+  const styleSrc = ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'];
   const frameSrc: string[] = [];
 
   // Cloud-only: Google and Stripe external origins
@@ -172,7 +176,7 @@ export const buildCSPPolicy = (nonce: string): string => {
     // /api/files/[id]/view redirects media requests straight to the storage
     // host, so it needs the same allowlist as connect-src (see comment above).
     'media-src': ["'self'", ...storageEntries],
-    'font-src': ["'self'", 'data:'],
+    'font-src': ["'self'", 'data:', 'https://fonts.gstatic.com'],
     // Monaco and other browser tooling may initialize workers from blob URLs.
     'worker-src': ["'self'", 'blob:'],
     ...(frameSrc.length > 0 ? { 'frame-src': frameSrc } : {}),


### PR DESCRIPTION
## Summary
- In-app canvas pages render via an `iframe srcDoc`, which inherits the outer app-wide CSP (`apps/web/src/middleware/security-headers.ts`) in addition to their own baked-in `<meta>` CSP (`packages/lib/src/canvas/csp.ts`)
- The outer CSP allowed `accounts.google.com` but never Google Fonts, so author-linked `fonts.googleapis.com` stylesheets were blocked in-app even though the canvas baseline CSP already allowed them — a regression missed by #1959's earlier CSP-hardening repair (which fixed `script-src` nonce inheritance but not `style-src`/`font-src`)
- Published `*.pagespace.site` canvas pages were unaffected (never framed via `srcDoc`, so only the baseline CSP applies)
- Adds `fonts.googleapis.com` to `style-src` and `fonts.gstatic.com` to `font-src` in `buildCSPPolicy()`, unconditionally (not gated on `IS_CLOUD`) since canvas isn't a cloud-only feature

## Test plan
- [x] Added test asserting both hosts are present in the CSP (`security-headers.test.ts`)
- [x] `vitest run src/middleware/__tests__/security-headers.test.ts` — 66/66 passing
- [x] `tsc --noEmit` on `apps/web` — clean
- [ ] Manual: open an in-app canvas page whose author HTML links a `fonts.googleapis.com` stylesheet, confirm it loads with no CSP console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016amPMcRF9dS9JX6e2MprEE