### PR TITLE
refactor(notifications): extract shared dedup hook, parallelize APNs listener setup

### DIFF
--- a/apps/web/src/hooks/__tests__/useNotificationToasts.test.tsx
+++ b/apps/web/src/hooks/__tests__/useNotificationToasts.test.tsx
@@ -216,4 +216,26 @@ describe('useNotificationToasts', () => {
 
     expect(mockToastCustom).toHaveBeenCalledTimes(1);
   });
+
+  it('regression: does not re-toast a notification that resurfaces at the top after the newer one on top of it is dismissed', () => {
+    renderHook(() => useNotificationToasts());
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build({ id: 'notif-a' }));
+    });
+    expect(mockToastCustom).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useNotificationStore.getState().addNotification(build({ id: 'notif-b' }));
+    });
+    expect(mockToastCustom).toHaveBeenCalledTimes(2);
+
+    // Dismissing/deleting the top notification ('notif-b') makes 'notif-a'
+    // the top again, unchanged — it must not be treated as new.
+    act(() => {
+      useNotificationStore.getState().removeNotification('notif-b');
+    });
+
+    expect(mockToastCustom).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/web/src/hooks/useDesktopNotifications.ts
+++ b/apps/web/src/hooks/useDesktopNotifications.ts
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { useNotificationStore } from '@/stores/useNotificationStore';
-import { resolveDestination, type StoredNotification } from '@/lib/notifications/resolve-destination';
+import { resolveDestination } from '@/lib/notifications/resolve-destination';
 import { isToastEligible } from '@/lib/notifications/toast-eligible-types';
 import { useToastPreferences } from '@/hooks/useToastPreferences';
 import { isDesktopPlatform } from '@/lib/desktop-auth';
+import { useNewStoreNotification } from '@/hooks/useNewStoreNotification';
 
 /**
  * Shows a native OS notification (Electron desktop only) whenever a new (or
@@ -15,57 +15,42 @@ import { isDesktopPlatform } from '@/lib/desktop-auth';
  * when the window is unfocused — a focused window is already covered by the
  * sonner toast from useNotificationToasts, so showing both would double-notify.
  *
- * Deliberately does NOT add its own socket listener; useNotificationStore is
- * the single parse/dedup source of truth, mirroring useNotificationToasts.
+ * Shares its "is this event worth considering" gate with useNotificationToasts
+ * via useNewStoreNotification so the two surfaces can never disagree about
+ * what counts as new.
  */
 export function useDesktopNotifications() {
   const router = useRouter();
   const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
   const { level, isLoading: isLoadingPreferences } = useToastPreferences();
 
-  const mountTimeRef = useRef(Date.now());
-  const notifiedRef = useRef(new Map<string, string>());
+  const canShowDesktopNotifications =
+    isDesktopPlatform() && typeof Notification !== 'undefined' && Notification.permission === 'granted';
 
-  useEffect(() => {
-    if (!isDesktopPlatform()) return;
-    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+  useNewStoreNotification((top) => {
+    // Default to silence, not the provisional 'all', while the real
+    // preference is still loading (e.g. on a cold start) — otherwise an
+    // opted-out user could briefly see banners before their saved 'off'/
+    // 'mentions' level has come back from the server.
+    if (isLoadingPreferences) return;
+    if (!isToastEligible(top.type, level)) return;
+    if (document.hasFocus()) return;
 
-    const unsubscribe = useNotificationStore.subscribe((state) => {
-      const top = state.notifications[0] as StoredNotification | undefined;
-      if (!top) return;
-      const createdAt = new Date(top.createdAt);
-      if (createdAt.getTime() < mountTimeRef.current) return;
-
-      const signature = `${top.message}|${createdAt.toISOString()}`;
-      if (notifiedRef.current.get(top.id) === signature) return;
-      notifiedRef.current.set(top.id, signature);
-
-      // Default to silence, not the provisional 'all', while the real
-      // preference is still loading (e.g. on a cold start) — otherwise an
-      // opted-out user could briefly see banners before their saved 'off'/
-      // 'mentions' level has come back from the server.
-      if (isLoadingPreferences) return;
-      if (!isToastEligible(top.type, level)) return;
-      if (document.hasFocus()) return;
-
-      const n = new Notification(top.title, { body: top.message, tag: top.id });
-      n.onclick = () => {
-        window.focus();
-        // Look up the live read state rather than the `top` closed over at
-        // notification-construction time — it may have been marked read via
-        // another surface (dropdown, sibling toast) in the meantime.
-        const current = useNotificationStore.getState().notifications.find((notif) => notif.id === top.id);
-        if (!current || !current.isRead) void handleNotificationRead(top.id);
-        const destination = resolveDestination(top);
-        if (destination) router.push(destination);
-        n.close();
-        // The sibling sonner toast (useNotificationToasts) may still be showing
-        // for the same notification id — dismiss it so it doesn't linger after
-        // the user has already navigated away via the OS notification.
-        toast.dismiss(top.id);
-      };
-    });
-
-    return unsubscribe;
-  }, [router, handleNotificationRead, level, isLoadingPreferences]);
+    const n = new Notification(top.title, { body: top.message, tag: top.id });
+    n.onclick = () => {
+      window.focus();
+      // Look up the live read state rather than the `top` closed over at
+      // notification-construction time — it may have been marked read via
+      // another surface (dropdown, sibling toast) in the meantime.
+      const current = useNotificationStore.getState().notifications.find((notif) => notif.id === top.id);
+      if (!current || !current.isRead) void handleNotificationRead(top.id);
+      const destination = resolveDestination(top);
+      if (destination) router.push(destination);
+      n.close();
+      // The sibling sonner toast (useNotificationToasts) may still be showing
+      // for the same notification id — dismiss it so it doesn't linger after
+      // the user has already navigated away via the OS notification.
+      toast.dismiss(top.id);
+    };
+  }, canShowDesktopNotifications);
 }

--- a/apps/web/src/hooks/useNewStoreNotification.ts
+++ b/apps/web/src/hooks/useNewStoreNotification.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+import type { StoredNotification } from '@/lib/notifications/resolve-destination';
+
+/**
+ * Subscribes to useNotificationStore and invokes `onNew` once for each
+ * notification that is new since mount, or updated in place (e.g. a
+ * NEW_DIRECT_MESSAGE bumped to the top with a new message/timestamp).
+ *
+ * Shared by every notification-delivery surface (toast, native OS banner) so
+ * the "is this event worth considering" gate can never diverge between them.
+ * Only the current top notification is compared against the last one seen —
+ * the store always prepends/re-sorts so the top is the only slot that can
+ * change, keeping this O(1) instead of an ever-growing per-id map.
+ *
+ * Pass `enabled: false` to skip subscribing entirely (e.g. a surface that
+ * only applies on some platforms) without violating the rules of hooks.
+ */
+export function useNewStoreNotification(
+  onNew: (notification: StoredNotification) => void,
+  enabled = true,
+) {
+  const mountTimeRef = useRef(Date.now());
+  const lastSeenRef = useRef<{ id: string; signature: string } | null>(null);
+  const onNewRef = useRef(onNew);
+  onNewRef.current = onNew;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    return useNotificationStore.subscribe((state) => {
+      const top = state.notifications[0] as StoredNotification | undefined;
+      if (!top) return;
+      const createdAt = new Date(top.createdAt);
+      if (createdAt.getTime() < mountTimeRef.current) return;
+
+      const signature = `${top.message}|${createdAt.toISOString()}`;
+      if (lastSeenRef.current?.id === top.id && lastSeenRef.current.signature === signature) return;
+      lastSeenRef.current = { id: top.id, signature };
+
+      onNewRef.current(top);
+    });
+  }, [enabled]);
+}

--- a/apps/web/src/hooks/useNewStoreNotification.ts
+++ b/apps/web/src/hooks/useNewStoreNotification.ts
@@ -4,6 +4,14 @@ import { useEffect, useRef } from 'react';
 import { useNotificationStore } from '@/stores/useNotificationStore';
 import type { StoredNotification } from '@/lib/notifications/resolve-destination';
 
+// Cap on tracked notification ids. A single last-seen ref isn't enough: if
+// the top notification is dismissed/deleted, the previous top can resurface
+// unchanged (same id+signature) and must NOT be treated as new again. A
+// per-id map is required for that — capped so a long-lived session doesn't
+// grow it unbounded, evicting the oldest entry (Map preserves insertion
+// order) once the cap is exceeded.
+const MAX_TRACKED_IDS = 200;
+
 /**
  * Subscribes to useNotificationStore and invokes `onNew` once for each
  * notification that is new since mount, or updated in place (e.g. a
@@ -11,9 +19,6 @@ import type { StoredNotification } from '@/lib/notifications/resolve-destination
  *
  * Shared by every notification-delivery surface (toast, native OS banner) so
  * the "is this event worth considering" gate can never diverge between them.
- * Only the current top notification is compared against the last one seen —
- * the store always prepends/re-sorts so the top is the only slot that can
- * change, keeping this O(1) instead of an ever-growing per-id map.
  *
  * Pass `enabled: false` to skip subscribing entirely (e.g. a surface that
  * only applies on some platforms) without violating the rules of hooks.
@@ -23,7 +28,7 @@ export function useNewStoreNotification(
   enabled = true,
 ) {
   const mountTimeRef = useRef(Date.now());
-  const lastSeenRef = useRef<{ id: string; signature: string } | null>(null);
+  const seenRef = useRef(new Map<string, string>());
   const onNewRef = useRef(onNew);
   onNewRef.current = onNew;
 
@@ -37,8 +42,12 @@ export function useNewStoreNotification(
       if (createdAt.getTime() < mountTimeRef.current) return;
 
       const signature = `${top.message}|${createdAt.toISOString()}`;
-      if (lastSeenRef.current?.id === top.id && lastSeenRef.current.signature === signature) return;
-      lastSeenRef.current = { id: top.id, signature };
+      if (seenRef.current.get(top.id) === signature) return;
+      seenRef.current.set(top.id, signature);
+      if (seenRef.current.size > MAX_TRACKED_IDS) {
+        const oldestId = seenRef.current.keys().next().value;
+        if (oldestId !== undefined) seenRef.current.delete(oldestId);
+      }
 
       onNewRef.current(top);
     });

--- a/apps/web/src/hooks/useNotificationToasts.tsx
+++ b/apps/web/src/hooks/useNotificationToasts.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { toast } from 'sonner';
 import { useNotificationStore } from '@/stores/useNotificationStore';
-import { resolveDestination, type StoredNotification } from '@/lib/notifications/resolve-destination';
+import { resolveDestination } from '@/lib/notifications/resolve-destination';
 import { isToastEligible } from '@/lib/notifications/toast-eligible-types';
 import { NotificationToast } from '@/components/notifications/NotificationToast';
 import { useToastPreferences } from '@/hooks/useToastPreferences';
+import { useNewStoreNotification } from '@/hooks/useNewStoreNotification';
 
 /**
  * Shows a live custom toast whenever a new (or updated-in-place, e.g.
@@ -25,47 +25,31 @@ export function useNotificationToasts() {
   const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
   const { level } = useToastPreferences();
 
-  const mountTimeRef = useRef(Date.now());
-  const toastedRef = useRef(new Map<string, string>());
+  useNewStoreNotification((top) => {
+    if (!isToastEligible(top.type, level)) return;
 
-  useEffect(() => {
-    const handleSelect = (notification: StoredNotification, toastId: string | number) => {
-      if (!notification.isRead) {
-        handleNotificationRead(notification.id);
+    const destination = resolveDestination(top);
+    if (destination && destination === pathname) return;
+
+    const handleSelect = (toastId: string | number) => {
+      if (!top.isRead) {
+        handleNotificationRead(top.id);
       }
-      const destination = resolveDestination(notification);
       if (destination) {
         router.push(destination);
       }
       toast.dismiss(toastId);
     };
 
-    const unsubscribe = useNotificationStore.subscribe((state) => {
-      const top = state.notifications[0] as StoredNotification | undefined;
-      if (!top) return;
-      if (new Date(top.createdAt).getTime() < mountTimeRef.current) return;
-
-      const signature = `${top.message}|${new Date(top.createdAt).toISOString()}`;
-      if (toastedRef.current.get(top.id) === signature) return;
-      toastedRef.current.set(top.id, signature);
-
-      if (!isToastEligible(top.type, level)) return;
-
-      const destination = resolveDestination(top);
-      if (destination && destination === pathname) return;
-
-      toast.custom(
-        (id) => (
-          <NotificationToast
-            notification={top}
-            onSelect={() => handleSelect(top, id)}
-            onDismiss={() => toast.dismiss(id)}
-          />
-        ),
-        { id: top.id, duration: 8000 },
-      );
-    });
-
-    return unsubscribe;
-  }, [router, pathname, handleNotificationRead, level]);
+    toast.custom(
+      (id) => (
+        <NotificationToast
+          notification={top}
+          onSelect={() => handleSelect(id)}
+          onDismiss={() => toast.dismiss(id)}
+        />
+      ),
+      { id: top.id, duration: 8000 },
+    );
+  });
 }

--- a/apps/web/src/hooks/usePushNotifications.ts
+++ b/apps/web/src/hooks/usePushNotifications.ts
@@ -69,61 +69,49 @@ export function usePushNotifications(): PushNotificationState & PushNotification
           const { PushNotifications } = await import('@capacitor/push-notifications');
           pushNotificationsRef.current = PushNotifications;
 
-          // Registration success
-          const registrationListener = await PushNotifications.addListener(
-            'registration',
-            (token: { value: string }) => {
-              console.log('[PushNotifications] Registered with token:', token.value.substring(0, 20) + '...');
-              tokenRef.current = token.value;
-              registerTokenWithServerRef.current(token.value);
-            }
-          );
-          listenersRef.current.push(() => registrationListener.remove());
-
-          // Registration error
-          const registrationErrorListener = await PushNotifications.addListener(
-            'registrationError',
-            (error: { error: string }) => {
-              console.error('[PushNotifications] Registration error:', error);
-              setState(prev => ({
-                ...prev,
-                error: error.error,
-                isLoading: false,
-              }));
-            }
-          );
-          listenersRef.current.push(() => registrationErrorListener.remove());
-
-          // Notification received while app is in foreground
-          const receivedListener = await PushNotifications.addListener(
-            'pushNotificationReceived',
-            (notification: PushNotificationSchema) => {
-              console.log('[PushNotifications] Received:', notification);
-              // Handle foreground notification
-              // Could dispatch an event or update state here
-              if (typeof window !== 'undefined') {
-                window.dispatchEvent(new CustomEvent('push:received', {
-                  detail: notification,
+          // Four independent listeners — register concurrently rather than
+          // sequentially awaiting each native-bridge round trip.
+          const [registrationListener, registrationErrorListener, receivedListener, actionListener] =
+            await Promise.all([
+              PushNotifications.addListener('registration', (token: { value: string }) => {
+                console.log('[PushNotifications] Registered with token:', token.value.substring(0, 20) + '...');
+                tokenRef.current = token.value;
+                registerTokenWithServerRef.current(token.value);
+              }),
+              PushNotifications.addListener('registrationError', (error: { error: string }) => {
+                console.error('[PushNotifications] Registration error:', error);
+                setState(prev => ({
+                  ...prev,
+                  error: error.error,
+                  isLoading: false,
                 }));
-              }
-            }
-          );
-          listenersRef.current.push(() => receivedListener.remove());
+              }),
+              // Notification received while app is in foreground
+              PushNotifications.addListener('pushNotificationReceived', (notification: PushNotificationSchema) => {
+                console.log('[PushNotifications] Received:', notification);
+                if (typeof window !== 'undefined') {
+                  window.dispatchEvent(new CustomEvent('push:received', {
+                    detail: notification,
+                  }));
+                }
+              }),
+              // Notification tapped
+              PushNotifications.addListener('pushNotificationActionPerformed', (action: ActionPerformed) => {
+                console.log('[PushNotifications] Action performed:', action);
+                if (typeof window !== 'undefined') {
+                  window.dispatchEvent(new CustomEvent('push:action', {
+                    detail: action,
+                  }));
+                }
+              }),
+            ]);
 
-          // Notification tapped
-          const actionListener = await PushNotifications.addListener(
-            'pushNotificationActionPerformed',
-            (action: ActionPerformed) => {
-              console.log('[PushNotifications] Action performed:', action);
-              // Handle notification tap
-              if (typeof window !== 'undefined') {
-                window.dispatchEvent(new CustomEvent('push:action', {
-                  detail: action,
-                }));
-              }
-            }
+          listenersRef.current.push(
+            () => registrationListener.remove(),
+            () => registrationErrorListener.remove(),
+            () => receivedListener.remove(),
+            () => actionListener.remove(),
           );
-          listenersRef.current.push(() => actionListener.remove());
 
           setState(prev => ({ ...prev, isSupported: true }));
         } catch {


### PR DESCRIPTION
## Summary

Follow-up to #1971 (merged). That PR's final commit — a proactive `/simplify` cleanup pass — was pushed after #1971 was already merged, so it never landed in master. This PR carries that commit forward as-is (cherry-picked, no changes).

## What changed

Multiple independent review passes on #1971 (both my own self-review and a dedicated `/simplify` pass) converged on the same finding: `useDesktopNotifications.ts` duplicated ~30 lines of `useNotificationToasts.tsx`'s subscribe/mount-time-filter/signature-dedup logic near verbatim. With a second delivery surface now existing (and a third plausible), extracted the shared "is this a new/updated notification worth considering" gate into a new `useNewStoreNotification.ts` hook. Both existing hooks now supply only their surface-specific render/click behavior — no behavior change.

The extraction also fixes an efficiency finding along the way: the duplicated logic used a `Map<string, string>` keyed by every notification id ever seen, growing unbounded for the life of a session.

## Follow-up: reviewer finding (chatgpt-codex-connector)

The efficiency fix above (replacing the map with a single last-seen ref, on the theory that only the previous top's id+signature can ever matter again) was wrong: if the top notification is dismissed/deleted, the previous one resurfaces at the top *unchanged*, and a single ref has no memory of it having already been shown — a real duplicate-toast/banner regression. Restored a per-id `Map`, now capped at 200 tracked ids with oldest-eviction so it still can't grow unbounded in a long session, satisfying both the correctness requirement and the original efficiency concern. Added a regression test encoding the exact scenario (add A, add B, remove B → A resurfaces at top, must not re-toast).

Also applied a review finding to `usePushNotifications.ts`: the four Capacitor `addListener` calls were awaited sequentially; they're independent, so now run concurrently via `Promise.all` to cut native-bridge round trips during Capacitor startup.

## Test plan

- [x] `bun run typecheck` — green
- [x] `useNotificationToasts.test.tsx` (11 tests, +1 regression) — passes
- [x] `useDesktopNotifications.test.tsx` (10 tests) — unaffected by the extraction, passes unmodified
- [x] `PushNotificationManager.test.tsx` (9 tests) — unaffected, passes unmodified
- [x] `useNotificationStore.test.ts` (32 tests) — unaffected, passes unmodified
- [x] `eslint` on all touched files — clean
- [x] No dedicated test file for `useNewStoreNotification.ts` — it has no independent public behavior beyond what the two consumers' full test suites already exercise end-to-end, including the dismiss/resurface regression case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhVuJyjjs2FYyUjWmnA6bR
