### PR TITLE
feat(machines): working-tree file browsing primitives + /api/machines/files route

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -160,6 +160,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['machines/branches', 'Audited via writeCodeExecutionAudit in machine-branches.ts (git clone/checkout on the branch Sprite)'],
   ['machines/projects', 'Audited via writeCodeExecutionAudit in machine-projects.ts (git clone on the owning Machine)'],
   ['machines/agent-terminals', 'Reserves/kills a named PTY session tracking row; the PTY itself is audited via writeCodeExecutionAudit when opened (see apps/realtime/src/index.ts)'],
+  ['machines/files', 'Read-only working-tree browse (fixed `ls` + single file read on an already-provisioned branch Sprite) — no data write, no code execution/provisioning, no git; GET-only, view-gated by canViewMachine and path-confined to the branch checkout root, consistent with the other read-only machines/* and drive/page read sub-routes'],
 
   // --- Integration-tool UI routes (audited via the shared executeToolSaga
   // audit path deep in the integrations engine, not directly in route.ts) ---

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * /api/machines/files contract + path-confinement tests.
+ *
+ * The security-critical property under test: the untrusted `path` query param
+ * is RELATIVE to the branch checkout root and is confined under it BEFORE the
+ * machine filesystem is touched. A `..` escape or an absolute path must be
+ * rejected (400) without ever calling listMachineDirectory/readMachineFile, so
+ * a viewer cannot read `/etc/passwd` or step outside `/workspace/repo`.
+ *
+ * `resolvePathWithinSync` (the real confinement helper) is intentionally NOT
+ * mocked — it is the code under test. Everything else (auth, access check,
+ * handle resolution, the fs primitives) is mocked so the test isolates the
+ * route's own request handling.
+ */
+
+// Inlined (not a top-level const) because vi.mock factories are hoisted above
+// any module-scope variable and cannot close over one.
+vi.mock('@pagespace/lib/services/machines/machine-branches', () => ({ BRANCH_REPO_PATH: '/workspace/repo' }));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(async () => ({ userId: 'user-1' })),
+  isAuthError: vi.fn(() => false),
+}));
+
+type HandleResult =
+  | { ok: true; handle: { machineId: string } }
+  | { ok: false; reason: 'not_found' | 'vanished' };
+
+const canViewMachine = vi.fn(async () => true);
+const resolveBranchMachineHandle = vi.fn(
+  async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
+);
+vi.mock('@/lib/machines/machine-files-runtime', () => ({
+  canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
+  resolveBranchMachineHandle: (...args: unknown[]) => resolveBranchMachineHandle(...(args as [])),
+}));
+
+const listMachineDirectory = vi.fn(async () => ({ ok: true, entries: [] }));
+const readMachineFile = vi.fn(async () => ({ ok: true, content: Buffer.from('hi', 'utf8') }));
+vi.mock('@pagespace/lib/services/sandbox/machine-fs', () => ({
+  listMachineDirectory: (...args: unknown[]) => listMachineDirectory(...(args as [])),
+  readMachineFile: (...args: unknown[]) => readMachineFile(...(args as [])),
+}));
+
+import { GET } from '../route';
+
+function get(query: Record<string, string>): Request {
+  const params = new URLSearchParams({ terminalId: 't1', projectName: 'p1', branchName: 'b1', ...query });
+  return new Request(`http://localhost/api/machines/files?${params.toString()}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canViewMachine.mockResolvedValue(true);
+  resolveBranchMachineHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
+  listMachineDirectory.mockResolvedValue({ ok: true, entries: [] });
+  readMachineFile.mockResolvedValue({ ok: true, content: Buffer.from('hi', 'utf8') });
+});
+
+describe('/api/machines/files path confinement', () => {
+  it('rejects a `..` traversal without touching the filesystem', async () => {
+    const res = await GET(get({ mode: 'read', path: '../../etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(listMachineDirectory).not.toHaveBeenCalled();
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects an absolute path without touching the filesystem', async () => {
+    const res = await GET(get({ mode: 'read', path: '/etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a URL-encoded traversal without touching the filesystem', async () => {
+    const res = await GET(get({ mode: 'read', path: '%2e%2e%2fetc%2fpasswd' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('confines a valid relative path under the checkout root before listing', async () => {
+    const res = await GET(get({ path: 'src' }));
+    expect(res.status).toBe(200);
+    expect(listMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/src' }),
+    );
+  });
+
+  it('defaults an empty path to the checkout root for a listing', async () => {
+    const res = await GET(get({}));
+    expect(res.status).toBe(200);
+    expect(listMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo' }),
+    );
+  });
+
+  it('confines a valid relative path before reading a file', async () => {
+    const res = await GET(get({ mode: 'read', path: 'src/index.ts' }));
+    expect(res.status).toBe(200);
+    expect(readMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/src/index.ts' }),
+    );
+  });
+});
+
+describe('/api/machines/files request contract', () => {
+  it('requires a path when mode=read', async () => {
+    const res = await GET(get({ mode: 'read' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown mode', async () => {
+    const res = await GET(get({ mode: 'delete' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('denies a user without view access before resolving the machine', async () => {
+    canViewMachine.mockResolvedValue(false);
+    const res = await GET(get({ path: 'src' }));
+    expect(res.status).toBe(403);
+    expect(resolveBranchMachineHandle).not.toHaveBeenCalled();
+    expect(listMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the branch machine has no tracking row', async () => {
+    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await GET(get({ path: 'src' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 503 when the branch Sprite has vanished', async () => {
+    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    const res = await GET(get({ path: 'src' }));
+    expect(res.status).toBe(503);
+  });
+});

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -102,6 +102,20 @@ describe('/api/machines/files path confinement', () => {
       expect.objectContaining({ path: '/workspace/repo/src/index.ts' }),
     );
   });
+
+  it('truncates a large file without corrupting a multi-byte char at the boundary', async () => {
+    // A >2MB buffer of only 3-byte '€' glyphs: whatever byte the 2MB cap lands
+    // on, it splits a codepoint. The response must still be clean UTF-8 (no
+    // U+FFFD) and end on a whole '€', proving the partial trailing byte was
+    // dropped rather than decoded into a replacement char.
+    readMachineFile.mockResolvedValue({ ok: true, content: Buffer.from('€'.repeat(1_000_000), 'utf8') });
+    const res = await GET(get({ mode: 'read', path: 'big.txt' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string; truncated: boolean };
+    expect(body.truncated).toBe(true);
+    expect(body.content.includes('�')).toBe(false);
+    expect(body.content.endsWith('€')).toBe(true);
+  });
 });
 
 describe('/api/machines/files request contract', () => {

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Machine Files API — the Machine page's surface onto a branch checkout's
+ * WORKING TREE (Machine page rebuild, Phase 1 — file browsing).
+ *
+ * GET ?terminalId=&projectName=&branchName=[&path=][&mode=list|read]
+ *   mode=list (default) → { entries: [{ name, type }] } for the directory `path`
+ *   mode=read           → { content, encoding, truncated } for the file `path`
+ *
+ * `path` defaults to the branch checkout root (`/workspace/repo`) for a listing;
+ * it is REQUIRED for a read. Reads the live filesystem only — no git ref (that
+ * is a separate git-object service). Session-only (no MCP/agent tokens) — this
+ * is a human/UI surface, so it does NOT route through the AI agent tool
+ * orchestration; every request re-checks view access for the Machine page,
+ * same as the Branches/Agent-Terminals APIs.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
+import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
+import { canViewMachine, resolveBranchMachineHandle } from '@/lib/machines/machine-files-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+/** A single file read is capped so a large blob can't flood the response. */
+const MAX_FILE_READ_BYTES = 2 * 1024 * 1024;
+
+function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { ok: false, error: NextResponse.json({ error: `${field} is required` }, { status: 400 }) };
+  }
+  return { ok: true, value };
+}
+
+const LIST_DENIAL_STATUS: Record<string, number> = {
+  not_found: 404,
+  exec_failed: 502,
+};
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const terminalId = requireString(url.searchParams.get('terminalId'), 'terminalId');
+  if (!terminalId.ok) return terminalId.error;
+  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
+  if (!projectName.ok) return projectName.error;
+  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
+  if (!branchName.ok) return branchName.error;
+
+  const mode = url.searchParams.get('mode') ?? 'list';
+  if (mode !== 'list' && mode !== 'read') {
+    return NextResponse.json({ error: "mode must be 'list' or 'read'" }, { status: 400 });
+  }
+
+  const rawPath = url.searchParams.get('path');
+  if (mode === 'read' && (rawPath === null || rawPath.length === 0)) {
+    return NextResponse.json({ error: 'path is required when mode=read' }, { status: 400 });
+  }
+  const path = rawPath !== null && rawPath.length > 0 ? rawPath : BRANCH_REPO_PATH;
+
+  if (!(await canViewMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const resolved = await resolveBranchMachineHandle({
+    terminalId: terminalId.value,
+    projectName: projectName.value,
+    branchName: branchName.value,
+  });
+  if (!resolved.ok) {
+    return NextResponse.json(
+      { error: `Branch machine ${resolved.reason}`, reason: resolved.reason },
+      { status: resolved.reason === 'not_found' ? 404 : 503 },
+    );
+  }
+
+  if (mode === 'read') {
+    const result = await readMachineFile({ handle: resolved.handle, path });
+    if (!result.ok) {
+      return NextResponse.json({ error: 'File not found', reason: result.reason }, { status: 404 });
+    }
+    const truncated = result.content.length > MAX_FILE_READ_BYTES;
+    const bytes = truncated ? result.content.subarray(0, MAX_FILE_READ_BYTES) : result.content;
+    return NextResponse.json({ content: bytes.toString('utf8'), encoding: 'utf8', truncated });
+  }
+
+  const result = await listMachineDirectory({ handle: resolved.handle, path });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.detail ?? result.reason, reason: result.reason },
+      { status: LIST_DENIAL_STATUS[result.reason] ?? 500 },
+    );
+  }
+  return NextResponse.json({ entries: result.entries });
+}

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -6,10 +6,13 @@
  *   mode=list (default) → { entries: [{ name, type }] } for the directory `path`
  *   mode=read           → { content, encoding, truncated } for the file `path`
  *
- * `path` defaults to the branch checkout root (`/workspace/repo`) for a listing;
- * it is REQUIRED for a read. Reads the live filesystem only — no git ref (that
- * is a separate git-object service). Session-only (no MCP/agent tokens) — this
- * is a human/UI surface, so it does NOT route through the AI agent tool
+ * `path` is RELATIVE to the branch checkout root (`/workspace/repo`) and is
+ * confined under it before the machine filesystem is touched — an absolute path
+ * or a `..` escape is rejected (400), so a viewer cannot read `/etc/passwd` or
+ * step out of the checkout. It defaults to the checkout root for a listing and
+ * is REQUIRED for a read. Reads the live filesystem only — no git ref (that is
+ * a separate git-object service). Session-only (no MCP/agent tokens) — this is
+ * a human/UI surface, so it does NOT route through the AI agent tool
  * orchestration; every request re-checks view access for the Machine page,
  * same as the Branches/Agent-Terminals APIs.
  */
@@ -18,6 +21,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
+import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
 import { canViewMachine, resolveBranchMachineHandle } from '@/lib/machines/machine-files-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -58,7 +62,16 @@ export async function GET(request: Request) {
   if (mode === 'read' && (rawPath === null || rawPath.length === 0)) {
     return NextResponse.json({ error: 'path is required when mode=read' }, { status: 400 });
   }
-  const path = rawPath !== null && rawPath.length > 0 ? rawPath : BRANCH_REPO_PATH;
+
+  // `path` is untrusted and RELATIVE to the checkout root; confine it under
+  // BRANCH_REPO_PATH before any filesystem access. An empty path lists the root
+  // itself; an absolute path or a `..` escape resolves to null → 400. Absolute
+  // path passed to the filesystem is the confined result, never the raw input.
+  const relativePath = rawPath !== null && rawPath.length > 0 ? rawPath : '';
+  const path = resolvePathWithinSync(BRANCH_REPO_PATH, relativePath);
+  if (path === null) {
+    return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
+  }
 
   if (!(await canViewMachine(auth.userId, terminalId.value))) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -54,6 +54,12 @@ export async function GET(request: Request) {
   const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
   if (!branchName.ok) return branchName.error;
 
+  // Authorize BEFORE parsing optional params, so a user without view access gets
+  // a uniform 403 and can never probe path/mode handling.
+  if (!(await canViewMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
   const mode = url.searchParams.get('mode') ?? 'list';
   if (mode !== 'list' && mode !== 'read') {
     return NextResponse.json({ error: "mode must be 'list' or 'read'" }, { status: 400 });
@@ -72,10 +78,6 @@ export async function GET(request: Request) {
   const path = resolvePathWithinSync(BRANCH_REPO_PATH, relativePath);
   if (path === null) {
     return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
-  }
-
-  if (!(await canViewMachine(auth.userId, terminalId.value))) {
-    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
 
   const resolved = await resolveBranchMachineHandle({

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -17,6 +17,7 @@
  * same as the Branches/Agent-Terminals APIs.
  */
 
+import { StringDecoder } from 'string_decoder';
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
@@ -96,7 +97,11 @@ export async function GET(request: Request) {
     }
     const truncated = result.content.length > MAX_FILE_READ_BYTES;
     const bytes = truncated ? result.content.subarray(0, MAX_FILE_READ_BYTES) : result.content;
-    return NextResponse.json({ content: bytes.toString('utf8'), encoding: 'utf8', truncated });
+    // Decode via StringDecoder so a cap landing mid-codepoint drops the trailing
+    // partial byte(s) instead of emitting U+FFFD; decoding only the capped slice
+    // (not the whole buffer) also bounds the work for a large file.
+    const content = new StringDecoder('utf8').write(bytes);
+    return NextResponse.json({ content, encoding: 'utf8', truncated });
   }
 
   const result = await listMachineDirectory({ handle: resolved.handle, path });

--- a/apps/web/src/lib/machines/machine-files-runtime.ts
+++ b/apps/web/src/lib/machines/machine-files-runtime.ts
@@ -1,0 +1,50 @@
+/**
+ * Production wiring for the Machine Files browse API (Machine page rebuild,
+ * Phase 1 — working-tree file browsing).
+ *
+ * Resolves a branch-terminal's LIVE `MachineHandle` (its own Sprite) so the
+ * route can drive the provider-neutral `listMachineDirectory`/`readMachineFile`
+ * primitives against it. Reuses the branch store + the `MachineHost` seam and
+ * the shared view-access check from machine-branches-runtime — no bespoke authz
+ * and no direct Sprites-SDK import.
+ *
+ * Branch scope only: a branch-terminal holds its own Sprite addressed by a
+ * stored `sandboxId`, so `host.attach` reconnects to exactly the machine whose
+ * checkout the user is browsing. Machine/project-scope browse would resolve
+ * through the shared persistent-session acquire path instead and is a separate
+ * follow-up.
+ */
+
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
+import type { MachineHandle } from '@pagespace/lib/services/sandbox/machine-host';
+import { canViewMachine, getMachineHostForBranches } from './machine-branches-runtime';
+
+export { canViewMachine };
+
+export type ResolveBranchMachineHandleResult =
+  | { ok: true; handle: MachineHandle }
+  | { ok: false; reason: 'not_found' | 'vanished' };
+
+/**
+ * Reconnect to a branch-terminal's Sprite and return its `MachineHandle`.
+ * `not_found` = no tracking row for this (terminal, project, branch);
+ * `vanished` = the row exists but the Sprite is gone.
+ */
+export async function resolveBranchMachineHandle({
+  terminalId,
+  projectName,
+  branchName,
+}: {
+  terminalId: string;
+  projectName: string;
+  branchName: string;
+}): Promise<ResolveBranchMachineHandleResult> {
+  const store = await createDbMachineBranchStore();
+  const existing = await store.findByName(terminalId, projectName, branchName);
+  if (!existing) return { ok: false, reason: 'not_found' };
+
+  const host = await getMachineHostForBranches();
+  const handle = await host.attach({ machineId: existing.sandboxId });
+  if (!handle) return { ok: false, reason: 'vanished' };
+  return { ok: true, handle };
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -457,6 +457,11 @@
       "import": "./dist/services/sandbox/machine-host.js",
       "require": "./dist/services/sandbox/machine-host.js"
     },
+    "./services/sandbox/machine-fs": {
+      "types": "./dist/services/sandbox/machine-fs.d.ts",
+      "import": "./dist/services/sandbox/machine-fs.js",
+      "require": "./dist/services/sandbox/machine-fs.js"
+    },
     "./services/sandbox/tool-runners": {
       "types": "./dist/services/sandbox/tool-runners.d.ts",
       "import": "./dist/services/sandbox/tool-runners.js",
@@ -1627,6 +1632,9 @@
       ],
       "services/sandbox/machine-host": [
         "./dist/services/sandbox/machine-host.d.ts"
+      ],
+      "services/sandbox/machine-fs": [
+        "./dist/services/sandbox/machine-fs.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { listMachineDirectory, readMachineFile } from '../machine-fs';
+import type { MachineHandle } from '../machine-host';
+import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
+
+/**
+ * The primitives take a `MachineHandle` as an injected dependency, so a fake
+ * one — exec/readFile programmable, the PTY surface stubbed — exercises every
+ * branch with zero real Sprite calls.
+ */
+function makeHandle(overrides: {
+  exec?: (args: RunCommandArgs) => Promise<SandboxRunResult>;
+  readFile?: (args: { path: string }) => Promise<Buffer | null>;
+}): MachineHandle {
+  return {
+    machineId: 'sbx-test',
+    exec: overrides.exec ?? (async () => ({ exitCode: 0, stdout: '', stderr: '' })),
+    readFile: overrides.readFile ?? (async () => null),
+    writeFiles: async () => {},
+    stream: async () => {
+      throw new Error('stream() is not used by the fs primitives');
+    },
+    listStreams: async () => [],
+  };
+}
+
+describe('listMachineDirectory', () => {
+  it('parses `ls -Ap` output into files and directories, stripping the dir slash', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 0,
+        stdout: 'Dockerfile\nsrc/\n.gitignore\nnode_modules/\nREADME.md\n',
+        stderr: '',
+      }),
+    });
+
+    const result = await listMachineDirectory({ handle, path: '/workspace/repo' });
+
+    expect(result).toEqual({
+      ok: true,
+      entries: [
+        { name: 'Dockerfile', type: 'file' },
+        { name: 'src', type: 'directory' },
+        { name: '.gitignore', type: 'file' },
+        { name: 'node_modules', type: 'directory' },
+        { name: 'README.md', type: 'file' },
+      ],
+    });
+  });
+
+  it('invokes `ls -Ap -- <path>` so a leading-dash path is never read as a flag', async () => {
+    let seen: RunCommandArgs | undefined;
+    const handle = makeHandle({
+      exec: async (args) => {
+        seen = args;
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    await listMachineDirectory({ handle, path: '-weird-dir' });
+
+    expect(seen).toEqual({ cmd: 'ls', args: ['-Ap', '--', '-weird-dir'] });
+  });
+
+  it('returns an empty list for an empty directory', async () => {
+    const handle = makeHandle({ exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }) });
+    const result = await listMachineDirectory({ handle, path: '/workspace/repo/empty' });
+    expect(result).toEqual({ ok: true, entries: [] });
+  });
+
+  it('maps a missing path (nonzero exit + "No such file") to not_found', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 2,
+        stdout: '',
+        stderr: "ls: cannot access '/nope': No such file or directory\n",
+      }),
+    });
+    const result = await listMachineDirectory({ handle, path: '/nope' });
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ reason: 'not_found' });
+  });
+
+  it('maps any other nonzero exit to exec_failed and surfaces stderr detail', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: 'ls: permission denied\n' }),
+    });
+    const result = await listMachineDirectory({ handle, path: '/root/private' });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'ls: permission denied' });
+  });
+});
+
+describe('readMachineFile', () => {
+  it('returns the file bytes from the handle', async () => {
+    const bytes = Buffer.from('hello world', 'utf8');
+    const handle = makeHandle({ readFile: async () => bytes });
+
+    const result = await readMachineFile({ handle, path: '/workspace/repo/README.md' });
+
+    expect(result).toEqual({ ok: true, content: bytes });
+  });
+
+  it('passes the requested path straight through to the handle', async () => {
+    let seen: { path: string } | undefined;
+    const handle = makeHandle({
+      readFile: async (args) => {
+        seen = args;
+        return Buffer.from('', 'utf8');
+      },
+    });
+
+    await readMachineFile({ handle, path: '/workspace/repo/src/index.ts' });
+
+    expect(seen).toEqual({ path: '/workspace/repo/src/index.ts' });
+  });
+
+  it('maps a missing file (handle returns null) to not_found', async () => {
+    const handle = makeHandle({ readFile: async () => null });
+    const result = await readMachineFile({ handle, path: '/workspace/repo/missing' });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});

--- a/packages/lib/src/services/sandbox/machine-fs.ts
+++ b/packages/lib/src/services/sandbox/machine-fs.ts
@@ -1,0 +1,91 @@
+/**
+ * Machine filesystem browsing primitives (pure, DI'd).
+ *
+ * Two functions the human-facing Machine page uses to browse a Machine's
+ * WORKING TREE — the live files on a Sprite's persistent filesystem, e.g. a
+ * branch-terminal's checkout at `/workspace/repo`:
+ *
+ *   listMachineDirectory — one directory's immediate children ({ name, type }).
+ *   readMachineFile      — one file's bytes.
+ *
+ * Both take a `MachineHandle` (./machine-host.ts) as an INJECTED dependency
+ * rather than constructing a Sprite host themselves, mirroring the DI shape of
+ * `runGitInSandbox` (./git-tool-runners.ts). That keeps them unit-testable
+ * against a fake handle with zero real Sprite calls, per the repo's
+ * pure-functions-plus-DI build mandate.
+ *
+ * SCOPE BOUNDARY: this reads the working tree ONLY — it is filesystem-level and
+ * takes no git ref. A diff tab's "before" content needs git-object reads, a
+ * separate git-ref-aware service that depends on this one; do NOT add a ref
+ * parameter here.
+ *
+ * This runs commands through `MachineHandle.exec`/`readFile`, deliberately NOT
+ * through the AI-agent tool-runner orchestration (billing holds, injection
+ * screening, LLM-facing denial vocabulary) — that layer is shaped for an agent,
+ * not a browsing UI.
+ */
+
+import type { MachineHandle } from './machine-host';
+
+export interface MachineDirectoryEntry {
+  name: string;
+  /** A symlink, socket, or any non-directory node is reported as 'file'. */
+  type: 'file' | 'directory';
+}
+
+export type ListMachineDirectoryResult =
+  | { ok: true; entries: MachineDirectoryEntry[] }
+  | { ok: false; reason: 'not_found' | 'exec_failed'; detail?: string };
+
+export type ReadMachineFileResult =
+  | { ok: true; content: Buffer }
+  | { ok: false; reason: 'not_found' };
+
+/**
+ * List a directory's immediate children on a Machine.
+ *
+ * Uses `ls -Ap` (one name per line; a trailing `/` marks a directory) rather
+ * than parsing `ls -la`'s locale-dependent long format: `-A` drops `.`/`..` but
+ * keeps dotfiles, `-p` is the POSIX "append `/` to directories" indicator, and
+ * one-name-per-line survives spaces in filenames. `--` stops a path that begins
+ * with `-` being read as a flag; `path` is an argv element, never shell-parsed.
+ */
+export async function listMachineDirectory({
+  handle,
+  path,
+}: {
+  handle: MachineHandle;
+  path: string;
+}): Promise<ListMachineDirectoryResult> {
+  const run = await handle.exec({ cmd: 'ls', args: ['-Ap', '--', path] });
+  if (run.exitCode !== 0) {
+    const reason = /no such file or directory/i.test(run.stderr) ? 'not_found' : 'exec_failed';
+    return { ok: false, reason, detail: run.stderr.trim() || undefined };
+  }
+
+  const entries: MachineDirectoryEntry[] = run.stdout
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) =>
+      line.endsWith('/')
+        ? { name: line.slice(0, -1), type: 'directory' }
+        : { name: line, type: 'file' },
+    );
+  return { ok: true, entries };
+}
+
+/**
+ * Read one file's bytes from a Machine's working tree. A thin wrapper over
+ * `MachineHandle.readFile`, which returns `null` for a missing file.
+ */
+export async function readMachineFile({
+  handle,
+  path,
+}: {
+  handle: MachineHandle;
+  path: string;
+}): Promise<ReadMachineFileResult> {
+  const content = await handle.readFile({ path });
+  if (content === null) return { ok: false, reason: 'not_found' };
+  return { ok: true, content };
+}


### PR DESCRIPTION
## What

Phase 1 of the **Machine page rebuild** epic (Terminal — GA Release). Adds the **net-new** human-facing path for browsing a Machine's Sprite filesystem — no such endpoint existed before.

### Primitives (`packages/lib/.../sandbox/machine-fs.ts`)
- **`listMachineDirectory({ handle, path })`** → `{ name, type: 'file'|'directory' }[]`. Built on `exec('ls -Ap')` — one name per line, a trailing `/` marks a directory. Chosen over parsing `ls -la`'s locale-dependent long format: `-A` drops `.`/`..` but keeps dotfiles, `-p` is the POSIX dir indicator, one-name-per-line survives spaces. `--` stops a leading-dash path being read as a flag; `path` is an argv element, never shell-parsed.
- **`readMachineFile({ handle, path })`** → thin wrapper over `MachineHandle.readFile` (maps `null` → `not_found`).
- Both take the **`MachineHandle` as an injected dependency** (mirroring `runGitInSandbox`'s `GitSandboxRunDeps` DI shape), never constructing a Sprite host internally — so both unit-test against a fake handle with **zero real Sprite calls**.
- **Working tree ONLY** — filesystem-level, no git ref. Diff-tab "before" content needs git-object reads, a separate git-ref-aware service that depends on this one; no ref param here by design.

### Route (`apps/web/src/app/api/machines/files/route.ts`)
- `GET ?terminalId=&projectName=&branchName=[&path=][&mode=list|read]`.
  - `mode=list` (default) → `{ entries }` for the directory `path`.
  - `mode=read` → `{ content, encoding, truncated }` for the file `path` (read capped at 2 MB).
- **Path confinement (security):** `path` is **relative to the branch checkout root** (`/workspace/repo`) and is confined under it via the existing, well-tested `resolvePathWithinSync` **before any filesystem access**. An absolute path or a `..`/URL-encoded traversal resolves to `null` → 400 without touching the machine — a viewer cannot read `/etc/passwd` or escape the checkout. Empty path lists the root; the absolute path handed to the primitives is always the confined result, never the raw input.
- Session-only (no MCP/agent tokens); re-checks **view access** every request via the shared `canViewMachine`, matching the Branches / Agent-Terminals routes' auth + denial-map convention.
- Resolves the branch-terminal's own Sprite handle through the existing `MachineHost` seam (`machine-files-runtime.ts`). Branch scope only for now; machine/project-scope browse (persistent-session acquire path) is a follow-up.
- Deliberately **parallel to** the AI-agent tool orchestration (`sandbox-tools`/`tool-runners`) — no billing holds / injection screening / LLM-facing denial vocabulary, which are wrong for a browsing UI.

## Verification
- `bun run typecheck` green (web + lib); lint clean.
- **19 tests pass:** 8 primitive unit tests (`machine-fs.test.ts`) + 11 route tests (`files/__tests__/route.test.ts`) covering path confinement (traversal / absolute / encoded escapes rejected 400 without touching the fs), valid-path confinement, view-access denial, and not_found/vanished handling.

## Notes for reviewer
- The task spec named `apps/web/src/lib/machines/machine-access-runtime.ts` for the Phase 0 shared access check, but that file is **not present on `master`** in this worktree. `canViewMachine` with the exact spec signature `(actorUserId, terminalId): Promise<boolean>` already lives in `machine-branches-runtime.ts` and is what `branches/route.ts` imports today, so I reused that (no bespoke authz). If Phase 0's shared module lands under a different path later, this import is the one-line swap.
- **Remaining human step (DONE-WHEN):** manual verification against a real Machine page in `bun run dev` (list a real branch checkout, read one file, confirm a no-view-access user is denied) needs `CODE_EXECUTION_ENABLED` + a live Sprite/branch, which isn't drivable here without a token — consistent with how the epic tracks Sprite-dependent smoke tests.
- Scope held deliberately narrow: no git-blob reading or diff-scope service — those are the separate Phase 1 tasks that depend on this one merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YV8dXB4HER18Sxcm61FQBc