### PR TITLE
fix(ai-chat): stamp synthesized remote-stream bubbles with a timestamp (#1180)

### DIFF
--- a/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
@@ -101,6 +101,7 @@ describe('GET /api/ai/chat/active-streams', () => {
         displayName: 'Alice',
         browserSessionId: 'session-2',
         parts,
+        startedAt: new Date('2024-01-01T00:00:00.000Z'),
       },
     ]);
 
@@ -111,6 +112,7 @@ describe('GET /api/ai/chat/active-streams', () => {
       {
         messageId: 'msg-1',
         conversationId: 'conv-1',
+        startedAt: '2024-01-01T00:00:00.000Z',
         parts,
         triggeredBy: {
           userId: 'user-2',
@@ -130,6 +132,7 @@ describe('GET /api/ai/chat/active-streams', () => {
         displayName: 'Alice',
         browserSessionId: 'session-2',
         parts: null,
+        startedAt: new Date('2024-01-01T00:00:00.000Z'),
       },
     ]);
 

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -69,6 +69,7 @@ export async function GET(request: Request) {
         displayName: aiStreamSessions.displayName,
         browserSessionId: aiStreamSessions.browserSessionId,
         parts: aiStreamSessions.parts,
+        startedAt: aiStreamSessions.startedAt,
       })
       .from(aiStreamSessions)
       .where(
@@ -84,6 +85,7 @@ export async function GET(request: Request) {
       streams: streams.map((s) => ({
         messageId: s.messageId,
         conversationId: s.conversationId,
+        startedAt: s.startedAt.toISOString(),
         // Last debounced snapshot of the stream's accumulated parts — lets the
         // client render mid-stream content immediately, without waiting on
         // (or depending on) the originator process's live multicast.

--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -18,6 +18,7 @@ import { UIMessage } from 'ai';
 import { SkeletonMessageBubble } from '@/components/ui/skeleton';
 import { Loader2 } from 'lucide-react';
 import { MessageRenderer } from './MessageRenderer';
+import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { StreamingIndicator } from './StreamingIndicator';
 import { UndoAiChangesDialog } from './UndoAiChangesDialog';
 import { VirtualizedMessageList, VirtualizedMessageListRef } from './VirtualizedMessageList';
@@ -267,9 +268,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
             <MessageRenderer
               key={stream.messageId}
               message={{
-                id: stream.messageId,
-                role: 'assistant',
-                parts: stream.parts,
+                ...synthesizeAssistantMessage(stream.messageId, stream.parts, stream.startedAt),
                 messageType: 'standard',
               }}
               isStreaming

--- a/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
@@ -124,6 +124,30 @@ describe('ChatMessagesArea — remoteStreams rendering', () => {
     expect(synthesizedCalls[1].message.parts).toEqual([]);
   });
 
+  it('given a remote stream carrying a startedAt, stamps the synthesized message with a createdAt so the timestamp footer renders', () => {
+    const remoteStreams = [
+      makeStream({
+        messageId: 'remote-ts',
+        parts: [textPart('partial')],
+        startedAt: '2024-01-01T00:00:00.000Z',
+      }),
+    ];
+
+    render(
+      <ChatMessagesArea
+        messages={[]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={remoteStreams}
+      />
+    );
+
+    const [call] = remoteRendererCalls();
+    expect((call.message as { createdAt?: Date }).createdAt).toEqual(
+      new Date('2024-01-01T00:00:00.000Z'),
+    );
+  });
+
   it('given a remote stream whose parts include a tool part, forwards the full tool shape to MessageRenderer (no flattening to text)', () => {
     const toolPart = {
       type: 'tool-list_pages',

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -231,7 +231,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       const ownStream = usePendingStreamsStore.getState().getOwnStreams(page.id)[0];
       const merged =
         ownStream?.conversationId === conversationId && ownStream.messageId
-          ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId)
+          ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt)
           : serverMessages;
 
       setMessages(merged);
@@ -648,7 +648,14 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
         setMessages((prev) =>
           prev.some((m) => m.id === messageId)
             ? prev
-            : [...prev, synthesizeAssistantMessage(messageId, stream.parts)],
+            : [
+                ...prev,
+                synthesizeAssistantMessage(
+                  messageId,
+                  stream.parts,
+                  stream.startedAt ? new Date(stream.startedAt) : undefined,
+                ),
+              ],
         );
         return;
       }
@@ -661,7 +668,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       if (!stream || stream.parts.length === 0) return;
 
       if (isPlaceholderConversationId(currentConversationId, page.id)) {
-        const { parts, conversationId: streamConvId } = stream;
+        const { parts, conversationId: streamConvId, startedAt } = stream;
         fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations?pageSize=1`)
           .then(async (res) => {
             if (pageIdRef.current !== page.id) return;
@@ -679,7 +686,14 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             setMessages((prev) =>
               prev.some((m) => m.id === messageId)
                 ? prev
-                : [...prev, synthesizeAssistantMessage(messageId, parts)],
+                : [
+                    ...prev,
+                    synthesizeAssistantMessage(
+                      messageId,
+                      parts,
+                      startedAt ? new Date(startedAt) : undefined,
+                    ),
+                  ],
             );
           })
           .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -648,14 +648,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
         setMessages((prev) =>
           prev.some((m) => m.id === messageId)
             ? prev
-            : [
-                ...prev,
-                synthesizeAssistantMessage(
-                  messageId,
-                  stream.parts,
-                  stream.startedAt ? new Date(stream.startedAt) : undefined,
-                ),
-              ],
+            : [...prev, synthesizeAssistantMessage(messageId, stream.parts, stream.startedAt)],
         );
         return;
       }
@@ -686,14 +679,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             setMessages((prev) =>
               prev.some((m) => m.id === messageId)
                 ? prev
-                : [
-                    ...prev,
-                    synthesizeAssistantMessage(
-                      messageId,
-                      parts,
-                      startedAt ? new Date(startedAt) : undefined,
-                    ),
-                  ],
+                : [...prev, synthesizeAssistantMessage(messageId, parts, startedAt)],
             );
           })
           .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -149,7 +149,11 @@ export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
       {inflightRemoteStreams.map((stream) => (
         <CompactMessageRenderer
           key={stream.messageId}
-          message={synthesizeAssistantMessage(stream.messageId, stream.parts)}
+          message={synthesizeAssistantMessage(
+            stream.messageId,
+            stream.parts,
+            stream.startedAt ? new Date(stream.startedAt) : undefined,
+          )}
           isStreaming
         />
       ))}
@@ -570,7 +574,7 @@ const SidebarChatTab: React.FC = () => {
         const ownStream = Array.from(usePendingStreamsStore.getState().streams.values())
           .find((s) => s.isOwn && s.conversationId === conversationId);
         const merged = ownStream
-          ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId)
+          ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt)
           : serverMessages;
         setGlobalMessages(merged);
         setGlobalMessagesLoadError(null);

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -149,11 +149,7 @@ export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
       {inflightRemoteStreams.map((stream) => (
         <CompactMessageRenderer
           key={stream.messageId}
-          message={synthesizeAssistantMessage(
-            stream.messageId,
-            stream.parts,
-            stream.startedAt ? new Date(stream.startedAt) : undefined,
-          )}
+          message={synthesizeAssistantMessage(stream.messageId, stream.parts, stream.startedAt)}
           isStreaming
         />
       ))}

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -110,6 +110,7 @@ const START_PAYLOAD: AiStreamStartPayload = {
   messageId: 'msg-1',
   pageId: 'page-a',
   conversationId: 'conv-1',
+  startedAt: '2024-01-01T00:00:00.000Z',
   triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
 };
 
@@ -198,6 +199,7 @@ describe('useChannelStreamSocket', () => {
         conversationId: 'conv-1',
         triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
         isOwn: false,
+        startedAt: '2024-01-01T00:00:00.000Z',
       });
       expect(mockConsumeStreamJoin).toHaveBeenCalledWith(
         'msg-1',
@@ -296,6 +298,7 @@ describe('useChannelStreamSocket', () => {
       expect(mockAddStream).toHaveBeenCalledWith(expect.objectContaining({
         messageId: 'msg-1',
         isOwn: false,
+        startedAt: '2024-01-01T00:00:00.000Z',
       }));
     });
   });

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -118,11 +118,7 @@ export function useAgentChannelMultiplayer({
       if (stream && stream.parts.length > 0 && stream.conversationId === agentConversationIdRef.current) {
         setLocalMessagesRef.current((prev) => [
           ...prev,
-          synthesizeAssistantMessage(
-            messageId,
-            stream.parts,
-            stream.startedAt ? new Date(stream.startedAt) : undefined,
-          ),
+          synthesizeAssistantMessage(messageId, stream.parts, stream.startedAt),
         ]);
         return;
       }

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -118,7 +118,11 @@ export function useAgentChannelMultiplayer({
       if (stream && stream.parts.length > 0 && stream.conversationId === agentConversationIdRef.current) {
         setLocalMessagesRef.current((prev) => [
           ...prev,
-          synthesizeAssistantMessage(messageId, stream.parts),
+          synthesizeAssistantMessage(
+            messageId,
+            stream.parts,
+            stream.startedAt ? new Date(stream.startedAt) : undefined,
+          ),
         ]);
         return;
       }

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -28,6 +28,8 @@ import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
 interface ActiveStreamRow {
   messageId: string;
   conversationId: string;
+  /** ISO timestamp of the stream's start; stamps synthesized bubbles with a `createdAt`. */
+  startedAt?: string;
   /** Last debounced snapshot persisted server-side — a prefix of the live multicast buffer, if still alive. */
   parts?: UIMessagePart[];
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
@@ -265,6 +267,7 @@ export function useChannelStreamSocket(
             triggeredBy: stream.triggeredBy,
             isOwn,
             parts: foldedParts,
+            startedAt: stream.startedAt,
           });
           if (isOwn) {
             ownStreamIds.add(stream.messageId);
@@ -295,6 +298,7 @@ export function useChannelStreamSocket(
         conversationId: payload.conversationId,
         triggeredBy: payload.triggeredBy,
         isOwn: false,
+        startedAt: payload.startedAt,
       });
 
       startConsume(payload.messageId, payload.conversationId);

--- a/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
@@ -131,6 +131,7 @@ describe('createStreamLifecycle', () => {
         displayName: 'Alice',
         browserSessionId: 'session-1',
         status: 'streaming',
+        startedAt: expect.any(Date),
       });
     });
 
@@ -174,13 +175,14 @@ describe('createStreamLifecycle', () => {
       expect(mockBroadcastStart).toHaveBeenCalled();
     });
 
-    it('given a successful start, should broadcast chat:stream_start with the full triggeredBy payload', async () => {
+    it('given a successful start, should broadcast chat:stream_start with the full triggeredBy payload and start time', async () => {
       await createStreamLifecycle(params());
 
       expect(mockBroadcastStart).toHaveBeenCalledWith({
         messageId: 'msg-1',
         pageId: 'page-1',
         conversationId: 'conv-1',
+        startedAt: expect.any(String),
         triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
       });
     });

--- a/apps/web/src/lib/ai/core/stream-lifecycle.ts
+++ b/apps/web/src/lib/ai/core/stream-lifecycle.ts
@@ -48,6 +48,10 @@ export const createStreamLifecycle = async (
     });
   }
 
+  // Captured once so the DB row and the broadcast agree on the stream's start
+  // time — remote surfaces stamp synthesized bubbles with this value.
+  const startedAt = new Date();
+
   try {
     await db
       .insert(aiStreamSessions)
@@ -59,6 +63,7 @@ export const createStreamLifecycle = async (
         displayName,
         browserSessionId,
         status: 'streaming',
+        startedAt,
       })
       .onConflictDoUpdate({
         target: aiStreamSessions.messageId,
@@ -69,7 +74,7 @@ export const createStreamLifecycle = async (
           displayName,
           browserSessionId,
           status: 'streaming',
-          startedAt: new Date(),
+          startedAt,
           completedAt: null,
           // A re-registered messageId gets a fresh (empty) in-memory buffer
           // above — the DB snapshot must reset with it, or a bootstrap
@@ -89,6 +94,7 @@ export const createStreamLifecycle = async (
     messageId,
     pageId: channelId,
     conversationId,
+    startedAt: startedAt.toISOString(),
     triggeredBy: { userId, displayName, browserSessionId },
   }).catch(() => {});
 

--- a/apps/web/src/lib/ai/streams/__tests__/mergeServerAndPending.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/mergeServerAndPending.test.ts
@@ -41,6 +41,21 @@ describe('mergeServerAndPending', () => {
     expect(result[0].id).toBe('pending-1');
   });
 
+  it('stamps the synthesized message with a createdAt derived from pendingStartedAt', () => {
+    const server = [makeMsg('m1', 'hello')];
+    const parts = [{ type: 'text' as const, text: 'streaming...' }];
+    const result = mergeServerAndPending(server, parts, 'pending-1', '2024-01-01T00:00:00.000Z');
+    const synthesized = result[1] as UIMessage & { createdAt?: Date };
+    expect(synthesized.createdAt).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+  });
+
+  it('omits createdAt when pendingStartedAt is absent', () => {
+    const server = [makeMsg('m1', 'hello')];
+    const parts = [{ type: 'text' as const, text: 'streaming...' }];
+    const result = mergeServerAndPending(server, parts, 'pending-1');
+    expect('createdAt' in result[1]).toBe(false);
+  });
+
   it('does not mutate the serverMessages array when appending', () => {
     const server = [makeMsg('m1', 'hello')];
     const parts = [{ type: 'text' as const, text: 'streaming...' }];

--- a/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
@@ -38,6 +38,19 @@ describe('synthesizeAssistantMessage', () => {
     expect(msg.parts.map((p) => p.type)).toEqual(['text', 'tool-list_pages']);
   });
 
+  it('given a createdAt, should attach it to the synthesized message', () => {
+    const createdAt = new Date('2024-01-01T00:00:00.000Z');
+    const msg = synthesizeAssistantMessage('msg-1', [{ type: 'text' as const, text: 'hi' }], createdAt);
+
+    expect(msg.createdAt).toBe(createdAt);
+  });
+
+  it('given no createdAt, should omit the field entirely (not set it to undefined)', () => {
+    const msg = synthesizeAssistantMessage('msg-1', []);
+
+    expect('createdAt' in msg).toBe(false);
+  });
+
   it('given the same input twice, should produce structurally equal messages but referentially independent parts arrays', () => {
     const parts = [{ type: 'text' as const, text: 'hi' }];
     const a = synthesizeAssistantMessage('msg-1', parts);

--- a/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
@@ -38,15 +38,20 @@ describe('synthesizeAssistantMessage', () => {
     expect(msg.parts.map((p) => p.type)).toEqual(['text', 'tool-list_pages']);
   });
 
-  it('given a createdAt, should attach it to the synthesized message', () => {
-    const createdAt = new Date('2024-01-01T00:00:00.000Z');
-    const msg = synthesizeAssistantMessage('msg-1', [{ type: 'text' as const, text: 'hi' }], createdAt);
+  it('given an ISO startedAt, should attach it as a createdAt Date', () => {
+    const msg = synthesizeAssistantMessage('msg-1', [{ type: 'text' as const, text: 'hi' }], '2024-01-01T00:00:00.000Z');
 
-    expect(msg.createdAt).toBe(createdAt);
+    expect(msg.createdAt).toEqual(new Date('2024-01-01T00:00:00.000Z'));
   });
 
-  it('given no createdAt, should omit the field entirely (not set it to undefined)', () => {
+  it('given no startedAt, should omit createdAt entirely (not set it to undefined)', () => {
     const msg = synthesizeAssistantMessage('msg-1', []);
+
+    expect('createdAt' in msg).toBe(false);
+  });
+
+  it('given an unparseable startedAt, should omit createdAt rather than attach an Invalid Date', () => {
+    const msg = synthesizeAssistantMessage('msg-1', [], 'not-a-date');
 
     expect('createdAt' in msg).toBe(false);
   });

--- a/apps/web/src/lib/ai/streams/mergeServerAndPending.ts
+++ b/apps/web/src/lib/ai/streams/mergeServerAndPending.ts
@@ -20,6 +20,5 @@ export const mergeServerAndPending = (
 ): UIMessage[] => {
   if (pendingMessageId === undefined) return serverMessages;
   if (serverMessages.some((m) => m.id === pendingMessageId)) return serverMessages;
-  const createdAt = pendingStartedAt ? new Date(pendingStartedAt) : undefined;
-  return [...serverMessages, synthesizeAssistantMessage(pendingMessageId, pendingParts, createdAt)];
+  return [...serverMessages, synthesizeAssistantMessage(pendingMessageId, pendingParts, pendingStartedAt)];
 };

--- a/apps/web/src/lib/ai/streams/mergeServerAndPending.ts
+++ b/apps/web/src/lib/ai/streams/mergeServerAndPending.ts
@@ -16,8 +16,10 @@ export const mergeServerAndPending = (
   serverMessages: UIMessage[],
   pendingParts: readonly UIMessagePart[],
   pendingMessageId: string | undefined,
+  pendingStartedAt?: string,
 ): UIMessage[] => {
   if (pendingMessageId === undefined) return serverMessages;
   if (serverMessages.some((m) => m.id === pendingMessageId)) return serverMessages;
-  return [...serverMessages, synthesizeAssistantMessage(pendingMessageId, pendingParts)];
+  const createdAt = pendingStartedAt ? new Date(pendingStartedAt) : undefined;
+  return [...serverMessages, synthesizeAssistantMessage(pendingMessageId, pendingParts, createdAt)];
 };

--- a/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
+++ b/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
@@ -8,20 +8,25 @@ type UIMessagePart = UIMessage['parts'][number];
  * real assistant message bubble (so MessageRenderer + ToolCallRenderer
  * render identically to the originator's view).
  *
- * When `createdAt` is provided (the stream's start time), it is attached so
- * the bubble carries a timestamp footer that matches its persisted neighbors;
- * omitted entirely when absent, so a synthesized bubble degrades to today's
- * timestamp-less behavior rather than an `Invalid Date`.
+ * When `startedAt` (the stream's ISO start time) is provided, it is attached
+ * as a `createdAt` Date so the bubble carries a timestamp footer that matches
+ * its persisted neighbors. It is omitted entirely when absent or unparseable,
+ * so a synthesized bubble degrades to today's timestamp-less behavior rather
+ * than rendering an `Invalid Date`.
  *
  * Pure — never mutates the input parts array.
  */
 export const synthesizeAssistantMessage = (
   messageId: string,
   parts: readonly UIMessagePart[],
-  createdAt?: Date,
-): UIMessage & { createdAt?: Date } => ({
-  id: messageId,
-  role: 'assistant',
-  parts: [...parts],
-  ...(createdAt ? { createdAt } : {}),
-});
+  startedAt?: string,
+): UIMessage & { createdAt?: Date } => {
+  const createdAt = startedAt ? new Date(startedAt) : undefined;
+  const validCreatedAt = createdAt && !Number.isNaN(createdAt.getTime()) ? createdAt : undefined;
+  return {
+    id: messageId,
+    role: 'assistant',
+    parts: [...parts],
+    ...(validCreatedAt ? { createdAt: validCreatedAt } : {}),
+  };
+};

--- a/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
+++ b/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
@@ -8,13 +8,20 @@ type UIMessagePart = UIMessage['parts'][number];
  * real assistant message bubble (so MessageRenderer + ToolCallRenderer
  * render identically to the originator's view).
  *
+ * When `createdAt` is provided (the stream's start time), it is attached so
+ * the bubble carries a timestamp footer that matches its persisted neighbors;
+ * omitted entirely when absent, so a synthesized bubble degrades to today's
+ * timestamp-less behavior rather than an `Invalid Date`.
+ *
  * Pure — never mutates the input parts array.
  */
 export const synthesizeAssistantMessage = (
   messageId: string,
   parts: readonly UIMessagePart[],
-): UIMessage => ({
+  createdAt?: Date,
+): UIMessage & { createdAt?: Date } => ({
   id: messageId,
   role: 'assistant',
   parts: [...parts],
+  ...(createdAt ? { createdAt } : {}),
 });

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -648,6 +648,7 @@ describe('socket-utils', () => {
         messageId: 'msg-1',
         pageId: 'page-1',
         conversationId: 'conv-1',
+        startedAt: '2024-01-01T00:00:00.000Z',
         triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
       };
 
@@ -668,6 +669,7 @@ describe('socket-utils', () => {
         messageId: 'msg-1',
         pageId: 'page-1',
         conversationId: 'conv-1',
+        startedAt: '2024-01-01T00:00:00.000Z',
         triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
       });
 
@@ -681,6 +683,7 @@ describe('socket-utils', () => {
         messageId: 'msg-1',
         pageId: 'page-1',
         conversationId: 'conv-1',
+        startedAt: '2024-01-01T00:00:00.000Z',
         triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
       })).resolves.not.toThrow();
     });

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -695,8 +695,13 @@ export interface AiStreamStartPayload {
   messageId: string;
   pageId: string;
   conversationId: string;
-  /** ISO timestamp of the stream's `aiStreamSessions.started_at`, so remote surfaces can stamp synthesized bubbles. */
-  startedAt: string;
+  /**
+   * ISO timestamp of the stream's `aiStreamSessions.started_at`, so remote
+   * surfaces can stamp synthesized bubbles. Optional for cross-version safety:
+   * during a rolling deploy an originator running the previous build emits this
+   * event without the field, and consumers degrade to a timestamp-less bubble.
+   */
+  startedAt?: string;
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -695,6 +695,8 @@ export interface AiStreamStartPayload {
   messageId: string;
   pageId: string;
   conversationId: string;
+  /** ISO timestamp of the stream's `aiStreamSessions.started_at`, so remote surfaces can stamp synthesized bubbles. */
+  startedAt: string;
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 

--- a/apps/web/src/stores/usePendingStreamsStore.ts
+++ b/apps/web/src/stores/usePendingStreamsStore.ts
@@ -11,6 +11,8 @@ export interface PendingStream {
   triggeredBy: { userId: string; displayName: string };
   parts: UIMessagePart[];
   isOwn: boolean;
+  /** ISO timestamp of the stream's start, used to stamp synthesized bubbles with a `createdAt`. */
+  startedAt?: string;
 }
 
 interface PendingStreamsState {


### PR DESCRIPTION
## Problem

Closes #1180.

When a remote AI stream renders on another user's screen, its bubble had no timestamp footer next to its timestamped neighbors — both while streaming and after completion, until a background conversation refresh swapped in the persisted DB row. This affected AiChatView, GlobalAssistantView agent mode, and SidebarChatTab.

`synthesizeAssistantMessage(messageId, parts)` returned `{ id, role, parts }` with **no `createdAt`**, and `MessageRenderer`/`CompactMessageRenderer` only show a bubble's timestamp footer when `message.createdAt` exists. Purely a visual-coherence bug; breaks no flow.

## Fix

Thread the stream's `startedAt` end-to-end:

`aiStreamSessions.started_at` (DB) → active-streams REST response **+** `chat:stream_start` socket payload → `PendingStream` store entry → `synthesizeAssistantMessage(..., startedAt)` → `MessageRenderer` timestamp footer.

**Correction to the issue body:** `startedAt` was *not* actually present on the active-streams response or the socket start payload — both are added here.

`synthesizeAssistantMessage` accepts the ISO `startedAt` string and normalizes it to a `createdAt` Date internally, with an Invalid-Date guard: a missing or unparseable timestamp omits `createdAt` entirely, so the bubble degrades to the prior timestamp-less behavior rather than rendering `Invalid Date`. Centralizing the conversion keeps all six callsites to a single `synthesizeAssistantMessage(id, parts, stream.startedAt)` call with no per-callsite date juggling.

### Changed files
- `lib/ai/core/stream-lifecycle.ts` — capture one `startedAt`, persist it on insert + conflict-update, and broadcast it
- `lib/websocket/socket-utils.ts` — `AiStreamStartPayload.startedAt`
- `app/api/ai/chat/active-streams/route.ts` — select + return `startedAt`
- `stores/usePendingStreamsStore.ts` — `PendingStream.startedAt`
- `hooks/useChannelStreamSocket.ts` — thread through both `addStream` calls (bootstrap + live socket)
- `lib/ai/streams/synthesizeAssistantMessage.ts` — accept ISO `startedAt`, normalize to `createdAt` Date + guard
- `lib/ai/streams/mergeServerAndPending.ts` — accept + forward `pendingStartedAt`
- `components/ai/shared/chat/ChatMessagesArea.tsx` — route live `visibleRemoteStreams` through the synthesizer so the main surfaces (AiChatView + GlobalAssistantView) stamp `createdAt` too (previously hand-built the message, missing `createdAt`)
- `hooks/useAgentChannelMultiplayer.ts`, `AiChatView.tsx`, `SidebarChatTab.tsx` — pass `stream.startedAt` at every synthesize callsite

## Known behavior / scope note

The synthesized bubble stamps the stream's **start** time. The persisted DB row records the message's persist time (stream **completion**), and the message-persistence path deliberately does not update `createdAt` on conflict. So when a remote observer's synthesized bubble is later replaced by the refetched DB row, the footer can shift forward by up to the stream's duration — visible only on the seconds-precision main-surface footer; the sidebar footer (HH:MM) is unchanged unless the stream crosses a minute boundary. This is **strictly better than the pre-fix behavior** (a blank footer that popped a timestamp in on refresh) and is purely cosmetic. Fully aligning the two would mean threading `startedAt` into the shared `saveMessageToDatabase` / `saveGlobalAssistantMessageToDatabase` completion path (used by many non-chat flows) and changing persisted `createdAt` semantics for all assistant messages — deliberately left as an out-of-scope follow-up to keep this fix off the billing-adjacent completion path.

## Testing

- `web typecheck` — clean (validates the threaded types across all files)
- `web lint` — clean on touched files (one pre-existing unrelated warning)
- Unit tests green (398 across the affected suites), incl. new cases in `synthesizeAssistantMessage` (ISO→Date, omit-when-absent, omit-on-unparseable), `mergeServerAndPending`, `ChatMessagesArea.remoteStreams`, `stream-lifecycle`, `socket-utils`, active-streams `route`, and `useChannelStreamSocket` asserting `startedAt`/`createdAt` are threaded through.
- Manual (not runnable in CI): two tabs/browsers on the same channel — the remote bubble now shows a timestamp footer matching its neighbors both while streaming and after completion (see the scope note above for the start-vs-persist-time nuance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rc4y514DeNakLU8vwkQb28
