### PR TITLE
fix(notifications): iOS permission-prompt race + Electron desktop OS notifications

### DIFF
--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -145,7 +145,7 @@ const TOAST_LEVEL_OPTIONS: Array<{ value: ToastNotificationLevel; label: string;
   {
     value: 'all',
     label: 'All notifications',
-    description: 'Show a pop-up for every notification (mentions, tasks, DMs, permissions, and more).',
+    description: 'Show a pop-up for every notification (mentions, tasks, DMs, permissions, and more). On the desktop app, this also governs native system notifications when the window is unfocused.',
   },
   {
     value: 'mentions',

--- a/apps/web/src/components/PushNotificationManager.tsx
+++ b/apps/web/src/components/PushNotificationManager.tsx
@@ -18,22 +18,18 @@ export function PushNotificationManager() {
 
   useEffect(() => {
     if (!isNative || !isSupported) return;
-
+    // Wait until native checkPermissions() has resolved — don't burn the guard on 'unknown'.
+    if (permissionStatus === 'unknown') return;
     // Prevent multiple attempts in strict mode dev
     if (attemptRef.current) return;
     attemptRef.current = true;
 
-    const initNotifications = async () => {
-      if (permissionStatus === 'prompt') {
-        await requestPermission();
-      } else if (permissionStatus === 'granted' && !isRegistered) {
-        await registerToken();
-      }
-    };
-
-    // Small delay to ensure Capacitor is fully ready
-    const timer = setTimeout(initNotifications, 1000);
-    return () => clearTimeout(timer);
+    if (permissionStatus === 'prompt') {
+      void requestPermission();
+    } else if (permissionStatus === 'granted' && !isRegistered) {
+      void registerToken();
+    }
+    // 'denied': burn the attempt, do nothing — user must enable in iOS Settings.
   }, [isNative, isSupported, permissionStatus, isRegistered, requestPermission, registerToken]);
 
   return null;

--- a/apps/web/src/components/__tests__/PushNotificationManager.test.tsx
+++ b/apps/web/src/components/__tests__/PushNotificationManager.test.tsx
@@ -29,7 +29,6 @@ const defaultPushState = {
 
 describe('PushNotificationManager', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.clearAllMocks();
 
     mockUseCapacitor.mockReturnValue({ isNative: true });
@@ -37,14 +36,13 @@ describe('PushNotificationManager', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('given non-native environment, should not call requestPermission or registerToken', async () => {
     mockUseCapacitor.mockReturnValue({ isNative: false });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(defaultPushState.requestPermission).not.toHaveBeenCalled();
     expect(defaultPushState.registerToken).not.toHaveBeenCalled();
@@ -57,13 +55,12 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(defaultPushState.requestPermission).not.toHaveBeenCalled();
     expect(defaultPushState.registerToken).not.toHaveBeenCalled();
   });
 
-  it('given native + supported + permission prompt, should call requestPermission after delay', async () => {
+  it('given native + supported + permission prompt, should call requestPermission immediately', async () => {
     const requestPermission = vi.fn().mockResolvedValue(true);
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
@@ -72,12 +69,11 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(requestPermission).toHaveBeenCalledOnce();
   });
 
-  it('given native + supported + permission granted + not registered, should call registerToken after delay', async () => {
+  it('given native + supported + permission granted + not registered, should call registerToken immediately', async () => {
     const registerToken = vi.fn().mockResolvedValue(true);
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
@@ -87,7 +83,6 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(registerToken).toHaveBeenCalledOnce();
   });
@@ -102,7 +97,6 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(registerToken).not.toHaveBeenCalled();
     expect(defaultPushState.requestPermission).not.toHaveBeenCalled();
@@ -119,7 +113,6 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(requestPermission).not.toHaveBeenCalled();
     expect(registerToken).not.toHaveBeenCalled();
@@ -131,20 +124,52 @@ describe('PushNotificationManager', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('should clean up timer on unmount before it fires', async () => {
+  it('regression: does not burn the attempt guard while permissionStatus is unknown, then prompts exactly once when it resolves to prompt', () => {
     const requestPermission = vi.fn().mockResolvedValue(true);
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'unknown',
+      requestPermission,
+    });
+
+    const { rerender } = render(<PushNotificationManager />);
+    expect(requestPermission).not.toHaveBeenCalled();
+
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
       permissionStatus: 'prompt',
       requestPermission,
     });
+    rerender(<PushNotificationManager />);
+    expect(requestPermission).toHaveBeenCalledOnce();
 
-    const { unmount } = render(<PushNotificationManager />);
+    // Further rerenders (e.g. unrelated state changes) must not re-trigger the prompt.
+    rerender(<PushNotificationManager />);
+    expect(requestPermission).toHaveBeenCalledOnce();
+  });
 
-    await vi.advanceTimersByTimeAsync(500);
-    unmount();
-    await vi.advanceTimersByTimeAsync(500);
+  it('regression: denied never calls requestPermission or registerToken, even after transitioning through unknown', () => {
+    const requestPermission = vi.fn().mockResolvedValue(false);
+    const registerToken = vi.fn().mockResolvedValue(false);
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'unknown',
+      requestPermission,
+      registerToken,
+    });
+
+    const { rerender } = render(<PushNotificationManager />);
+    expect(requestPermission).not.toHaveBeenCalled();
+
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'denied',
+      requestPermission,
+      registerToken,
+    });
+    rerender(<PushNotificationManager />);
 
     expect(requestPermission).not.toHaveBeenCalled();
+    expect(registerToken).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useSocket } from "@/hooks/useSocket";
 import { useAccessRevocation } from "@/hooks/useAccessRevocation";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
+import { useDesktopNotifications } from "@/hooks/useDesktopNotifications";
 import TopBar from "@/components/layout/main-header";
 import MemoizedSidebar from "@/components/layout/left-sidebar/MemoizedSidebar";
 import CenterPanel from "@/components/layout/middle-content/CenterPanel";
@@ -132,6 +133,9 @@ function Layout({ children }: LayoutProps) {
 
   // Show live toast popups for new notifications, anywhere in the app
   useNotificationToasts();
+
+  // Show native OS notifications for new notifications when the desktop app is unfocused
+  useDesktopNotifications();
 
   // Monitor performance
   usePerformanceMonitor();

--- a/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { LegacyNotification } from '@pagespace/lib/notifications/types';
+
+const { mockPush, mockHandleNotificationRead } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockHandleNotificationRead: vi.fn().mockResolvedValue(undefined),
+}));
+
+let mockToastLevel: 'all' | 'mentions' | 'off' = 'all';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/hooks/useToastPreferences', () => ({
+  useToastPreferences: () => ({
+    level: mockToastLevel,
+    isLoading: false,
+    updateLevel: vi.fn(),
+  }),
+}));
+
+import { useDesktopNotifications } from '../useDesktopNotifications';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+
+type TestNotification = LegacyNotification & { title: string; message: string };
+
+function build(overrides: Partial<TestNotification> = {}): TestNotification {
+  return {
+    id: 'notif-1',
+    userId: 'user-1',
+    type: 'MENTION',
+    title: 'You were mentioned',
+    message: 'Jonathan mentioned you in "Roadmap"',
+    isRead: false,
+    createdAt: new Date(),
+    metadata: { mentionerName: 'Jonathan', pageTitle: 'Roadmap', pageType: 'DOCUMENT' },
+    pageId: 'page-1',
+    driveId: 'drive-1',
+    ...overrides,
+  };
+}
+
+class MockNotification {
+  static permission: NotificationPermission = 'granted';
+  static instances: MockNotification[] = [];
+
+  onclick: (() => void) | null = null;
+  title: string;
+  options?: NotificationOptions;
+  close = vi.fn();
+
+  constructor(title: string, options?: NotificationOptions) {
+    this.title = title;
+    this.options = options;
+    MockNotification.instances.push(this);
+  }
+}
+
+describe('useDesktopNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastLevel = 'all';
+    useNotificationStore.setState({
+      notifications: [],
+      unreadCount: 0,
+      handleNotificationRead: mockHandleNotificationRead,
+    });
+
+    MockNotification.permission = 'granted';
+    MockNotification.instances = [];
+    // @ts-expect-error -- test stub replaces global Notification constructor
+    global.Notification = MockNotification;
+
+    // @ts-expect-error -- test stub for Electron desktop detection
+    window.electron = { isDesktop: true };
+
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    vi.spyOn(window, 'focus').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.electron;
+    // @ts-expect-error -- cleanup test stub
+    delete global.Notification;
+  });
+
+  it('does not construct a Notification when not on desktop', () => {
+    delete window.electron;
+
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(MockNotification.instances).toHaveLength(0);
+  });
+
+  it('does not construct a Notification when permission is not granted', () => {
+    MockNotification.permission = 'default';
+
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(MockNotification.instances).toHaveLength(0);
+  });
+
+  it('does not construct a Notification when the window is focused', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(MockNotification.instances).toHaveLength(0);
+  });
+
+  it('constructs a Notification with title/body/tag when unfocused and eligible', () => {
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(MockNotification.instances).toHaveLength(1);
+    expect(MockNotification.instances[0].title).toBe('You were mentioned');
+    expect(MockNotification.instances[0].options).toEqual({
+      body: 'Jonathan mentioned you in "Roadmap"',
+      tag: 'notif-1',
+    });
+  });
+
+  it('constructs only once for the same id + same signature', () => {
+    renderHook(() => useDesktopNotifications());
+
+    const notification = build();
+
+    act(() => {
+      useNotificationStore.getState().addNotification(notification);
+    });
+    expect(MockNotification.instances).toHaveLength(1);
+
+    act(() => {
+      useNotificationStore.getState().setIsDropdownOpen(true);
+    });
+
+    expect(MockNotification.instances).toHaveLength(1);
+  });
+
+  it('constructs again for the same id when the signature changes (e.g. NEW_DIRECT_MESSAGE update-in-place)', () => {
+    renderHook(() => useDesktopNotifications());
+
+    const dm = build({
+      id: 'notif-dm',
+      type: 'NEW_DIRECT_MESSAGE',
+      message: 'First message',
+      metadata: { conversationId: 'conv-1', messageId: 'm1', senderId: 'sender-1' },
+      pageId: null,
+      driveId: null,
+    });
+
+    act(() => {
+      useNotificationStore.getState().addNotification(dm);
+    });
+
+    act(() => {
+      useNotificationStore.getState().addNotification({
+        ...dm,
+        message: 'Second message',
+        createdAt: new Date(dm.createdAt.getTime() + 1000),
+      });
+    });
+
+    expect(MockNotification.instances).toHaveLength(2);
+  });
+
+  it('does not construct a Notification when the preference level is off', () => {
+    mockToastLevel = 'off';
+
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(MockNotification.instances).toHaveLength(0);
+  });
+
+  it('on click: focuses the window, marks as read, and navigates to the resolved destination', () => {
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    const instance = MockNotification.instances[0];
+
+    act(() => {
+      instance.onclick?.();
+    });
+
+    expect(window.focus).toHaveBeenCalled();
+    expect(mockHandleNotificationRead).toHaveBeenCalledWith('notif-1');
+    expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/page-1');
+    expect(instance.close).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
@@ -9,6 +9,7 @@ const { mockPush, mockHandleNotificationRead, mockToastDismiss } = vi.hoisted(()
 }));
 
 let mockToastLevel: 'all' | 'mentions' | 'off' = 'all';
+let mockIsLoadingPreferences = false;
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
@@ -23,7 +24,7 @@ vi.mock('sonner', () => ({
 vi.mock('@/hooks/useToastPreferences', () => ({
   useToastPreferences: () => ({
     level: mockToastLevel,
-    isLoading: false,
+    isLoading: mockIsLoadingPreferences,
     updateLevel: vi.fn(),
   }),
 }));
@@ -69,6 +70,7 @@ describe('useDesktopNotifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockToastLevel = 'all';
+    mockIsLoadingPreferences = false;
     useNotificationStore.setState({
       notifications: [],
       unreadCount: 0,
@@ -187,6 +189,19 @@ describe('useDesktopNotifications', () => {
     });
 
     expect(MockNotification.instances).toHaveLength(2);
+  });
+
+  it('regression: does not construct a Notification while the toast preference is still loading, even though the provisional level defaults to all', () => {
+    mockIsLoadingPreferences = true;
+    mockToastLevel = 'all';
+
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(MockNotification.instances).toHaveLength(0);
   });
 
   it('does not construct a Notification when the preference level is off', () => {

--- a/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
@@ -2,15 +2,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { LegacyNotification } from '@pagespace/lib/notifications/types';
 
-const { mockPush, mockHandleNotificationRead } = vi.hoisted(() => ({
+const { mockPush, mockHandleNotificationRead, mockToastDismiss } = vi.hoisted(() => ({
   mockPush: vi.fn(),
   mockHandleNotificationRead: vi.fn().mockResolvedValue(undefined),
+  mockToastDismiss: vi.fn(),
 }));
 
 let mockToastLevel: 'all' | 'mentions' | 'off' = 'all';
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    dismiss: mockToastDismiss,
+  },
 }));
 
 vi.mock('@/hooks/useToastPreferences', () => ({
@@ -194,7 +201,7 @@ describe('useDesktopNotifications', () => {
     expect(MockNotification.instances).toHaveLength(0);
   });
 
-  it('on click: focuses the window, marks as read, and navigates to the resolved destination', () => {
+  it('on click: focuses the window, marks as read, navigates to the resolved destination, and dismisses the sibling toast', () => {
     renderHook(() => useDesktopNotifications());
 
     act(() => {
@@ -211,5 +218,33 @@ describe('useDesktopNotifications', () => {
     expect(mockHandleNotificationRead).toHaveBeenCalledWith('notif-1');
     expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/page-1');
     expect(instance.close).toHaveBeenCalled();
+    expect(mockToastDismiss).toHaveBeenCalledWith('notif-1');
+  });
+
+  it('regression: on click, reads the LIVE store state rather than the stale closure — does not re-mark-read a notification already read via another surface (e.g. the sibling toast) before the click', () => {
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    const instance = MockNotification.instances[0];
+
+    // Simulate the notification being marked read through another surface
+    // (e.g. the in-app dropdown, or the sibling sonner toast) before the
+    // user clicks the still-visible native OS notification.
+    act(() => {
+      useNotificationStore.setState((state) => ({
+        notifications: state.notifications.map((n) =>
+          n.id === 'notif-1' ? { ...n, isRead: true } : n
+        ),
+      }));
+    });
+
+    act(() => {
+      instance.onclick?.();
+    });
+
+    expect(mockHandleNotificationRead).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/useDesktopNotifications.ts
+++ b/apps/web/src/hooks/useDesktopNotifications.ts
@@ -21,7 +21,7 @@ import { isDesktopPlatform } from '@/lib/desktop-auth';
 export function useDesktopNotifications() {
   const router = useRouter();
   const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
-  const { level } = useToastPreferences();
+  const { level, isLoading: isLoadingPreferences } = useToastPreferences();
 
   const mountTimeRef = useRef(Date.now());
   const notifiedRef = useRef(new Map<string, string>());
@@ -40,6 +40,11 @@ export function useDesktopNotifications() {
       if (notifiedRef.current.get(top.id) === signature) return;
       notifiedRef.current.set(top.id, signature);
 
+      // Default to silence, not the provisional 'all', while the real
+      // preference is still loading (e.g. on a cold start) — otherwise an
+      // opted-out user could briefly see banners before their saved 'off'/
+      // 'mentions' level has come back from the server.
+      if (isLoadingPreferences) return;
       if (!isToastEligible(top.type, level)) return;
       if (document.hasFocus()) return;
 
@@ -62,5 +67,5 @@ export function useDesktopNotifications() {
     });
 
     return unsubscribe;
-  }, [router, handleNotificationRead, level]);
+  }, [router, handleNotificationRead, level, isLoadingPreferences]);
 }

--- a/apps/web/src/hooks/useDesktopNotifications.ts
+++ b/apps/web/src/hooks/useDesktopNotifications.ts
@@ -2,10 +2,12 @@
 
 import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { useNotificationStore } from '@/stores/useNotificationStore';
 import { resolveDestination, type StoredNotification } from '@/lib/notifications/resolve-destination';
 import { isToastEligible } from '@/lib/notifications/toast-eligible-types';
 import { useToastPreferences } from '@/hooks/useToastPreferences';
+import { isDesktopPlatform } from '@/lib/desktop-auth';
 
 /**
  * Shows a native OS notification (Electron desktop only) whenever a new (or
@@ -25,15 +27,16 @@ export function useDesktopNotifications() {
   const notifiedRef = useRef(new Map<string, string>());
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !window.electron?.isDesktop) return;
+    if (!isDesktopPlatform()) return;
     if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
 
     const unsubscribe = useNotificationStore.subscribe((state) => {
       const top = state.notifications[0] as StoredNotification | undefined;
       if (!top) return;
-      if (new Date(top.createdAt).getTime() < mountTimeRef.current) return;
+      const createdAt = new Date(top.createdAt);
+      if (createdAt.getTime() < mountTimeRef.current) return;
 
-      const signature = `${top.message}|${new Date(top.createdAt).toISOString()}`;
+      const signature = `${top.message}|${createdAt.toISOString()}`;
       if (notifiedRef.current.get(top.id) === signature) return;
       notifiedRef.current.set(top.id, signature);
 
@@ -43,10 +46,18 @@ export function useDesktopNotifications() {
       const n = new Notification(top.title, { body: top.message, tag: top.id });
       n.onclick = () => {
         window.focus();
-        if (!top.isRead) void handleNotificationRead(top.id);
+        // Look up the live read state rather than the `top` closed over at
+        // notification-construction time — it may have been marked read via
+        // another surface (dropdown, sibling toast) in the meantime.
+        const current = useNotificationStore.getState().notifications.find((notif) => notif.id === top.id);
+        if (!current || !current.isRead) void handleNotificationRead(top.id);
         const destination = resolveDestination(top);
         if (destination) router.push(destination);
         n.close();
+        // The sibling sonner toast (useNotificationToasts) may still be showing
+        // for the same notification id — dismiss it so it doesn't linger after
+        // the user has already navigated away via the OS notification.
+        toast.dismiss(top.id);
       };
     });
 

--- a/apps/web/src/hooks/useDesktopNotifications.ts
+++ b/apps/web/src/hooks/useDesktopNotifications.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+import { resolveDestination, type StoredNotification } from '@/lib/notifications/resolve-destination';
+import { isToastEligible } from '@/lib/notifications/toast-eligible-types';
+import { useToastPreferences } from '@/hooks/useToastPreferences';
+
+/**
+ * Shows a native OS notification (Electron desktop only) whenever a new (or
+ * updated-in-place) notification lands in useNotificationStore, but only
+ * when the window is unfocused — a focused window is already covered by the
+ * sonner toast from useNotificationToasts, so showing both would double-notify.
+ *
+ * Deliberately does NOT add its own socket listener; useNotificationStore is
+ * the single parse/dedup source of truth, mirroring useNotificationToasts.
+ */
+export function useDesktopNotifications() {
+  const router = useRouter();
+  const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
+  const { level } = useToastPreferences();
+
+  const mountTimeRef = useRef(Date.now());
+  const notifiedRef = useRef(new Map<string, string>());
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.electron?.isDesktop) return;
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+
+    const unsubscribe = useNotificationStore.subscribe((state) => {
+      const top = state.notifications[0] as StoredNotification | undefined;
+      if (!top) return;
+      if (new Date(top.createdAt).getTime() < mountTimeRef.current) return;
+
+      const signature = `${top.message}|${new Date(top.createdAt).toISOString()}`;
+      if (notifiedRef.current.get(top.id) === signature) return;
+      notifiedRef.current.set(top.id, signature);
+
+      if (!isToastEligible(top.type, level)) return;
+      if (document.hasFocus()) return;
+
+      const n = new Notification(top.title, { body: top.message, tag: top.id });
+      n.onclick = () => {
+        window.focus();
+        if (!top.isRead) void handleNotificationRead(top.id);
+        const destination = resolveDestination(top);
+        if (destination) router.push(destination);
+        n.close();
+      };
+    });
+
+    return unsubscribe;
+  }, [router, handleNotificationRead, level]);
+}

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -50,8 +50,15 @@ export function usePushNotifications(): PushNotificationState & PushNotification
   const hasRegisteredRef = useRef(false);
   const pushNotificationsRef = useRef<typeof import('@capacitor/push-notifications').PushNotifications | null>(null);
   const registerTokenWithServerRef = useRef<(token: string) => Promise<void>>(async () => { });
+  const listenersRef = useRef<(() => void)[]>([]);
 
-  // Check if push notifications are supported
+  // Check support and set up event listeners BEFORE marking supported.
+  // isSupported unlocks the permission-check effect and, from consumers like
+  // PushNotificationManager, an immediate registerToken()/register() call —
+  // if that raced ahead of the 'registration' listener being attached, the
+  // APNs token event could fire with no listener present to catch it.
+  // Registering listeners first guarantees they exist by the time anything
+  // downstream can trigger a native registration.
   useEffect(() => {
     if (!isReady) return;
 
@@ -61,6 +68,63 @@ export function usePushNotifications(): PushNotificationState & PushNotification
         try {
           const { PushNotifications } = await import('@capacitor/push-notifications');
           pushNotificationsRef.current = PushNotifications;
+
+          // Registration success
+          const registrationListener = await PushNotifications.addListener(
+            'registration',
+            (token: { value: string }) => {
+              console.log('[PushNotifications] Registered with token:', token.value.substring(0, 20) + '...');
+              tokenRef.current = token.value;
+              registerTokenWithServerRef.current(token.value);
+            }
+          );
+          listenersRef.current.push(() => registrationListener.remove());
+
+          // Registration error
+          const registrationErrorListener = await PushNotifications.addListener(
+            'registrationError',
+            (error: { error: string }) => {
+              console.error('[PushNotifications] Registration error:', error);
+              setState(prev => ({
+                ...prev,
+                error: error.error,
+                isLoading: false,
+              }));
+            }
+          );
+          listenersRef.current.push(() => registrationErrorListener.remove());
+
+          // Notification received while app is in foreground
+          const receivedListener = await PushNotifications.addListener(
+            'pushNotificationReceived',
+            (notification: PushNotificationSchema) => {
+              console.log('[PushNotifications] Received:', notification);
+              // Handle foreground notification
+              // Could dispatch an event or update state here
+              if (typeof window !== 'undefined') {
+                window.dispatchEvent(new CustomEvent('push:received', {
+                  detail: notification,
+                }));
+              }
+            }
+          );
+          listenersRef.current.push(() => receivedListener.remove());
+
+          // Notification tapped
+          const actionListener = await PushNotifications.addListener(
+            'pushNotificationActionPerformed',
+            (action: ActionPerformed) => {
+              console.log('[PushNotifications] Action performed:', action);
+              // Handle notification tap
+              if (typeof window !== 'undefined') {
+                window.dispatchEvent(new CustomEvent('push:action', {
+                  detail: action,
+                }));
+              }
+            }
+          );
+          listenersRef.current.push(() => actionListener.remove());
+
           setState(prev => ({ ...prev, isSupported: true }));
         } catch {
           setState(prev => ({ ...prev, isSupported: false }));
@@ -71,6 +135,11 @@ export function usePushNotifications(): PushNotificationState & PushNotification
     };
 
     checkSupport();
+
+    return () => {
+      listenersRef.current.forEach(remove => remove());
+      listenersRef.current = [];
+    };
   }, [isNative, platform, isReady]);
 
   // Check permission status
@@ -93,78 +162,6 @@ export function usePushNotifications(): PushNotificationState & PushNotification
     };
 
     checkPermission();
-  }, [state.isSupported]);
-
-  // Set up listeners for push notification events
-  useEffect(() => {
-    if (!state.isSupported || !pushNotificationsRef.current) return;
-
-    const PushNotifications = pushNotificationsRef.current;
-    const listeners: (() => void)[] = [];
-
-    const setupListeners = async () => {
-      // Registration success
-      const registrationListener = await PushNotifications.addListener(
-        'registration',
-        (token: { value: string }) => {
-          console.log('[PushNotifications] Registered with token:', token.value.substring(0, 20) + '...');
-          tokenRef.current = token.value;
-          registerTokenWithServerRef.current(token.value);
-        }
-      );
-      listeners.push(() => registrationListener.remove());
-
-      // Registration error
-      const registrationErrorListener = await PushNotifications.addListener(
-        'registrationError',
-        (error: { error: string }) => {
-          console.error('[PushNotifications] Registration error:', error);
-          setState(prev => ({
-            ...prev,
-            error: error.error,
-            isLoading: false,
-          }));
-        }
-      );
-      listeners.push(() => registrationErrorListener.remove());
-
-      // Notification received while app is in foreground
-      const receivedListener = await PushNotifications.addListener(
-        'pushNotificationReceived',
-        (notification: PushNotificationSchema) => {
-          console.log('[PushNotifications] Received:', notification);
-          // Handle foreground notification
-          // Could dispatch an event or update state here
-          if (typeof window !== 'undefined') {
-            window.dispatchEvent(new CustomEvent('push:received', {
-              detail: notification,
-            }));
-          }
-        }
-      );
-      listeners.push(() => receivedListener.remove());
-
-      // Notification tapped
-      const actionListener = await PushNotifications.addListener(
-        'pushNotificationActionPerformed',
-        (action: ActionPerformed) => {
-          console.log('[PushNotifications] Action performed:', action);
-          // Handle notification tap
-          if (typeof window !== 'undefined') {
-            window.dispatchEvent(new CustomEvent('push:action', {
-              detail: action,
-            }));
-          }
-        }
-      );
-      listeners.push(() => actionListener.remove());
-    };
-
-    setupListeners();
-
-    return () => {
-      listeners.forEach(remove => remove());
-    };
   }, [state.isSupported]);
 
   // Register token with server

--- a/apps/web/src/stores/__tests__/useNotificationStore.test.ts
+++ b/apps/web/src/stores/__tests__/useNotificationStore.test.ts
@@ -224,6 +224,29 @@ describe('useNotificationStore', () => {
 
       expect(useNotificationStore.getState().unreadCount).toBe(0);
     });
+
+    it('regression: given a notification already marked read, calling markAsRead again should be a no-op (does not double-decrement unreadCount)', () => {
+      const notif = createMockNotification({ id: 'to-read', isRead: false });
+      useNotificationStore.setState({ notifications: [notif], unreadCount: 3 });
+      const { markAsRead } = useNotificationStore.getState();
+
+      // Two independent UI surfaces (e.g. an in-app toast and a native OS
+      // notification) can both call markAsRead for the same notification —
+      // the second call must not decrement unreadCount again.
+      markAsRead('to-read');
+      markAsRead('to-read');
+
+      expect(useNotificationStore.getState().unreadCount).toBe(2);
+    });
+
+    it('given an unknown notification ID, should not decrement unreadCount', () => {
+      useNotificationStore.setState({ notifications: [], unreadCount: 3 });
+      const { markAsRead } = useNotificationStore.getState();
+
+      markAsRead('does-not-exist');
+
+      expect(useNotificationStore.getState().unreadCount).toBe(3);
+    });
   });
 
   describe('markAllAsRead', () => {

--- a/apps/web/src/stores/useNotificationStore.ts
+++ b/apps/web/src/stores/useNotificationStore.ts
@@ -91,12 +91,16 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     };
   }),
   
-  markAsRead: (notificationId) => set((state) => ({
-    notifications: state.notifications.map(n => 
-      n.id === notificationId ? { ...n, isRead: true, readAt: new Date() } : n
-    ),
-    unreadCount: Math.max(0, state.unreadCount - 1),
-  })),
+  markAsRead: (notificationId) => set((state) => {
+    const existing = state.notifications.find((n) => n.id === notificationId);
+    if (!existing || existing.isRead) return state;
+    return {
+      notifications: state.notifications.map(n =>
+        n.id === notificationId ? { ...n, isRead: true, readAt: new Date() } : n
+      ),
+      unreadCount: Math.max(0, state.unreadCount - 1),
+    };
+  }),
   
   markAllAsRead: () => set((state) => ({
     notifications: state.notifications.map(n => ({ ...n, isRead: true, readAt: new Date() })),


### PR DESCRIPTION
## Summary

Push notifications never appeared on the iOS Capacitor app or the Electron desktop app, despite notification events arriving over Socket.IO. Two independent root causes, one PR.

### iOS — permission-prompt race (`PushNotificationManager.tsx`)

The effect gated on `isNative && isSupported`, then burned a one-shot `attemptRef.current = true`. On the first render where those gates passed, `permissionStatus` was still `'unknown'` (native `checkPermissions()` hadn't resolved yet), so `initNotifications` did nothing — but the guard was already burned. When status later became `'prompt'`, the effect early-returned and the permission dialog never fired.

**Fix:** early-return while `permissionStatus === 'unknown'`, ordered *before* the `attemptRef` guard is set, so the guard is only consumed once a real status is known. Also removed the 1s `setTimeout` (unneeded — `isSupported` already proves the plugin resolved, and a non-`'unknown'` status proves a native-bridge round trip succeeded), which incidentally also fixes a latent timer-cancellation defect on dependency changes within that second.

### Desktop — no code path existed (`useDesktopNotifications.ts`, new)

Electron's permission handler already grants the `notifications` permission to the loaded page, but nothing ever called `new Notification(...)`. Since the desktop app remote-loads pagespace.ai, shipping this purely in `apps/web` reaches all installed desktop apps immediately — no `apps/desktop` changes needed (out of scope for this PR).

`useDesktopNotifications` subscribes to `useNotificationStore` (not the socket), mirroring `useNotificationToasts` so the OS banner and in-app toast/dropdown can never disagree or double-fire. Gated on `isDesktopPlatform()` (shared helper, see below), `Notification.permission === 'granted'`, and `!document.hasFocus()` (a focused window is already covered by the existing sonner toast). Reuses `resolveDestination` and `isToastEligible`/`useToastPreferences` so the existing "in-app pop-up" preference level also governs desktop banners; `'off'` silences both.

Mounted alongside `useNotificationToasts()` in `Layout.tsx`. Settings copy updated to note the pop-up preference also governs desktop system notifications.

## Scope

- No Android/FCM, no browser VAPID web push, no `apps/desktop` changes (as specified).

## Follow-up: self-review fixes

Ran an 8-angle review pass on the diff after opening the PR and fixed three real issues it surfaced:

- **Reuse**: `useDesktopNotifications.ts` inlined `window.electron?.isDesktop` instead of the existing `isDesktopPlatform()` helper (`lib/desktop-auth.ts`), already used by `PasskeyManager`, `PasskeyLoginButton`, `useOAuthSignIn`, and `useDesktopExchangeHandler`. Switched to the shared helper.
- **Correctness (stale closure)**: the native notification's `onclick` closed over the `top` notification snapshotted at construction time. If the notification was marked read via another surface (in-app dropdown, the sibling sonner toast) before the OS banner was clicked, the stale `top.isRead` was still `false`, so `handleNotificationRead` fired again. `useNotificationStore.markAsRead` unconditionally decremented `unreadCount` with no already-read guard (unlike its sibling `updateNotification`, which already guards this), so the duplicate call undercounted the unread badge. Fixed at the root: `markAsRead` is now a no-op when the notification is already read or missing, and the `onclick` handler reads live store state instead of the closed-over snapshot before deciding whether to call `handleNotificationRead`.
- **UX**: clicking the native OS notification never dismissed the sibling sonner toast for the same notification id, so it could linger on screen for up to 8s after the user had already navigated away via the OS banner. Now calls `toast.dismiss(top.id)` alongside `n.close()`.

Reviewed but deliberately **not** changed:
- If the window is unfocused but still visible (e.g. a second monitor), the sonner toast and the native OS banner can technically both render for the same event — this is the accepted tradeoff described in the gating logic (`!document.hasFocus()`), not a regression. The toast-dismiss-on-click fix above mitigates the worst symptom (a lingering stale toast after acting on the native banner).
- A native OS permission grant that happens mid-session (after mount, without a reload) is not live-detected — matches how most desktop apps handle this; requires a session restart to pick up, which is an acceptable limitation for a v1.

## Follow-up: reviewer findings (chatgpt-codex-connector)

Two review comments came in after the self-review round, both confirmed real and fixed:

- **P1 — APNs listener ordering** (`usePushNotifications.ts`): once the permission-prompt race was fixed, `registerToken()`/`register()` could fire as soon as `isSupported` flipped true for a user with permission already granted on startup. The `registration` listener that captures the APNs token was set up in a separate effect with the same `isSupported` dependency — no ordering guarantee it existed first, so a `registration` event could fire with nothing listening and the token would never reach the server. Fixed by moving listener setup into the same effect that resolves support, awaiting all four `addListener` calls before setting `isSupported: true`.
- **P2 — preference-load race** (`useDesktopNotifications.ts`): `useToastPreferences()` returns the provisional default (`'all'`) while its SWR request is still loading. A notification arriving during a cold start could show a native banner even for a user whose saved preference is `'off'`/`'mentions'`. Added an `isLoadingPreferences` gate that defaults to silence instead of the provisional level, with a regression test. Noted (not fixed, out of scope): the sibling `useNotificationToasts.tsx` has the identical pre-existing gap for its in-app toast.

## Follow-up: /simplify pass

Ran a second, independent 4-angle cleanup review after the reviewer-finding fixes. Three of four angles (reuse, efficiency, altitude) independently converged on the same finding I'd previously deferred: `useDesktopNotifications.ts`'s subscribe/mount-time-filter/signature-dedup logic was a near-verbatim copy of `useNotificationToasts.tsx`. Given the repeated, independent signal (now flagged by 5 separate review passes across two rounds) and a working test suite to guard against regressions, extracted the shared logic into a new `useNewStoreNotification.ts` hook — both existing hooks now supply only their surface-specific render/click behavior, no behavior change (both hooks' full existing test suites pass unmodified).

The extraction also resolved an efficiency finding along the way: the duplicated `Map<string, string>` dedup structure grew unbounded per session; since the store only ever exposes `notifications[0]`, only the previous top matters, so it's now a single ref instead of a growing map.

Also applied a suggestion to parallelize the four independent `PushNotifications.addListener` calls in `usePushNotifications.ts` via `Promise.all` instead of sequential awaits, cutting native-bridge round trips during Capacitor startup.

## Test plan

- [x] `bun run typecheck` — green
- [x] `PushNotificationManager.test.tsx` — regression tests for the `'unknown'` → `'prompt'` transition (requests exactly once) and `'unknown'` → `'denied'` (never requests)
- [x] `useDesktopNotifications.test.tsx` — not-desktop, permission-not-granted, focused-window, unfocused+eligible, dedup by signature, preference `'off'`, preference-still-loading, click → focus + mark-read + navigate + dismiss sibling toast, regression: live read-state check avoids re-marking an already-read notification
- [x] `useNotificationStore.test.ts` — regression: `markAsRead` is idempotent (no double-decrement) and a no-op for an unknown id
- [x] `useNotificationToasts.test.tsx` — unaffected by the shared-hook extraction, still green (10/10)
- [x] `useNewStoreNotification.ts` — covered indirectly via both consumers' full test suites (20 tests); no dedicated suite added since it has no independent public behavior beyond what those suites already exercise
- [x] `eslint` on all touched files — clean
- [ ] TestFlight verification for iOS (manual, post-merge)
- [ ] Local desktop manual test: unfocus window → native banner appears; click → window focuses + navigates to the resolved destination + sibling toast dismissed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aNT7AoGneWHx6jXPEJpwn
https://claude.ai/code/session_01AhVuJyjjs2FYyUjWmnA6bR


