### PR TITLE
fix(tasks): decrypt assignee/user names in task list responses

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -16,7 +16,7 @@ import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger
 import { checkSubTasksComplete, SUBTASKS_INCOMPLETE_STATUS } from '@/lib/tasks/completion-guard';
 import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
-import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
+import { decryptTaskUserRelationsOne } from '@/lib/tasks/decrypt-task-relations';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -420,7 +420,7 @@ export async function PATCH(
     return NextResponse.json({ error: 'Task not found after update' }, { status: 404 });
   }
 
-  const [taskWithRelations] = await decryptTaskUserRelations([fetchedTask]);
+  const taskWithRelations = await decryptTaskUserRelationsOne(fetchedTask);
 
   const responseTitle = taskWithRelations.page?.title ?? '';
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -16,6 +16,7 @@ import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger
 import { checkSubTasksComplete, SUBTASKS_INCOMPLETE_STATUS } from '@/lib/tasks/completion-guard';
 import { reorderTaskPeers } from '@/lib/ai/tools/task-helpers';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
+import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -387,7 +388,7 @@ export async function PATCH(
   }
 
   // Fetch with relations (including assignees)
-  const taskWithRelations = await db.query.taskItems.findFirst({
+  const fetchedTask = await db.query.taskItems.findFirst({
     where: eq(taskItems.id, updatedTask.id),
     with: {
       assignee: {
@@ -415,9 +416,11 @@ export async function PATCH(
     },
   });
 
-  if (!taskWithRelations) {
+  if (!fetchedTask) {
     return NextResponse.json({ error: 'Task not found after update' }, { status: 404 });
   }
+
+  const [taskWithRelations] = await decryptTaskUserRelations([fetchedTask]);
 
   const responseTitle = taskWithRelations.page?.title ?? '';
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -15,7 +15,7 @@ import { createTaskAssignedNotification } from '@pagespace/lib/notifications/not
 import { computeHasContent } from './task-utils';
 import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
-import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
+import { decryptTaskUserRelations, decryptTaskUserRelationsOne } from '@/lib/tasks/decrypt-task-relations';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -548,9 +548,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       },
     },
   });
-  const taskWithRelations = fetchedTask
-    ? (await decryptTaskUserRelations([fetchedTask]))[0]
-    : fetchedTask;
+  const taskWithRelations = await decryptTaskUserRelationsOne(fetchedTask);
 
   const createdTitle = result.page.title;
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -15,6 +15,7 @@ import { createTaskAssignedNotification } from '@pagespace/lib/notifications/not
 import { computeHasContent } from './task-utils';
 import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
+import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -218,7 +219,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     },
   });
 
-  let tasks = await query;
+  let tasks = await decryptTaskUserRelations(await query);
 
   // Sort by page.position (source of truth), fallback to task.position
   tasks.sort((a, b) => {
@@ -520,7 +521,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   });
 
   // Fetch task with relations (including assignees)
-  const taskWithRelations = await db.query.taskItems.findFirst({
+  const fetchedTask = await db.query.taskItems.findFirst({
     where: eq(taskItems.id, result.task.id),
     with: {
       assignee: {
@@ -547,6 +548,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       },
     },
   });
+  const taskWithRelations = fetchedTask
+    ? (await decryptTaskUserRelations([fetchedTask]))[0]
+    : fetchedTask;
 
   const createdTitle = result.page.title;
 

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -16,6 +16,7 @@ import {
   getPrincipalDriveIds,
   getPrincipalBatchPagePermissions,
 } from '@/lib/auth';
+import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -416,9 +417,11 @@ export async function GET(request: Request) {
       offset: params.offset,
     });
 
+    const decryptedTasks = await decryptTaskUserRelations(tasks);
+
     // Enrich tasks with drive, task list page info, and status metadata
     // Filter out orphaned tasks where parent list is not accessible
-    const enrichedTasks = tasks
+    const enrichedTasks = decryptedTasks
       .map(task => {
         const listPageId = task.page?.parentId;
         const pageInfo = listPageId ? taskListPageMap.get(listPageId) : undefined;

--- a/apps/web/src/lib/ai/tools/task-helpers.ts
+++ b/apps/web/src/lib/ai/tools/task-helpers.ts
@@ -10,6 +10,7 @@ import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity
 import { createTaskTriggerWorkflow, disableTaskTriggers } from '@/lib/workflows/task-trigger-helpers';
 import type { AgentTriggerInput } from '@/lib/workflows/task-trigger-helpers';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
 
 /**
  * The Drizzle transaction handle passed to `db.transaction(async (tx) => ...)`.
@@ -172,7 +173,7 @@ export async function syncTaskAssignees(
 }
 
 export async function fetchEnrichedTasks(parentPageId: string) {
-  return db.query.taskItems.findMany({
+  const tasks = await db.query.taskItems.findMany({
     where: inArray(taskItems.pageId, db.select({ id: pages.id }).from(pages).where(and(
       eq(pages.parentId, parentPageId),
       eq(pages.type, 'TASK_LIST'),
@@ -191,6 +192,7 @@ export async function fetchEnrichedTasks(parentPageId: string) {
       },
     },
   });
+  return decryptTaskUserRelations(tasks);
 }
 
 type EnrichedTaskItem = Awaited<ReturnType<typeof fetchEnrichedTasks>>[number];

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -18,6 +18,7 @@ import {
 import { agentTriggerBaseSchema } from '@/lib/workflows/agent-trigger-shared';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 import { checkSubTasksComplete, toToolFailure } from '@/lib/tasks/completion-guard';
+import { decryptTaskUserRelations } from '@/lib/tasks/decrypt-task-relations';
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import {
   normalizeTaskAgentTriggerInput,
@@ -561,7 +562,7 @@ This helps agents understand their responsibilities and coordinate work with oth
         }
 
         // Query tasks assigned to the agent (task list membership derived from pages.parentId)
-        const tasks = await db.query.taskItems.findMany({
+        const fetchedTasks = await db.query.taskItems.findMany({
           where: and(...conditions),
           orderBy: [asc(taskItems.position)],
           with: {
@@ -573,6 +574,7 @@ This helps agents understand their responsibilities and coordinate work with oth
             },
           },
         });
+        const tasks = await decryptTaskUserRelations(fetchedTasks);
 
         // Collect unique task list page IDs from task parents
         const taskListPageIds = [...new Set(

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -562,7 +562,7 @@ This helps agents understand their responsibilities and coordinate work with oth
         }
 
         // Query tasks assigned to the agent (task list membership derived from pages.parentId)
-        const fetchedTasks = await db.query.taskItems.findMany({
+        const tasks = await db.query.taskItems.findMany({
           where: and(...conditions),
           orderBy: [asc(taskItems.position)],
           with: {
@@ -574,7 +574,6 @@ This helps agents understand their responsibilities and coordinate work with oth
             },
           },
         });
-        const tasks = await decryptTaskUserRelations(fetchedTasks);
 
         // Collect unique task list page IDs from task parents
         const taskListPageIds = [...new Set(
@@ -620,7 +619,7 @@ This helps agents understand their responsibilities and coordinate work with oth
         );
 
         // Filter out tasks with trashed pages, inaccessible drives, and optionally by driveId
-        const filteredTasks = tasks.filter(task => {
+        const matchingTasks = tasks.filter(task => {
           if (task.page?.isTrashed) return false;
           const parentId = task.page?.parentId;
           const taskDriveId = parentId ? taskListPageInfoMap.get(parentId)?.driveId : undefined;
@@ -630,6 +629,9 @@ This helps agents understand their responsibilities and coordinate work with oth
           if (driveId && taskDriveId !== driveId) return false;
           return true;
         });
+
+        // Decrypt after filtering — none of the filters read PII, so skip crypto work for dropped rows
+        const filteredTasks = await decryptTaskUserRelations(matchingTasks);
 
         // Build group lookup from status configs across all task lists
         const uniqueTaskListIds = taskListsInfo.map(tl => tl.id);

--- a/apps/web/src/lib/tasks/__tests__/decrypt-task-relations.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/decrypt-task-relations.test.ts
@@ -1,43 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { decryptUsersByIdOnceMock } = vi.hoisted(() => ({
-  decryptUsersByIdOnceMock: vi.fn(),
+const { decryptUserRowMock, warnMock } = vi.hoisted(() => ({
+  decryptUserRowMock: vi.fn(),
+  warnMock: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/user-repository', () => ({
-  decryptUsersByIdOnce: decryptUsersByIdOnceMock,
+  decryptUserRow: decryptUserRowMock,
 }));
 
-import { decryptTaskUserRelations } from '../decrypt-task-relations';
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { warn: warnMock } },
+}));
+
+import { decryptTaskUserRelations, decryptTaskUserRelationsOne } from '../decrypt-task-relations';
 
 describe('decryptTaskUserRelations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Simulate decryption: strip a "enc:" ciphertext marker off `name`/`email`.
-    decryptUsersByIdOnceMock.mockImplementation(async (rows: Array<{ id: string; name?: string | null; email?: string | null }>) => {
-      const map = new Map<string, unknown>();
-      for (const row of rows) {
-        map.set(row.id, {
-          ...row,
-          name: typeof row.name === 'string' ? row.name.replace(/^enc:/, '') : row.name,
-          email: typeof row.email === 'string' ? row.email.replace(/^enc:/, '') : row.email,
-        });
-      }
-      return map;
-    });
+    // Simulate decryption: strip an "enc:" ciphertext marker off `name`/`email`.
+    decryptUserRowMock.mockImplementation(async (row: { name?: string | null; email?: string | null }) => ({
+      ...row,
+      name: typeof row.name === 'string' ? row.name.replace(/^enc:/, '') : row.name,
+      email: typeof row.email === 'string' ? row.email.replace(/^enc:/, '') : row.email,
+    }));
   });
 
   it('returns an empty array unchanged and skips the decrypt call', async () => {
     const result = await decryptTaskUserRelations([]);
     expect(result).toEqual([]);
-    expect(decryptUsersByIdOnceMock).not.toHaveBeenCalled();
+    expect(decryptUserRowMock).not.toHaveBeenCalled();
   });
 
   it('passes through a task with no assignee/user/assignees relations', async () => {
     const task = { id: 't1', status: 'pending' };
     const result = await decryptTaskUserRelations([task]);
     expect(result).toEqual([task]);
-    expect(decryptUsersByIdOnceMock).not.toHaveBeenCalled();
+    expect(decryptUserRowMock).not.toHaveBeenCalled();
   });
 
   it('decrypts assignee, user, and assignees[].user, leaving other fields intact', async () => {
@@ -72,11 +71,26 @@ describe('decryptTaskUserRelations', () => {
 
     const results = await decryptTaskUserRelations(tasks);
 
-    expect(decryptUsersByIdOnceMock).toHaveBeenCalledTimes(1);
-    expect(decryptUsersByIdOnceMock).toHaveBeenCalledWith([sharedUser, sharedUser, sharedUser]);
+    expect(decryptUserRowMock).toHaveBeenCalledTimes(1);
     expect(results[0]?.assignee?.name).toBe('Shared');
     expect(results[1]?.user?.name).toBe('Shared');
     expect(results[2]?.assignees?.[0].user?.name).toBe('Shared');
+  });
+
+  it('preserves each relation\'s own column shape when the same user is selected with different projections', async () => {
+    // fetchEnrichedTasks selects assignee={id,name,image} but assignees[].user={id,name}:
+    // the wide projection must keep `image`, and the narrow one must not gain fields.
+    const tasks = [
+      { id: 't1', assignees: [{ user: { id: 'u1', name: 'enc:Alice' } }] },
+      { id: 't2', assignee: { id: 'u1', name: 'enc:Alice', image: 'a.png', email: 'enc:a@x.io' } },
+    ];
+
+    const results = await decryptTaskUserRelations(tasks);
+
+    expect(decryptUserRowMock).toHaveBeenCalledTimes(1);
+    expect(results[1]?.assignee).toEqual({ id: 'u1', name: 'Alice', image: 'a.png', email: 'a@x.io' });
+    // Narrow projection: decrypted name, and no image/email keys leak in from the merge.
+    expect(results[0]?.assignees?.[0].user).toEqual({ id: 'u1', name: 'Alice' });
   });
 
   it('tolerates a user relation with no email field (task queries only select id/name/image)', async () => {
@@ -92,6 +106,48 @@ describe('decryptTaskUserRelations', () => {
     expect(result.assignee).toBeNull();
     expect(result.user).toBeNull();
     expect(result.assignees).toEqual([]);
-    expect(decryptUsersByIdOnceMock).not.toHaveBeenCalled();
+    expect(decryptUserRowMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the stored value for a user whose decrypt fails, without failing the batch', async () => {
+    decryptUserRowMock.mockImplementation(async (row: { id?: string; name?: string | null }) => {
+      if (row.id === 'u-corrupt') throw new Error('Decryption failed');
+      return { ...row, name: typeof row.name === 'string' ? row.name.replace(/^enc:/, '') : row.name };
+    });
+    const tasks = [
+      { id: 't1', assignee: { id: 'u-corrupt', name: 'enc:Garbled' } },
+      { id: 't2', assignee: { id: 'u-ok', name: 'enc:Bob' } },
+    ];
+
+    const results = await decryptTaskUserRelations(tasks);
+
+    expect(results[0]?.assignee?.name).toBe('enc:Garbled');
+    expect(results[1]?.assignee?.name).toBe('Bob');
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.stringContaining('decrypt failed'),
+      expect.objectContaining({ userId: 'u-corrupt' }),
+    );
+  });
+});
+
+describe('decryptTaskUserRelationsOne', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    decryptUserRowMock.mockImplementation(async (row: { name?: string | null }) => ({
+      ...row,
+      name: typeof row.name === 'string' ? row.name.replace(/^enc:/, '') : row.name,
+    }));
+  });
+
+  it('decrypts a single task', async () => {
+    const result = await decryptTaskUserRelationsOne({ id: 't1', assignee: { id: 'u1', name: 'enc:Alice' } });
+    expect(result.assignee?.name).toBe('Alice');
+  });
+
+  it('passes through null and undefined', async () => {
+    expect(await decryptTaskUserRelationsOne(null)).toBeNull();
+    expect(await decryptTaskUserRelationsOne(undefined)).toBeUndefined();
+    expect(decryptUserRowMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/tasks/__tests__/decrypt-task-relations.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/decrypt-task-relations.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { decryptUsersByIdOnceMock } = vi.hoisted(() => ({
+  decryptUsersByIdOnceMock: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/user-repository', () => ({
+  decryptUsersByIdOnce: decryptUsersByIdOnceMock,
+}));
+
+import { decryptTaskUserRelations } from '../decrypt-task-relations';
+
+describe('decryptTaskUserRelations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Simulate decryption: strip a "enc:" ciphertext marker off `name`/`email`.
+    decryptUsersByIdOnceMock.mockImplementation(async (rows: Array<{ id: string; name?: string | null; email?: string | null }>) => {
+      const map = new Map<string, unknown>();
+      for (const row of rows) {
+        map.set(row.id, {
+          ...row,
+          name: typeof row.name === 'string' ? row.name.replace(/^enc:/, '') : row.name,
+          email: typeof row.email === 'string' ? row.email.replace(/^enc:/, '') : row.email,
+        });
+      }
+      return map;
+    });
+  });
+
+  it('returns an empty array unchanged and skips the decrypt call', async () => {
+    const result = await decryptTaskUserRelations([]);
+    expect(result).toEqual([]);
+    expect(decryptUsersByIdOnceMock).not.toHaveBeenCalled();
+  });
+
+  it('passes through a task with no assignee/user/assignees relations', async () => {
+    const task = { id: 't1', status: 'pending' };
+    const result = await decryptTaskUserRelations([task]);
+    expect(result).toEqual([task]);
+    expect(decryptUsersByIdOnceMock).not.toHaveBeenCalled();
+  });
+
+  it('decrypts assignee, user, and assignees[].user, leaving other fields intact', async () => {
+    const task = {
+      id: 't1',
+      status: 'pending',
+      assignee: { id: 'u1', name: 'enc:Alice', image: 'a.png' },
+      user: { id: 'u2', name: 'enc:Bob', image: 'b.png' },
+      assignees: [
+        { userId: 'u3', user: { id: 'u3', name: 'enc:Carol', image: 'c.png' } },
+        { userId: null, user: null, agentPageId: 'agent1' },
+      ],
+    };
+
+    const [result] = await decryptTaskUserRelations([task]);
+
+    expect(result.status).toBe('pending');
+    expect(result.assignee).toEqual({ id: 'u1', name: 'Alice', image: 'a.png' });
+    expect(result.user).toEqual({ id: 'u2', name: 'Bob', image: 'b.png' });
+    expect(result.assignees[0].user).toEqual({ id: 'u3', name: 'Carol', image: 'c.png' });
+    expect(result.assignees[1].user).toBeNull();
+    expect(result.assignees[1].agentPageId).toBe('agent1');
+  });
+
+  it('decrypts each unique user id exactly once across a batch of tasks', async () => {
+    const sharedUser = { id: 'u1', name: 'enc:Shared', image: null };
+    const tasks = [
+      { id: 't1', assignee: sharedUser },
+      { id: 't2', user: sharedUser },
+      { id: 't3', assignees: [{ user: sharedUser }] },
+    ];
+
+    const results = await decryptTaskUserRelations(tasks);
+
+    expect(decryptUsersByIdOnceMock).toHaveBeenCalledTimes(1);
+    expect(decryptUsersByIdOnceMock).toHaveBeenCalledWith([sharedUser, sharedUser, sharedUser]);
+    expect(results[0]?.assignee?.name).toBe('Shared');
+    expect(results[1]?.user?.name).toBe('Shared');
+    expect(results[2]?.assignees?.[0].user?.name).toBe('Shared');
+  });
+
+  it('tolerates a user relation with no email field (task queries only select id/name/image)', async () => {
+    const task = { id: 't1', assignee: { id: 'u1', name: 'enc:Alice', image: null } };
+    const [result] = await decryptTaskUserRelations([task]);
+    expect(result.assignee).toEqual({ id: 'u1', name: 'Alice', image: null });
+    expect((result.assignee as { email?: string }).email).toBeUndefined();
+  });
+
+  it('passes through null assignee/user without invoking decrypt for them', async () => {
+    const task = { id: 't1', assignee: null, user: null, assignees: [] };
+    const [result] = await decryptTaskUserRelations([task]);
+    expect(result.assignee).toBeNull();
+    expect(result.user).toBeNull();
+    expect(result.assignees).toEqual([]);
+    expect(decryptUsersByIdOnceMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/tasks/decrypt-task-relations.ts
+++ b/apps/web/src/lib/tasks/decrypt-task-relations.ts
@@ -1,0 +1,40 @@
+import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+
+type UserLike = { id: string; name?: string | null; email?: string | null } & Record<string, unknown>;
+
+interface TaskRelationsShape {
+  assignee?: UserLike | null;
+  user?: UserLike | null;
+  assignees?: ReadonlyArray<{ user?: UserLike | null } & Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+/**
+ * Decrypt the `name` (and `email`, if present) on every embedded user relation
+ * across a batch of task rows — assignee, user, assignees[].user. GDPR PII
+ * encryption means these come back as ciphertext unless decrypted at the edge.
+ * Dedupes decrypt work per unique user id across the whole batch.
+ */
+export async function decryptTaskUserRelations<T extends TaskRelationsShape>(
+  tasks: readonly T[],
+): Promise<T[]> {
+  const allUsers: UserLike[] = [];
+  for (const t of tasks) {
+    if (t.assignee) allUsers.push(t.assignee);
+    if (t.user) allUsers.push(t.user);
+    if (t.assignees) for (const a of t.assignees) if (a.user) allUsers.push(a.user);
+  }
+  if (allUsers.length === 0) return tasks.slice();
+
+  const decryptedById = await decryptUsersByIdOnce(allUsers);
+
+  return tasks.map((t) => ({
+    ...t,
+    assignee: t.assignee ? (decryptedById.get(t.assignee.id) ?? t.assignee) : t.assignee,
+    user: t.user ? (decryptedById.get(t.user.id) ?? t.user) : t.user,
+    assignees: t.assignees?.map((a) => ({
+      ...a,
+      user: a.user ? (decryptedById.get(a.user.id) ?? a.user) : a.user,
+    })),
+  })) as T[];
+}

--- a/apps/web/src/lib/tasks/decrypt-task-relations.ts
+++ b/apps/web/src/lib/tasks/decrypt-task-relations.ts
@@ -1,4 +1,5 @@
-import { decryptUsersByIdOnce } from '@pagespace/lib/auth/user-repository';
+import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 type UserLike = { id: string; name?: string | null; email?: string | null } & Record<string, unknown>;
 
@@ -10,10 +11,18 @@ interface TaskRelationsShape {
 }
 
 /**
- * Decrypt the `name` (and `email`, if present) on every embedded user relation
+ * Decrypt the `name` (and `email`, if selected) on every embedded user relation
  * across a batch of task rows — assignee, user, assignees[].user. GDPR PII
  * encryption means these come back as ciphertext unless decrypted at the edge.
- * Dedupes decrypt work per unique user id across the whole batch.
+ *
+ * Each unique user id is decrypted once per batch. The same user can be selected
+ * with different column sets across relations (e.g. assignee selects `image`,
+ * assignees[].user does not), so projections are merged for decryption and only
+ * the PII fields each relation actually selected are overlaid back — the
+ * original row shape is always preserved.
+ *
+ * A row whose ciphertext fails to decrypt keeps its stored value (the pre-encryption
+ * rendering behavior) rather than failing the whole response.
  */
 export async function decryptTaskUserRelations<T extends TaskRelationsShape>(
   tasks: readonly T[],
@@ -26,15 +35,66 @@ export async function decryptTaskUserRelations<T extends TaskRelationsShape>(
   }
   if (allUsers.length === 0) return tasks.slice();
 
-  const decryptedById = await decryptUsersByIdOnce(allUsers);
+  const decryptedById = await decryptPiiByIdOnce(allUsers);
+
+  const overlay = (user: UserLike | null | undefined) => {
+    if (!user) return user;
+    const decrypted = decryptedById.get(user.id);
+    if (!decrypted) return user;
+    const out: UserLike = { ...user };
+    if ('name' in user) out.name = decrypted.name;
+    if ('email' in user) out.email = decrypted.email;
+    return out;
+  };
 
   return tasks.map((t) => ({
     ...t,
-    assignee: t.assignee ? (decryptedById.get(t.assignee.id) ?? t.assignee) : t.assignee,
-    user: t.user ? (decryptedById.get(t.user.id) ?? t.user) : t.user,
-    assignees: t.assignees?.map((a) => ({
-      ...a,
-      user: a.user ? (decryptedById.get(a.user.id) ?? a.user) : a.user,
-    })),
+    assignee: overlay(t.assignee),
+    user: overlay(t.user),
+    assignees: t.assignees?.map((a) => ({ ...a, user: overlay(a.user) })),
   })) as T[];
+}
+
+/** Single-task convenience wrapper around {@link decryptTaskUserRelations} (null/undefined pass through). */
+export async function decryptTaskUserRelationsOne<T extends TaskRelationsShape>(task: T): Promise<T>;
+export async function decryptTaskUserRelationsOne<T extends TaskRelationsShape>(
+  task: T | undefined,
+): Promise<T | undefined>;
+export async function decryptTaskUserRelationsOne<T extends TaskRelationsShape>(
+  task: T | null,
+): Promise<T | null>;
+export async function decryptTaskUserRelationsOne<T extends TaskRelationsShape>(
+  task: T | null | undefined,
+): Promise<T | null | undefined> {
+  if (!task) return task;
+  const [decrypted] = await decryptTaskUserRelations([task]);
+  return decrypted;
+}
+
+/**
+ * Merge every projection of the same user id (union of the selected columns),
+ * then decrypt each merged row once. A per-user decrypt failure falls back to
+ * that user's stored row instead of rejecting the batch.
+ */
+async function decryptPiiByIdOnce(users: readonly UserLike[]): Promise<Map<string, UserLike>> {
+  const mergedById = new Map<string, UserLike>();
+  for (const u of users) {
+    const prev = mergedById.get(u.id);
+    mergedById.set(u.id, prev ? { ...prev, ...u } : u);
+  }
+
+  const entries = await Promise.all(
+    Array.from(mergedById.entries()).map(async ([id, row]) => {
+      try {
+        return [id, await decryptUserRow(row)] as const;
+      } catch (error) {
+        loggers.api.warn('Task relations: user PII decrypt failed; returning stored value', {
+          userId: id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return [id, row] as const;
+      }
+    }),
+  );
+  return new Map(entries);
 }


### PR DESCRIPTION
## Summary
- `users.name` is GDPR-encrypted at rest, but 5 task-read call sites returned `taskItems.assignee`/`.user`/`.assignees[].user` straight off the DB without decrypting — clients rendered ciphertext (`0120032...`) next to a normal avatar instead of the assignee's name, matching the reported screenshot.
- Adds a shared `decryptTaskUserRelations()` helper (`apps/web/src/lib/tasks/decrypt-task-relations.ts`) plus a `decryptTaskUserRelationsOne()` single-task wrapper, and wires them into all 5 affected call sites: the page-scoped tasks GET/POST/PATCH routes, the cross-drive `/api/tasks` "My Tasks" feed, `fetchEnrichedTasks()` (backs create/update/delete/reorder AI tools), and the `get_assigned_tasks` MCP tool.
- No frontend changes needed — the task-list UI components already just read `.name` off the payload.

## Hardening (review round 1)
- **Shape-preserving decrypt**: the same user can be selected with different column sets across relations (`assignee` selects `{id,name,image}`, `assignees[].user` selects `{id,name}`). Projections are merged for a single decrypt per user id, then only the PII fields each relation actually selected are overlaid back — so no relation loses fields (e.g. `assignee.image`) or gains fields it didn't select.
- **Fault tolerance**: a users row whose ciphertext fails to decrypt (key rotation mismatch, corrupted ciphertext) falls back to its stored value with a warning log — matching pre-encryption rendering behavior — instead of 500ing an entire task-list GET or a PATCH whose write already committed.
- **`get_assigned_tasks` decrypts after filtering** (trashed/drive-access/driveId) since no filter reads PII — no crypto work for dropped rows.

## Test plan
- [x] `bun run typecheck` — all 16 turbo tasks pass, including `web:build`
- [x] Unit tests in `apps/web/src/lib/tasks/__tests__/decrypt-task-relations.test.ts` (10 cases) mock at the `decryptUserRow` layer so the helper's own dedup, projection-merge, shape-preservation, and failure-fallback logic is genuinely exercised: empty batch, no-relations passthrough, full decrypt of assignee/user/assignees[].user, decrypt-once-per-unique-id across a batch, cross-projection shape preservation, missing-email tolerance, null passthrough, per-user decrypt-failure fallback (batch survives + warn log), single-task wrapper, null/undefined wrapper passthrough — all passing
- [x] Re-swept the repo for any other `taskItems`/`taskAssignees` query with a user relation selecting `name` — all remaining sites select only non-PII columns (`page`, id-only assignee rows)
- [ ] Manual verification in a running dev server with `ENCRYPTION_KEY`/`PII_ENCRYPTION_ENABLED` set: open a TASK_LIST page with assignees and confirm the Assignee column renders plaintext names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FbZEMkuP4qhVMdUY7XSpn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task-related API responses now consistently display decrypted assignee and user information.
  * Improved handling of task relations with different field selections.
  * A decryption failure no longer prevents task results from being returned; affected data falls back safely.

* **Tests**
  * Added coverage for relation decryption, nested assignees, duplicate users, missing fields, null values, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->