### PR TITLE
feat(machines): Monaco diff editor wrapper for the Diff tab

### DIFF
--- a/apps/web/src/components/editors/MonacoDiffEditor.tsx
+++ b/apps/web/src/components/editors/MonacoDiffEditor.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useMemo } from 'react';
+import { DiffEditor, useMonaco } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+import { detectLanguageFromFilename } from '@pagespace/lib/utils/language-detection';
+import { useMonacoTheme } from '@/hooks/useMonacoTheme';
+import { configureMonacoLoader } from '@/lib/editor/monaco/loader-config';
+
+interface MonacoDiffEditorProps {
+  original: string;
+  modified: string;
+  filename?: string;
+  language?: string;
+  readOnly?: boolean;
+  options?: editor.IDiffEditorConstructionOptions;
+  className?: string;
+}
+
+configureMonacoLoader();
+
+const MonacoDiffEditor = ({
+  original,
+  modified,
+  filename,
+  language,
+  readOnly = true,
+  options: optionOverrides,
+  className,
+}: MonacoDiffEditorProps) => {
+  const monaco = useMonaco();
+  const theme = useMonacoTheme(monaco);
+
+  const resolvedLanguage = language ?? (filename ? detectLanguageFromFilename(filename) : 'plaintext');
+
+  const defaultOptions = useMemo<editor.IDiffEditorConstructionOptions>(() => ({
+    readOnly,
+    originalEditable: false,
+    contextmenu: true,
+    selectOnLineNumbers: true,
+    copyWithSyntaxHighlighting: true,
+    minimap: { enabled: true },
+    wordWrap: 'on',
+    scrollBeyondLastLine: false,
+    fontSize: 16,
+    lineNumbers: 'on',
+    glyphMargin: true,
+    folding: true,
+    lineDecorationsWidth: 10,
+    lineNumbersMinChars: 3,
+    renderSideBySide: true,
+    scrollbar: {
+      vertical: 'auto',
+      horizontal: 'auto',
+    },
+  }), [readOnly]);
+
+  const mergedOptions = useMemo(() => ({ ...defaultOptions, ...optionOverrides }), [defaultOptions, optionOverrides]);
+
+  return (
+    <div className={className} style={{ height: '100%' }}>
+      <DiffEditor
+        height="100%"
+        language={resolvedLanguage}
+        theme={theme}
+        original={original}
+        modified={modified}
+        options={mergedOptions}
+      />
+    </div>
+  );
+};
+
+export default MonacoDiffEditor;

--- a/apps/web/src/components/editors/__tests__/MonacoDiffEditor.test.tsx
+++ b/apps/web/src/components/editors/__tests__/MonacoDiffEditor.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const { mockUseMonaco, mockUseMonacoTheme, mockConfigureMonacoLoader } = vi.hoisted(() => ({
+  mockUseMonaco: vi.fn(),
+  mockUseMonacoTheme: vi.fn(),
+  mockConfigureMonacoLoader: vi.fn(),
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  DiffEditor: (props: {
+    language: string;
+    theme: string;
+    original: string;
+    modified: string;
+  }) => (
+    <div
+      data-testid="mock-diff-editor"
+      data-language={props.language}
+      data-theme={props.theme}
+      data-original={props.original}
+      data-modified={props.modified}
+    />
+  ),
+  useMonaco: () => mockUseMonaco(),
+}));
+
+vi.mock('@/hooks/useMonacoTheme', () => ({
+  useMonacoTheme: () => mockUseMonacoTheme(),
+}));
+
+vi.mock('@/lib/editor/monaco/loader-config', () => ({
+  configureMonacoLoader: () => mockConfigureMonacoLoader(),
+}));
+
+import MonacoDiffEditor from '../MonacoDiffEditor';
+
+describe('MonacoDiffEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMonaco.mockReturnValue(null);
+    mockUseMonacoTheme.mockReturnValue('vs');
+  });
+
+  it('passes original and modified text through to the diff editor', () => {
+    render(<MonacoDiffEditor original="const a = 1;" modified="const a = 2;" />);
+    const editor = screen.getByTestId('mock-diff-editor');
+    expect(editor.getAttribute('data-original')).toBe('const a = 1;');
+    expect(editor.getAttribute('data-modified')).toBe('const a = 2;');
+  });
+
+  it('detects language from filename when no explicit language is given', () => {
+    render(<MonacoDiffEditor original="a" modified="b" filename="app.tsx" />);
+    expect(screen.getByTestId('mock-diff-editor').getAttribute('data-language')).toBe('typescript');
+  });
+
+  it('falls back to plaintext when neither language nor filename is given', () => {
+    render(<MonacoDiffEditor original="a" modified="b" />);
+    expect(screen.getByTestId('mock-diff-editor').getAttribute('data-language')).toBe('plaintext');
+  });
+
+  it('an explicit language prop takes precedence over filename detection', () => {
+    render(<MonacoDiffEditor original="a" modified="b" filename="app.tsx" language="markdown" />);
+    expect(screen.getByTestId('mock-diff-editor').getAttribute('data-language')).toBe('markdown');
+  });
+
+  it('wires the resolved theme from useMonacoTheme into the diff editor', () => {
+    mockUseMonacoTheme.mockReturnValue('pagespace-dark');
+    render(<MonacoDiffEditor original="a" modified="b" />);
+    expect(screen.getByTestId('mock-diff-editor').getAttribute('data-theme')).toBe('pagespace-dark');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `MonacoDiffEditor` — a wrapper around `@monaco-editor/react`'s `DiffEditor`, sibling to the existing `MonacoEditor.tsx`, for the Machine page's upcoming Diff tab (Terminal — GA Release epic, Phase 2).
- Takes `original`/`modified` text props directly (no unified-diff parsing — `DiffEditor` computes the diff internally).
- Reuses the shared Monaco loader config (`configureMonacoLoader`), the `useMonacoTheme` hook (live light/dark token wiring), and `packages/lib`'s `detectLanguageFromFilename` for language detection — no duplicate language map.
- Colocated tests cover: original/modified text pass-through, filename → language detection, explicit `language` prop precedence over filename, plaintext fallback, and theme wiring — mocking `@monaco-editor/react`'s `DiffEditor` the same way this codebase mocks other external UI deps.

This task is fully independent of Phase 1's backend filesystem/git-blob routes — the component only needs the two text strings as props, which a later integration task will wire up.

## Test plan
- [x] `bun run --filter 'web' typecheck` — 0 errors
- [x] `bun run --filter 'web' lint` — no new warnings (pre-existing warnings only, unrelated files)
- [x] `bun run test src/components/editors/__tests__/MonacoDiffEditor.test.tsx` — 5/5 passing