### PR TITLE
feat(machines): git-blob read primitive + /api/machines/git-blob route

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -161,6 +161,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['machines/projects', 'Audited via writeCodeExecutionAudit in machine-projects.ts (git clone on the owning Machine)'],
   ['machines/agent-terminals', 'Reserves/kills a named PTY session tracking row; the PTY itself is audited via writeCodeExecutionAudit when opened (see apps/realtime/src/index.ts)'],
   ['machines/files', 'Read-only working-tree browse (fixed `ls` + single file read on an already-provisioned branch Sprite) — no data write, no code execution/provisioning, no git; GET-only, view-gated by canViewMachine and path-confined to the branch checkout root, consistent with the other read-only machines/* and drive/page read sub-routes'],
+  ['machines/git-blob', 'Audited via writeCodeExecutionAudit inside runGitInSandbox (machine-git-blob.ts\'s `git show <ref>:<path>` on the branch Sprite) — same deep audit path as machines/branches and machines/projects, not a direct route.ts call'],
 
   // --- Integration-tool UI routes (audited via the shared executeToolSaga
   // audit path deep in the integrations engine, not directly in route.ts) ---

--- a/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * /api/machines/git-blob request contract tests.
+ *
+ * Everything IO — auth, access check, handle resolution, the git-blob
+ * primitive — is mocked so the tests isolate the route's own request
+ * handling: required-param validation, authz-before-parsing ordering, and the
+ * result → status-code mapping (invalid_ref → 400, not_found → 404,
+ * exec_failed → 502).
+ */
+
+vi.mock('@pagespace/lib/services/machines/machine-branches', () => ({ BRANCH_REPO_PATH: '/workspace/repo' }));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(async () => ({ userId: 'user-1' })),
+  isAuthError: vi.fn(() => false),
+}));
+
+type HandleResult =
+  | { ok: true; handle: { machineId: string } }
+  | { ok: false; reason: 'not_found' | 'vanished' };
+
+const canViewMachine = vi.fn(async () => true);
+const resolveBranchMachineHandle = vi.fn(
+  async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
+);
+const resolveMachineActorContext = vi.fn(async () => ({
+  userId: 'user-1',
+  tenantId: 'user-1',
+  actorEmail: 'user-1@example.com',
+  tier: 'pro' as const,
+}));
+const buildGitBlobActorContext = vi.fn(() => ({ conversationId: 'scope' }));
+const buildGitBlobDepsForHandle = vi.fn(() => ({}));
+
+vi.mock('@/lib/machines/machine-git-blob-runtime', () => ({
+  canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
+  resolveBranchMachineHandle: (...args: unknown[]) => resolveBranchMachineHandle(...(args as [])),
+  resolveMachineActorContext: (...args: unknown[]) => resolveMachineActorContext(...(args as [])),
+  buildGitBlobActorContext: (...args: unknown[]) => buildGitBlobActorContext(...(args as [])),
+  buildGitBlobDepsForHandle: (...args: unknown[]) => buildGitBlobDepsForHandle(...(args as [])),
+}));
+
+type GitBlobResult =
+  | { ok: true; content: string; truncated: boolean }
+  | { ok: false; reason: 'not_found' | 'invalid_ref' | 'exec_failed'; detail?: string };
+
+const readMachineGitBlob = vi.fn(async (): Promise<GitBlobResult> => ({ ok: true, content: 'file body', truncated: false }));
+vi.mock('@pagespace/lib/services/sandbox/machine-git-blob', () => ({
+  readMachineGitBlob: (...args: unknown[]) => readMachineGitBlob(...(args as [])),
+}));
+
+import { GET } from '../route';
+
+function get(query: Record<string, string>): Request {
+  const params = new URLSearchParams({
+    terminalId: 't1',
+    projectName: 'p1',
+    branchName: 'b1',
+    ref: 'origin/master',
+    path: 'src/index.ts',
+    ...query,
+  });
+  return new Request(`http://localhost/api/machines/git-blob?${params.toString()}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canViewMachine.mockResolvedValue(true);
+  resolveBranchMachineHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
+  resolveMachineActorContext.mockResolvedValue({
+    userId: 'user-1',
+    tenantId: 'user-1',
+    actorEmail: 'user-1@example.com',
+    tier: 'pro',
+  });
+  readMachineGitBlob.mockResolvedValue({ ok: true, content: 'file body', truncated: false });
+});
+
+describe('/api/machines/git-blob request contract', () => {
+  it('requires terminalId, projectName, branchName, ref, and path', async () => {
+    for (const missing of ['terminalId', 'projectName', 'branchName', 'ref', 'path']) {
+      const params = new URLSearchParams({
+        terminalId: 't1',
+        projectName: 'p1',
+        branchName: 'b1',
+        ref: 'origin/master',
+        path: 'src/index.ts',
+      });
+      params.delete(missing);
+      const res = await GET(new Request(`http://localhost/api/machines/git-blob?${params.toString()}`));
+      expect(res.status).toBe(400);
+    }
+    expect(readMachineGitBlob).not.toHaveBeenCalled();
+  });
+
+  it('denies a user without view access before checking ref/path or resolving the machine', async () => {
+    canViewMachine.mockResolvedValue(false);
+    const res = await GET(get({}));
+    expect(res.status).toBe(403);
+    expect(resolveBranchMachineHandle).not.toHaveBeenCalled();
+    expect(readMachineGitBlob).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the branch machine has no tracking row', async () => {
+    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await GET(get({}));
+    expect(res.status).toBe(404);
+    expect(readMachineGitBlob).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when the branch Sprite has vanished', async () => {
+    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    const res = await GET(get({}));
+    expect(res.status).toBe(503);
+  });
+
+  it('reads the blob and returns its content on success', async () => {
+    const res = await GET(get({ ref: 'abc123', path: 'src/index.ts' }));
+    expect(res.status).toBe(200);
+    expect(readMachineGitBlob).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'abc123', path: 'src/index.ts', cwd: '/workspace/repo' }),
+    );
+    const body = (await res.json()) as { content: string; truncated: boolean };
+    expect(body).toEqual({ content: 'file body', truncated: false });
+  });
+
+  it('maps invalid_ref to 400', async () => {
+    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'invalid_ref' });
+    const res = await GET(get({ ref: '--output=/tmp/x' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('maps not_found to 404', async () => {
+    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'not_found', detail: "does not exist in 'HEAD'" });
+    const res = await GET(get({}));
+    expect(res.status).toBe(404);
+  });
+
+  it('maps exec_failed to 502', async () => {
+    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'boom' });
+    const res = await GET(get({}));
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/api/machines/git-blob/route.ts
+++ b/apps/web/src/app/api/machines/git-blob/route.ts
@@ -1,0 +1,106 @@
+/**
+ * Machine Git Blob API — the Diff tab's surface onto ONE file's content as it
+ * existed at a git ref, read from the branch checkout's git OBJECT STORE (not
+ * the working tree — that's `/api/machines/files`; see `machine-git-blob.ts`'s
+ * scope-boundary note for why these stay separate primitives).
+ *
+ * GET ?terminalId=&projectName=&branchName=&ref=&path=
+ *   → { content, truncated }
+ *
+ * `ref` is a resolved commit-ish (a branch, tag, SHA, or a merge-base the
+ * caller already computed — see `sandbox-git-tools.ts`'s `gitDiff` three-dot
+ * `base...head` composition for how a caller derives one); this route does not
+ * itself resolve merge-bases or compound ref expressions, it only reads `path`
+ * as of the given `ref`. `path` is resolved INSIDE `ref`'s own git tree, not
+ * the host filesystem, so a `..` or absolute `path` cannot escape onto disk —
+ * it only ever misses (404). The Diff tab's 'Uncommitted' scope does NOT call
+ * this route for its modified side — that side is the working tree, served by
+ * `/api/machines/files` instead.
+ *
+ * Session-only (no MCP/agent tokens) — a human/UI browsing surface, so this
+ * does NOT route through the AI agent tool orchestration (billing holds,
+ * injection screening) — same convention as the Files/Settings routes.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { readMachineGitBlob } from '@pagespace/lib/services/sandbox/machine-git-blob';
+import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
+import {
+  canViewMachine,
+  resolveBranchMachineHandle,
+  resolveMachineActorContext,
+  buildGitBlobActorContext,
+  buildGitBlobDepsForHandle,
+} from '@/lib/machines/machine-git-blob-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { ok: false, error: NextResponse.json({ error: `${field} is required` }, { status: 400 }) };
+  }
+  return { ok: true, value };
+}
+
+const DENIAL_STATUS: Record<string, number> = {
+  invalid_ref: 400,
+  not_found: 404,
+  exec_failed: 502,
+};
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const terminalId = requireString(url.searchParams.get('terminalId'), 'terminalId');
+  if (!terminalId.ok) return terminalId.error;
+  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
+  if (!projectName.ok) return projectName.error;
+  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
+  if (!branchName.ok) return branchName.error;
+
+  // Authorize BEFORE parsing ref/path, so a user without view access gets a
+  // uniform 403 and can never probe ref/path handling.
+  if (!(await canViewMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const ref = requireString(url.searchParams.get('ref'), 'ref');
+  if (!ref.ok) return ref.error;
+  const path = requireString(url.searchParams.get('path'), 'path');
+  if (!path.ok) return path.error;
+
+  const resolved = await resolveBranchMachineHandle({
+    terminalId: terminalId.value,
+    projectName: projectName.value,
+    branchName: branchName.value,
+  });
+  if (!resolved.ok) {
+    return NextResponse.json(
+      { error: `Branch machine ${resolved.reason}`, reason: resolved.reason },
+      { status: resolved.reason === 'not_found' ? 404 : 503 },
+    );
+  }
+
+  const actor = await resolveMachineActorContext(auth.userId);
+  const scopeKey = `${terminalId.value}:${projectName.value}:${branchName.value}:git-blob`;
+  const ctx = buildGitBlobActorContext(scopeKey, actor);
+  const deps = buildGitBlobDepsForHandle(resolved.handle);
+
+  const result = await readMachineGitBlob({
+    ref: ref.value,
+    path: path.value,
+    cwd: BRANCH_REPO_PATH,
+    ctx,
+    deps,
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.detail ?? result.reason, reason: result.reason },
+      { status: DENIAL_STATUS[result.reason] ?? 500 },
+    );
+  }
+  return NextResponse.json({ content: result.content, truncated: result.truncated });
+}

--- a/apps/web/src/lib/machines/machine-git-blob-runtime.ts
+++ b/apps/web/src/lib/machines/machine-git-blob-runtime.ts
@@ -1,0 +1,67 @@
+/**
+ * Production wiring for the Machine git-blob read API (Machine page rebuild,
+ * Diff tab — git-versioned 'before' content).
+ *
+ * Resolves a branch-terminal's LIVE `MachineHandle` (reusing
+ * `resolveBranchMachineHandle` from `./machine-files-runtime`) and binds
+ * `runGitInSandbox`'s `GitSandboxRunDeps` directly to it — the same DI shape
+ * `machine-branches.ts`'s (private) `buildGitDepsForHandle` uses for
+ * clone/checkout, since a branch-terminal already holds its own live handle
+ * rather than going through a page-keyed acquire/reconnect lookup.
+ *
+ * Access is gated through the shared `machine-access.ts` module (Phase 0, PR
+ * #1962, already on master when this branch forked) via
+ * `./machine-access-runtime` — NOT the older inline `canViewMachine` copies in
+ * `machine-branches-runtime.ts` / `machine-files-runtime.ts`, per that
+ * module's own "new code going forward" docstring.
+ */
+
+import { adaptMachineHandleToExecutableSandbox } from '@pagespace/lib/services/sandbox/sandbox-client/machine-host-adapter';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
+import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
+import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
+import { defaultBuildEnv } from '@pagespace/lib/services/sandbox/tool-runners';
+import type { SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
+import { resolveGitHubTokenForSandbox } from '@pagespace/lib/services/sandbox/github-token';
+import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
+import type { MachineHandle } from '@pagespace/lib/services/sandbox/machine-host';
+import type { MachineActorContext } from '@pagespace/lib/services/machines/machine-branches';
+import { db } from '@pagespace/db/db';
+import { canViewMachine } from './machine-access-runtime';
+import { resolveBranchMachineHandle } from './machine-files-runtime';
+import { resolveMachineActorContext } from './machine-branches-runtime';
+
+export { canViewMachine, resolveBranchMachineHandle, resolveMachineActorContext };
+
+/** Build the `SandboxActorContext` a git-blob read runs under — no conversation, so `scopeKey` is an opaque label. */
+export function buildGitBlobActorContext(scopeKey: string, actor: MachineActorContext): SandboxActorContext {
+  return {
+    userId: actor.userId,
+    tenantId: actor.tenantId,
+    driveId: undefined,
+    conversationId: scopeKey,
+    actorEmail: actor.actorEmail,
+    actorDisplayName: actor.actorDisplayName,
+    tier: actor.tier,
+  };
+}
+
+/**
+ * Build `runGitInSandbox` deps bound directly to an already-resolved branch
+ * `MachineHandle` — no page-keyed acquire/reconnect lookup, mirroring
+ * `machine-branches.ts`'s `buildGitDepsForHandle` (the Branches DI shape this
+ * task was told to mirror).
+ */
+export function buildGitBlobDepsForHandle(handle: MachineHandle): GitSandboxRunDeps {
+  const sandbox = adaptMachineHandleToExecutableSandbox(handle);
+  return {
+    isEnabled: isCodeExecutionEnabled,
+    resolveGitHubToken: (userId) => resolveGitHubTokenForSandbox({ userId, db }),
+    acquireSandbox: async () => ({ ok: true, sandboxId: handle.machineId, resumed: false }),
+    reconnect: async () => sandbox,
+    quota: { acquireSlot: acquireCodeExecutionSlot, releaseSlot: releaseCodeExecutionSlot },
+    buildEnv: defaultBuildEnv,
+    audit: (input) => writeCodeExecutionAudit({ input }),
+    now: () => new Date(),
+  };
+}

--- a/apps/web/src/lib/machines/machine-git-blob-runtime.ts
+++ b/apps/web/src/lib/machines/machine-git-blob-runtime.ts
@@ -7,7 +7,15 @@
  * `runGitInSandbox`'s `GitSandboxRunDeps` directly to it — the same DI shape
  * `machine-branches.ts`'s (private) `buildGitDepsForHandle` uses for
  * clone/checkout, since a branch-terminal already holds its own live handle
- * rather than going through a page-keyed acquire/reconnect lookup.
+ * rather than going through a page-keyed acquire/reconnect lookup. The
+ * individual bindings (kill-switch, GitHub token, quota, env, audit) are NOT
+ * re-derived here — they're pulled straight off `buildMachineBranchesDeps()`
+ * (`./machine-branches-runtime`), the one place those real-service bindings
+ * are already assembled, so a future change to that wiring (e.g. the audit
+ * input shape) only needs fixing in one spot. Likewise `buildActorCtx` is
+ * imported from `machine-branches.ts` (exported for this reuse) rather than
+ * re-typed here, so a future required field on `SandboxActorContext` can't
+ * drift between the two Machine-scope call sites.
  *
  * Access is gated through the shared `machine-access.ts` module (Phase 0, PR
  * #1962, already on master when this branch forked) via
@@ -17,51 +25,33 @@
  */
 
 import { adaptMachineHandleToExecutableSandbox } from '@pagespace/lib/services/sandbox/sandbox-client/machine-host-adapter';
-import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
-import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
-import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
-import { defaultBuildEnv } from '@pagespace/lib/services/sandbox/tool-runners';
-import type { SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
-import { resolveGitHubTokenForSandbox } from '@pagespace/lib/services/sandbox/github-token';
 import type { GitSandboxRunDeps } from '@pagespace/lib/services/sandbox/git-tool-runners';
 import type { MachineHandle } from '@pagespace/lib/services/sandbox/machine-host';
-import type { MachineActorContext } from '@pagespace/lib/services/machines/machine-branches';
-import { db } from '@pagespace/db/db';
+import { buildActorCtx } from '@pagespace/lib/services/machines/machine-branches';
 import { canViewMachine } from './machine-access-runtime';
 import { resolveBranchMachineHandle } from './machine-files-runtime';
-import { resolveMachineActorContext } from './machine-branches-runtime';
+import { resolveMachineActorContext, buildMachineBranchesDeps } from './machine-branches-runtime';
 
-export { canViewMachine, resolveBranchMachineHandle, resolveMachineActorContext };
-
-/** Build the `SandboxActorContext` a git-blob read runs under — no conversation, so `scopeKey` is an opaque label. */
-export function buildGitBlobActorContext(scopeKey: string, actor: MachineActorContext): SandboxActorContext {
-  return {
-    userId: actor.userId,
-    tenantId: actor.tenantId,
-    driveId: undefined,
-    conversationId: scopeKey,
-    actorEmail: actor.actorEmail,
-    actorDisplayName: actor.actorDisplayName,
-    tier: actor.tier,
-  };
-}
+export { canViewMachine, resolveBranchMachineHandle, resolveMachineActorContext, buildActorCtx as buildGitBlobActorContext };
 
 /**
  * Build `runGitInSandbox` deps bound directly to an already-resolved branch
- * `MachineHandle` — no page-keyed acquire/reconnect lookup, mirroring
- * `machine-branches.ts`'s `buildGitDepsForHandle` (the Branches DI shape this
- * task was told to mirror).
+ * `MachineHandle` — no page-keyed acquire/reconnect lookup (the branch already
+ * holds its own live handle) — while reusing `buildMachineBranchesDeps()` for
+ * every binding that ISN'T handle-specific (kill-switch, GitHub token, quota,
+ * env, audit, clock).
  */
 export function buildGitBlobDepsForHandle(handle: MachineHandle): GitSandboxRunDeps {
+  const branchDeps = buildMachineBranchesDeps();
   const sandbox = adaptMachineHandleToExecutableSandbox(handle);
   return {
-    isEnabled: isCodeExecutionEnabled,
-    resolveGitHubToken: (userId) => resolveGitHubTokenForSandbox({ userId, db }),
+    isEnabled: branchDeps.isEnabled,
+    resolveGitHubToken: branchDeps.resolveGitHubToken,
+    quota: branchDeps.quota,
+    buildEnv: branchDeps.buildEnv,
+    audit: branchDeps.audit,
+    now: branchDeps.now,
     acquireSandbox: async () => ({ ok: true, sandboxId: handle.machineId, resumed: false }),
     reconnect: async () => sandbox,
-    quota: { acquireSlot: acquireCodeExecutionSlot, releaseSlot: releaseCodeExecutionSlot },
-    buildEnv: defaultBuildEnv,
-    audit: (input) => writeCodeExecutionAudit({ input }),
-    now: () => new Date(),
   };
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -467,6 +467,11 @@
       "import": "./dist/services/sandbox/machine-fs.js",
       "require": "./dist/services/sandbox/machine-fs.js"
     },
+    "./services/sandbox/machine-git-blob": {
+      "types": "./dist/services/sandbox/machine-git-blob.d.ts",
+      "import": "./dist/services/sandbox/machine-git-blob.js",
+      "require": "./dist/services/sandbox/machine-git-blob.js"
+    },
     "./services/sandbox/tool-runners": {
       "types": "./dist/services/sandbox/tool-runners.d.ts",
       "import": "./dist/services/sandbox/tool-runners.js",
@@ -1656,6 +1661,9 @@
       ],
       "services/sandbox/machine-fs": [
         "./dist/services/sandbox/machine-fs.d.ts"
+      ],
+      "services/sandbox/machine-git-blob": [
+        "./dist/services/sandbox/machine-git-blob.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -90,7 +90,13 @@ export type SpawnBranchResult =
   | { ok: true; sandboxId: string; resumed: boolean }
   | { ok: false; reason: SpawnBranchDenialReason | FullEgressDenialReason; detail?: string };
 
-function buildActorCtx(scopeKey: string, actor: MachineActorContext): SandboxActorContext {
+/**
+ * Exported so other Machine-scope callers that build a `SandboxActorContext`
+ * for a branch-terminal op (e.g. `machine-git-blob-runtime.ts`) share this one
+ * definition instead of re-typing the same literal — a future required field
+ * on `SandboxActorContext` then only needs fixing here.
+ */
+export function buildActorCtx(scopeKey: string, actor: MachineActorContext): SandboxActorContext {
   return {
     userId: actor.userId,
     tenantId: actor.tenantId,

--- a/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
@@ -164,5 +164,12 @@ describe('readMachineGitBlob', () => {
       expect(result).toEqual({ ok: false, reason: 'invalid_ref' });
       expect(calls).toHaveLength(0);
     });
+
+    it('rejects an empty path without calling git, so a bypass of the route\'s own check can never fall through to `git show <ref>:` (a tree listing, not a file)', async () => {
+      const { deps, calls } = makeDeps(async () => ({ exitCode: 0, stdout: 'tree HEAD:\n\na.txt\n', stderr: '' }));
+      const result = await readMachineGitBlob({ ref: 'HEAD', path: '', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+      expect(result).toEqual({ ok: false, reason: 'not_found' });
+      expect(calls).toHaveLength(0);
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import { readMachineGitBlob } from '../machine-git-blob';
+import type { GitSandboxRunDeps } from '../git-tool-runners';
+import type { SandboxActorContext } from '../tool-runners';
+import type { ExecutableSandbox, RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
+
+/**
+ * `readMachineGitBlob` drives the real `runGitInSandbox` (not mocked — it's
+ * pure orchestration over the injected deps), so a fake `ExecutableSandbox`
+ * whose `runCommand` is scripted exercises every branch with zero real
+ * Sprite/git calls, mirroring `git-tool-runners.test.ts`'s harness.
+ */
+function makeCtx(): SandboxActorContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    conversationId: 'c1',
+    actorEmail: 'u1@example.com',
+    tier: 'pro',
+  };
+}
+
+function makeDeps(runCommand: (args: RunCommandArgs) => Promise<SandboxRunResult>): {
+  deps: GitSandboxRunDeps;
+  calls: Array<{ cmd: string; args: string[] }>;
+} {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const sandbox: ExecutableSandbox = {
+    sandboxId: 'sbx-1',
+    runCommand: async (opts) => {
+      calls.push({ cmd: opts.cmd, args: opts.args ?? [] });
+      return runCommand(opts);
+    },
+    writeFiles: async () => {},
+    readFileToBuffer: async () => Buffer.from(''),
+  };
+  const deps: GitSandboxRunDeps = {
+    isEnabled: () => true,
+    acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+    reconnect: async () => sandbox,
+    quota: { acquireSlot: () => true, releaseSlot: () => {} },
+    buildEnv: () => ({}),
+    audit: async () => {},
+    now: () => new Date('2026-06-01T12:00:00.000Z'),
+    resolveGitHubToken: async () => null,
+  };
+  return { deps, calls };
+}
+
+describe('readMachineGitBlob', () => {
+  it('runs `git show <ref>:<path>` against the given cwd', async () => {
+    const { deps, calls } = makeDeps(async () => ({ exitCode: 0, stdout: 'file body', stderr: '' }));
+    const result = await readMachineGitBlob({
+      ref: 'origin/master',
+      path: 'src/index.ts',
+      cwd: '/workspace/repo',
+      ctx: makeCtx(),
+      deps,
+    });
+
+    expect(calls).toEqual([{ cmd: 'git', args: ['show', 'origin/master:src/index.ts'] }]);
+    expect(result).toEqual({ ok: true, content: 'file body', truncated: false });
+  });
+
+  it('maps a missing path ("does not exist in") to not_found', async () => {
+    const { deps } = makeDeps(async () => ({
+      exitCode: 128,
+      stdout: '',
+      stderr: "fatal: path 'nope.txt' does not exist in 'HEAD'\n",
+    }));
+    const result = await readMachineGitBlob({ ref: 'HEAD', path: 'nope.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+    expect(result).toEqual({ ok: false, reason: 'not_found', detail: "fatal: path 'nope.txt' does not exist in 'HEAD'" });
+  });
+
+  it('maps "exists on disk, but not in" (a `../`-normalized miss) to not_found', async () => {
+    const { deps } = makeDeps(async () => ({
+      exitCode: 128,
+      stdout: '',
+      stderr: "fatal: path 'sub/../file.txt' exists on disk, but not in 'HEAD'\n",
+    }));
+    const result = await readMachineGitBlob({
+      ref: 'HEAD',
+      path: 'sub/../file.txt',
+      cwd: '/workspace/repo',
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ reason: 'not_found' });
+  });
+
+  it('maps a bad ref ("invalid object name") to not_found', async () => {
+    const { deps } = makeDeps(async () => ({
+      exitCode: 128,
+      stdout: '',
+      stderr: "fatal: invalid object name 'nope-branch'.\n",
+    }));
+    const result = await readMachineGitBlob({ ref: 'nope-branch', path: 'file.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ ok: false, reason: 'not_found' });
+  });
+
+  it('maps any other nonzero exit to exec_failed and surfaces stderr detail', async () => {
+    const { deps } = makeDeps(async () => ({ exitCode: 1, stdout: '', stderr: 'fatal: not a git repository\n' }));
+    const result = await readMachineGitBlob({ ref: 'HEAD', path: 'file.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'fatal: not a git repository' });
+  });
+
+  it('maps a hard runGitInSandbox failure (success: false) to exec_failed', async () => {
+    const deps: GitSandboxRunDeps = {
+      isEnabled: () => false,
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+      reconnect: async () => {
+        throw new Error('unreachable');
+      },
+      quota: { acquireSlot: () => true, releaseSlot: () => {} },
+      buildEnv: () => ({}),
+      audit: async () => {},
+      now: () => new Date(),
+      resolveGitHubToken: async () => null,
+    };
+    const result = await readMachineGitBlob({ ref: 'HEAD', path: 'file.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'Code execution is disabled.' });
+  });
+
+  it('reports content truncation from runGitInSandbox through to the caller', async () => {
+    const deps: GitSandboxRunDeps = {
+      isEnabled: () => true,
+      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+      reconnect: async () => ({
+        sandboxId: 'sbx-1',
+        runCommand: async () => ({ exitCode: 0, stdout: 'x'.repeat(10), stderr: '' }),
+        writeFiles: async () => {},
+        readFileToBuffer: async () => Buffer.from(''),
+      }),
+      quota: { acquireSlot: () => true, releaseSlot: () => {} },
+      buildEnv: () => ({}),
+      audit: async () => {},
+      now: () => new Date(),
+      resolveGitHubToken: async () => null,
+    };
+    // SANDBOX_MAX_OUTPUT_BYTES is large in real config; instead assert the
+    // pass-through wiring by checking the untruncated case reports false, and
+    // trust git-tool-runners.test.ts to cover the truncation boundary itself.
+    const result = await readMachineGitBlob({ ref: 'HEAD', path: 'file.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ ok: true, truncated: false });
+  });
+
+  describe('ref validation — argument-injection guard', () => {
+    it('rejects an empty ref without calling git', async () => {
+      const { deps, calls } = makeDeps(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+      const result = await readMachineGitBlob({ ref: '', path: 'file.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+      expect(result).toEqual({ ok: false, reason: 'invalid_ref' });
+      expect(calls).toHaveLength(0);
+    });
+
+    it('rejects a `-`-leading ref without calling git, so it can never be parsed as a git show flag', async () => {
+      const { deps, calls } = makeDeps(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+      const result = await readMachineGitBlob({
+        ref: '--output=/tmp/pwned',
+        path: 'file.txt',
+        cwd: '/workspace/repo',
+        ctx: makeCtx(),
+        deps,
+      });
+      expect(result).toEqual({ ok: false, reason: 'invalid_ref' });
+      expect(calls).toHaveLength(0);
+    });
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
@@ -3,6 +3,7 @@ import { readMachineGitBlob } from '../machine-git-blob';
 import type { GitSandboxRunDeps } from '../git-tool-runners';
 import type { SandboxActorContext } from '../tool-runners';
 import type { ExecutableSandbox, RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
+import { SANDBOX_MAX_OUTPUT_BYTES } from '../execution-policy';
 
 /**
  * `readMachineGitBlob` drives the real `runGitInSandbox` (not mocked — it's
@@ -122,27 +123,25 @@ describe('readMachineGitBlob', () => {
     expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'Code execution is disabled.' });
   });
 
-  it('reports content truncation from runGitInSandbox through to the caller', async () => {
-    const deps: GitSandboxRunDeps = {
-      isEnabled: () => true,
-      acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
-      reconnect: async () => ({
-        sandboxId: 'sbx-1',
-        runCommand: async () => ({ exitCode: 0, stdout: 'x'.repeat(10), stderr: '' }),
-        writeFiles: async () => {},
-        readFileToBuffer: async () => Buffer.from(''),
-      }),
-      quota: { acquireSlot: () => true, releaseSlot: () => {} },
-      buildEnv: () => ({}),
-      audit: async () => {},
-      now: () => new Date(),
-      resolveGitHubToken: async () => null,
-    };
-    // SANDBOX_MAX_OUTPUT_BYTES is large in real config; instead assert the
-    // pass-through wiring by checking the untruncated case reports false, and
-    // trust git-tool-runners.test.ts to cover the truncation boundary itself.
+  it('reports content truncation from runGitInSandbox through to the caller (small, untruncated case)', async () => {
+    const { deps } = makeDeps(async () => ({ exitCode: 0, stdout: 'x'.repeat(10), stderr: '' }));
     const result = await readMachineGitBlob({ ref: 'HEAD', path: 'file.txt', cwd: '/workspace/repo', ctx: makeCtx(), deps });
     expect(result).toMatchObject({ ok: true, truncated: false });
+  });
+
+  it('reports truncated for a blob over SANDBOX_MAX_OUTPUT_BYTES and keeps content within the byte cap', async () => {
+    // '€' is 3 UTF-8 bytes; enough repeats to comfortably exceed the real cap.
+    // The exact byte-boundary behavior (a split multi-byte sequence may decode
+    // to a lossy replacement char) is `truncateToBytes`'s own documented,
+    // separately-tested contract (output-limit.test.ts) — see
+    // machine-git-blob.ts's "KNOWN TRUNCATION TRADEOFF" note for why this
+    // primitive inherits it rather than re-deriving byte-perfect truncation.
+    const { deps } = makeDeps(async () => ({ exitCode: 0, stdout: '€'.repeat(SANDBOX_MAX_OUTPUT_BYTES), stderr: '' }));
+    const result = await readMachineGitBlob({ ref: 'HEAD', path: 'big.bin', cwd: '/workspace/repo', ctx: makeCtx(), deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.truncated).toBe(true);
+    expect(Buffer.byteLength(result.content, 'utf8')).toBeLessThanOrEqual(SANDBOX_MAX_OUTPUT_BYTES);
   });
 
   describe('ref validation — argument-injection guard', () => {

--- a/packages/lib/src/services/sandbox/machine-git-blob.ts
+++ b/packages/lib/src/services/sandbox/machine-git-blob.ts
@@ -66,6 +66,14 @@ const NOT_FOUND_PATTERN =
  * primitive. Every valid git ref/branch/tag/SHA is already barred from a
  * leading `-` by git's own `check-ref-format` rules, so this excludes no
  * legitimate ref.
+ *
+ * An empty `path` is rejected as `not_found` rather than passed through:
+ * `git show <ref>:` (nothing after the colon) is valid git syntax for "list
+ * this ref's root tree" and succeeds with exit 0 (verified against a real
+ * repo) — silently returning a directory listing mislabeled as one file's
+ * content instead of an error. The shipped route already requires a non-empty
+ * `path` before calling this, but the primitive guards it too so a future
+ * caller can't reach that surprise by skipping the route's own check.
  */
 export async function readMachineGitBlob({
   ref,
@@ -82,6 +90,9 @@ export async function readMachineGitBlob({
 }): Promise<ReadMachineGitBlobResult> {
   if (ref.length === 0 || ref.startsWith('-')) {
     return { ok: false, reason: 'invalid_ref' };
+  }
+  if (path.length === 0) {
+    return { ok: false, reason: 'not_found' };
   }
 
   const run = await runGitInSandbox({

--- a/packages/lib/src/services/sandbox/machine-git-blob.ts
+++ b/packages/lib/src/services/sandbox/machine-git-blob.ts
@@ -1,0 +1,84 @@
+/**
+ * Machine git-object read primitive (pure, DI'd).
+ *
+ * `readMachineGitBlob` reads ONE file's content as it existed at a given git
+ * ref — via `git show <ref>:<path>` run through the hardened `runGitInSandbox`
+ * path (./git-tool-runners.ts) — NOT `MachineHandle.readFile`, which only ever
+ * reads the CURRENT working tree (see machine-fs.ts's scope-boundary note).
+ * This is the git-object-store counterpart to machine-fs.ts's working-tree
+ * `readMachineFile`: a DIFFERENT backend (git's object store vs. the live
+ * filesystem), so it is kept a separate primitive rather than folded into a
+ * single "read a file" function.
+ *
+ * SCOPE BOUNDARY: the Diff tab's 'Uncommitted' scope is the one exception —
+ * its modified side IS the working tree, so that caller reuses machine-fs.ts's
+ * `readMachineFile` directly rather than routing an implicit `git show
+ * HEAD:path` through here.
+ *
+ * Takes `GitSandboxRunDeps` + `SandboxActorContext` as injected params — the
+ * same DI shape `runGitInSandbox` itself takes, mirroring how
+ * `machine-branches.ts` drives clone/checkout — so this is unit-testable
+ * against a fake deps object with zero real Sprite/git calls.
+ */
+
+import { runGitInSandbox, type GitSandboxRunDeps } from './git-tool-runners';
+import type { SandboxActorContext } from './tool-runners';
+
+export type ReadMachineGitBlobResult =
+  | { ok: true; content: string; truncated: boolean }
+  | { ok: false; reason: 'not_found' | 'invalid_ref' | 'exec_failed'; detail?: string };
+
+/** Git's own "missing object/path" messages, across the ref-missing and path-missing cases. */
+const NOT_FOUND_PATTERN =
+  /does not exist in|exists on disk, but not in|invalid object name|unknown revision|bad revision/i;
+
+/**
+ * Read `path` as it existed at `ref`, inside the repo checked out at `cwd`.
+ *
+ * `ref` and `path` are combined into ONE `<ref>:<path>` argument — git's own
+ * blob-addressing syntax — rather than passed as separate argv elements. Git
+ * resolves that argument against `ref`'s own tree, so a `path` (even one
+ * containing `../` or a leading `/`) can never escape onto the host
+ * filesystem the way a raw fs path could; it just fails to resolve inside the
+ * tree, surfaced below as `not_found`.
+ *
+ * A leading `-` on `ref` is rejected outright rather than passed through: git
+ * parses a `-`-leading token as an OPTION, not an object name, and this is not
+ * a cosmetic parse failure — `git show "--output=/tmp/x:path"` genuinely
+ * writes `/tmp/x:path` to disk (verified against a real repo) instead of
+ * erroring, making an unsanitized leading-dash `ref` an arbitrary-file-write
+ * primitive. Every valid git ref/branch/tag/SHA is already barred from a
+ * leading `-` by git's own `check-ref-format` rules, so this excludes no
+ * legitimate ref.
+ */
+export async function readMachineGitBlob({
+  ref,
+  path,
+  cwd,
+  ctx,
+  deps,
+}: {
+  ref: string;
+  path: string;
+  cwd: string;
+  ctx: SandboxActorContext;
+  deps: GitSandboxRunDeps;
+}): Promise<ReadMachineGitBlobResult> {
+  if (ref.length === 0 || ref.startsWith('-')) {
+    return { ok: false, reason: 'invalid_ref' };
+  }
+
+  const run = await runGitInSandbox({
+    cmd: 'git',
+    args: ['show', `${ref}:${path}`],
+    cwd,
+    ctx,
+    deps,
+  });
+  if (!run.success) return { ok: false, reason: 'exec_failed', detail: run.error };
+  if (run.exitCode !== 0) {
+    const reason = NOT_FOUND_PATTERN.test(run.stderr) ? 'not_found' : 'exec_failed';
+    return { ok: false, reason, detail: run.stderr.trim() || undefined };
+  }
+  return { ok: true, content: run.stdout, truncated: run.truncated };
+}

--- a/packages/lib/src/services/sandbox/machine-git-blob.ts
+++ b/packages/lib/src/services/sandbox/machine-git-blob.ts
@@ -19,6 +19,22 @@
  * same DI shape `runGitInSandbox` itself takes, mirroring how
  * `machine-branches.ts` drives clone/checkout — so this is unit-testable
  * against a fake deps object with zero real Sprite/git calls.
+ *
+ * KNOWN TRUNCATION TRADEOFF: `runGitInSandbox` caps stdout at
+ * `SANDBOX_MAX_OUTPUT_BYTES` (256 KB) via `truncateToBytes`, which is
+ * DELIBERATELY lossy at the byte boundary (a split multi-byte UTF-8 sequence
+ * decodes to a trailing replacement character) — correct for that helper's
+ * primary use (arbitrary command stdout/stderr, i.e. untrusted log-like
+ * output shared by every `runGitInSandbox`/bash-tool caller), but it means a
+ * >256 KB blob with non-ASCII content near the cut can show a corrupted
+ * trailing character here, unlike `machine-fs.ts`'s `readMachineFile` (whose
+ * 2 MB cap decodes via `StringDecoder` and withholds an incomplete trailing
+ * sequence instead of corrupting it). Byte-perfect truncation here would
+ * require plumbing raw bytes through the shared exec/audit/injection-screening
+ * pipeline that every other `runGitInSandbox` caller also depends on being a
+ * plain string — out of scope for this primitive; revisit only if the Diff
+ * tab needs an exact match with the Files tab's truncation guarantee for
+ * large blobs.
  */
 
 import { runGitInSandbox, type GitSandboxRunDeps } from './git-tool-runners';


### PR DESCRIPTION
## Summary

Backend primitive for the Machine page rebuild's Diff tab (Terminal — GA Release epic, Phase 1). `MonacoDiffEditor` (merged separately as PR #1977, a pure presentational `original`/`modified` props component with no route dependency yet) needs git-versioned "before" content for a file — this reads it from a branch checkout's git object store, separately from Phase 1's working-tree `readMachineFile` (`/api/machines/files`, PR #1966).

- **`packages/lib/src/services/sandbox/machine-git-blob.ts`** — `readMachineGitBlob({ ref, path, cwd, ctx, deps })` runs `git show <ref>:<path>` through the hardened `runGitInSandbox` path (`git-tool-runners.ts`). Takes `GitSandboxRunDeps` as an injected param, mirroring `runGitInSandbox`'s own DI shape and `machine-branches.ts`'s clone/checkout convention.
  - Deliberately kept separate from `machine-fs.ts`'s `readMachineFile` — different backend (git object store vs. live filesystem), not folded into one "read a file" function. The Diff tab's `Uncommitted` scope is the one exception: its modified side is the working tree, so that caller should reuse `readMachineFile` directly rather than going through this route.
  - **Security finding while building this**: `ref` and `path` combine into one `<ref>:<path>` git object-addressing argument. A `ref` starting with `-` is parsed by `git show` as an option, not an object name — verified against a real repo that `git show "--output=/tmp/pwned:file"` exits 0 and genuinely writes an arbitrary file to disk, not just a parse error. The primitive rejects any leading-`-` ref before it reaches `git show` (`invalid_ref`). Every legitimate git ref/branch/tag/SHA is already barred from a leading `-` by git's own `check-ref-format` rules, so this excludes nothing valid.
  - **Defense-in-depth**: an empty `path` is also rejected (`not_found`) rather than passed through — `git show <ref>:` (nothing after the colon) is valid syntax for "list this ref's root tree" and succeeds with exit 0, which would otherwise silently return a directory listing mislabeled as one file's content. The shipped route already requires a non-empty `path`, but the primitive guards it too.
  - `git show`'s own error messages ("does not exist in", "exists on disk, but not in", "invalid object name") map to `not_found`; anything else maps to `exec_failed`.
  - **Known truncation tradeoff** (documented in the module header): `runGitInSandbox`'s shared `truncateToBytes` caps stdout at 256 KB and is deliberately lossy at the byte boundary (a split multi-byte UTF-8 sequence can decode to a trailing replacement char) — correct for its primary use (arbitrary command output), but it means a >256 KB blob with non-ASCII content near the cut can differ from `machine-fs.ts`'s byte-perfect (`StringDecoder`-based) truncation. Re-deriving byte-perfect truncation here would mean plumbing raw bytes through the shared exec/audit/injection-screening pipeline every other `runGitInSandbox` caller also depends on being a plain string — out of scope for this primitive.

- **`apps/web/src/lib/machines/machine-git-blob-runtime.ts`** — production wiring: binds `GitSandboxRunDeps` to a resolved branch `MachineHandle`, and re-exports view-access from the shared `machine-access.ts`/`machine-access-runtime.ts` module (Phase 0, PR #1962) rather than the older inline `canViewMachine` copies the two earlier sibling PRs fell back to before that module landed. Reuses `buildMachineBranchesDeps()` (`machine-branches-runtime.ts`) for every non-handle-specific binding (kill-switch, GitHub token, quota, env, audit, clock) and the newly-exported `buildActorCtx` from `machine-branches.ts`, rather than re-deriving either — a self-review pass (see below) flagged the original draft as duplicating both, which is a drift risk if that shared wiring ever changes.

- **`apps/web/src/app/api/machines/git-blob/route.ts`** — `GET ?terminalId&projectName&branchName&ref&path` → `{ content, truncated }`. Gated on view access (checked before parsing `ref`/`path`). Session-only, no AI-agent tool orchestration (billing holds, injection screening) — same convention as the Files/Settings routes. Maps `invalid_ref`→400, `not_found`→404, `exec_failed`→502.

- **`apps/web/src/app/api/__tests__/security-audit-coverage.test.ts`** — added `machines/git-blob` to the audit-exemption allowlist alongside `machines/branches`/`machines/projects`: the coverage gate scans `route.ts` for a literal audit call, which misses the audit that happens deep inside `runGitInSandbox`'s `safeAudit` (via `writeCodeExecutionAudit`), several files away from the route.

`ref` is expected to be an already-resolved commit-ish (branch, tag, SHA, or a merge-base the caller computed elsewhere — see `sandbox-git-tools.ts`'s `gitDiff` three-dot `base...head` composition for that pattern); this route doesn't itself resolve compound ref expressions.

## Test plan

- [x] `readMachineGitBlob` unit tests (11 cases): happy path, `not_found` variants, `exec_failed`, hard `runGitInSandbox` failure, real truncation-boundary behavior at `SANDBOX_MAX_OUTPUT_BYTES`, and the leading-`-`/empty ref + empty-path rejections.
- [x] Route contract tests (8 cases): required-param validation, authz-before-parsing ordering, handle-resolution 404/503, success, and the `invalid_ref`/`not_found`/`exec_failed` → status-code mapping.
- [x] `bun run typecheck` clean across the whole monorepo (`packages/lib`, `apps/web`, and all 16 Turbo packages including `web:build`), re-verified after every follow-up commit.
- [x] `bun run build` clean across all 16 Turbo packages.
- [x] Reran sibling suites for regressions after every change: `machine-fs`, `machine-branches`, `machine-settings`, `machine-access`, `security-audit-coverage`, and the `files`/`settings`/`branches` route tests — all green, no regressions.
- [x] Workflow-backed self-review (code-review, high effort) — surfaced and fixed 2 confirmed duplication/drift-risk findings (see the runtime-wiring commit).
- [ ] Live-Sprite smoke test against a real branch checkout (no token in this environment — same gap the Files-route PR flagged).

https://claude.ai/code/session_01Fv2QN4CuPSck2LeXyHwWLf
