### PR TITLE
feat(audit): Phase 0 repository seam — injectable audit surface, zero behavior change (#890 Phase 0)

### DIFF
--- a/packages/lib/src/audit/__tests__/audit-query.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-query.test.ts
@@ -39,7 +39,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((col: string, val: unknown) => ({ eq: [col, val] })),
 }));
 
-import { queryAuditEvents } from '../audit-query';
+import { queryAuditEvents, type AuditQueryDeps } from '../audit-query';
 import { eq, or, gte, lte } from '@pagespace/db/operators';
 
 describe('queryAuditEvents()', () => {
@@ -176,5 +176,35 @@ describe('queryAuditEvents()', () => {
     await expect(queryAuditEvents({ limit: 1.5 })).rejects.toThrow(
       'limit must be a non-negative integer'
     );
+  });
+
+  describe('given an injected db client', () => {
+    function createInjectedDb(rows: unknown[]) {
+      const limit = vi.fn().mockResolvedValue(rows);
+      const orderBy = vi.fn().mockReturnValue({ limit, then: (resolve: (v: unknown) => void) => resolve(rows) });
+      const where = vi.fn().mockReturnValue({ orderBy });
+      const from = vi.fn().mockReturnValue({ where });
+      const select = vi.fn().mockReturnValue({ from });
+      return { select, _chain: { select, from, where, orderBy, limit } };
+    }
+
+    it('should use the injected client exclusively, never the module-level singleton', async () => {
+      const injectedEvents = [{ id: 'injected-1', eventType: 'auth.logout', userId: 'user-9' }];
+      const injectedDb = createInjectedDb(injectedEvents);
+
+      const deps: AuditQueryDeps = { db: injectedDb as unknown as AuditQueryDeps['db'] };
+      const result = await queryAuditEvents({}, deps);
+
+      expect(injectedDb.select).toHaveBeenCalled();
+      expect(mockDb.select).not.toHaveBeenCalled();
+      expect(result).toEqual(injectedEvents);
+    });
+
+    it('given no injected client, should fall back to the default db (parity with today)', async () => {
+      const result = await queryAuditEvents({});
+
+      expect(mockDb.select).toHaveBeenCalled();
+      expect(result).toEqual(mockEvents);
+    });
   });
 });

--- a/packages/lib/src/audit/__tests__/phase0-regression.test.ts
+++ b/packages/lib/src/audit/__tests__/phase0-regression.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Phase 0 regression suite (DB Decomposition epic, #890).
+ *
+ * Leaves 1-3 extracted the repository/service/reader/verifier seams via DI.
+ * This suite is the safety net for Phases 1-2, which will re-point these
+ * seams at a dedicated audit Postgres: it pins the CURRENT hash/chain
+ * semantics so any future change to hashing, chain serialization, or DI
+ * wiring fails loudly here first.
+ *
+ * Maps to the four Phase 0 requirements on the phase page:
+ *   1. Hash golden vectors           -> describe block 1
+ *   2. Concurrent-append chain integrity -> describe block 2
+ *   3. DI completeness sweep         -> describe block 3
+ *   4. Zero-call-site regression     -> describe block 4
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ count: 0 }]),
+      }),
+    }),
+    query: {
+      securityAuditLog: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    },
+  },
+}));
+vi.mock('@pagespace/db/schema/security-audit', () => ({ securityAuditLog: {} }));
+vi.mock('@pagespace/db/operators', () => ({
+  desc: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  eq: vi.fn(),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+}));
+
+import {
+  computeSecurityEventHash,
+  createSecurityAuditService,
+  securityAudit,
+  type AuditEvent,
+} from '../security-audit';
+import {
+  createSecurityAuditRepository,
+  type SecurityAuditRepository,
+  type SecurityAuditRepositoryDeps,
+} from '../security-audit-repository';
+import { queryAuditEvents, type AuditQueryDeps } from '../audit-query';
+import {
+  verifySecurityAuditChain,
+  type VerifySecurityChainDeps,
+} from '../security-audit-chain-verifier';
+import { verifyAndAlert } from '../security-audit-alerting';
+
+// ============================================================================
+// 1. Hash golden vectors
+// ============================================================================
+// Pinned literal hex outputs of computeSecurityEventHash for fixed inputs.
+// Regenerated with the exact production algorithm (sha256 over
+// stableStringify of the same payload shape) — if this suite ever fails,
+// hashing semantics changed and every historical chain entry is now
+// unverifiable against a fresh recomputation.
+describe('1. Hash golden vectors (pinned)', () => {
+  const GENESIS_HASH = '352808abde213c0a20c3d2a5d709f4e33955aa33b6971d6960993755606b7aef';
+  const CHAINED_HASH = '7566053c513943d7842722b5f40cc6e1654fdd0d939d32f5df2c37a7f621af77';
+  const DETAILS_HASH = 'e4e3c56dececa1b30b46d9902ed54be7a5ba2630246024ec61e9925b0beb319f';
+  const ALL_FIELDS_HASH = '13b4892e73c5c0b2ad4a245875afbe4c28884cc1b6f65760b989e258a97f7f50';
+  const UNICODE_HASH = 'fe00f0e287d8282ec3bae0f5759c54d9fead54387da06fca94b324231bba8066';
+
+  it('genesis event (minimal fields, previousHash="genesis") matches the pinned hash', () => {
+    const event: AuditEvent = { eventType: 'auth.login.success' };
+    const hash = computeSecurityEventHash(event, 'genesis', new Date('2026-01-25T10:00:00.000Z'));
+
+    expect(hash).toBe(GENESIS_HASH);
+  });
+
+  it('chained event (previousHash = prior genesis hash) matches the pinned hash', () => {
+    const event: AuditEvent = {
+      eventType: 'auth.logout',
+      userId: 'user-1',
+      resourceType: 'session',
+      resourceId: 'sess-1',
+    };
+    const hash = computeSecurityEventHash(event, GENESIS_HASH, new Date('2026-01-25T10:00:01.000Z'));
+
+    expect(hash).toBe(CHAINED_HASH);
+  });
+
+  it('event with a details jsonb payload matches the pinned hash', () => {
+    const event: AuditEvent = {
+      eventType: 'data.export',
+      resourceType: 'drive',
+      resourceId: 'drive-42',
+      details: { format: 'pdf', pageCount: 12, tags: ['q1', 'report'] },
+      riskScore: 0.2,
+    };
+    const hash = computeSecurityEventHash(event, CHAINED_HASH, new Date('2026-01-25T10:00:02.000Z'));
+
+    expect(hash).toBe(DETAILS_HASH);
+  });
+
+  it('event with every PII field present matches the pinned hash AND equals the PII-stripped equivalent (proves PII exclusion)', () => {
+    const timestamp = new Date('2026-01-25T10:00:03.000Z');
+    const withPii: AuditEvent = {
+      eventType: 'security.anomaly.detected',
+      userId: 'user-pii-123',
+      sessionId: 'sess-pii-456',
+      serviceId: 'web',
+      resourceType: 'account',
+      resourceId: 'acct-1',
+      ipAddress: '203.0.113.7',
+      userAgent: 'Mozilla/5.0 (PII-Agent)',
+      geoLocation: 'US-CA',
+      details: { flag: 'impossible_travel' },
+      riskScore: 0.9,
+      anomalyFlags: ['impossible_travel', 'new_device'],
+    };
+    const withoutPii: AuditEvent = {
+      eventType: 'security.anomaly.detected',
+      serviceId: 'web',
+      resourceType: 'account',
+      resourceId: 'acct-1',
+      details: { flag: 'impossible_travel' },
+      riskScore: 0.9,
+      anomalyFlags: ['impossible_travel', 'new_device'],
+    };
+
+    const hashWithPii = computeSecurityEventHash(withPii, CHAINED_HASH, timestamp);
+    const hashWithoutPii = computeSecurityEventHash(withoutPii, CHAINED_HASH, timestamp);
+
+    expect(hashWithPii).toBe(ALL_FIELDS_HASH);
+    expect(hashWithPii).toBe(hashWithoutPii);
+  });
+
+  it('unicode content and reversed key order produce the same pinned hash (stableStringify stress)', () => {
+    const timestamp = new Date('2026-01-25T10:00:04.000Z');
+    const a: AuditEvent = {
+      eventType: 'data.write',
+      resourceType: 'page',
+      resourceId: 'page-ü',
+      details: { title: '日本語テスト', emoji: '🔒', z_last: 1, a_first: 2 },
+    };
+    const b: AuditEvent = {
+      eventType: 'data.write',
+      resourceType: 'page',
+      resourceId: 'page-ü',
+      details: { a_first: 2, z_last: 1, emoji: '🔒', title: '日本語テスト' },
+    };
+
+    const hashA = computeSecurityEventHash(a, GENESIS_HASH, timestamp);
+    const hashB = computeSecurityEventHash(b, GENESIS_HASH, timestamp);
+
+    expect(hashA).toBe(UNICODE_HASH);
+    expect(hashA).toBe(hashB);
+  });
+});
+
+// ============================================================================
+// 2. Concurrent-append chain integrity
+// ============================================================================
+// Models pg_advisory_xact_lock as a real mutual-exclusion primitive: a
+// transaction's lock-acquire `execute()` call blocks (via an unresolved
+// promise) until the previously-queued transaction commits and releases.
+// Firing appendEvent calls through Promise.all (rather than sequential
+// awaits) means the mock genuinely interleaves at the point each call first
+// suspends, exercising the same ordering hazard a real concurrent workload
+// would hit if the lock were ever taken after the head read instead of before.
+function createSerializingMockDb(initialHead: string | undefined) {
+  // Each entry tagged with the transaction that issued it, since genuinely
+  // concurrent dispatch (Promise.all) interleaves at the synchronous-dispatch
+  // phase: every transaction's lock-acquire call fires (and is recorded)
+  // before any of them resolve their `myTurn` wait, so global array adjacency
+  // does NOT mean same-transaction — only per-transaction order is meaningful.
+  const executedSql: Array<{ txId: number; sqlObj: { strings: TemplateStringsArray; values: unknown[] } }> = [];
+  const inserts: Array<{ previousHash: string; eventHash: string }> = [];
+  let currentHead = initialHead;
+  let mutexTail: Promise<void> = Promise.resolve();
+  let txCounter = 0;
+
+  const db = {
+    transaction: async (callback: (tx: unknown) => Promise<void>) => {
+      const txId = txCounter++;
+      const myTurn = mutexTail;
+      let releaseMutex: () => void = () => {};
+      mutexTail = new Promise((resolve) => {
+        releaseMutex = resolve;
+      });
+
+      const tx = {
+        execute: async (sqlObj: { strings: TemplateStringsArray; values: unknown[] }) => {
+          executedSql.push({ txId, sqlObj });
+          const joined = sqlObj.strings.join('');
+          if (joined.includes('pg_advisory_xact_lock')) {
+            await myTurn;
+            return { rows: [] };
+          }
+          return { rows: currentHead ? [{ event_hash: currentHead }] : [] };
+        },
+        insert: () => ({
+          values: (value: { previousHash: string; eventHash: string }) => {
+            inserts.push(value);
+            currentHead = value.eventHash;
+            return Promise.resolve(undefined);
+          },
+        }),
+      };
+
+      await callback(tx);
+      releaseMutex();
+    },
+  } as unknown as SecurityAuditRepositoryDeps['db'];
+
+  return { db, inserts, executedSql };
+}
+
+describe('2. Concurrent-append chain integrity', () => {
+  it('given N concurrent appendEvent calls dispatched via Promise.all, should never fork the chain', async () => {
+    const { db, inserts } = createSerializingMockDb(undefined);
+    const repo = createSecurityAuditRepository({ db });
+    const events: AuditEvent[] = Array.from({ length: 5 }, (_, i) => ({
+      eventType: 'auth.login.success',
+      userId: `user-${i}`,
+    }));
+
+    await Promise.all(
+      events.map((event, i) => repo.appendEvent(event, { now: new Date(Date.UTC(2026, 0, 25, 10, 0, i)) }))
+    );
+
+    expect(inserts).toHaveLength(5);
+    expect(inserts[0]!.previousHash).toBe('genesis');
+
+    // Linear chain: each insert's previousHash is the exact prior insert's
+    // eventHash, in commit order — no two inserts share a previousHash (a
+    // fork), and no hash repeats.
+    for (let i = 1; i < inserts.length; i++) {
+      expect(inserts[i]!.previousHash).toBe(inserts[i - 1]!.eventHash);
+    }
+    const previousHashes = inserts.map((r) => r.previousHash);
+    expect(new Set(previousHashes).size).toBe(previousHashes.length);
+    const eventHashes = inserts.map((r) => r.eventHash);
+    expect(new Set(eventHashes).size).toBe(eventHashes.length);
+  });
+
+  it('for every one of N concurrent transactions, the lock is acquired before its head read', async () => {
+    const { db, executedSql } = createSerializingMockDb(undefined);
+    const repo = createSecurityAuditRepository({ db });
+    const events: AuditEvent[] = Array.from({ length: 4 }, () => ({ eventType: 'auth.logout' }));
+
+    await Promise.all(events.map((event) => repo.appendEvent(event)));
+
+    const byTx = new Map<number, Array<{ strings: TemplateStringsArray; values: unknown[] }>>();
+    for (const { txId, sqlObj } of executedSql) {
+      const calls = byTx.get(txId) ?? [];
+      calls.push(sqlObj);
+      byTx.set(txId, calls);
+    }
+
+    expect(byTx.size).toBe(4);
+    for (const calls of byTx.values()) {
+      expect(calls).toHaveLength(2);
+      expect(calls[0]!.strings.join('')).toContain('pg_advisory_xact_lock');
+      expect(calls[1]!.strings.join('')).toContain('ORDER BY chain_seq DESC');
+    }
+  });
+});
+
+// ============================================================================
+// 3. DI completeness sweep — no seam silently falls through to a singleton
+// ============================================================================
+describe('3. DI completeness sweep (no singleton fallthrough)', () => {
+  it('repository: two repositories built from two distinct db clients never cross-touch each other', async () => {
+    const { db: dbA, inserts: insertsA } = createSerializingMockDb(undefined);
+    const { db: dbB, inserts: insertsB } = createSerializingMockDb(undefined);
+    const repoA = createSecurityAuditRepository({ db: dbA });
+    const repoB = createSecurityAuditRepository({ db: dbB });
+
+    await repoA.appendEvent({ eventType: 'auth.login.success' });
+
+    expect(insertsA).toHaveLength(1);
+    expect(insertsB).toHaveLength(0);
+  });
+
+  it('service factory: two services built from two distinct repositories never cross-call each other', async () => {
+    function mockRepo(): SecurityAuditRepository & { appendEvent: ReturnType<typeof vi.fn> } {
+      return { appendEvent: vi.fn().mockResolvedValue(undefined), readChainHead: vi.fn() };
+    }
+    const repoA = mockRepo();
+    const repoB = mockRepo();
+    const serviceA = createSecurityAuditService({ repository: repoA });
+    const serviceB = createSecurityAuditService({ repository: repoB });
+
+    await serviceA.logEvent({ eventType: 'auth.login.success' });
+
+    expect(repoA.appendEvent).toHaveBeenCalledTimes(1);
+    expect(repoB.appendEvent).not.toHaveBeenCalled();
+    expect(serviceB.isInitialized()).toBe(false);
+  });
+
+  it('queryAuditEvents: given an injected db, never touches the default db (seam confirmed, see audit-query.test.ts for full coverage)', async () => {
+    const limit = vi.fn().mockResolvedValue([]);
+    const orderBy = vi.fn().mockReturnValue({ limit, then: (r: (v: unknown) => void) => r([]) });
+    const where = vi.fn().mockReturnValue({ orderBy });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const deps: AuditQueryDeps = { db: { select } as unknown as AuditQueryDeps['db'] };
+
+    await queryAuditEvents({}, deps);
+
+    expect(select).toHaveBeenCalled();
+  });
+
+  it('verifySecurityAuditChain: given an injected db, never touches the default db (seam confirmed, see security-audit-chain-verifier.test.ts for full coverage)', async () => {
+    const select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 0 }]) }),
+    });
+    const findMany = vi.fn().mockResolvedValue([]);
+    const deps: VerifySecurityChainDeps = {
+      db: { select, query: { securityAuditLog: { findMany } } } as unknown as VerifySecurityChainDeps['db'],
+    };
+
+    const result = await verifySecurityAuditChain({}, deps);
+
+    expect(select).toHaveBeenCalled();
+    expect(result.totalEntries).toBe(0);
+  });
+
+  it('verifyAndAlert: threads deps through to verifySecurityAuditChain (seam confirmed, see security-audit-alerting.test.ts for full coverage)', async () => {
+    const select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 0 }]) }),
+    });
+    const findMany = vi.fn().mockResolvedValue([]);
+    const deps: VerifySecurityChainDeps = {
+      db: { select, query: { securityAuditLog: { findMany } } } as unknown as VerifySecurityChainDeps['db'],
+    };
+
+    const result = await verifyAndAlert('manual', undefined, deps);
+
+    expect(select).toHaveBeenCalled();
+    expect(result.isValid).toBe(true);
+  });
+
+  it('given no AUDIT_DATABASE_URL seam exists yet, its presence in the environment has no effect on any reader (forward-compat guard for Phase 1)', async () => {
+    const prev = process.env.AUDIT_DATABASE_URL;
+    process.env.AUDIT_DATABASE_URL = 'postgres://not-yet-wired-up/audit';
+    try {
+      // No deps injected -> falls back to the (mocked) default db, exactly as
+      // it would with the env var absent. Phase 0 has no code path that reads
+      // this variable, so its presence must be a complete no-op.
+      const result = await verifySecurityAuditChain();
+      expect(result.isValid).toBe(true);
+      expect(result.totalEntries).toBe(0);
+    } finally {
+      if (prev === undefined) delete process.env.AUDIT_DATABASE_URL;
+      else process.env.AUDIT_DATABASE_URL = prev;
+    }
+  });
+});
+
+// ============================================================================
+// 4. Zero-call-site regression: securityAudit singleton public surface
+// ============================================================================
+// The 248 existing audit()/auditRequest() call sites (via audit-log.ts) and
+// any direct securityAudit.* callers depend on this exact surface. Phase 0
+// must not add, remove, or rename anything on it.
+describe('4. Zero-call-site regression: securityAudit public surface', () => {
+  const EXPECTED_METHODS = [
+    'initialize',
+    'isInitialized',
+    'logEvent',
+    'logAuthSuccess',
+    'logAuthFailure',
+    'logAccessDenied',
+    'logTokenCreated',
+    'logTokenRevoked',
+    'logAnomalyDetected',
+    'logDataAccess',
+    'logLogout',
+    'logRateLimited',
+    'logBruteForceDetected',
+    'queryEvents',
+  ] as const;
+
+  it('exposes exactly logEvent + the 10 convenience wrappers + queryEvents + initialize/isInitialized (14 total)', () => {
+    expect(EXPECTED_METHODS).toHaveLength(14);
+    expect(Object.keys(securityAudit).sort()).toEqual([...EXPECTED_METHODS].sort());
+  });
+
+  it('every surface member is callable', () => {
+    for (const method of EXPECTED_METHODS) {
+      expect(typeof securityAudit[method]).toBe('function');
+    }
+  });
+});

--- a/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
@@ -77,6 +77,8 @@ import {
   isPeriodicVerificationRunning,
   type ChainVerificationAlert,
 } from '../security-audit-alerting';
+import type { VerifySecurityChainDeps } from '../security-audit-chain-verifier';
+import { db as mockDefaultDb } from '@pagespace/db/db';
 
 describe('security-audit-alerting (#544)', () => {
   beforeEach(() => {
@@ -175,6 +177,31 @@ describe('security-audit-alerting (#544)', () => {
         expect.stringContaining('[SecurityAuditAlerting] Alert handler failed:'),
         expect.objectContaining({ error: expect.any(Error) })
       );
+    });
+
+    it('threads an injected db client through to verifySecurityAuditChain, never touching the module-level singleton', async () => {
+      const injectedEntries = createValidSecurityChain(2);
+      const select = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ count: injectedEntries.length }]),
+        }),
+      });
+      const findMany = vi.fn().mockImplementation(async (opts) => {
+        let result = [...injectedEntries].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        if (opts?.offset) result = result.slice(opts.offset);
+        if (opts?.limit) result = result.slice(0, opts.limit);
+        return result;
+      });
+      const injectedDb = { select, query: { securityAuditLog: { findMany } } };
+      const deps: VerifySecurityChainDeps = { db: injectedDb as unknown as VerifySecurityChainDeps['db'] };
+
+      const result = await verifyAndAlert('manual', undefined, deps);
+
+      expect(select).toHaveBeenCalled();
+      expect(findMany).toHaveBeenCalled();
+      expect(mockDefaultDb.select).not.toHaveBeenCalled();
+      expect(result.isValid).toBe(true);
+      expect(result.totalEntries).toBe(2);
     });
 
     it('returns verification result on empty chain without alert', async () => {

--- a/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
@@ -87,8 +87,10 @@ vi.mock('@pagespace/db/schema/security-audit', () => ({
 import {
   verifySecurityAuditChain,
   type SecurityChainVerificationResult,
+  type VerifySecurityChainDeps,
 } from '../security-audit-chain-verifier';
 import { computeSecurityEventHash, type AuditEvent } from '../security-audit';
+import { db as mockDefaultDb } from '@pagespace/db/db';
 
 describe('security-audit-chain-verifier', () => {
   beforeEach(() => {
@@ -305,6 +307,50 @@ describe('security-audit-chain-verifier', () => {
 
       expect(result.isValid).toBe(true);
       expect(result.breakPoint).toBeNull();
+    });
+
+    describe('given an injected db client', () => {
+      function createInjectedDb(entries: MockSecurityAuditEntry[]) {
+        const select = vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([{ count: entries.length }]),
+          }),
+        });
+        const findMany = vi.fn().mockImplementation(async (opts) => {
+          let result = [...entries].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+          if (opts?.offset) result = result.slice(opts.offset);
+          if (opts?.limit) result = result.slice(0, opts.limit);
+          return result;
+        });
+        return { select, query: { securityAuditLog: { findMany } } };
+      }
+
+      it('should use the injected client exclusively, never the module-level singleton', async () => {
+        mockEntries = [];
+        const injectedEntries = createValidSecurityChain(3);
+        const injectedDb = createInjectedDb(injectedEntries);
+        const deps: VerifySecurityChainDeps = { db: injectedDb as unknown as VerifySecurityChainDeps['db'] };
+
+        const result = await verifySecurityAuditChain({}, deps);
+
+        expect(injectedDb.select).toHaveBeenCalled();
+        expect(injectedDb.query.securityAuditLog.findMany).toHaveBeenCalled();
+        expect(mockDefaultDb.select).not.toHaveBeenCalled();
+        expect(mockDefaultDb.query.securityAuditLog.findMany).not.toHaveBeenCalled();
+        expect(result.isValid).toBe(true);
+        expect(result.totalEntries).toBe(3);
+      });
+
+      it('given no injected client, should fall back to the default db (parity with today)', async () => {
+        mockEntries = createValidSecurityChain(2);
+
+        const result = await verifySecurityAuditChain();
+
+        expect(mockDefaultDb.select).toHaveBeenCalled();
+        expect(mockDefaultDb.query.securityAuditLog.findMany).toHaveBeenCalled();
+        expect(result.isValid).toBe(true);
+        expect(result.entriesVerified).toBe(2);
+      });
     });
   });
 });

--- a/packages/lib/src/audit/__tests__/security-audit-repository.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-repository.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+}));
+
+import {
+  createSecurityAuditRepository,
+  SECURITY_AUDIT_CHAIN_LOCK_KEY,
+  type SecurityAuditRepositoryDeps,
+} from '../security-audit-repository';
+import { computeSecurityEventHash, type AuditEvent } from '../security-audit';
+
+interface CapturedInsert {
+  values: Record<string, unknown>;
+}
+
+interface ExecutedSql {
+  strings: TemplateStringsArray;
+  values: unknown[];
+}
+
+function createMockDb(initialHead: string | undefined) {
+  const executedSql: ExecutedSql[] = [];
+  const inserts: CapturedInsert[] = [];
+  let currentHead = initialHead;
+
+  const execute = (sqlObj: ExecutedSql) => {
+    executedSql.push(sqlObj);
+    const joined = sqlObj.strings.join('');
+    if (joined.includes('pg_advisory_xact_lock')) {
+      return Promise.resolve({ rows: [] });
+    }
+    return Promise.resolve({ rows: currentHead ? [{ event_hash: currentHead }] : [] });
+  };
+
+  const insert = () => ({
+    values: (value: Record<string, unknown>) => {
+      inserts.push({ values: value });
+      currentHead = value.eventHash as string;
+      return Promise.resolve(undefined);
+    },
+  });
+
+  const tx = { execute, insert };
+
+  const db = {
+    execute,
+    transaction: async (callback: (transactionClient: typeof tx) => Promise<void>) => callback(tx),
+  } as unknown as SecurityAuditRepositoryDeps['db'];
+
+  return { db, executedSql, inserts };
+}
+
+describe('createSecurityAuditRepository', () => {
+  describe('appendEvent', () => {
+    it('given a fresh chain with no existing rows, should use "genesis" as previousHash', async () => {
+      const { db, inserts } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+
+      await repo.appendEvent(
+        { eventType: 'auth.login.success', userId: 'user1' },
+        { now: new Date('2026-07-09T00:00:00Z') }
+      );
+
+      expect(inserts).toHaveLength(1);
+      expect(inserts[0]!.values.previousHash).toBe('genesis');
+    });
+
+    it('given an existing chain head, should read it as previousHash', async () => {
+      const { db, inserts } = createMockDb('existing-hash-abc');
+      const repo = createSecurityAuditRepository({ db });
+
+      await repo.appendEvent(
+        { eventType: 'auth.logout', userId: 'user1' },
+        { now: new Date('2026-07-09T00:00:00Z') }
+      );
+
+      expect(inserts[0]!.values.previousHash).toBe('existing-hash-abc');
+    });
+
+    it('should compute a byte-identical hash to computeSecurityEventHash for the same inputs (golden vector)', async () => {
+      const { db, inserts } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+      const event: AuditEvent = {
+        eventType: 'auth.login.success',
+        userId: 'user123',
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+      };
+      const now = new Date('2026-01-25T10:00:00Z');
+
+      await repo.appendEvent(event, { now });
+
+      const expectedHash = computeSecurityEventHash(event, 'genesis', now);
+      expect(inserts[0]!.values.eventHash).toBe(expectedHash);
+    });
+
+    it('should acquire the advisory lock with key 8370291546 before reading the chain head', async () => {
+      const { db, executedSql } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+
+      await repo.appendEvent(
+        { eventType: 'auth.login.success' },
+        { now: new Date('2026-07-09T00:00:00Z') }
+      );
+
+      expect(executedSql.length).toBeGreaterThanOrEqual(2);
+      const lockSql = executedSql[0]!;
+      expect(lockSql.strings.join('')).toContain('pg_advisory_xact_lock');
+      expect(lockSql.values).toContain(SECURITY_AUDIT_CHAIN_LOCK_KEY);
+      expect(SECURITY_AUDIT_CHAIN_LOCK_KEY).toBe(8370291546);
+    });
+
+    it('should read the chain head via chain_seq DESC LIMIT 1 without FOR UPDATE', async () => {
+      const { db, executedSql } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+
+      await repo.appendEvent(
+        { eventType: 'auth.login.success' },
+        { now: new Date('2026-07-09T00:00:00Z') }
+      );
+
+      const headSql = executedSql[1]!.strings.join('');
+      expect(headSql).toContain('event_hash');
+      expect(headSql).toContain('ORDER BY chain_seq DESC');
+      expect(headSql).not.toContain('FOR UPDATE');
+    });
+
+    it('given two concurrent appendEvent calls, should never fork the chain', async () => {
+      const { db, inserts } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+
+      await repo.appendEvent(
+        { eventType: 'auth.login.success', userId: 'user1' },
+        { now: new Date('2026-07-09T00:00:00Z') }
+      );
+      await repo.appendEvent(
+        { eventType: 'auth.logout', userId: 'user1' },
+        { now: new Date('2026-07-09T00:00:01Z') }
+      );
+
+      expect(inserts).toHaveLength(2);
+      expect(inserts[0]!.values.previousHash).toBe('genesis');
+      expect(inserts[1]!.values.previousHash).toBe(inserts[0]!.values.eventHash);
+      expect(inserts[1]!.values.eventHash).not.toBe(inserts[0]!.values.eventHash);
+    });
+
+    it('encrypts the IP address at rest and excludes it from the computed hash', async () => {
+      const { db, inserts } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+      const now = new Date('2026-07-09T00:00:00Z');
+
+      await repo.appendEvent(
+        { eventType: 'auth.login.success', ipAddress: '10.0.0.5' },
+        { now }
+      );
+
+      const withoutIp = computeSecurityEventHash(
+        { eventType: 'auth.login.success' },
+        'genesis',
+        now
+      );
+      expect(inserts[0]!.values.eventHash).toBe(withoutIp);
+      expect(inserts[0]!.values.ipAddress).not.toBe('10.0.0.5');
+      expect(inserts[0]!.values.ipBidx).toEqual(expect.any(String));
+    });
+  });
+
+  describe('readChainHead', () => {
+    it('given no rows, should return "genesis"', async () => {
+      const { db } = createMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+
+      await expect(repo.readChainHead()).resolves.toBe('genesis');
+    });
+
+    it('given an existing head row, should return its event_hash', async () => {
+      const { db } = createMockDb('head-hash-xyz');
+      const repo = createSecurityAuditRepository({ db });
+
+      await expect(repo.readChainHead()).resolves.toBe('head-hash-xyz');
+    });
+  });
+});

--- a/packages/lib/src/audit/__tests__/security-audit-service.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-service.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../audit-query', () => ({
+  queryAuditEvents: vi.fn(),
+}));
+
+import { createSecurityAuditService } from '../security-audit';
+import type { SecurityAuditRepository } from '../security-audit-repository';
+import { queryAuditEvents } from '../audit-query';
+
+function createMockRepository(): SecurityAuditRepository & {
+  appendEvent: ReturnType<typeof vi.fn>;
+  readChainHead: ReturnType<typeof vi.fn>;
+} {
+  return {
+    appendEvent: vi.fn().mockResolvedValue(undefined),
+    readChainHead: vi.fn().mockResolvedValue('genesis'),
+  };
+}
+
+describe('createSecurityAuditService', () => {
+  let repository: ReturnType<typeof createMockRepository>;
+  let service: ReturnType<typeof createSecurityAuditService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = createMockRepository();
+    service = createSecurityAuditService({ repository });
+  });
+
+  describe('initialize / isInitialized', () => {
+    it('given a fresh service, should report not initialized', () => {
+      expect(service.isInitialized()).toBe(false);
+    });
+
+    it('given initialize() was called, should report initialized', async () => {
+      await service.initialize();
+
+      expect(service.isInitialized()).toBe(true);
+    });
+
+    it('given initialize() called multiple times, should stay idempotent', async () => {
+      await service.initialize();
+      await service.initialize();
+      await service.initialize();
+
+      expect(service.isInitialized()).toBe(true);
+    });
+  });
+
+  describe('logEvent', () => {
+    it('given an event, should pass it verbatim to repository.appendEvent', async () => {
+      const event = {
+        eventType: 'auth.login.success' as const,
+        userId: 'user123',
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+      };
+
+      await service.logEvent(event);
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith(event);
+    });
+
+    it('given logEvent is called before initialize(), should self-initialize', async () => {
+      expect(service.isInitialized()).toBe(false);
+
+      await service.logEvent({ eventType: 'auth.logout', userId: 'user123' });
+
+      expect(service.isInitialized()).toBe(true);
+    });
+
+    it('given multiple logEvent calls, should call repository.appendEvent once per event', async () => {
+      await service.logEvent({ eventType: 'auth.login.success', userId: 'user1' });
+      await service.logEvent({ eventType: 'auth.logout', userId: 'user1' });
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('convenience methods', () => {
+    it('logAuthSuccess should log auth.login.success with the given fields', async () => {
+      await service.logAuthSuccess('user123', 'sess456', '192.168.1.1', 'Mozilla/5.0');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'auth.login.success',
+        userId: 'user123',
+        sessionId: 'sess456',
+        ipAddress: '192.168.1.1',
+        userAgent: 'Mozilla/5.0',
+      });
+    });
+
+    it('logAuthFailure should log auth.login.failure with risk score 0.3', async () => {
+      await service.logAuthFailure('attempted@email.com', '192.168.1.1', 'Invalid password');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'auth.login.failure',
+        ipAddress: '192.168.1.1',
+        details: { attemptedUser: 'attempted@email.com', reason: 'Invalid password' },
+        riskScore: 0.3,
+      });
+    });
+
+    it('logAccessDenied should log authz.access.denied with risk score 0.5', async () => {
+      await service.logAccessDenied('user123', 'page', 'page456', 'Insufficient permissions');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'authz.access.denied',
+        userId: 'user123',
+        resourceType: 'page',
+        resourceId: 'page456',
+        details: { reason: 'Insufficient permissions' },
+        riskScore: 0.5,
+      });
+    });
+
+    it('logTokenCreated should log auth.token.created', async () => {
+      await service.logTokenCreated('user123', 'service', '192.168.1.1');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'auth.token.created',
+        userId: 'user123',
+        ipAddress: '192.168.1.1',
+        details: { tokenType: 'service' },
+      });
+    });
+
+    it('logTokenRevoked should log auth.token.revoked', async () => {
+      await service.logTokenRevoked('user123', 'service', 'User logout');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'auth.token.revoked',
+        userId: 'user123',
+        details: { tokenType: 'service', reason: 'User logout' },
+      });
+    });
+
+    it('logAnomalyDetected should log security.anomaly.detected with flags', async () => {
+      await service.logAnomalyDetected('user123', '192.168.1.1', 0.8, ['impossible_travel', 'new_device']);
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'security.anomaly.detected',
+        userId: 'user123',
+        ipAddress: '192.168.1.1',
+        riskScore: 0.8,
+        anomalyFlags: ['impossible_travel', 'new_device'],
+      });
+    });
+
+    it.each([
+      ['read', 'data.read'],
+      ['write', 'data.write'],
+      ['delete', 'data.delete'],
+      ['export', 'data.export'],
+      ['share', 'data.share'],
+    ] as const)('logDataAccess(%s) should map to %s', async (operation, eventType) => {
+      await service.logDataAccess('user123', operation, 'page', 'page456', { extra: true });
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType,
+        userId: 'user123',
+        resourceType: 'page',
+        resourceId: 'page456',
+        details: { extra: true },
+      });
+    });
+
+    it('logLogout should log auth.logout', async () => {
+      await service.logLogout('user123', 'sess456', '192.168.1.1');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'auth.logout',
+        userId: 'user123',
+        sessionId: 'sess456',
+        ipAddress: '192.168.1.1',
+      });
+    });
+
+    it('logRateLimited should log security.rate.limited with risk score 0.4', async () => {
+      await service.logRateLimited('192.168.1.1', '/api/foo', 'user123');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'security.rate.limited',
+        userId: 'user123',
+        ipAddress: '192.168.1.1',
+        details: { endpoint: '/api/foo' },
+        riskScore: 0.4,
+      });
+    });
+
+    it('logBruteForceDetected should log security.brute.force.detected with risk score 0.8', async () => {
+      await service.logBruteForceDetected('192.168.1.1', 5, 'targetUser');
+
+      expect(repository.appendEvent).toHaveBeenCalledTimes(1);
+      expect(repository.appendEvent).toHaveBeenCalledWith({
+        eventType: 'security.brute.force.detected',
+        ipAddress: '192.168.1.1',
+        details: { attemptCount: 5, targetUser: 'targetUser' },
+        riskScore: 0.8,
+        anomalyFlags: ['brute_force'],
+      });
+    });
+  });
+
+  describe('queryEvents', () => {
+    it('should delegate to the standalone queryAuditEvents() function', async () => {
+      const mockEvents = [{ id: 'evt1' }];
+      vi.mocked(queryAuditEvents).mockResolvedValue(mockEvents as never);
+
+      const options = { userId: 'user123' };
+      const result = await service.queryEvents(options);
+
+      expect(queryAuditEvents).toHaveBeenCalledTimes(1);
+      expect(queryAuditEvents).toHaveBeenCalledWith(options);
+      expect(result).toBe(mockEvents);
+    });
+  });
+});

--- a/packages/lib/src/audit/__tests__/security-audit.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit.test.ts
@@ -73,10 +73,13 @@ vi.mock('@pagespace/db/operators', () => ({
 
 // Import after mocking
 import {
-  SecurityAuditService,
+  createSecurityAuditService,
+  CHAIN_LOCK_KEY,
   computeSecurityEventHash,
   type AuditEvent,
+  type SecurityAuditService,
 } from '../security-audit';
+import { createSecurityAuditRepository } from '../security-audit-repository';
 import { db } from '@pagespace/db/db';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 
@@ -93,7 +96,7 @@ describe('Security Audit Service', () => {
     });
     testState.capturedInserts.length = 0;
     testState.executedSql.length = 0;
-    service = new SecurityAuditService();
+    service = createSecurityAuditService({ repository: createSecurityAuditRepository({ db }) });
   });
 
   afterEach(() => {
@@ -293,7 +296,7 @@ describe('Security Audit Service', () => {
     });
 
     it('uses fixed lock key for all events (#542)', async () => {
-      expect(SecurityAuditService.CHAIN_LOCK_KEY).toBe(8370291546);
+      expect(CHAIN_LOCK_KEY).toBe(8370291546);
     });
 
     it('reads latest hash after acquiring lock, not with FOR UPDATE (#542)', async () => {

--- a/packages/lib/src/audit/audit-query.ts
+++ b/packages/lib/src/audit/audit-query.ts
@@ -5,7 +5,7 @@
  * so callers don't need a class instance or initialization ceremony.
  */
 
-import { db } from '@pagespace/db/db';
+import { db as defaultDb } from '@pagespace/db/db';
 import { desc, and, or, gte, lte, eq } from '@pagespace/db/operators';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import type { SelectSecurityAuditLog } from '@pagespace/db/schema/security-audit';
@@ -14,13 +14,20 @@ import { deriveIndexKey } from '../encryption/blind-index';
 import { auditIpBlindIndex } from '../encryption/audit-ip-crypto';
 import { decryptField } from '../encryption/field-crypto';
 
+export interface AuditQueryDeps {
+  /** Drizzle client to query. Defaults to the main app db. */
+  db?: typeof defaultDb;
+}
+
 /**
  * Query audit events with filtering options.
  * Standalone equivalent of SecurityAuditService.queryEvents().
  */
 export async function queryAuditEvents(
-  options: QueryEventsOptions
+  options: QueryEventsOptions,
+  deps: AuditQueryDeps = {}
 ): Promise<SelectSecurityAuditLog[]> {
+  const db = deps.db ?? defaultDb;
   const conditions = [];
 
   if (options.userId) {

--- a/packages/lib/src/audit/security-audit-alerting.ts
+++ b/packages/lib/src/audit/security-audit-alerting.ts
@@ -12,6 +12,7 @@ import {
   verifySecurityAuditChain,
   type SecurityChainVerificationResult,
   type VerifySecurityChainOptions,
+  type VerifySecurityChainDeps,
 } from './security-audit-chain-verifier';
 
 /**
@@ -83,13 +84,15 @@ export function getChainAlertHandler(): ChainAlertHandler | null {
  *
  * @param source - Whether triggered by periodic cron or manual invocation
  * @param options - Verification options passed to verifySecurityAuditChain
+ * @param deps - Injected client passed through to verifySecurityAuditChain (defaults to the main app db)
  * @returns The verification result
  */
 export async function verifyAndAlert(
   source: 'periodic' | 'manual' = 'manual',
-  options?: VerifySecurityChainOptions
+  options?: VerifySecurityChainOptions,
+  deps?: VerifySecurityChainDeps
 ): Promise<SecurityChainVerificationResult> {
-  const result = await verifySecurityAuditChain(options);
+  const result = await verifySecurityAuditChain(options, deps);
 
   if (!result.isValid && alertHandler) {
     const alert: ChainVerificationAlert = {

--- a/packages/lib/src/audit/security-audit-chain-verifier.ts
+++ b/packages/lib/src/audit/security-audit-chain-verifier.ts
@@ -11,7 +11,7 @@
  * - 'genesis' as the chain start (no chainSeed concept)
  */
 
-import { db } from '@pagespace/db/db';
+import { db as defaultDb } from '@pagespace/db/db';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import { asc, count, and, gte, lte, type SQL } from 'drizzle-orm';
 import { loggers } from '../logging/logger-config';
@@ -49,6 +49,11 @@ export interface VerifySecurityChainOptions {
   batchSize?: number;
 }
 
+export interface VerifySecurityChainDeps {
+  /** Drizzle client to read from. Defaults to the main app db. */
+  db?: typeof defaultDb;
+}
+
 /**
  * Stored entry shape used for verification.
  */
@@ -81,13 +86,15 @@ interface StoredSecurityEntry {
  * 4. Verify previousHash matches the prior entry's eventHash (chain-link check)
  */
 export async function verifySecurityAuditChain(
-  options: VerifySecurityChainOptions = {}
+  options: VerifySecurityChainOptions = {},
+  deps: VerifySecurityChainDeps = {}
 ): Promise<SecurityChainVerificationResult> {
   const {
     limit,
     stopOnFirstBreak = true,
     batchSize = 1000,
   } = options;
+  const db = deps.db ?? defaultDb;
 
   const verificationStartedAt = new Date();
   let totalEntries = 0;

--- a/packages/lib/src/audit/security-audit-repository.ts
+++ b/packages/lib/src/audit/security-audit-repository.ts
@@ -1,0 +1,110 @@
+/**
+ * Security Audit Repository
+ *
+ * Transactional append machinery for the tamper-evident security audit hash
+ * chain: advisory-lock serialization, chain-head lookup, and insert.
+ * Extracted verbatim from SecurityAuditService.logEvent (security-audit.ts)
+ * so the backend is swappable by dependency injection — Phase 0 of the
+ * database decomposition epic (#890). Zero behavior change: same lock key,
+ * same chain_seq head query, same 'genesis' sentinel, same hash computation.
+ */
+
+import type { db as defaultDb } from '@pagespace/db/db';
+import { sql } from '@pagespace/db/operators';
+import { securityAuditLog } from '@pagespace/db/schema/security-audit';
+import { deriveIndexKey } from '../encryption/blind-index';
+import { encryptAuditIp } from '../encryption/audit-ip-crypto';
+import { computeSecurityEventHash, type AuditEvent } from './security-audit';
+
+/**
+ * Advisory lock key for serializing hash chain writes. Fixed bigint derived
+ * from the string 'security_audit_chain'. pg_advisory_xact_lock holds the
+ * lock until the transaction commits/rolls back. Must match
+ * SecurityAuditService.CHAIN_LOCK_KEY.
+ */
+export const SECURITY_AUDIT_CHAIN_LOCK_KEY = 8370291546;
+
+/**
+ * Derive the blind-index key from ENCRYPTION_KEY, or null when no usable key
+ * is configured (e.g. dev/test) so audit IPs fall back to plaintext storage.
+ */
+function auditIndexKey(): Buffer | null {
+  const master = process.env.ENCRYPTION_KEY ?? '';
+  return master.length >= 32 ? deriveIndexKey(master) : null;
+}
+
+type ChainHeadExecutor = Pick<typeof defaultDb, 'execute'>;
+
+async function fetchChainHead(executor: ChainHeadExecutor): Promise<string> {
+  const lastRecord = await executor.execute(sql`
+    SELECT event_hash
+    FROM security_audit_log
+    ORDER BY chain_seq DESC
+    LIMIT 1
+  `);
+
+  return (lastRecord.rows[0] as { event_hash: string } | undefined)?.event_hash ?? 'genesis';
+}
+
+export interface SecurityAuditRepositoryDeps {
+  db: typeof defaultDb;
+}
+
+export interface AppendEventOptions {
+  /** Override the event timestamp (default: `new Date()`). Mainly for tests. */
+  now?: Date;
+}
+
+export interface SecurityAuditRepository {
+  appendEvent(event: AuditEvent, opts?: AppendEventOptions): Promise<void>;
+  readChainHead(): Promise<string>;
+}
+
+/**
+ * Build a security audit repository backed by the given Drizzle client.
+ */
+export function createSecurityAuditRepository({ db }: SecurityAuditRepositoryDeps): SecurityAuditRepository {
+  async function readChainHead(): Promise<string> {
+    return fetchChainHead(db);
+  }
+
+  async function appendEvent(event: AuditEvent, opts: AppendEventOptions = {}): Promise<void> {
+    const timestamp = opts.now ?? new Date();
+
+    await db.transaction(async (tx) => {
+      // Acquire advisory lock scoped to this transaction.
+      // Blocks concurrent writers until this transaction completes.
+      await tx.execute(sql`SELECT pg_advisory_xact_lock(${SECURITY_AUDIT_CHAIN_LOCK_KEY})`);
+
+      // Read the latest hash — safe from races under the advisory lock
+      const previousHash = await fetchChainHead(tx);
+
+      const eventHash = computeSecurityEventHash(event, previousHash, timestamp);
+
+      // GDPR #965/#969: encrypt the IP at rest + populate its blind index.
+      // ipAddress is excluded from the event hash, so this is chain-safe.
+      const { ipAddress: storedIp, ipBidx } = await encryptAuditIp(event.ipAddress, auditIndexKey());
+
+      await tx.insert(securityAuditLog).values({
+        eventType: event.eventType,
+        userId: event.userId,
+        sessionId: event.sessionId,
+        serviceId: event.serviceId,
+        resourceType: event.resourceType,
+        resourceId: event.resourceId,
+        ipAddress: storedIp,
+        ipBidx,
+        userAgent: event.userAgent,
+        geoLocation: event.geoLocation,
+        details: event.details,
+        riskScore: event.riskScore,
+        anomalyFlags: event.anomalyFlags,
+        timestamp,
+        previousHash,
+        eventHash,
+      });
+    });
+  }
+
+  return { appendEvent, readChainHead };
+}

--- a/packages/lib/src/audit/security-audit-repository.ts
+++ b/packages/lib/src/audit/security-audit-repository.ts
@@ -19,8 +19,7 @@ import { computeSecurityEventHash, type AuditEvent } from './security-audit';
 /**
  * Advisory lock key for serializing hash chain writes. Fixed bigint derived
  * from the string 'security_audit_chain'. pg_advisory_xact_lock holds the
- * lock until the transaction commits/rolls back. Must match
- * SecurityAuditService.CHAIN_LOCK_KEY.
+ * lock until the transaction commits/rolls back.
  */
 export const SECURITY_AUDIT_CHAIN_LOCK_KEY = 8370291546;
 

--- a/packages/lib/src/audit/security-audit-repository.ts
+++ b/packages/lib/src/audit/security-audit-repository.ts
@@ -64,6 +64,9 @@ export interface SecurityAuditRepository {
  * Build a security audit repository backed by the given Drizzle client.
  */
 export function createSecurityAuditRepository({ db }: SecurityAuditRepositoryDeps): SecurityAuditRepository {
+  // Unused outside this module's tests until Phase 2: the single-writer
+  // chainer (#890) reads the head directly instead of racing appendEvent's
+  // internal lookup. Staged now so the seam doesn't need to be re-added then.
   async function readChainHead(): Promise<string> {
     return fetchChainHead(db);
   }

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -95,266 +95,270 @@ export function computeSecurityEventHash(
 }
 
 /**
- * Security Audit Service with hash chain integrity.
- *
- * Must be initialized before first use by calling initialize().
- * Each logEvent() reads the previous hash from the DB inside an advisory lock,
- * so multi-instance deployments are safe without any in-memory state.
+ * Advisory lock key for serializing hash chain writes.
+ * Uses a fixed bigint derived from the string 'security_audit_chain'.
+ * pg_advisory_xact_lock holds the lock until the transaction commits/rolls back.
+ * Must match SECURITY_AUDIT_CHAIN_LOCK_KEY in security-audit-repository.ts.
  */
-export class SecurityAuditService {
-  private initialized = false;
-  private repository: SecurityAuditRepository | null = null;
+export const CHAIN_LOCK_KEY = 8370291546;
 
+export interface SecurityAuditServiceDeps {
+  repository: SecurityAuditRepository;
+}
+
+export interface SecurityAuditService {
   /**
    * Mark the service as initialized. Retained for callers that invoke it at
    * app startup; logEvent() also self-initializes. Idempotent.
    */
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async initialize(): Promise<void> {
-    this.initialized = true;
-  }
-
-  /**
-   * Advisory lock key for serializing hash chain writes.
-   * Uses a fixed bigint derived from the string 'security_audit_chain'.
-   * pg_advisory_xact_lock holds the lock until the transaction commits/rolls back.
-   */
-  static readonly CHAIN_LOCK_KEY = 8370291546;
-
-  /**
-   * Lazily build the default repository instance. Deferred (rather than built
-   * eagerly at construction) so module load order between security-audit.ts
-   * and security-audit-repository.ts never matters.
-   */
-  private getRepository(): SecurityAuditRepository {
-    if (!this.repository) {
-      this.repository = createSecurityAuditRepository({ db });
-    }
-    return this.repository;
-  }
-
-  /**
-   * Log a security event with hash chain integrity.
-   *
-   * Uses a PostgreSQL advisory lock to serialize concurrent writes and prevent
-   * hash chain forking. Advisory locks work even when the table is empty (genesis),
-   * unlike FOR UPDATE which requires an existing row to lock.
-   *
-   * @param event - The security event to log
-   */
-  async logEvent(event: AuditEvent): Promise<void> {
-    if (!this.initialized) {
-      await this.initialize();
-    }
-
-    return this.getRepository().appendEvent(event);
-  }
-
-  // ==========================================================================
-  // Convenience Methods
-  // ==========================================================================
-
-  /**
-   * Log successful authentication.
-   */
-  async logAuthSuccess(
-    userId: string,
-    sessionId: string,
-    ipAddress: string,
-    userAgent: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'auth.login.success',
-      userId,
-      sessionId,
-      ipAddress,
-      userAgent,
-    });
-  }
-
-  /**
-   * Log failed authentication attempt.
-   */
-  async logAuthFailure(
-    attemptedUser: string,
-    ipAddress: string,
-    reason: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'auth.login.failure',
-      ipAddress,
-      details: { attemptedUser, reason },
-      riskScore: 0.3,
-    });
-  }
-
-  /**
-   * Log access denied event.
-   */
-  async logAccessDenied(
-    userId: string,
-    resourceType: string,
-    resourceId: string,
-    reason: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'authz.access.denied',
-      userId,
-      resourceType,
-      resourceId,
-      details: { reason },
-      riskScore: 0.5,
-    });
-  }
-
-  /**
-   * Log token creation event.
-   */
-  async logTokenCreated(
-    userId: string,
-    tokenType: string,
-    ipAddress?: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'auth.token.created',
-      userId,
-      ipAddress,
-      details: { tokenType },
-    });
-  }
-
-  /**
-   * Log token revocation event.
-   */
-  async logTokenRevoked(
-    userId: string,
-    tokenType: string,
-    reason: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'auth.token.revoked',
-      userId,
-      details: { tokenType, reason },
-    });
-  }
-
-  /**
-   * Log security anomaly detection.
-   */
-  async logAnomalyDetected(
-    userId: string,
-    ipAddress: string,
-    riskScore: number,
-    anomalyFlags: string[]
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'security.anomaly.detected',
-      userId,
-      ipAddress,
-      riskScore,
-      anomalyFlags,
-    });
-  }
-
-  /**
-   * Log data access event.
-   */
-  async logDataAccess(
+  initialize(): Promise<void>;
+  isInitialized(): boolean;
+  logEvent(event: AuditEvent): Promise<void>;
+  logAuthSuccess(userId: string, sessionId: string, ipAddress: string, userAgent: string): Promise<void>;
+  logAuthFailure(attemptedUser: string, ipAddress: string, reason: string): Promise<void>;
+  logAccessDenied(userId: string, resourceType: string, resourceId: string, reason: string): Promise<void>;
+  logTokenCreated(userId: string, tokenType: string, ipAddress?: string): Promise<void>;
+  logTokenRevoked(userId: string, tokenType: string, reason: string): Promise<void>;
+  logAnomalyDetected(userId: string, ipAddress: string, riskScore: number, anomalyFlags: string[]): Promise<void>;
+  logDataAccess(
     userId: string,
     operation: 'read' | 'write' | 'delete' | 'export' | 'share',
     resourceType: string,
     resourceId: string,
     details?: Record<string, unknown>
-  ): Promise<void> {
-    const eventTypeMap: Record<string, SecurityEventType> = {
-      read: 'data.read',
-      write: 'data.write',
-      delete: 'data.delete',
-      export: 'data.export',
-      share: 'data.share',
-    };
+  ): Promise<void>;
+  logLogout(userId: string, sessionId: string, ipAddress?: string): Promise<void>;
+  logRateLimited(ipAddress: string, endpoint: string, userId?: string): Promise<void>;
+  logBruteForceDetected(ipAddress: string, attemptCount: number, targetUser?: string): Promise<void>;
+  /** Query audit events with filtering options. Delegates to queryAuditEvents(). */
+  queryEvents(options: QueryEventsOptions): Promise<SelectSecurityAuditLog[]>;
+}
 
-    return this.logEvent({
-      eventType: eventTypeMap[operation],
-      userId,
-      resourceType,
-      resourceId,
-      details,
-    });
+/**
+ * Build a Security Audit Service with hash chain integrity from an injected
+ * repository. Must be initialized before first use by calling initialize().
+ * Each logEvent() reads the previous hash from the DB inside an advisory lock
+ * (see the repository), so multi-instance deployments are safe without any
+ * in-memory state beyond the `initialized` flag.
+ */
+export function createSecurityAuditService({ repository }: SecurityAuditServiceDeps): SecurityAuditService {
+  let initialized = false;
+
+  // Convenience methods call `api.logEvent(...)` (not a bare closure reference)
+  // so that replacing `api.logEvent` — e.g. via a test spy — is observed by
+  // every wrapper, matching the previous class's `this.logEvent` semantics.
+  const api: SecurityAuditService = {
+    async initialize(): Promise<void> {
+      initialized = true;
+    },
+
+    isInitialized(): boolean {
+      return initialized;
+    },
+
+    async logEvent(event: AuditEvent): Promise<void> {
+      if (!initialized) {
+        await api.initialize();
+      }
+
+      return repository.appendEvent(event);
+    },
+
+    async logAuthSuccess(
+      userId: string,
+      sessionId: string,
+      ipAddress: string,
+      userAgent: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'auth.login.success',
+        userId,
+        sessionId,
+        ipAddress,
+        userAgent,
+      });
+    },
+
+    async logAuthFailure(
+      attemptedUser: string,
+      ipAddress: string,
+      reason: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'auth.login.failure',
+        ipAddress,
+        details: { attemptedUser, reason },
+        riskScore: 0.3,
+      });
+    },
+
+    async logAccessDenied(
+      userId: string,
+      resourceType: string,
+      resourceId: string,
+      reason: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'authz.access.denied',
+        userId,
+        resourceType,
+        resourceId,
+        details: { reason },
+        riskScore: 0.5,
+      });
+    },
+
+    async logTokenCreated(
+      userId: string,
+      tokenType: string,
+      ipAddress?: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'auth.token.created',
+        userId,
+        ipAddress,
+        details: { tokenType },
+      });
+    },
+
+    async logTokenRevoked(
+      userId: string,
+      tokenType: string,
+      reason: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'auth.token.revoked',
+        userId,
+        details: { tokenType, reason },
+      });
+    },
+
+    async logAnomalyDetected(
+      userId: string,
+      ipAddress: string,
+      riskScore: number,
+      anomalyFlags: string[]
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'security.anomaly.detected',
+        userId,
+        ipAddress,
+        riskScore,
+        anomalyFlags,
+      });
+    },
+
+    async logDataAccess(
+      userId: string,
+      operation: 'read' | 'write' | 'delete' | 'export' | 'share',
+      resourceType: string,
+      resourceId: string,
+      details?: Record<string, unknown>
+    ): Promise<void> {
+      const eventTypeMap: Record<string, SecurityEventType> = {
+        read: 'data.read',
+        write: 'data.write',
+        delete: 'data.delete',
+        export: 'data.export',
+        share: 'data.share',
+      };
+
+      return api.logEvent({
+        eventType: eventTypeMap[operation],
+        userId,
+        resourceType,
+        resourceId,
+        details,
+      });
+    },
+
+    async logLogout(
+      userId: string,
+      sessionId: string,
+      ipAddress?: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'auth.logout',
+        userId,
+        sessionId,
+        ipAddress,
+      });
+    },
+
+    async logRateLimited(
+      ipAddress: string,
+      endpoint: string,
+      userId?: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'security.rate.limited',
+        userId,
+        ipAddress,
+        details: { endpoint },
+        riskScore: 0.4,
+      });
+    },
+
+    async logBruteForceDetected(
+      ipAddress: string,
+      attemptCount: number,
+      targetUser?: string
+    ): Promise<void> {
+      return api.logEvent({
+        eventType: 'security.brute.force.detected',
+        ipAddress,
+        details: { attemptCount, targetUser },
+        riskScore: 0.8,
+        anomalyFlags: ['brute_force'],
+      });
+    },
+
+    async queryEvents(options: QueryEventsOptions): Promise<SelectSecurityAuditLog[]> {
+      return queryAuditEvents(options);
+    },
+  };
+
+  return api;
+}
+
+/**
+ * Lazily build the default repository instance. Deferred (rather than built
+ * eagerly at module load) so module load order between security-audit.ts
+ * and security-audit-repository.ts never matters.
+ */
+let defaultRepository: SecurityAuditRepository | null = null;
+function getDefaultRepository(): SecurityAuditRepository {
+  if (!defaultRepository) {
+    defaultRepository = createSecurityAuditRepository({ db });
   }
+  return defaultRepository;
+}
 
-  /**
-   * Log logout event.
-   */
-  async logLogout(
-    userId: string,
-    sessionId: string,
-    ipAddress?: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'auth.logout',
-      userId,
-      sessionId,
-      ipAddress,
-    });
+let defaultService: SecurityAuditService | null = null;
+function getDefaultService(): SecurityAuditService {
+  if (!defaultService) {
+    defaultService = createSecurityAuditService({ repository: getDefaultRepository() });
   }
-
-  /**
-   * Log rate limiting event.
-   */
-  async logRateLimited(
-    ipAddress: string,
-    endpoint: string,
-    userId?: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'security.rate.limited',
-      userId,
-      ipAddress,
-      details: { endpoint },
-      riskScore: 0.4,
-    });
-  }
-
-  /**
-   * Log brute force detection.
-   */
-  async logBruteForceDetected(
-    ipAddress: string,
-    attemptCount: number,
-    targetUser?: string
-  ): Promise<void> {
-    return this.logEvent({
-      eventType: 'security.brute.force.detected',
-      ipAddress,
-      details: { attemptCount, targetUser },
-      riskScore: 0.8,
-      anomalyFlags: ['brute_force'],
-    });
-  }
-
-  // ==========================================================================
-  // Query Methods
-  // ==========================================================================
-
-  /**
-   * Query audit events with filtering options.
-   * Delegates to the standalone queryAuditEvents() function.
-   */
-  async queryEvents(options: QueryEventsOptions): Promise<SelectSecurityAuditLog[]> {
-    return queryAuditEvents(options);
-  }
-
-  /**
-   * Check if the service is initialized.
-   */
-  isInitialized(): boolean {
-    return this.initialized;
-  }
+  return defaultService;
 }
 
 /**
  * Singleton instance for application-wide use.
  * Call securityAudit.initialize() during app startup.
  */
-export const securityAudit = new SecurityAuditService();
+export const securityAudit: SecurityAuditService = {
+  initialize: () => getDefaultService().initialize(),
+  isInitialized: () => getDefaultService().isInitialized(),
+  logEvent: (event) => getDefaultService().logEvent(event),
+  logAuthSuccess: (...args) => getDefaultService().logAuthSuccess(...args),
+  logAuthFailure: (...args) => getDefaultService().logAuthFailure(...args),
+  logAccessDenied: (...args) => getDefaultService().logAccessDenied(...args),
+  logTokenCreated: (...args) => getDefaultService().logTokenCreated(...args),
+  logTokenRevoked: (...args) => getDefaultService().logTokenRevoked(...args),
+  logAnomalyDetected: (...args) => getDefaultService().logAnomalyDetected(...args),
+  logDataAccess: (...args) => getDefaultService().logDataAccess(...args),
+  logLogout: (...args) => getDefaultService().logLogout(...args),
+  logRateLimited: (...args) => getDefaultService().logRateLimited(...args),
+  logBruteForceDetected: (...args) => getDefaultService().logBruteForceDetected(...args),
+  queryEvents: (options) => getDefaultService().queryEvents(options),
+};

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -95,12 +95,10 @@ export function computeSecurityEventHash(
 }
 
 /**
- * Advisory lock key for serializing hash chain writes.
- * Uses a fixed bigint derived from the string 'security_audit_chain'.
- * pg_advisory_xact_lock holds the lock until the transaction commits/rolls back.
- * Must match SECURITY_AUDIT_CHAIN_LOCK_KEY in security-audit-repository.ts.
+ * Advisory lock key for serializing hash chain writes. Re-exported from the
+ * repository (single source of truth) under the name existing tests expect.
  */
-export const CHAIN_LOCK_KEY = 8370291546;
+export { SECURITY_AUDIT_CHAIN_LOCK_KEY as CHAIN_LOCK_KEY } from './security-audit-repository';
 
 export interface SecurityAuditServiceDeps {
   repository: SecurityAuditRepository;

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -17,22 +17,10 @@
 
 import { createHash } from 'crypto';
 import { db } from '@pagespace/db/db';
-import { sql } from '@pagespace/db/operators';
-import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import type { SecurityEventType, SelectSecurityAuditLog } from '@pagespace/db/schema/security-audit';
 import { queryAuditEvents } from './audit-query';
 import { stableStringify } from '../utils/stable-stringify';
-import { deriveIndexKey } from '../encryption/blind-index';
-import { encryptAuditIp } from '../encryption/audit-ip-crypto';
-
-/**
- * Derive the blind-index key from ENCRYPTION_KEY, or null when no usable key is
- * configured (e.g. dev/test) so audit IPs fall back to plaintext storage.
- */
-function auditIndexKey(): Buffer | null {
-  const master = process.env.ENCRYPTION_KEY ?? '';
-  return master.length >= 32 ? deriveIndexKey(master) : null;
-}
+import { createSecurityAuditRepository, type SecurityAuditRepository } from './security-audit-repository';
 
 /**
  * Audit event input structure
@@ -115,6 +103,7 @@ export function computeSecurityEventHash(
  */
 export class SecurityAuditService {
   private initialized = false;
+  private repository: SecurityAuditRepository | null = null;
 
   /**
    * Mark the service as initialized. Retained for callers that invoke it at
@@ -133,6 +122,18 @@ export class SecurityAuditService {
   static readonly CHAIN_LOCK_KEY = 8370291546;
 
   /**
+   * Lazily build the default repository instance. Deferred (rather than built
+   * eagerly at construction) so module load order between security-audit.ts
+   * and security-audit-repository.ts never matters.
+   */
+  private getRepository(): SecurityAuditRepository {
+    if (!this.repository) {
+      this.repository = createSecurityAuditRepository({ db });
+    }
+    return this.repository;
+  }
+
+  /**
    * Log a security event with hash chain integrity.
    *
    * Uses a PostgreSQL advisory lock to serialize concurrent writes and prevent
@@ -146,49 +147,7 @@ export class SecurityAuditService {
       await this.initialize();
     }
 
-    const timestamp = new Date();
-
-    await db.transaction(async (tx) => {
-      // Acquire advisory lock scoped to this transaction.
-      // Blocks concurrent writers until this transaction completes.
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(${SecurityAuditService.CHAIN_LOCK_KEY})`);
-
-      // Read the latest hash — safe from races under the advisory lock
-      const lastRecord = await tx.execute(sql`
-        SELECT event_hash
-        FROM security_audit_log
-        ORDER BY chain_seq DESC
-        LIMIT 1
-      `);
-
-      const previousHash = (lastRecord.rows[0] as { event_hash: string } | undefined)?.event_hash ?? 'genesis';
-
-      const eventHash = computeSecurityEventHash(event, previousHash, timestamp);
-
-      // GDPR #965/#969: encrypt the IP at rest + populate its blind index.
-      // ipAddress is excluded from the event hash, so this is chain-safe.
-      const { ipAddress: storedIp, ipBidx } = await encryptAuditIp(event.ipAddress, auditIndexKey());
-
-      await tx.insert(securityAuditLog).values({
-        eventType: event.eventType,
-        userId: event.userId,
-        sessionId: event.sessionId,
-        serviceId: event.serviceId,
-        resourceType: event.resourceType,
-        resourceId: event.resourceId,
-        ipAddress: storedIp,
-        ipBidx,
-        userAgent: event.userAgent,
-        geoLocation: event.geoLocation,
-        details: event.details,
-        riskScore: event.riskScore,
-        anomalyFlags: event.anomalyFlags,
-        timestamp,
-        previousHash,
-        eventHash,
-      });
-
-    });
+    return this.getRepository().appendEvent(event);
   }
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

Phase 0 of the [Database Decomposition & Zero-Trust Logging epic](https://github.com/2witstudios/PageSpace/issues/890) — a zero-behavior-change functional-core repository seam for the security audit chain, in preparation for the Phase 1+ trust-plane cutover.

**Why:** the epic's end state moves `security_audit_log` off the app DB into a dedicated, hash-chained, externally-anchored trust plane (Phase 1-2), removing the global `pg_advisory_xact_lock` that every authenticated request currently takes. Before any of that can happen, the Postgres-specific plumbing needs to be extracted behind an injectable seam so later phases can swap the executor (main DB → audit DB) without touching call sites. This phase does none of that cutover — it only makes the swap possible later.

**What changed (4 leaves, functional-core / imperative-shell style — no classes, no ambient singletons in new code):**
- **Leaf 1** — extracted `createSecurityAuditRepository({ db })`, performing the exact current transactional append (advisory lock key `8370291546`, `chain_seq` head lookup, `'genesis'` sentinel) with byte-identical hashes vs. today.
- **Leaf 2** — converted `SecurityAuditService` from a class to `createSecurityAuditService({ repository })` factory composition; the `securityAudit` singleton is now built lazily from the factory. `CHAIN_LOCK_KEY` is now a standalone export.
- **Leaf 3** — threaded `deps.db` through `queryAuditEvents`, `verifySecurityAuditChain`, and `verifyAndAlert` (query/verifier readers), defaulting to the main app DB when not injected — no singleton fallthrough.
- **Leaf 4** — full-phase regression suite: requirement→test mapping, golden-hash vectors, concurrency (no chain forking), and a DI sweep proving identical behavior whether or not deps are injected.

All 248 existing `audit()`/`auditRequest()` call sites compile and behave identically — no call-site edits. The pure core (`computeSecurityEventHash`, `stableStringify`) is untouched and still imports no db/env/schema.

**Review outcome:** 1 minor finding during the REVIEW leaf — an unused `readChainHead()` method on the new repository with no callers outside its own test file. Resolved (kept, staged for Phase 2's chainer, comment added) per orchestrator ruling; see Phase 0 page `## Findings`.

**Tests:** 173/173 passing in `packages/lib/src/audit` (up from 132 pre-Phase-0), typecheck clean across the monorepo.

## Test plan
- [x] `bunx vitest run src/audit` from `packages/lib` — 173/173 passing
- [x] `bun run typecheck` — clean, 16/16 turbo tasks successful
- [x] Rebased onto current `origin/master`, no conflicts
- [x] Zero call-site changes verified (grep sweep during leaf 2/3 sessions)

## Convergence
- [x] CodeRabbit nitpick (duplicated `CHAIN_LOCK_KEY` constant + stale comment) fixed in a6a1c3a33 — single source of truth via re-export, 173/173 tests + typecheck still green
- [x] Codex P2 finding (removed runtime `SecurityAuditService` export) investigated and resolved with evidence: zero in-repo callers of `new SecurityAuditService(`, package is workspace-only (no publishConfig), epic Constraints mandate moving away from classes — thread resolved
- [x] CI green (Lint & TypeScript Check, Unit Tests), mergeable CLEAN, 3 consecutive clean scans, 0 unresolved threads

Refs #890 (Phase 0 of 7 — do not close on merge, 6 phases remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rvEhYZ5aESs49stXTTsee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved audit event integrity with tamper-evident hash chaining and safer handling of audit IP data.
  * Strengthened protection against concurrent audit writes to help prevent gaps or chain inconsistencies.
* **Reliability**
  * Improved audit verification, alerting, querying, and event logging consistency.
  * Preserved existing default behavior while enabling more flexible database configurations.
* **Bug Fixes**
  * Resolved scenarios where audit operations could use unintended database connections instead of the configured connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
