### PR TITLE
feat(onprem): local passkey onboarding for admin-created users (#860)

### DIFF
--- a/apps/admin/src/app/api/admin/users/create/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/users/create/__tests__/route.test.ts
@@ -14,11 +14,15 @@ const {
   mockDbInsertValues,
   mockUserEmailMatch,
   mockPrepareUserWrite,
+  mockIsOnPrem,
+  mockGenerateSetupLink,
 } = vi.hoisted(() => ({
   mockDbFindFirst: vi.fn(),
   mockDbInsertValues: vi.fn().mockResolvedValue(undefined),
   mockUserEmailMatch: vi.fn((email: string) => ({ emailMatch: email })),
   mockPrepareUserWrite: vi.fn(async (values: Record<string, unknown>) => ({ ...values, emailBidx: 'bidx-of-' + values.email })),
+  mockIsOnPrem: vi.fn(() => false),
+  mockGenerateSetupLink: vi.fn(async () => 'http://web.local/api/auth/magic-link/verify?token=abc'),
 }));
 
 vi.mock('@pagespace/db/db', () => ({
@@ -38,7 +42,11 @@ vi.mock('@pagespace/lib/auth/user-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/deployment-mode', () => ({
-  isOnPrem: vi.fn(() => false),
+  isOnPrem: mockIsOnPrem,
+}));
+
+vi.mock('@pagespace/lib/auth/onprem-setup-link', () => ({
+  generateOnPremSetupLink: mockGenerateSetupLink,
 }));
 
 vi.mock('@pagespace/lib/onprem-defaults', () => ({
@@ -74,6 +82,8 @@ describe('POST /api/admin/users/create', () => {
     mockDbInsertValues.mockClear().mockResolvedValue(undefined);
     mockUserEmailMatch.mockClear();
     mockPrepareUserWrite.mockClear();
+    mockIsOnPrem.mockReset().mockReturnValue(false);
+    mockGenerateSetupLink.mockClear().mockResolvedValue('http://web.local/api/auth/magic-link/verify?token=abc');
   });
 
   it('checks for an existing user via the dual-lookup helper, not a raw equality match', async () => {
@@ -104,5 +114,29 @@ describe('POST /api/admin/users/create', () => {
     expect(mockDbInsertValues).toHaveBeenCalledWith(
       expect.objectContaining({ email: 'jane@example.com', emailBidx: 'bidx-of-jane@example.com' })
     );
+  });
+
+  it('on-prem: returns a one-time setup link so the credential-less user can bootstrap a passkey', async () => {
+    mockIsOnPrem.mockReturnValue(true);
+    mockDbFindFirst.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ name: 'Jane Doe', email: 'jane@example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(mockGenerateSetupLink).toHaveBeenCalledOnce();
+    expect(body.setupLink).toBe('http://web.local/api/auth/magic-link/verify?token=abc');
+  });
+
+  it('cloud/tenant: does not mint or return a setup link (email delivery works there)', async () => {
+    mockIsOnPrem.mockReturnValue(false);
+    mockDbFindFirst.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ name: 'Jane Doe', email: 'jane@example.com' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(mockGenerateSetupLink).not.toHaveBeenCalled();
+    expect(body.setupLink).toBeUndefined();
   });
 });

--- a/apps/admin/src/app/api/admin/users/create/route.ts
+++ b/apps/admin/src/app/api/admin/users/create/route.ts
@@ -5,6 +5,7 @@ import { users } from '@pagespace/db/schema/auth'
 import { createId } from '@paralleldrive/cuid2';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { getOnPremUserDefaults } from '@pagespace/lib/onprem-defaults';
+import { generateOnPremSetupLink } from '@pagespace/lib/auth/onprem-setup-link';
 import { userEmailMatch, prepareUserWrite } from '@pagespace/lib/auth/user-repository';
 import { withAdminAuth } from '@/lib/auth/auth';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
@@ -72,8 +73,31 @@ export const POST = withAdminAuth(async (adminUser, request) => {
       role,
     });
 
+    // On-prem has no outbound email, so the new user can't receive a magic-link
+    // email and has no passkey yet. Hand the admin a one-time setup link to pass
+    // to the user out-of-band; first sign-in funnels them into passkey enrollment.
+    let setupLink: string | undefined;
+    if (onPrem) {
+      try {
+        setupLink = await generateOnPremSetupLink(userId);
+        loggers.api.info('Issued on-prem setup link for admin-created user', {
+          adminId: adminUser.id,
+          newUserId: userId,
+        });
+      } catch (error) {
+        // The account exists regardless; surface creation success even if the
+        // link mint fails. The admin can re-issue via `bun run setup:admin`.
+        loggers.api.error('Failed to mint on-prem setup link', error as Error, { userId });
+      }
+    }
+
     return NextResponse.json(
-      { success: true, userId, message: `User ${normalizedEmail} created successfully` },
+      {
+        success: true,
+        userId,
+        message: `User ${normalizedEmail} created successfully`,
+        ...(setupLink ? { setupLink } : {}),
+      },
       { status: 201 }
     );
   } catch (error) {

--- a/apps/admin/src/app/api/admin/users/create/route.ts
+++ b/apps/admin/src/app/api/admin/users/create/route.ts
@@ -85,8 +85,11 @@ export const POST = withAdminAuth(async (adminUser, request) => {
           newUserId: userId,
         });
       } catch (error) {
-        // The account exists regardless; surface creation success even if the
-        // link mint fails. The admin can re-issue via `bun run setup:admin`.
+        // The account was created regardless; report success even if the link
+        // mint fails (rare — a DB error minting the token). The user simply has
+        // no first-login link yet; an admin re-issues one out-of-band. Note
+        // `setup:admin` is admin-only and would wrongly elevate a regular user,
+        // so it is NOT a valid re-issue path for role: 'user' accounts.
         loggers.api.error('Failed to mint on-prem setup link', error as Error, { userId });
       }
     }

--- a/apps/admin/src/components/admin/CreateUserForm.tsx
+++ b/apps/admin/src/components/admin/CreateUserForm.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Loader2, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Loader2, AlertCircle, CheckCircle2, Copy, Check } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 interface CreateUserFormProps {
@@ -25,11 +25,15 @@ export function CreateUserForm({ onSuccess }: CreateUserFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [setupLink, setSetupLink] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
     setSuccess(null);
+    setSetupLink(null);
+    setCopied(false);
 
     setIsSubmitting(true);
 
@@ -48,6 +52,9 @@ export function CreateUserForm({ onSuccess }: CreateUserFormProps) {
       }
 
       setSuccess(data.message || 'User created successfully');
+      if (typeof data.setupLink === 'string') {
+        setSetupLink(data.setupLink);
+      }
       setName('');
       setEmail('');
       setRole('user');
@@ -56,6 +63,18 @@ export function CreateUserForm({ onSuccess }: CreateUserFormProps) {
       setError('Network error. Please try again.');
     } finally {
       setIsSubmitting(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!setupLink) return;
+    try {
+      await navigator.clipboard.writeText(setupLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard can be unavailable (insecure context); the link is still
+      // selectable in the read-only input as a fallback.
     }
   }
 
@@ -71,6 +90,22 @@ export function CreateUserForm({ onSuccess }: CreateUserFormProps) {
         <div className="flex items-start gap-2 rounded-md border border-success/30 bg-success/10 p-3 text-sm text-success">
           <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
           <span>{success}</span>
+        </div>
+      )}
+
+      {setupLink && (
+        <div className="space-y-2 rounded-md border border-border bg-muted/40 p-3">
+          <p className="text-sm font-medium">One-time setup link</p>
+          <p className="text-xs text-muted-foreground">
+            Send this link to the user (expires in 60 minutes). On first sign-in
+            they&apos;ll register a passkey to secure their account.
+          </p>
+          <div className="flex items-center gap-2">
+            <Input readOnly value={setupLink} onFocus={(e) => e.target.select()} className="font-mono text-xs" />
+            <Button type="button" variant="outline" size="icon" onClick={handleCopy} aria-label="Copy setup link">
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </Button>
+          </div>
         </div>
       )}
 

--- a/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
+++ b/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
@@ -53,10 +53,10 @@ describe('AdminSeeder', () => {
       )
       expect(insertCall).toBeDefined()
       expect(insertCall![0]).not.toContain('password')
-      expect(insertCall![1]).toHaveLength(6) // id, email, name, role, emailBidx, emailVerified
+      expect(insertCall![1]).toHaveLength(5) // id, email, name, role, emailVerified
     })
 
-    test('given a new user, should set emailBidx + emailVerified columns (encryption-aware, pre-verified)', async () => {
+    test('given a new user, seeds plaintext + emailVerified and does NOT write a cross-key emailBidx', async () => {
       const db = makeMockDb(null)
       const connect = makeMockDbConnector(db)
       const seeder = createAdminSeeder({ connect })
@@ -70,14 +70,15 @@ describe('AdminSeeder', () => {
       const insertCall = (db.query as ReturnType<typeof vi.fn>).mock.calls.find(
         (call: unknown[]) => (call[0] as string).includes('INSERT')
       )
-      // Blind-index and email-verified columns are written so the seeded admin
-      // is findable by email and doesn't need a separate verification step.
-      expect(insertCall![0]).toContain('emailBidx')
+      // emailBidx is deliberately NOT written: the control-plane can't compute
+      // the tenant's blind index (per-tenant key it doesn't hold). emailVerified
+      // is pre-set so the admin needs no separate verification step.
+      expect(insertCall![0]).not.toContain('emailBidx')
       expect(insertCall![0]).toContain('emailVerified')
-      // Email is normalized (lowercased) at the write, matching every other create site.
+      // Email is normalized (lowercased) at the write.
       expect(insertCall![1][1]).toBe('owner@acme.com')
-      // emailVerified is a concrete timestamp (pre-verified on-prem/tenant admin).
-      expect(insertCall![1][5]).toBeInstanceOf(Date)
+      // emailVerified is a concrete timestamp (pre-verified tenant admin).
+      expect(insertCall![1][4]).toBeInstanceOf(Date)
     })
 
     test('given the seeder, should connect using the tenant database URL', async () => {
@@ -125,7 +126,7 @@ describe('AdminSeeder', () => {
         (call: unknown[]) => (call[0] as string).includes('INSERT')
       )
       expect(insertCall![0]).toContain('id')
-      expect(insertCall![1]).toHaveLength(6) // id, email, name, role, emailBidx, emailVerified
+      expect(insertCall![1]).toHaveLength(5) // id, email, name, role, emailVerified
       expect(typeof insertCall![1][0]).toBe('string')
       expect(insertCall![1][0].length).toBeGreaterThan(0)
     })

--- a/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
+++ b/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
@@ -133,6 +133,34 @@ describe('AdminSeeder', () => {
   })
 
   describe('idempotent seeding', () => {
+    test('given a legacy mixed-case admin row, matches case-insensitively so no duplicate is inserted', async () => {
+      // The old seeder inserted `ownerEmail` verbatim, so a pre-normalization
+      // tenant may hold a mixed-case admin row. The existence check must match
+      // it case-insensitively, else a re-run inserts a second admin.
+      const existingUser = { id: 'legacy-1', email: 'Owner@ACME.com', role: 'admin' }
+      const db = makeMockDb(existingUser)
+      const connect = makeMockDbConnector(db)
+      const seeder = createAdminSeeder({ connect })
+
+      const result = await seeder.seed({
+        slug: 'acme',
+        ownerEmail: 'Owner@ACME.com',
+        databaseUrl: 'postgres://localhost/ps_acme',
+      })
+
+      const selectCall = (db.query as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: unknown[]) => (call[0] as string).includes('SELECT')
+      )
+      expect(selectCall![0]).toContain('lower(email)')
+      // Lowercased param compared against lower(email) matches the legacy row.
+      expect(selectCall![1][0]).toBe('owner@acme.com')
+      expect(result.alreadyExisted).toBe(true)
+      const insertCall = (db.query as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: unknown[]) => (call[0] as string).includes('INSERT')
+      )
+      expect(insertCall).toBeUndefined()
+    })
+
     test('given an existing user with that email, should skip insert and return existing info', async () => {
       const existingUser = { id: 'existing-id', email: 'owner@acme.com', role: 'admin' }
       const db = makeMockDb(existingUser)

--- a/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
+++ b/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
@@ -53,7 +53,31 @@ describe('AdminSeeder', () => {
       )
       expect(insertCall).toBeDefined()
       expect(insertCall![0]).not.toContain('password')
-      expect(insertCall![1]).toHaveLength(4) // id, email, role, name
+      expect(insertCall![1]).toHaveLength(6) // id, email, name, role, emailBidx, emailVerified
+    })
+
+    test('given a new user, should set emailBidx + emailVerified columns (encryption-aware, pre-verified)', async () => {
+      const db = makeMockDb(null)
+      const connect = makeMockDbConnector(db)
+      const seeder = createAdminSeeder({ connect })
+
+      await seeder.seed({
+        slug: 'acme',
+        ownerEmail: 'Owner@ACME.com',
+        databaseUrl: 'postgres://localhost/ps_acme',
+      })
+
+      const insertCall = (db.query as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: unknown[]) => (call[0] as string).includes('INSERT')
+      )
+      // Blind-index and email-verified columns are written so the seeded admin
+      // is findable by email and doesn't need a separate verification step.
+      expect(insertCall![0]).toContain('emailBidx')
+      expect(insertCall![0]).toContain('emailVerified')
+      // Email is normalized (lowercased) at the write, matching every other create site.
+      expect(insertCall![1][1]).toBe('owner@acme.com')
+      // emailVerified is a concrete timestamp (pre-verified on-prem/tenant admin).
+      expect(insertCall![1][5]).toBeInstanceOf(Date)
     })
 
     test('given the seeder, should connect using the tenant database URL', async () => {
@@ -101,7 +125,7 @@ describe('AdminSeeder', () => {
         (call: unknown[]) => (call[0] as string).includes('INSERT')
       )
       expect(insertCall![0]).toContain('id')
-      expect(insertCall![1]).toHaveLength(4) // id, email, role, name
+      expect(insertCall![1]).toHaveLength(6) // id, email, name, role, emailBidx, emailVerified
       expect(typeof insertCall![1][0]).toBe('string')
       expect(insertCall![1][0].length).toBeGreaterThan(0)
     })

--- a/apps/control-plane/src/services/admin-seeder.ts
+++ b/apps/control-plane/src/services/admin-seeder.ts
@@ -40,8 +40,14 @@ export function createAdminSeeder(deps: AdminSeederDeps) {
         // it (re)computes `emailBidx`/ciphertext with the correct tenant key on
         // the next write to this user. Passwordless by design — the admin enrolls
         // a passkey or uses a magic link on first sign-in.
+        // Match case-insensitively (`lower(email)`) so re-runs stay idempotent
+        // even for tenants whose admin row was seeded before this normalization
+        // landed — the old seeder inserted `ownerEmail` verbatim, so a legacy row
+        // may hold mixed case (e.g. `Owner@ACME.com`). Postgres `text` equality is
+        // case-sensitive, so a plain `email = $1` on the lowercased value would
+        // miss that row and insert a duplicate admin.
         const existing = await db.query(
-          'SELECT id FROM users WHERE email = $1 LIMIT 1',
+          'SELECT id FROM users WHERE lower(email) = $1 LIMIT 1',
           [email]
         )
 

--- a/apps/control-plane/src/services/admin-seeder.ts
+++ b/apps/control-plane/src/services/admin-seeder.ts
@@ -1,9 +1,4 @@
 import { createId } from '@paralleldrive/cuid2'
-import {
-  prepareUserWrite,
-  getUserIndexKey,
-  userEmailLookupTargets,
-} from '@pagespace/lib/auth/user-repository'
 
 export type TenantDbConnection = {
   query(sql: string, params?: unknown[]): Promise<unknown[]>
@@ -32,46 +27,32 @@ export function createAdminSeeder(deps: AdminSeederDeps) {
       try {
         const email = input.ownerEmail.toLowerCase().trim()
 
-        // Look up by blind index first (the canonical email key), falling back
-        // to the plaintext `email` column for the no-key / not-yet-encrypted
-        // rollout state. Mirrors `buildUserEmailMatch` in the web app so a
-        // ciphertext-stored email is still found here.
-        const lookup = userEmailLookupTargets(email, getUserIndexKey())
-        const existing = lookup.emailBidx
-          ? await db.query(
-              'SELECT id FROM users WHERE "emailBidx" = $1 OR email = $2 LIMIT 1',
-              [lookup.emailBidx, lookup.email]
-            )
-          : await db.query('SELECT id FROM users WHERE email = $1 LIMIT 1', [lookup.email])
+        // Seed PLAINTEXT deliberately, and do NOT compute `emailBidx` here.
+        //
+        // This runs in the control-plane process but writes into the *tenant*
+        // database, whose `ENCRYPTION_KEY` is generated per-tenant and lives in
+        // the tenant web service — the control-plane doesn't have it. Deriving a
+        // blind index / ciphertext from the control-plane's own env would write
+        // values keyed to the wrong key, and the tenant app could then neither
+        // match by `emailBidx` nor decrypt the email (silent admin lockout).
+        // Plaintext + NULL `emailBidx` is safe: the tenant app's dual-lookup
+        // (`buildUserEmailMatch`) falls back to the plaintext `email` column, and
+        // it (re)computes `emailBidx`/ciphertext with the correct tenant key on
+        // the next write to this user. Passwordless by design — the admin enrolls
+        // a passkey or uses a magic link on first sign-in.
+        const existing = await db.query(
+          'SELECT id FROM users WHERE email = $1 LIMIT 1',
+          [email]
+        )
 
         if (existing.length > 0) {
           return { email, alreadyExisted: true }
         }
 
-        // Route through the shared write preparer so the seeded admin gets a
-        // blind-index (`emailBidx`) and PII encryption consistent with every
-        // other user-create site. Passwordless by design — the admin enrolls a
-        // passkey or uses a magic link on first sign-in. Degrades to plaintext
-        // + no emailBidx when the encryption env is absent.
-        const values = await prepareUserWrite({
-          id: createId(),
-          email,
-          name: 'Admin',
-          role: 'admin' as const,
-          emailVerified: new Date(),
-        })
-
         await db.query(
-          `INSERT INTO users (id, email, name, role, "emailBidx", "emailVerified")
-           VALUES ($1, $2, $3, $4, $5, $6)`,
-          [
-            values.id,
-            values.email,
-            values.name,
-            values.role,
-            values.emailBidx ?? null,
-            values.emailVerified,
-          ]
+          `INSERT INTO users (id, email, name, role, "emailVerified")
+           VALUES ($1, $2, $3, $4, $5)`,
+          [createId(), email, 'Admin', 'admin', new Date()]
         )
 
         return { email, alreadyExisted: false }

--- a/apps/control-plane/src/services/admin-seeder.ts
+++ b/apps/control-plane/src/services/admin-seeder.ts
@@ -1,4 +1,9 @@
 import { createId } from '@paralleldrive/cuid2'
+import {
+  prepareUserWrite,
+  getUserIndexKey,
+  userEmailLookupTargets,
+} from '@pagespace/lib/auth/user-repository'
 
 export type TenantDbConnection = {
   query(sql: string, params?: unknown[]): Promise<unknown[]>
@@ -25,23 +30,51 @@ export function createAdminSeeder(deps: AdminSeederDeps) {
     async seed(input: SeedInput): Promise<SeedResult> {
       const db = await deps.connect(input.databaseUrl)
       try {
-        const existing = await db.query(
-          'SELECT id, email FROM users WHERE email = $1 LIMIT 1',
-          [input.ownerEmail]
-        )
+        const email = input.ownerEmail.toLowerCase().trim()
+
+        // Look up by blind index first (the canonical email key), falling back
+        // to the plaintext `email` column for the no-key / not-yet-encrypted
+        // rollout state. Mirrors `buildUserEmailMatch` in the web app so a
+        // ciphertext-stored email is still found here.
+        const lookup = userEmailLookupTargets(email, getUserIndexKey())
+        const existing = lookup.emailBidx
+          ? await db.query(
+              'SELECT id FROM users WHERE "emailBidx" = $1 OR email = $2 LIMIT 1',
+              [lookup.emailBidx, lookup.email]
+            )
+          : await db.query('SELECT id FROM users WHERE email = $1 LIMIT 1', [lookup.email])
 
         if (existing.length > 0) {
-          return { email: input.ownerEmail, alreadyExisted: true }
+          return { email, alreadyExisted: true }
         }
 
-        const id = createId()
+        // Route through the shared write preparer so the seeded admin gets a
+        // blind-index (`emailBidx`) and PII encryption consistent with every
+        // other user-create site. Passwordless by design — the admin enrolls a
+        // passkey or uses a magic link on first sign-in. Degrades to plaintext
+        // + no emailBidx when the encryption env is absent.
+        const values = await prepareUserWrite({
+          id: createId(),
+          email,
+          name: 'Admin',
+          role: 'admin' as const,
+          emailVerified: new Date(),
+        })
 
         await db.query(
-          'INSERT INTO users (id, email, role, name) VALUES ($1, $2, $3, $4) RETURNING id, email, role',
-          [id, input.ownerEmail, 'admin', 'Admin']
+          `INSERT INTO users (id, email, name, role, "emailBidx", "emailVerified")
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [
+            values.id,
+            values.email,
+            values.name,
+            values.role,
+            values.emailBidx ?? null,
+            values.emailVerified,
+          ]
         )
 
-        return { email: input.ownerEmail, alreadyExisted: false }
+        return { email, alreadyExisted: false }
       } finally {
         await db.end()
       }

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -59,6 +59,14 @@ vi.mock('@pagespace/lib/auth/account-lockout', () => ({
   resetFailedLoginAttempts: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('@pagespace/lib/deployment-mode', () => ({
+  isOnPrem: vi.fn(() => false),
+}));
+
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+  userHasPasskey: vi.fn().mockResolvedValue(false),
+}));
+
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     auth: {
@@ -131,6 +139,8 @@ import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
 import { consumeAnyInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 import { resetFailedLoginAttempts } from '@pagespace/lib/auth/account-lockout';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { userHasPasskey } from '@pagespace/lib/auth/passkey-service';
 
 const createVerifyRequest = (token?: string) => {
   const url = token
@@ -154,6 +164,11 @@ describe('GET /api/auth/magic-link/verify', () => {
       data: { userId: 'test-user-id', isNewUser: false },
     });
     vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
+    // Default to cloud with the on-prem enrollment funnel OFF; `clearAllMocks`
+    // clears call history but not implementations, so re-assert them here to
+    // stop a per-test on-prem override from leaking into later tests.
+    vi.mocked(isOnPrem).mockReturnValue(false);
+    vi.mocked(userHasPasskey).mockResolvedValue(false);
     // @ts-expect-error - partial mock data
     vi.mocked(sessionService.validateSession).mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -817,6 +832,45 @@ describe('GET /api/auth/magic-link/verify', () => {
         expect.any(Error),
         expect.objectContaining({ userId: 'test-user-id' }),
       );
+    });
+  });
+
+  describe('on-prem passkey enrollment funnel', () => {
+    it('on-prem + no passkey: funnels to /auth/passkey-setup carrying the dashboard as next', async () => {
+      vi.mocked(isOnPrem).mockReturnValue(true);
+      vi.mocked(userHasPasskey).mockResolvedValue(false);
+
+      const response = await GET(createVerifyRequest('valid-token'));
+
+      expect(response.status).toBe(302);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/auth/passkey-setup');
+      expect(location).toContain(`next=${encodeURIComponent('/dashboard')}`);
+      expect(location).toContain('auth=success');
+      expect(userHasPasskey).toHaveBeenCalledWith('test-user-id');
+    });
+
+    it('on-prem + already has a passkey: lands on /dashboard, no enrollment detour', async () => {
+      vi.mocked(isOnPrem).mockReturnValue(true);
+      vi.mocked(userHasPasskey).mockResolvedValue(true);
+
+      const response = await GET(createVerifyRequest('valid-token'));
+
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard');
+      expect(location).not.toContain('/auth/passkey-setup');
+    });
+
+    it('cloud/tenant: never funnels to enrollment even with no passkey (short-circuits before the check)', async () => {
+      vi.mocked(isOnPrem).mockReturnValue(false);
+      vi.mocked(userHasPasskey).mockResolvedValue(false);
+
+      const response = await GET(createVerifyRequest('valid-token'));
+
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard');
+      expect(location).not.toContain('/auth/passkey-setup');
+      expect(userHasPasskey).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -344,9 +344,20 @@ export async function GET(req: Request) {
     // (on-prem has no password and no email delivery, so a passkey is their only
     // durable credential). Cloud/tenant are untouched. Enrollment is skippable
     // and forwards to `next`, so this never hard-blocks the user.
+    // Wrapped like every other post-session DB call in this handler: the session
+    // is already committed, so a transient failure on the passkey lookup must
+    // NOT fall through to the outer catch (which returns without the session
+    // cookie and bounces the user to signin — fatal on-prem, where there is no
+    // other login channel). On error, skip the funnel and use the normal redirect.
     let effectiveRedirectPath = redirectPath;
-    if (isOnPrem() && !(await userHasPasskey(userId))) {
-      effectiveRedirectPath = `/auth/passkey-setup?next=${encodeURIComponent(redirectPath)}`;
+    try {
+      if (isOnPrem() && !(await userHasPasskey(userId))) {
+        effectiveRedirectPath = `/auth/passkey-setup?next=${encodeURIComponent(redirectPath)}`;
+      }
+    } catch (error) {
+      loggers.auth.error('Passkey enrollment funnel check failed; using normal redirect', error as Error, {
+        userId,
+      });
     }
 
     const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -11,6 +11,8 @@ import {
   type MagicLinkMetadata,
 } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { userHasPasskey } from '@pagespace/lib/auth/passkey-service';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { resetFailedLoginAttempts } from '@pagespace/lib/auth/account-lockout';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -337,8 +339,18 @@ export async function GET(req: Request) {
               provisionedDriveId, next: safeNext, invitedDriveId,
             });
 
+    // On-prem onboarding funnel: a user who just signed in via an admin-issued
+    // setup link and has no passkey yet is sent to first-run passkey enrollment
+    // (on-prem has no password and no email delivery, so a passkey is their only
+    // durable credential). Cloud/tenant are untouched. Enrollment is skippable
+    // and forwards to `next`, so this never hard-blocks the user.
+    let effectiveRedirectPath = redirectPath;
+    if (isOnPrem() && !(await userHasPasskey(userId))) {
+      effectiveRedirectPath = `/auth/passkey-setup?next=${encodeURIComponent(redirectPath)}`;
+    }
+
     const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || new URL(req.url).origin;
-    const redirectUrl = new URL(redirectPath, baseUrl);
+    const redirectUrl = new URL(effectiveRedirectPath, baseUrl);
     redirectUrl.searchParams.set('auth', 'success');
     if (inviteResult?.kind === 'connection') {
       redirectUrl.searchParams.set('connection_requested', '1');

--- a/apps/web/src/app/auth/passkey-setup/page.tsx
+++ b/apps/web/src/app/auth/passkey-setup/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Suspense, useCallback, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { startRegistration } from "@simplewebauthn/browser";
+import { motion } from "motion/react";
+import { toast } from "sonner";
+import { Fingerprint, Key, Loader2 } from "lucide-react";
+import { AuthShell, useWebAuthnSupport } from "@/components/auth";
+import { Button } from "@/components/ui/button";
+import { fetchWithAuth } from "@/lib/auth/auth-fetch";
+import { isDesktopPlatform } from "@/lib/desktop-auth";
+import { isSafeNextPath, SIGNIN_NEXT_ALLOWED_PREFIXES } from "@/lib/auth/url-utils";
+
+/**
+ * First-run passkey enrollment. On-prem users arrive here right after their
+ * first sign-in via an admin-issued setup link (see the magic-link verify
+ * route), because on-prem has no password and no email delivery — a passkey is
+ * how they secure the account for future logins. Enrollment is encouraged but
+ * skippable so a user is never hard-blocked out of their own workspace.
+ */
+function PasskeySetupForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isSupported = useWebAuthnSupport();
+  const [isRegistering, setIsRegistering] = useState(false);
+
+  const rawNext = searchParams.get("next");
+  const nextPath =
+    rawNext && isSafeNextPath({ path: rawNext, allowedPrefixes: SIGNIN_NEXT_ALLOWED_PREFIXES })
+      ? rawNext
+      : "/dashboard";
+
+  const goNext = useCallback(() => {
+    router.replace(nextPath);
+  }, [router, nextPath]);
+
+  const handleRegister = useCallback(async () => {
+    // Electron's embedded Chromium can't drive platform authenticators without
+    // entitlements we don't ship — the desktop passkey flow lives in Settings
+    // (handoff to the system browser). Don't attempt the ceremony here.
+    if (isDesktopPlatform()) {
+      toast.info("Add a passkey from Settings → Account after signing in.");
+      goNext();
+      return;
+    }
+
+    setIsRegistering(true);
+    try {
+      const optionsRes = await fetchWithAuth("/api/auth/passkey/register/options", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!optionsRes.ok) {
+        const err = await optionsRes.json().catch(() => ({}));
+        toast.error(err.error || "Failed to start passkey registration");
+        return;
+      }
+
+      const { options } = await optionsRes.json();
+      const registrationResponse = await startRegistration({ optionsJSON: options });
+
+      const verifyRes = await fetchWithAuth("/api/auth/passkey/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          response: registrationResponse,
+          expectedChallenge: options.challenge,
+        }),
+      });
+
+      if (!verifyRes.ok) {
+        const err = await verifyRes.json().catch(() => ({}));
+        toast.error(err.error || "Failed to register passkey");
+        return;
+      }
+
+      toast.success("Passkey registered");
+      goNext();
+    } catch (err) {
+      if (err instanceof Error && err.name === "NotAllowedError") {
+        toast.error("Registration was cancelled");
+      } else if (err instanceof Error && err.name === "InvalidStateError") {
+        toast.error("This passkey is already registered");
+      } else {
+        toast.error("Passkey registration failed");
+      }
+    } finally {
+      setIsRegistering(false);
+    }
+  }, [goNext]);
+
+  return (
+    <AuthShell>
+      <motion.div
+        className="mb-8 text-center"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+          <Fingerprint className="h-6 w-6 text-muted-foreground" />
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Secure your account
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Register a passkey to sign in with your device&apos;s fingerprint, face,
+          or security key. This is how you&apos;ll log in from now on.
+        </p>
+      </motion.div>
+
+      {isSupported === false ? (
+        <div className="space-y-4 text-center">
+          <p className="text-sm text-muted-foreground">
+            This browser doesn&apos;t support passkeys. Continue for now and add a
+            passkey later from Settings → Account on a supported device.
+          </p>
+          <Button onClick={goNext} className="w-full">
+            Continue
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <Button
+            onClick={handleRegister}
+            disabled={isRegistering || isSupported === null}
+            className="w-full"
+          >
+            {isRegistering ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Registering...
+              </>
+            ) : (
+              <>
+                <Key className="mr-2 h-4 w-4" />
+                Register a passkey
+              </>
+            )}
+          </Button>
+          <button
+            type="button"
+            onClick={goNext}
+            className="w-full text-center text-sm text-muted-foreground hover:text-foreground"
+          >
+            Skip for now
+          </button>
+        </div>
+      )}
+    </AuthShell>
+  );
+}
+
+export default function PasskeySetupPage() {
+  return (
+    <Suspense fallback={null}>
+      <PasskeySetupForm />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -143,12 +143,13 @@ function SignInForm() {
           </motion.div>
         )}
 
-        <AuthDivider delay={0.3} />
-
-        <MagicLinkForm
-          {...(nextPath && { nextPath })}
-          {...(inviteToken && { inviteToken })}
-        />
+        {/* On-prem has no outbound email and no self-registration, so magic-link
+            sign-in can't be delivered. Passkeys are the only credential; a new
+            user's first passkey is enrolled from a one-time admin-issued setup
+            link (see the admin user-creation flow). */}
+        <p className="mt-6 text-center text-sm text-muted-foreground">
+          No passkey yet? Ask your administrator for a one-time setup link.
+        </p>
       </AuthShell>
     );
   }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -232,6 +232,11 @@
       "import": "./dist/auth/user-repository.js",
       "require": "./dist/auth/user-repository.js"
     },
+    "./auth/onprem-setup-link": {
+      "types": "./dist/auth/onprem-setup-link.d.ts",
+      "import": "./dist/auth/onprem-setup-link.js",
+      "require": "./dist/auth/onprem-setup-link.js"
+    },
     "./auth/token-lifecycle-policy": {
       "types": "./dist/auth/token-lifecycle-policy.d.ts",
       "import": "./dist/auth/token-lifecycle-policy.js",
@@ -1696,6 +1701,12 @@
       ],
       "auth/verification-utils": [
         "./dist/auth/verification-utils.d.ts"
+      ],
+      "auth/user-repository": [
+        "./dist/auth/user-repository.d.ts"
+      ],
+      "auth/onprem-setup-link": [
+        "./dist/auth/onprem-setup-link.d.ts"
       ],
       "services/email-service": [
         "./dist/services/email-service.d.ts"

--- a/packages/lib/src/auth/__tests__/onprem-setup-link.test.ts
+++ b/packages/lib/src/auth/__tests__/onprem-setup-link.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression guard for the on-prem setup-link token format.
+ *
+ * The verify route (`magic-link-service.verifyMagicLinkToken`) rejects any token
+ * that does not start with `ps_magic_`. A bare `createVerificationToken` hex
+ * token therefore always fails with `invalid_token`, which would leave
+ * credential-less on-prem users unable to bootstrap a passkey. These tests lock
+ * the helper to the `ps_magic_` mint + `verificationTokens` persistence used by
+ * the real magic-link send flow.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const insertValues = vi.fn();
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    insert: vi.fn(() => ({ values: insertValues })),
+  },
+}));
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  verificationTokens: {
+    id: 'id',
+    userId: 'userId',
+    tokenHash: 'tokenHash',
+    tokenPrefix: 'tokenPrefix',
+    type: 'type',
+    expiresAt: 'expiresAt',
+  },
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn(() => 'test-cuid'),
+  init: vi.fn(() => vi.fn(() => 'test-cuid')),
+}));
+
+import { generateOnPremSetupLink } from '../onprem-setup-link';
+
+describe('generateOnPremSetupLink', () => {
+  beforeEach(() => {
+    insertValues.mockReset().mockResolvedValue(undefined);
+    vi.stubEnv('WEB_APP_URL', 'https://onprem.local');
+  });
+
+  it('mints a ps_magic_-prefixed token so the verify route accepts it', async () => {
+    const link = await generateOnPremSetupLink('user-1');
+
+    const url = new URL(link);
+    const token = url.searchParams.get('token')!;
+    expect(token.startsWith('ps_magic_')).toBe(true);
+  });
+
+  it('persists the token as a magic_link verificationTokens row for the user', async () => {
+    await generateOnPremSetupLink('user-1');
+
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    const row = insertValues.mock.calls[0][0];
+    expect(row).toMatchObject({ userId: 'user-1', type: 'magic_link' });
+    // Stores the HASH, never the plaintext token.
+    expect(typeof row.tokenHash).toBe('string');
+    expect(row.tokenHash.startsWith('ps_magic_')).toBe(false);
+    expect(row.expiresAt).toBeInstanceOf(Date);
+    expect(row.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('points the link at the web app verify endpoint', async () => {
+    const link = await generateOnPremSetupLink('user-1');
+    expect(link.startsWith('https://onprem.local/api/auth/magic-link/verify?token=')).toBe(true);
+  });
+});

--- a/packages/lib/src/auth/onprem-setup-link.ts
+++ b/packages/lib/src/auth/onprem-setup-link.ts
@@ -1,0 +1,30 @@
+import { createVerificationToken } from './verification-utils';
+
+/**
+ * Mint a one-time sign-in ("setup") link for on-prem onboarding.
+ *
+ * On-prem deployments disable outbound email (see {@link import('../services/email-service')}),
+ * so admin-created users can't receive a magic-link email and have no passkey yet. This produces a
+ * magic-link **verify** URL that works fully offline — only the magic-link *send* route needs email.
+ * An operator hands the link to the user out-of-band; on first sign-in the user is funnelled to
+ * passkey enrollment (`/auth/passkey-setup`).
+ *
+ * Used by both `scripts/setup-onprem-admin.ts` (CLI bootstrap) and the admin user-creation route so
+ * the token type, TTL, and URL shape stay in one place.
+ *
+ * The link points at the **web app** (where `/api/auth/magic-link/verify` lives), not the admin app,
+ * so the base URL prefers the web app env vars.
+ */
+export async function generateOnPremSetupLink(userId: string): Promise<string> {
+  const token = await createVerificationToken({
+    userId,
+    type: 'magic_link',
+    expiresInMinutes: 60,
+  });
+  const baseUrl =
+    process.env.WEB_APP_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    'http://localhost:3000';
+  return `${baseUrl.replace(/\/$/, '')}/api/auth/magic-link/verify?token=${token}`;
+}

--- a/packages/lib/src/auth/onprem-setup-link.ts
+++ b/packages/lib/src/auth/onprem-setup-link.ts
@@ -1,4 +1,10 @@
-import { createVerificationToken } from './verification-utils';
+import { createId } from '@paralleldrive/cuid2';
+import { db } from '@pagespace/db/db';
+import { verificationTokens } from '@pagespace/db/schema/auth';
+import { generateToken } from './token-utils';
+
+/** Setup links stay valid for 60 minutes — long enough to hand off out-of-band. */
+const SETUP_LINK_EXPIRY_MINUTES = 60;
 
 /**
  * Mint a one-time sign-in ("setup") link for on-prem onboarding.
@@ -12,19 +18,32 @@ import { createVerificationToken } from './verification-utils';
  * Used by both `scripts/setup-onprem-admin.ts` (CLI bootstrap) and the admin user-creation route so
  * the token type, TTL, and URL shape stay in one place.
  *
+ * The token MUST be minted the same way the real magic-link send flow mints it
+ * (`generateToken('ps_magic')` persisted to `verificationTokens` with `type: 'magic_link'`): the
+ * verify route's schema rejects any token that does not start with `ps_magic_`, so a bare
+ * `createVerificationToken` hex token would always redirect with `invalid_token`. See
+ * `magic-link-service.verifyMagicLinkToken` and the `createTokenAndPersist` adapter.
+ *
  * The link points at the **web app** (where `/api/auth/magic-link/verify` lives), not the admin app,
  * so the base URL prefers the web app env vars.
  */
 export async function generateOnPremSetupLink(userId: string): Promise<string> {
-  const token = await createVerificationToken({
+  const { token, hash, tokenPrefix } = generateToken('ps_magic');
+  const expiresAt = new Date(Date.now() + SETUP_LINK_EXPIRY_MINUTES * 60 * 1000);
+
+  await db.insert(verificationTokens).values({
+    id: createId(),
     userId,
+    tokenHash: hash,
+    tokenPrefix,
     type: 'magic_link',
-    expiresInMinutes: 60,
+    expiresAt,
   });
+
   const baseUrl =
     process.env.WEB_APP_URL ||
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.NEXTAUTH_URL ||
     'http://localhost:3000';
-  return `${baseUrl.replace(/\/$/, '')}/api/auth/magic-link/verify?token=${token}`;
+  return `${baseUrl.replace(/\/$/, '')}/api/auth/magic-link/verify?token=${encodeURIComponent(token)}`;
 }

--- a/packages/lib/src/auth/passkey-service.ts
+++ b/packages/lib/src/auth/passkey-service.ts
@@ -502,6 +502,20 @@ export async function findUserIdByCredentialId(credentialId: string): Promise<st
   return passkey?.userId ?? null;
 }
 
+/**
+ * True if the user has at least one registered passkey. A light existence check
+ * (single-row lookup, no crypto) used to decide whether to funnel a freshly
+ * signed-in on-prem user into first-run passkey enrollment.
+ */
+export async function userHasPasskey(userId: string): Promise<boolean> {
+  if (!userId) return false;
+  const passkey = await db.query.passkeys.findFirst({
+    where: eq(passkeys.userId, userId),
+    columns: { id: true },
+  });
+  return passkey !== undefined;
+}
+
 export async function verifyAuthentication(input: unknown): Promise<VerifyAuthResult> {
   const parsed = verifyAuthSchema.safeParse(input);
   if (!parsed.success) {

--- a/packages/lib/src/deployment-mode.ts
+++ b/packages/lib/src/deployment-mode.ts
@@ -9,7 +9,9 @@
  *                      infrastructure topology and billing path (control plane, not Stripe).
  *   onprem           — Self-hosted. Restricts cloud integrations: no Google Calendar,
  *                      no external AI providers (only ollama/lmstudio/azure_openai),
- *                      no OAuth login, no Stripe, no self-registration. Password auth only.
+ *                      no OAuth login, no Stripe, no self-registration. Sign-in is
+ *                      passkey-based, bootstrapped by admin-issued one-time setup links
+ *                      (outbound email is disabled, so magic-link email can't be sent).
  *
  * Guard selection:
  *   isOnPrem()        — gate cloud integrations (Calendar, AI providers). Tenant keeps them.

--- a/scripts/__tests__/setup-onprem-admin.test.ts
+++ b/scripts/__tests__/setup-onprem-admin.test.ts
@@ -47,8 +47,14 @@ vi.mock('@pagespace/lib/onprem-defaults', () => ({
   getOnPremUserDefaults: vi.fn(() => ({ subscriptionTier: 'business' })),
 }));
 
-vi.mock('@pagespace/lib/auth/verification-utils', () => ({
-  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
+// The script now delegates one-time link minting to the shared
+// `generateOnPremSetupLink` helper (which touches the DB). Mock it so this test
+// stays focused on the script's dual-lookup / prepareUserWrite behavior; the
+// helper's own token format is covered by onprem-setup-link.test.ts.
+vi.mock('@pagespace/lib/auth/onprem-setup-link', () => ({
+  generateOnPremSetupLink: vi
+    .fn()
+    .mockResolvedValue('http://localhost:3000/api/auth/magic-link/verify?token=ps_magic_mock'),
 }));
 
 vi.mock('@paralleldrive/cuid2', () => ({

--- a/scripts/setup-onprem-admin.ts
+++ b/scripts/setup-onprem-admin.ts
@@ -16,19 +16,9 @@ import { users } from '@pagespace/db/schema/auth';
 import { eq } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
 import { getOnPremUserDefaults } from '@pagespace/lib/onprem-defaults';
-import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { generateOnPremSetupLink } from '@pagespace/lib/auth/onprem-setup-link';
 import { userEmailMatch, prepareUserWrite } from '@pagespace/lib/auth/user-repository';
 import { parseArgs } from 'node:util';
-
-async function generateSetupLink(userId: string): Promise<string> {
-  const token = await createVerificationToken({
-    userId,
-    type: 'magic_link',
-    expiresInMinutes: 60,
-  });
-  const baseUrl = process.env.NEXTAUTH_URL || process.env.WEB_APP_URL || 'http://localhost:3000';
-  return `${baseUrl}/api/auth/magic-link/verify?token=${token}`;
-}
 
 async function main() {
   const { values } = parseArgs({
@@ -71,7 +61,7 @@ async function main() {
 
   if (existing) {
     if (existing.role === 'admin') {
-      const link = await generateSetupLink(existing.id);
+      const link = await generateOnPremSetupLink(existing.id);
       console.log(`Admin user ${email} already exists.`);
       console.log('');
       console.log('One-time sign-in link (expires in 60 minutes):');
@@ -82,7 +72,7 @@ async function main() {
         .set({ role: 'admin', ...getOnPremUserDefaults() })
         .where(eq(users.id, existing.id));
 
-      const link = await generateSetupLink(existing.id);
+      const link = await generateOnPremSetupLink(existing.id);
       console.log(`Existing user ${email} promoted to admin with business tier.`);
       console.log('');
       console.log('One-time sign-in link (expires in 60 minutes):');
@@ -102,7 +92,7 @@ async function main() {
     ...getOnPremUserDefaults(),
   }));
 
-  const link = await generateSetupLink(userId);
+  const link = await generateOnPremSetupLink(userId);
 
   console.log('');
   console.log('Admin user created successfully!');


### PR DESCRIPTION
Closes #860.

## Context

#860 asked to "implement local passkey auth to replace password login" for on-prem. On investigation, **password auth was already fully removed** on this branch and a complete, production-grade passkey system already existed (`passkey-service.ts` + routes + UI + desktop handoff). The real remaining work was closing the **on-prem onboarding gaps** that password removal left behind.

## What was broken

1. **Admin-created on-prem users were stranded** — `POST /api/admin/users/create` created a user with no credential, but on-prem disables outbound email (`email-service.ts` short-circuits when `isOnPrem()`) and the user had no passkey yet → **no working first-login path**. The CLI (`setup-onprem-admin.ts`) already solved this by printing an offline magic-link *verify* URL, but the admin web UI had no equivalent.
2. **On-prem signin rendered a magic-link email form that silently failed** (email disabled).
3. **`admin-seeder.ts`** created users but the tenant couldn't reliably find them by blind index.
4. Stale "Password auth only" docs.

## Changes

- **Shared setup-link helper** — new `packages/lib/src/auth/onprem-setup-link.ts` (`generateOnPremSetupLink`), extracted from the inline copy in `setup-onprem-admin.ts`. Mints a `ps_magic_`-prefixed token via `generateToken('ps_magic')` persisted to `verificationTokens` with `type: 'magic_link'` — the same primitive the real magic-link send flow uses, so the verify route accepts it. Produces an offline-working *verify* URL.
- **Admin bootstrap link** — on-prem, `/api/admin/users/create` mints and returns a one-time `setupLink`; `CreateUserForm` shows it in a copyable field for the admin to hand off.
- **First-login enrollment** — new `/auth/passkey-setup` page (reuses the existing register endpoints + `startRegistration`, skippable). `magic-link/verify` funnels on-prem zero-passkey users there via a light `userHasPasskey()` helper. Cloud/tenant untouched.
- **Passkey-only on-prem signin** — removed the dead magic-link form from the on-prem branch; added "ask your admin for a setup link" guidance.
- **Seeder fix** — `admin-seeder.ts` now seeds passwordless + pre-verified (`emailVerified`) plaintext. It deliberately does NOT compute `emailBidx` from the control-plane's env: it writes into the *tenant* DB (per-tenant key the control-plane doesn't hold), and the tenant's dual-lookup finds the plaintext email and recomputes the index with the correct key on next write.
- Docs fix in `deployment-mode.ts`; added the missing `@pagespace/lib` `exports`/`typesVersions` entries.

## Review fixes

- **P1 (Codex)** — setup links minted a bare-hex token via `createVerificationToken`, which `verifyMagicLinkToken` rejects (`ps_magic_` prefix required), so every link would 302 to `invalid_token`. Fixed by minting `ps_magic_` tokens the way the real send flow does (also repairs the pre-existing bug in `setup-onprem-admin.ts`). Added `onprem-setup-link.test.ts`.
- **P2 (self-review)** — the on-prem `userHasPasskey()` funnel check in `magic-link/verify` ran after the session was committed but wasn't wrapped in try/catch; a DB blip fell through to the outer catch and bounced the user to signin *without* a session cookie (fatal on-prem). Now wrapped, defaulting to the normal redirect on error.
- **P3 (self-review)** — seeder cross-key hazard (above); corrected a misleading re-issue comment in the admin route.
- **P4 (Codex)** — seeder idempotency across the email normalization: the new seeder lowercases `ownerEmail`, but the prior seeder inserted it verbatim, so a legacy tenant admin row could hold mixed case. A case-sensitive `email = $1` lookup on the lowercased value would miss it and insert a duplicate admin. Now matches on `lower(email) = $1`; added a legacy-mixed-case regression test.

## Validation

- **Typecheck** all packages · **Lint** clean (only pre-existing warnings elsewhere)
- **Unit tests**: onprem-setup-link 3/3 (ps_magic_ prefix + row shape), admin-seeder 10/10, admin create-route 5/5, magic-link verify 47/47 (on-prem funnel), desktop-verify 9/9, full passkey suite 171/171

Full E2E `DEPLOYMENT_MODE=onprem` needs a live stack + DB (not available in the worktree); on-prem logic is covered by the new/updated unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019c3hAuhaVgv3XcotshzYmZ
