### PR TITLE
feat(terminal): extract reusable MachineTree component from Navigator

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
@@ -1,0 +1,123 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SWRConfig } from 'swr';
+import { assert } from '@/stores/__tests__/riteway';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('@/hooks/useGithubRepos', () => ({
+  useGithubRepos: () => ({ repos: [], connected: true, isLoading: false, error: undefined, mutate: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useIntegrations', () => ({
+  useProviders: () => ({ providers: [] }),
+}));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import MachineTree, { type MachineTreeNode } from './MachineTree';
+
+const TERMINAL_ID = 'machine-1';
+
+const cannedFetch = () =>
+  vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+    const url = String(args[0]);
+    if (url.includes('/api/machines/projects')) {
+      return new Response(
+        JSON.stringify({ projects: [{ name: 'my-repo', repoUrl: 'https://github.com/org/my-repo.git', path: '/repo', createdAt: '2026-01-01' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (url.includes('/api/machines/branches')) {
+      return new Response(
+        JSON.stringify({ branches: [{ branchName: 'main', createdAt: '2026-01-01' }] }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return new Response('{}', { status: 200 });
+  });
+
+const renderTree = (props: Partial<Parameters<typeof MachineTree>[0]> = {}) =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <MachineTree terminalId={TERMINAL_ID} {...props} />
+    </SWRConfig>,
+  );
+
+describe('MachineTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cannedFetch();
+  });
+
+  test('renders the same Machine -> Project -> Branch data the hooks report', async () => {
+    renderTree();
+
+    const projectRow = await waitFor(() => screen.getByText('my-repo'));
+    await userEvent.click(projectRow);
+
+    const branchRow = await waitFor(() => screen.getByText('main'));
+
+    assert({
+      given: 'a machine with one project and that project expanded',
+      should: 'show the branch reported by useMachineBranches',
+      actual: branchRow.textContent,
+      expected: 'main',
+    });
+  });
+
+  test('clicking a project row calls onSelectNode with that project node, not a hardcoded action', async () => {
+    const onSelectNode = vi.fn();
+    renderTree({ onSelectNode });
+
+    const projectRow = await waitFor(() => screen.getByText('my-repo'));
+    await userEvent.click(projectRow);
+
+    const expected: MachineTreeNode = { level: 'project', projectName: 'my-repo' };
+    assert({
+      given: 'onSelectNode passed as a prop and a project row clicked',
+      should: 'invoke onSelectNode with the project node — no useTerminalWorkspaceStore coupling',
+      actual: onSelectNode.mock.calls[0]?.[0],
+      expected,
+    });
+  });
+
+  test('renderNodeChildren injects caller content under an expanded node', async () => {
+    renderTree({
+      renderNodeChildren: (node: MachineTreeNode) =>
+        node.level === 'machine' ? <div data-testid="injected-slot">injected</div> : null,
+    });
+
+    const injected = await waitFor(() => screen.getByTestId('injected-slot'));
+    assert({
+      given: 'a renderNodeChildren slot targeting the machine node',
+      should: 'render the caller-provided content under the expanded machine node',
+      actual: injected.textContent,
+      expected: 'injected',
+    });
+  });
+
+  test('a branch row has no expand chevron when renderNodeChildren is not provided', async () => {
+    renderTree();
+
+    const projectRow = await waitFor(() => screen.getByText('my-repo'));
+    await userEvent.click(projectRow);
+    await waitFor(() => screen.getByText('main'));
+
+    // Machine and Project rows each have a chevron; a bare branch row (no renderNodeChildren) should not add a third.
+    assert({
+      given: 'no renderNodeChildren slot passed',
+      should: 'not offer an expand/collapse control on branch rows (they render as flat, selectable leaves)',
+      actual: screen.getAllByTestId('expand-chevron').length,
+      expected: 2,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import { assert } from '@/stores/__tests__/riteway';
@@ -52,6 +52,13 @@ const renderTree = (props: Partial<Parameters<typeof MachineTree>[0]> = {}) =>
     </SWRConfig>,
   );
 
+/** The row's chevron and its label live in separate buttons (see TreeRow) — find the row by its label text, then click just the chevron within it. */
+const expandRowFor = async (labelText: string) => {
+  const label = await waitFor(() => screen.getByText(labelText));
+  const row = label.closest('.group') as HTMLElement;
+  await userEvent.click(within(row).getByTestId('expand-chevron'));
+};
+
 describe('MachineTree', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -61,13 +68,11 @@ describe('MachineTree', () => {
   test('renders the same Machine -> Project -> Branch data the hooks report', async () => {
     renderTree();
 
-    const projectRow = await waitFor(() => screen.getByText('my-repo'));
-    await userEvent.click(projectRow);
-
+    await expandRowFor('my-repo');
     const branchRow = await waitFor(() => screen.getByText('main'));
 
     assert({
-      given: 'a machine with one project and that project expanded',
+      given: 'a machine with one project and that project expanded via its chevron',
       should: 'show the branch reported by useMachineBranches',
       actual: branchRow.textContent,
       expected: 'main',
@@ -90,6 +95,24 @@ describe('MachineTree', () => {
     });
   });
 
+  test('selecting a project does not also toggle its expansion', async () => {
+    const onSelectNode = vi.fn();
+    renderTree({ onSelectNode });
+
+    const projectRow = await waitFor(() => screen.getByText('my-repo'));
+    await userEvent.click(projectRow);
+
+    // Selecting must not be coupled to expand/collapse — a caller re-selecting an
+    // already-expanded row (or just selecting a collapsed one) shouldn't flip its
+    // disclosure state as a side effect.
+    assert({
+      given: 'a project row clicked to select it (not its chevron)',
+      should: 'leave the row collapsed — its branches stay hidden',
+      actual: screen.queryByText('main'),
+      expected: null,
+    });
+  });
+
   test('renderNodeChildren injects caller content under an expanded node', async () => {
     renderTree({
       renderNodeChildren: (node: MachineTreeNode) =>
@@ -108,8 +131,7 @@ describe('MachineTree', () => {
   test('a branch row has no expand chevron when renderNodeChildren is not provided', async () => {
     renderTree();
 
-    const projectRow = await waitFor(() => screen.getByText('my-repo'));
-    await userEvent.click(projectRow);
+    await expandRowFor('my-repo');
     await waitFor(() => screen.getByText('main'));
 
     // Machine and Project rows each have a chevron; a bare branch row (no renderNodeChildren) should not add a third.

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
@@ -96,27 +96,27 @@ function TreeRow({
   onRemove?(): void;
   removeTitle?: string;
 }) {
-  const clickable = Boolean(onToggleExpand || onSelect);
-  const handleClick = () => {
-    onToggleExpand?.();
-    onSelect?.();
-  };
-
   return (
     <div className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
+      {onToggleExpand ? (
+        <button
+          type="button"
+          onClick={onToggleExpand}
+          className="shrink-0 rounded-sm p-0.5 hover:bg-accent"
+          aria-label={expanded ? 'Collapse' : 'Expand'}
+          data-testid="expand-chevron"
+        >
+          {expanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
+        </button>
+      ) : (
+        <span className="size-3.5 shrink-0" aria-hidden="true" />
+      )}
       <button
         type="button"
-        onClick={clickable ? handleClick : undefined}
-        disabled={!clickable}
-        className={cn('flex flex-1 items-center gap-1 text-left', !clickable && 'cursor-default')}
+        onClick={onSelect}
+        disabled={!onSelect}
+        className={cn('flex flex-1 items-center gap-1 text-left', !onSelect && 'cursor-default')}
       >
-        {onToggleExpand ? (
-          <span data-testid="expand-chevron" aria-hidden="true">
-            {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
-          </span>
-        ) : (
-          <span className="size-3.5 shrink-0" aria-hidden="true" />
-        )}
         {icon}
         <span className={cn('truncate', labelClassName)}>{label}</span>
       </button>

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
@@ -1,0 +1,539 @@
+"use client";
+
+import { useState, type ReactNode } from 'react';
+import { usePathname } from 'next/navigation';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import {
+  ChevronRight,
+  ChevronDown,
+  Cpu,
+  FolderGit2,
+  Github,
+  GitBranch,
+  Plus,
+  X,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useMachineProjects } from '@/hooks/useMachineProjects';
+import { useMachineBranches } from '@/hooks/useMachineBranches';
+import { useGithubRepos, type GithubRepo } from '@/hooks/useGithubRepos';
+import { useProviders } from '@/hooks/useIntegrations';
+import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
+import EmptyState from './EmptyState';
+
+/** A node in the Machine → Project → Branch tree, passed to `onSelectNode` and `renderNodeChildren`. */
+export type MachineTreeNode =
+  | { level: 'machine' }
+  | { level: 'project'; projectName: string }
+  | { level: 'branch'; projectName: string; branchName: string };
+
+interface MachineTreeProps {
+  terminalId: string;
+  /** Called when a Machine/Project/Branch row is clicked. Omit if the tree itself isn't selectable (e.g. selection lives on injected leaf content instead). */
+  onSelectNode?: (node: MachineTreeNode) => void;
+  /** Renders caller-owned content under a node when it's expanded (e.g. session-terminal rows). Branch nodes are only expandable when this is provided — otherwise they render as a flat, non-expandable row. */
+  renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
+}
+
+/** Presentation-only Machine → Project → Branch tree, reusable across any tab that needs this navigation shape (Terminal, Diff, …). Has no opinion on what a row click does — callers own that via `onSelectNode`. */
+export default function MachineTree({ terminalId, onSelectNode, renderNodeChildren }: MachineTreeProps) {
+  return (
+    <div className="p-1 text-sm">
+      <MachineNode terminalId={terminalId} onSelectNode={onSelectNode} renderNodeChildren={renderNodeChildren} />
+    </div>
+  );
+}
+
+function TreeRow({
+  expanded,
+  onToggleExpand,
+  onSelect,
+  icon,
+  label,
+  labelClassName,
+  onRemove,
+  removeTitle,
+}: {
+  expanded?: boolean;
+  onToggleExpand?(): void;
+  onSelect?(): void;
+  icon: ReactNode;
+  label: string;
+  labelClassName?: string;
+  onRemove?(): void;
+  removeTitle?: string;
+}) {
+  const clickable = Boolean(onToggleExpand || onSelect);
+  const handleClick = () => {
+    onToggleExpand?.();
+    onSelect?.();
+  };
+
+  return (
+    <div className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
+      <button
+        type="button"
+        onClick={clickable ? handleClick : undefined}
+        disabled={!clickable}
+        className={cn('flex flex-1 items-center gap-1 text-left', !clickable && 'cursor-default')}
+      >
+        {onToggleExpand ? (
+          <span data-testid="expand-chevron" aria-hidden="true">
+            {expanded ? <ChevronDown className="size-3.5 shrink-0" /> : <ChevronRight className="size-3.5 shrink-0" />}
+          </span>
+        ) : (
+          <span className="size-3.5 shrink-0" aria-hidden="true" />
+        )}
+        {icon}
+        <span className={cn('truncate', labelClassName)}>{label}</span>
+      </button>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          className="invisible size-5 shrink-0 rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive group-hover:visible"
+          title={removeTitle}
+        >
+          <X className="mx-auto size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface TreeLevelProps {
+  onSelectNode?: (node: MachineTreeNode) => void;
+  renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
+}
+
+function MachineNode({ terminalId, onSelectNode, renderNodeChildren }: TreeLevelProps & { terminalId: string }) {
+  const [expanded, setExpanded] = useState(true);
+  const node: MachineTreeNode = { level: 'machine' };
+  const { projects, isLoading: projectsLoading, addProject, removeProject } = useMachineProjects(expanded ? terminalId : null);
+
+  return (
+    <div>
+      <TreeRow
+        expanded={expanded}
+        onToggleExpand={() => setExpanded((e) => !e)}
+        onSelect={onSelectNode ? () => onSelectNode(node) : undefined}
+        icon={<Cpu className="size-3.5 shrink-0" />}
+        label="Machine"
+        labelClassName="font-medium"
+      />
+      {expanded && (
+        <div className="pl-4">
+          {renderNodeChildren?.(node)}
+          <div className="mt-1 flex items-center justify-between py-0.5 pr-1">
+            <span className="text-xs text-muted-foreground">Projects</span>
+            <AddProjectDialog onAdd={addProject} />
+          </div>
+          {projectsLoading && <div className="px-2 py-1 text-xs text-muted-foreground">Loading projects…</div>}
+          {!projectsLoading && projects.length === 0 && (
+            <EmptyState
+              title="No projects yet"
+              description="Add a git repo to this machine to start a branch-terminal."
+            >
+              <AddProjectDialog onAdd={addProject} triggerLabel="Add your first project" />
+            </EmptyState>
+          )}
+          {projects.map((project) => (
+            <ProjectNode
+              key={project.name}
+              terminalId={terminalId}
+              projectName={project.name}
+              onSelectNode={onSelectNode}
+              renderNodeChildren={renderNodeChildren}
+              onRemoveProject={() => removeProject(project.name)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProjectNode({
+  terminalId,
+  projectName,
+  onSelectNode,
+  renderNodeChildren,
+  onRemoveProject,
+}: TreeLevelProps & {
+  terminalId: string;
+  projectName: string;
+  onRemoveProject(): Promise<unknown>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const node: MachineTreeNode = { level: 'project', projectName };
+  const { branches, isLoading: branchesLoading, addBranch, removeBranch } = useMachineBranches(expanded ? terminalId : null, projectName);
+
+  return (
+    <div>
+      <TreeRow
+        expanded={expanded}
+        onToggleExpand={() => setExpanded((e) => !e)}
+        onSelect={onSelectNode ? () => onSelectNode(node) : undefined}
+        icon={<FolderGit2 className="size-3.5 shrink-0" />}
+        label={projectName}
+        labelClassName="font-medium"
+        onRemove={() => setConfirmingRemove(true)}
+        removeTitle="Remove project"
+      />
+      <ConfirmRemoveDialog
+        open={confirmingRemove}
+        onOpenChange={setConfirmingRemove}
+        title="Remove project?"
+        description={`Remove project "${projectName}"? This does not touch its branch-terminals.`}
+        onConfirm={onRemoveProject}
+      />
+      {expanded && (
+        <div className="pl-4">
+          {renderNodeChildren?.(node)}
+          <div className="mt-1 flex items-center justify-between py-0.5 pr-1">
+            <span className="text-xs text-muted-foreground">Branches</span>
+            <AddBranchDialog onAdd={addBranch} />
+          </div>
+          {branchesLoading && <div className="px-2 py-1 text-xs text-muted-foreground">Loading branches…</div>}
+          {!branchesLoading && branches.length === 0 && (
+            <div className="px-2 py-1 text-xs text-muted-foreground">No branches yet</div>
+          )}
+          {branches.map((branch) => (
+            <BranchNode
+              key={branch.branchName}
+              projectName={projectName}
+              branchName={branch.branchName}
+              onSelectNode={onSelectNode}
+              renderNodeChildren={renderNodeChildren}
+              onRemoveBranch={() => removeBranch(branch.branchName)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BranchNode({
+  projectName,
+  branchName,
+  onSelectNode,
+  renderNodeChildren,
+  onRemoveBranch,
+}: TreeLevelProps & {
+  projectName: string;
+  branchName: string;
+  onRemoveBranch(): Promise<unknown>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+  const node: MachineTreeNode = { level: 'branch', projectName, branchName };
+  const expandable = renderNodeChildren !== undefined;
+
+  return (
+    <div>
+      <TreeRow
+        expanded={expandable ? expanded : undefined}
+        onToggleExpand={expandable ? () => setExpanded((e) => !e) : undefined}
+        onSelect={onSelectNode ? () => onSelectNode(node) : undefined}
+        icon={<GitBranch className="size-3.5 shrink-0" />}
+        label={branchName}
+        onRemove={() => setConfirmingRemove(true)}
+        removeTitle="Remove branch-terminal"
+      />
+      <ConfirmRemoveDialog
+        open={confirmingRemove}
+        onOpenChange={setConfirmingRemove}
+        title="Remove branch-terminal?"
+        description={`Remove branch-terminal "${branchName}"? Its Sprite will be destroyed.`}
+        onConfirm={onRemoveBranch}
+      />
+      {expandable && expanded && <div className="pl-4">{renderNodeChildren?.(node)}</div>}
+    </div>
+  );
+}
+
+function ConfirmRemoveDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  title: string;
+  description: string;
+  onConfirm(): Promise<unknown>;
+}) {
+  const [removing, setRemoving] = useState(false);
+
+  const handleConfirm = async () => {
+    setRemoving(true);
+    try {
+      await onConfirm();
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove');
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={(v) => !removing && onOpenChange(v)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={removing}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={removing}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {removing ? 'Removing…' : 'Remove'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function GithubRepoPicker({
+  repos,
+  isLoading,
+  error,
+  selectedLabel,
+  onSelect,
+}: {
+  repos: GithubRepo[];
+  isLoading: boolean;
+  error?: Error;
+  selectedLabel?: string;
+  onSelect(repo: GithubRepo): void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  return (
+    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" role="combobox" aria-expanded={pickerOpen} className="w-full justify-between font-normal">
+          <span className="flex min-w-0 items-center gap-2">
+            <Github className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className={cn('truncate', !selectedLabel && 'text-muted-foreground')}>
+              {selectedLabel || 'Select a repo…'}
+            </span>
+          </span>
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search your repos…" />
+          <CommandList onWheel={(e) => e.stopPropagation()}>
+            <CommandEmpty>
+              {error ? `Failed to load repos: ${error.message}` : isLoading ? 'Loading repos…' : 'No repos found.'}
+            </CommandEmpty>
+            {repos.map((repo) => (
+              <CommandItem key={repo.full_name} value={repo.full_name} onSelect={() => { onSelect(repo); setPickerOpen(false); }}>
+                <FolderGit2 className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm">{repo.full_name}</span>
+                {repo.private && (
+                  <span className="ml-auto shrink-0 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">private</span>
+                )}
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function deriveProjectFieldsFromRepo(repo: { full_name: string; clone_url: string }): { name: string; repoUrl: string } {
+  const segments = repo.full_name.split('/');
+  return { name: segments[segments.length - 1] || repo.full_name, repoUrl: repo.clone_url };
+}
+
+function AddProjectDialog({ onAdd, triggerLabel }: { onAdd(name: string, repoUrl: string): Promise<unknown>; triggerLabel?: string }) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [manualMode, setManualMode] = useState(false);
+  const [connectDialogOpen, setConnectDialogOpen] = useState(false);
+
+  const { repos, connected, isLoading: reposLoading, error: reposError, mutate: refetchRepos } = useGithubRepos(open && !manualMode);
+  // Only needed to resolve the github provider for the "Connect GitHub" fallback CTA, so it's gated the same as useGithubRepos rather than fetched on every mount.
+  const { providers } = useProviders(open);
+  const githubProvider = providers.find((p) => p.slug === 'github') ?? null;
+
+  const mode: 'manual' | 'connect' | 'picker' = manualMode ? 'manual' : connected === false ? 'connect' : 'picker';
+
+  const resetAndClose = () => {
+    setOpen(false);
+    setName('');
+    setRepoUrl('');
+    setManualMode(false);
+  };
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(name.trim(), repoUrl.trim());
+      resetAndClose();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add project');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSelectRepo = (repo: GithubRepo) => {
+    const fields = deriveProjectFieldsFromRepo(repo);
+    setName(fields.name);
+    setRepoUrl(fields.repoUrl);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) resetAndClose(); }}>
+      <DialogTrigger asChild>
+        {triggerLabel ? (
+          <Button variant="outline" size="sm" className="h-7 text-xs">
+            {triggerLabel}
+          </Button>
+        ) : (
+          <Button variant="ghost" size="icon" className="size-6" title="Add project">
+            <Plus className="size-3.5" />
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add project</DialogTitle>
+          <DialogDescription>Clone a git repo onto this machine&apos;s persistent filesystem.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          <Input placeholder="Project name" value={name} onChange={(e) => setName(e.target.value)} />
+
+          {mode === 'manual' && (
+            <Input placeholder="Repo URL (https://github.com/org/repo.git)" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} />
+          )}
+          {mode === 'connect' && (
+            <Button type="button" variant="outline" onClick={() => setConnectDialogOpen(true)} className="justify-start gap-2 font-normal text-muted-foreground">
+              <Github className="size-3.5 shrink-0" />
+              Connect GitHub to browse your repos
+            </Button>
+          )}
+          {mode === 'picker' && (
+            <GithubRepoPicker repos={repos} isLoading={reposLoading} error={reposError} selectedLabel={name} onSelect={handleSelectRepo} />
+          )}
+
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto justify-start p-0 text-xs text-muted-foreground"
+            onClick={() => setManualMode((m) => !m)}
+          >
+            {manualMode ? 'Pick from your GitHub repos instead' : 'Enter a repo URL manually'}
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !name.trim() || !repoUrl.trim()}>
+            {submitting ? 'Adding…' : 'Add project'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+      <ConnectIntegrationDialog
+        provider={githubProvider}
+        open={connectDialogOpen}
+        onOpenChange={setConnectDialogOpen}
+        onConnected={() => {
+          setConnectDialogOpen(false);
+          refetchRepos();
+        }}
+        returnUrl={pathname}
+      />
+    </Dialog>
+  );
+}
+
+function AddBranchDialog({ onAdd }: { onAdd(branchName: string): Promise<unknown> }) {
+  const [open, setOpen] = useState(false);
+  const [branchName, setBranchName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(branchName.trim());
+      setOpen(false);
+      setBranchName('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add branch');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon" className="size-5" title="Add branch-terminal">
+          <Plus className="size-3.5" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add branch-terminal</DialogTitle>
+          <DialogDescription>Checks out this branch in its own isolated Sprite.</DialogDescription>
+        </DialogHeader>
+        <Input placeholder="Branch name" value={branchName} onChange={(e) => setBranchName(e.target.value)} />
+        <DialogFooter>
+          <Button onClick={handleSubmit} disabled={submitting || !branchName.trim()}>
+            {submitting ? 'Spawning…' : 'Add branch'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts the Machine → Project → Branch tree rendering from `Navigator.tsx` into a new, presentation-only `MachineTree.tsx`, dropping its hardcoded coupling to `useTerminalWorkspaceStore.openTerminal`.
- Adds an `onSelectNode?: (node: MachineTreeNode) => void` callback so callers decide what a row click does, and a `renderNodeChildren?: (node) => ReactNode` slot so leaf content (e.g. session-terminal rows) can be injected under any node.
- Branch rows only get an expand chevron when `renderNodeChildren` is supplied — a caller with no leaves (branch itself is the selectable target, per the upcoming Diff tab) gets a flat, selectable row instead of a dead-end expand control.
- Keeps the underlying data hooks (`useMachineProjects`, `useMachineBranches`) and add/remove dialogs (`AddProjectDialog`, `AddBranchDialog`, `ConfirmRemoveDialog`, `GithubRepoPicker`) as-is, matching Navigator's icons/indentation/hover conventions.
- `useAgentTerminals` and terminal-leaf rendering are intentionally NOT part of this component — that's injected via `renderNodeChildren` by whichever tab needs it (Terminal tab, in a later task).
- `Navigator.tsx` and the right-sidebar Terminal panel are untouched — this is purely additive, ahead of the Terminal/Diff tab rebuild (Machine page rebuild epic, Phase 0).
- **Fix-up commit `00f5ddfa9`**: an independent code-review pass caught that the row's single click handler fired both `onToggleExpand` and `onSelect`, so any caller using `onSelectNode` would also flip the row's expand state on every selection click (re-selecting an already-expanded project silently collapsed it). Split the chevron and the label back into two independent buttons — chevron toggles, label selects — with a regression test.

## Known, deliberate trade-offs (flagged by review, not fixed here — see reasoning below)
- **`AddProjectDialog`'s manual/picker mode toggle doesn't reset `name`/`repoUrl`** when switching modes, so a user who picks a GitHub repo, switches to manual entry, edits the URL, then switches back to the picker can submit a mismatched name/URL pair. This is copied verbatim from `Navigator.tsx`'s identical, pre-existing behavior — not a regression introduced by this extraction. Since this task's brief explicitly required keeping the dialogs "as-is" and explicitly forbids modifying `Navigator.tsx`, fixing it only in `MachineTree.tsx` would make the two copies diverge instead of staying identical. Filing as a follow-up to fix in both places together (or once one of them is retired).
- **`AddProjectDialog`/`AddBranchDialog`/`ConfirmRemoveDialog`/`GithubRepoPicker`/`deriveProjectFieldsFromRepo` are duplicated verbatim** between `Navigator.tsx` and `MachineTree.tsx`, as are the shape of `MachineNode`/`ProjectNode`/`BranchNode`. This is the direct, unavoidable consequence of this task's scope: `Navigator.tsx` must stay untouched and working as-is (right-sidebar Terminal panel keeps using it) until a **later, out-of-scope task migrates Navigator's callers onto `MachineTree`** — at that point the duplication collapses naturally (Navigator either re-exports these from `MachineTree`'s module or is retired outright). Extracting a shared module now would require editing `Navigator.tsx`, which this task's brief explicitly prohibits.

## Test plan
- [x] `bun run --filter=web typecheck` passes
- [x] `bunx eslint` on the new files passes
- [x] Colocated `MachineTree.test.tsx` (5 tests, all passing): renders the same Machine/Project/Branch data the hooks report, `onSelectNode` fires with the correct node instead of a hardcoded action, **selecting a row does not also toggle its expansion** (regression test for the fix-up commit), `renderNodeChildren` injects caller content under an expanded node, branch rows omit the expand chevron when no slot is passed
- [x] Grepped the new file for `useTerminalWorkspaceStore`/`OpenTerminalScope`/`openTerminal` — no matches, confirming no right-sidebar-specific coupling
- [x] Ran an independent workflow-based code review (5 finders + verifier pass) against the diff; the one correctness bug found (click-handler coupling) is fixed in `00f5ddfa9`, the remaining findings are addressed above as deliberate scope trade-offs
- [ ] Manual verification against a real Machine page in dev — not done in this task: the component isn't wired into any page yet (out of scope here; a later task migrates callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFb2F3megJDEpRgqPU3dJA
