### PR TITLE
fix(notifications): iOS permission-prompt race + Electron desktop OS notifications

### DIFF
--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -269,7 +269,7 @@ export default function NotificationsSettingsPage() {
             In-app Pop-ups
           </CardTitle>
           <CardDescription>
-            Choose how live pop-up notifications show up while you&apos;re using PageSpace. This doesn&apos;t affect the notification bell, which always shows everything.
+            Choose how live pop-up notifications show up while you&apos;re using PageSpace. On the desktop app, this also governs system notifications when PageSpace is in the background. This doesn&apos;t affect the notification bell, which always shows everything.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/apps/web/src/components/PushNotificationManager.tsx
+++ b/apps/web/src/components/PushNotificationManager.tsx
@@ -19,21 +19,19 @@ export function PushNotificationManager() {
   useEffect(() => {
     if (!isNative || !isSupported) return;
 
+    // Wait until native checkPermissions() has resolved — don't burn the guard on 'unknown'.
+    if (permissionStatus === 'unknown') return;
+
     // Prevent multiple attempts in strict mode dev
     if (attemptRef.current) return;
     attemptRef.current = true;
 
-    const initNotifications = async () => {
-      if (permissionStatus === 'prompt') {
-        await requestPermission();
-      } else if (permissionStatus === 'granted' && !isRegistered) {
-        await registerToken();
-      }
-    };
-
-    // Small delay to ensure Capacitor is fully ready
-    const timer = setTimeout(initNotifications, 1000);
-    return () => clearTimeout(timer);
+    if (permissionStatus === 'prompt') {
+      void requestPermission();
+    } else if (permissionStatus === 'granted' && !isRegistered) {
+      void registerToken();
+    }
+    // 'denied': burn the attempt, do nothing — user must enable in iOS Settings.
   }, [isNative, isSupported, permissionStatus, isRegistered, requestPermission, registerToken]);
 
   return null;

--- a/apps/web/src/components/__tests__/PushNotificationManager.test.tsx
+++ b/apps/web/src/components/__tests__/PushNotificationManager.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/react';
 
 const { mockUsePushNotifications, mockUseCapacitor } = vi.hoisted(() => ({
@@ -29,41 +29,34 @@ const defaultPushState = {
 
 describe('PushNotificationManager', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.clearAllMocks();
 
     mockUseCapacitor.mockReturnValue({ isNative: true });
     mockUsePushNotifications.mockReturnValue({ ...defaultPushState });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('given non-native environment, should not call requestPermission or registerToken', async () => {
+  it('given non-native environment, should not call requestPermission or registerToken', () => {
     mockUseCapacitor.mockReturnValue({ isNative: false });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(defaultPushState.requestPermission).not.toHaveBeenCalled();
     expect(defaultPushState.registerToken).not.toHaveBeenCalled();
   });
 
-  it('given not supported, should not call requestPermission or registerToken', async () => {
+  it('given not supported, should not call requestPermission or registerToken', () => {
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
       isSupported: false,
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(defaultPushState.requestPermission).not.toHaveBeenCalled();
     expect(defaultPushState.registerToken).not.toHaveBeenCalled();
   });
 
-  it('given native + supported + permission prompt, should call requestPermission after delay', async () => {
+  it('given native + supported + permission prompt, should call requestPermission immediately', () => {
     const requestPermission = vi.fn().mockResolvedValue(true);
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
@@ -72,12 +65,11 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(requestPermission).toHaveBeenCalledOnce();
   });
 
-  it('given native + supported + permission granted + not registered, should call registerToken after delay', async () => {
+  it('given native + supported + permission granted + not registered, should call registerToken immediately', () => {
     const registerToken = vi.fn().mockResolvedValue(true);
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
@@ -87,12 +79,11 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(registerToken).toHaveBeenCalledOnce();
   });
 
-  it('given native + supported + permission granted + already registered, should not call registerToken', async () => {
+  it('given native + supported + permission granted + already registered, should not call registerToken', () => {
     const registerToken = vi.fn().mockResolvedValue(true);
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
@@ -102,13 +93,12 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(registerToken).not.toHaveBeenCalled();
     expect(defaultPushState.requestPermission).not.toHaveBeenCalled();
   });
 
-  it('given permission denied, should not call requestPermission or registerToken', async () => {
+  it('given permission denied, should not call requestPermission or registerToken', () => {
     const requestPermission = vi.fn().mockResolvedValue(false);
     const registerToken = vi.fn().mockResolvedValue(false);
     mockUsePushNotifications.mockReturnValue({
@@ -119,7 +109,6 @@ describe('PushNotificationManager', () => {
     });
 
     render(<PushNotificationManager />);
-    await vi.advanceTimersByTimeAsync(1000);
 
     expect(requestPermission).not.toHaveBeenCalled();
     expect(registerToken).not.toHaveBeenCalled();
@@ -131,20 +120,52 @@ describe('PushNotificationManager', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('should clean up timer on unmount before it fires', async () => {
+  it('regression: does not burn the attempt while permissionStatus is unknown, then prompts exactly once when it resolves to prompt', () => {
     const requestPermission = vi.fn().mockResolvedValue(true);
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'unknown',
+      requestPermission,
+    });
+
+    const { rerender } = render(<PushNotificationManager />);
+    expect(requestPermission).not.toHaveBeenCalled();
+
     mockUsePushNotifications.mockReturnValue({
       ...defaultPushState,
       permissionStatus: 'prompt',
       requestPermission,
     });
+    rerender(<PushNotificationManager />);
+    expect(requestPermission).toHaveBeenCalledOnce();
 
-    const { unmount } = render(<PushNotificationManager />);
+    // Further rerenders (e.g. unrelated state changes) must not re-trigger it.
+    rerender(<PushNotificationManager />);
+    expect(requestPermission).toHaveBeenCalledOnce();
+  });
 
-    await vi.advanceTimersByTimeAsync(500);
-    unmount();
-    await vi.advanceTimersByTimeAsync(500);
+  it('regression: permissionStatus unknown then denied never calls requestPermission or registerToken', () => {
+    const requestPermission = vi.fn().mockResolvedValue(false);
+    const registerToken = vi.fn().mockResolvedValue(false);
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'unknown',
+      requestPermission,
+      registerToken,
+    });
+
+    const { rerender } = render(<PushNotificationManager />);
+    expect(requestPermission).not.toHaveBeenCalled();
+
+    mockUsePushNotifications.mockReturnValue({
+      ...defaultPushState,
+      permissionStatus: 'denied',
+      requestPermission,
+      registerToken,
+    });
+    rerender(<PushNotificationManager />);
 
     expect(requestPermission).not.toHaveBeenCalled();
+    expect(registerToken).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useSocket } from "@/hooks/useSocket";
 import { useAccessRevocation } from "@/hooks/useAccessRevocation";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
+import { useDesktopNotifications } from "@/hooks/useDesktopNotifications";
 import TopBar from "@/components/layout/main-header";
 import MemoizedSidebar from "@/components/layout/left-sidebar/MemoizedSidebar";
 import CenterPanel from "@/components/layout/middle-content/CenterPanel";
@@ -132,6 +133,9 @@ function Layout({ children }: LayoutProps) {
 
   // Show live toast popups for new notifications, anywhere in the app
   useNotificationToasts();
+
+  // Show native OS notifications for new notifications when the desktop app is unfocused
+  useDesktopNotifications();
 
   // Monitor performance
   usePerformanceMonitor();

--- a/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
+++ b/apps/web/src/hooks/__tests__/useDesktopNotifications.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { LegacyNotification } from '@pagespace/lib/notifications/types';
+
+const { mockPush } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+}));
+
+let mockToastLevel: 'all' | 'mentions' | 'off' = 'all';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('@/hooks/useToastPreferences', () => ({
+  useToastPreferences: () => ({
+    level: mockToastLevel,
+    isLoading: false,
+    updateLevel: vi.fn(),
+  }),
+}));
+
+import { useDesktopNotifications } from '../useDesktopNotifications';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+
+type TestNotification = LegacyNotification & { title: string; message: string };
+
+function build(overrides: Partial<TestNotification> = {}): TestNotification {
+  return {
+    id: 'notif-1',
+    userId: 'user-1',
+    type: 'MENTION',
+    title: 'You were mentioned',
+    message: 'Jonathan mentioned you in "Roadmap"',
+    isRead: false,
+    createdAt: new Date(),
+    metadata: { mentionerName: 'Jonathan', pageTitle: 'Roadmap', pageType: 'DOCUMENT' },
+    pageId: 'page-1',
+    driveId: 'drive-1',
+    ...overrides,
+  };
+}
+
+interface MockNotificationInstance {
+  title: string;
+  body?: string;
+  tag?: string;
+  onclick: (() => void) | null;
+  close: ReturnType<typeof vi.fn>;
+}
+
+let notificationInstances: MockNotificationInstance[];
+let NotificationMock: ReturnType<typeof vi.fn>;
+
+describe('useDesktopNotifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockToastLevel = 'all';
+    useNotificationStore.setState({ notifications: [], unreadCount: 0 });
+    useNotificationStore.setState({ handleNotificationRead: vi.fn().mockResolvedValue(undefined) });
+
+    notificationInstances = [];
+    NotificationMock = vi.fn().mockImplementation((title: string, options?: { body?: string; tag?: string }) => {
+      const instance: MockNotificationInstance = {
+        title,
+        body: options?.body,
+        tag: options?.tag,
+        onclick: null,
+        close: vi.fn(),
+      };
+      notificationInstances.push(instance);
+      return instance;
+    });
+    Object.defineProperty(NotificationMock, 'permission', { value: 'granted', configurable: true });
+    // @ts-expect-error - test stub of the global Notification constructor
+    global.Notification = NotificationMock;
+
+    // @ts-expect-error - test stub of Electron's renderer bridge
+    window.electron = { isDesktop: true };
+
+    vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    vi.spyOn(window, 'focus').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.electron;
+    // @ts-expect-error - cleanup test stub
+    delete global.Notification;
+  });
+
+  it('does not construct a Notification when not running in the desktop app', () => {
+    delete window.electron;
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('does not construct a Notification when the window is focused', () => {
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('constructs a Notification with title/body/tag when unfocused and eligible', () => {
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(NotificationMock).toHaveBeenCalledTimes(1);
+    expect(NotificationMock).toHaveBeenCalledWith('You were mentioned', {
+      body: 'Jonathan mentioned you in "Roadmap"',
+      tag: 'notif-1',
+    });
+  });
+
+  it('does not construct a second Notification for the same id and signature', () => {
+    renderHook(() => useDesktopNotifications());
+
+    const notification = build();
+
+    act(() => {
+      useNotificationStore.getState().addNotification(notification);
+    });
+    expect(NotificationMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useNotificationStore.getState().markAllAsRead();
+    });
+
+    expect(NotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('constructs a second Notification when the signature changes for the same id', () => {
+    renderHook(() => useDesktopNotifications());
+
+    const dm = build({
+      id: 'notif-dm',
+      type: 'NEW_DIRECT_MESSAGE',
+      message: 'First message',
+      metadata: { conversationId: 'conv-1', messageId: 'm1', senderId: 'sender-1' },
+      pageId: null,
+      driveId: null,
+    });
+
+    act(() => {
+      useNotificationStore.getState().addNotification(dm);
+    });
+
+    act(() => {
+      useNotificationStore.getState().addNotification({
+        ...dm,
+        message: 'Second message',
+        createdAt: new Date(dm.createdAt.getTime() + 1000),
+      });
+    });
+
+    expect(NotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not construct a Notification when the preference level is off', () => {
+    mockToastLevel = 'off';
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    expect(NotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('on click: focuses the window, marks the notification read, navigates, and closes', () => {
+    renderHook(() => useDesktopNotifications());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build());
+    });
+
+    const instance = notificationInstances[0];
+    expect(instance.onclick).toBeTypeOf('function');
+
+    act(() => {
+      instance.onclick?.();
+    });
+
+    expect(window.focus).toHaveBeenCalledTimes(1);
+    expect(useNotificationStore.getState().handleNotificationRead).toHaveBeenCalledWith('notif-1');
+    expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/page-1');
+    expect(instance.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/hooks/useDesktopNotifications.ts
+++ b/apps/web/src/hooks/useDesktopNotifications.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+import { resolveDestination, type StoredNotification } from '@/lib/notifications/resolve-destination';
+import { isToastEligible } from '@/lib/notifications/toast-eligible-types';
+import { useToastPreferences } from '@/hooks/useToastPreferences';
+
+/**
+ * Shows a native OS notification (Electron desktop only) whenever a new
+ * notification lands in useNotificationStore, mirroring useNotificationToasts'
+ * store-subscription/dedup pattern rather than listening to the socket directly.
+ *
+ * Unlike the in-app toast, this fires even when the destination matches the
+ * current pathname: an unfocused window means the user hasn't actually seen it.
+ */
+export function useDesktopNotifications() {
+  const router = useRouter();
+  const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
+  const { level } = useToastPreferences();
+
+  const mountTimeRef = useRef(Date.now());
+  const notifiedRef = useRef(new Map<string, string>());
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.electron?.isDesktop) return;
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+
+    const unsubscribe = useNotificationStore.subscribe((state) => {
+      const top = state.notifications[0] as StoredNotification | undefined;
+      if (!top) return;
+      if (new Date(top.createdAt).getTime() < mountTimeRef.current) return;
+
+      const signature = `${top.message}|${new Date(top.createdAt).toISOString()}`;
+      if (notifiedRef.current.get(top.id) === signature) return;
+      notifiedRef.current.set(top.id, signature);
+
+      if (!isToastEligible(top.type, level)) return;
+      if (document.hasFocus()) return;
+
+      const notification = new Notification(top.title, { body: top.message, tag: top.id });
+      notification.onclick = () => {
+        window.focus();
+        if (!top.isRead) {
+          void handleNotificationRead(top.id);
+        }
+        const destination = resolveDestination(top);
+        if (destination) {
+          router.push(destination);
+        }
+        notification.close();
+      };
+    });
+
+    return unsubscribe;
+  }, [router, handleNotificationRead, level]);
+}


### PR DESCRIPTION
## Summary

Two independent root causes, one branch, per the confirmed diagnosis:

**iOS — permission-prompt race.** `PushNotificationManager` gated its one-shot `attemptRef` guard on `isNative && isSupported`, but on the first render where that gate passes, `permissionStatus` from `usePushNotifications` is still `'unknown'` (the native `checkPermissions()` call hasn't resolved yet). Since `initNotifications` only acted on `'prompt'`/`'granted'`, nothing happened — but the guard was already burned. By the time status resolved to `'prompt'` a moment later, the effect early-returned and the native permission dialog never fired. Fixed by returning early on `'unknown'` *before* setting `attemptRef`, and removing the 1s `setTimeout` (now redundant, and it had its own defect — cleanup cancelled it whenever any dependency changed within that second).

**Desktop — no notification code path.** Electron's `media-permissions.ts` already grants the `notifications` permission to the loaded page, but nothing ever called `new Notification(...)`. Added `useDesktopNotifications`, modeled on the existing `useNotificationToasts` (same store-subscription/dedup pattern off `useNotificationStore`, not the socket directly), mounted in `Layout.tsx`. Fires a native OS notification when the Electron window is unfocused and the user's toast-preference level allows it (`'off'` silences it too); clicking focuses the window, marks the notification read, and navigates to its resolved destination. Since the desktop app remote-loads pagespace.ai, this ships to all installed desktop apps without any apps/desktop changes.

## Test plan

- [x] `bun run typecheck` — all 16 packages pass, including `web:build`
- [x] `PushNotificationManager.test.tsx` — 9 tests, including 2 new regression tests encoding the race (unknown → prompt fires exactly once; unknown → denied never fires)
- [x] `useDesktopNotifications.test.tsx` (new) — 7 tests: non-desktop gate, focused-window suppression, eligible unfocused fire, dedup by id+signature, re-fire on signature change, `'off'` preference suppression, click → focus + mark-read + navigate
- [x] `settings/notifications/page.test.tsx` — unaffected, still passing (copy-only tweak)
- [ ] TestFlight verification: install build, deny/re-grant permission in iOS Settings, confirm the prompt now fires on first launch
- [ ] Local desktop verification: unfocus the Electron window, trigger a notification, confirm the OS banner appears; click it and confirm focus + navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pW2pwdKAuZPHAuEpdsvns