### PR TITLE
feat(machines): shared Machine view/edit access-check function

### DIFF
--- a/apps/web/src/lib/machines/machine-access-runtime.ts
+++ b/apps/web/src/lib/machines/machine-access-runtime.ts
@@ -1,0 +1,47 @@
+/**
+ * Production wiring for the shared Machine access checks
+ * (`@pagespace/lib/services/machines/machine-access`) — binds the pure
+ * view/edit decision to the real DB page lookup and the real permission
+ * functions. New Phase 1 routes (files/diff/settings) should import
+ * `canViewMachine`/`canEditMachine` from here instead of re-deriving the
+ * check inline, the way `machine-branches-runtime.ts` and
+ * `agent-terminals-runtime.ts` each already do for their own operations —
+ * those two are left untouched, this is for new code going forward.
+ *
+ * Callers first resolve a `MachineActorContext` via `resolveMachineActorContext`
+ * (`./machine-branches-runtime`), then pass it to `canViewMachine`/`canEditMachine`
+ * here alongside the target `terminalId`.
+ */
+
+import { eq } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import {
+  canViewMachine as canViewMachineCore,
+  canEditMachine as canEditMachineCore,
+  type MachineAccessDeps,
+} from '@pagespace/lib/services/machines/machine-access';
+import type { MachineActorContext } from '@pagespace/lib/services/machines/machine-branches';
+import type { PageType } from '@pagespace/lib/utils/enums';
+
+function buildMachineAccessDeps(): MachineAccessDeps {
+  return {
+    findPageType: async (terminalId) => {
+      const page = await db.query.pages.findFirst({ where: eq(pages.id, terminalId), columns: { type: true } });
+      return (page?.type as PageType | undefined) ?? null;
+    },
+    canUserViewPage,
+    canUserEditPage,
+  };
+}
+
+/** View-level access (e.g. read files/diff/settings) for a Machine page. */
+export async function canViewMachine(actor: MachineActorContext, terminalId: string): Promise<boolean> {
+  return canViewMachineCore(buildMachineAccessDeps(), actor, terminalId);
+}
+
+/** Edit-level access (e.g. mutate settings, write files) for a Machine page — re-checked on every call, never cached. */
+export async function canEditMachine(actor: MachineActorContext, terminalId: string): Promise<boolean> {
+  return canEditMachineCore(buildMachineAccessDeps(), actor, terminalId);
+}

--- a/apps/web/src/lib/machines/machine-access-runtime.ts
+++ b/apps/web/src/lib/machines/machine-access-runtime.ts
@@ -8,9 +8,11 @@
  * `agent-terminals-runtime.ts` each already do for their own operations —
  * those two are left untouched, this is for new code going forward.
  *
- * Callers first resolve a `MachineActorContext` via `resolveMachineActorContext`
- * (`./machine-branches-runtime`), then pass it to `canViewMachine`/`canEditMachine`
- * here alongside the target `terminalId`.
+ * Takes the actor's user id directly — mirroring `canAccessMachine`/
+ * `canViewMachine` in `./machine-branches-runtime`, which the same
+ * `MachineAccessDeps` pattern was extracted from — rather than a full
+ * `MachineActorContext`, so a caller never has to pay for
+ * `resolveMachineActorContext`'s DB round trip just to gate access.
  */
 
 import { eq } from '@pagespace/db/operators';
@@ -22,7 +24,6 @@ import {
   canEditMachine as canEditMachineCore,
   type MachineAccessDeps,
 } from '@pagespace/lib/services/machines/machine-access';
-import type { MachineActorContext } from '@pagespace/lib/services/machines/machine-branches';
 import type { PageType } from '@pagespace/lib/utils/enums';
 
 function buildMachineAccessDeps(): MachineAccessDeps {
@@ -37,11 +38,11 @@ function buildMachineAccessDeps(): MachineAccessDeps {
 }
 
 /** View-level access (e.g. read files/diff/settings) for a Machine page. */
-export async function canViewMachine(actor: MachineActorContext, terminalId: string): Promise<boolean> {
-  return canViewMachineCore(buildMachineAccessDeps(), actor, terminalId);
+export async function canViewMachine(actorUserId: string, terminalId: string): Promise<boolean> {
+  return canViewMachineCore(buildMachineAccessDeps(), actorUserId, terminalId);
 }
 
 /** Edit-level access (e.g. mutate settings, write files) for a Machine page — re-checked on every call, never cached. */
-export async function canEditMachine(actor: MachineActorContext, terminalId: string): Promise<boolean> {
-  return canEditMachineCore(buildMachineAccessDeps(), actor, terminalId);
+export async function canEditMachine(actorUserId: string, terminalId: string): Promise<boolean> {
+  return canEditMachineCore(buildMachineAccessDeps(), actorUserId, terminalId);
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -517,6 +517,11 @@
       "import": "./dist/services/machines/agent-terminals.js",
       "require": "./dist/services/machines/agent-terminals.js"
     },
+    "./services/machines/machine-access": {
+      "types": "./dist/services/machines/machine-access.d.ts",
+      "import": "./dist/services/machines/machine-access.js",
+      "require": "./dist/services/machines/machine-access.js"
+    },
     "./services/sandbox/tool-gate": {
       "types": "./dist/services/sandbox/tool-gate.d.ts",
       "import": "./dist/services/sandbox/tool-gate.js",
@@ -1612,6 +1617,9 @@
       ],
       "services/machines/agent-terminals": [
         "./dist/services/machines/agent-terminals.d.ts"
+      ],
+      "services/machines/machine-access": [
+        "./dist/services/machines/machine-access.d.ts"
       ],
       "services/sandbox/sandbox-client/types": [
         "./dist/services/sandbox/sandbox-client/types.d.ts"

--- a/packages/lib/src/services/machines/__tests__/machine-access.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-access.test.ts
@@ -1,16 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { canViewMachine, canEditMachine, type MachineAccessDeps } from '../machine-access';
-import type { MachineActorContext } from '../machine-branches';
 import { PageType } from '../../../utils/enums';
 
 const TERMINAL_ID = 'terminal-1';
-
-const actor: MachineActorContext = {
-  userId: 'user-1',
-  tenantId: 'user-1',
-  actorEmail: 'user-1@example.com',
-  tier: 'pro',
-};
+const ACTOR_USER_ID = 'user-1';
 
 function makeDeps(overrides: Partial<MachineAccessDeps> = {}): MachineAccessDeps {
   return {
@@ -24,22 +17,22 @@ function makeDeps(overrides: Partial<MachineAccessDeps> = {}): MachineAccessDeps
 describe('canViewMachine', () => {
   it('allows when the page is a Terminal page and the user can view it', async () => {
     const deps = makeDeps();
-    expect(await canViewMachine(deps, actor, TERMINAL_ID)).toBe(true);
+    expect(await canViewMachine(deps, ACTOR_USER_ID, TERMINAL_ID)).toBe(true);
   });
 
   it('denies when the user cannot view the page', async () => {
     const deps = makeDeps({ canUserViewPage: async () => false });
-    expect(await canViewMachine(deps, actor, TERMINAL_ID)).toBe(false);
+    expect(await canViewMachine(deps, ACTOR_USER_ID, TERMINAL_ID)).toBe(false);
   });
 
   it('denies when the page does not exist', async () => {
     const deps = makeDeps({ findPageType: async () => null });
-    expect(await canViewMachine(deps, actor, 'missing')).toBe(false);
+    expect(await canViewMachine(deps, ACTOR_USER_ID, 'missing')).toBe(false);
   });
 
   it('denies when the page exists but is not a Terminal page', async () => {
     const deps = makeDeps({ findPageType: async () => PageType.DOCUMENT });
-    expect(await canViewMachine(deps, actor, TERMINAL_ID)).toBe(false);
+    expect(await canViewMachine(deps, ACTOR_USER_ID, TERMINAL_ID)).toBe(false);
   });
 
   it('never calls the permission check for a non-Terminal page', async () => {
@@ -51,7 +44,7 @@ describe('canViewMachine', () => {
         return true;
       },
     });
-    await canViewMachine(deps, actor, TERMINAL_ID);
+    await canViewMachine(deps, ACTOR_USER_ID, TERMINAL_ID);
     expect(called).toBe(false);
   });
 });
@@ -59,21 +52,21 @@ describe('canViewMachine', () => {
 describe('canEditMachine', () => {
   it('allows when the page is a Terminal page and the user can edit it', async () => {
     const deps = makeDeps();
-    expect(await canEditMachine(deps, actor, TERMINAL_ID)).toBe(true);
+    expect(await canEditMachine(deps, ACTOR_USER_ID, TERMINAL_ID)).toBe(true);
   });
 
   it('denies when the user can view but not edit the page', async () => {
     const deps = makeDeps({ canUserViewPage: async () => true, canUserEditPage: async () => false });
-    expect(await canEditMachine(deps, actor, TERMINAL_ID)).toBe(false);
+    expect(await canEditMachine(deps, ACTOR_USER_ID, TERMINAL_ID)).toBe(false);
   });
 
   it('denies when the page does not exist', async () => {
     const deps = makeDeps({ findPageType: async () => null });
-    expect(await canEditMachine(deps, actor, 'missing')).toBe(false);
+    expect(await canEditMachine(deps, ACTOR_USER_ID, 'missing')).toBe(false);
   });
 
   it('denies when the page exists but is not a Terminal page', async () => {
     const deps = makeDeps({ findPageType: async () => PageType.FOLDER });
-    expect(await canEditMachine(deps, actor, TERMINAL_ID)).toBe(false);
+    expect(await canEditMachine(deps, ACTOR_USER_ID, TERMINAL_ID)).toBe(false);
   });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-access.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-access.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { canViewMachine, canEditMachine, type MachineAccessDeps } from '../machine-access';
+import type { MachineActorContext } from '../machine-branches';
+import { PageType } from '../../../utils/enums';
+
+const TERMINAL_ID = 'terminal-1';
+
+const actor: MachineActorContext = {
+  userId: 'user-1',
+  tenantId: 'user-1',
+  actorEmail: 'user-1@example.com',
+  tier: 'pro',
+};
+
+function makeDeps(overrides: Partial<MachineAccessDeps> = {}): MachineAccessDeps {
+  return {
+    findPageType: async () => PageType.TERMINAL,
+    canUserViewPage: async () => true,
+    canUserEditPage: async () => true,
+    ...overrides,
+  };
+}
+
+describe('canViewMachine', () => {
+  it('allows when the page is a Terminal page and the user can view it', async () => {
+    const deps = makeDeps();
+    expect(await canViewMachine(deps, actor, TERMINAL_ID)).toBe(true);
+  });
+
+  it('denies when the user cannot view the page', async () => {
+    const deps = makeDeps({ canUserViewPage: async () => false });
+    expect(await canViewMachine(deps, actor, TERMINAL_ID)).toBe(false);
+  });
+
+  it('denies when the page does not exist', async () => {
+    const deps = makeDeps({ findPageType: async () => null });
+    expect(await canViewMachine(deps, actor, 'missing')).toBe(false);
+  });
+
+  it('denies when the page exists but is not a Terminal page', async () => {
+    const deps = makeDeps({ findPageType: async () => PageType.DOCUMENT });
+    expect(await canViewMachine(deps, actor, TERMINAL_ID)).toBe(false);
+  });
+
+  it('never calls the permission check for a non-Terminal page', async () => {
+    let called = false;
+    const deps = makeDeps({
+      findPageType: async () => PageType.DOCUMENT,
+      canUserViewPage: async () => {
+        called = true;
+        return true;
+      },
+    });
+    await canViewMachine(deps, actor, TERMINAL_ID);
+    expect(called).toBe(false);
+  });
+});
+
+describe('canEditMachine', () => {
+  it('allows when the page is a Terminal page and the user can edit it', async () => {
+    const deps = makeDeps();
+    expect(await canEditMachine(deps, actor, TERMINAL_ID)).toBe(true);
+  });
+
+  it('denies when the user can view but not edit the page', async () => {
+    const deps = makeDeps({ canUserViewPage: async () => true, canUserEditPage: async () => false });
+    expect(await canEditMachine(deps, actor, TERMINAL_ID)).toBe(false);
+  });
+
+  it('denies when the page does not exist', async () => {
+    const deps = makeDeps({ findPageType: async () => null });
+    expect(await canEditMachine(deps, actor, 'missing')).toBe(false);
+  });
+
+  it('denies when the page exists but is not a Terminal page', async () => {
+    const deps = makeDeps({ findPageType: async () => PageType.FOLDER });
+    expect(await canEditMachine(deps, actor, TERMINAL_ID)).toBe(false);
+  });
+});

--- a/packages/lib/src/services/machines/machine-access.ts
+++ b/packages/lib/src/services/machines/machine-access.ts
@@ -11,7 +11,6 @@
 
 import type { PageType } from '../../utils/enums';
 import { isTerminalPage } from '../../content/page-types.config';
-import type { MachineActorContext } from './machine-branches';
 
 export interface MachineAccessDeps {
   /** Looks up a page's type by id — returns null if the page doesn't exist. */
@@ -28,19 +27,19 @@ async function isMachine(deps: MachineAccessDeps, terminalId: string): Promise<b
 /** View-level access (e.g. read files/diff/settings) — looser than edit-level. */
 export async function canViewMachine(
   deps: MachineAccessDeps,
-  actor: MachineActorContext,
+  actorUserId: string,
   terminalId: string,
 ): Promise<boolean> {
   if (!(await isMachine(deps, terminalId))) return false;
-  return deps.canUserViewPage(actor.userId, terminalId);
+  return deps.canUserViewPage(actorUserId, terminalId);
 }
 
 /** Edit-level access (e.g. mutate settings, write files) — re-check on every call, never cache. */
 export async function canEditMachine(
   deps: MachineAccessDeps,
-  actor: MachineActorContext,
+  actorUserId: string,
   terminalId: string,
 ): Promise<boolean> {
   if (!(await isMachine(deps, terminalId))) return false;
-  return deps.canUserEditPage(actor.userId, terminalId);
+  return deps.canUserEditPage(actorUserId, terminalId);
 }

--- a/packages/lib/src/services/machines/machine-access.ts
+++ b/packages/lib/src/services/machines/machine-access.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared Machine (Terminal page) access checks — view vs edit.
+ *
+ * Extracted from the inline pattern already used by machine-branches-runtime.ts
+ * (`findTerminalPage` + `canAccessMachine`/`canViewMachine`) and mirrored by
+ * agent-terminals-runtime.ts, generalized behind DI so new callers (the
+ * upcoming Machine files/diff/settings API routes) import one shared check
+ * instead of each writing a slightly different copy. Those two runtimes keep
+ * their own inline versions untouched — this is for new code going forward.
+ */
+
+import type { PageType } from '../../utils/enums';
+import { isTerminalPage } from '../../content/page-types.config';
+import type { MachineActorContext } from './machine-branches';
+
+export interface MachineAccessDeps {
+  /** Looks up a page's type by id — returns null if the page doesn't exist. */
+  findPageType: (terminalId: string) => Promise<PageType | null>;
+  canUserViewPage: (userId: string, pageId: string) => Promise<boolean>;
+  canUserEditPage: (userId: string, pageId: string) => Promise<boolean>;
+}
+
+async function isMachine(deps: MachineAccessDeps, terminalId: string): Promise<boolean> {
+  const type = await deps.findPageType(terminalId);
+  return type !== null && isTerminalPage(type);
+}
+
+/** View-level access (e.g. read files/diff/settings) — looser than edit-level. */
+export async function canViewMachine(
+  deps: MachineAccessDeps,
+  actor: MachineActorContext,
+  terminalId: string,
+): Promise<boolean> {
+  if (!(await isMachine(deps, terminalId))) return false;
+  return deps.canUserViewPage(actor.userId, terminalId);
+}
+
+/** Edit-level access (e.g. mutate settings, write files) — re-check on every call, never cache. */
+export async function canEditMachine(
+  deps: MachineAccessDeps,
+  actor: MachineActorContext,
+  terminalId: string,
+): Promise<boolean> {
+  if (!(await isMachine(deps, terminalId))) return false;
+  return deps.canUserEditPage(actor.userId, terminalId);
+}


### PR DESCRIPTION
## Summary
- Extracts the "is this a Terminal page + does the user have view/edit access" pattern already duplicated inline in `machine-branches-runtime.ts` and `agent-terminals-runtime.ts` into a shared, DI-based pair: `canViewMachine`/`canEditMachine` in `packages/lib/src/services/machines/machine-access.ts`.
- Pure logic takes injected `findPageType`/`canUserViewPage`/`canUserEditPage` deps (mirrors the `GitSandboxRunDeps` DI pattern used by `git-tool-runners.ts`) — fully unit-testable without a real DB.
- Real-DB wiring lives in `apps/web/src/lib/machines/machine-access-runtime.ts`, exposing `canViewMachine(actorUserId: string, terminalId)` / `canEditMachine(actorUserId, terminalId)` — matching the existing `canAccessMachine`/`canViewMachine` shape in `machine-branches-runtime.ts` this was extracted from, so callers pass the id they already have instead of paying for `resolveMachineActorContext`'s DB round trip just to gate access.
- Adds the new subpath to `packages/lib/package.json` exports/typesVersions.
- `machine-branches-runtime.ts` and `agent-terminals-runtime.ts` are untouched — out of scope for this task; upcoming Phase 1 routes (files/diff/settings) will import from the new shared module going forward.

This is Phase 0 of the Machine page rebuild epic — the three Phase 1 human-facing API routes each depend on this shared check.

## Test plan
- [x] `bunx vitest run src/services/machines/__tests__/machine-access.test.ts` — 9 tests covering view/edit allow/deny, missing page, non-Terminal page type
- [x] `bunx vitest run src/services/machines/` — full directory, 152 tests, no regressions
- [x] `bun run --filter @pagespace/lib typecheck` — clean
- [x] `bun run --filter web typecheck` — clean
- [x] Self-review workflow (high effort) found one cleanup issue (context-object-vs-plain-userId param), fixed in a follow-up commit
- [x] CodeRabbit review passed with no findings on the current commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139VPvr6mkL1L7vyKaauqho
