### PR TITLE
feat(machines): Diff tab 3-way scope service — pure resolveDiffScope + /api/machines/diff route

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -162,6 +162,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['machines/agent-terminals', 'Reserves/kills a named PTY session tracking row; the PTY itself is audited via writeCodeExecutionAudit when opened (see apps/realtime/src/index.ts)'],
   ['machines/files', 'Read-only working-tree browse (fixed `ls` + single file read on an already-provisioned branch Sprite) — no data write, no code execution/provisioning, no git; GET-only, view-gated by canViewMachine and path-confined to the branch checkout root, consistent with the other read-only machines/* and drive/page read sub-routes'],
   ['machines/git-blob', 'Audited via writeCodeExecutionAudit inside runGitInSandbox (machine-git-blob.ts\'s `git show <ref>:<path>` on the branch Sprite) — same deep audit path as machines/branches and machines/projects, not a direct route.ts call'],
+  ['machines/diff', 'Audited via writeCodeExecutionAudit inside runGitInSandbox (machine-diff.ts\'s status/diff/merge-base/`git show` calls on the branch Sprite — same deep audit path as machines/git-blob); its only non-git read is the same read-only, path-confined working-tree file read machines/files documents'],
 
   // --- Integration-tool UI routes (audited via the shared executeToolSaga
   // audit path deep in the integrations engine, not directly in route.ts) ---

--- a/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * /api/machines/diff request contract tests.
+ *
+ * Everything IO — auth, access check, handle resolution, the diff service —
+ * is mocked so the tests isolate the route's own request handling:
+ * required-param validation, authz-before-parsing ordering, the EXPLICIT
+ * 200 `{ notApplicable: true }` answer for main-branch committed/branch
+ * scopes (returned before the machine handle is even resolved), the
+ * path-confinement gate on the pair form, and the result → status-code
+ * mapping (exec_failed / merge_base_failed → 502).
+ *
+ * The pure scope module (`machine-diff-scope.ts`) is intentionally NOT
+ * mocked — the route's notApplicable short-circuit runs the real
+ * `resolveDiffScope`/`isMainBranchName`, as does the real
+ * `resolvePathWithinSync` confinement helper.
+ */
+
+vi.mock('@pagespace/lib/services/machines/machine-branches', () => ({ BRANCH_REPO_PATH: '/workspace/repo' }));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(async () => ({ userId: 'user-1' })),
+  isAuthError: vi.fn(() => false),
+}));
+
+type HandleResult =
+  | { ok: true; handle: { machineId: string } }
+  | { ok: false; reason: 'not_found' | 'vanished' };
+
+const canViewMachine = vi.fn(async () => true);
+const resolveBranchMachineHandle = vi.fn(
+  async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
+);
+const resolveMachineActorContext = vi.fn(async () => ({
+  userId: 'user-1',
+  tenantId: 'user-1',
+  actorEmail: 'user-1@example.com',
+  tier: 'pro' as const,
+}));
+const buildDiffActorContext = vi.fn(() => ({ conversationId: 'scope' }));
+const buildDiffGitDepsForHandle = vi.fn(() => ({}));
+
+vi.mock('@/lib/machines/machine-diff-runtime', () => ({
+  canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
+  resolveBranchMachineHandle: (...args: unknown[]) => resolveBranchMachineHandle(...(args as [])),
+  resolveMachineActorContext: (...args: unknown[]) => resolveMachineActorContext(...(args as [])),
+  buildDiffActorContext: (...args: unknown[]) => buildDiffActorContext(...(args as [])),
+  buildDiffGitDepsForHandle: (...args: unknown[]) => buildDiffGitDepsForHandle(...(args as [])),
+}));
+
+type ListResult =
+  | { ok: true; notApplicable: true }
+  | {
+      ok: true;
+      notApplicable: false;
+      files: Array<{ path: string; status: string; previousPath?: string }>;
+      truncated: boolean;
+      mergeBase: string | null;
+    }
+  | { ok: false; reason: 'exec_failed' | 'merge_base_failed'; detail?: string };
+
+type PairResult =
+  | { ok: true; notApplicable: true }
+  | {
+      ok: true;
+      notApplicable: false;
+      original: { content: string; truncated: boolean } | null;
+      modified: { content: string; truncated: boolean } | null;
+    }
+  | { ok: false; reason: 'exec_failed' | 'merge_base_failed'; detail?: string };
+
+const listMachineDiffFiles = vi.fn(
+  async (): Promise<ListResult> => ({
+    ok: true,
+    notApplicable: false,
+    files: [{ path: 'src/a.ts', status: 'modified' }],
+    truncated: false,
+    mergeBase: null,
+  }),
+);
+const readMachineDiffPair = vi.fn(
+  async (): Promise<PairResult> => ({
+    ok: true,
+    notApplicable: false,
+    original: { content: 'old', truncated: false },
+    modified: { content: 'new', truncated: false },
+  }),
+);
+vi.mock('@pagespace/lib/services/sandbox/machine-diff', () => ({
+  listMachineDiffFiles: (...args: unknown[]) => listMachineDiffFiles(...(args as [])),
+  readMachineDiffPair: (...args: unknown[]) => readMachineDiffPair(...(args as [])),
+}));
+
+import { GET } from '../route';
+
+function get(query: Record<string, string>): Request {
+  const params = new URLSearchParams({
+    terminalId: 't1',
+    projectName: 'p1',
+    branchName: 'feature/x',
+    scope: 'uncommitted',
+    ...query,
+  });
+  return new Request(`http://localhost/api/machines/diff?${params.toString()}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canViewMachine.mockResolvedValue(true);
+  resolveBranchMachineHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
+  resolveMachineActorContext.mockResolvedValue({
+    userId: 'user-1',
+    tenantId: 'user-1',
+    actorEmail: 'user-1@example.com',
+    tier: 'pro',
+  });
+  listMachineDiffFiles.mockResolvedValue({
+    ok: true,
+    notApplicable: false,
+    files: [{ path: 'src/a.ts', status: 'modified' }],
+    truncated: false,
+    mergeBase: null,
+  });
+  readMachineDiffPair.mockResolvedValue({
+    ok: true,
+    notApplicable: false,
+    original: { content: 'old', truncated: false },
+    modified: { content: 'new', truncated: false },
+  });
+});
+
+describe('GET /api/machines/diff — request validation', () => {
+  it.each(['terminalId', 'projectName', 'branchName'])('400s when %s is missing', async (field) => {
+    const params = new URLSearchParams({
+      terminalId: 't1',
+      projectName: 'p1',
+      branchName: 'feature/x',
+      scope: 'uncommitted',
+    });
+    params.delete(field);
+    const res = await GET(new Request(`http://localhost/api/machines/diff?${params.toString()}`));
+    expect(res.status).toBe(400);
+  });
+
+  it('400s on a missing or unknown scope', async () => {
+    const missing = new URLSearchParams({ terminalId: 't1', projectName: 'p1', branchName: 'feature/x' });
+    expect((await GET(new Request(`http://localhost/api/machines/diff?${missing.toString()}`))).status).toBe(400);
+    expect((await GET(get({ scope: 'everything' }))).status).toBe(400);
+  });
+
+  it('403s a viewer without machine access BEFORE scope/path are even parsed', async () => {
+    canViewMachine.mockResolvedValue(false);
+    const res = await GET(get({ scope: 'not-even-a-scope', path: '../../etc/passwd' }));
+    expect(res.status).toBe(403);
+    expect(listMachineDiffFiles).not.toHaveBeenCalled();
+    expect(readMachineDiffPair).not.toHaveBeenCalled();
+  });
+
+  it('400s a path that escapes the checkout root without touching the machine', async () => {
+    const res = await GET(get({ path: '../../etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(resolveBranchMachineHandle).not.toHaveBeenCalled();
+    expect(readMachineDiffPair).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/machines/diff — main-branch notApplicable', () => {
+  it.each(['committed', 'branch'])(
+    'answers 200 { notApplicable: true } for %s scope on master without resolving the machine handle',
+    async (scope) => {
+      const res = await GET(get({ branchName: 'master', scope }));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ notApplicable: true });
+      expect(resolveBranchMachineHandle).not.toHaveBeenCalled();
+      expect(listMachineDiffFiles).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps the uncommitted scope fully applicable on the main branch', async () => {
+    const res = await GET(get({ branchName: 'main', scope: 'uncommitted' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ notApplicable: false, scope: 'uncommitted' });
+  });
+});
+
+describe('GET /api/machines/diff — list form', () => {
+  it('returns the changed-file list with truncation flag and merge-base', async () => {
+    listMachineDiffFiles.mockResolvedValue({
+      ok: true,
+      notApplicable: false,
+      files: [{ path: 'new/name.ts', status: 'renamed', previousPath: 'old/name.ts' }],
+      truncated: true,
+      mergeBase: 'a'.repeat(40),
+    });
+    const res = await GET(get({ branchName: 'feature/x', scope: 'committed' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      notApplicable: false,
+      scope: 'committed',
+      files: [{ path: 'new/name.ts', status: 'renamed', previousPath: 'old/name.ts' }],
+      truncated: true,
+      mergeBase: 'a'.repeat(40),
+    });
+    expect(listMachineDiffFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branchName: 'feature/x',
+        isMainBranch: false,
+        scope: 'committed',
+        cwd: '/workspace/repo',
+      }),
+    );
+  });
+
+  it('404s / 503s when the branch machine cannot be resolved', async () => {
+    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    expect((await GET(get({}))).status).toBe(404);
+    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    expect((await GET(get({}))).status).toBe(503);
+  });
+
+  it.each([
+    { reason: 'exec_failed' as const, status: 502 },
+    { reason: 'merge_base_failed' as const, status: 502 },
+  ])('maps a $reason service failure to $status', async ({ reason, status }) => {
+    listMachineDiffFiles.mockResolvedValue({ ok: false, reason, detail: 'boom' });
+    const res = await GET(get({}));
+    expect(res.status).toBe(status);
+    expect(await res.json()).toEqual({ error: 'boom', reason });
+  });
+});
+
+describe('GET /api/machines/diff — per-file pair form', () => {
+  it('returns the original/modified pair for a confined repo-relative path', async () => {
+    const res = await GET(get({ path: 'src/a.ts' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      notApplicable: false,
+      scope: 'uncommitted',
+      path: 'src/a.ts',
+      original: { content: 'old', truncated: false },
+      modified: { content: 'new', truncated: false },
+    });
+    expect(readMachineDiffPair).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'src/a.ts',
+        workingTreePath: '/workspace/repo/src/a.ts',
+        cwd: '/workspace/repo',
+      }),
+    );
+  });
+
+  it('passes null sides through (added file has no original)', async () => {
+    readMachineDiffPair.mockResolvedValue({
+      ok: true,
+      notApplicable: false,
+      original: null,
+      modified: { content: 'brand new', truncated: false },
+    });
+    const res = await GET(get({ path: 'new.ts' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ original: null, modified: { content: 'brand new' } });
+  });
+
+  it('404s when the file exists on neither side of the scope', async () => {
+    readMachineDiffPair.mockResolvedValue({ ok: true, notApplicable: false, original: null, modified: null });
+    const res = await GET(get({ path: 'ghost.ts' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('maps a pair-read exec failure to 502', async () => {
+    readMachineDiffPair.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'boom' });
+    const res = await GET(get({ path: 'src/a.ts' }));
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
@@ -262,6 +262,23 @@ describe('GET /api/machines/diff — per-file pair form', () => {
     );
   });
 
+  it('forwards a valid status so the pair reader can skip a nonexistent side', async () => {
+    const res = await GET(get({ path: 'src/a.ts', status: 'deleted' }));
+    expect(res.status).toBe(200);
+    expect(readMachineDiffPair).toHaveBeenCalledWith(expect.objectContaining({ status: 'deleted' }));
+  });
+
+  it('400s an invalid status value without touching the machine', async () => {
+    const res = await GET(get({ path: 'src/a.ts', status: 'bogus' }));
+    expect(res.status).toBe(400);
+    expect(readMachineDiffPair).not.toHaveBeenCalled();
+  });
+
+  it('omits status (undefined) when absent or empty', async () => {
+    await GET(get({ path: 'src/a.ts' }));
+    expect(readMachineDiffPair).toHaveBeenCalledWith(expect.objectContaining({ status: undefined }));
+  });
+
   it('omits previousPath (undefined) when absent or empty', async () => {
     await GET(get({ path: 'src/a.ts' }));
     expect(readMachineDiffPair).toHaveBeenCalledWith(expect.objectContaining({ previousPath: undefined }));

--- a/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
@@ -250,6 +250,32 @@ describe('GET /api/machines/diff — per-file pair form', () => {
     );
   });
 
+  it('forwards previousPath (rename source) so the original side reads the pre-rename blob', async () => {
+    const res = await GET(get({ path: 'src/new-name.ts', previousPath: 'src/old-name.ts' }));
+    expect(res.status).toBe(200);
+    expect(readMachineDiffPair).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: 'src/new-name.ts',
+        previousPath: 'src/old-name.ts',
+        workingTreePath: '/workspace/repo/src/new-name.ts',
+      }),
+    );
+  });
+
+  it('omits previousPath (undefined) when absent or empty', async () => {
+    await GET(get({ path: 'src/a.ts' }));
+    expect(readMachineDiffPair).toHaveBeenCalledWith(expect.objectContaining({ previousPath: undefined }));
+    vi.clearAllMocks();
+    readMachineDiffPair.mockResolvedValue({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'old', truncated: false },
+      modified: { content: 'new', truncated: false },
+    });
+    await GET(get({ path: 'src/a.ts', previousPath: '' }));
+    expect(readMachineDiffPair).toHaveBeenCalledWith(expect.objectContaining({ previousPath: undefined }));
+  });
+
   it('passes null sides through (added file has no original)', async () => {
     readMachineDiffPair.mockResolvedValue({
       ok: true,

--- a/apps/web/src/app/api/machines/diff/route.ts
+++ b/apps/web/src/app/api/machines/diff/route.ts
@@ -12,12 +12,15 @@
  *     scopes) is the concrete SHA a client may pass as `ref` to
  *     `/api/machines/git-blob` for 'original' sides.
  *
- * GET …&path=<repo-relative file>
+ * GET …&path=<repo-relative file>[&previousPath=<repo-relative source>]
  *   → { notApplicable: false, scope, path, original, modified }
  *     ONE file's diff pair, each side read from the scope's source
  *     (merge-base blob / HEAD blob / working tree); a side is null when the
  *     file does not exist there (added file's original, deleted file's
- *     modified).
+ *     modified). For a RENAMED file the client passes `previousPath` (the
+ *     rename source from the list entry) so the 'original' side is read from
+ *     the pre-rename location instead of resolving to null and mis-showing the
+ *     rename as an add.
  *
  * On the main branch ('master'/'main' — the literal default-branch names,
  * there is no schema flag), the 'committed' and 'branch' scopes are
@@ -100,6 +103,13 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
   }
 
+  // `previousPath` (the rename source) addresses ONLY the 'original' blob side
+  // via git's `<ref>:<path>` syntax, which resolves inside the ref's own tree
+  // and cannot escape onto the host filesystem — so it needs no working-tree
+  // confinement (unlike `path`, whose working-tree side is a real fs path).
+  const rawPreviousPath = url.searchParams.get('previousPath');
+  const previousPath = rawPreviousPath !== null && rawPreviousPath.length > 0 ? rawPreviousPath : undefined;
+
   const resolved = await resolveBranchMachineHandle({
     terminalId: terminalId.value,
     projectName: projectName.value,
@@ -123,6 +133,7 @@ export async function GET(request: Request) {
       isMainBranch,
       scope,
       path: rawPath,
+      previousPath,
       workingTreePath,
       cwd: BRANCH_REPO_PATH,
       handle: resolved.handle,

--- a/apps/web/src/app/api/machines/diff/route.ts
+++ b/apps/web/src/app/api/machines/diff/route.ts
@@ -1,0 +1,173 @@
+/**
+ * Machine Diff API — the Diff tab's 3-way scope surface (Machine page
+ * rebuild, Phase 1). Composes the two merged read primitives (working-tree
+ * `/api/machines/files`, git-object `/api/machines/git-blob`) behind one
+ * scope-aware endpoint; all scope semantics live in the PURE
+ * `machine-diff-scope.ts` and are executed by the DI'd `machine-diff.ts`.
+ *
+ * GET ?terminalId=&projectName=&branchName=&scope=uncommitted|committed|branch
+ *   → { notApplicable: false, scope, files: [{ path, status, previousPath? }],
+ *       truncated, mergeBase }
+ *     the changed-file list for the scope; `mergeBase` (committed/branch
+ *     scopes) is the concrete SHA a client may pass as `ref` to
+ *     `/api/machines/git-blob` for 'original' sides.
+ *
+ * GET …&path=<repo-relative file>
+ *   → { notApplicable: false, scope, path, original, modified }
+ *     ONE file's diff pair, each side read from the scope's source
+ *     (merge-base blob / HEAD blob / working tree); a side is null when the
+ *     file does not exist there (added file's original, deleted file's
+ *     modified).
+ *
+ * On the main branch ('master'/'main' — the literal default-branch names,
+ * there is no schema flag), the 'committed' and 'branch' scopes are
+ * meaningless (a merge-base with itself), so both forms return
+ * `{ notApplicable: true }` as an EXPLICIT 200 — not empty data, not a 4xx —
+ * so the client renders a disabled scope toggle without inferring anything.
+ * That answer needs no sandbox, so it is returned before the machine handle
+ * is even resolved — it works while the machine is off.
+ *
+ * Session-only (no MCP/agent tokens) — a human/UI browsing surface; the git
+ * calls go through `runGitInSandbox`, NOT the AI-tool orchestration — same
+ * convention as the Files/Git-Blob routes.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { listMachineDiffFiles, readMachineDiffPair } from '@pagespace/lib/services/sandbox/machine-diff';
+import { isMachineDiffScope, isMainBranchName, resolveDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
+import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
+import {
+  canViewMachine,
+  resolveBranchMachineHandle,
+  resolveMachineActorContext,
+  buildDiffActorContext,
+  buildDiffGitDepsForHandle,
+} from '@/lib/machines/machine-diff-runtime';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { ok: false, error: NextResponse.json({ error: `${field} is required` }, { status: 400 }) };
+  }
+  return { ok: true, value };
+}
+
+const DENIAL_STATUS: Record<string, number> = {
+  exec_failed: 502,
+  merge_base_failed: 502,
+};
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const terminalId = requireString(url.searchParams.get('terminalId'), 'terminalId');
+  if (!terminalId.ok) return terminalId.error;
+  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
+  if (!projectName.ok) return projectName.error;
+  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
+  if (!branchName.ok) return branchName.error;
+
+  // Authorize BEFORE parsing scope/path, so a user without view access gets a
+  // uniform 403 and can never probe scope/path handling.
+  if (!(await canViewMachine(auth.userId, terminalId.value))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const scope = url.searchParams.get('scope');
+  if (scope === null || !isMachineDiffScope(scope)) {
+    return NextResponse.json({ error: "scope must be 'uncommitted', 'committed', or 'branch'" }, { status: 400 });
+  }
+
+  // The main-branch answer is pure — no handle, no git — so it comes first
+  // and holds even while the machine is stopped.
+  const isMainBranch = isMainBranchName(branchName.value);
+  if ('notApplicable' in resolveDiffScope(branchName.value, isMainBranch, scope)) {
+    return NextResponse.json({ notApplicable: true });
+  }
+
+  // `path` selects the per-file pair form; it is untrusted and repo-relative,
+  // so confine its working-tree resolution under the checkout root before any
+  // filesystem access (blob sides resolve inside a ref's own git tree and
+  // cannot escape by construction).
+  const rawPath = url.searchParams.get('path');
+  const workingTreePath = rawPath !== null && rawPath.length > 0 ? resolvePathWithinSync(BRANCH_REPO_PATH, rawPath) : null;
+  if (rawPath !== null && rawPath.length > 0 && workingTreePath === null) {
+    return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
+  }
+
+  const resolved = await resolveBranchMachineHandle({
+    terminalId: terminalId.value,
+    projectName: projectName.value,
+    branchName: branchName.value,
+  });
+  if (!resolved.ok) {
+    return NextResponse.json(
+      { error: `Branch machine ${resolved.reason}`, reason: resolved.reason },
+      { status: resolved.reason === 'not_found' ? 404 : 503 },
+    );
+  }
+
+  const actor = await resolveMachineActorContext(auth.userId);
+  const scopeKey = `${terminalId.value}:${projectName.value}:${branchName.value}:diff`;
+  const ctx = buildDiffActorContext(scopeKey, actor);
+  const deps = buildDiffGitDepsForHandle(resolved.handle);
+
+  if (rawPath !== null && rawPath.length > 0 && workingTreePath !== null) {
+    const result = await readMachineDiffPair({
+      branchName: branchName.value,
+      isMainBranch,
+      scope,
+      path: rawPath,
+      workingTreePath,
+      cwd: BRANCH_REPO_PATH,
+      handle: resolved.handle,
+      ctx,
+      deps,
+    });
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.detail ?? result.reason, reason: result.reason },
+        { status: DENIAL_STATUS[result.reason] ?? 500 },
+      );
+    }
+    if (result.notApplicable) return NextResponse.json({ notApplicable: true });
+    if (result.original === null && result.modified === null) {
+      return NextResponse.json({ error: 'File not found in this diff scope' }, { status: 404 });
+    }
+    return NextResponse.json({
+      notApplicable: false,
+      scope,
+      path: rawPath,
+      original: result.original,
+      modified: result.modified,
+    });
+  }
+
+  const result = await listMachineDiffFiles({
+    branchName: branchName.value,
+    isMainBranch,
+    scope,
+    cwd: BRANCH_REPO_PATH,
+    ctx,
+    deps,
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.detail ?? result.reason, reason: result.reason },
+      { status: DENIAL_STATUS[result.reason] ?? 500 },
+    );
+  }
+  if (result.notApplicable) return NextResponse.json({ notApplicable: true });
+  return NextResponse.json({
+    notApplicable: false,
+    scope,
+    files: result.files,
+    truncated: result.truncated,
+    mergeBase: result.mergeBase,
+  });
+}

--- a/apps/web/src/app/api/machines/diff/route.ts
+++ b/apps/web/src/app/api/machines/diff/route.ts
@@ -74,12 +74,12 @@ export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
   if (isAuthError(auth)) return auth.error;
 
-  const url = new URL(request.url);
-  const terminalId = requireString(url.searchParams.get('terminalId'), 'terminalId');
+  const { searchParams } = new URL(request.url);
+  const terminalId = requireString(searchParams.get('terminalId'), 'terminalId');
   if (!terminalId.ok) return terminalId.error;
-  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
+  const projectName = requireString(searchParams.get('projectName'), 'projectName');
   if (!projectName.ok) return projectName.error;
-  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
+  const branchName = requireString(searchParams.get('branchName'), 'branchName');
   if (!branchName.ok) return branchName.error;
 
   // Authorize BEFORE parsing scope/path, so a user without view access gets a
@@ -88,7 +88,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
 
-  const scope = url.searchParams.get('scope');
+  const scope = searchParams.get('scope');
   if (scope === null || !isMachineDiffScope(scope)) {
     return NextResponse.json({ error: "scope must be 'uncommitted', 'committed', or 'branch'" }, { status: 400 });
   }
@@ -104,7 +104,7 @@ export async function GET(request: Request) {
   // so confine its working-tree resolution under the checkout root before any
   // filesystem access (blob sides resolve inside a ref's own git tree and
   // cannot escape by construction).
-  const rawPath = url.searchParams.get('path');
+  const rawPath = searchParams.get('path');
   const workingTreePath = rawPath !== null && rawPath.length > 0 ? resolvePathWithinSync(BRANCH_REPO_PATH, rawPath) : null;
   if (rawPath !== null && rawPath.length > 0 && workingTreePath === null) {
     return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
@@ -114,7 +114,7 @@ export async function GET(request: Request) {
   // via git's `<ref>:<path>` syntax, which resolves inside the ref's own tree
   // and cannot escape onto the host filesystem — so it needs no working-tree
   // confinement (unlike `path`, whose working-tree side is a real fs path).
-  const rawPreviousPath = url.searchParams.get('previousPath');
+  const rawPreviousPath = searchParams.get('previousPath');
   const previousPath = rawPreviousPath !== null && rawPreviousPath.length > 0 ? rawPreviousPath : undefined;
 
   // `status` (the file's status from the changed-file list) lets the pair
@@ -122,7 +122,7 @@ export async function GET(request: Request) {
   // working-tree modified side, which could otherwise surface an untracked
   // file masquerading at the same path (e.g. after `git rm --cached`). Optional
   // but validated when present so a bad value fails fast rather than silently.
-  const rawStatus = url.searchParams.get('status');
+  const rawStatus = searchParams.get('status');
   if (rawStatus !== null && rawStatus.length > 0 && !isMachineDiffFileStatus(rawStatus)) {
     return NextResponse.json(
       { error: "status must be 'added', 'modified', 'deleted', or 'renamed'" },

--- a/apps/web/src/app/api/machines/diff/route.ts
+++ b/apps/web/src/app/api/machines/diff/route.ts
@@ -12,7 +12,7 @@
  *     scopes) is the concrete SHA a client may pass as `ref` to
  *     `/api/machines/git-blob` for 'original' sides.
  *
- * GET …&path=<repo-relative file>[&previousPath=<repo-relative source>]
+ * GET …&path=<repo-relative file>[&previousPath=<source>][&status=<list status>]
  *   → { notApplicable: false, scope, path, original, modified }
  *     ONE file's diff pair, each side read from the scope's source
  *     (merge-base blob / HEAD blob / working tree); a side is null when the
@@ -20,7 +20,9 @@
  *     modified). For a RENAMED file the client passes `previousPath` (the
  *     rename source from the list entry) so the 'original' side is read from
  *     the pre-rename location instead of resolving to null and mis-showing the
- *     rename as an add.
+ *     rename as an add. The client also passes `status` (the file's list
+ *     status) so a deletion's modified side is forced null rather than reading
+ *     an untracked file masquerading at the same path (e.g. `git rm --cached`).
  *
  * On the main branch ('master'/'main' — the literal default-branch names,
  * there is no schema flag), the 'committed' and 'branch' scopes are
@@ -38,7 +40,12 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { listMachineDiffFiles, readMachineDiffPair } from '@pagespace/lib/services/sandbox/machine-diff';
-import { isMachineDiffScope, isMainBranchName, resolveDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+import {
+  isMachineDiffFileStatus,
+  isMachineDiffScope,
+  isMainBranchName,
+  resolveDiffScope,
+} from '@pagespace/lib/services/sandbox/machine-diff-scope';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
 import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
 import {
@@ -110,6 +117,20 @@ export async function GET(request: Request) {
   const rawPreviousPath = url.searchParams.get('previousPath');
   const previousPath = rawPreviousPath !== null && rawPreviousPath.length > 0 ? rawPreviousPath : undefined;
 
+  // `status` (the file's status from the changed-file list) lets the pair
+  // reader skip a side that can't exist — critically, a 'deleted' file's
+  // working-tree modified side, which could otherwise surface an untracked
+  // file masquerading at the same path (e.g. after `git rm --cached`). Optional
+  // but validated when present so a bad value fails fast rather than silently.
+  const rawStatus = url.searchParams.get('status');
+  if (rawStatus !== null && rawStatus.length > 0 && !isMachineDiffFileStatus(rawStatus)) {
+    return NextResponse.json(
+      { error: "status must be 'added', 'modified', 'deleted', or 'renamed'" },
+      { status: 400 },
+    );
+  }
+  const status = rawStatus !== null && isMachineDiffFileStatus(rawStatus) ? rawStatus : undefined;
+
   const resolved = await resolveBranchMachineHandle({
     terminalId: terminalId.value,
     projectName: projectName.value,
@@ -134,6 +155,7 @@ export async function GET(request: Request) {
       scope,
       path: rawPath,
       previousPath,
+      status,
       workingTreePath,
       cwd: BRANCH_REPO_PATH,
       handle: resolved.handle,

--- a/apps/web/src/lib/machines/machine-diff-runtime.ts
+++ b/apps/web/src/lib/machines/machine-diff-runtime.ts
@@ -1,0 +1,20 @@
+/**
+ * Production wiring for the Machine Diff API (Machine page rebuild, Diff tab
+ * — 3-way scope service).
+ *
+ * The Diff route needs EXACTLY the deps the git-blob route needs — a branch
+ * terminal's live `MachineHandle`, `runGitInSandbox` deps bound to it, the
+ * canonical access check, and the shared actor-context builders — so this
+ * module is pure re-export aliasing over `./machine-git-blob-runtime` (see
+ * that module's docstring for how each binding is assembled and why access
+ * goes through `machine-access-runtime`, not the older inline copies). One
+ * file to touch if the Diff route's wiring ever needs to diverge.
+ */
+
+export {
+  canViewMachine,
+  resolveBranchMachineHandle,
+  resolveMachineActorContext,
+  buildGitBlobActorContext as buildDiffActorContext,
+  buildGitBlobDepsForHandle as buildDiffGitDepsForHandle,
+} from './machine-git-blob-runtime';

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -472,6 +472,16 @@
       "import": "./dist/services/sandbox/machine-git-blob.js",
       "require": "./dist/services/sandbox/machine-git-blob.js"
     },
+    "./services/sandbox/machine-diff-scope": {
+      "types": "./dist/services/sandbox/machine-diff-scope.d.ts",
+      "import": "./dist/services/sandbox/machine-diff-scope.js",
+      "require": "./dist/services/sandbox/machine-diff-scope.js"
+    },
+    "./services/sandbox/machine-diff": {
+      "types": "./dist/services/sandbox/machine-diff.d.ts",
+      "import": "./dist/services/sandbox/machine-diff.js",
+      "require": "./dist/services/sandbox/machine-diff.js"
+    },
     "./services/sandbox/tool-runners": {
       "types": "./dist/services/sandbox/tool-runners.d.ts",
       "import": "./dist/services/sandbox/tool-runners.js",
@@ -1664,6 +1674,12 @@
       ],
       "services/sandbox/machine-git-blob": [
         "./dist/services/sandbox/machine-git-blob.d.ts"
+      ],
+      "services/sandbox/machine-diff-scope": [
+        "./dist/services/sandbox/machine-diff-scope.d.ts"
+      ],
+      "services/sandbox/machine-diff": [
+        "./dist/services/sandbox/machine-diff.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
@@ -5,7 +5,6 @@ import {
   isMachineDiffScope,
   isMainBranchName,
   parseNameStatusZ,
-  parseStatusPorcelainZ,
   parseUntrackedPorcelainZ,
   resolveDiffScope,
   DIFF_BASE_REF,
@@ -29,18 +28,24 @@ describe('resolveDiffScope', () => {
     expected: MachineDiffScopeResolution;
   }> = [
     {
-      name: 'uncommitted on a feature branch → git status --porcelain -z',
+      name: 'uncommitted on a feature branch → git diff --name-status -z HEAD plus an untracked-file supplement',
       branchName: 'feature/x',
       isMainBranch: false,
       scope: 'uncommitted',
-      expected: { gitArgs: ['status', '--porcelain', '-z', '-uall'] },
+      expected: {
+        gitArgs: ['diff', '--name-status', '-z', 'HEAD'],
+        untrackedArgs: ['status', '--porcelain', '-z', '-uall'],
+      },
     },
     {
       name: 'uncommitted on the main branch stays applicable (working tree vs last commit is always meaningful)',
       branchName: 'master',
       isMainBranch: true,
       scope: 'uncommitted',
-      expected: { gitArgs: ['status', '--porcelain', '-z', '-uall'] },
+      expected: {
+        gitArgs: ['diff', '--name-status', '-z', 'HEAD'],
+        untrackedArgs: ['status', '--porcelain', '-z', '-uall'],
+      },
     },
     {
       name: 'committed on a feature branch → three-dot diff (merge-base..HEAD) against the default branch',
@@ -98,13 +103,13 @@ describe('resolveDiffScope', () => {
     }
   });
 
-  it('attaches untrackedArgs ONLY to branch scope (the diff-omits-untracked supplement)', () => {
-    const branch = resolveDiffScope('feature/x', false, 'branch');
-    expect('gitArgs' in branch && branch.untrackedArgs).toEqual(['status', '--porcelain', '-z', '-uall']);
-    for (const scope of ['uncommitted', 'committed'] as const) {
+  it('attaches untrackedArgs to the working-tree scopes (uncommitted, branch) but NOT committed', () => {
+    for (const scope of ['uncommitted', 'branch'] as const) {
       const resolution = resolveDiffScope('feature/x', false, scope);
-      expect('gitArgs' in resolution && resolution.untrackedArgs).toBeUndefined();
+      expect('gitArgs' in resolution && resolution.untrackedArgs).toEqual(['status', '--porcelain', '-z', '-uall']);
     }
+    const committed = resolveDiffScope('feature/x', false, 'committed');
+    expect('gitArgs' in committed && committed.untrackedArgs).toBeUndefined();
   });
 });
 
@@ -155,55 +160,6 @@ describe('diffScopeSides', () => {
 
   it.each(table)('$scope → original from $expected.original, modified from $expected.modified', ({ scope, expected }) => {
     expect(diffScopeSides(scope)).toEqual(expected);
-  });
-});
-
-describe('parseStatusPorcelainZ', () => {
-  it('returns [] for empty output (clean working tree)', () => {
-    expect(parseStatusPorcelainZ('')).toEqual([]);
-  });
-
-  it('parses modified / staged / untracked / deleted entries', () => {
-    const stdout = ' M src/a.ts\0M  src/b.ts\0?? new.ts\0 D gone.ts\0D  staged-gone.ts\0A  added.ts\0';
-    expect(parseStatusPorcelainZ(stdout)).toEqual([
-      { path: 'src/a.ts', status: 'modified' },
-      { path: 'src/b.ts', status: 'modified' },
-      { path: 'new.ts', status: 'added' },
-      { path: 'gone.ts', status: 'deleted' },
-      { path: 'staged-gone.ts', status: 'deleted' },
-      { path: 'added.ts', status: 'added' },
-    ]);
-  });
-
-  it('parses a rename entry — target path first, NUL-separated source second', () => {
-    const stdout = 'R  renamed-to.ts\0renamed-from.ts\0 M other.ts\0';
-    expect(parseStatusPorcelainZ(stdout)).toEqual([
-      { path: 'renamed-to.ts', status: 'renamed', previousPath: 'renamed-from.ts' },
-      { path: 'other.ts', status: 'modified' },
-    ]);
-  });
-
-  it('reports a rename that was then deleted in the worktree as deleted (D wins over R)', () => {
-    expect(parseStatusPorcelainZ('RD new.ts\0old.ts\0')).toEqual([
-      { path: 'new.ts', status: 'deleted', previousPath: 'old.ts' },
-    ]);
-  });
-
-  it('handles paths with spaces and non-ASCII without quoting (-z never C-quotes)', () => {
-    const stdout = ' M dir with space/naïve file.ts\0?? über.md\0';
-    expect(parseStatusPorcelainZ(stdout)).toEqual([
-      { path: 'dir with space/naïve file.ts', status: 'modified' },
-      { path: 'über.md', status: 'added' },
-    ]);
-  });
-
-  it('drops a truncated trailing entry instead of guessing (output-cap cut)', () => {
-    // every complete -z entry ends in NUL, so a non-empty final token is a cut field:
-    expect(parseStatusPorcelainZ(' M full.ts\0 M par')).toEqual([{ path: 'full.ts', status: 'modified' }]);
-    expect(parseStatusPorcelainZ(' M full.ts\0 M')).toEqual([{ path: 'full.ts', status: 'modified' }]);
-    // a rename cut before its source field is dropped:
-    expect(parseStatusPorcelainZ(' M full.ts\0R  new.ts\0old')).toEqual([{ path: 'full.ts', status: 'modified' }]);
-    expect(parseStatusPorcelainZ(' M full.ts\0R  new.ts\0')).toEqual([{ path: 'full.ts', status: 'modified' }]);
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
@@ -32,14 +32,14 @@ describe('resolveDiffScope', () => {
       branchName: 'feature/x',
       isMainBranch: false,
       scope: 'uncommitted',
-      expected: { gitArgs: ['status', '--porcelain', '-z'] },
+      expected: { gitArgs: ['status', '--porcelain', '-z', '-uall'] },
     },
     {
       name: 'uncommitted on the main branch stays applicable (working tree vs last commit is always meaningful)',
       branchName: 'master',
       isMainBranch: true,
       scope: 'uncommitted',
-      expected: { gitArgs: ['status', '--porcelain', '-z'] },
+      expected: { gitArgs: ['status', '--porcelain', '-z', '-uall'] },
     },
     {
       name: 'committed on a feature branch → three-dot diff (merge-base..HEAD) against the default branch',
@@ -62,7 +62,7 @@ describe('resolveDiffScope', () => {
       scope: 'branch',
       expected: {
         gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF],
-        untrackedArgs: ['status', '--porcelain', '-z'],
+        untrackedArgs: ['status', '--porcelain', '-z', '-uall'],
       },
     },
     {
@@ -99,7 +99,7 @@ describe('resolveDiffScope', () => {
 
   it('attaches untrackedArgs ONLY to branch scope (the diff-omits-untracked supplement)', () => {
     const branch = resolveDiffScope('feature/x', false, 'branch');
-    expect('gitArgs' in branch && branch.untrackedArgs).toEqual(['status', '--porcelain', '-z']);
+    expect('gitArgs' in branch && branch.untrackedArgs).toEqual(['status', '--porcelain', '-z', '-uall']);
     for (const scope of ['uncommitted', 'committed'] as const) {
       const resolution = resolveDiffScope('feature/x', false, scope);
       expect('gitArgs' in resolution && resolution.untrackedArgs).toBeUndefined();

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  diffScopeSides,
+  isMachineDiffScope,
+  isMainBranchName,
+  parseNameStatusZ,
+  parseStatusPorcelainZ,
+  resolveDiffScope,
+  DIFF_BASE_REF,
+  type MachineDiffScope,
+  type MachineDiffScopeResolution,
+  type MachineDiffSides,
+} from '../machine-diff-scope';
+
+/**
+ * The pure core of the Diff tab's 3-way scope service — everything here runs
+ * with ZERO mocks: no sandbox, no DI, no fakes. The tables below pin the
+ * exact git argv per scope and the notApplicable rule on the main branch.
+ */
+
+describe('resolveDiffScope', () => {
+  const table: Array<{
+    name: string;
+    branchName: string;
+    isMainBranch: boolean;
+    scope: MachineDiffScope;
+    expected: MachineDiffScopeResolution;
+  }> = [
+    {
+      name: 'uncommitted on a feature branch → git status --porcelain -z',
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      expected: { gitArgs: ['status', '--porcelain', '-z'] },
+    },
+    {
+      name: 'uncommitted on the main branch stays applicable (working tree vs last commit is always meaningful)',
+      branchName: 'master',
+      isMainBranch: true,
+      scope: 'uncommitted',
+      expected: { gitArgs: ['status', '--porcelain', '-z'] },
+    },
+    {
+      name: 'committed on a feature branch → three-dot diff (merge-base..HEAD) against the default branch',
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'committed',
+      expected: { gitArgs: ['diff', '--name-status', '-z', `${DIFF_BASE_REF}...HEAD`] },
+    },
+    {
+      name: 'committed on the main branch → notApplicable (merge-base with itself is empty)',
+      branchName: 'master',
+      isMainBranch: true,
+      scope: 'committed',
+      expected: { notApplicable: true },
+    },
+    {
+      name: 'branch on a feature branch → --merge-base working-tree diff against the default branch',
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      expected: { gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF] },
+    },
+    {
+      name: 'branch on the main branch → notApplicable',
+      branchName: 'main',
+      isMainBranch: true,
+      scope: 'branch',
+      expected: { notApplicable: true },
+    },
+  ];
+
+  it.each(table)('$name', ({ branchName, isMainBranch, scope, expected }) => {
+    expect(resolveDiffScope(branchName, isMainBranch, scope)).toEqual(expected);
+  });
+
+  it.each([
+    { branchName: 'master', scope: 'committed' as const },
+    { branchName: 'master', scope: 'branch' as const },
+    { branchName: 'main', scope: 'committed' as const },
+    { branchName: 'main', scope: 'branch' as const },
+  ])(
+    'still returns notApplicable for $scope when the caller passes a stale isMainBranch=false for "$branchName"',
+    ({ branchName, scope }) => {
+      expect(resolveDiffScope(branchName, false, scope)).toEqual({ notApplicable: true });
+    },
+  );
+
+  it('never emits empty gitArgs — an applicable scope always resolves to a runnable command', () => {
+    for (const scope of ['uncommitted', 'committed', 'branch'] as const) {
+      const resolution = resolveDiffScope('feature/x', false, scope);
+      expect('gitArgs' in resolution && resolution.gitArgs.length > 0).toBe(true);
+    }
+  });
+});
+
+describe('isMainBranchName', () => {
+  it.each([
+    { branchName: 'master', expected: true },
+    { branchName: 'main', expected: true },
+    { branchName: 'Master', expected: false }, // case-sensitive, matching the codebase convention
+    { branchName: 'main-2', expected: false },
+    { branchName: 'feature/main', expected: false },
+    { branchName: '', expected: false },
+  ])('"$branchName" → $expected', ({ branchName, expected }) => {
+    expect(isMainBranchName(branchName)).toBe(expected);
+  });
+});
+
+describe('isMachineDiffScope', () => {
+  it.each([
+    { value: 'uncommitted', expected: true },
+    { value: 'committed', expected: true },
+    { value: 'branch', expected: true },
+    { value: 'all', expected: false },
+    { value: '', expected: false },
+  ])('"$value" → $expected', ({ value, expected }) => {
+    expect(isMachineDiffScope(value)).toBe(expected);
+  });
+});
+
+describe('diffScopeSides', () => {
+  const table: Array<{ scope: MachineDiffScope; expected: MachineDiffSides }> = [
+    { scope: 'uncommitted', expected: { original: 'head-blob', modified: 'working-tree' } },
+    { scope: 'committed', expected: { original: 'merge-base-blob', modified: 'head-blob' } },
+    { scope: 'branch', expected: { original: 'merge-base-blob', modified: 'working-tree' } },
+  ];
+
+  it.each(table)('$scope → original from $expected.original, modified from $expected.modified', ({ scope, expected }) => {
+    expect(diffScopeSides(scope)).toEqual(expected);
+  });
+});
+
+describe('parseStatusPorcelainZ', () => {
+  it('returns [] for empty output (clean working tree)', () => {
+    expect(parseStatusPorcelainZ('')).toEqual([]);
+  });
+
+  it('parses modified / staged / untracked / deleted entries', () => {
+    const stdout = ' M src/a.ts\0M  src/b.ts\0?? new.ts\0 D gone.ts\0D  staged-gone.ts\0A  added.ts\0';
+    expect(parseStatusPorcelainZ(stdout)).toEqual([
+      { path: 'src/a.ts', status: 'modified' },
+      { path: 'src/b.ts', status: 'modified' },
+      { path: 'new.ts', status: 'added' },
+      { path: 'gone.ts', status: 'deleted' },
+      { path: 'staged-gone.ts', status: 'deleted' },
+      { path: 'added.ts', status: 'added' },
+    ]);
+  });
+
+  it('parses a rename entry — target path first, NUL-separated source second', () => {
+    const stdout = 'R  renamed-to.ts\0renamed-from.ts\0 M other.ts\0';
+    expect(parseStatusPorcelainZ(stdout)).toEqual([
+      { path: 'renamed-to.ts', status: 'renamed', previousPath: 'renamed-from.ts' },
+      { path: 'other.ts', status: 'modified' },
+    ]);
+  });
+
+  it('reports a rename that was then deleted in the worktree as deleted (D wins over R)', () => {
+    expect(parseStatusPorcelainZ('RD new.ts\0old.ts\0')).toEqual([
+      { path: 'new.ts', status: 'deleted', previousPath: 'old.ts' },
+    ]);
+  });
+
+  it('handles paths with spaces and non-ASCII without quoting (-z never C-quotes)', () => {
+    const stdout = ' M dir with space/naïve file.ts\0?? über.md\0';
+    expect(parseStatusPorcelainZ(stdout)).toEqual([
+      { path: 'dir with space/naïve file.ts', status: 'modified' },
+      { path: 'über.md', status: 'added' },
+    ]);
+  });
+
+  it('drops a truncated trailing entry instead of guessing (output-cap cut)', () => {
+    // every complete -z entry ends in NUL, so a non-empty final token is a cut field:
+    expect(parseStatusPorcelainZ(' M full.ts\0 M par')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+    expect(parseStatusPorcelainZ(' M full.ts\0 M')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+    // a rename cut before its source field is dropped:
+    expect(parseStatusPorcelainZ(' M full.ts\0R  new.ts\0old')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+    expect(parseStatusPorcelainZ(' M full.ts\0R  new.ts\0')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+  });
+});
+
+describe('parseNameStatusZ', () => {
+  it('returns [] for empty output (no commits diverge)', () => {
+    expect(parseNameStatusZ('')).toEqual([]);
+  });
+
+  it('parses added / modified / deleted / type-change entries', () => {
+    const stdout = 'M\0src/a.ts\0A\0src/new.ts\0D\0src/gone.ts\0T\0link.ts\0';
+    expect(parseNameStatusZ(stdout)).toEqual([
+      { path: 'src/a.ts', status: 'modified' },
+      { path: 'src/new.ts', status: 'added' },
+      { path: 'src/gone.ts', status: 'deleted' },
+      { path: 'link.ts', status: 'modified' },
+    ]);
+  });
+
+  it('parses a rename entry — source path first, target second (reverse of status --porcelain -z)', () => {
+    const stdout = 'R100\0old/name.ts\0new/name.ts\0M\0other.ts\0';
+    expect(parseNameStatusZ(stdout)).toEqual([
+      { path: 'new/name.ts', status: 'renamed', previousPath: 'old/name.ts' },
+      { path: 'other.ts', status: 'modified' },
+    ]);
+  });
+
+  it('reports a copy target as an added file with its source as previousPath', () => {
+    expect(parseNameStatusZ('C75\0src/base.ts\0src/copy.ts\0')).toEqual([
+      { path: 'src/copy.ts', status: 'added', previousPath: 'src/base.ts' },
+    ]);
+  });
+
+  it('handles paths with spaces and non-ASCII without quoting', () => {
+    expect(parseNameStatusZ('M\0dir with space/naïve file.ts\0')).toEqual([
+      { path: 'dir with space/naïve file.ts', status: 'modified' },
+    ]);
+  });
+
+  it('drops a truncated trailing entry instead of guessing (output-cap cut)', () => {
+    // status letter present but its path cut mid-way (no terminating NUL):
+    expect(parseNameStatusZ('M\0full.ts\0A\0par')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+    // status letter present but its path entirely cut off:
+    expect(parseNameStatusZ('M\0full.ts\0A\0')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+    // rename cut before its target field:
+    expect(parseNameStatusZ('M\0full.ts\0R100\0old.ts\0')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+    expect(parseNameStatusZ('M\0full.ts\0R100\0old.ts\0new')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
@@ -5,6 +5,7 @@ import {
   isMainBranchName,
   parseNameStatusZ,
   parseStatusPorcelainZ,
+  parseUntrackedPorcelainZ,
   resolveDiffScope,
   DIFF_BASE_REF,
   type MachineDiffScope,
@@ -55,11 +56,14 @@ describe('resolveDiffScope', () => {
       expected: { notApplicable: true },
     },
     {
-      name: 'branch on a feature branch → --merge-base working-tree diff against the default branch',
+      name: 'branch on a feature branch → --merge-base working-tree diff plus an untracked-file supplement',
       branchName: 'feature/x',
       isMainBranch: false,
       scope: 'branch',
-      expected: { gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF] },
+      expected: {
+        gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF],
+        untrackedArgs: ['status', '--porcelain', '-z'],
+      },
     },
     {
       name: 'branch on the main branch → notApplicable',
@@ -90,6 +94,15 @@ describe('resolveDiffScope', () => {
     for (const scope of ['uncommitted', 'committed', 'branch'] as const) {
       const resolution = resolveDiffScope('feature/x', false, scope);
       expect('gitArgs' in resolution && resolution.gitArgs.length > 0).toBe(true);
+    }
+  });
+
+  it('attaches untrackedArgs ONLY to branch scope (the diff-omits-untracked supplement)', () => {
+    const branch = resolveDiffScope('feature/x', false, 'branch');
+    expect('gitArgs' in branch && branch.untrackedArgs).toEqual(['status', '--porcelain', '-z']);
+    for (const scope of ['uncommitted', 'committed'] as const) {
+      const resolution = resolveDiffScope('feature/x', false, scope);
+      expect('gitArgs' in resolution && resolution.untrackedArgs).toBeUndefined();
     }
   });
 });
@@ -223,5 +236,40 @@ describe('parseNameStatusZ', () => {
     // rename cut before its target field:
     expect(parseNameStatusZ('M\0full.ts\0R100\0old.ts\0')).toEqual([{ path: 'full.ts', status: 'modified' }]);
     expect(parseNameStatusZ('M\0full.ts\0R100\0old.ts\0new')).toEqual([{ path: 'full.ts', status: 'modified' }]);
+  });
+});
+
+describe('parseUntrackedPorcelainZ', () => {
+  it('returns [] for empty output', () => {
+    expect(parseUntrackedPorcelainZ('')).toEqual([]);
+  });
+
+  it('keeps only the untracked (??) entries, each as added, skipping tracked changes', () => {
+    const stdout = ' M src/a.ts\0?? new.ts\0M  staged.ts\0?? dir/other.ts\0 D gone.ts\0';
+    expect(parseUntrackedPorcelainZ(stdout)).toEqual([
+      { path: 'new.ts', status: 'added' },
+      { path: 'dir/other.ts', status: 'added' },
+    ]);
+  });
+
+  it('steps over a rename/copy source field so it is never mis-read as an untracked entry', () => {
+    // 'R  to.ts\0from.ts' — the source 'from.ts' must not be treated as a file.
+    expect(parseUntrackedPorcelainZ('R  to.ts\0from.ts\0?? really-new.ts\0')).toEqual([
+      { path: 'really-new.ts', status: 'added' },
+    ]);
+    expect(parseUntrackedPorcelainZ('C75 copy.ts\0base.ts\0?? really-new.ts\0')).toEqual([
+      { path: 'really-new.ts', status: 'added' },
+    ]);
+  });
+
+  it('handles untracked paths with spaces and non-ASCII (-z never C-quotes)', () => {
+    expect(parseUntrackedPorcelainZ('?? über dir/naïve file.ts\0')).toEqual([
+      { path: 'über dir/naïve file.ts', status: 'added' },
+    ]);
+  });
+
+  it('drops a truncated trailing entry instead of guessing', () => {
+    expect(parseUntrackedPorcelainZ('?? full.ts\0?? par')).toEqual([{ path: 'full.ts', status: 'added' }]);
+    expect(parseUntrackedPorcelainZ('?? full.ts\0??')).toEqual([{ path: 'full.ts', status: 'added' }]);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   diffScopeSides,
+  isMachineDiffFileStatus,
   isMachineDiffScope,
   isMainBranchName,
   parseNameStatusZ,
@@ -129,6 +130,19 @@ describe('isMachineDiffScope', () => {
     { value: '', expected: false },
   ])('"$value" → $expected', ({ value, expected }) => {
     expect(isMachineDiffScope(value)).toBe(expected);
+  });
+});
+
+describe('isMachineDiffFileStatus', () => {
+  it.each([
+    { value: 'added', expected: true },
+    { value: 'modified', expected: true },
+    { value: 'deleted', expected: true },
+    { value: 'renamed', expected: true },
+    { value: 'copied', expected: false },
+    { value: '', expected: false },
+  ])('"$value" → $expected', ({ value, expected }) => {
+    expect(isMachineDiffFileStatus(value)).toBe(expected);
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -487,6 +487,63 @@ describe('readMachineDiffPair', () => {
     });
   });
 
+  it("status='deleted' (branch): forces the modified side null WITHOUT reading the working tree, so an untracked file masquerading at the path can't be surfaced", async () => {
+    // `git rm --cached f` leaves f on disk untracked; the branch list dedups to
+    // the tracked deletion, and the pair reader must not read that leftover file.
+    const { deps, calls } = makeDeps(
+      scriptGit({
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+        [`show ${MERGE_BASE_SHA}:src/a.ts`]: { exitCode: 0, stdout: 'base content', stderr: '' },
+      }),
+    );
+    // handle DOES have the file on disk (the masquerading untracked leftover):
+    const { handle, reads } = makeHandle({ [`${CWD}/src/a.ts`]: 'leftover untracked bytes' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      status: 'deleted',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls.map((c) => c.args)).toEqual([
+      ['merge-base', 'origin/HEAD', 'HEAD'],
+      ['show', `${MERGE_BASE_SHA}:src/a.ts`],
+    ]);
+    expect(reads).toHaveLength(0); // working tree never touched for a deletion
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'base content', truncated: false },
+      modified: null,
+    });
+  });
+
+  it("status='added': forces the original side null and skips the blob read (and merge-base) entirely", async () => {
+    const { deps, calls } = makeDeps(scriptGit({})); // no git calls should happen at all
+    const { handle, reads } = makeHandle({ [`${CWD}/src/a.ts`]: 'brand new' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      status: 'added',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls).toHaveLength(0); // original (HEAD blob) skipped; no merge-base for uncommitted
+    expect(reads).toEqual([`${CWD}/src/a.ts`]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: null,
+      modified: { content: 'brand new', truncated: false },
+    });
+  });
+
   it('an added file has a null original (blob not_found is not an error)', async () => {
     const { deps } = makeDeps(
       scriptGit({

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -210,6 +210,35 @@ describe('listMachineDiffFiles', () => {
     });
   });
 
+  it('branch: dedups an untracked path that also appears in the tracked diff (tracked entry wins)', async () => {
+    const { deps } = makeDeps(
+      scriptGit({
+        // pathological: same path deleted in the tracked diff AND present untracked on disk
+        'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'D\0src/dup.ts\0', stderr: '' },
+        'status --porcelain -z': { exitCode: 0, stdout: '?? src/dup.ts\0?? src/genuinely-new.ts\0', stderr: '' },
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      files: [
+        { path: 'src/dup.ts', status: 'deleted' }, // tracked entry kept, not duplicated as 'added'
+        { path: 'src/genuinely-new.ts', status: 'added' },
+      ],
+      truncated: false,
+      mergeBase: MERGE_BASE_SHA,
+    });
+  });
+
   it('branch: an output-capped untracked supplement flags the whole list truncated', async () => {
     // runGitInSandbox recomputes `truncated` from real byte length (256 KB cap),
     // so the untracked run must genuinely overflow it to exercise the OR.

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -175,10 +175,12 @@ describe('listMachineDiffFiles', () => {
     });
   });
 
-  it('branch: runs the --merge-base working-tree diff (one ref, no second side)', async () => {
+  it('branch: unions the --merge-base tracked diff with untracked working-tree files, then resolves the merge-base', async () => {
     const { deps, calls } = makeDeps(
       scriptGit({
         'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
+        // `git diff` omits untracked files — the supplement supplies the brand-new one.
+        'status --porcelain -z': { exitCode: 0, stdout: ' M src/a.ts\0?? brand-new.ts\0', stderr: '' },
         'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
       }),
     );
@@ -190,8 +192,62 @@ describe('listMachineDiffFiles', () => {
       ctx: makeCtx(),
       deps,
     });
-    expect(calls[0]).toEqual({ cmd: 'git', args: ['diff', '--name-status', '-z', '--merge-base', 'origin/HEAD'] });
-    expect(result).toMatchObject({ ok: true, notApplicable: false, mergeBase: MERGE_BASE_SHA });
+    expect(calls.map((c) => c.args)).toEqual([
+      ['diff', '--name-status', '-z', '--merge-base', 'origin/HEAD'],
+      ['status', '--porcelain', '-z'],
+      ['merge-base', 'origin/HEAD', 'HEAD'],
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      // tracked diff entry first, then the appended untracked file (never a tracked one)
+      files: [
+        { path: 'src/a.ts', status: 'modified' },
+        { path: 'brand-new.ts', status: 'added' },
+      ],
+      truncated: false,
+      mergeBase: MERGE_BASE_SHA,
+    });
+  });
+
+  it('branch: an output-capped untracked supplement flags the whole list truncated', async () => {
+    // runGitInSandbox recomputes `truncated` from real byte length (256 KB cap),
+    // so the untracked run must genuinely overflow it to exercise the OR.
+    const oversized = `?? ${'a'.repeat(270 * 1024)}\0`;
+    const { deps } = makeDeps(
+      scriptGit({
+        'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
+        'status --porcelain -z': { exitCode: 0, stdout: oversized, stderr: '' },
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, notApplicable: false, truncated: true });
+  });
+
+  it('branch: a failing untracked supplement fails the whole list (exec_failed)', async () => {
+    const { deps } = makeDeps(
+      scriptGit({
+        'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
+        'status --porcelain -z': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'fatal: not a git repository' });
   });
 
   it('committed on the main branch: notApplicable, and git is never invoked', async () => {
@@ -336,6 +392,69 @@ describe('readMachineDiffPair', () => {
       notApplicable: false,
       original: { content: 'base content', truncated: false },
       modified: { content: 'tree content', truncated: false },
+    });
+  });
+
+  it('renamed file (committed): reads the original from previousPath, the modified from the target path', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+        // original side is addressed at the PRE-rename source, not the target:
+        [`show ${MERGE_BASE_SHA}:src/old-name.ts`]: { exitCode: 0, stdout: 'base content', stderr: '' },
+        'show HEAD:src/new-name.ts': { exitCode: 0, stdout: 'head content', stderr: '' },
+      }),
+    );
+    const { handle, reads } = makeHandle({});
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'committed',
+      path: 'src/new-name.ts',
+      previousPath: 'src/old-name.ts',
+      workingTreePath: `${CWD}/src/new-name.ts`,
+      cwd: CWD,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls.map((c) => c.args)).toEqual([
+      ['merge-base', 'origin/HEAD', 'HEAD'],
+      ['show', `${MERGE_BASE_SHA}:src/old-name.ts`],
+      ['show', 'HEAD:src/new-name.ts'],
+    ]);
+    expect(reads).toHaveLength(0);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'base content', truncated: false },
+      modified: { content: 'head content', truncated: false },
+    });
+  });
+
+  it('renamed file (uncommitted): original = HEAD blob at previousPath, modified = working tree at the target', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({ 'show HEAD:src/old-name.ts': { exitCode: 0, stdout: 'old content', stderr: '' } }),
+    );
+    const { handle, reads } = makeHandle({ [`${CWD}/src/new-name.ts`]: 'renamed content' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      path: 'src/new-name.ts',
+      previousPath: 'src/old-name.ts',
+      workingTreePath: `${CWD}/src/new-name.ts`,
+      cwd: CWD,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls).toEqual([{ cmd: 'git', args: ['show', 'HEAD:src/old-name.ts'] }]);
+    expect(reads).toEqual([`${CWD}/src/new-name.ts`]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'old content', truncated: false },
+      modified: { content: 'renamed content', truncated: false },
     });
   });
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -121,7 +121,7 @@ describe('resolveMachineMergeBase', () => {
 describe('listMachineDiffFiles', () => {
   it('uncommitted: runs status --porcelain -z only (no merge-base) and parses the working-tree list', async () => {
     const { deps, calls } = makeDeps(
-      scriptGit({ 'status --porcelain -z': { exitCode: 0, stdout: ' M src/a.ts\0?? new.ts\0', stderr: '' } }),
+      scriptGit({ 'status --porcelain -z -uall': { exitCode: 0, stdout: ' M src/a.ts\0?? new.ts\0', stderr: '' } }),
     );
     const result = await listMachineDiffFiles({
       branchName: 'feature/x',
@@ -131,7 +131,7 @@ describe('listMachineDiffFiles', () => {
       ctx: makeCtx(),
       deps,
     });
-    expect(calls).toEqual([{ cmd: 'git', args: ['status', '--porcelain', '-z'] }]);
+    expect(calls).toEqual([{ cmd: 'git', args: ['status', '--porcelain', '-z', '-uall'] }]);
     expect(result).toEqual({
       ok: true,
       notApplicable: false,
@@ -180,7 +180,7 @@ describe('listMachineDiffFiles', () => {
       scriptGit({
         'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
         // `git diff` omits untracked files — the supplement supplies the brand-new one.
-        'status --porcelain -z': { exitCode: 0, stdout: ' M src/a.ts\0?? brand-new.ts\0', stderr: '' },
+        'status --porcelain -z -uall': { exitCode: 0, stdout: ' M src/a.ts\0?? brand-new.ts\0', stderr: '' },
         'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
       }),
     );
@@ -194,7 +194,7 @@ describe('listMachineDiffFiles', () => {
     });
     expect(calls.map((c) => c.args)).toEqual([
       ['diff', '--name-status', '-z', '--merge-base', 'origin/HEAD'],
-      ['status', '--porcelain', '-z'],
+      ['status', '--porcelain', '-z', '-uall'],
       ['merge-base', 'origin/HEAD', 'HEAD'],
     ]);
     expect(result).toEqual({
@@ -215,7 +215,7 @@ describe('listMachineDiffFiles', () => {
       scriptGit({
         // pathological: same path deleted in the tracked diff AND present untracked on disk
         'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'D\0src/dup.ts\0', stderr: '' },
-        'status --porcelain -z': { exitCode: 0, stdout: '?? src/dup.ts\0?? src/genuinely-new.ts\0', stderr: '' },
+        'status --porcelain -z -uall': { exitCode: 0, stdout: '?? src/dup.ts\0?? src/genuinely-new.ts\0', stderr: '' },
         'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
       }),
     );
@@ -246,7 +246,7 @@ describe('listMachineDiffFiles', () => {
     const { deps } = makeDeps(
       scriptGit({
         'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
-        'status --porcelain -z': { exitCode: 0, stdout: oversized, stderr: '' },
+        'status --porcelain -z -uall': { exitCode: 0, stdout: oversized, stderr: '' },
         'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
       }),
     );
@@ -265,7 +265,7 @@ describe('listMachineDiffFiles', () => {
     const { deps } = makeDeps(
       scriptGit({
         'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
-        'status --porcelain -z': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
+        'status --porcelain -z -uall': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
       }),
     );
     const result = await listMachineDiffFiles({
@@ -316,7 +316,7 @@ describe('listMachineDiffFiles', () => {
   it('maps a failing diff command to exec_failed with stderr detail', async () => {
     const { deps } = makeDeps(
       scriptGit({
-        'status --porcelain -z': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
+        'status --porcelain -z -uall': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
       }),
     );
     const result = await listMachineDiffFiles({

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -1,0 +1,470 @@
+import { describe, it, expect } from 'vitest';
+import { listMachineDiffFiles, readMachineDiffPair, resolveMachineMergeBase } from '../machine-diff';
+import type { GitSandboxRunDeps } from '../git-tool-runners';
+import type { MachineHandle } from '../machine-host';
+import type { SandboxActorContext } from '../tool-runners';
+import type { ExecutableSandbox, RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
+
+/**
+ * The Diff service drives the real `runGitInSandbox` / `readMachineGitBlob` /
+ * `readMachineFile` (none mocked — they're pure orchestration over injected
+ * deps), so a fake `ExecutableSandbox` whose `runCommand` is scripted per git
+ * argv, plus a fake `MachineHandle` for working-tree reads, exercises every
+ * scope with zero real Sprite/git calls — the same harness shape as
+ * `machine-git-blob.test.ts`.
+ */
+
+const MERGE_BASE_SHA = 'a'.repeat(40);
+
+function makeCtx(): SandboxActorContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    conversationId: 'c1',
+    actorEmail: 'u1@example.com',
+    tier: 'pro',
+  };
+}
+
+function makeDeps(runCommand: (args: RunCommandArgs) => Promise<SandboxRunResult>): {
+  deps: GitSandboxRunDeps;
+  calls: Array<{ cmd: string; args: string[] }>;
+} {
+  const calls: Array<{ cmd: string; args: string[] }> = [];
+  const sandbox: ExecutableSandbox = {
+    sandboxId: 'sbx-1',
+    runCommand: async (opts) => {
+      calls.push({ cmd: opts.cmd, args: opts.args ?? [] });
+      return runCommand(opts);
+    },
+    writeFiles: async () => {},
+    readFileToBuffer: async () => Buffer.from(''),
+  };
+  const deps: GitSandboxRunDeps = {
+    isEnabled: () => true,
+    acquireSandbox: async () => ({ ok: true, sandboxId: 'sbx-1', resumed: false }),
+    reconnect: async () => sandbox,
+    quota: { acquireSlot: () => true, releaseSlot: () => {} },
+    buildEnv: () => ({}),
+    audit: async () => {},
+    now: () => new Date('2026-07-09T12:00:00.000Z'),
+    resolveGitHubToken: async () => null,
+  };
+  return { deps, calls };
+}
+
+/** Script git responses by subcommand; anything unscripted fails the test loudly. */
+function scriptGit(
+  responses: Record<string, SandboxRunResult>,
+): (args: RunCommandArgs) => Promise<SandboxRunResult> {
+  return async (opts) => {
+    const key = (opts.args ?? []).join(' ');
+    const scripted = responses[key];
+    if (!scripted) throw new Error(`unscripted git call: ${key}`);
+    return scripted;
+  };
+}
+
+function makeHandle(files: Record<string, string>): { handle: MachineHandle; reads: string[] } {
+  const reads: string[] = [];
+  const handle: MachineHandle = {
+    machineId: 'sbx-1',
+    exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    writeFiles: async () => {},
+    readFile: async ({ path }) => {
+      reads.push(path);
+      const content = files[path];
+      return content === undefined ? null : Buffer.from(content, 'utf8');
+    },
+    stream: async () => {
+      throw new Error('not used');
+    },
+    listStreams: async () => [],
+  };
+  return { handle, reads };
+}
+
+const CWD = '/workspace/repo';
+
+describe('resolveMachineMergeBase', () => {
+  it('runs `git merge-base origin/HEAD HEAD` and returns the trimmed SHA', async () => {
+    const { deps, calls } = makeDeps(async () => ({ exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' }));
+    const result = await resolveMachineMergeBase({ cwd: CWD, ctx: makeCtx(), deps });
+    expect(calls).toEqual([{ cmd: 'git', args: ['merge-base', 'origin/HEAD', 'HEAD'] }]);
+    expect(result).toEqual({ ok: true, sha: MERGE_BASE_SHA });
+  });
+
+  it('rejects output that is not a lone SHA (it becomes a git-blob ref, so garbage must never pass)', async () => {
+    const { deps } = makeDeps(async () => ({ exitCode: 0, stdout: 'not-a-sha\n', stderr: '' }));
+    const result = await resolveMachineMergeBase({ cwd: CWD, ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ ok: false, reason: 'merge_base_failed' });
+  });
+
+  it('maps a nonzero exit (no common ancestor / missing origin/HEAD) to merge_base_failed with stderr detail', async () => {
+    const { deps } = makeDeps(async () => ({
+      exitCode: 128,
+      stdout: '',
+      stderr: "fatal: ambiguous argument 'origin/HEAD'\n",
+    }));
+    const result = await resolveMachineMergeBase({ cwd: CWD, ctx: makeCtx(), deps });
+    expect(result).toEqual({ ok: false, reason: 'merge_base_failed', detail: "fatal: ambiguous argument 'origin/HEAD'" });
+  });
+
+  it('maps a hard runGitInSandbox failure to exec_failed', async () => {
+    const { deps } = makeDeps(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
+    const disabled: GitSandboxRunDeps = { ...deps, isEnabled: () => false };
+    const result = await resolveMachineMergeBase({ cwd: CWD, ctx: makeCtx(), deps: disabled });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'Code execution is disabled.' });
+  });
+});
+
+describe('listMachineDiffFiles', () => {
+  it('uncommitted: runs status --porcelain -z only (no merge-base) and parses the working-tree list', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({ 'status --porcelain -z': { exitCode: 0, stdout: ' M src/a.ts\0?? new.ts\0', stderr: '' } }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls).toEqual([{ cmd: 'git', args: ['status', '--porcelain', '-z'] }]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      files: [
+        { path: 'src/a.ts', status: 'modified' },
+        { path: 'new.ts', status: 'added' },
+      ],
+      truncated: false,
+      mergeBase: null,
+    });
+  });
+
+  it('committed: runs the three-dot name-status diff, then resolves the concrete merge-base SHA for the client', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({
+        'diff --name-status -z origin/HEAD...HEAD': { exitCode: 0, stdout: 'A\0src/new.ts\0M\0src/a.ts\0', stderr: '' },
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'committed',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls.map((c) => c.args)).toEqual([
+      ['diff', '--name-status', '-z', 'origin/HEAD...HEAD'],
+      ['merge-base', 'origin/HEAD', 'HEAD'],
+    ]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      files: [
+        { path: 'src/new.ts', status: 'added' },
+        { path: 'src/a.ts', status: 'modified' },
+      ],
+      truncated: false,
+      mergeBase: MERGE_BASE_SHA,
+    });
+  });
+
+  it('branch: runs the --merge-base working-tree diff (one ref, no second side)', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({
+        'diff --name-status -z --merge-base origin/HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls[0]).toEqual({ cmd: 'git', args: ['diff', '--name-status', '-z', '--merge-base', 'origin/HEAD'] });
+    expect(result).toMatchObject({ ok: true, notApplicable: false, mergeBase: MERGE_BASE_SHA });
+  });
+
+  it('committed on the main branch: notApplicable, and git is never invoked', async () => {
+    const { deps, calls } = makeDeps(async () => {
+      throw new Error('must not run');
+    });
+    const result = await listMachineDiffFiles({
+      branchName: 'master',
+      isMainBranch: true,
+      scope: 'committed',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({ ok: true, notApplicable: true });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('propagates a failed merge-base resolution instead of returning a list without it', async () => {
+    const { deps } = makeDeps(
+      scriptGit({
+        'diff --name-status -z origin/HEAD...HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
+        'merge-base origin/HEAD HEAD': { exitCode: 1, stdout: '', stderr: '' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'committed',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'merge_base_failed' });
+  });
+
+  it('maps a failing diff command to exec_failed with stderr detail', async () => {
+    const { deps } = makeDeps(
+      scriptGit({
+        'status --porcelain -z': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
+      }),
+    );
+    const result = await listMachineDiffFiles({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      cwd: CWD,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'fatal: not a git repository' });
+  });
+});
+
+describe('readMachineDiffPair', () => {
+  const PAIR_BASE = {
+    path: 'src/a.ts',
+    workingTreePath: `${CWD}/src/a.ts`,
+    cwd: CWD,
+  };
+
+  it('uncommitted: original = HEAD blob (git show), modified = working tree (handle.readFile); no merge-base run', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({ 'show HEAD:src/a.ts': { exitCode: 0, stdout: 'old content', stderr: '' } }),
+    );
+    const { handle, reads } = makeHandle({ [`${CWD}/src/a.ts`]: 'new content' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls).toEqual([{ cmd: 'git', args: ['show', 'HEAD:src/a.ts'] }]);
+    expect(reads).toEqual([`${CWD}/src/a.ts`]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'old content', truncated: false },
+      modified: { content: 'new content', truncated: false },
+    });
+  });
+
+  it('committed: original = merge-base blob, modified = HEAD blob; the working tree is never read', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+        [`show ${MERGE_BASE_SHA}:src/a.ts`]: { exitCode: 0, stdout: 'base content', stderr: '' },
+        'show HEAD:src/a.ts': { exitCode: 0, stdout: 'head content', stderr: '' },
+      }),
+    );
+    const { handle, reads } = makeHandle({});
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'committed',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls.map((c) => c.args)).toEqual([
+      ['merge-base', 'origin/HEAD', 'HEAD'],
+      ['show', `${MERGE_BASE_SHA}:src/a.ts`],
+      ['show', 'HEAD:src/a.ts'],
+    ]);
+    expect(reads).toHaveLength(0);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'base content', truncated: false },
+      modified: { content: 'head content', truncated: false },
+    });
+  });
+
+  it('branch: original = merge-base blob, modified = working tree', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({
+        'merge-base origin/HEAD HEAD': { exitCode: 0, stdout: `${MERGE_BASE_SHA}\n`, stderr: '' },
+        [`show ${MERGE_BASE_SHA}:src/a.ts`]: { exitCode: 0, stdout: 'base content', stderr: '' },
+      }),
+    );
+    const { handle, reads } = makeHandle({ [`${CWD}/src/a.ts`]: 'tree content' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'branch',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(calls.map((c) => c.args)).toEqual([
+      ['merge-base', 'origin/HEAD', 'HEAD'],
+      ['show', `${MERGE_BASE_SHA}:src/a.ts`],
+    ]);
+    expect(reads).toEqual([`${CWD}/src/a.ts`]);
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'base content', truncated: false },
+      modified: { content: 'tree content', truncated: false },
+    });
+  });
+
+  it('an added file has a null original (blob not_found is not an error)', async () => {
+    const { deps } = makeDeps(
+      scriptGit({
+        'show HEAD:src/a.ts': {
+          exitCode: 128,
+          stdout: '',
+          stderr: "fatal: path 'src/a.ts' does not exist in 'HEAD'\n",
+        },
+      }),
+    );
+    const { handle } = makeHandle({ [`${CWD}/src/a.ts`]: 'brand new' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: null,
+      modified: { content: 'brand new', truncated: false },
+    });
+  });
+
+  it('a deleted file has a null modified (working-tree not_found is not an error)', async () => {
+    const { deps } = makeDeps(
+      scriptGit({ 'show HEAD:src/a.ts': { exitCode: 0, stdout: 'was here', stderr: '' } }),
+    );
+    const { handle } = makeHandle({});
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({
+      ok: true,
+      notApplicable: false,
+      original: { content: 'was here', truncated: false },
+      modified: null,
+    });
+  });
+
+  it('branch scope on the main branch: notApplicable, and nothing is executed or read', async () => {
+    const { deps, calls } = makeDeps(async () => {
+      throw new Error('must not run');
+    });
+    const { handle, reads } = makeHandle({});
+    const result = await readMachineDiffPair({
+      branchName: 'main',
+      isMainBranch: true,
+      scope: 'branch',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({ ok: true, notApplicable: true });
+    expect(calls).toHaveLength(0);
+    expect(reads).toHaveLength(0);
+  });
+
+  it('propagates a blob-side execution failure as exec_failed', async () => {
+    const { deps } = makeDeps(
+      scriptGit({ 'show HEAD:src/a.ts': { exitCode: 1, stdout: '', stderr: 'fatal: not a git repository\n' } }),
+    );
+    const { handle } = makeHandle({ [`${CWD}/src/a.ts`]: 'x' });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'fatal: not a git repository' });
+  });
+
+  it('propagates a failed merge-base resolution before reading either side', async () => {
+    const { deps, calls } = makeDeps(
+      scriptGit({ 'merge-base origin/HEAD HEAD': { exitCode: 1, stdout: '', stderr: '' } }),
+    );
+    const { handle, reads } = makeHandle({});
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'committed',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'merge_base_failed' });
+    expect(calls).toHaveLength(1);
+    expect(reads).toHaveLength(0);
+  });
+
+  it('caps a working-tree side at 2 MB and marks it truncated without corrupting a split UTF-8 sequence', async () => {
+    const CAP = 2 * 1024 * 1024;
+    // '€' is 3 bytes; build a buffer whose cap boundary lands mid-codepoint.
+    const big = '€'.repeat(Math.ceil((CAP + 16) / 3));
+    const { deps } = makeDeps(
+      scriptGit({ 'show HEAD:src/a.ts': { exitCode: 0, stdout: 'old', stderr: '' } }),
+    );
+    const { handle } = makeHandle({ [`${CWD}/src/a.ts`]: big });
+    const result = await readMachineDiffPair({
+      branchName: 'feature/x',
+      isMainBranch: false,
+      scope: 'uncommitted',
+      ...PAIR_BASE,
+      handle,
+      ctx: makeCtx(),
+      deps,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.notApplicable) throw new Error('unreachable');
+    expect(result.modified?.truncated).toBe(true);
+    expect(result.modified?.content.includes('�')).toBe(false);
+    expect(Buffer.byteLength(result.modified?.content ?? '', 'utf8')).toBeLessThanOrEqual(CAP);
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -119,9 +119,14 @@ describe('resolveMachineMergeBase', () => {
 });
 
 describe('listMachineDiffFiles', () => {
-  it('uncommitted: runs status --porcelain -z only (no merge-base) and parses the working-tree list', async () => {
+  it('uncommitted: runs diff --name-status -z HEAD then the untracked supplement (no merge-base) and unions them', async () => {
     const { deps, calls } = makeDeps(
-      scriptGit({ 'status --porcelain -z -uall': { exitCode: 0, stdout: ' M src/a.ts\0?? new.ts\0', stderr: '' } }),
+      scriptGit({
+        // HEAD-vs-working-tree tracked diff (net of staged + unstaged) — matches the rendered pair.
+        'diff --name-status -z HEAD': { exitCode: 0, stdout: 'M\0src/a.ts\0', stderr: '' },
+        // untracked supplement; the ` M src/a.ts` tracked line is ignored, only ?? new.ts is added.
+        'status --porcelain -z -uall': { exitCode: 0, stdout: ' M src/a.ts\0?? new.ts\0', stderr: '' },
+      }),
     );
     const result = await listMachineDiffFiles({
       branchName: 'feature/x',
@@ -131,7 +136,10 @@ describe('listMachineDiffFiles', () => {
       ctx: makeCtx(),
       deps,
     });
-    expect(calls).toEqual([{ cmd: 'git', args: ['status', '--porcelain', '-z', '-uall'] }]);
+    expect(calls.map((c) => c.args)).toEqual([
+      ['diff', '--name-status', '-z', 'HEAD'],
+      ['status', '--porcelain', '-z', '-uall'],
+    ]);
     expect(result).toEqual({
       ok: true,
       notApplicable: false,
@@ -316,7 +324,7 @@ describe('listMachineDiffFiles', () => {
   it('maps a failing diff command to exec_failed with stderr detail', async () => {
     const { deps } = makeDeps(
       scriptGit({
-        'status --porcelain -z -uall': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
+        'diff --name-status -z HEAD': { exitCode: 128, stdout: '', stderr: 'fatal: not a git repository\n' },
       }),
     );
     const result = await listMachineDiffFiles({

--- a/packages/lib/src/services/sandbox/machine-diff-scope.ts
+++ b/packages/lib/src/services/sandbox/machine-diff-scope.ts
@@ -1,0 +1,243 @@
+/**
+ * Machine Diff scope resolution — the PURE core of the Diff tab's 3-way scope
+ * service (Machine page rebuild, Phase 1). Zero I/O: every function here is a
+ * plain data transformation, unit-testable with no sandbox, no mocks, no DI.
+ * The imperative shell that actually runs git / reads blobs lives in
+ * `./machine-diff.ts`; keep it that way — this split is the repo's
+ * pure-functions-plus-DI build mandate, not a style preference.
+ *
+ * The three scopes and their exact semantics:
+ *
+ *   uncommitted — working tree vs the last commit.
+ *     File list: `git status --porcelain -z`.
+ *     original = blob at HEAD, modified = working-tree file.
+ *
+ *   committed — the branch's own commits vs where it forked from the main
+ *     branch.
+ *     File list: `git diff --name-status -z <base>...HEAD` (git's three-dot
+ *     form IS merge-base(<base>, HEAD)..HEAD — git computes the merge-base
+ *     itself, which is what keeps this resolvable without I/O).
+ *     original = blob at the merge-base, modified = blob at HEAD.
+ *
+ *   branch — everything the branch differs from the main branch, INCLUDING
+ *     uncommitted working-tree changes.
+ *     File list: `git diff --name-status -z --merge-base <base>` (one ref, no
+ *     second side — `--merge-base <commit>` compares the WORKING TREE against
+ *     merge-base(<commit>, HEAD)).
+ *     original = blob at the merge-base, modified = working-tree file.
+ *
+ * On the main branch itself, 'committed' and 'branch' are meaningless — the
+ * merge-base of the main branch with itself is its own tip, so both scopes
+ * would always diff to nothing. `resolveDiffScope` returns
+ * `{ notApplicable: true }` for those two, NOT empty gitArgs the caller would
+ * have to interpret, so the route can tell the client to disable the toggle
+ * instead of rendering an empty diff.
+ *
+ * The diff BASE is `origin/HEAD`, not a guessed 'master'/'main' literal: a
+ * branch terminal's checkout is a full `git clone`
+ * (`machine-branches.ts`'s `cloneAndCheckoutBranch`), and a full clone always
+ * carries `origin/HEAD` as a symref to the remote's actual default branch —
+ * so the base is correct whether the repo's default is master, main, or
+ * anything else. The 'master'/'main' literal comparison
+ * (`isMainBranchName`) answers a DIFFERENT question — "is this terminal ON
+ * the main branch?" — matching the default-branch naming convention used
+ * elsewhere in this codebase; there is deliberately no schema flag for it.
+ *
+ * Both file-list commands use `-z` (NUL-separated) output: with `-z` git never
+ * C-quotes pathnames, so the parsers below handle spaces, quotes, and
+ * non-ASCII filenames with one code path instead of a C-unquoting fallback.
+ */
+
+export type MachineDiffScope = 'uncommitted' | 'committed' | 'branch';
+
+export const MACHINE_DIFF_SCOPES: readonly MachineDiffScope[] = ['uncommitted', 'committed', 'branch'];
+
+export function isMachineDiffScope(value: string): value is MachineDiffScope {
+  return (MACHINE_DIFF_SCOPES as readonly string[]).includes(value);
+}
+
+/**
+ * The ref the 'committed'/'branch' scopes diff against — the remote's default
+ * branch, as recorded by the full clone. See the module docstring for why
+ * this is `origin/HEAD` and not a 'master'/'main' guess.
+ */
+export const DIFF_BASE_REF = 'origin/HEAD';
+
+/**
+ * Is this branch name the repo's main branch? Compared against the literal
+ * default-branch names ('master'/'main', case-sensitive) — the convention this
+ * codebase already uses for default-branch naming; deliberately NOT a new DB
+ * column.
+ */
+export function isMainBranchName(branchName: string): boolean {
+  return branchName === 'master' || branchName === 'main';
+}
+
+export type MachineDiffScopeResolution = { gitArgs: string[] } | { notApplicable: true };
+
+/**
+ * Resolve a requested Diff scope to the exact `git` argv that produces its
+ * changed-file list — or `{ notApplicable: true }` when the scope is
+ * meaningless on the main branch.
+ *
+ * `isMainBranch` is the caller's own derivation (from `isMainBranchName`),
+ * kept explicit in the signature so the decision is visible at the call site;
+ * `branchName` is still re-checked here so a caller passing a stale or wrong
+ * flag can never get a self-merge-base diff for a main-branch terminal.
+ */
+export function resolveDiffScope(
+  branchName: string,
+  isMainBranch: boolean,
+  requestedScope: MachineDiffScope,
+): MachineDiffScopeResolution {
+  const onMainBranch = isMainBranch || isMainBranchName(branchName);
+  if (onMainBranch && requestedScope !== 'uncommitted') {
+    return { notApplicable: true };
+  }
+  switch (requestedScope) {
+    case 'uncommitted':
+      return { gitArgs: ['status', '--porcelain', '-z'] };
+    case 'committed':
+      return { gitArgs: ['diff', '--name-status', '-z', `${DIFF_BASE_REF}...HEAD`] };
+    case 'branch':
+      return { gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF] };
+  }
+}
+
+/** Where each side of a file's diff pair is read from, per scope. */
+export type MachineDiffSideSource = 'merge-base-blob' | 'head-blob' | 'working-tree';
+
+export interface MachineDiffSides {
+  original: MachineDiffSideSource;
+  modified: MachineDiffSideSource;
+}
+
+/**
+ * The original/modified content source for each scope — the pure counterpart
+ * of the file-list resolution above, consumed by `machine-diff.ts`'s
+ * `readMachineDiffPair`. Blob sides go through the git object store
+ * (`machine-git-blob.ts`), working-tree sides through the live filesystem
+ * (`machine-fs.ts`) — see those modules' scope-boundary notes.
+ */
+export function diffScopeSides(scope: MachineDiffScope): MachineDiffSides {
+  switch (scope) {
+    case 'uncommitted':
+      return { original: 'head-blob', modified: 'working-tree' };
+    case 'committed':
+      return { original: 'merge-base-blob', modified: 'head-blob' };
+    case 'branch':
+      return { original: 'merge-base-blob', modified: 'working-tree' };
+  }
+}
+
+export type MachineDiffFileStatus = 'added' | 'modified' | 'deleted' | 'renamed';
+
+export interface MachineDiffFile {
+  /** Repo-relative path (the rename/copy TARGET for renamed entries). */
+  path: string;
+  status: MachineDiffFileStatus;
+  /** The rename/copy SOURCE path, present only for renamed/copied entries. */
+  previousPath?: string;
+}
+
+function statusFromPorcelainXY(x: string, y: string): MachineDiffFileStatus {
+  if (x === '?' && y === '?') return 'added';
+  if (x === 'D' || y === 'D') return 'deleted';
+  if (x === 'R' || y === 'R') return 'renamed';
+  // 'C' (copy): the target is a NEW file — the source still exists.
+  if (x === 'A' || y === 'A' || x === 'C') return 'added';
+  return 'modified';
+}
+
+/**
+ * Every complete `-z` entry ends in NUL, so complete output always splits to
+ * a trailing '' — a non-empty final token is a field the 256 KB
+ * `runGitInSandbox` output cap cut mid-way, and is dropped rather than parsed
+ * as a bogus short path (the caller surfaces the run's `truncated` flag
+ * alongside the parsed list).
+ */
+function splitZDroppingTruncatedTail(stdout: string): string[] {
+  const tokens = stdout.split('\0');
+  tokens.pop();
+  return tokens;
+}
+
+/**
+ * Parse `git status --porcelain -z` output into the uncommitted-scope file
+ * list. Entry format: `XY<SP><path>NUL`, and for a rename/copy the SOURCE
+ * path follows as its own NUL-terminated field: `XY<SP><target>NUL<source>NUL`
+ * (note: target FIRST — the reverse of `git diff --name-status -z`).
+ *
+ * A malformed or partial trailing entry (see `splitZDroppingTruncatedTail`)
+ * is dropped rather than guessed at.
+ */
+export function parseStatusPorcelainZ(stdout: string): MachineDiffFile[] {
+  const tokens = splitZDroppingTruncatedTail(stdout);
+  const files: MachineDiffFile[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    // Shortest valid entry is 'XY p' (4 chars); anything shorter is the empty
+    // trailing split or a truncated tail.
+    if (token.length < 4 || token[2] !== ' ') continue;
+    const x = token[0];
+    const y = token[1];
+    const path = token.slice(3);
+    let previousPath: string | undefined;
+    if (x === 'R' || x === 'C') {
+      previousPath = tokens[i + 1];
+      i++;
+      if (previousPath === undefined || previousPath.length === 0) continue; // truncated tail
+    }
+    files.push({
+      path,
+      status: statusFromPorcelainXY(x, y),
+      ...(previousPath !== undefined ? { previousPath } : {}),
+    });
+  }
+  return files;
+}
+
+function statusFromNameStatusLetter(letter: string): MachineDiffFileStatus {
+  if (letter === 'A') return 'added';
+  if (letter === 'D') return 'deleted';
+  // T (type change), M, U (unmerged) all render as a content diff.
+  return 'modified';
+}
+
+/**
+ * Parse `git diff --name-status -z` output into the committed/branch-scope
+ * file list. Entry format: `<status>NUL<path>NUL`, and for a rename/copy
+ * (`R<score>`/`C<score>`): `<status>NUL<source>NUL<target>NUL` (source FIRST —
+ * the reverse of `git status --porcelain -z`).
+ */
+export function parseNameStatusZ(stdout: string): MachineDiffFile[] {
+  const tokens = splitZDroppingTruncatedTail(stdout);
+  const files: MachineDiffFile[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const status = tokens[i];
+    if (status === undefined || status.length === 0) {
+      i++;
+      continue;
+    }
+    const letter = status[0];
+    if (letter === 'R' || letter === 'C') {
+      const source = tokens[i + 1];
+      const target = tokens[i + 2];
+      if (source === undefined || source.length === 0 || target === undefined || target.length === 0) break; // truncated tail
+      files.push({
+        path: target,
+        // A copy's target is a new file; a rename's target replaced its source.
+        status: letter === 'R' ? 'renamed' : 'added',
+        previousPath: source,
+      });
+      i += 3;
+      continue;
+    }
+    const path = tokens[i + 1];
+    if (path === undefined || path.length === 0) break; // truncated tail
+    files.push({ path, status: statusFromNameStatusLetter(letter) });
+    i += 2;
+  }
+  return files;
+}

--- a/packages/lib/src/services/sandbox/machine-diff-scope.ts
+++ b/packages/lib/src/services/sandbox/machine-diff-scope.ts
@@ -9,7 +9,8 @@
  * The three scopes and their exact semantics:
  *
  *   uncommitted — working tree vs the last commit.
- *     File list: `git status --porcelain -z`.
+ *     File list: `git status --porcelain -z -uall` (see STATUS_PORCELAIN_ARGS
+ *     for why `-uall`).
  *     original = blob at HEAD, modified = working-tree file.
  *
  *   committed — the branch's own commits vs where it forked from the main
@@ -24,7 +25,7 @@
  *     File list: `git diff --name-status -z --merge-base <base>` (one ref, no
  *     second side — `--merge-base <commit>` compares the WORKING TREE against
  *     merge-base(<commit>, HEAD)) UNIONED with the untracked working-tree
- *     files from `git status --porcelain -z`. `git diff` lists only TRACKED
+ *     files from `git status --porcelain -z -uall`. `git diff` lists only TRACKED
  *     differences, so a brand-new never-added file would otherwise be missing
  *     from a scope that is documented to include all uncommitted working-tree
  *     changes; `untrackedArgs` on the resolution below supplies exactly that
@@ -71,6 +72,17 @@ export function isMachineDiffScope(value: string): value is MachineDiffScope {
 export const DIFF_BASE_REF = 'origin/HEAD';
 
 /**
+ * The `git status` argv shared by the uncommitted scope's file list and the
+ * branch scope's untracked supplement. `-uall` (`--untracked-files=all`) is
+ * REQUIRED, not cosmetic: the default (`normal`) mode collapses a brand-new
+ * untracked directory into a single `dir/` entry, which the per-file pair
+ * route would then try to `readMachineFile` as a file (→ null/404) instead of
+ * showing the files inside. `-uall` expands the directory into its individual
+ * untracked files. `-z` keeps NUL framing so paths are never C-quoted.
+ */
+const STATUS_PORCELAIN_ARGS: readonly string[] = ['status', '--porcelain', '-z', '-uall'];
+
+/**
  * Is this branch name the repo's main branch? Compared against the literal
  * default-branch names ('master'/'main', case-sensitive) — the convention this
  * codebase already uses for default-branch naming; deliberately NOT a new DB
@@ -115,13 +127,13 @@ export function resolveDiffScope(
   }
   switch (requestedScope) {
     case 'uncommitted':
-      return { gitArgs: ['status', '--porcelain', '-z'] };
+      return { gitArgs: [...STATUS_PORCELAIN_ARGS] };
     case 'committed':
       return { gitArgs: ['diff', '--name-status', '-z', `${DIFF_BASE_REF}...HEAD`] };
     case 'branch':
       return {
         gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF],
-        untrackedArgs: ['status', '--porcelain', '-z'],
+        untrackedArgs: [...STATUS_PORCELAIN_ARGS],
       };
   }
 }

--- a/packages/lib/src/services/sandbox/machine-diff-scope.ts
+++ b/packages/lib/src/services/sandbox/machine-diff-scope.ts
@@ -23,7 +23,13 @@
  *     uncommitted working-tree changes.
  *     File list: `git diff --name-status -z --merge-base <base>` (one ref, no
  *     second side — `--merge-base <commit>` compares the WORKING TREE against
- *     merge-base(<commit>, HEAD)).
+ *     merge-base(<commit>, HEAD)) UNIONED with the untracked working-tree
+ *     files from `git status --porcelain -z`. `git diff` lists only TRACKED
+ *     differences, so a brand-new never-added file would otherwise be missing
+ *     from a scope that is documented to include all uncommitted working-tree
+ *     changes; `untrackedArgs` on the resolution below supplies exactly that
+ *     gap. Untracked paths cannot collide with the diff's tracked paths, so
+ *     the shell simply appends them (no dedup needed).
  *     original = blob at the merge-base, modified = working-tree file.
  *
  * On the main branch itself, 'committed' and 'branch' are meaningless — the
@@ -73,7 +79,19 @@ export function isMainBranchName(branchName: string): boolean {
   return branchName === 'master' || branchName === 'main';
 }
 
-export type MachineDiffScopeResolution = { gitArgs: string[] } | { notApplicable: true };
+export type MachineDiffScopeResolution =
+  | {
+      /** The git argv whose stdout is the scope's primary changed-file list. */
+      gitArgs: string[];
+      /**
+       * Present ONLY for 'branch' scope: a second git argv whose untracked
+       * (`??`) entries are appended to the list (parsed via
+       * `parseUntrackedPorcelainZ`), because `gitArgs`' `git diff` omits
+       * untracked working-tree files. See the module docstring.
+       */
+      untrackedArgs?: string[];
+    }
+  | { notApplicable: true };
 
 /**
  * Resolve a requested Diff scope to the exact `git` argv that produces its
@@ -100,7 +118,10 @@ export function resolveDiffScope(
     case 'committed':
       return { gitArgs: ['diff', '--name-status', '-z', `${DIFF_BASE_REF}...HEAD`] };
     case 'branch':
-      return { gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF] };
+      return {
+        gitArgs: ['diff', '--name-status', '-z', '--merge-base', DIFF_BASE_REF],
+        untrackedArgs: ['status', '--porcelain', '-z'],
+      };
   }
 }
 
@@ -193,6 +214,39 @@ export function parseStatusPorcelainZ(stdout: string): MachineDiffFile[] {
       status: statusFromPorcelainXY(x, y),
       ...(previousPath !== undefined ? { previousPath } : {}),
     });
+  }
+  return files;
+}
+
+/**
+ * Parse ONLY the untracked (`?? <path>`) entries from `git status
+ * --porcelain -z`, each as an 'added' file. This is the 'branch' scope's
+ * untracked-file supplement: `git diff --merge-base` lists every TRACKED
+ * difference from the merge-base but omits untracked working-tree files, so
+ * these are appended to complete the scope (see the module docstring).
+ *
+ * Tracked entries (modified/deleted/added/renamed) are skipped — they are
+ * already covered by the diff. A rename/copy entry (never untracked) carries a
+ * trailing source field, so its second token is stepped over to keep the
+ * source path from being mis-read as a standalone entry. A truncated trailing
+ * entry is dropped via `splitZDroppingTruncatedTail`.
+ */
+export function parseUntrackedPorcelainZ(stdout: string): MachineDiffFile[] {
+  const tokens = splitZDroppingTruncatedTail(stdout);
+  const files: MachineDiffFile[] = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token.length < 4 || token[2] !== ' ') continue;
+    const x = token[0];
+    const y = token[1];
+    // Rename/copy entries carry a NUL-separated source path as the next token.
+    if (x === 'R' || x === 'C') {
+      i++;
+      continue;
+    }
+    if (x === '?' && y === '?') {
+      files.push({ path: token.slice(3), status: 'added' });
+    }
   }
   return files;
 }

--- a/packages/lib/src/services/sandbox/machine-diff-scope.ts
+++ b/packages/lib/src/services/sandbox/machine-diff-scope.ts
@@ -9,8 +9,15 @@
  * The three scopes and their exact semantics:
  *
  *   uncommitted — working tree vs the last commit.
- *     File list: `git status --porcelain -z -uall` (see STATUS_PORCELAIN_ARGS
- *     for why `-uall`).
+ *     File list: `git diff --name-status -z HEAD` (HEAD tree vs the WORKING
+ *     TREE — the net of staged + unstaged, which is exactly what the rendered
+ *     HEAD-vs-working-tree pair shows) UNIONED with untracked working-tree
+ *     files from `git status --porcelain -z -uall` (see STATUS_PORCELAIN_ARGS
+ *     for `-uall`). Deliberately NOT `git status` for the tracked list: status
+ *     reports the index column too, so a staged-then-reverted file (`MM` then
+ *     restore) or a staged-add-then-delete (`AD`) would appear in the list yet
+ *     render as unchanged / 404 in the pair — the diff-vs-HEAD list can't
+ *     drift from the rendered sides that way.
  *     original = blob at HEAD, modified = working-tree file.
  *
  *   committed — the branch's own commits vs where it forked from the main
@@ -51,9 +58,12 @@
  * the main branch?" — matching the default-branch naming convention used
  * elsewhere in this codebase; there is deliberately no schema flag for it.
  *
- * Both file-list commands use `-z` (NUL-separated) output: with `-z` git never
+ * Every git command here uses `-z` (NUL-separated) output: with `-z` git never
  * C-quotes pathnames, so the parsers below handle spaces, quotes, and
  * non-ASCII filenames with one code path instead of a C-unquoting fallback.
+ * All three scopes' tracked lists are `git diff --name-status` (parsed by
+ * `parseNameStatusZ`); only the untracked supplement is porcelain-formatted
+ * (parsed by `parseUntrackedPorcelainZ`).
  */
 
 export type MachineDiffScope = 'uncommitted' | 'committed' | 'branch';
@@ -72,13 +82,15 @@ export function isMachineDiffScope(value: string): value is MachineDiffScope {
 export const DIFF_BASE_REF = 'origin/HEAD';
 
 /**
- * The `git status` argv shared by the uncommitted scope's file list and the
- * branch scope's untracked supplement. `-uall` (`--untracked-files=all`) is
- * REQUIRED, not cosmetic: the default (`normal`) mode collapses a brand-new
- * untracked directory into a single `dir/` entry, which the per-file pair
- * route would then try to `readMachineFile` as a file (→ null/404) instead of
- * showing the files inside. `-uall` expands the directory into its individual
- * untracked files. `-z` keeps NUL framing so paths are never C-quoted.
+ * The `git status` argv for the untracked-file supplement shared by the
+ * uncommitted and branch scopes (both diff against a base into the working
+ * tree, and `git diff` omits untracked files). `-uall`
+ * (`--untracked-files=all`) is REQUIRED, not cosmetic: the default (`normal`)
+ * mode collapses a brand-new untracked directory into a single `dir/` entry,
+ * which the per-file pair route would then try to `readMachineFile` as a file
+ * (→ null/404) instead of showing the files inside. `-uall` expands the
+ * directory into its individual untracked files. `-z` keeps NUL framing so
+ * paths are never C-quoted.
  */
 const STATUS_PORCELAIN_ARGS: readonly string[] = ['status', '--porcelain', '-z', '-uall'];
 
@@ -127,7 +139,10 @@ export function resolveDiffScope(
   }
   switch (requestedScope) {
     case 'uncommitted':
-      return { gitArgs: [...STATUS_PORCELAIN_ARGS] };
+      return {
+        gitArgs: ['diff', '--name-status', '-z', 'HEAD'],
+        untrackedArgs: [...STATUS_PORCELAIN_ARGS],
+      };
     case 'committed':
       return { gitArgs: ['diff', '--name-status', '-z', `${DIFF_BASE_REF}...HEAD`] };
     case 'branch':
@@ -185,15 +200,6 @@ export interface MachineDiffFile {
   previousPath?: string;
 }
 
-function statusFromPorcelainXY(x: string, y: string): MachineDiffFileStatus {
-  if (x === '?' && y === '?') return 'added';
-  if (x === 'D' || y === 'D') return 'deleted';
-  if (x === 'R' || y === 'R') return 'renamed';
-  // 'C' (copy): the target is a NEW file — the source still exists.
-  if (x === 'A' || y === 'A' || x === 'C') return 'added';
-  return 'modified';
-}
-
 /**
  * Every complete `-z` entry ends in NUL, so complete output always splits to
  * a trailing '' — a non-empty final token is a field the 256 KB
@@ -208,46 +214,12 @@ function splitZDroppingTruncatedTail(stdout: string): string[] {
 }
 
 /**
- * Parse `git status --porcelain -z` output into the uncommitted-scope file
- * list. Entry format: `XY<SP><path>NUL`, and for a rename/copy the SOURCE
- * path follows as its own NUL-terminated field: `XY<SP><target>NUL<source>NUL`
- * (note: target FIRST — the reverse of `git diff --name-status -z`).
- *
- * A malformed or partial trailing entry (see `splitZDroppingTruncatedTail`)
- * is dropped rather than guessed at.
- */
-export function parseStatusPorcelainZ(stdout: string): MachineDiffFile[] {
-  const tokens = splitZDroppingTruncatedTail(stdout);
-  const files: MachineDiffFile[] = [];
-  for (let i = 0; i < tokens.length; i++) {
-    const token = tokens[i];
-    // Shortest valid entry is 'XY p' (4 chars); anything shorter is the empty
-    // trailing split or a truncated tail.
-    if (token.length < 4 || token[2] !== ' ') continue;
-    const x = token[0];
-    const y = token[1];
-    const path = token.slice(3);
-    let previousPath: string | undefined;
-    if (x === 'R' || x === 'C') {
-      previousPath = tokens[i + 1];
-      i++;
-      if (previousPath === undefined || previousPath.length === 0) continue; // truncated tail
-    }
-    files.push({
-      path,
-      status: statusFromPorcelainXY(x, y),
-      ...(previousPath !== undefined ? { previousPath } : {}),
-    });
-  }
-  return files;
-}
-
-/**
  * Parse ONLY the untracked (`?? <path>`) entries from `git status
- * --porcelain -z`, each as an 'added' file. This is the 'branch' scope's
- * untracked-file supplement: `git diff --merge-base` lists every TRACKED
- * difference from the merge-base but omits untracked working-tree files, so
- * these are appended to complete the scope (see the module docstring).
+ * --porcelain -z`, each as an 'added' file. This is the untracked-file
+ * supplement shared by the uncommitted and branch scopes: their `git diff`
+ * lists every TRACKED difference from the base but omits untracked
+ * working-tree files, so these are appended to complete the scope (see the
+ * module docstring).
  *
  * Tracked entries (modified/deleted/added/renamed) are skipped — they are
  * already covered by the diff. A rename/copy entry (never untracked) carries a

--- a/packages/lib/src/services/sandbox/machine-diff-scope.ts
+++ b/packages/lib/src/services/sandbox/machine-diff-scope.ts
@@ -166,6 +166,17 @@ export function diffScopeSides(scope: MachineDiffScope): MachineDiffSides {
 
 export type MachineDiffFileStatus = 'added' | 'modified' | 'deleted' | 'renamed';
 
+export const MACHINE_DIFF_FILE_STATUSES: readonly MachineDiffFileStatus[] = [
+  'added',
+  'modified',
+  'deleted',
+  'renamed',
+];
+
+export function isMachineDiffFileStatus(value: string): value is MachineDiffFileStatus {
+  return (MACHINE_DIFF_FILE_STATUSES as readonly string[]).includes(value);
+}
+
 export interface MachineDiffFile {
   /** Repo-relative path (the rename/copy TARGET for renamed entries). */
   path: string;

--- a/packages/lib/src/services/sandbox/machine-diff-scope.ts
+++ b/packages/lib/src/services/sandbox/machine-diff-scope.ts
@@ -28,8 +28,9 @@
  *     differences, so a brand-new never-added file would otherwise be missing
  *     from a scope that is documented to include all uncommitted working-tree
  *     changes; `untrackedArgs` on the resolution below supplies exactly that
- *     gap. Untracked paths cannot collide with the diff's tracked paths, so
- *     the shell simply appends them (no dedup needed).
+ *     gap. Untracked paths normally cannot collide with the diff's tracked
+ *     paths, but the shell dedups by path anyway (tracked entry wins) to cover
+ *     the pathological deleted-from-index-yet-present-untracked case.
  *     original = blob at the merge-base, modified = working-tree file.
  *
  * On the main branch itself, 'committed' and 'branch' are meaningless — the

--- a/packages/lib/src/services/sandbox/machine-diff.ts
+++ b/packages/lib/src/services/sandbox/machine-diff.ts
@@ -37,7 +37,6 @@ import type { SandboxActorContext } from './tool-runners';
 import {
   diffScopeSides,
   parseNameStatusZ,
-  parseStatusPorcelainZ,
   parseUntrackedPorcelainZ,
   resolveDiffScope,
   DIFF_BASE_REF,
@@ -134,13 +133,13 @@ export async function listMachineDiffFiles({
   if (run.exitCode !== 0) {
     return { ok: false, reason: 'exec_failed', detail: run.stderr.trim() || undefined };
   }
-  const files = scope === 'uncommitted' ? parseStatusPorcelainZ(run.stdout) : parseNameStatusZ(run.stdout);
+  const files = parseNameStatusZ(run.stdout);
   let truncated = run.truncated;
 
-  // 'branch' scope: `git diff --merge-base` lists only tracked differences, so
-  // append the untracked working-tree files (a second run) — otherwise a
-  // brand-new never-added file is invisible in a scope documented to include
-  // all uncommitted working-tree changes. Untracked paths normally can't
+  // uncommitted / branch scopes: their `git diff` lists only tracked
+  // differences, so append the untracked working-tree files (a second run) —
+  // otherwise a brand-new never-added file is invisible in a scope documented
+  // to include untracked working-tree changes. Untracked paths normally can't
   // collide with the diff's tracked paths, but a path deleted from the index
   // yet still present untracked on disk can appear in both; dedup so the
   // tracked diff entry always wins and no path is listed twice.

--- a/packages/lib/src/services/sandbox/machine-diff.ts
+++ b/packages/lib/src/services/sandbox/machine-diff.ts
@@ -38,6 +38,7 @@ import {
   diffScopeSides,
   parseNameStatusZ,
   parseStatusPorcelainZ,
+  parseUntrackedPorcelainZ,
   resolveDiffScope,
   DIFF_BASE_REF,
   type MachineDiffFile,
@@ -133,6 +134,22 @@ export async function listMachineDiffFiles({
     return { ok: false, reason: 'exec_failed', detail: run.stderr.trim() || undefined };
   }
   const files = scope === 'uncommitted' ? parseStatusPorcelainZ(run.stdout) : parseNameStatusZ(run.stdout);
+  let truncated = run.truncated;
+
+  // 'branch' scope: `git diff --merge-base` lists only tracked differences, so
+  // append the untracked working-tree files (a second run) — otherwise a
+  // brand-new never-added file is invisible in a scope documented to include
+  // all uncommitted working-tree changes. Untracked paths can't collide with
+  // the diff's tracked paths, so they simply extend the list.
+  if (resolution.untrackedArgs) {
+    const untracked = await runGitInSandbox({ cmd: 'git', args: resolution.untrackedArgs, cwd, ctx, deps });
+    if (!untracked.success) return { ok: false, reason: 'exec_failed', detail: untracked.error };
+    if (untracked.exitCode !== 0) {
+      return { ok: false, reason: 'exec_failed', detail: untracked.stderr.trim() || undefined };
+    }
+    files.push(...parseUntrackedPorcelainZ(untracked.stdout));
+    truncated = truncated || untracked.truncated;
+  }
 
   let mergeBase: string | null = null;
   if (scope !== 'uncommitted') {
@@ -140,7 +157,7 @@ export async function listMachineDiffFiles({
     if (!resolved.ok) return resolved;
     mergeBase = resolved.sha;
   }
-  return { ok: true, notApplicable: false, files, truncated: run.truncated, mergeBase };
+  return { ok: true, notApplicable: false, files, truncated, mergeBase };
 }
 
 export interface MachineDiffSideContent {
@@ -173,12 +190,20 @@ const MAX_WORKING_TREE_READ_BYTES = 2 * 1024 * 1024;
  * or working tree). A side that does not exist (`not_found`) is `null` — an
  * added file legitimately has no original and a deleted file no modified —
  * only a real execution failure is an error.
+ *
+ * RENAMES: `path` is the file's CURRENT location (the rename target — where it
+ * lives in HEAD/working tree), but its ORIGINAL side lives at the pre-rename
+ * source. So the 'original' blob side reads from `previousPath` when given; the
+ * 'modified' side (HEAD blob or working tree) always uses `path`. Without this,
+ * a pure rename's original blob would not resolve at `path` in the old ref and
+ * the file would be mis-presented as an add.
  */
 export async function readMachineDiffPair({
   branchName,
   isMainBranch,
   scope,
   path,
+  previousPath,
   workingTreePath,
   cwd,
   handle,
@@ -188,8 +213,14 @@ export async function readMachineDiffPair({
   branchName: string;
   isMainBranch: boolean;
   scope: MachineDiffScope;
-  /** Repo-relative path — addresses blobs inside a ref's own git tree. */
+  /** Repo-relative path — the file's CURRENT location; addresses the 'modified' blob side inside a ref's own git tree. */
   path: string;
+  /**
+   * Repo-relative rename/copy SOURCE, when the file list reported one. The
+   * 'original' blob side reads from here (the file's pre-rename location);
+   * absent for non-renamed files, where the original side falls back to `path`.
+   */
+  previousPath?: string;
   /** Absolute working-tree path, ALREADY confined under the checkout root by the caller. */
   workingTreePath: string;
   cwd: string;
@@ -211,6 +242,8 @@ export async function readMachineDiffPair({
 
   const readSide = async (
     source: MachineDiffSideSource,
+    /** Repo-relative path for a blob side (rename source for 'original', target for 'modified'). */
+    blobPath: string,
   ): Promise<{ ok: true; content: MachineDiffSideContent | null } | MachineDiffFailure> => {
     if (source === 'working-tree') {
       const result = await readMachineFile({ handle, path: workingTreePath });
@@ -224,15 +257,18 @@ export async function readMachineDiffPair({
     // mergeBase is always resolved above when a side needs it; the fallback
     // 'HEAD' is unreachable but keeps the ref a plain string for the compiler.
     const ref = source === 'head-blob' ? 'HEAD' : (mergeBase ?? 'HEAD');
-    const result = await readMachineGitBlob({ ref, path, cwd, ctx, deps });
+    const result = await readMachineGitBlob({ ref, path: blobPath, cwd, ctx, deps });
     if (result.ok) return { ok: true, content: { content: result.content, truncated: result.truncated } };
     if (result.reason === 'not_found') return { ok: true, content: null };
     return { ok: false, reason: 'exec_failed', detail: result.detail };
   };
 
-  const original = await readSide(sides.original);
+  // The original side lives at the pre-rename source when the list reported
+  // one; the modified side is always the file's current path. A working-tree
+  // side ignores its blobPath argument (it reads `workingTreePath`).
+  const original = await readSide(sides.original, previousPath ?? path);
   if (!original.ok) return original;
-  const modified = await readSide(sides.modified);
+  const modified = await readSide(sides.modified, path);
   if (!modified.ok) return modified;
 
   return { ok: true, notApplicable: false, original: original.content, modified: modified.content };

--- a/packages/lib/src/services/sandbox/machine-diff.ts
+++ b/packages/lib/src/services/sandbox/machine-diff.ts
@@ -42,6 +42,7 @@ import {
   resolveDiffScope,
   DIFF_BASE_REF,
   type MachineDiffFile,
+  type MachineDiffFileStatus,
   type MachineDiffScope,
   type MachineDiffSideSource,
 } from './machine-diff-scope';
@@ -202,6 +203,14 @@ const MAX_WORKING_TREE_READ_BYTES = 2 * 1024 * 1024;
  * 'modified' side (HEAD blob or working tree) always uses `path`. Without this,
  * a pure rename's original blob would not resolve at `path` in the old ref and
  * the file would be mis-presented as an add.
+ *
+ * STATUS HINT: when the list `status` is provided, a 'deleted' file's modified
+ * side and an 'added' file's original side are forced to `null` WITHOUT reading
+ * the backend. This is load-bearing for the working-tree modified side: a file
+ * deleted from the index can still sit on disk as an UNTRACKED file at the same
+ * path (e.g. `git rm --cached f`), so blindly reading the working tree would
+ * surface that masquerading file as the deletion's modified content and render
+ * a deletion as unchanged. The list status is authoritative; honor it.
  */
 export async function readMachineDiffPair({
   branchName,
@@ -209,6 +218,7 @@ export async function readMachineDiffPair({
   scope,
   path,
   previousPath,
+  status,
   workingTreePath,
   cwd,
   handle,
@@ -226,6 +236,12 @@ export async function readMachineDiffPair({
    * absent for non-renamed files, where the original side falls back to `path`.
    */
   previousPath?: string;
+  /**
+   * The file's status from the changed-file list. When given, a 'deleted' file
+   * skips its (modified) side and an 'added' file skips its (original) side —
+   * see the STATUS HINT note above. Omit to read both sides unconditionally.
+   */
+  status?: MachineDiffFileStatus;
   /** Absolute working-tree path, ALREADY confined under the checkout root by the caller. */
   workingTreePath: string;
   cwd: string;
@@ -237,9 +253,15 @@ export async function readMachineDiffPair({
   if ('notApplicable' in resolution) return { ok: true, notApplicable: true };
 
   const sides = diffScopeSides(scope);
+  // A 'deleted' file has no modified side and an 'added' file no original side.
+  const readOriginal = status !== 'added';
+  const readModified = status !== 'deleted';
 
   let mergeBase: string | null = null;
-  if (sides.original === 'merge-base-blob' || sides.modified === 'merge-base-blob') {
+  const needsMergeBase =
+    (readOriginal && sides.original === 'merge-base-blob') ||
+    (readModified && sides.modified === 'merge-base-blob');
+  if (needsMergeBase) {
     const resolved = await resolveMachineMergeBase({ cwd, ctx, deps });
     if (!resolved.ok) return resolved;
     mergeBase = resolved.sha;
@@ -270,10 +292,15 @@ export async function readMachineDiffPair({
 
   // The original side lives at the pre-rename source when the list reported
   // one; the modified side is always the file's current path. A working-tree
-  // side ignores its blobPath argument (it reads `workingTreePath`).
-  const original = await readSide(sides.original, previousPath ?? path);
+  // side ignores its blobPath argument (it reads `workingTreePath`). A side the
+  // status says can't exist is forced null without any read (see STATUS HINT).
+  const original = readOriginal
+    ? await readSide(sides.original, previousPath ?? path)
+    : { ok: true as const, content: null };
   if (!original.ok) return original;
-  const modified = await readSide(sides.modified, path);
+  const modified = readModified
+    ? await readSide(sides.modified, path)
+    : { ok: true as const, content: null };
   if (!modified.ok) return modified;
 
   return { ok: true, notApplicable: false, original: original.content, modified: modified.content };

--- a/packages/lib/src/services/sandbox/machine-diff.ts
+++ b/packages/lib/src/services/sandbox/machine-diff.ts
@@ -1,0 +1,239 @@
+/**
+ * Machine Diff service — the imperative shell over `machine-diff-scope.ts`'s
+ * pure scope resolution (Machine page rebuild, Phase 1 — the Diff tab's 3-way
+ * scope service). Every scope decision, git argv, side mapping, and output
+ * parser lives in the pure module; this file only EXECUTES what the pure core
+ * resolved — through the same DI seams the merged siblings use:
+ *
+ *   changed-file lists / merge-base — `runGitInSandbox`
+ *     (./git-tool-runners.ts), the hardened human+agent git path, NOT the
+ *     AI-tool orchestration in tool-runners.ts/sandbox-tools.ts (billing
+ *     holds, injection vocabulary — wrong layer for a browsing UI).
+ *   git-object ('original'/'modified' blob) sides — `readMachineGitBlob`
+ *     (./machine-git-blob.ts).
+ *   working-tree sides — `readMachineFile` (./machine-fs.ts) against an
+ *     injected `MachineHandle`.
+ *
+ * Like those siblings, everything here takes `GitSandboxRunDeps` +
+ * `SandboxActorContext` (+ a `MachineHandle` where a working-tree side
+ * exists) as injected params, so the whole service is unit-testable against a
+ * scripted fake sandbox with zero real Sprite/git calls.
+ *
+ * MERGE-BASE: the file-list commands let git resolve the merge-base
+ * internally (three-dot / `--merge-base` syntax — see the pure module), but
+ * blob reads need it as a CONCRETE ref, so `resolveMachineMergeBase` runs
+ * `git merge-base origin/HEAD HEAD` and validates the output is a lone SHA
+ * before it is ever used as a `readMachineGitBlob` ref. The list result also
+ * carries that SHA so the client can address 'original' blobs through
+ * `/api/machines/git-blob` (whose contract is "a merge-base the caller
+ * already computed") without re-deriving it.
+ */
+
+import { runGitInSandbox, type GitSandboxRunDeps } from './git-tool-runners';
+import { readMachineGitBlob } from './machine-git-blob';
+import { readMachineFile } from './machine-fs';
+import type { MachineHandle } from './machine-host';
+import type { SandboxActorContext } from './tool-runners';
+import {
+  diffScopeSides,
+  parseNameStatusZ,
+  parseStatusPorcelainZ,
+  resolveDiffScope,
+  DIFF_BASE_REF,
+  type MachineDiffFile,
+  type MachineDiffScope,
+  type MachineDiffSideSource,
+} from './machine-diff-scope';
+import { StringDecoder } from 'string_decoder';
+
+export type MachineDiffFailure = {
+  ok: false;
+  reason: 'exec_failed' | 'merge_base_failed';
+  detail?: string;
+};
+
+/** A full merge-base SHA (git may emit SHA-1 or SHA-256 object names). */
+const MERGE_BASE_SHA_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+
+export type ResolveMachineMergeBaseResult = { ok: true; sha: string } | MachineDiffFailure;
+
+/**
+ * Resolve the concrete merge-base SHA between the repo's default branch
+ * (`origin/HEAD`) and the checked-out branch's HEAD. The output is validated
+ * as a lone SHA before use — it becomes a `readMachineGitBlob` ref and a
+ * client-facing value, so garbage (or a multi-line octopus result) must never
+ * pass through.
+ */
+export async function resolveMachineMergeBase({
+  cwd,
+  ctx,
+  deps,
+}: {
+  cwd: string;
+  ctx: SandboxActorContext;
+  deps: GitSandboxRunDeps;
+}): Promise<ResolveMachineMergeBaseResult> {
+  const run = await runGitInSandbox({
+    cmd: 'git',
+    args: ['merge-base', DIFF_BASE_REF, 'HEAD'],
+    cwd,
+    ctx,
+    deps,
+  });
+  if (!run.success) return { ok: false, reason: 'exec_failed', detail: run.error };
+  if (run.exitCode !== 0) {
+    return { ok: false, reason: 'merge_base_failed', detail: run.stderr.trim() || undefined };
+  }
+  const sha = run.stdout.trim();
+  if (!MERGE_BASE_SHA_PATTERN.test(sha)) {
+    return { ok: false, reason: 'merge_base_failed', detail: 'merge-base did not resolve to a single commit' };
+  }
+  return { ok: true, sha };
+}
+
+export type ListMachineDiffFilesResult =
+  | { ok: true; notApplicable: true }
+  | {
+      ok: true;
+      notApplicable: false;
+      files: MachineDiffFile[];
+      /** True when the file list was cut by the sandbox output cap — the list is a prefix, not the whole diff. */
+      truncated: boolean;
+      /** The concrete merge-base SHA for 'committed'/'branch' scopes (a git-blob ref for 'original' sides); null for 'uncommitted'. */
+      mergeBase: string | null;
+    }
+  | MachineDiffFailure;
+
+/**
+ * Produce the changed-file list for a scope — `{ notApplicable: true }` when
+ * the pure resolution says the scope is meaningless on the main branch (no
+ * git is run at all in that case).
+ */
+export async function listMachineDiffFiles({
+  branchName,
+  isMainBranch,
+  scope,
+  cwd,
+  ctx,
+  deps,
+}: {
+  branchName: string;
+  isMainBranch: boolean;
+  scope: MachineDiffScope;
+  cwd: string;
+  ctx: SandboxActorContext;
+  deps: GitSandboxRunDeps;
+}): Promise<ListMachineDiffFilesResult> {
+  const resolution = resolveDiffScope(branchName, isMainBranch, scope);
+  if ('notApplicable' in resolution) return { ok: true, notApplicable: true };
+
+  const run = await runGitInSandbox({ cmd: 'git', args: resolution.gitArgs, cwd, ctx, deps });
+  if (!run.success) return { ok: false, reason: 'exec_failed', detail: run.error };
+  if (run.exitCode !== 0) {
+    return { ok: false, reason: 'exec_failed', detail: run.stderr.trim() || undefined };
+  }
+  const files = scope === 'uncommitted' ? parseStatusPorcelainZ(run.stdout) : parseNameStatusZ(run.stdout);
+
+  let mergeBase: string | null = null;
+  if (scope !== 'uncommitted') {
+    const resolved = await resolveMachineMergeBase({ cwd, ctx, deps });
+    if (!resolved.ok) return resolved;
+    mergeBase = resolved.sha;
+  }
+  return { ok: true, notApplicable: false, files, truncated: run.truncated, mergeBase };
+}
+
+export interface MachineDiffSideContent {
+  content: string;
+  truncated: boolean;
+}
+
+export type ReadMachineDiffPairResult =
+  | { ok: true; notApplicable: true }
+  | {
+      ok: true;
+      notApplicable: false;
+      /** null = the file has no content on that side (added file's original, deleted file's modified). */
+      original: MachineDiffSideContent | null;
+      modified: MachineDiffSideContent | null;
+    }
+  | MachineDiffFailure;
+
+/**
+ * Working-tree sides are capped at the same 2 MB the Files route uses — a
+ * blob side inherits `runGitInSandbox`'s smaller 256 KB stdout cap instead
+ * (see machine-git-blob.ts's KNOWN TRUNCATION TRADEOFF note for why that
+ * asymmetry stands).
+ */
+const MAX_WORKING_TREE_READ_BYTES = 2 * 1024 * 1024;
+
+/**
+ * Read ONE changed file's original/modified content pair for a scope, each
+ * side from the source `diffScopeSides` resolved (merge-base blob, HEAD blob,
+ * or working tree). A side that does not exist (`not_found`) is `null` — an
+ * added file legitimately has no original and a deleted file no modified —
+ * only a real execution failure is an error.
+ */
+export async function readMachineDiffPair({
+  branchName,
+  isMainBranch,
+  scope,
+  path,
+  workingTreePath,
+  cwd,
+  handle,
+  ctx,
+  deps,
+}: {
+  branchName: string;
+  isMainBranch: boolean;
+  scope: MachineDiffScope;
+  /** Repo-relative path — addresses blobs inside a ref's own git tree. */
+  path: string;
+  /** Absolute working-tree path, ALREADY confined under the checkout root by the caller. */
+  workingTreePath: string;
+  cwd: string;
+  handle: MachineHandle;
+  ctx: SandboxActorContext;
+  deps: GitSandboxRunDeps;
+}): Promise<ReadMachineDiffPairResult> {
+  const resolution = resolveDiffScope(branchName, isMainBranch, scope);
+  if ('notApplicable' in resolution) return { ok: true, notApplicable: true };
+
+  const sides = diffScopeSides(scope);
+
+  let mergeBase: string | null = null;
+  if (sides.original === 'merge-base-blob' || sides.modified === 'merge-base-blob') {
+    const resolved = await resolveMachineMergeBase({ cwd, ctx, deps });
+    if (!resolved.ok) return resolved;
+    mergeBase = resolved.sha;
+  }
+
+  const readSide = async (
+    source: MachineDiffSideSource,
+  ): Promise<{ ok: true; content: MachineDiffSideContent | null } | MachineDiffFailure> => {
+    if (source === 'working-tree') {
+      const result = await readMachineFile({ handle, path: workingTreePath });
+      if (!result.ok) return { ok: true, content: null };
+      const truncated = result.content.length > MAX_WORKING_TREE_READ_BYTES;
+      const bytes = truncated ? result.content.subarray(0, MAX_WORKING_TREE_READ_BYTES) : result.content;
+      // StringDecoder withholds a trailing partial UTF-8 sequence at the cap
+      // instead of emitting U+FFFD — same decode the Files route uses.
+      return { ok: true, content: { content: new StringDecoder('utf8').write(bytes), truncated } };
+    }
+    // mergeBase is always resolved above when a side needs it; the fallback
+    // 'HEAD' is unreachable but keeps the ref a plain string for the compiler.
+    const ref = source === 'head-blob' ? 'HEAD' : (mergeBase ?? 'HEAD');
+    const result = await readMachineGitBlob({ ref, path, cwd, ctx, deps });
+    if (result.ok) return { ok: true, content: { content: result.content, truncated: result.truncated } };
+    if (result.reason === 'not_found') return { ok: true, content: null };
+    return { ok: false, reason: 'exec_failed', detail: result.detail };
+  };
+
+  const original = await readSide(sides.original);
+  if (!original.ok) return original;
+  const modified = await readSide(sides.modified);
+  if (!modified.ok) return modified;
+
+  return { ok: true, notApplicable: false, original: original.content, modified: modified.content };
+}

--- a/packages/lib/src/services/sandbox/machine-diff.ts
+++ b/packages/lib/src/services/sandbox/machine-diff.ts
@@ -139,15 +139,20 @@ export async function listMachineDiffFiles({
   // 'branch' scope: `git diff --merge-base` lists only tracked differences, so
   // append the untracked working-tree files (a second run) — otherwise a
   // brand-new never-added file is invisible in a scope documented to include
-  // all uncommitted working-tree changes. Untracked paths can't collide with
-  // the diff's tracked paths, so they simply extend the list.
+  // all uncommitted working-tree changes. Untracked paths normally can't
+  // collide with the diff's tracked paths, but a path deleted from the index
+  // yet still present untracked on disk can appear in both; dedup so the
+  // tracked diff entry always wins and no path is listed twice.
   if (resolution.untrackedArgs) {
     const untracked = await runGitInSandbox({ cmd: 'git', args: resolution.untrackedArgs, cwd, ctx, deps });
     if (!untracked.success) return { ok: false, reason: 'exec_failed', detail: untracked.error };
     if (untracked.exitCode !== 0) {
       return { ok: false, reason: 'exec_failed', detail: untracked.stderr.trim() || undefined };
     }
-    files.push(...parseUntrackedPorcelainZ(untracked.stdout));
+    const trackedPaths = new Set(files.map((f) => f.path));
+    for (const file of parseUntrackedPorcelainZ(untracked.stdout)) {
+      if (!trackedPaths.has(file.path)) files.push(file);
+    }
     truncated = truncated || untracked.truncated;
   }
 


### PR DESCRIPTION
## Summary

The **last Phase 1 task** of the Machine page rebuild (Terminal — GA Release epic): the Diff tab's 3-way scope resolution, composed over the two merged read primitives (#1966 working-tree files, #1978 git-blob).

### Pure core — `packages/lib/src/services/sandbox/machine-diff-scope.ts` (zero I/O)

- `resolveDiffScope(branchName, isMainBranch, requestedScope) → { gitArgs, untrackedArgs? } | { notApplicable: true }` — maps each scope to the exact git argv for its changed-file list:
  - **uncommitted** → `git diff --name-status -z HEAD` (HEAD vs the working tree — the net the rendered pair shows, so the list can't drift from the sides the way `git status`'s index column would) plus the untracked supplement below
  - **committed** → `git diff --name-status -z origin/HEAD...HEAD` (three-dot **is** merge-base..HEAD — git resolves the merge-base itself, which is what keeps this resolvable without I/O)
  - **branch** → `git diff --name-status -z --merge-base origin/HEAD` (one ref, no second side — compares the **working tree** against the merge-base), **plus** an `untrackedArgs` supplement (`git status --porcelain -z -uall`, shared with the uncommitted list via one `STATUS_PORCELAIN_ARGS` constant). `git diff` lists only *tracked* differences, so the untracked (`??`) entries are appended via `parseUntrackedPorcelainZ` — otherwise a brand-new never-added file is invisible in a scope documented to include all uncommitted working-tree changes. The shell dedups by path (tracked entry wins) to cover the pathological deleted-from-index-yet-present-untracked case.
  - On the main branch, committed/branch return `{ notApplicable: true }` — never empty gitArgs the caller has to interpret. `isMainBranchName` compares against the literal `master`/`main` names (the codebase's default-branch convention; deliberately no new DB column), and `resolveDiffScope` re-checks it so a stale caller flag can't produce a self-merge-base diff.
  - Diff base is `origin/HEAD`, not a master-vs-main guess — a branch terminal's checkout is a full clone, which always carries it.
- `diffScopeSides(scope)` — the original/modified content source per scope (merge-base blob / HEAD blob / working tree).
- `-z` output parsers for all three list commands (NUL framing → no C-quoting to unescape; handles renames' **reversed field order** between the status and name-status formats; drops output-cap-truncated tails instead of guessing).

### Imperative shell — `machine-diff.ts` (DI'd, same seams as the merged siblings)

- `listMachineDiffFiles` / `readMachineDiffPair` / `resolveMachineMergeBase` — execute the pure resolution through `runGitInSandbox` (NOT the AI-tool orchestration), `readMachineGitBlob` for blob sides, `readMachineFile` for working-tree sides.
- For the branch scope, `listMachineDiffFiles` runs the untracked supplement and appends its entries; its truncation/exec-failure propagate to the whole result.
- Merge-base output is validated as a lone SHA before it is ever used as a blob ref or returned to the client.
- **Renames:** `readMachineDiffPair` reads the *original* blob side from the rename source (`previousPath`) and the *modified* side from the current `path`. Without this a pure rename's original didn't resolve at the target path in the old ref and was mis-shown as an add.
- **Status hint:** `readMachineDiffPair` also takes the file's list `status`; a 'deleted' file's modified side and an 'added' file's original side are forced null without a read (and the merge-base resolution skipped when unneeded). This stops a deletion whose file still sits on disk as an untracked leftover (`git rm --cached`) from surfacing that leftover as its modified content.
- A missing side is `null` (added file's original, deleted file's modified), not an error.

### Route — `GET /api/machines/diff`

- `?terminalId&projectName&branchName&scope` → changed-file list + `truncated` + concrete `mergeBase` (the ref a client passes to `/api/machines/git-blob` for 'original' sides, per that route's "merge-base the caller already computed" contract).
- `…&path=` → one file's `{ original, modified }` pair. For a renamed file the client also passes `…&previousPath=` (the rename source from the list entry) so the 'original' side reads the pre-rename blob; it addresses only the blob side via git's `<ref>:<path>` syntax (can't escape the ref's tree), so unlike `path` it needs no working-tree confinement. `…&status=` (validated) lets a deletion's modified side be forced null rather than reading a masquerading untracked file at the path.
- Main-branch committed/branch → **explicit 200 `{ notApplicable: true }`**, answered before the machine handle is resolved (works while the machine is off) — the client renders a disabled scope toggle without inferring from empty data.
- View access via the canonical `machine-access-runtime` module; authz before any param probing; working-tree `path` confined under the checkout root (`resolvePathWithinSync`).
- `machine-diff-runtime.ts` re-exports the git-blob runtime wiring (identical deps).

## Tests (86 new, all colocated)

- `machine-diff-scope.test.ts` — **table-driven, zero mocks**: all 3 scopes × main/non-main, stale-flag defense, the branch `untrackedArgs` supplement, all three parsers incl. renames, copies, spaces/non-ASCII paths, truncated tails, and `parseUntrackedPorcelainZ` (only `??` kept, rename-source fields stepped over).
- `machine-diff.test.ts` — over a scripted fake sandbox (real `runGitInSandbox`/`readMachineGitBlob`/`readMachineFile`, mirroring `machine-git-blob.test.ts`'s harness): per-scope argv, side selection, merge-base validation, null sides, rename original-from-`previousPath` (committed + uncommitted), branch untracked union / dedup / truncation / failure, 2 MB working-tree cap without UTF-8 corruption.
- `route.test.ts` — contract tests: param validation, authz-before-parsing, notApplicable short-circuit, path confinement, `previousPath` forwarding, error → status mapping.

## Verification

- `packages/lib` + `packages/db` build clean (tsc), `apps/web` typecheck clean
- New tests all passing; full sandbox suite (475 tests) + diff route suite (19 tests) green
- Lint clean (only pre-existing warnings in unrelated hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KDtB8hbca5d83Wz3WyCA6
