### PR TITLE
fix(processor,security): stop /health from exposing raw SIEM webhook error bodies (#989)

### DIFF
--- a/apps/processor/src/__tests__/server.test.ts
+++ b/apps/processor/src/__tests__/server.test.ts
@@ -205,6 +205,19 @@ vi.mock('../middleware/resource-binding', () => ({
 vi.mock('../services/siem-adapter', () => ({
   loadSiemConfig: vi.fn(() => ({ enabled: false, type: 'webhook' })),
   validateSiemConfig: vi.fn(() => ({ valid: true, errors: [] })),
+  // Real allowlist used by siem-health-builder's read-time redaction guard.
+  // Kept in sync with DeliveryErrorClass in siem-adapter.ts (#989).
+  SAFE_DELIVERY_ERROR_CLASSES: new Set([
+    'transport_error',
+    'http_client_error',
+    'http_server_error',
+    'ssrf_blocked',
+    'invalid_config',
+    'chain_tamper',
+    'preflight_unavailable',
+    'internal_error',
+    'unclassified_error',
+  ]),
 }));
 
 vi.mock('../db', () => ({
@@ -842,6 +855,64 @@ describe('GET /health', () => {
     // Receipts table missing — lastReceipt must be omitted
     expect(siem.sources.activity_logs.lastReceipt).toBeUndefined();
     expect(siem.sources.security_audit_log.lastReceipt).toBeUndefined();
+  });
+
+  it('given a cursor row holding a raw webhook body, should never surface it on unauthenticated /health (redacts to unclassified_error)', async () => {
+    // Acceptance test for #989: even if a legacy cursor row still contains a
+    // raw, customer-controlled webhook response body (secrets, PII, stack
+    // traces), the unauthenticated /health endpoint must expose only the safe
+    // classification marker — never the raw string.
+    const rawBody =
+      'HTTP 500: {"error":"invalid token: sk-live-abc123","user":"u_42","stack":"at h (/srv/app.js:9)"}';
+
+    const { loadSiemConfig } = await import('../services/siem-adapter');
+    const { getPoolForWorker } = await import('../db');
+    const { refreshSiemCursorCache } = await import('../server');
+
+    (loadSiemConfig as ReturnType<typeof vi.fn>).mockReturnValue({ enabled: true, type: 'webhook' });
+
+    const mockRelease = vi.fn();
+    const mockQuery = vi.fn().mockImplementation((sql: string) => {
+      if (sql.includes('siem_delivery_cursors')) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: 'activity_logs',
+              lastDeliveredId: null,
+              lastDeliveredAt: null,
+              lastError: rawBody,
+              lastErrorAt: new Date('2026-04-10T12:05:00Z'),
+              deliveryCount: 0,
+              updatedAt: new Date('2026-04-10T12:05:05Z'),
+            },
+          ],
+          rowCount: 1,
+        });
+      }
+      if (sql.includes('siem_delivery_receipts')) {
+        const err: Error & { code?: string } = Object.assign(
+          new Error('relation "siem_delivery_receipts" does not exist'),
+          { code: '42P01' },
+        );
+        return Promise.reject(err);
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+    (getPoolForWorker as ReturnType<typeof vi.fn>).mockReturnValue({
+      connect: vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease }),
+    });
+
+    await refreshSiemCursorCache();
+
+    const { req, res, jsonMock } = makeReqRes();
+    await getHealthHandler()(req, res);
+
+    const { siem } = jsonMock.mock.calls[0][0];
+    // Status still reflects the error…
+    expect(siem.sources.activity_logs.status).toBe('error');
+    // …but the message is the safe marker, and the raw secret is gone.
+    expect(siem.sources.activity_logs.lastError).toBe('unclassified_error');
+    expect(JSON.stringify(jsonMock.mock.calls[0][0])).not.toContain('sk-live-abc123');
   });
 
   it('given a SIEM section DB error, should return 200 with a siem.error field instead of 500', async () => {

--- a/apps/processor/src/__tests__/server.test.ts
+++ b/apps/processor/src/__tests__/server.test.ts
@@ -202,22 +202,13 @@ vi.mock('../middleware/resource-binding', () => ({
   ),
 }));
 
-vi.mock('../services/siem-adapter', () => ({
+vi.mock('../services/siem-adapter', async (importOriginal) => ({
+  // Spread the real module so exports the health builder relies on (notably
+  // SAFE_DELIVERY_ERROR_CLASSES, used by its read-time redaction guard) stay in
+  // sync automatically; only the config accessors are stubbed. See #989.
+  ...(await importOriginal<typeof import('../services/siem-adapter')>()),
   loadSiemConfig: vi.fn(() => ({ enabled: false, type: 'webhook' })),
   validateSiemConfig: vi.fn(() => ({ valid: true, errors: [] })),
-  // Real allowlist used by siem-health-builder's read-time redaction guard.
-  // Kept in sync with DeliveryErrorClass in siem-adapter.ts (#989).
-  SAFE_DELIVERY_ERROR_CLASSES: new Set([
-    'transport_error',
-    'http_client_error',
-    'http_server_error',
-    'ssrf_blocked',
-    'invalid_config',
-    'chain_tamper',
-    'preflight_unavailable',
-    'internal_error',
-    'unclassified_error',
-  ]),
 }));
 
 vi.mock('../db', () => ({

--- a/apps/processor/src/services/__tests__/siem-adapter.test.ts
+++ b/apps/processor/src/services/__tests__/siem-adapter.test.ts
@@ -492,6 +492,7 @@ describe('sendWebhook', () => {
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(false);
     expect(result.error).toContain('SSRF blocked');
+    expect(result.errorClass).toBe('ssrf_blocked');
   });
 
   it('returns retryable failure on 500 response', async () => {
@@ -503,6 +504,23 @@ describe('sendWebhook', () => {
     const result = await sendWebhook(webhookConfig, [makeEntry()]);
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(true);
+    expect(result.errorClass).toBe('http_server_error');
+  });
+
+  it('classifies a 5xx as http_server_error while keeping the raw body on error (logging contract)', async () => {
+    // The receiver's body may embed secrets/PII. It must stay on `error` (for
+    // the operator-only stdout log) but must NOT become the errorClass that is
+    // persisted and surfaced on /health. See #989.
+    const secretBody = 'invalid token: sk-live-abc123; user=42; at handler (/srv/app.js:99)';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: vi.fn().mockResolvedValue(secretBody),
+    }));
+    const result = await sendWebhook(webhookConfig, [makeEntry()]);
+    expect(result.errorClass).toBe('http_server_error');
+    expect(result.error).toContain(secretBody);
+    expect(result.errorClass).not.toContain('sk-live-abc123');
   });
 
   it('returns non-retryable failure on 401 response', async () => {
@@ -514,6 +532,7 @@ describe('sendWebhook', () => {
     const result = await sendWebhook(webhookConfig, [makeEntry()]);
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(false);
+    expect(result.errorClass).toBe('http_client_error');
   });
 
   it('returns retryable failure on network error', async () => {
@@ -522,6 +541,7 @@ describe('sendWebhook', () => {
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(true);
     expect(result.error).toBe('Network error');
+    expect(result.errorClass).toBe('transport_error');
   });
 
   it('handles 429 as retryable', async () => {
@@ -533,6 +553,7 @@ describe('sendWebhook', () => {
     const result = await sendWebhook(webhookConfig, [makeEntry()]);
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(true);
+    expect(result.errorClass).toBe('http_server_error');
   });
 });
 
@@ -577,6 +598,7 @@ describe('sendSyslogTcp', () => {
     const result = await sendSyslogTcp(config, [makeEntry()]);
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(true);
+    expect(result.errorClass).toBe('transport_error');
   });
 
   it('resolves with failure when socket emits error', async () => {

--- a/apps/processor/src/services/__tests__/siem-adapter.test.ts
+++ b/apps/processor/src/services/__tests__/siem-adapter.test.ts
@@ -725,6 +725,7 @@ describe('sendSyslog', () => {
     const result = await sendSyslog(tcpConfig, [makeEntry()]);
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(false);
+    expect(result.errorClass).toBe('ssrf_blocked');
   });
 
   it('returns failure when validation throws', async () => {
@@ -733,6 +734,7 @@ describe('sendSyslog', () => {
     expect(result.success).toBe(false);
     expect(result.retryable).toBe(false);
     expect(result.error).toContain('DNS error');
+    expect(result.errorClass).toBe('transport_error');
   });
 
   it('routes to TCP when protocol is tcp', async () => {
@@ -787,6 +789,7 @@ describe('deliverToSiem', () => {
     const result = await deliverToSiem(config, [makeEntry()]);
     expect(result.success).toBe(false);
     expect(result.error).toBe('Invalid SIEM configuration');
+    expect(result.errorClass).toBe('invalid_config');
   });
 
   it('calls sendWebhook when webhook type', async () => {

--- a/apps/processor/src/services/__tests__/siem-health-builder.test.ts
+++ b/apps/processor/src/services/__tests__/siem-health-builder.test.ts
@@ -326,6 +326,89 @@ describe('buildSiemHealth', () => {
     });
   });
 
+  it('given a cursor whose lastError holds a raw webhook body, should redact it to unclassified_error on /health while keeping error status', () => {
+    const rawBody =
+      'HTTP 500: {"error":"invalid token: sk-live-abc123","stack":"at handler (/srv/app.js:42)"}';
+    const cursors: CursorSnapshot[] = [
+      makeCursor({
+        id: 'activity_logs',
+        lastDeliveredId: null,
+        lastDeliveredAt: null,
+        lastError: rawBody,
+        lastErrorAt: new Date('2026-04-10T12:05:00Z'),
+        deliveryCount: 0,
+      }),
+    ];
+
+    const result = buildSiemHealth({
+      enabled: true,
+      type: 'webhook',
+      sources: SOURCES,
+      cursors,
+      recentReceipts: null,
+      cursorInitSentinel: SENTINEL,
+    });
+
+    assert({
+      given: 'a legacy cursor row containing a raw customer-controlled webhook body',
+      should: 'replace lastError with the safe marker but still report error status',
+      actual: {
+        lastError: result.sources.activity_logs!.lastError,
+        status: result.sources.activity_logs!.status,
+      },
+      expected: { lastError: 'unclassified_error', status: 'error' },
+    });
+  });
+
+  it('given a cursor whose lastError is a recognized safe class, should pass it through unchanged on /health', () => {
+    const cursors: CursorSnapshot[] = [
+      makeCursor({
+        id: 'activity_logs',
+        lastDeliveredId: null,
+        lastDeliveredAt: null,
+        lastError: 'http_server_error',
+        lastErrorAt: new Date('2026-04-10T12:05:00Z'),
+        deliveryCount: 0,
+      }),
+    ];
+
+    const result = buildSiemHealth({
+      enabled: true,
+      type: 'webhook',
+      sources: SOURCES,
+      cursors,
+      recentReceipts: null,
+      cursorInitSentinel: SENTINEL,
+    });
+
+    assert({
+      given: 'a cursor whose lastError is already a safe DeliveryErrorClass',
+      should: 'pass the class through to /health verbatim',
+      actual: result.sources.activity_logs!.lastError,
+      expected: 'http_server_error',
+    });
+  });
+
+  it('given a cursor with no error, should leave lastError null on /health', () => {
+    const cursors: CursorSnapshot[] = [makeCursor({ id: 'activity_logs', lastError: null })];
+
+    const result = buildSiemHealth({
+      enabled: true,
+      type: 'webhook',
+      sources: SOURCES,
+      cursors,
+      recentReceipts: null,
+      cursorInitSentinel: SENTINEL,
+    });
+
+    assert({
+      given: 'a healthy cursor with lastError null',
+      should: 'keep lastError null (no spurious marker)',
+      actual: result.sources.activity_logs!.lastError,
+      expected: null,
+    });
+  });
+
   it('given a cursor lastDeliveredAt, should serialize it to ISO string in the output', () => {
     const cursors: CursorSnapshot[] = [
       makeCursor({

--- a/apps/processor/src/services/siem-adapter.ts
+++ b/apps/processor/src/services/siem-adapter.ts
@@ -40,24 +40,12 @@ export interface AuditLogEntry {
  * response body (stack traces, auth tokens, PII, schema) — never crosses this
  * boundary; full detail stays in the processor's stdout logs for operator
  * triage. See issue #989.
+ *
+ * This array is the single source of truth: the `DeliveryErrorClass` union and
+ * the `SAFE_DELIVERY_ERROR_CLASSES` allowlist are both derived from it, so a new
+ * class can never be added to one without the other.
  */
-export type DeliveryErrorClass =
-  | 'transport_error'
-  | 'http_client_error'
-  | 'http_server_error'
-  | 'ssrf_blocked'
-  | 'invalid_config'
-  | 'chain_tamper'
-  | 'preflight_unavailable'
-  | 'internal_error'
-  | 'unclassified_error';
-
-// Allowlist form of DeliveryErrorClass for the read-time zero-trust guard in
-// siem-health-builder. Typed as ReadonlySet<string> so an arbitrary persisted
-// value (e.g. a legacy raw body already at rest in the DB) can be membership-
-// tested; anything not in this set is replaced with 'unclassified_error' before
-// it can reach /health.
-export const SAFE_DELIVERY_ERROR_CLASSES: ReadonlySet<string> = new Set<DeliveryErrorClass>([
+export const DELIVERY_ERROR_CLASSES = [
   'transport_error',
   'http_client_error',
   'http_server_error',
@@ -67,7 +55,16 @@ export const SAFE_DELIVERY_ERROR_CLASSES: ReadonlySet<string> = new Set<Delivery
   'preflight_unavailable',
   'internal_error',
   'unclassified_error',
-]);
+] as const;
+
+export type DeliveryErrorClass = (typeof DELIVERY_ERROR_CLASSES)[number];
+
+// Allowlist form of DeliveryErrorClass for the read-time zero-trust guard in
+// siem-health-builder. Typed as ReadonlySet<string> so an arbitrary persisted
+// value (e.g. a legacy raw body already at rest in the DB) can be membership-
+// tested; anything not in this set is replaced with 'unclassified_error' before
+// it can reach /health.
+export const SAFE_DELIVERY_ERROR_CLASSES: ReadonlySet<string> = new Set(DELIVERY_ERROR_CLASSES);
 
 /**
  * Pure classifier mapping an HTTP status to a safe delivery-error class. Mirrors

--- a/apps/processor/src/services/siem-adapter.ts
+++ b/apps/processor/src/services/siem-adapter.ts
@@ -67,8 +67,10 @@ export type DeliveryErrorClass = (typeof DELIVERY_ERROR_CLASSES)[number];
 export const SAFE_DELIVERY_ERROR_CLASSES: ReadonlySet<string> = new Set(DELIVERY_ERROR_CLASSES);
 
 /**
- * Pure classifier mapping an HTTP status to a safe delivery-error class. Mirrors
- * the retryable computation (5xx + 429 are server-side/transient).
+ * Pure classifier mapping an HTTP status to a safe delivery-error class. 5xx and
+ * 429 are treated as server-side/transient (`http_server_error`), everything
+ * else 4xx as `http_client_error`. `sendWebhook` derives its `retryable` flag
+ * straight from this result, so the class and retryability can never drift.
  */
 export function classifyHttpStatus(status: number): DeliveryErrorClass {
   return status >= 500 || status === 429 ? 'http_server_error' : 'http_client_error';
@@ -375,15 +377,16 @@ export async function sendWebhook(
       };
     }
 
-    // Determine if error is retryable
-    const retryable = response.status >= 500 || response.status === 429;
+    // Classify once; retryability is derived from the class so the two can
+    // never drift (5xx + 429 → http_server_error → retryable).
+    const errorClass = classifyHttpStatus(response.status);
 
     return {
       success: false,
       entriesDelivered: 0,
       error: `HTTP ${response.status}: ${responseBody || 'Unknown error'}`,
-      errorClass: classifyHttpStatus(response.status),
-      retryable,
+      errorClass,
+      retryable: errorClass === 'http_server_error',
       deliveryId,
       webhookStatus: response.status,
       ackReceivedAt,

--- a/apps/processor/src/services/siem-adapter.ts
+++ b/apps/processor/src/services/siem-adapter.ts
@@ -32,11 +32,60 @@ export interface AuditLogEntry {
   logHash: string | null;
 }
 
+/**
+ * Closed set of safe, non-customer-controlled classifications for a failed SIEM
+ * delivery. This is the ONLY value that may be persisted to
+ * siem_delivery_cursors.lastError and surfaced on the unauthenticated /health
+ * endpoint. The raw error string — which can contain a customer's webhook
+ * response body (stack traces, auth tokens, PII, schema) — never crosses this
+ * boundary; full detail stays in the processor's stdout logs for operator
+ * triage. See issue #989.
+ */
+export type DeliveryErrorClass =
+  | 'transport_error'
+  | 'http_client_error'
+  | 'http_server_error'
+  | 'ssrf_blocked'
+  | 'invalid_config'
+  | 'chain_tamper'
+  | 'preflight_unavailable'
+  | 'internal_error'
+  | 'unclassified_error';
+
+// Allowlist form of DeliveryErrorClass for the read-time zero-trust guard in
+// siem-health-builder. Typed as ReadonlySet<string> so an arbitrary persisted
+// value (e.g. a legacy raw body already at rest in the DB) can be membership-
+// tested; anything not in this set is replaced with 'unclassified_error' before
+// it can reach /health.
+export const SAFE_DELIVERY_ERROR_CLASSES: ReadonlySet<string> = new Set<DeliveryErrorClass>([
+  'transport_error',
+  'http_client_error',
+  'http_server_error',
+  'ssrf_blocked',
+  'invalid_config',
+  'chain_tamper',
+  'preflight_unavailable',
+  'internal_error',
+  'unclassified_error',
+]);
+
+/**
+ * Pure classifier mapping an HTTP status to a safe delivery-error class. Mirrors
+ * the retryable computation (5xx + 429 are server-side/transient).
+ */
+export function classifyHttpStatus(status: number): DeliveryErrorClass {
+  return status >= 500 || status === 429 ? 'http_server_error' : 'http_client_error';
+}
+
 // SIEM delivery result
 export interface SiemDeliveryResult {
   success: boolean;
   entriesDelivered: number;
   error?: string;
+  // Safe, non-customer-controlled classification of `error`. Persisted to
+  // siem_delivery_cursors.lastError in place of the raw `error` string, which
+  // may embed untrusted webhook response bodies. See DeliveryErrorClass / #989.
+  errorClass?: DeliveryErrorClass;
   retryable?: boolean;
   // Delivery attestation — stamped by the delivery path so the worker can
   // persist receipts without re-doing any of the work.
@@ -268,6 +317,7 @@ export async function sendWebhook(
         success: false,
         entriesDelivered: 0,
         error: `Invalid webhook URL: ${validation.error || 'SSRF protection blocked request'}`,
+        errorClass: 'ssrf_blocked',
         retryable: false, // Don't retry blocked URLs
         deliveryId,
         webhookStatus: null,
@@ -335,6 +385,7 @@ export async function sendWebhook(
       success: false,
       entriesDelivered: 0,
       error: `HTTP ${response.status}: ${responseBody || 'Unknown error'}`,
+      errorClass: classifyHttpStatus(response.status),
       retryable,
       deliveryId,
       webhookStatus: response.status,
@@ -347,6 +398,7 @@ export async function sendWebhook(
       success: false,
       entriesDelivered: 0,
       error: error instanceof Error ? error.message : 'Network error',
+      errorClass: 'transport_error',
       retryable: true,
       deliveryId,
       webhookStatus: null,
@@ -498,6 +550,7 @@ export function sendSyslogTcp(
         success: false,
         entriesDelivered,
         error: 'Connection timeout',
+        errorClass: 'transport_error',
         retryable: true,
       });
     }, 10000);
@@ -526,6 +579,7 @@ export function sendSyslogTcp(
               success: false,
               entriesDelivered,
               error: err.message,
+              errorClass: 'transport_error',
               retryable: true,
             });
             return;
@@ -545,6 +599,7 @@ export function sendSyslogTcp(
         success: false,
         entriesDelivered,
         error: err.message,
+        errorClass: 'transport_error',
         retryable: true,
       });
     });
@@ -571,6 +626,7 @@ export function sendSyslogUdp(
           success: !hasError,
           entriesDelivered,
           error: hasError ? 'UDP send error' : undefined,
+          errorClass: hasError ? 'transport_error' : undefined,
           retryable: hasError,
         });
         return;
@@ -587,6 +643,7 @@ export function sendSyslogUdp(
             success: false,
             entriesDelivered,
             error: err.message,
+            errorClass: 'transport_error',
             retryable: true,
           });
           return;
@@ -603,6 +660,7 @@ export function sendSyslogUdp(
         success: false,
         entriesDelivered,
         error: err.message,
+        errorClass: 'transport_error',
         retryable: true,
       });
     });
@@ -636,6 +694,7 @@ export async function sendSyslog(
         success: false,
         entriesDelivered: 0,
         error: `Invalid syslog host: ${validation.error || 'SSRF protection blocked connection'}`,
+        errorClass: 'ssrf_blocked',
         retryable: false, // Don't retry blocked hosts
       };
     }
@@ -649,6 +708,7 @@ export async function sendSyslog(
       success: false,
       entriesDelivered: 0,
       error: `Host validation failed: ${validationError instanceof Error ? validationError.message : 'Unknown error'}`,
+      errorClass: 'transport_error',
       retryable: false,
     };
   }
@@ -701,6 +761,7 @@ export async function deliverToSiem(
     success: false,
     entriesDelivered: 0,
     error: 'Invalid SIEM configuration',
+    errorClass: 'invalid_config',
     retryable: false,
   };
 }
@@ -739,6 +800,7 @@ export async function deliverToSiemBatched(
         success: false,
         entriesDelivered: totalDelivered,
         error: lastError,
+        errorClass: result.errorClass,
         retryable: result.retryable,
         deliveryId,
         webhookStatus: result.webhookStatus ?? null,
@@ -819,6 +881,7 @@ export async function deliverToSiemWithRetry(
         success: false,
         entriesDelivered: cumulativeDelivered,
         error: result.error,
+        errorClass: result.errorClass,
         retryable: result.retryable,
         deliveryId,
         webhookStatus: result.webhookStatus ?? null,
@@ -836,6 +899,7 @@ export async function deliverToSiemWithRetry(
     success: false,
     entriesDelivered: cumulativeDelivered,
     error: 'Max retries exceeded',
+    errorClass: lastResult?.errorClass ?? 'transport_error',
     retryable: false,
     deliveryId,
     webhookStatus: lastResult?.webhookStatus ?? null,

--- a/apps/processor/src/services/siem-health-builder.ts
+++ b/apps/processor/src/services/siem-health-builder.ts
@@ -1,4 +1,4 @@
-import type { AuditLogSource, SiemType } from './siem-adapter';
+import { SAFE_DELIVERY_ERROR_CLASSES, type AuditLogSource, type SiemType } from './siem-adapter';
 
 export interface CursorSnapshot {
   id: AuditLogSource;
@@ -92,10 +92,23 @@ function cursorToPerSource(
     status: deriveStatus(cursor, cursorInitSentinel),
     lastDeliveredAt: toIsoOrNull(cursor.lastDeliveredAt),
     lastErrorAt: toIsoOrNull(cursor.lastErrorAt),
-    lastError: cursor.lastError,
+    lastError: toSafeErrorClass(cursor.lastError),
     deliveryCount: cursor.deliveryCount,
     updatedAt: cursor.updatedAt.toISOString(),
   };
+}
+
+// Read-time zero-trust guard for the unauthenticated /health surface. The write
+// path (siem-delivery-worker.recordError) only ever persists a DeliveryErrorClass,
+// but this endpoint must not trust the DB row: a legacy row written before #989
+// may still hold a raw webhook response body. Any value that is not a recognized
+// safe class is collapsed to 'unclassified_error'. `null` is preserved as `null`
+// (no error) so deriveStatus continues to report 'error' only when one occurred.
+function toSafeErrorClass(lastError: string | null): string | null {
+  if (lastError === null) {
+    return null;
+  }
+  return SAFE_DELIVERY_ERROR_CLASSES.has(lastError) ? lastError : 'unclassified_error';
 }
 
 function missingPerSource(): SiemHealthPerSource {

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -359,6 +359,7 @@ describe('processSiemDelivery', () => {
       success: false,
       entriesDelivered: 0,
       error: 'HTTP 502: Bad Gateway',
+      errorClass: 'http_server_error',
     });
 
     // Two error upserts — one per source
@@ -402,9 +403,9 @@ describe('processSiemDelivery', () => {
 
     assert({
       given: 'failed delivery with 0 entries delivered',
-      should: 'record the error message',
+      should: 'record the safe error class (not the raw message)',
       actual: (errorCalls[0][1] as unknown[])[1],
-      expected: 'HTTP 502: Bad Gateway',
+      expected: 'http_server_error',
     });
   });
 
@@ -432,6 +433,7 @@ describe('processSiemDelivery', () => {
       success: false,
       entriesDelivered: 2,
       error: 'TCP connection reset',
+      errorClass: 'transport_error',
     });
 
     stubBegin();
@@ -469,9 +471,9 @@ describe('processSiemDelivery', () => {
     );
     assert({
       given: 'partial delivery failure',
-      should: 'record the error on both sources',
+      should: 'record the safe error class on both sources',
       actual: errorCalls.map((c) => (c[1] as unknown[])[1]),
-      expected: ['TCP connection reset', 'TCP connection reset'],
+      expected: ['transport_error', 'transport_error'],
     });
   });
 
@@ -1153,10 +1155,15 @@ describe('processSiemDelivery', () => {
     stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 0);
     stubSourceRows([makeSecurityRow('sec_1', new Date('2026-04-10T01:00:01Z'))]);
 
+    // The adapter stamps a safe errorClass alongside the raw error string. The
+    // raw string embeds a customer-controlled webhook response body here; only
+    // the class may be persisted to the /health-visible cursor. See #989.
+    const rawBody = 'HTTP 500: invalid token: sk-live-abc123 (user=42)';
     mockDeliverToSiemWithRetry.mockResolvedValue({
       success: false,
       entriesDelivered: 0,
-      error: 'webhook unreachable',
+      error: rawBody,
+      errorClass: 'http_server_error',
     });
 
     stubErrorUpsert();
@@ -1178,9 +1185,16 @@ describe('processSiemDelivery', () => {
 
     assert({
       given: 'a total delivery failure',
-      should: 'propagate the error message to every cursor',
-      actual: errorCalls.every((c) => (c[1] as unknown[])[1] === 'webhook unreachable'),
+      should: 'persist only the safe error class to every cursor',
+      actual: errorCalls.every((c) => (c[1] as unknown[])[1] === 'http_server_error'),
       expected: true,
+    });
+
+    assert({
+      given: 'a webhook response body carrying a secret',
+      should: 'never persist the raw body into the /health-visible cursor',
+      actual: errorCalls.some((c) => String((c[1] as unknown[])[1]).includes('sk-live-abc123')),
+      expected: false,
     });
 
     const advanceCalls = mockQuery.mock.calls.filter(
@@ -1541,14 +1555,21 @@ describe('processSiemDelivery', () => {
 
     assert({
       given: 'a tampered activity_logs row',
-      should: 'include the break index, reason, expected and actual hashes in the error message',
+      should: 'persist the safe chain_tamper class (forensic detail stays in logs/alert)',
+      actual: (errorCalls[0][1] as unknown[])[1],
+      expected: 'chain_tamper',
+    });
+
+    assert({
+      given: 'a tampered activity_logs row',
+      should: 'not leak break index, entry id, or hashes into the /health-visible cursor',
       actual:
         typeof (errorCalls[0][1] as unknown[])[1] === 'string' &&
-        ((errorCalls[0][1] as string[])[1] as string).includes('hash_mismatch') &&
-        ((errorCalls[0][1] as string[])[1] as string).includes('log_tampered') &&
-        ((errorCalls[0][1] as string[])[1] as string).includes('expected=expected') &&
-        ((errorCalls[0][1] as string[])[1] as string).includes('actual=tampered'),
-      expected: true,
+        (((errorCalls[0][1] as string[])[1] as string).includes('hash_mismatch') ||
+          ((errorCalls[0][1] as string[])[1] as string).includes('log_tampered') ||
+          ((errorCalls[0][1] as string[])[1] as string).includes('expected') ||
+          ((errorCalls[0][1] as string[])[1] as string).includes('tampered')),
+      expected: false,
     });
   });
 
@@ -1764,6 +1785,13 @@ describe('processSiemDelivery', () => {
       should: 'record the error on the activity_logs cursor',
       actual: errorCalls.length === 1 && (errorCalls[0][1] as unknown[])[0] === 'activity_logs',
       expected: true,
+    });
+
+    assert({
+      given: 'a preflight db_error carrying an internal message',
+      should: 'persist the safe preflight_unavailable class, not the raw DB message',
+      actual: (errorCalls[0][1] as unknown[])[1],
+      expected: 'preflight_unavailable',
     });
 
     assert({

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -589,6 +589,13 @@ describe('processSiemDelivery', () => {
       actual: errorCalls.length,
       expected: 2,
     });
+
+    assert({
+      given: 'an unexpected worker error (raw message may carry internal detail)',
+      should: 'persist only the safe internal_error class, never the raw message',
+      actual: errorCalls.map((c) => (c[1] as unknown[])[1]),
+      expected: ['internal_error', 'internal_error'],
+    });
   });
 
   it('acquires advisory lock before reading cursor', async () => {

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -5,6 +5,7 @@ import {
   deliverToSiemWithRetry,
   type AuditLogEntry,
   type AuditLogSource,
+  type DeliveryErrorClass,
 } from '../services/siem-adapter';
 import {
   mapActivityLogsToSiemEntries,
@@ -170,10 +171,15 @@ async function queryRowsForSource(
   return querySecurityAuditLog(client, afterTimestamp, afterId, batchSize);
 }
 
+// The persisted `lastError` is deliberately typed as DeliveryErrorClass, not a
+// free-text string. This makes it a compile-time error to write a raw webhook
+// response body (or any customer-controlled text) into the column that the
+// unauthenticated /health endpoint surfaces. Full error detail is retained in
+// the processor's stdout logs at each call site for operator triage. See #989.
 async function recordError(
   client: PgClient,
   source: AuditLogSource,
-  message: string
+  errorClass: DeliveryErrorClass
 ): Promise<void> {
   await client.query(
     `INSERT INTO siem_delivery_cursors (id, "lastError", "lastErrorAt", "updatedAt")
@@ -182,7 +188,7 @@ async function recordError(
        "lastError" = $2,
        "lastErrorAt" = NOW(),
        "updatedAt" = NOW()`,
-    [source, message]
+    [source, errorClass]
   );
 }
 
@@ -356,20 +362,19 @@ export async function processSiemDelivery(): Promise<void> {
         // but do NOT fire the chain verification webhook — a transient DB
         // failure is not tamper, and a false tamper page erodes the
         // alert's credibility. The next poll cycle will retry naturally.
-        await recordError(
-          client,
-          preflightResult.source,
-          `Chain preflight data unavailable: ${preflightResult.message}`
-        );
+        await recordError(client, preflightResult.source, 'preflight_unavailable');
         console.warn(
           `[siem-delivery] Chain preflight data unavailable source=${preflightResult.source}: ${preflightResult.message}`
         );
         return;
       }
 
-      // Include expected/actual hashes when present so /health can
-      // distinguish hash_mismatch from chain_break from missing_hash
-      // without re-reading the cursor row. missing_hash leaves both null.
+      // /health only ever shows the safe 'chain_tamper' class. The full
+      // forensic detail (index, reason, expected/actual hashes) stays in the
+      // operator-only channels below: the structured console.error line and
+      // the notifyChainPreflightFailure alert. Hashes are internally computed,
+      // not customer-controlled, but there is no reason to widen the
+      // unauthenticated /health surface with them.
       const hashDetail = [
         preflightResult.expectedHash !== null
           ? `expected=${preflightResult.expectedHash}`
@@ -380,9 +385,8 @@ export async function processSiemDelivery(): Promise<void> {
       ]
         .filter((s): s is string => s !== null)
         .join(' ');
-      const errorMessage = `Hash chain broken at index ${preflightResult.breakAtIndex}: ${preflightResult.breakReason} (entry=${preflightResult.entryId})${hashDetail ? ` ${hashDetail}` : ''}`;
 
-      await recordError(client, preflightResult.source, errorMessage);
+      await recordError(client, preflightResult.source, 'chain_tamper');
 
       // Fire the existing chain verification webhook. notifyChainPreflightFailure
       // swallows alert-handler errors internally, but we still wrap the call
@@ -408,7 +412,7 @@ export async function processSiemDelivery(): Promise<void> {
       }
 
       console.error(
-        `[siem-delivery] CHAIN TAMPER DETECTED source=${preflightResult.source} index=${preflightResult.breakAtIndex} reason=${preflightResult.breakReason} entry=${preflightResult.entryId}`
+        `[siem-delivery] CHAIN TAMPER DETECTED source=${preflightResult.source} index=${preflightResult.breakAtIndex} reason=${preflightResult.breakReason} entry=${preflightResult.entryId}${hashDetail ? ` ${hashDetail}` : ''}`
       );
       return;
     }
@@ -510,26 +514,31 @@ export async function processSiemDelivery(): Promise<void> {
       // error write runs after the cursor advance above, so sources that made
       // partial progress still show lastError in /health.
       const errorMessage = result.error ?? 'Unknown delivery error';
+      const errorClass = result.errorClass ?? 'internal_error';
       for (const source of SIEM_SOURCES) {
-        await recordError(client, source, errorMessage);
+        await recordError(client, source, errorClass);
       }
       const partial =
         result.entriesDelivered > 0
           ? ` (${result.entriesDelivered} entries delivered before failure)`
           : '';
-      console.error(`[siem-delivery] Delivery failed: ${errorMessage}${partial}`);
+      // Raw error text (may embed the receiver's response body) stays in the
+      // operator-only log; only `errorClass` was persisted to the cursor above.
+      console.error(`[siem-delivery] Delivery failed [${errorClass}]: ${errorMessage}${partial}`);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 
     try {
       for (const source of SIEM_SOURCES) {
-        await recordError(client, source, message);
+        await recordError(client, source, 'internal_error');
       }
     } catch {
       // best-effort only — don't mask the original error
     }
 
+    // Persist only the safe class; the raw message (which may include internal
+    // detail) stays in the operator-only log.
     console.error('[siem-delivery] Worker error:', message);
     throw error;
   } finally {


### PR DESCRIPTION
Closes #989.

## Problem

The processor's `GET /health` endpoint is unauthenticated by design (k8s liveness probe) but surfaced `siem.sources.<source>.lastError`, which was populated **verbatim** from the SIEM delivery worker as `HTTP <status>: <full response.text()>`. If a customer's SIEM receiver returns a verbose error (stack trace, `invalid token: abc123…`, schema, user IDs), that content became readable by anyone who can reach the health endpoint. In `cloud` mode where processors share infrastructure this is a **cross-tenant information-disclosure** surface; even on-prem it aids downstream-SIEM fingerprinting.

## Fix — zero-trust + pure functions

The untrusted external body must never cross into the persisted/exposed domain. Enforced at three points:

1. **Classify at the write boundary** (`siem-adapter.ts`) — a closed union `DeliveryErrorClass` (`transport_error`, `http_client_error`, `http_server_error`, `ssrf_blocked`, `invalid_config`, `chain_tamper`, `preflight_unavailable`, `internal_error`, `unclassified_error`) is stamped on every failed `SiemDeliveryResult`. A pure `classifyHttpStatus()` handles the 4xx/5xx split. The raw `error` string is kept for logging only.
2. **Make illegal states unrepresentable** (`siem-delivery-worker.ts`) — `recordError`'s signature changed from `message: string` to `errorClass: DeliveryErrorClass`. It is now a **compile-time error** to persist a raw body into the `/health`-visible cursor from any call site.
3. **Read-time zero-trust guard** (`siem-health-builder.ts`) — `cursorToPerSource` allowlists `lastError` against the safe classes; anything else (e.g. a legacy raw-body row already at rest in the DB) collapses to `unclassified_error`. `null` is preserved so `deriveStatus` still reports `error` only when one occurred — this neutralizes pre-existing rows with **no migration**.

Full raw error detail is retained in the processor's **stdout logs** at every write site for operator triage.

## Deliberately out of scope

- **No** authenticated `/health/detail` endpoint — raw bodies already reach stdout at all write sites; a re-exposure endpoint just relocates the hazard behind an auth check that can be misconfigured.
- **No** DB scrub migration — the read-time allowlist neutralizes legacy rows on the only unauthenticated surface (`/siem/receipts` does not read the column).

## Acceptance criteria

- [x] `siem.sources.<source>.lastError` on unauthenticated `/health` never contains customer-controlled strings.
- [x] Operators can still see the raw error during triage (processor stdout logs at every write site).
- [x] Tests cover error-classification mapping, and that raw bodies do not appear in `/health` even when the cursor row contains them.
- [x] Change documented (this PR description + code comments referencing #989).

## Testing

- `bun run --filter=@pagespace/processor typecheck` ✓ (the `recordError` signature change proves at compile time no call site can persist free text)
- `bun run --filter=@pagespace/processor lint` ✓
- **221** tests pass across the four affected files, including a new end-to-end `/health` test proving a cursor row containing `sk-live-abc123` surfaces as `unclassified_error` with the secret absent from the response JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Sensitive SIEM delivery and webhook error details are no longer exposed through health checks or stored cursor status.
  * Error information is standardized into safe categories, including configuration, network, HTTP, validation, and tampering errors.
  * Chain verification failures now report safe status indicators without revealing forensic details.

* **Reliability**
  * SIEM delivery failures retain clearer classifications while preserving retry behavior and operational diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->